### PR TITLE
feat: add custom prompt support for comparison generation

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1170,10 +1170,15 @@
                 "visibilityConfirmPrivate": "Yes, Make Private",
                 "advancedPrompts": {
                     "title": "Advanced Prompts",
-                    "subtitle": "Customize AI prompts for directory generation. Leave empty to use defaults.",
+                    "subtitle": "Customize AI prompts for item generation and comparison generation. Leave empty to use defaults.",
                     "save": "Save Prompts",
                     "saveSuccess": "Advanced prompts saved successfully",
                     "saveFailed": "Failed to save advanced prompts",
+                    "saveComparisonSuccess": "Comparison prompt saved successfully",
+                    "sections": {
+                        "itemGeneration": "Item Generation",
+                        "comparisonGeneration": "Comparison Generation"
+                    },
                     "prompts": {
                         "relevanceAssessment": {
                             "title": "Relevance Assessment",
@@ -1209,6 +1214,11 @@
                             "title": "Source Validation",
                             "description": "Additional instructions for validating item source URLs.",
                             "placeholder": "e.g., Prefer official project websites over third-party reviews..."
+                        },
+                        "comparisonCustomPrompt": {
+                            "title": "Custom Prompt",
+                            "description": "Additional instructions appended to comparison generation prompts.",
+                            "placeholder": "e.g., \"Focus on pricing differences\", \"Write in a casual tone\""
                         }
                     }
                 },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -632,6 +632,10 @@
                 "generationStatus": "Generation Status",
                 "daysActive": "Days Active"
             },
+            "comparisons": {
+                "extendedAnalysisLabel": "Extended Analysis",
+                "extendedAnalysisDescription": "Generate an in-depth deep-dive analysis alongside each comparison"
+            },
             "history": {
                 "title": "Generation History",
                 "subtitle": "Track past generation runs, items created, and execution details.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -633,8 +633,89 @@
                 "daysActive": "Days Active"
             },
             "comparisons": {
-                "extendedAnalysisLabel": "Extended Analysis",
-                "extendedAnalysisDescription": "Generate an in-depth deep-dive analysis alongside each comparison"
+                "title": "Comparisons",
+                "subtitle": "A vs B comparison pages between directory items",
+                "vs": "vs",
+                "winner": "Winner: {name}",
+                "tie": "Tie",
+
+                "actions": {
+                    "compareItems": "Compare Items",
+                    "generateNext": "Generate Next",
+                    "generating": "Generating...",
+                    "generateAll": "Generate All",
+                    "save": "Save",
+                    "stop": "Stop",
+                    "generate": "Generate",
+                    "cancel": "Cancel",
+                    "delete": "Delete"
+                },
+
+                "aiModel": {
+                    "title": "AI Model",
+                    "provider": "Provider",
+                    "model": "Model",
+                    "default": "Default",
+                    "defaultSuffix": "(Default)",
+                    "loadingModels": "Loading models...",
+                    "providerDefault": "Provider default",
+                    "extendedAnalysisLabel": "Extended Analysis",
+                    "extendedAnalysisDescription": "Generate an in-depth deep-dive analysis alongside each comparison"
+                },
+
+                "manualForm": {
+                    "title": "Compare Two Items",
+                    "itemA": "Item A",
+                    "itemB": "Item B",
+                    "searchPlaceholder": "Search items...",
+                    "noItems": "No items found"
+                },
+
+                "progress": {
+                    "generating": "Generating comparisons: {completed} / {total} complete",
+                    "error": "{count, plural, one {# error} other {# errors}}",
+                    "stopped": "Stopped. Generated {count, plural, one {# comparison} other {# comparisons}} with {errors, plural, one {# error} other {# errors}}.",
+                    "done": "Done! Generated {count, plural, one {# comparison} other {# comparisons}}."
+                },
+
+                "pagination": {
+                    "showing": "Showing {from}\u2013{to} of {total}"
+                },
+
+                "empty": {
+                    "title": "No comparisons yet",
+                    "description": "Click \"Generate Next\" to auto-pick items, or \"Compare Items\" to choose a specific pair."
+                },
+
+                "deleteDialog": {
+                    "title": "Delete Comparison",
+                    "confirmation": "Are you sure you want to delete \"{title}\"? This action cannot be undone."
+                },
+
+                "generateAllDialog": {
+                    "title": "Generate All Comparisons",
+                    "confirmation": "Generate {count} remaining {count, plural, one {comparison} other {comparisons}}? This may take several minutes. You can stop at any time."
+                },
+
+                "toast": {
+                    "selectTwo": "Please select two items to compare",
+                    "cannotCompareSelf": "Cannot compare an item with itself",
+                    "noRemaining": "No remaining pairs to generate",
+                    "consecutiveErrors": "Stopped after 3 consecutive errors",
+                    "deleted": "Comparison deleted",
+                    "aiConfigSaved": "AI model settings saved",
+                    "aiConfigFailed": "Failed to save AI config"
+                },
+
+                "detail": {
+                    "backToComparisons": "Back to comparisons",
+                    "summary": "Summary",
+                    "dimensions": "Dimensions",
+                    "verdict": "Verdict",
+                    "article": "Article",
+                    "extendedAnalysis": "Extended Analysis",
+                    "sources": "Sources"
+                }
             },
             "history": {
                 "title": "Generation History",

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/comparisons/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/comparisons/[slug]/page.tsx
@@ -30,6 +30,7 @@ export default async function ComparisonDetailPage({ params }: Params) {
                 directoryId={id}
                 comparison={result.comparison}
                 markdown={result.markdown}
+                extendedAnalysisMarkdown={result.extendedAnalysisMarkdown}
             />
         );
     } catch {

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/comparisons/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/comparisons/page.tsx
@@ -22,6 +22,7 @@ export default async function DirectoryComparisonsPage({ params }: Params) {
         currentConfig: {
             provider: null as string | null,
             model: null as string | null,
+            extendedAnalysis: false,
         },
         availableProviders: [] as Awaited<
             ReturnType<typeof getComparisonAiConfig>

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/comparisons/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/comparisons/page.tsx
@@ -19,7 +19,10 @@ export default async function DirectoryComparisonsPage({ params }: Params) {
     let items: Array<{ slug: string; name: string; category: string | string[] }> = [];
 
     const defaultAiConfig = {
-        currentConfig: { provider: null as string | null, model: null as string | null },
+        currentConfig: {
+            provider: null as string | null,
+            model: null as string | null,
+        },
         availableProviders: [] as Awaited<
             ReturnType<typeof getComparisonAiConfig>
         >['availableProviders'],

--- a/apps/web/src/app/actions/dashboard/comparisons.ts
+++ b/apps/web/src/app/actions/dashboard/comparisons.ts
@@ -140,13 +140,19 @@ export async function getComparisonAiConfig(directoryId: string) {
                 provider: (settings.ai_provider as string) || null,
                 model: (settings.ai_model as string) || null,
                 customPrompt: (settings.custom_prompt as string) || null,
+                extendedAnalysis: !!settings.extended_analysis,
             },
             availableProviders,
         };
     } catch (error) {
         console.error('Get comparison AI config error:', error);
         return {
-            currentConfig: { provider: null, model: null, customPrompt: null },
+            currentConfig: {
+                provider: null,
+                model: null,
+                customPrompt: null,
+                extendedAnalysis: false,
+            },
             availableProviders: [],
         };
     }
@@ -154,7 +160,7 @@ export async function getComparisonAiConfig(directoryId: string) {
 
 export async function saveComparisonAiConfig(
     directoryId: string,
-    config: { provider: string | null; model: string | null },
+    config: { provider: string | null; model: string | null; extendedAnalysis?: boolean },
 ) {
     const user = await getAuthFromCookie();
     if (!user) {
@@ -172,6 +178,7 @@ export async function saveComparisonAiConfig(
                 ...existing,
                 ai_provider: config.provider || null,
                 ai_model: config.model || null,
+                extended_analysis: config.extendedAnalysis ?? false,
             },
         });
 
@@ -185,6 +192,7 @@ export async function saveComparisonAiConfig(
                     settings: {
                         ai_provider: config.provider || null,
                         ai_model: config.model || null,
+                        extended_analysis: config.extendedAnalysis ?? false,
                     },
                 });
                 revalidatePath(`/directories/${directoryId}/comparisons`);

--- a/apps/web/src/app/actions/dashboard/comparisons.ts
+++ b/apps/web/src/app/actions/dashboard/comparisons.ts
@@ -209,10 +209,7 @@ export async function saveComparisonAiConfig(
     }
 }
 
-export async function saveComparisonCustomPrompt(
-    directoryId: string,
-    customPrompt: string | null,
-) {
+export async function saveComparisonCustomPrompt(directoryId: string, customPrompt: string | null) {
     const user = await getAuthFromCookie();
     if (!user) {
         redirect(ROUTES.AUTH_LOGIN);

--- a/apps/web/src/app/actions/dashboard/comparisons.ts
+++ b/apps/web/src/app/actions/dashboard/comparisons.ts
@@ -139,13 +139,14 @@ export async function getComparisonAiConfig(directoryId: string) {
             currentConfig: {
                 provider: (settings.ai_provider as string) || null,
                 model: (settings.ai_model as string) || null,
+                customPrompt: (settings.custom_prompt as string) || null,
             },
             availableProviders,
         };
     } catch (error) {
         console.error('Get comparison AI config error:', error);
         return {
-            currentConfig: { provider: null, model: null },
+            currentConfig: { provider: null, model: null, customPrompt: null },
             availableProviders: [],
         };
     }
@@ -161,8 +162,14 @@ export async function saveComparisonAiConfig(
     }
 
     try {
+        // Read existing settings to preserve custom_prompt
+        const dirPlugins = await pluginsAPI.listForDirectory(directoryId);
+        const compPlugin = dirPlugins.plugins.find((p) => p.id === 'comparison-generator');
+        const existing = compPlugin?.directorySettings ?? {};
+
         await pluginsAPI.updateDirectorySettings(directoryId, 'comparison-generator', {
             settings: {
+                ...existing,
                 ai_provider: config.provider || null,
                 ai_model: config.model || null,
             },
@@ -198,6 +205,60 @@ export async function saveComparisonAiConfig(
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to save AI config',
+        };
+    }
+}
+
+export async function saveComparisonCustomPrompt(
+    directoryId: string,
+    customPrompt: string | null,
+) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        // Read existing settings to preserve ai_provider/ai_model
+        const dirPlugins = await pluginsAPI.listForDirectory(directoryId);
+        const compPlugin = dirPlugins.plugins.find((p) => p.id === 'comparison-generator');
+        const existing = compPlugin?.directorySettings ?? {};
+
+        await pluginsAPI.updateDirectorySettings(directoryId, 'comparison-generator', {
+            settings: {
+                ...existing,
+                custom_prompt: customPrompt || null,
+            },
+        });
+
+        revalidatePath(`/directories/${directoryId}/settings`);
+        return { success: true };
+    } catch (error: any) {
+        if (error?.status === 404 || error?.statusCode === 404) {
+            try {
+                await pluginsAPI.enableForDirectory(directoryId, 'comparison-generator', {
+                    settings: {
+                        custom_prompt: customPrompt || null,
+                    },
+                });
+                revalidatePath(`/directories/${directoryId}/settings`);
+                return { success: true };
+            } catch (retryError) {
+                console.error('Enable + save comparison custom prompt error:', retryError);
+                return {
+                    success: false,
+                    error:
+                        retryError instanceof Error
+                            ? retryError.message
+                            : 'Failed to save comparison prompt',
+                };
+            }
+        }
+
+        console.error('Save comparison custom prompt error:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to save comparison prompt',
         };
     }
 }

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonDetailClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonDetailClient.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useTranslations } from 'next-intl';
 import type { ComparisonData } from '@/lib/api/directory';
 import { ROUTES } from '@/lib/constants';
 
@@ -23,10 +24,11 @@ function WinnerBadge({
     itemAName: string;
     itemBName: string;
 }) {
-    const label = winner === 'item_a' ? itemAName : winner === 'item_b' ? itemBName : 'Tie';
+    const t = useTranslations('dashboard.directoryDetail.comparisons');
+    const name = winner === 'item_a' ? itemAName : winner === 'item_b' ? itemBName : t('tie');
     return (
         <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
-            Winner: {label}
+            {t('winner', { name })}
         </span>
     );
 }
@@ -51,6 +53,7 @@ export function ComparisonDetailClient({
     markdown,
     extendedAnalysisMarkdown,
 }: ComparisonDetailClientProps) {
+    const t = useTranslations('dashboard.directoryDetail.comparisons');
     const [isExtendedOpen, setIsExtendedOpen] = useState(false);
 
     return (
@@ -68,7 +71,7 @@ export function ComparisonDetailClient({
                         d="M15 19l-7-7 7-7"
                     />
                 </svg>
-                Back to comparisons
+                {t('detail.backToComparisons')}
             </Link>
 
             {/* Title & meta */}
@@ -78,7 +81,7 @@ export function ComparisonDetailClient({
                 </h1>
                 <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-text-secondary dark:text-text-secondary-dark">
                     <span>
-                        {comparison.item_a_name} vs {comparison.item_b_name}
+                        {comparison.item_a_name} {t('vs')} {comparison.item_b_name}
                     </span>
                     <span className="text-border dark:text-border-dark">|</span>
                     <span>{comparison.category}</span>
@@ -89,7 +92,9 @@ export function ComparisonDetailClient({
 
             {/* Summary */}
             <section className="rounded-lg border border-border dark:border-border-dark p-4">
-                <h2 className="text-lg font-medium text-text dark:text-text-dark mb-2">Summary</h2>
+                <h2 className="text-lg font-medium text-text dark:text-text-dark mb-2">
+                    {t('detail.summary')}
+                </h2>
                 <p className="text-text-secondary dark:text-text-secondary-dark">
                     {comparison.summary}
                 </p>
@@ -99,7 +104,7 @@ export function ComparisonDetailClient({
             {comparison.dimensions && comparison.dimensions.length > 0 && (
                 <section>
                     <h2 className="text-lg font-medium text-text dark:text-text-dark mb-4">
-                        Dimensions
+                        {t('detail.dimensions')}
                     </h2>
                     <div className="space-y-4">
                         {comparison.dimensions.map((dim) => (
@@ -151,7 +156,9 @@ export function ComparisonDetailClient({
 
             {/* Verdict */}
             <section className="rounded-lg border border-border dark:border-border-dark p-4">
-                <h2 className="text-lg font-medium text-text dark:text-text-dark mb-2">Verdict</h2>
+                <h2 className="text-lg font-medium text-text dark:text-text-dark mb-2">
+                    {t('detail.verdict')}
+                </h2>
                 {comparison.verdict_winner && (
                     <div className="mb-3">
                         <WinnerBadge
@@ -170,7 +177,7 @@ export function ComparisonDetailClient({
             {markdown && (
                 <section>
                     <h2 className="text-lg font-medium text-text dark:text-text-dark mb-4">
-                        Article
+                        {t('detail.article')}
                     </h2>
                     <div className="prose prose-sm dark:prose-invert prose-a:text-primary hover:prose-a:text-primary-hover max-w-none">
                         <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
@@ -186,7 +193,7 @@ export function ComparisonDetailClient({
                         onClick={() => setIsExtendedOpen(!isExtendedOpen)}
                         className="flex w-full items-center justify-between px-4 py-3 text-lg font-medium text-text dark:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark transition-colors rounded-lg"
                     >
-                        <span>Extended Analysis</span>
+                        <span>{t('detail.extendedAnalysis')}</span>
                         <svg
                             className={`h-5 w-5 text-text-muted transition-transform duration-200 ${isExtendedOpen ? 'rotate-180' : ''}`}
                             fill="none"
@@ -217,7 +224,7 @@ export function ComparisonDetailClient({
             {comparison.sources && comparison.sources.length > 0 && (
                 <section className="rounded-lg border border-border dark:border-border-dark p-4">
                     <h2 className="text-lg font-medium text-text dark:text-text-dark mb-2">
-                        Sources
+                        {t('detail.sources')}
                     </h2>
                     <ul className="space-y-1">
                         {comparison.sources.map((source, i) => (

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonDetailClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonDetailClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -10,6 +11,7 @@ interface ComparisonDetailClientProps {
     directoryId: string;
     comparison: ComparisonData;
     markdown?: string;
+    extendedAnalysisMarkdown?: string;
 }
 
 function WinnerBadge({
@@ -47,7 +49,10 @@ export function ComparisonDetailClient({
     directoryId,
     comparison,
     markdown,
+    extendedAnalysisMarkdown,
 }: ComparisonDetailClientProps) {
+    const [isExtendedOpen, setIsExtendedOpen] = useState(false);
+
     return (
         <div className="space-y-8">
             {/* Back link */}
@@ -170,6 +175,41 @@ export function ComparisonDetailClient({
                     <div className="prose prose-sm dark:prose-invert prose-a:text-primary hover:prose-a:text-primary-hover max-w-none">
                         <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
                     </div>
+                </section>
+            )}
+
+            {/* Extended Analysis */}
+            {extendedAnalysisMarkdown && (
+                <section className="rounded-lg border border-border dark:border-border-dark">
+                    <button
+                        type="button"
+                        onClick={() => setIsExtendedOpen(!isExtendedOpen)}
+                        className="flex w-full items-center justify-between px-4 py-3 text-lg font-medium text-text dark:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark transition-colors rounded-lg"
+                    >
+                        <span>Extended Analysis</span>
+                        <svg
+                            className={`h-5 w-5 text-text-muted transition-transform duration-200 ${isExtendedOpen ? 'rotate-180' : ''}`}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M19 9l-7 7-7-7"
+                            />
+                        </svg>
+                    </button>
+                    {isExtendedOpen && (
+                        <div className="border-t border-border dark:border-border-dark px-4 py-4">
+                            <div className="prose prose-sm dark:prose-invert prose-a:text-primary hover:prose-a:text-primary-hover max-w-none">
+                                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                                    {extendedAnalysisMarkdown}
+                                </ReactMarkdown>
+                            </div>
+                        </div>
+                    )}
                 </section>
             )}
 

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
@@ -19,6 +19,7 @@ import {
     ComboboxOptions,
     ComboboxOption,
 } from '@headlessui/react';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
 import { Button } from '@/components/ui/button';
 import {
@@ -57,6 +58,7 @@ export function ComparisonsPageClient({
     availableProviders,
     initialAiConfig,
 }: ComparisonsPageClientProps) {
+    const t = useTranslations('dashboard.directoryDetail.comparisons');
     const [comparisons, setComparisons] = useState<ComparisonData[]>(initialComparisons);
     const [isPending, startTransition] = useTransition();
     const [selectedItemA, setSelectedItemA] = useState('');
@@ -152,12 +154,12 @@ export function ComparisonsPageClient({
 
     const handleManualGenerate = () => {
         if (!selectedItemA || !selectedItemB) {
-            toast.error('Please select two items to compare');
+            toast.error(t('toast.selectTwo'));
             return;
         }
 
         if (selectedItemA === selectedItemB) {
-            toast.error('Cannot compare an item with itself');
+            toast.error(t('toast.cannotCompareSelf'));
             return;
         }
 
@@ -188,7 +190,7 @@ export function ComparisonsPageClient({
             const result = await deleteComparison(directoryId, slug);
 
             if (result.status === 'success') {
-                toast.success('Comparison deleted');
+                toast.success(t('toast.deleted'));
                 setComparisons((prev) => {
                     const updated = prev.filter((c) => c.slug !== slug);
                     const newTotalPages = Math.max(1, Math.ceil(updated.length / pageSize));
@@ -206,7 +208,7 @@ export function ComparisonsPageClient({
     const handleGenerateAllClick = async () => {
         const { count } = await getRemainingComparisonCount(directoryId);
         if (count === 0) {
-            toast.info('No remaining pairs to generate');
+            toast.info(t('toast.noRemaining'));
             return;
         }
         setRemainingCount(count);
@@ -237,7 +239,7 @@ export function ComparisonsPageClient({
                 consecutiveErrors++;
                 setGenerateAllProgress({ completed, total: remainingCount, errors });
                 if (consecutiveErrors >= 3) {
-                    toast.error('Stopped after 3 consecutive errors');
+                    toast.error(t('toast.consecutiveErrors'));
                     break;
                 }
             }
@@ -246,13 +248,9 @@ export function ComparisonsPageClient({
         setIsGeneratingAll(false);
 
         if (cancelRef.current) {
-            toast.info(
-                `Stopped. Generated ${completed} comparison${completed !== 1 ? 's' : ''}${errors > 0 ? `, ${errors} error${errors !== 1 ? 's' : ''}` : ''}.`,
-            );
+            toast.info(t('progress.stopped', { count: completed, errors }));
         } else {
-            toast.success(
-                `Done! Generated ${completed} comparison${completed !== 1 ? 's' : ''}${errors > 0 ? `, ${errors} error${errors !== 1 ? 's' : ''}` : ''}.`,
-            );
+            toast.success(t('progress.done', { count: completed }));
         }
 
         window.location.reload();
@@ -291,12 +289,12 @@ export function ComparisonsPageClient({
                 extendedAnalysis,
             });
             if (result.success) {
-                toast.success('AI model settings saved');
+                toast.success(t('toast.aiConfigSaved'));
             } else {
-                toast.error(result.error ?? 'Failed to save AI config');
+                toast.error(result.error ?? t('toast.aiConfigFailed'));
             }
         } catch {
-            toast.error('Failed to save AI config');
+            toast.error(t('toast.aiConfigFailed'));
         } finally {
             setIsSavingAiConfig(false);
         }
@@ -310,10 +308,10 @@ export function ComparisonsPageClient({
             <div className="flex items-center justify-between">
                 <div>
                     <h2 className="text-2xl font-semibold text-text dark:text-text-dark">
-                        Comparisons
+                        {t('title')}
                     </h2>
                     <p className="mt-1 text-text-secondary dark:text-text-secondary-dark">
-                        A vs B comparison pages between directory items
+                        {t('subtitle')}
                     </p>
                 </div>
                 <div className="flex gap-2">
@@ -323,10 +321,10 @@ export function ComparisonsPageClient({
                         onClick={() => setShowManualForm(!showManualForm)}
                         disabled={isBusy || items.length < 2}
                     >
-                        Compare Items
+                        {t('actions.compareItems')}
                     </Button>
                     <Button size="sm" onClick={handleGenerateNext} disabled={isBusy}>
-                        {isPending ? 'Generating...' : 'Generate Next'}
+                        {isPending ? t('actions.generating') : t('actions.generateNext')}
                     </Button>
                     <Button
                         size="sm"
@@ -334,7 +332,7 @@ export function ComparisonsPageClient({
                         onClick={handleGenerateAllClick}
                         disabled={isBusy}
                     >
-                        Generate All
+                        {t('actions.generateAll')}
                     </Button>
                 </div>
             </div>
@@ -347,7 +345,7 @@ export function ComparisonsPageClient({
                         onClick={() => setShowAiSettings(!showAiSettings)}
                         className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-text dark:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark transition-colors rounded-lg"
                     >
-                        <span>AI Model</span>
+                        <span>{t('aiModel.title')}</span>
                         <ChevronDown
                             className={cn(
                                 'h-4 w-4 text-text-muted transition-transform duration-200',
@@ -360,7 +358,7 @@ export function ComparisonsPageClient({
                             <div className="flex gap-4 items-end">
                                 <div className="flex-1">
                                     <label className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1">
-                                        Provider
+                                        {t('aiModel.provider')}
                                     </label>
                                     <select
                                         value={aiProvider}
@@ -373,18 +371,20 @@ export function ComparisonsPageClient({
                                             'focus:ring-2 focus:ring-primary/20 focus:outline-none',
                                         )}
                                     >
-                                        <option value="">Default</option>
+                                        <option value="">{t('aiModel.default')}</option>
                                         {availableProviders.map((p) => (
                                             <option key={p.id} value={p.id}>
                                                 {p.name}
-                                                {p.isDefault ? ' (Default)' : ''}
+                                                {p.isDefault
+                                                    ? ` ${t('aiModel.defaultSuffix')}`
+                                                    : ''}
                                             </option>
                                         ))}
                                     </select>
                                 </div>
                                 <div className="flex-1">
                                     <label className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1">
-                                        Model
+                                        {t('aiModel.model')}
                                     </label>
                                     <select
                                         value={aiModel}
@@ -401,8 +401,8 @@ export function ComparisonsPageClient({
                                     >
                                         <option value="">
                                             {isLoadingModels
-                                                ? 'Loading models...'
-                                                : 'Provider default'}
+                                                ? t('aiModel.loadingModels')
+                                                : t('aiModel.providerDefault')}
                                         </option>
                                         {availableModels.map((m) => (
                                             <option key={m.id} value={m.id}>
@@ -417,16 +417,16 @@ export function ComparisonsPageClient({
                                     disabled={isSavingAiConfig}
                                     loading={isSavingAiConfig}
                                 >
-                                    Save
+                                    {t('actions.save')}
                                 </Button>
                             </div>
                             <div className="flex items-center justify-between">
                                 <div>
                                     <p className="text-sm font-medium text-text dark:text-text-dark">
-                                        Extended Analysis
+                                        {t('aiModel.extendedAnalysisLabel')}
                                     </p>
                                     <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
-                                        Generate an in-depth deep-dive alongside each comparison
+                                        {t('aiModel.extendedAnalysisDescription')}
                                     </p>
                                 </div>
                                 <button
@@ -459,18 +459,19 @@ export function ComparisonsPageClient({
                 <div className="rounded-lg border border-border dark:border-border-dark p-4 space-y-3">
                     <div className="flex items-center justify-between">
                         <p className="text-sm font-medium text-text dark:text-text-dark">
-                            Generating comparisons: {generateAllProgress.completed} /{' '}
-                            {generateAllProgress.total} complete
+                            {t('progress.generating', {
+                                completed: generateAllProgress.completed,
+                                total: generateAllProgress.total,
+                            })}
                             {generateAllProgress.errors > 0 && (
                                 <span className="text-danger ml-2">
-                                    ({generateAllProgress.errors} error
-                                    {generateAllProgress.errors !== 1 ? 's' : ''})
+                                    ({t('progress.error', { count: generateAllProgress.errors })})
                                 </span>
                             )}
                         </p>
                         <Button size="sm" variant="secondary" onClick={handleStopGenerateAll}>
                             <Square className="w-3 h-3 mr-1 fill-current" />
-                            Stop
+                            {t('actions.stop')}
                         </Button>
                     </div>
                     <div className="w-full bg-surface-hover dark:bg-surface-hover-dark rounded-full h-2">
@@ -488,12 +489,12 @@ export function ComparisonsPageClient({
             {showManualForm && (
                 <div className="rounded-lg border border-border dark:border-border-dark p-4 space-y-4">
                     <h3 className="text-lg font-medium text-text dark:text-text-dark">
-                        Compare Two Items
+                        {t('manualForm.title')}
                     </h3>
                     <div className="flex gap-4 items-end">
                         <div className="flex-1">
                             <label className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1">
-                                Item A
+                                {t('manualForm.itemA')}
                             </label>
                             <Combobox
                                 value={selectedItemAObj}
@@ -523,7 +524,7 @@ export function ComparisonsPageClient({
                                                 item?.name ?? ''
                                             }
                                             onChange={(e) => setQueryA(e.target.value)}
-                                            placeholder="Search items..."
+                                            placeholder={t('manualForm.searchPlaceholder')}
                                         />
                                         <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pr-3">
                                             {({ open }) => (
@@ -547,7 +548,7 @@ export function ComparisonsPageClient({
                                     >
                                         {filteredItemsA.length === 0 ? (
                                             <div className="py-2 px-4 text-sm text-text-muted dark:text-text-muted-dark">
-                                                No items found
+                                                {t('manualForm.noItems')}
                                             </div>
                                         ) : (
                                             filteredItemsA.map((item) => (
@@ -599,11 +600,11 @@ export function ComparisonsPageClient({
                             </Combobox>
                         </div>
                         <span className="pb-2 text-text-secondary dark:text-text-secondary-dark font-medium">
-                            vs
+                            {t('vs')}
                         </span>
                         <div className="flex-1">
                             <label className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1">
-                                Item B
+                                {t('manualForm.itemB')}
                             </label>
                             <Combobox
                                 value={selectedItemBObj}
@@ -633,7 +634,7 @@ export function ComparisonsPageClient({
                                                 item?.name ?? ''
                                             }
                                             onChange={(e) => setQueryB(e.target.value)}
-                                            placeholder="Search items..."
+                                            placeholder={t('manualForm.searchPlaceholder')}
                                         />
                                         <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pr-3">
                                             {({ open }) => (
@@ -657,7 +658,7 @@ export function ComparisonsPageClient({
                                     >
                                         {filteredItemsB.length === 0 ? (
                                             <div className="py-2 px-4 text-sm text-text-muted dark:text-text-muted-dark">
-                                                No items found
+                                                {t('manualForm.noItems')}
                                             </div>
                                         ) : (
                                             filteredItemsB.map((item) => (
@@ -713,7 +714,7 @@ export function ComparisonsPageClient({
                             onClick={handleManualGenerate}
                             disabled={isBusy || !selectedItemA || !selectedItemB}
                         >
-                            {isPending ? 'Generating...' : 'Generate'}
+                            {isPending ? t('actions.generating') : t('actions.generate')}
                         </Button>
                     </div>
                 </div>
@@ -760,11 +761,10 @@ export function ComparisonsPageClient({
                         />
                     </svg>
                     <h3 className="mt-4 text-lg font-medium text-text dark:text-text-dark">
-                        No comparisons yet
+                        {t('empty.title')}
                     </h3>
                     <p className="mt-2 text-text-secondary dark:text-text-secondary-dark">
-                        Click &quot;Generate Next&quot; to auto-pick items, or &quot;Compare
-                        Items&quot; to choose a specific pair.
+                        {t('empty.description')}
                     </p>
                 </div>
             ) : (
@@ -823,7 +823,8 @@ export function ComparisonsPageClient({
                                     </div>
                                     <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-text-secondary dark:text-text-secondary-dark">
                                         <span>
-                                            {comparison.item_a_name} vs {comparison.item_b_name}
+                                            {comparison.item_a_name} {t('vs')}{' '}
+                                            {comparison.item_b_name}
                                         </span>
                                         <span className="text-border dark:text-border-dark">|</span>
                                         <span>{comparison.category}</span>
@@ -838,12 +839,14 @@ export function ComparisonsPageClient({
                                     {comparison.verdict_winner && (
                                         <div className="mt-2">
                                             <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
-                                                Winner:{' '}
-                                                {comparison.verdict_winner === 'item_a'
-                                                    ? comparison.item_a_name
-                                                    : comparison.verdict_winner === 'item_b'
-                                                      ? comparison.item_b_name
-                                                      : 'Tie'}
+                                                {t('winner', {
+                                                    name:
+                                                        comparison.verdict_winner === 'item_a'
+                                                            ? comparison.item_a_name
+                                                            : comparison.verdict_winner === 'item_b'
+                                                              ? comparison.item_b_name
+                                                              : t('tie'),
+                                                })}
                                             </span>
                                         </div>
                                     )}
@@ -858,9 +861,11 @@ export function ComparisonsPageClient({
             {comparisons.length > pageSize && (
                 <div className="flex items-center justify-between">
                     <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
-                        Showing {(currentPage - 1) * pageSize + 1}–
-                        {Math.min(currentPage * pageSize, comparisons.length)} of{' '}
-                        {comparisons.length}
+                        {t('pagination.showing', {
+                            from: (currentPage - 1) * pageSize + 1,
+                            to: Math.min(currentPage * pageSize, comparisons.length),
+                            total: comparisons.length,
+                        })}
                     </p>
                     <div className="flex items-center gap-2">
                         <Button
@@ -893,21 +898,22 @@ export function ComparisonsPageClient({
                     <DialogHeader>
                         <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark flex items-center gap-2">
                             <AlertTriangle className="w-5 h-5 text-danger" />
-                            Delete Comparison
+                            {t('deleteDialog.title')}
                         </DialogTitle>
                     </DialogHeader>
 
                     <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
-                        Are you sure you want to delete{' '}
-                        <span className="font-medium text-text dark:text-text-dark">
-                            {comparisons.find((c) => c.slug === deleteSlug)?.title ?? deleteSlug}
-                        </span>
-                        ? This action cannot be undone.
+                        {t('deleteDialog.confirmation', {
+                            title:
+                                comparisons.find((c) => c.slug === deleteSlug)?.title ??
+                                deleteSlug ??
+                                '',
+                        })}
                     </p>
 
                     <DialogFooter>
                         <Button size="sm" variant="ghost" onClick={() => setDeleteSlug(null)}>
-                            Cancel
+                            {t('actions.cancel')}
                         </Button>
                         <Button
                             size="sm"
@@ -917,7 +923,7 @@ export function ComparisonsPageClient({
                             loading={isPending}
                             className="text-danger hover:text-danger hover:bg-danger/10"
                         >
-                            Delete
+                            {t('actions.delete')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
@@ -931,17 +937,12 @@ export function ComparisonsPageClient({
                     <DialogClose onClose={() => setShowGenerateAllConfirm(false)} />
                     <DialogHeader>
                         <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
-                            Generate All Comparisons
+                            {t('generateAllDialog.title')}
                         </DialogTitle>
                     </DialogHeader>
 
                     <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
-                        Generate{' '}
-                        <span className="font-medium text-text dark:text-text-dark">
-                            {remainingCount}
-                        </span>{' '}
-                        remaining comparison{remainingCount !== 1 ? 's' : ''}? This may take several
-                        minutes. You can stop at any time.
+                        {t('generateAllDialog.confirmation', { count: remainingCount })}
                     </p>
 
                     <DialogFooter>
@@ -950,10 +951,10 @@ export function ComparisonsPageClient({
                             variant="ghost"
                             onClick={() => setShowGenerateAllConfirm(false)}
                         >
-                            Cancel
+                            {t('actions.cancel')}
                         </Button>
                         <Button size="sm" onClick={handleGenerateAllConfirm}>
-                            Generate All
+                            {t('actions.generateAll')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
@@ -335,7 +335,7 @@ export function ComparisonsPageClient({
                 </div>
             </div>
 
-            {/* AI Model settings */}
+            {/* AI Model */}
             {availableProviders.length > 0 && (
                 <div className="rounded-lg border border-border dark:border-border-dark">
                     <button
@@ -352,7 +352,7 @@ export function ComparisonsPageClient({
                         />
                     </button>
                     {showAiSettings && (
-                        <div className="border-t border-border dark:border-border-dark px-4 py-4">
+                        <div className="border-t border-border dark:border-border-dark px-4 py-4 space-y-4">
                             <div className="flex gap-4 items-end">
                                 <div className="flex-1">
                                     <label className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1">

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
@@ -47,7 +47,7 @@ interface ComparisonsPageClientProps {
     initialComparisons: ComparisonData[];
     items: Array<{ slug: string; name: string; category: string | string[] }>;
     availableProviders: ProviderOption[];
-    initialAiConfig: { provider: string | null; model: string | null };
+    initialAiConfig: { provider: string | null; model: string | null; extendedAnalysis?: boolean };
 }
 
 export function ComparisonsPageClient({
@@ -75,6 +75,9 @@ export function ComparisonsPageClient({
     const [availableModels, setAvailableModels] = useState<Array<{ id: string; name: string }>>([]);
     const [isLoadingModels, setIsLoadingModels] = useState(false);
     const [isSavingAiConfig, setIsSavingAiConfig] = useState(false);
+    const [extendedAnalysis, setExtendedAnalysis] = useState(
+        initialAiConfig.extendedAnalysis ?? false,
+    );
 
     // Generate All state
     const [isGeneratingAll, setIsGeneratingAll] = useState(false);
@@ -285,6 +288,7 @@ export function ComparisonsPageClient({
             const result = await saveComparisonAiConfig(directoryId, {
                 provider: aiProvider || null,
                 model: aiModel || null,
+                extendedAnalysis,
             });
             if (result.success) {
                 toast.success('AI model settings saved');
@@ -415,6 +419,35 @@ export function ComparisonsPageClient({
                                 >
                                     Save
                                 </Button>
+                            </div>
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                                        Extended Analysis
+                                    </p>
+                                    <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                                        Generate an in-depth deep-dive alongside each comparison
+                                    </p>
+                                </div>
+                                <button
+                                    type="button"
+                                    role="switch"
+                                    aria-checked={extendedAnalysis}
+                                    onClick={() => setExtendedAnalysis(!extendedAnalysis)}
+                                    className={cn(
+                                        'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary/20',
+                                        extendedAnalysis
+                                            ? 'bg-primary'
+                                            : 'bg-surface-hover dark:bg-surface-hover-dark',
+                                    )}
+                                >
+                                    <span
+                                        className={cn(
+                                            'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                                            extendedAnalysis ? 'translate-x-4' : 'translate-x-0',
+                                        )}
+                                    />
+                                </button>
                             </div>
                         </div>
                     )}

--- a/apps/web/src/components/directories/detail/settings/AdvancedPromptsSettings.tsx
+++ b/apps/web/src/components/directories/detail/settings/AdvancedPromptsSettings.tsx
@@ -9,7 +9,10 @@ import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import { getAdvancedPrompts, updateAdvancedPrompts } from '@/app/actions/dashboard/directories';
 import { DirectoryAdvancedPrompts } from '@/lib/api/directory';
-import { getComparisonAiConfig, saveComparisonCustomPrompt } from '@/app/actions/dashboard/comparisons';
+import {
+    getComparisonAiConfig,
+    saveComparisonCustomPrompt,
+} from '@/app/actions/dashboard/comparisons';
 
 interface AdvancedPromptsSettingsProps {
     directoryId: string;

--- a/apps/web/src/components/directories/detail/settings/AdvancedPromptsSettings.tsx
+++ b/apps/web/src/components/directories/detail/settings/AdvancedPromptsSettings.tsx
@@ -9,6 +9,7 @@ import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import { getAdvancedPrompts, updateAdvancedPrompts } from '@/app/actions/dashboard/directories';
 import { DirectoryAdvancedPrompts } from '@/lib/api/directory';
+import { getComparisonAiConfig, saveComparisonCustomPrompt } from '@/app/actions/dashboard/comparisons';
 
 interface AdvancedPromptsSettingsProps {
     directoryId: string;
@@ -37,6 +38,8 @@ export function AdvancedPromptsSettings({ directoryId }: AdvancedPromptsSettings
     const [isExpanded, setIsExpanded] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
+    const [isSavingComparison, setIsSavingComparison] = useState(false);
+    const [comparisonPrompt, setComparisonPrompt] = useState('');
     const [formData, setFormData] = useState<FormData>({
         relevanceAssessment: '',
         itemGeneration: '',
@@ -58,7 +61,11 @@ export function AdvancedPromptsSettings({ directoryId }: AdvancedPromptsSettings
     const loadAdvancedPrompts = async () => {
         setIsLoading(true);
         try {
-            const result = await getAdvancedPrompts(directoryId);
+            const [result, comparisonConfig] = await Promise.all([
+                getAdvancedPrompts(directoryId),
+                getComparisonAiConfig(directoryId),
+            ]);
+
             if (result.success && result.data) {
                 const data = result.data as DirectoryAdvancedPrompts;
                 setFormData({
@@ -71,6 +78,8 @@ export function AdvancedPromptsSettings({ directoryId }: AdvancedPromptsSettings
                     sourceValidation: data.sourceValidation || '',
                 });
             }
+
+            setComparisonPrompt(comparisonConfig.currentConfig.customPrompt || '');
         } catch (error) {
             console.error('Failed to load advanced prompts:', error);
         } finally {
@@ -101,6 +110,27 @@ export function AdvancedPromptsSettings({ directoryId }: AdvancedPromptsSettings
             toast.error(t('saveFailed'));
         } finally {
             setIsSaving(false);
+        }
+    };
+
+    const handleSaveComparison = async () => {
+        setIsSavingComparison(true);
+        try {
+            const result = await saveComparisonCustomPrompt(
+                directoryId,
+                comparisonPrompt.trim() || null,
+            );
+
+            if (result.success) {
+                toast.success(t('saveComparisonSuccess'));
+            } else {
+                toast.error(result.error || t('saveFailed'));
+            }
+        } catch (error) {
+            console.error('Failed to save comparison prompt:', error);
+            toast.error(t('saveFailed'));
+        } finally {
+            setIsSavingComparison(false);
         }
     };
 
@@ -149,6 +179,11 @@ export function AdvancedPromptsSettings({ directoryId }: AdvancedPromptsSettings
                         </div>
                     ) : (
                         <>
+                            {/* Item Generation Section */}
+                            <h4 className="text-base font-medium text-text dark:text-text-dark">
+                                {t('sections.itemGeneration')}
+                            </h4>
+
                             {PROMPT_FIELDS.map((field) => (
                                 <div key={field} className="space-y-2">
                                     <AutoResizeTextarea
@@ -173,6 +208,40 @@ export function AdvancedPromptsSettings({ directoryId }: AdvancedPromptsSettings
                                 onClick={handleSave}
                                 disabled={isSaving}
                                 loading={isSaving}
+                                variant="secondary"
+                            >
+                                {t('save')}
+                            </Button>
+
+                            {/* Comparison Generation Section */}
+                            <hr className="border-border dark:border-border-dark" />
+
+                            <h4 className="text-base font-medium text-text dark:text-text-dark">
+                                {t('sections.comparisonGeneration')}
+                            </h4>
+
+                            <div className="space-y-2">
+                                <AutoResizeTextarea
+                                    label={t('prompts.comparisonCustomPrompt.title')}
+                                    value={comparisonPrompt}
+                                    onChange={(e) => setComparisonPrompt(e.target.value)}
+                                    placeholder={t('prompts.comparisonCustomPrompt.placeholder')}
+                                    rows={3}
+                                    variant="form"
+                                    minRows={2}
+                                    maxHeight={200}
+                                    maxLength={2000}
+                                />
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t('prompts.comparisonCustomPrompt.description')}
+                                </p>
+                            </div>
+
+                            <Button
+                                type="button"
+                                onClick={handleSaveComparison}
+                                disabled={isSavingComparison}
+                                loading={isSavingComparison}
                                 variant="secondary"
                             >
                                 {t('save')}

--- a/apps/web/src/lib/api/directory.ts
+++ b/apps/web/src/lib/api/directory.ts
@@ -812,9 +812,11 @@ export const directoryAPI = {
     },
 
     getComparison: async (id: string, slug: string) => {
-        return serverFetch<{ comparison: ComparisonData; markdown?: string }>(
-            `/directories/${id}/comparisons/${slug}`,
-        );
+        return serverFetch<{
+            comparison: ComparisonData;
+            markdown?: string;
+            extendedAnalysisMarkdown?: string;
+        }>(`/directories/${id}/comparisons/${slug}`);
     },
 
     getRemainingComparisonCount: async (id: string) => {

--- a/packages/agent/src/generators/data-generator/data-repository.ts
+++ b/packages/agent/src/generators/data-generator/data-repository.ts
@@ -561,6 +561,25 @@ export class DataRepository {
         await fs.writeFile(filepath, markdown, 'utf-8');
     }
 
+    async writeComparisonExtendedMarkdown(slug: string, markdown: string): Promise<void> {
+        const compDir = this.getComparisonPath(slug);
+        await fs.mkdir(compDir, { recursive: true });
+        const filepath = path.join(compDir, `${slug}-extended.md`);
+        await fs.writeFile(filepath, markdown, 'utf-8');
+    }
+
+    async getComparisonExtendedMarkdown(slug: string): Promise<string | undefined> {
+        const mdPath = path.join(this.getComparisonPath(slug), `${slug}-extended.md`);
+        try {
+            return await fs.readFile(mdPath, 'utf-8');
+        } catch (err) {
+            if (err?.code === 'ENOENT') {
+                return undefined;
+            }
+            throw err;
+        }
+    }
+
     async comparisonExists(slug: string): Promise<boolean> {
         const compDir = this.getComparisonPath(slug);
         try {

--- a/packages/agent/src/services/comparison-generation.service.ts
+++ b/packages/agent/src/services/comparison-generation.service.ts
@@ -84,6 +84,7 @@ export class ComparisonGenerationService {
                 DEFAULT_COMPARISON_SETTINGS.min_items_for_comparison,
             ai_provider: (settings.ai_provider as string) || undefined,
             ai_model: (settings.ai_model as string) || undefined,
+            custom_prompt: (settings.custom_prompt as string) || undefined,
         };
     }
 
@@ -406,6 +407,7 @@ export class ComparisonGenerationService {
         const result = await generateComparison(pair, research, aiDeps, {
             name: directory.name,
             description: directory.description,
+            customPrompt: pluginSettings.custom_prompt,
         });
 
         // 3. Write to data repo

--- a/packages/agent/src/services/comparison-generation.service.ts
+++ b/packages/agent/src/services/comparison-generation.service.ts
@@ -85,6 +85,7 @@ export class ComparisonGenerationService {
             ai_provider: (settings.ai_provider as string) || undefined,
             ai_model: (settings.ai_model as string) || undefined,
             custom_prompt: (settings.custom_prompt as string) || undefined,
+            extended_analysis: !!settings.extended_analysis,
         };
     }
 
@@ -264,7 +265,11 @@ export class ComparisonGenerationService {
         directoryId: string,
         userId: string,
         slug: string,
-    ): Promise<{ comparison: ComparisonData | null; markdown?: string }> {
+    ): Promise<{
+        comparison: ComparisonData | null;
+        markdown?: string;
+        extendedAnalysisMarkdown?: string;
+    }> {
         const directory = await this.findDirectoryOrFail(directoryId);
 
         const gitOptions: GitFacadeOptions = {
@@ -279,8 +284,11 @@ export class ComparisonGenerationService {
         const dataRepo = await DataRepository.create(dest);
         const comparison = await dataRepo.getComparison(slug);
         const markdown = comparison ? await dataRepo.getComparisonMarkdown(slug) : undefined;
+        const extendedAnalysisMarkdown = comparison
+            ? await dataRepo.getComparisonExtendedMarkdown(slug)
+            : undefined;
 
-        return { comparison, markdown };
+        return { comparison, markdown, extendedAnalysisMarkdown };
     }
 
     /**
@@ -408,11 +416,18 @@ export class ComparisonGenerationService {
             name: directory.name,
             description: directory.description,
             customPrompt: pluginSettings.custom_prompt,
+            extendedAnalysis: pluginSettings.extended_analysis,
         });
 
         // 3. Write to data repo
         await dataRepo.writeComparison(result.comparison);
         await dataRepo.writeComparisonMarkdown(result.comparison.slug, result.markdown);
+        if (result.extendedAnalysisMarkdown) {
+            await dataRepo.writeComparisonExtendedMarkdown(
+                result.comparison.slug,
+                result.extendedAnalysisMarkdown,
+            );
+        }
 
         // 4. Update comparison state
         comparisonState.generated_pairs.push(result.comparison.slug);

--- a/packages/plugins/comparison-generator/src/__tests__/comparison-generator.plugin.spec.ts
+++ b/packages/plugins/comparison-generator/src/__tests__/comparison-generator.plugin.spec.ts
@@ -48,15 +48,16 @@ describe('ComparisonGeneratorPlugin', () => {
 			expect(plugin.settingsSchema.type).toBe('object');
 		});
 
-		it('should have 6 properties', () => {
+		it('should have 7 properties', () => {
 			const props = plugin.settingsSchema.properties!;
-			expect(Object.keys(props)).toHaveLength(6);
+			expect(Object.keys(props)).toHaveLength(7);
 			expect(props).toHaveProperty('cadence_override');
 			expect(props).toHaveProperty('max_comparisons_mode');
 			expect(props).toHaveProperty('max_comparisons');
 			expect(props).toHaveProperty('min_items_for_comparison');
 			expect(props).toHaveProperty('ai_provider');
 			expect(props).toHaveProperty('ai_model');
+			expect(props).toHaveProperty('custom_prompt');
 		});
 
 		it('should have title and description on every property', () => {

--- a/packages/plugins/comparison-generator/src/__tests__/comparison-generator.plugin.spec.ts
+++ b/packages/plugins/comparison-generator/src/__tests__/comparison-generator.plugin.spec.ts
@@ -48,9 +48,9 @@ describe('ComparisonGeneratorPlugin', () => {
 			expect(plugin.settingsSchema.type).toBe('object');
 		});
 
-		it('should have 7 properties', () => {
+		it('should have 8 properties', () => {
 			const props = plugin.settingsSchema.properties!;
-			expect(Object.keys(props)).toHaveLength(7);
+			expect(Object.keys(props)).toHaveLength(8);
 			expect(props).toHaveProperty('cadence_override');
 			expect(props).toHaveProperty('max_comparisons_mode');
 			expect(props).toHaveProperty('max_comparisons');
@@ -58,6 +58,7 @@ describe('ComparisonGeneratorPlugin', () => {
 			expect(props).toHaveProperty('ai_provider');
 			expect(props).toHaveProperty('ai_model');
 			expect(props).toHaveProperty('custom_prompt');
+			expect(props).toHaveProperty('extended_analysis');
 		});
 
 		it('should have title and description on every property', () => {

--- a/packages/plugins/comparison-generator/src/__tests__/comparison-writer.spec.ts
+++ b/packages/plugins/comparison-generator/src/__tests__/comparison-writer.spec.ts
@@ -204,4 +204,43 @@ describe('generateComparison', () => {
 		const prompt = askJson.mock.calls[0][0] as string;
 		expect(prompt).not.toContain('Directory Context');
 	});
+
+	it('should call askText twice when extendedAnalysis is true', async () => {
+		const ai = makeAi();
+
+		const result = await generateComparison(pair, research, ai, {
+			name: 'Test',
+			extendedAnalysis: true
+		});
+
+		expect(ai.askJson).toHaveBeenCalledTimes(1);
+		expect(ai.askText).toHaveBeenCalledTimes(2);
+		expect(result.extendedAnalysisMarkdown).toBe(MOCK_MARKDOWN);
+	});
+
+	it('should call askText once when extendedAnalysis is false', async () => {
+		const ai = makeAi();
+
+		const result = await generateComparison(pair, research, ai, {
+			name: 'Test',
+			extendedAnalysis: false
+		});
+
+		expect(ai.askText).toHaveBeenCalledTimes(1);
+		expect(result.extendedAnalysisMarkdown).toBeUndefined();
+	});
+
+	it('should include item names in extended analysis prompt', async () => {
+		const askText = vi.fn().mockResolvedValue(MOCK_MARKDOWN);
+		const ai = makeAi({ askText });
+
+		await generateComparison(pair, research, ai, {
+			name: 'Test',
+			extendedAnalysis: true
+		});
+
+		const extendedPrompt = askText.mock.calls[1][0] as string;
+		expect(extendedPrompt).toContain('Vercel');
+		expect(extendedPrompt).toContain('Netlify');
+	});
 });

--- a/packages/plugins/comparison-generator/src/comparison-generator.plugin.ts
+++ b/packages/plugins/comparison-generator/src/comparison-generator.plugin.ts
@@ -72,6 +72,13 @@ export class ComparisonGeneratorPlugin implements IPlugin, IFormSchemaProvider {
 				title: 'Custom Prompt',
 				description: 'Additional instructions to append to comparison generation prompts',
 				'x-hidden': true
+			},
+			extended_analysis: {
+				type: 'boolean',
+				title: 'Extended Analysis',
+				description: 'When enabled, generates a deeper analysis alongside the standard comparison',
+				default: false,
+				'x-hidden': true
 			}
 		}
 	};

--- a/packages/plugins/comparison-generator/src/comparison-generator.plugin.ts
+++ b/packages/plugins/comparison-generator/src/comparison-generator.plugin.ts
@@ -66,6 +66,12 @@ export class ComparisonGeneratorPlugin implements IPlugin, IFormSchemaProvider {
 				title: 'AI Model',
 				description: 'Override the AI model used for comparison generation (leave empty for provider default)',
 				'x-hidden': true
+			},
+			custom_prompt: {
+				type: 'string',
+				title: 'Custom Prompt',
+				description: 'Additional instructions to append to comparison generation prompts',
+				'x-hidden': true
 			}
 		}
 	};

--- a/packages/plugins/comparison-generator/src/comparison-writer.ts
+++ b/packages/plugins/comparison-generator/src/comparison-writer.ts
@@ -142,6 +142,47 @@ Do NOT include a top-level heading (the title will be rendered separately). Star
 	return prompt;
 }
 
+function buildExtendedAnalysisPrompt(
+	pair: ComparisonPair,
+	structure: AiComparisonStructure,
+	research: ComparisonResearch,
+	customPrompt?: string
+): string {
+	let prompt = `You are an expert technology analyst. Write an in-depth extended analysis comparing ${pair.itemA.name} and ${pair.itemB.name}.
+
+## Structured Comparison Summary
+- Title: ${structure.title}
+- Verdict: ${structure.verdict}
+- Category: ${pair.category}
+
+## Research
+${research.content || 'No additional research available.'}
+
+Write a comprehensive deep-dive markdown document covering the following sections:
+
+1. **Detailed Feature-by-Feature Breakdown** — Go beyond the high-level dimensions and compare specific features, capabilities, and limitations in detail.
+
+2. **Use-Case Analysis** — Provide concrete guidance on when to choose ${pair.itemA.name} vs ${pair.itemB.name}. Cover scenarios like team size, project type, scale, and budget.
+
+3. **Migration Considerations** — What should users know if switching from one to the other? Cover data migration, API compatibility, learning curve, and timeline estimates.
+
+4. **Technical Deep-Dive** — Compare architecture, performance characteristics, scalability, security, and integration capabilities in depth.
+
+5. **Cost & Pricing Analysis** — Compare pricing models, free tiers, hidden costs, and total cost of ownership at different usage levels.
+
+6. **Ecosystem & Community** — Compare third-party integrations, community size, documentation quality, support options, and plugin/extension ecosystems.
+
+7. **Future Outlook** — Based on recent developments, roadmap announcements, and market trends, where is each heading?
+
+Do NOT include a top-level heading. Start directly with the first section. Use markdown formatting with headers, tables, and lists where appropriate.`;
+
+	if (customPrompt?.trim()) {
+		prompt += `\n\n## Additional User Instructions:\n${customPrompt.trim()}`;
+	}
+
+	return prompt;
+}
+
 /**
  * Generate a full comparison using AI (structured data + markdown article).
  */
@@ -149,13 +190,19 @@ export async function generateComparison(
 	pair: ComparisonPair,
 	research: ComparisonResearch,
 	ai: ComparisonAiDependencies,
-	directoryContext?: { name?: string; description?: string; customPrompt?: string }
+	directoryContext?: { name?: string; description?: string; customPrompt?: string; extendedAnalysis?: boolean }
 ): Promise<ComparisonGenerationResult> {
 	const structurePrompt = buildStructurePrompt(pair, research, directoryContext);
 	const structure = await ai.askJson<AiComparisonStructure>(structurePrompt, COMPARISON_JSON_SCHEMA);
 
 	const markdownPrompt = buildMarkdownPrompt(pair, structure, research, directoryContext?.customPrompt);
 	const markdown = await ai.askText(markdownPrompt);
+
+	let extendedAnalysisMarkdown: string | undefined;
+	if (directoryContext?.extendedAnalysis) {
+		const extendedPrompt = buildExtendedAnalysisPrompt(pair, structure, research, directoryContext?.customPrompt);
+		extendedAnalysisMarkdown = await ai.askText(extendedPrompt);
+	}
 
 	const slug = buildPairKey(pair.itemA.slug!, pair.itemB.slug!);
 
@@ -176,6 +223,7 @@ export async function generateComparison(
 			sources: research.sources,
 			generated_at: new Date().toISOString()
 		},
-		markdown
+		markdown,
+		extendedAnalysisMarkdown
 	};
 }

--- a/packages/plugins/comparison-generator/src/comparison-writer.ts
+++ b/packages/plugins/comparison-generator/src/comparison-writer.ts
@@ -59,7 +59,7 @@ const COMPARISON_JSON_SCHEMA = {
 function buildStructurePrompt(
 	pair: ComparisonPair,
 	research: ComparisonResearch,
-	directoryContext?: { name?: string; description?: string }
+	directoryContext?: { name?: string; description?: string; customPrompt?: string }
 ): string {
 	const itemADescription = pair.itemA.description || 'No description available';
 	const itemBDescription = pair.itemB.description || 'No description available';
@@ -87,6 +87,10 @@ function buildStructurePrompt(
 		prompt += `\n\n## Web Research\n${research.content}`;
 	}
 
+	if (directoryContext?.customPrompt?.trim()) {
+		prompt += `\n\n## Additional User Instructions:\n${directoryContext.customPrompt.trim()}`;
+	}
+
 	prompt += `\n\nGenerate a comprehensive, fair, and balanced comparison. Analyze both items across 4-6 relevant dimensions. Score each dimension 1-10. Provide an honest verdict with clear reasoning. The title should be SEO-optimized.`;
 
 	return prompt;
@@ -95,9 +99,10 @@ function buildStructurePrompt(
 function buildMarkdownPrompt(
 	pair: ComparisonPair,
 	structure: AiComparisonStructure,
-	research: ComparisonResearch
+	research: ComparisonResearch,
+	customPrompt?: string
 ): string {
-	return `Write a detailed comparison article in markdown format. Use the structured data below as the foundation.
+	let prompt = `Write a detailed comparison article in markdown format. Use the structured data below as the foundation.
 
 ## Title: ${structure.title}
 
@@ -116,7 +121,13 @@ ${structure.dimensions.map((d) => `### ${d.name}\n- ${pair.itemA.name}: ${d.item
 ${structure.verdict}
 
 ## Sources
-${research.sources.map((s) => `- ${s}`).join('\n')}
+${research.sources.map((s) => `- ${s}`).join('\n')}`;
+
+	if (customPrompt?.trim()) {
+		prompt += `\n\n## Additional User Instructions:\n${customPrompt.trim()}`;
+	}
+
+	prompt += `
 
 Write a comprehensive, well-structured markdown article with:
 1. An engaging introduction
@@ -127,6 +138,8 @@ Write a comprehensive, well-structured markdown article with:
 6. Sources cited at the end
 
 Do NOT include a top-level heading (the title will be rendered separately). Start with the introduction paragraph directly.`;
+
+	return prompt;
 }
 
 /**
@@ -136,12 +149,12 @@ export async function generateComparison(
 	pair: ComparisonPair,
 	research: ComparisonResearch,
 	ai: ComparisonAiDependencies,
-	directoryContext?: { name?: string; description?: string }
+	directoryContext?: { name?: string; description?: string; customPrompt?: string }
 ): Promise<ComparisonGenerationResult> {
 	const structurePrompt = buildStructurePrompt(pair, research, directoryContext);
 	const structure = await ai.askJson<AiComparisonStructure>(structurePrompt, COMPARISON_JSON_SCHEMA);
 
-	const markdownPrompt = buildMarkdownPrompt(pair, structure, research);
+	const markdownPrompt = buildMarkdownPrompt(pair, structure, research, directoryContext?.customPrompt);
 	const markdown = await ai.askText(markdownPrompt);
 
 	const slug = buildPairKey(pair.itemA.slug!, pair.itemB.slug!);

--- a/packages/plugins/comparison-generator/src/types.ts
+++ b/packages/plugins/comparison-generator/src/types.ts
@@ -24,6 +24,7 @@ export interface ComparisonPluginSettings {
 	readonly min_items_for_comparison: number;
 	readonly ai_provider?: string;
 	readonly ai_model?: string;
+	readonly custom_prompt?: string;
 }
 
 export const DEFAULT_COMPARISON_SETTINGS: ComparisonPluginSettings = {

--- a/packages/plugins/comparison-generator/src/types.ts
+++ b/packages/plugins/comparison-generator/src/types.ts
@@ -15,6 +15,7 @@ export interface ComparisonResearch {
 export interface ComparisonGenerationResult {
 	readonly comparison: ComparisonData;
 	readonly markdown: string;
+	readonly extendedAnalysisMarkdown?: string;
 }
 
 export interface ComparisonPluginSettings {
@@ -25,6 +26,7 @@ export interface ComparisonPluginSettings {
 	readonly ai_provider?: string;
 	readonly ai_model?: string;
 	readonly custom_prompt?: string;
+	readonly extended_analysis?: boolean;
 }
 
 export const DEFAULT_COMPARISON_SETTINGS: ComparisonPluginSettings = {


### PR DESCRIPTION
- Add custom_prompt field to comparison-generator plugin schema and types
- Thread custom prompt through comparison-writer and generation service
- Move custom prompt textarea from Comparisons tab to Settings → Advanced Prompts card
- Add saveComparisonCustomPrompt action with read-merge-write to avoid overwriting AI config
- Add i18n translations for Item Generation / Comparison Generation sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended Analysis for comparisons — generate and view deeper analysis alongside standard comparison results.
  * Custom comparison prompts — write and save tailored prompts in Advanced Prompts.
  * UI toggle to enable/disable extended analysis in comparison settings.
  * Comparison detail page now shows extended analysis when available.
  * Improved localized text and UI labels across comparison flows and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->