### PR TITLE
feat(api): change data repo structure

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -19,7 +19,7 @@ export class AppController {
   async createDirectory(
     @Body('slug') slug: string,
     @Body('name') name: string,
-    @Body('slug') description: string,
+    @Body('description') description: string,
     @Body('owner') owner?: string,
   ) {
     const user = await User.sessionMock();
@@ -30,7 +30,7 @@ export class AppController {
       dir.owner = owner;
     } else {
       const owner = await this.githubService.getUser(user.getGitToken());
-      dir.owner = owner.name;
+      dir.owner = owner.login;
     }
     dir.name = name;
     dir.description = description;

--- a/apps/api/src/data-generator/data-generator.service.ts
+++ b/apps/api/src/data-generator/data-generator.service.ts
@@ -66,7 +66,7 @@ export class DataGeneratorService {
             const dirs = await this.ensureDirectoriesExist(dest);
             const updatedAt = new Date();
 
-            const existingFiles = new Set(await fs.readdir(dirs.ymlDir));
+            const existingFiles = new Set(await fs.readdir(dirs.dataDir));
 
             for (const item of items) {
                 const filename = slugify(item.name, { lower: true, trim: true });
@@ -85,21 +85,17 @@ export class DataGeneratorService {
         }
     }
 
+    /* it's still in seperated function in case we will need more dirs */
     private async ensureDirectoriesExist(dir: string) {
-        const ymlDir = join(dir, 'data');
-        const mdDir = join(dir, 'details');
+        const dataDir = join(dir, 'data');
+        await fs.mkdir(dataDir, { recursive: true });
 
-        await Promise.all([
-            fs.mkdir(ymlDir, { recursive: true }),
-            fs.mkdir(mdDir, { recursive: true }),
-        ]);
-
-        return { ymlDir, mdDir };
+        return { dataDir };
     }
 
-    private async processItem(item: ItemData, filename: string, dirs: { ymlDir: string; mdDir: string }, updatedAt: Date, dir: string) {
-        const ymlPath = join(dirs.ymlDir, `${filename}.yml`);
-        const mdPath = join(dirs.mdDir, `${filename}.md`);
+    private async processItem(item: ItemData, filename: string, dirs: { dataDir: string }, updatedAt: Date, dir: string) {
+        const ymlPath = join(dirs.dataDir, `${filename}.yml`);
+        const mdPath = join(dirs.dataDir, `${filename}.md`);
 
         const yaml = yamlStringify({ ...item, updated_at: updatedAt.toISOString() });
         const markdown = await this.aiEngine.getItemDetails(item);

--- a/apps/api/src/markdown-generator/markdown-generator.service.ts
+++ b/apps/api/src/markdown-generator/markdown-generator.service.ts
@@ -47,6 +47,9 @@ export class MarkdownGeneratorService {
             const entries = await fs.readdir(entriesPath);
 
             for (const entry of entries) {
+                if (path.extname(entry) !== '.yml')
+                    continue;
+
                 const file = await fs.readFile(path.join(entriesPath, entry), { encoding: 'utf-8' });
                 const obj: ItemData = yamlParse(file);
 


### PR DESCRIPTION
This PR:
- changes structure for data repo - now both yml and md files will be stored inside `data` directory.
- fixes creating repos as regular user....