### PR TITLE
fix: address code review findings in community PR processing

### DIFF
--- a/apps/api/src/directories/directories.controller.ts
+++ b/apps/api/src/directories/directories.controller.ts
@@ -7,6 +7,7 @@ import {
     HttpCode,
     HttpStatus,
     Inject,
+    NotFoundException,
     Param,
     Post,
     Put,
@@ -779,7 +780,7 @@ export class DirectoriesController {
         // Get full entity and check if community PR processing is enabled
         const directory = await this.directoryRepository.findById(id);
         if (!directory) {
-            throw new BadRequestException('Directory not found');
+            throw new NotFoundException('Directory not found');
         }
         if (!directory.communityPrEnabled) {
             throw new BadRequestException(

--- a/packages/agent/src/community-pr/community-pr-processor.service.ts
+++ b/packages/agent/src/community-pr/community-pr-processor.service.ts
@@ -18,7 +18,7 @@ const extractedItemSchema = z.object({
         z.object({
             name: z.string(),
             description: z.string(),
-            source_url: z.string().url(),
+            source_url: z.string(),
             category: z.string(),
             tags: z.array(z.string()),
         }),

--- a/packages/agent/src/community-pr/community-pr-processor.service.ts
+++ b/packages/agent/src/community-pr/community-pr-processor.service.ts
@@ -18,7 +18,7 @@ const extractedItemSchema = z.object({
         z.object({
             name: z.string(),
             description: z.string(),
-            source_url: z.string(),
+            source_url: z.string().url(),
             category: z.string(),
             tags: z.array(z.string()),
         }),
@@ -81,7 +81,7 @@ export class CommunityPrProcessorService {
         const openPRs = await this.gitFacade.listPullRequests(
             owner,
             mainRepo,
-            { state: 'open' },
+            { state: 'open', perPage: 100 },
             gitOptions,
         );
 
@@ -141,12 +141,9 @@ export class CommunityPrProcessorService {
         // Persist updated state to directory
         await this.directoryRepository.update(directory.id, { communityPrState: state });
 
-        // Update directory itemsCount in the database
+        // Atomically increment directory itemsCount
         if (totalItemsAdded > 0) {
-            const currentCount = directory.itemsCount || 0;
-            await this.directoryRepository.update(directory.id, {
-                itemsCount: currentCount + totalItemsAdded,
-            });
+            await this.directoryRepository.increment(directory.id, 'itemsCount', totalItemsAdded);
         }
 
         return totalItemsAdded;

--- a/packages/agent/src/database/repositories/directory.repository.ts
+++ b/packages/agent/src/database/repositories/directory.repository.ts
@@ -166,6 +166,10 @@ export class DirectoryRepository {
         return await this.findById(id);
     }
 
+    async increment(id: string, column: keyof Directory, value: number): Promise<void> {
+        await this.repository.increment({ id }, column as string, value);
+    }
+
     async delete(id: string): Promise<boolean> {
         const result = await this.repository.delete(id);
         return result.affected > 0;

--- a/packages/plugins/github/src/github-api.service.ts
+++ b/packages/plugins/github/src/github-api.service.ts
@@ -524,7 +524,8 @@ export class GitHubApiService {
 		const { data } = await octokit.rest.pulls.listFiles({
 			owner,
 			repo,
-			pull_number: prNumber
+			pull_number: prNumber,
+			per_page: 100
 		});
 
 		return data.map((file) => ({


### PR DESCRIPTION
Add per_page: 100 to GitHub listFiles to prevent silent file truncation,  pass perPage: 100 from community PR caller for listPullRequests, validate source_url with Zod .url(), use atomic increment for directory itemsCount, and use NotFoundException for missing directory in controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing directory requests now return 404 (Not Found) instead of 400.

* **Improvements**
  * Increased pagination when fetching pull requests and PR files to retrieve more items per call.
  * Atomic increment for directory item counts to improve update consistency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->