### PR TITLE
feat(api): add tags

### DIFF
--- a/apps/api/src/ai-engine/ai-engine.service.ts
+++ b/apps/api/src/ai-engine/ai-engine.service.ts
@@ -7,6 +7,11 @@ export interface Category {
     icon_url?: string;
 }
 
+export interface Tag {
+    id: string;
+    name: string;
+}
+
 export interface ItemData {
     name: string;
     description: string;
@@ -14,123 +19,148 @@ export interface ItemData {
     source_url: string;
     category: string | string[] | Category | Category[];
     slug?: string;
+    tags: string[] | Tag[];
 }
+
+export const tags: Tag[] = [
+    { id: 'productivity', name: 'Productivity' },
+    { id: 'project-management', name: 'Project Management' },
+    { id: 'business-management', name: 'Business Management' },
+];
 
 const data: Array<ItemData> = [
     {
         name: 'Ever Cloc',
         description: 'Open Time Tracking Platform (WIP)',
         source_url: 'https://github.com/ever-co/ever-cloc',
-        category: 'open-source'
+        category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Ever Team',
         description: 'Open Work and Project Management Platform (including optional screenshots, Desktop & Mobile Apps, etc.)',
         source_url: 'https://ever.team',
         category: 'open-source',
+        tags: ['productivity', 'project-management'],
     },
     {
         name: 'Ever Gauzy',
         description: 'Open Business Management Platform (ERP/CRM/HRM) with Time-Tracking functionality (including optional screenshots, Desktop Timer App, etc.)',
         source_url: 'https://gauzy.co',
         category: 'open-source',
+        tags: ['business-management', 'productivity'],
     },
     {
         name: 'ActivityWatch',
         description: 'Free and open-source automated time tracker. Cross-platform, extensible, privacy-focused.',
         source_url: 'https://activitywatch.net',
-        category: 'open-source'
+        category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Timewarrior',
         description: 'Commandline Time Tracking and Reporting.',
         source_url: 'https://github.com/GothenburgBitFactory/timewarrior',
-        category: 'open-source'
+        category: 'open-source',
+        tags: ['productivity'],
 
     },
     {
         name: 'Time Tracker',
         description: 'Time Tracker, to be the best time tracker for browsers',
         source_url: 'https://www.wfhg.cc',
-        category: 'open-source'
+        category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'TomeTracker',
         description: 'Time tracking app using localstorage.',
         source_url: 'https://github.com/tommerty/TomeTracker',
-        category: 'open-source'
+        category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'HubStaff',
         description: 'One app to automate time-tracking processes, workforce management, and productivity metrics.',
         source_url: 'https://hubstaff.com',
         category: 'commercial',
+        tags: ['productivity'],
     },
     {
         name: 'TimeOS',
         description: 'AI productivity companion that captures and summarizes your day, organizes all relevant information within the right tool, and proactively surfaces the knowledge you need, when you need it.',
         source_url: 'https://www.timeos.ai',
         category: 'commercial',
+        tags: ['productivity'],
     },
     {
         name: 'Invobook',
         description: 'Self-hosted app for Time Tracking, Invoice Generation, Project & Client Management, built with Laravel & Filament.',
         source_url: 'https://github.com/Hasnayeen/invobook',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Titra',
         description: 'Modern open source project time tracking for freelancers and small teams.',
         source_url: 'https://titra.io/en',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Selfspy',
         description: 'Log everything you do on the computer, for statistics, future reference and all-around fun!',
         source_url: 'https://github.com/selfspy/selfspy',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Shion',
         description: 'Time Tracker.',
         source_url: 'https://shion.app',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Timestrap',
         description: 'Time-tracking you can host anywhere. Full export support in multiple formats and easily extensible.',
         source_url: 'https://timestrap.bythewood.me',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'GNOME Time Tracker',
         description: 'Hamster is time tracking for individuals. It helps you to keep track of how much time you have spent during the day on activities you choose to track.',
         source_url: 'https://github.com/projecthamster/hamster',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'TimeTrex',
         description: 'Taking the Work Out of Workforce Management. Automate your time & attendance, payroll and HR management in one easy-to-use platform',
         source_url: 'https://www.timetrex.com',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'ULogMe',
         description: 'Automatically collect and visualize usage statistics in Ubuntu/OSX environments.',
         source_url: 'https://github.com/karpathy/ulogme',
         category: 'open-source',
+        tags: ['productivity'],
     },
     {
         name: 'Traggo',
         description: 'Self-hosted tag-based time tracking.',
         source_url: 'https://traggo.net',
         category: 'open-source',
+        tags: ['productivity'],
     }
-]
+];
 
 @Injectable()
 export class AiEngineService {
-    async getItemsList(input: { prompt: string, categories: Category[], }) {
+    async getItemsList(input: { prompt: string, categories: Category[], tags: Tag[] }) {
         return data;
     }
 
@@ -141,9 +171,13 @@ export class AiEngineService {
         ]
     }
 
+    async getTagsList() {
+        return tags;
+    }
+
     async getItemDetails(item: ItemData) {
         return (
-            `# ${item.name}\n` +
+            `# ${item.name}\n\n` +
             'Lorem ipsum odor amet, consectetuer adipiscing elit.\n' +
             'Augue lobortis tempus ridiculus phasellus platea quis.\n' +
             'Suspendisse enim auctor luctus phasellus pretium natoque laoreet.\n' +

--- a/apps/api/src/data-generator/data-generator.service.ts
+++ b/apps/api/src/data-generator/data-generator.service.ts
@@ -14,7 +14,7 @@ export class DataGeneratorService {
     constructor(
         private readonly githubService: GithubService,
         private readonly aiEngine: AiEngineService
-    ) {}
+    ) { }
 
     async initialize(directory: Directory, user: User, prompt: string) {
         const categories = await this.aiEngine.getCategoryList();
@@ -28,13 +28,14 @@ export class DataGeneratorService {
         } else {
             await this.githubService.createEmptyRepo(repo, description, token);
         }
-        
+
         const dest = await this.githubService.clone(directory.owner, repo, token);
         const data = new DataRepository(dest);
-        
+
         try {
             await data.ensureDirectoriesExist();
             await Promise.all([
+                data.writeReadme(this.getDefaultReadme(directory)),
                 data.writeConfig(DEFAULT_DATA_CONFIG),
                 data.writeCategories(categories),
                 data.writeMarkdownTemplate(this.getHeader(directory), this.getFooter()),
@@ -65,11 +66,11 @@ export class DataGeneratorService {
         const categories = await data.getCategories();
         const items = await this.aiEngine.getItemsList({ prompt, categories });
         // mock adding some new item:
-        items.push({ 
+        items.push({
             name: 'Test Sample',
             category: 'testing',
             description: 'Best service ever',
-            source_url: 'https://example.com', 
+            source_url: 'https://example.com',
         });
 
         try {
@@ -106,9 +107,15 @@ export class DataGeneratorService {
         await this.githubService.commit(data.dir, `add ${item.name}`, user.asCommitter());
     }
 
+    private getDefaultReadme(directory: Directory) {
+        const markdownURL = this.githubService.getURL(directory.owner, directory.slug);
+        return `# ${directory.getDataRepo()}\n\n` +
+            `This repository holds data used to generate [${directory.slug}](${markdownURL}]\n\n`;
+    }
+
     private getHeader(directory: Directory) {
-        return `# ${directory.name}\n` +
-                `${directory.description}\n\n`;
+        return `# ${directory.name}\n\n` +
+            `${directory.description}\n\n`;
     }
 
     private getFooter() {

--- a/apps/api/src/data-generator/data-generator.service.ts
+++ b/apps/api/src/data-generator/data-generator.service.ts
@@ -18,7 +18,8 @@ export class DataGeneratorService {
 
     async initialize(directory: Directory, user: User, prompt: string) {
         const categories = await this.aiEngine.getCategoryList();
-        const items = await this.aiEngine.getItemsList({ prompt, categories });
+        const tags = await this.aiEngine.getTagsList();
+        const items = await this.aiEngine.getItemsList({ prompt, categories, tags });
         const token = user.getGitToken();
         const repo = directory.getDataRepo();
         const description = `machine-readable data for ${directory.slug}`;
@@ -38,6 +39,7 @@ export class DataGeneratorService {
                 data.writeReadme(this.getDefaultReadme(directory)),
                 data.writeConfig(DEFAULT_DATA_CONFIG),
                 data.writeCategories(categories),
+                data.writeTags(tags),
                 data.writeMarkdownTemplate(this.getHeader(directory), this.getFooter()),
             ]);
             await this.githubService.add(data.dir, '.');
@@ -64,13 +66,15 @@ export class DataGeneratorService {
         const data = new DataRepository(dest);
 
         const categories = await data.getCategories();
-        const items = await this.aiEngine.getItemsList({ prompt, categories });
+        const tags = await data.getTags();
+        const items = await this.aiEngine.getItemsList({ prompt, categories, tags });
         // mock adding some new item:
         items.push({
             name: 'Test Sample',
             category: 'testing',
             description: 'Best service ever',
             source_url: 'https://example.com',
+            tags: [ { name: 'Test', id: 'test' } ],
         });
 
         try {
@@ -110,7 +114,7 @@ export class DataGeneratorService {
     private getDefaultReadme(directory: Directory) {
         const markdownURL = this.githubService.getURL(directory.owner, directory.slug);
         return `# ${directory.getDataRepo()}\n\n` +
-            `This repository holds data used to generate [${directory.slug}](${markdownURL}]\n\n`;
+            `This repository holds data used to generate [${directory.slug}](${markdownURL})\n\n`;
     }
 
     private getHeader(directory: Directory) {

--- a/apps/api/src/data-generator/data-generator.service.ts
+++ b/apps/api/src/data-generator/data-generator.service.ts
@@ -34,8 +34,13 @@ export class DataGeneratorService {
         
         try {
             await data.ensureDirectoriesExist();
-            await data.writeConfig(DEFAULT_DATA_CONFIG);
-            await data.writeCategories(categories);
+            await Promise.all([
+                data.writeConfig(DEFAULT_DATA_CONFIG),
+                data.writeCategories(categories),
+                data.writeMarkdownTemplate(this.getHeader(directory), this.getFooter()),
+            ]);
+            await this.githubService.add(data.dir, '.');
+            await this.githubService.commit(data.dir, `init repository`, user.asCommitter());
 
             for (const item of items) {
                 item.slug = slugify(item.name, { lower: true });
@@ -94,10 +99,26 @@ export class DataGeneratorService {
 
         await Promise.all([
             data.writeItem(item),
-            data.writeMarkdown(item, markdown),
+            data.writeItemMarkdown(item, markdown),
         ]);
 
         await this.githubService.add(data.dir, '.');
         await this.githubService.commit(data.dir, `add ${item.name}`, user.asCommitter());
+    }
+
+    private getHeader(directory: Directory) {
+        return `# ${directory.name}\n` +
+                `${directory.description}\n\n`;
+    }
+
+    private getFooter() {
+        return "## License\n\n" +
+            "Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]\n\n" +
+            "This work is licensed under a\n\n" +
+            "[Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].\n\n" +
+            "[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]\n\n" +
+            "[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/\n\n" +
+            "[cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png\n\n" +
+            "[cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg\n\n";
     }
 }

--- a/apps/api/src/data-generator/data-repository.ts
+++ b/apps/api/src/data-generator/data-repository.ts
@@ -170,4 +170,9 @@ export class DataRepository {
         const filepath = path.join(this.getItemPath(item.slug), `${item.slug}.md`);
         await fs.writeFile(filepath, markdown, 'utf-8');
     }
+
+    async writeReadme(content: string) {
+        const filepath = path.join(this.dir, 'README.md');
+        await fs.writeFile(filepath, content, 'utf-8');
+    }
 }

--- a/apps/api/src/data-generator/data-repository.ts
+++ b/apps/api/src/data-generator/data-repository.ts
@@ -21,6 +21,7 @@ export class DataRepository {
     private categories?: Category[];
     private readonly configPath: string;
     private readonly categoriesPath: string;
+    private readonly markdownTemplatePath: string;
     public readonly dataDir: string;
 
     constructor(public readonly dir: string) {
@@ -41,6 +42,7 @@ export class DataRepository {
          */
         this.configPath = path.join(dir, 'config.yml');
         this.categoriesPath = path.join(dir, 'categories.yml');
+        this.markdownTemplatePath = path.join(dir, 'markdown');
         this.dataDir = path.join(dir, 'data');
     }
 
@@ -53,7 +55,10 @@ export class DataRepository {
     }
 
     async ensureDirectoriesExist() {
-        await fs.mkdir(this.dataDir, { recursive: true });
+        await Promise.all([
+            fs.mkdir(this.markdownTemplatePath, { recursive: true }),
+            fs.mkdir(this.dataDir, { recursive: true })
+        ]);
     }
 
     async getConfig(): Promise<IDataConfig> {
@@ -138,6 +143,21 @@ export class DataRepository {
         await fs.mkdir(itemDir, { recursive: true });
     }
 
+    async writeMarkdownTemplate(header: string, footer: string) {
+        await Promise.all([
+            fs.writeFile(path.join(this.markdownTemplatePath, 'header.md'), header, 'utf-8'),
+            fs.writeFile(path.join(this.markdownTemplatePath, 'footer.md'), footer, 'utf-8'),
+        ]);
+    }
+
+    async readMarkdownTemplate() {
+        const [header, footer] = await Promise.all([
+            fs.readFile(path.join(this.markdownTemplatePath, 'header.md'), 'utf-8'),
+            fs.readFile(path.join(this.markdownTemplatePath, 'footer.md'), 'utf-8'),
+        ]);
+        return { header, footer };
+    }
+
     async writeItem(item: ItemData) {
         const { slug, ...rest } = item; // we don't want to write slug to the file
         const updated_at = format(new Date(), "yyyy-MM-dd HH:mm");
@@ -146,7 +166,7 @@ export class DataRepository {
         await fs.writeFile(filepath, str, 'utf-8');
     }
 
-    async writeMarkdown(item: ItemData, markdown: string) {
+    async writeItemMarkdown(item: ItemData, markdown: string) {
         const filepath = path.join(this.getItemPath(item.slug), `${item.slug}.md`);
         await fs.writeFile(filepath, markdown, 'utf-8');
     }

--- a/apps/api/src/data-generator/data-repository.ts
+++ b/apps/api/src/data-generator/data-repository.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as fs from 'fs/promises';
 import * as yaml from 'yaml';
-import { Category, ItemData } from "../ai-engine/ai-engine.service";
+import { Category, ItemData, Tag } from "../ai-engine/ai-engine.service";
 import { format } from "date-fns";
 
 export interface IDataConfig {
@@ -21,6 +21,7 @@ export class DataRepository {
     private categories?: Category[];
     private readonly configPath: string;
     private readonly categoriesPath: string;
+    private readonly tagsPath: string;
     private readonly markdownTemplatePath: string;
     public readonly dataDir: string;
 
@@ -29,6 +30,7 @@ export class DataRepository {
          *   File structure:
          *      - config.yml
          *      - categories.yml
+         *      - tags.yml
          *      - data/
          *          - item1/
          *              - item1.yml
@@ -42,6 +44,7 @@ export class DataRepository {
          */
         this.configPath = path.join(dir, 'config.yml');
         this.categoriesPath = path.join(dir, 'categories.yml');
+        this.tagsPath = path.join(dir, 'tags.yml');
         this.markdownTemplatePath = path.join(dir, 'markdown');
         this.dataDir = path.join(dir, 'data');
     }
@@ -89,6 +92,18 @@ export class DataRepository {
         return this.categories;
     }
 
+    async getTags(): Promise<Tag[]> {
+        try {
+            const tags = await fs.readFile(this.tagsPath, 'utf-8');
+            return yaml.parse(tags);
+        } catch (err) {
+            if (err?.code === 'ENOENT') {
+                return [];
+            }
+            throw err;
+        }
+    }
+
     async getItem(slug: string): Promise<ItemData> {
         const ymlPath = path.join(this.getItemPath(slug), `${slug}.yml`);
 
@@ -102,7 +117,7 @@ export class DataRepository {
                 const yamlPath = path.join(this.getItemPath(slug), `${slug}.yaml`);
                 const content = await fs.readFile(yamlPath, 'utf-8');
                 const item = yaml.parse(content);
-                
+
                 return { ...item, slug };
             }
             throw err;
@@ -122,10 +137,6 @@ export class DataRepository {
         }
     }
 
-    getCategoryName(id: string): string {
-        return this.categories?.find(c => c.id === id)?.name || id;
-    }
-
     async writeConfig(config: IDataConfig) {
         this.config = config;
         const str = yaml.stringify(config);
@@ -136,6 +147,11 @@ export class DataRepository {
         this.categories = categories;
         const str = yaml.stringify(categories);
         await fs.writeFile(this.categoriesPath, str, 'utf-8');
+    }
+
+    async writeTags(tags: Tag[]) {
+        const str = yaml.stringify(tags);
+        await fs.writeFile(this.tagsPath, str, 'utf-8');
     }
 
     async createItemDir(item: ItemData) {

--- a/apps/api/src/markdown-generator/markdown-generator.service.ts
+++ b/apps/api/src/markdown-generator/markdown-generator.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import * as fs from 'fs/promises';
 import { GithubService } from '../git/github.service';
-import type { Category, ItemData } from '../ai-engine/ai-engine.service';
+import type { Category, ItemData, Tag } from '../ai-engine/ai-engine.service';
 import { Directory } from '../entities/directory.entity';
 import { User } from '../entities/user.entity';
 import { DataRepository } from '../data-generator/data-repository';
@@ -20,7 +20,7 @@ export class MarkdownGeneratorService {
                 directory.owner,
                 directory.slug,
                 directory.description,
-                token
+                token,
             );
         } else {
             await this.githubService.createEmptyRepo(directory.slug, directory.description, token);
@@ -42,6 +42,7 @@ export class MarkdownGeneratorService {
         const dataRepo = new DataRepository(dataPath);
         const markdowns = new Set<string>(); // will be needed to check if markdown exists before referencing them in README
         const categories = await this.loadCategories(dataRepo);
+        const tags = await this.loadTags(dataRepo);
 
         try {
             const slugs = await fs.readdir(dataRepo.dataDir);
@@ -56,6 +57,10 @@ export class MarkdownGeneratorService {
                 }
 
                 const item = await dataRepo.getItem(slug);
+                if (Array.isArray(item.tags)) {
+                    item.tags = item.tags.map(tag => this.populateTag(tag, tags));
+                }
+
                 if (Array.isArray(item.category)) {
                     item.category = item.category.map(category => this.populateCategory(category, categories));
                 } else {
@@ -133,6 +138,17 @@ export class MarkdownGeneratorService {
         return categories;
     }
 
+    private async loadTags(data: DataRepository): Promise<Map<string, Category>> {
+        const list = await data.getTags();
+        const tags = new Map<string, Category>();
+
+        for (const tag of list) {
+            tags.set(tag.id, tag);
+        }
+
+        return tags;
+    }
+
     private populateCategory(category: string | Category, categories: Map<string, Category>): Category {
         const id = typeof category === 'string' ? category : category.id;
         const populated = categories.get(id);
@@ -149,5 +165,24 @@ export class MarkdownGeneratorService {
 
         categories.set(category.id, category);
         return category
+    }
+
+    
+    private populateTag(tag: string | Tag, tags: Map<string, Tag>): Tag {
+        const id = typeof tag === 'string' ? tag : tag.id;
+        const populated = tags.get(id);
+
+        if (populated) {
+            return populated;
+        }
+
+        if (typeof tag === 'string') {
+            const result = { id, name: tag };
+            tags.set(id, result);
+            return result;
+        }
+
+        tags.set(tag.id, tag);
+        return tag;
     }
 }

--- a/apps/api/src/markdown-generator/markdown-generator.service.ts
+++ b/apps/api/src/markdown-generator/markdown-generator.service.ts
@@ -72,7 +72,7 @@ export class MarkdownGeneratorService {
                 }
             }
 
-            const readme: string = await this.generateReadme(dataRepo, directory, markdowns, groups, categories);
+            const readme: string = await this.generateReadme(dataRepo, markdowns, groups, categories);
             await markdownRepo.writeReadme(readme);
             await this.githubService.add(markdownPath, '.');
             await this.githubService.commit(markdownPath, 'sync README.md',  user.asCommitter());
@@ -89,16 +89,13 @@ export class MarkdownGeneratorService {
 
     private async generateReadme(
         data: DataRepository,
-        directory: Directory,
         markdowns: Set<string>,
         groups: Record<string, Array<ItemData>>,
         categories: Map<string, Category>
     ) {
         const config = await data.getConfig();
-        const builder = new ReadmeBuilder(markdowns);
-
-        builder.setTitle(directory.name);
-        builder.setDescription(directory.description);
+        const { header, footer } = await data.readMarkdownTemplate();
+        const builder = new ReadmeBuilder(header, footer);
 
         if (config.content_table) {
             builder.enableToC();
@@ -116,7 +113,7 @@ export class MarkdownGeneratorService {
             });
 
             for (const item of items) {
-                builder.addItem(item);
+                builder.addItem(item, { hasDetails: item.slug && markdowns.has(item.slug) });
             }
 
             builder.addNewLine();

--- a/apps/api/src/markdown-generator/readme-builder.ts
+++ b/apps/api/src/markdown-generator/readme-builder.ts
@@ -1,5 +1,5 @@
 import slugify from "slugify";
-import { ItemData } from "../ai-engine/ai-engine.service";
+import { ItemData, Tag } from "../ai-engine/ai-engine.service";
 
 export class ReadmeBuilder {
     private content: string = '';
@@ -52,10 +52,15 @@ export class ReadmeBuilder {
         return toc;
     }
 
-    addItem(item: ItemData, { hasDetails = false } = {}) {
+    addItem(item: ItemData, options: { hasDetails?: boolean } = {}) {
         this.content += `- [${item.name}](${item.source_url}) - ${item.description}`;
-        if (hasDetails) {
+        if (options.hasDetails) {
             this.content += ` ([Read more](/details/${item.slug}.md))`;
+        }
+
+        if (item.tags && item.tags.length > 0) {
+            const tags = item.tags.map(tag => `\`${tag.name}\``).join(' ');
+            this.content += ` ${tags}`;
         }
         this.content += '\n';
         return this;

--- a/apps/api/src/markdown-generator/readme-builder.ts
+++ b/apps/api/src/markdown-generator/readme-builder.ts
@@ -2,22 +2,14 @@ import slugify from "slugify";
 import { ItemData } from "../ai-engine/ai-engine.service";
 
 export class ReadmeBuilder {
-    private top: string = '';
     private content: string = '';
     private isTocEnabled: boolean = false;
     private readonly toc: string[] = []; // Table of Contents
 
-    constructor(private readonly markdowns: Set<string>) { }
-
-    setTitle(title: string) {
-        this.top += `# ${title}\n\n`;
-        return this;
-    }
-
-    setDescription(description: string) {
-        this.top += `${description}\n\n`;
-        return this;
-    }
+    constructor(
+        private readonly header: string,
+        private readonly footer: string,
+    ) {}
 
     addHeader(header: string) {
         this.content += `# ${header}\n\n`;
@@ -60,9 +52,9 @@ export class ReadmeBuilder {
         return toc;
     }
 
-    addItem(item: ItemData) {
+    addItem(item: ItemData, { hasDetails = false } = {}) {
         this.content += `- [${item.name}](${item.source_url}) - ${item.description}`;
-        if (item.slug && this.markdowns.has(item.slug)) {
+        if (hasDetails) {
             this.content += ` ([Read more](/details/${item.slug}.md))`;
         }
         this.content += '\n';
@@ -70,13 +62,13 @@ export class ReadmeBuilder {
     }
 
     build(): string {
-        let result = this.top + '\n';
+        let result = this.header + '\n';
         
         if (this.isTocEnabled) {
             result += this.generateToC();
             result += '\n';
         }
 
-        return result + this.content;
+        return result + this.content + '\n' + this.footer;
     }
 }


### PR DESCRIPTION
This PR:
- [x] adds `header.md` and `footer.md` inside data repository (they will be used for README generation inside markdown repository)
- [x] adds making seperate commit for initial generation of files like `readme.md`, `config.yml` and `categories.yml` (previously these files were commited with first item). Not intended behavior fixed.
- [x] generates default `README.md` for data repository
- [x] adds tags support