### PR TITLE
feat: enable ScreenshotOne caching with cache URL support

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -78,6 +78,7 @@ VERCEL_TOKEN=
 # ScreenshotOne Configuration
 # =============================================================================
 SCREENSHOTONE_ACCESS_KEY=
+SCREENSHOTONE_SECRET_KEY=
 SCREENSHOTONE_VIEWPORT_WIDTH=1280
 SCREENSHOTONE_VIEWPORT_HEIGHT=800
 SCREENSHOTONE_FORMAT=png

--- a/apps/api/src/screenshot/screenshot.controller.ts
+++ b/apps/api/src/screenshot/screenshot.controller.ts
@@ -94,7 +94,8 @@ export class ScreenshotController {
 
         return {
             status: 'success',
-            imageUrl: result.imageUrl,
+            imageUrl: result.cacheUrl || result.imageUrl,
+            cacheUrl: result.cacheUrl,
             // Convert buffer to base64 for JSON response
             imageBase64: result.imageBuffer ? result.imageBuffer.toString('base64') : null,
         };

--- a/apps/web/src/components/settings/ApiTokenSettings.tsx
+++ b/apps/web/src/components/settings/ApiTokenSettings.tsx
@@ -356,7 +356,7 @@ export function ApiTokenSettings({ user }: ApiTokenSettingsProps) {
                             <p className="text-xs text-text-muted dark:text-text-muted-dark mt-2">
                                 {t('screenshotone.secretKeyHelp')}{' '}
                                 <a
-                                    href="https://screenshotone.com/dashboard"
+                                    href="https://dash.screenshotone.com/dashboard"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="text-primary dark:text-primary-dark hover:underline"

--- a/apps/web/src/lib/api/screenshot.ts
+++ b/apps/web/src/lib/api/screenshot.ts
@@ -29,6 +29,7 @@ export interface CaptureScreenshotDto {
 export interface CaptureScreenshotResponse {
     status: 'success' | 'error';
     imageUrl?: string;
+    cacheUrl?: string;
     imageBase64?: string;
     message?: string;
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"prettier": "^3.7.4",
 		"prettier-eslint-cli": "^8.0.1",
 		"prettier-plugin-tailwindcss": "^0.5.14",
-		"turbo": "^2.7.4"
+		"turbo": "^2.7.5"
 	},
 	"engines": {
 		"node": ">=20",

--- a/packages/agent/src/screenshot/screenshot-one.service.ts
+++ b/packages/agent/src/screenshot/screenshot-one.service.ts
@@ -14,11 +14,14 @@ export interface ScreenshotOptions {
     blockAds?: boolean;
     blockTrackers?: boolean;
     blockCookieBanners?: boolean;
+    cache?: boolean;
+    cacheTtl?: number;
 }
 
 export interface ScreenshotResult {
     success: boolean;
     imageUrl?: string;
+    cacheUrl?: string;
     imageBuffer?: Buffer;
     error?: string;
 }
@@ -55,7 +58,10 @@ export class ScreenshotOneService {
         return new screenshotone.Client(keys.accessKey, keys.secretKey || '');
     }
 
-    private buildTakeOptions(options: ScreenshotOptions): screenshotone.TakeOptions {
+    private buildTakeOptions(
+        options: ScreenshotOptions,
+        enableCache = true,
+    ): screenshotone.TakeOptions {
         const takeOptions = screenshotone.TakeOptions.url(options.url)
             .viewportWidth(options.viewportWidth || config.screenshotone.getDefaultViewportWidth())
             .viewportHeight(
@@ -83,6 +89,12 @@ export class ScreenshotOneService {
             takeOptions.blockCookieBanners(true);
         }
 
+        // Enable caching by default (7 days = 604800 seconds)
+        if (enableCache && options.cache !== false) {
+            takeOptions.cache(true);
+            takeOptions.cacheTtl(options.cacheTtl || 604800);
+        }
+
         return takeOptions;
     }
 
@@ -102,21 +114,34 @@ export class ScreenshotOneService {
             const takeOptions = this.buildTakeOptions(options);
 
             this.logger.debug(
-                `Capturing screenshot for URL: ${options.url} (signed: ${!!keys.secretKey})`,
+                `Capturing screenshot for URL: ${options.url} (signed: ${!!keys.secretKey}, cache: true)`,
             );
 
-            // Use SDK's take() method to fetch the screenshot
-            const imageBlob = await client.take(takeOptions);
-            const imageBuffer = Buffer.from(await imageBlob.arrayBuffer());
-
-            // Generate signed URL for reference (if secret key is available)
+            // Generate the API URL (signed if secret key available)
             const screenshotUrl = keys.secretKey
                 ? await client.generateSignedTakeURL(takeOptions)
                 : await client.generateTakeURL(takeOptions);
 
+            // Make HTTP request to capture screenshot and get cache URL from headers
+            const response = await axios.get(screenshotUrl, {
+                responseType: 'arraybuffer',
+                timeout: 60000,
+                validateStatus: (status) => status >= 200 && status < 400,
+            });
+
+            const imageBuffer = Buffer.from(response.data);
+
+            // Extract cache URL from response headers (clean URL without access key)
+            const cacheUrl = response.headers['x-screenshotone-cache-url'] as string | undefined;
+
+            this.logger.debug(
+                `Screenshot captured for ${options.url}, cache URL: ${cacheUrl ? 'obtained' : 'not available'}`,
+            );
+
             return {
                 success: true,
                 imageUrl: screenshotUrl,
+                cacheUrl: cacheUrl || undefined,
                 imageBuffer,
             };
         } catch (error) {
@@ -127,6 +152,20 @@ export class ScreenshotOneService {
                 return {
                     success: false,
                     error: error.errorMessage || `API error: ${error.errorCode}`,
+                };
+            }
+
+            if (axios.isAxiosError(error)) {
+                const status = error.response?.status;
+                const message = error.response?.data
+                    ? Buffer.from(error.response.data).toString('utf-8')
+                    : error.message;
+                this.logger.error(
+                    `ScreenshotOne HTTP error for ${options.url}: ${status} - ${message}`,
+                );
+                return {
+                    success: false,
+                    error: `HTTP ${status}: ${message}`,
                 };
             }
 
@@ -155,10 +194,7 @@ export class ScreenshotOneService {
             : await client.generateTakeURL(takeOptions);
     }
 
-    async validateKeys(
-        accessKey: string,
-        secretKey?: string,
-    ): Promise<ScreenshotValidationResult> {
+    async validateKeys(accessKey: string, secretKey?: string): Promise<ScreenshotValidationResult> {
         if (!accessKey || typeof accessKey !== 'string') {
             return {
                 valid: false,

--- a/packages/agent/src/screenshot/smart-image-router.service.ts
+++ b/packages/agent/src/screenshot/smart-image-router.service.ts
@@ -242,10 +242,11 @@ export class SmartImageRouterService {
             };
         }
 
-        // Return the ScreenshotOne URL (the image was captured successfully)
-        // In the future, we could store the imageBuffer and return a storage URL
+        // Prefer cache URL (clean CDN URL without access key) over API URL
+        const imageUrl = result.cacheUrl || result.imageUrl || null;
+
         return {
-            primaryImage: result.imageUrl || null,
+            primaryImage: imageUrl,
             source: 'screenshot',
             confidence: 1.0, // Screenshot is always reliable once captured
         };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.5.14
         version: 0.5.14(prettier@3.7.4)
       turbo:
-        specifier: ^2.7.4
-        version: 2.7.4
+        specifier: ^2.7.5
+        version: 2.7.5
 
   apps/api:
     dependencies:
@@ -7854,38 +7854,38 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@2.7.4:
-    resolution: {integrity: sha512-xDR30ltfkSsRfGzABBckvl1nz1cZ3ssTujvdj+TPwOweeDRvZ0e06t5DS0rmRBvyKpgGs42K/EK6Mn2qLlFY9A==}
+  turbo-darwin-64@2.7.5:
+    resolution: {integrity: sha512-nN3wfLLj4OES/7awYyyM7fkU8U8sAFxsXau2bYJwAWi6T09jd87DgHD8N31zXaJ7LcpyppHWPRI2Ov9MuZEwnQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.7.4:
-    resolution: {integrity: sha512-P7sjqXtOL/+nYWPvcDGWhi8wf8M8mZHHB8XEzw2VX7VJrS8IGHyJHGD1AYfDvhAEcr7pnk3gGifz3/xyhI655w==}
+  turbo-darwin-arm64@2.7.5:
+    resolution: {integrity: sha512-wCoDHMiTf3FgLAbZHDDx/unNNonSGhsF5AbbYODbxnpYyoKDpEYacUEPjZD895vDhNvYCH0Nnk24YsP4n/cD6g==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.7.4:
-    resolution: {integrity: sha512-GofFOxRO/IhG8BcPyMSSB3Y2+oKQotsaYbHxL9yD6JPb20/o35eo+zUSyazOtilAwDHnak5dorAJFoFU8MIg2A==}
+  turbo-linux-64@2.7.5:
+    resolution: {integrity: sha512-KKPvhOmJMmzWj/yjeO4LywkQ85vOJyhru7AZk/+c4B6OUh/odQ++SiIJBSbTG2lm1CuV5gV5vXZnf/2AMlu3Zg==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.7.4:
-    resolution: {integrity: sha512-+RQKgNjksVPxYAyAgmDV7w/1qj++qca+nSNTAOKGOfJiDtSvRKoci89oftJ6anGs00uamLKVEQ712TI/tfNAIw==}
+  turbo-linux-arm64@2.7.5:
+    resolution: {integrity: sha512-8PIva4L6BQhiPikUTds9lSFSHXVDAsEvV6QUlgwPsXrtXVQMVi6Sv9p+IxtlWQFvGkdYJUgX9GnK2rC030Xcmw==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.7.4:
-    resolution: {integrity: sha512-rfak1+g+ON3czs1mDYsCS4X74ZmK6gOgRQTXjDICtzvR4o61paqtgAYtNPofcVsMWeF4wvCajSeoAkkeAnQ1kg==}
+  turbo-windows-64@2.7.5:
+    resolution: {integrity: sha512-rupskv/mkIUgQXzX/wUiK00mKMorQcK8yzhGFha/D5lm05FEnLx8dsip6rWzMcVpvh+4GUMA56PgtnOgpel2AA==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.7.4:
-    resolution: {integrity: sha512-1ZgBNjNRbDu/fPeqXuX9i26x3CJ/Y1gcwUpQ+Vp7kN9Un6RZ9kzs164f/knrjcu5E+szCRexVjRSJay1k5jApA==}
+  turbo-windows-arm64@2.7.5:
+    resolution: {integrity: sha512-G377Gxn6P42RnCzfMyDvsqQV7j69kVHKlhz9J4RhtJOB5+DyY4yYh/w0oTIxZQ4JRMmhjwLu3w9zncMoQ6nNDw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.7.4:
-    resolution: {integrity: sha512-bkO4AddmDishzJB2ze7aYYPaejMoJVfS0XnaR6RCdXFOY8JGJfQE+l9fKiV7uDPa5Ut44gmOWJL3894CIMeH9g==}
+  turbo@2.7.5:
+    resolution: {integrity: sha512-7Imdmg37joOloTnj+DPrab9hIaQcDdJ5RwSzcauo/wMOSAgO+A/I/8b3hsGGs6PWQz70m/jkPgdqWsfNKtwwDQ==}
     hasBin: true
 
   turndown@7.2.2:
@@ -16579,32 +16579,32 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@2.7.4:
+  turbo-darwin-64@2.7.5:
     optional: true
 
-  turbo-darwin-arm64@2.7.4:
+  turbo-darwin-arm64@2.7.5:
     optional: true
 
-  turbo-linux-64@2.7.4:
+  turbo-linux-64@2.7.5:
     optional: true
 
-  turbo-linux-arm64@2.7.4:
+  turbo-linux-arm64@2.7.5:
     optional: true
 
-  turbo-windows-64@2.7.4:
+  turbo-windows-64@2.7.5:
     optional: true
 
-  turbo-windows-arm64@2.7.4:
+  turbo-windows-arm64@2.7.5:
     optional: true
 
-  turbo@2.7.4:
+  turbo@2.7.5:
     optionalDependencies:
-      turbo-darwin-64: 2.7.4
-      turbo-darwin-arm64: 2.7.4
-      turbo-linux-64: 2.7.4
-      turbo-linux-arm64: 2.7.4
-      turbo-windows-64: 2.7.4
-      turbo-windows-arm64: 2.7.4
+      turbo-darwin-64: 2.7.5
+      turbo-darwin-arm64: 2.7.5
+      turbo-linux-64: 2.7.5
+      turbo-linux-arm64: 2.7.5
+      turbo-windows-64: 2.7.5
+      turbo-windows-arm64: 2.7.5
 
   turndown@7.2.2:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screenshot caching capability with configurable TTL settings, reducing repeated requests for the same content.
  * API responses now include a cache URL, prioritizing CDN-cached versions for faster delivery.

* **Bug Fixes**
  * Updated screenshotone dashboard integration link.

* **Chores**
  * Bumped turbo dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->