### PR TITLE
feat: updates directory items count in various components

### DIFF
--- a/apps/cli/src/commands/directory/submit-item.ts
+++ b/apps/cli/src/commands/directory/submit-item.ts
@@ -115,6 +115,7 @@ export const submitItemCommand = new Command('submit-item')
                               .filter((tag: string) => tag.length > 0)
                         : undefined,
                     featured: answers.featured || false,
+                    pay_and_publish_now: true,
                 };
 
                 const response = await apiService.submitItem(directory.id, submitDto);

--- a/apps/internal-cli/src/commands/directory/submit-item.subcommand.ts
+++ b/apps/internal-cli/src/commands/directory/submit-item.subcommand.ts
@@ -59,7 +59,7 @@ export class SubmitItemSubCommand extends CommandRunner {
             }
             console.log(chalk.gray('Featured:'), chalk.white(itemData.featured ? 'Yes' : 'No'));
             console.log(
-                chalk.gray('Pay and Publish Now:'),
+                chalk.gray('Push to main without PR:'),
                 chalk.white(itemData.pay_and_publish_now ? 'Yes' : 'No'),
             );
 
@@ -204,7 +204,7 @@ export class SubmitItemSubCommand extends CommandRunner {
                 type: 'confirm',
                 name: 'pay_and_publish_now',
                 message: 'Pay and publish now?',
-                default: false,
+                default: true,
             },
         ]);
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -346,7 +346,12 @@
         },
         "directoryCard": {
             "status": {
-                "active": "Active"
+                "active": "Active",
+                "notStarted": "Not Started",
+                "generating": "Generating",
+                "generated": "Generated",
+                "error": "Error",
+                "idle": "Idle"
             },
             "noDescription": "No description provided",
             "items": "{count} items",
@@ -359,6 +364,7 @@
             "createButton": "Create Directory"
         },
         "directoryDetail": {
+            "failedToGenerateItems": "Failed to generate items. Please try again.",
             "status": {
                 "notStarted": "Not Started",
                 "generating": "Generating",

--- a/apps/web/src/components/directories/DirectoryCard.tsx
+++ b/apps/web/src/components/directories/DirectoryCard.tsx
@@ -74,7 +74,7 @@ export function DirectoryCard({ directory }: DirectoryCardProps) {
             </p>
 
             {/* Stats */}
-            <div className="flex items-center gap-4 mb-4 text-sm text-text-muted dark:text-text-muted-dark">
+            <div className="items-center gap-4 mb-4 text-sm text-text-muted dark:text-text-muted-dark flex">
                 <span className="flex items-center gap-1">
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path
@@ -84,24 +84,7 @@ export function DirectoryCard({ directory }: DirectoryCardProps) {
                             d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                         />
                     </svg>
-                    {t('items', { count: 0 })}
-                </span>
-                <span className="flex items-center gap-1">
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                        />
-                        <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                        />
-                    </svg>
-                    {t('views', { count: 0 })}
+                    {t('items', { count: directory.itemsCount || 0 })}
                 </span>
             </div>
 

--- a/apps/web/src/components/directories/DirectoryCard.tsx
+++ b/apps/web/src/components/directories/DirectoryCard.tsx
@@ -74,7 +74,7 @@ export function DirectoryCard({ directory }: DirectoryCardProps) {
             </p>
 
             {/* Stats */}
-            <div className="items-center gap-4 mb-4 text-sm text-text-muted dark:text-text-muted-dark flex">
+            <div className="flex items-center gap-4 mb-4 text-sm text-text-muted dark:text-text-muted-dark">
                 <span className="flex items-center gap-1">
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path

--- a/apps/web/src/components/directories/DirectoryCard.tsx
+++ b/apps/web/src/components/directories/DirectoryCard.tsx
@@ -5,6 +5,7 @@ import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { useTranslations, useLocale } from 'next-intl';
 import type { Directory } from '@/lib/api/directory';
+import { GenerateStatusType } from '@/lib/api/enums';
 
 interface DirectoryCardProps {
     directory: Directory;
@@ -21,6 +22,9 @@ const formatDate = (date: string, locale: string) => {
 export function DirectoryCard({ directory }: DirectoryCardProps) {
     const t = useTranslations('dashboard.directoryCard');
     const locale = useLocale();
+
+    const status = directory.generateStatus?.status;
+
     return (
         <Link
             href={ROUTES.DASHBOARD_DIRECTORY(directory.id)}
@@ -47,10 +51,16 @@ export function DirectoryCard({ directory }: DirectoryCardProps) {
                 <div
                     className={cn(
                         'px-2 py-1 rounded-full text-xs font-medium',
-                        'bg-success/10 text-success',
+                        status === GenerateStatusType.ERROR && 'bg-danger/20 text-danger',
+                        status === GenerateStatusType.GENERATING && 'bg-info/20 text-info',
+                        status === GenerateStatusType.GENERATED && 'bg-success/20 text-success',
+                        !status && 'bg-gray-200 text-gray-700',
                     )}
                 >
-                    {t('status.active')}
+                    {status === GenerateStatusType.ERROR && t('status.error')}
+                    {status === GenerateStatusType.GENERATING && t('status.generating')}
+                    {status === GenerateStatusType.GENERATED && t('status.generated')}
+                    {!status && t('status.idle')}
                 </div>
             </div>
 

--- a/apps/web/src/components/directories/detail/DirectoryLayoutClient.tsx
+++ b/apps/web/src/components/directories/detail/DirectoryLayoutClient.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { ConnectionInfo, Directory } from '@/lib/api/types-only';
 import { DirectoryHeader } from './DirectoryHeader';
 import { DirectoryTabs } from './DirectoryTabs';
 import { GenerateStatusType, RepoProvider } from '@/lib/api/enums';
 import { DirectoryDetailProvider } from './DirectoryDetailContext';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 
 interface DirectoryLayoutClientProps {
     directory: Directory;
@@ -20,7 +22,22 @@ export function DirectoryLayoutClient({
     children,
 }: DirectoryLayoutClientProps) {
     const router = useRouter();
+    const t = useTranslations('dashboard.directoryDetail');
     const isGenerating = directory.generateStatus?.status === GenerateStatusType.GENERATING;
+    const lastGenerateStatus = useRef(directory.generateStatus);
+
+    useEffect(() => {
+        const lastStatus = lastGenerateStatus.current?.status;
+        const currentStatus = directory.generateStatus?.status;
+
+        if (lastStatus !== currentStatus && currentStatus === GenerateStatusType.ERROR) {
+            toast.error(t('failedToGenerateItems'), {
+                id: 'failed-to-generate-items',
+            });
+        }
+
+        lastGenerateStatus.current = directory.generateStatus;
+    }, [directory.generateStatus]);
 
     useEffect(() => {
         if (isGenerating) {

--- a/apps/web/src/components/directories/detail/items/AddItemModal.tsx
+++ b/apps/web/src/components/directories/detail/items/AddItemModal.tsx
@@ -35,7 +35,7 @@ export const AddItemModal = memo(function AddItemModal({
         category: categories[0] || '',
         tags: [],
         featured: false,
-        pay_and_publish_now: false,
+        pay_and_publish_now: true,
         slug: '',
     });
 
@@ -77,7 +77,7 @@ export const AddItemModal = memo(function AddItemModal({
                             category: categories[0] || '',
                             tags: [],
                             featured: false,
-                            pay_and_publish_now: false,
+                            pay_and_publish_now: true,
                             slug: '',
                         });
                     } else {

--- a/apps/web/src/lib/api/directory.ts
+++ b/apps/web/src/lib/api/directory.ts
@@ -60,6 +60,7 @@ export interface Directory {
     generateStatus?: GenerateStatus;
     createdAt: string;
     updatedAt: string;
+    itemsCount?: number;
     lastPullRequest?: { main?: PRUpdate; data?: PRUpdate };
 }
 

--- a/packages/agent/src/data-generator/data-generator.service.ts
+++ b/packages/agent/src/data-generator/data-generator.service.ts
@@ -68,6 +68,11 @@ export class DataGeneratorService {
             return;
         }
 
+        // Update directory items count
+        this.directoryRepository.update(directory.id, {
+            itemsCount: generatedItems.items.length + existingData.existingItems.length,
+        });
+
         const { categories: newCategories, items: newItems, tags: newTags } = generatedItems;
         const { existingCategories, existingTags } = existingData;
 

--- a/packages/agent/src/entities/directory.entity.ts
+++ b/packages/agent/src/entities/directory.entity.ts
@@ -54,6 +54,9 @@ export class Directory {
     @Column('simple-json', { nullable: true })
     lastPullRequest?: { main?: PRUpdate; data?: PRUpdate };
 
+    @Column({ nullable: true })
+    itemsCount?: number;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/services/agent.service.ts
+++ b/packages/agent/src/services/agent.service.ts
@@ -759,7 +759,7 @@ export class AgentService {
         const lowerMessage = message.toLowerCase();
 
         // Repository not found
-        if (lowerMessage.includes('Repository not found')) {
+        if (lowerMessage.includes('not found')) {
             return 'Repository not found. Please verify the repository exists and try again.';
         }
 

--- a/packages/agent/src/services/agent.service.ts
+++ b/packages/agent/src/services/agent.service.ts
@@ -156,9 +156,14 @@ export class AgentService {
             // Update generate status if repository is already existing
             const items = await this.dataGenerator.getItems(dir, user).catch(() => []);
             if (items.length > 0) {
-                await this.directoryRepository.updateGenerateStatus(dir.id, {
-                    status: GenerateStatusType.GENERATED,
-                });
+                await Promise.all([
+                    this.directoryRepository.updateGenerateStatus(dir.id, {
+                        status: GenerateStatusType.GENERATED,
+                    }),
+                    this.directoryRepository.update(dir.id, {
+                        itemsCount: items.length,
+                    }),
+                ]);
             }
 
             return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Directory cards show generation status (idle, generating, generated, error) with localized labels and display item counts; views removed.
  - Error toast notifies users when item generation fails.
  - “Pay and publish now” defaults to on in CLI and Add Item modal; submission summary label changed to “Push to main without PR.”
  - Added localized strings for statuses and generation failure.

- Bug Fixes
  - Improved detection for “Repository not found” to surface clearer error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->