### PR TITLE
fix(api): resolve AI chat 401 by passing directory context for plugin…

### DIFF
--- a/apps/api/src/ai-conversation/ai-conversation.controller.ts
+++ b/apps/api/src/ai-conversation/ai-conversation.controller.ts
@@ -24,6 +24,7 @@ export class AiConversationController {
 
         const stream = this.aiConversationService.streamChat(body, {
             userId: auth.userId,
+            directoryId: body.directoryId,
         });
 
         for await (const chunk of stream) {

--- a/apps/api/src/ai-conversation/ai-conversation.module.ts
+++ b/apps/api/src/ai-conversation/ai-conversation.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { FacadesModule } from '@ever-works/agent/facades';
+import { DatabaseModule } from '@ever-works/agent/database';
 import { AiConversationController } from './ai-conversation.controller';
 import { AiConversationService } from './ai-conversation.service';
 
 @Module({
-    imports: [FacadesModule],
+    imports: [FacadesModule, DatabaseModule],
     controllers: [AiConversationController],
     providers: [AiConversationService],
 })

--- a/apps/api/src/ai-conversation/ai-conversation.service.ts
+++ b/apps/api/src/ai-conversation/ai-conversation.service.ts
@@ -1,11 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AiFacadeService, type FacadeOptions } from '@ever-works/agent/facades';
+import { DirectoryRepository } from '@ever-works/agent/database';
 import type { ChatMessage, ChatCompletionChunk } from '@ever-works/plugin';
 
 export interface ChatRequestDto {
     messages: ChatMessage[];
     model?: string;
     temperature?: number;
+    directoryId?: string;
 }
 
 export interface StreamChunk {
@@ -18,13 +20,18 @@ export interface StreamChunk {
 export class AiConversationService {
     private readonly logger = new Logger(AiConversationService.name);
 
-    constructor(private readonly aiFacade: AiFacadeService) {}
+    constructor(
+        private readonly aiFacade: AiFacadeService,
+        private readonly directoryRepository: DirectoryRepository,
+    ) {}
 
     async *streamChat(
         dto: ChatRequestDto,
         facadeOptions: FacadeOptions,
     ): AsyncGenerator<StreamChunk> {
         try {
+            const resolvedOptions = await this.resolveDirectoryContext(facadeOptions);
+
             const stream = this.aiFacade.createStreamingChatCompletion(
                 {
                     messages: dto.messages,
@@ -32,7 +39,7 @@ export class AiConversationService {
                     temperature: dto.temperature ?? 0.7,
                     stream: true,
                 },
-                facadeOptions,
+                resolvedOptions,
             );
 
             for await (const chunk of stream) {
@@ -55,5 +62,16 @@ export class AiConversationService {
                 done: true,
             };
         }
+    }
+
+    private async resolveDirectoryContext(options: FacadeOptions): Promise<FacadeOptions> {
+        if (options.directoryId) return options;
+
+        const directories = await this.directoryRepository.findByUser(options.userId);
+        if (directories.length > 0) {
+            return { ...options, directoryId: directories[0].id };
+        }
+
+        return options;
     }
 }


### PR DESCRIPTION
… settings

The AI chat endpoint only passed userId to the AI facade, never directoryId. Without directory context, directory-scoped plugin secrets (where users typically save their API key) were invisible to the settings resolver, causing OpenAI to reject requests with 401 Missing Authentication header. Fall back to the user's first
  directory when no directoryId is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI conversation system now supports directory context in chat requests, enabling conversations to be automatically associated with user directories.
  * Enhanced streaming responses with improved content delivery and proper completion detection.
  * Added error handling for streaming operations to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->