### PR TITLE
feat: add custom domain management per directory

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard, CurrentUser } from '../../auth';
 import { AuthenticatedUser } from '../../auth/types/jwt.types';
@@ -8,6 +8,7 @@ import { DeployService } from './deploy.service';
 import { DeploymentVerifierService } from './tasks/deployment-verifier.service';
 import { DeployDirectoryDto } from './dto/deploy.dto';
 import { BatchDeployDto, BatchDeployResponseDto } from './dto/batch-deploy.dto';
+import { AddDomainDto } from './dto/domain.dto';
 
 @ApiTags('Deploy')
 @ApiBearerAuth('JWT-auth')
@@ -393,5 +394,141 @@ export class DeployController {
             failed: result.failed,
             results: result.results,
         };
+    }
+
+    /**
+     * List domains for a directory deployment
+     */
+    @Get('/directories/:id/domains')
+    @ApiOperation({
+        summary: 'List domains',
+        description: 'Get custom domains for a deployed directory',
+    })
+    @ApiParam({ name: 'id', description: 'Directory ID' })
+    @ApiResponse({ status: 200, description: 'List of domains' })
+    async listDomains(@CurrentUser() auth: AuthenticatedUser, @Param('id') id: string) {
+        const { directory, isCreator } = await this.ownershipService.ensureCanView(id, auth.userId);
+
+        if (!directory.website) {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'No deployment exists for this directory. Deploy first before managing domains.',
+            });
+        }
+
+        try {
+            const domains = await this.deployFacade.getDomains({
+                userId: isCreator ? auth.userId : directory.user.id,
+                directoryId: id,
+            });
+            return { status: 'success', domains };
+        } catch (error) {
+            throw new BadRequestException({
+                status: 'error',
+                message: error?.message || 'Failed to get domains',
+            });
+        }
+    }
+
+    /**
+     * Add a domain to a directory deployment
+     */
+    @Post('/directories/:id/domains')
+    @ApiOperation({
+        summary: 'Add domain',
+        description: 'Add a custom domain to a deployed directory',
+    })
+    @ApiParam({ name: 'id', description: 'Directory ID' })
+    @ApiResponse({ status: 200, description: 'Domain added' })
+    async addDomain(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+        @Body() dto: AddDomainDto,
+    ) {
+        const { directory, isCreator } = await this.ownershipService.ensureCanEdit(id, auth.userId);
+
+        if (!directory.website) {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'No deployment exists for this directory. Deploy first before adding domains.',
+            });
+        }
+
+        try {
+            const result = await this.deployFacade.addDomain(dto.domain, {
+                userId: isCreator ? auth.userId : directory.user.id,
+                directoryId: id,
+            });
+            return { status: 'success', ...result };
+        } catch (error) {
+            throw new BadRequestException({
+                status: 'error',
+                message: error?.message || 'Failed to add domain',
+            });
+        }
+    }
+
+    /**
+     * Remove a domain from a directory deployment
+     */
+    @Delete('/directories/:id/domains/:domain')
+    @ApiOperation({
+        summary: 'Remove domain',
+        description: 'Remove a custom domain from a deployed directory',
+    })
+    @ApiParam({ name: 'id', description: 'Directory ID' })
+    @ApiParam({ name: 'domain', description: 'Domain name to remove' })
+    @ApiResponse({ status: 200, description: 'Domain removed' })
+    async removeDomain(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+        @Param('domain') domain: string,
+    ) {
+        const { isCreator, directory } = await this.ownershipService.ensureCanEdit(id, auth.userId);
+
+        try {
+            const removed = await this.deployFacade.removeDomain(domain, {
+                userId: isCreator ? auth.userId : directory.user.id,
+                directoryId: id,
+            });
+            return { status: 'success', removed };
+        } catch (error) {
+            throw new BadRequestException({
+                status: 'error',
+                message: error?.message || 'Failed to remove domain',
+            });
+        }
+    }
+
+    /**
+     * Verify a domain on a directory deployment
+     */
+    @Post('/directories/:id/domains/:domain/verify')
+    @ApiOperation({
+        summary: 'Verify domain',
+        description: 'Trigger DNS verification for a domain on a deployed directory',
+    })
+    @ApiParam({ name: 'id', description: 'Directory ID' })
+    @ApiParam({ name: 'domain', description: 'Domain name to verify' })
+    @ApiResponse({ status: 200, description: 'Verification result' })
+    async verifyDomain(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+        @Param('domain') domain: string,
+    ) {
+        const { isCreator, directory } = await this.ownershipService.ensureCanEdit(id, auth.userId);
+
+        try {
+            const result = await this.deployFacade.verifyDomain(domain, {
+                userId: isCreator ? auth.userId : directory.user.id,
+                directoryId: id,
+            });
+            return { status: 'success', domain: result };
+        } catch (error) {
+            throw new BadRequestException({
+                status: 'error',
+                message: error?.message || 'Failed to verify domain',
+            });
+        }
     }
 }

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -497,6 +497,14 @@ export class DeployController {
     ) {
         const { isCreator, directory } = await this.ownershipService.ensureCanEdit(id, auth.userId);
 
+        if (!directory.website) {
+            throw new BadRequestException({
+                status: 'error',
+                message:
+                    'No deployment exists for this directory. Deploy first before managing domains.',
+            });
+        }
+
         try {
             const removed = await this.deployFacade.removeDomain(domain, {
                 userId: isCreator ? auth.userId : directory.user.id,
@@ -528,6 +536,14 @@ export class DeployController {
         @Param('domain') domain: string,
     ) {
         const { isCreator, directory } = await this.ownershipService.ensureCanEdit(id, auth.userId);
+
+        if (!directory.website) {
+            throw new BadRequestException({
+                status: 'error',
+                message:
+                    'No deployment exists for this directory. Deploy first before managing domains.',
+            });
+        }
 
         try {
             const result = await this.deployFacade.verifyDomain(domain, {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -1,4 +1,13 @@
-import { BadRequestException, Body, Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard, CurrentUser } from '../../auth';
 import { AuthenticatedUser } from '../../auth/types/jwt.types';
@@ -412,7 +421,8 @@ export class DeployController {
         if (!directory.website) {
             throw new BadRequestException({
                 status: 'error',
-                message: 'No deployment exists for this directory. Deploy first before managing domains.',
+                message:
+                    'No deployment exists for this directory. Deploy first before managing domains.',
             });
         }
 
@@ -450,7 +460,8 @@ export class DeployController {
         if (!directory.website) {
             throw new BadRequestException({
                 status: 'error',
-                message: 'No deployment exists for this directory. Deploy first before adding domains.',
+                message:
+                    'No deployment exists for this directory. Deploy first before adding domains.',
             });
         }
 

--- a/apps/api/src/plugins-capabilities/deploy/dto/domain.dto.ts
+++ b/apps/api/src/plugins-capabilities/deploy/dto/domain.dto.ts
@@ -2,11 +2,14 @@ import { IsString, IsNotEmpty, Matches } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class AddDomainDto {
-	@ApiProperty({ description: 'Domain name to add (e.g., example.com)', example: 'example.com' })
-	@IsString()
-	@IsNotEmpty()
-	@Matches(/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/, {
-		message: 'Invalid domain format. Example: example.com',
-	})
-	domain: string;
+    @ApiProperty({ description: 'Domain name to add (e.g., example.com)', example: 'example.com' })
+    @IsString()
+    @IsNotEmpty()
+    @Matches(
+        /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/,
+        {
+            message: 'Invalid domain format. Example: example.com',
+        },
+    )
+    domain: string;
 }

--- a/apps/api/src/plugins-capabilities/deploy/dto/domain.dto.ts
+++ b/apps/api/src/plugins-capabilities/deploy/dto/domain.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddDomainDto {
+	@ApiProperty({ description: 'Domain name to add (e.g., example.com)', example: 'example.com' })
+	@IsString()
+	@IsNotEmpty()
+	@Matches(/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/, {
+		message: 'Invalid domain format. Example: example.com',
+	})
+	domain: string;
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1508,6 +1508,32 @@
                         "skipAndDeploy": "Skip & Deploy",
                         "cancel": "Cancel"
                     }
+                },
+                "domains": {
+                    "title": "Custom Domains",
+                    "description": "Add custom domains to your deployed website.",
+                    "placeholder": "example.com",
+                    "addButton": "Add",
+                    "loading": "Loading domains...",
+                    "added": "Domain added. Configure DNS to verify it.",
+                    "addedAndVerified": "Domain added and verified!",
+                    "addFailed": "Failed to add domain",
+                    "removed": "Domain removed",
+                    "removeFailed": "Failed to remove domain",
+                    "verified": "Domain verified successfully!",
+                    "verifyPending": "DNS not verified yet. Please check your DNS settings and try again later.",
+                    "verifyFailed": "Failed to verify domain",
+                    "copied": "Copied to clipboard",
+                    "autoAssigned": "Auto-assigned",
+                    "verifiedBadge": "Verified",
+                    "pendingBadge": "Pending",
+                    "verifyButton": "Verify DNS",
+                    "removeButton": "Remove domain",
+                    "dnsInstructions": "Show DNS instructions",
+                    "dnsTitle": "Configure these DNS records:",
+                    "dnsName": "Name:",
+                    "dnsValue": "Value:",
+                    "copyButton": "Copy"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1515,6 +1515,8 @@
                     "placeholder": "example.com",
                     "addButton": "Add",
                     "loading": "Loading domains...",
+                    "loadFailed": "Failed to load domains",
+                    "noDomains": "No custom domains configured. Add one above to get started.",
                     "added": "Domain added. Configure DNS to verify it.",
                     "addedAndVerified": "Domain added and verified!",
                     "addFailed": "Failed to add domain",

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/deploy/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/deploy/page.tsx
@@ -7,6 +7,7 @@ import { DeployForm } from '@/components/directories/detail/deploy/DeployForm';
 import { DeployTokenAlert } from '@/components/directories/detail/deploy/DeployTokenAlert';
 import { DeployProviderSelector } from '@/components/directories/detail/deploy/DeployProviderSelector';
 import { SharedDirectoryNoTokenAlert } from '@/components/directories/detail/deploy/SharedDirectoryNoTokenAlert';
+import { DomainManagement } from '@/components/directories/detail/deploy/DomainManagement';
 import { GenerateStatusType } from '@/lib/api/enums';
 import { canDeploy } from '@/lib/permissions';
 
@@ -114,6 +115,7 @@ export default async function DeployPage({ params }: DeployPageParams) {
                 isDeploying={isDeploying(directory)}
                 providerName={providerName}
             />
+            {directory.website && <DomainManagement directory={directory} />}
         </div>
     );
 }

--- a/apps/web/src/app/actions/dashboard/deploy.ts
+++ b/apps/web/src/app/actions/dashboard/deploy.ts
@@ -135,6 +135,97 @@ export async function lookupExistingDeployment(directoryId: string) {
     }
 }
 
+export async function getDomains(directoryId: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await deployAPI.getDomains(directoryId);
+        return {
+            success: response.status === 'success',
+            domains: response.domains ?? [],
+        };
+    } catch (error) {
+        console.error('Get domains error:', error);
+        return {
+            success: false,
+            domains: [] as { name: string; verified: boolean; verification?: any[] }[],
+            error: error instanceof Error ? error.message : 'Failed to get domains',
+        };
+    }
+}
+
+export async function addDomain(directoryId: string, domain: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await deployAPI.addDomain(directoryId, domain);
+        revalidatePath(ROUTES.DASHBOARD_DIRECTORY_DEPLOY(directoryId));
+        return {
+            success: response.status === 'success',
+            domain: response.domain,
+            verified: response.verified ?? false,
+        };
+    } catch (error) {
+        console.error('Add domain error:', error);
+        return {
+            success: false,
+            domain: undefined,
+            verified: false,
+            error: error instanceof Error ? error.message : 'Failed to add domain',
+        };
+    }
+}
+
+export async function removeDomain(directoryId: string, domain: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await deployAPI.removeDomain(directoryId, domain);
+        revalidatePath(ROUTES.DASHBOARD_DIRECTORY_DEPLOY(directoryId));
+        return {
+            success: response.status === 'success',
+        };
+    } catch (error) {
+        console.error('Remove domain error:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to remove domain',
+        };
+    }
+}
+
+export async function verifyDomain(directoryId: string, domain: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await deployAPI.verifyDomain(directoryId, domain);
+        revalidatePath(ROUTES.DASHBOARD_DIRECTORY_DEPLOY(directoryId));
+        return {
+            success: response.status === 'success',
+            domain: response.domain,
+        };
+    } catch (error) {
+        console.error('Verify domain error:', error);
+        return {
+            success: false,
+            domain: undefined,
+            error: error instanceof Error ? error.message : 'Failed to verify domain',
+        };
+    }
+}
+
 export async function updateWebsiteTemplateSettings(
     directoryId: string,
     settings: {

--- a/apps/web/src/components/directories/detail/deploy/DomainManagement.tsx
+++ b/apps/web/src/components/directories/detail/deploy/DomainManagement.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import type { Directory } from '@/lib/api';
+import type { DeploymentDomain } from '@/lib/api/plugins-capabilities/deploy';
+import { cn } from '@/lib/utils/cn';
+import { toast } from 'sonner';
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/navigation';
+import {
+	getDomains,
+	addDomain as addDomainAction,
+	removeDomain as removeDomainAction,
+	verifyDomain as verifyDomainAction,
+} from '@/app/actions/dashboard/deploy';
+import { Globe, Plus, Trash2, CheckCircle2, Clock, ChevronDown, ChevronUp, Copy, RefreshCw, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface DomainManagementProps {
+	directory: Directory;
+}
+
+export function DomainManagement({ directory }: DomainManagementProps) {
+	const t = useTranslations('dashboard.directoryDetail.deploy.domains');
+	const [isPending, startTransition] = useTransition();
+	const router = useRouter();
+	const [domains, setDomains] = useState<DeploymentDomain[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [newDomain, setNewDomain] = useState('');
+	const [expandedDomain, setExpandedDomain] = useState<string | null>(null);
+
+	useEffect(() => {
+		getDomains(directory.id).then((result) => {
+			if (result.success) {
+				setDomains(result.domains);
+			}
+			setIsLoading(false);
+		});
+	}, [directory.id]);
+
+	const handleAddDomain = () => {
+		const domain = newDomain.trim();
+		if (!domain) return;
+
+		startTransition(async () => {
+			const result = await addDomainAction(directory.id, domain);
+			if (result.success && result.domain) {
+				setDomains((prev) => [...prev, result.domain!]);
+				setNewDomain('');
+				if (result.verified) {
+					toast.success(t('addedAndVerified'));
+					router.refresh();
+				} else {
+					toast.success(t('added'));
+					setExpandedDomain(result.domain.name);
+				}
+			} else {
+				toast.error(result.error || t('addFailed'));
+			}
+		});
+	};
+
+	const handleRemoveDomain = (domain: string) => {
+		startTransition(async () => {
+			const result = await removeDomainAction(directory.id, domain);
+			if (result.success) {
+				setDomains((prev) => prev.filter((d) => d.name !== domain));
+				toast.success(t('removed'));
+				router.refresh();
+			} else {
+				toast.error(result.error || t('removeFailed'));
+			}
+		});
+	};
+
+	const handleVerifyDomain = (domain: string) => {
+		startTransition(async () => {
+			const result = await verifyDomainAction(directory.id, domain);
+			if (result.success && result.domain) {
+				setDomains((prev) => prev.map((d) => (d.name === domain ? result.domain! : d)));
+				if (result.domain.verified) {
+					toast.success(t('verified'));
+					router.refresh();
+				} else {
+					toast.info(t('verifyPending'));
+				}
+			} else {
+				toast.error(result.error || t('verifyFailed'));
+			}
+		});
+	};
+
+	const copyToClipboard = (text: string) => {
+		navigator.clipboard.writeText(text);
+		toast.success(t('copied'));
+	};
+
+	const isVercelAutoAssigned = (name: string) => name.endsWith('.vercel.app');
+
+	return (
+		<div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">
+			<div className="flex items-start gap-4">
+				<div
+					className={cn(
+						'shrink-0 w-10 h-10 rounded-full flex items-center justify-center',
+						'bg-primary/10 dark:bg-primary-dark/10',
+					)}
+				>
+					<Globe className="w-5 h-5 text-primary dark:text-primary-dark" />
+				</div>
+				<div className="flex-1">
+					<h3 className="text-lg font-semibold text-text dark:text-text-dark mb-2">
+						{t('title')}
+					</h3>
+					<p className="text-text-secondary dark:text-text-secondary-dark mb-4">
+						{t('description')}
+					</p>
+
+					{/* Add domain form */}
+					<div className="flex gap-2 mb-4">
+						<div className="flex-1">
+							<Input
+								value={newDomain}
+								onChange={(e) => setNewDomain(e.target.value)}
+								placeholder={t('placeholder')}
+								variant="form"
+								disabled={isPending}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter') {
+										e.preventDefault();
+										handleAddDomain();
+									}
+								}}
+							/>
+						</div>
+						<Button
+							onClick={handleAddDomain}
+							disabled={isPending || !newDomain.trim()}
+							size="lg"
+						>
+							{isPending ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : (
+								<Plus className="w-4 h-4" />
+							)}
+							<span className="ml-1">{t('addButton')}</span>
+						</Button>
+					</div>
+
+					{/* Domain list */}
+					{isLoading ? (
+						<div className="flex items-center gap-2 text-text-secondary dark:text-text-secondary-dark text-sm py-4">
+							<Loader2 className="w-4 h-4 animate-spin" />
+							{t('loading')}
+						</div>
+					) : domains.length > 0 ? (
+						<div className="space-y-2">
+							{domains.map((domain) => (
+								<div
+									key={domain.name}
+									className="border border-border dark:border-border-dark rounded-lg"
+								>
+									<div className="flex items-center justify-between p-3">
+										<div className="flex items-center gap-2 min-w-0">
+											<span className="text-sm text-text dark:text-text-dark font-medium truncate">
+												{domain.name}
+											</span>
+											{isVercelAutoAssigned(domain.name) ? (
+												<span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark">
+													{t('autoAssigned')}
+												</span>
+											) : domain.verified ? (
+												<span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-success/10 dark:bg-success-dark/10 text-success dark:text-success-dark">
+													<CheckCircle2 className="w-3 h-3" />
+													{t('verifiedBadge')}
+												</span>
+											) : (
+												<span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-warning/10 dark:bg-warning-dark/10 text-warning dark:text-warning-dark">
+													<Clock className="w-3 h-3" />
+													{t('pendingBadge')}
+												</span>
+											)}
+										</div>
+										<div className="flex items-center gap-1 shrink-0 ml-2">
+											{!domain.verified && !isVercelAutoAssigned(domain.name) && (
+												<>
+													<button
+														onClick={() => handleVerifyDomain(domain.name)}
+														disabled={isPending}
+														className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+														title={t('verifyButton')}
+													>
+														<RefreshCw className={cn('w-4 h-4', isPending && 'animate-spin')} />
+													</button>
+													<button
+														onClick={() =>
+															setExpandedDomain(
+																expandedDomain === domain.name ? null : domain.name,
+															)
+														}
+														className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+														title={t('dnsInstructions')}
+													>
+														{expandedDomain === domain.name ? (
+															<ChevronUp className="w-4 h-4" />
+														) : (
+															<ChevronDown className="w-4 h-4" />
+														)}
+													</button>
+												</>
+											)}
+											{!isVercelAutoAssigned(domain.name) && (
+												<button
+													onClick={() => handleRemoveDomain(domain.name)}
+													disabled={isPending}
+													className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:text-error dark:hover:text-error-dark hover:bg-error/10 dark:hover:bg-error-dark/10 transition-colors"
+													title={t('removeButton')}
+												>
+													<Trash2 className="w-4 h-4" />
+												</button>
+											)}
+										</div>
+									</div>
+
+									{/* DNS verification instructions */}
+									{expandedDomain === domain.name &&
+										!domain.verified &&
+										domain.verification?.length && (
+											<div className="border-t border-border dark:border-border-dark p-3 bg-surface-secondary/50 dark:bg-surface-secondary-dark/50 rounded-b-lg">
+												<p className="text-sm font-medium text-text dark:text-text-dark mb-2">
+													{t('dnsTitle')}
+												</p>
+												<div className="space-y-2">
+													{domain.verification.map((v, i) => (
+														<div
+															key={i}
+															className="text-sm text-text-secondary dark:text-text-secondary-dark"
+														>
+															<div className="flex items-center gap-2 mb-1">
+																<span className="font-mono text-xs px-1.5 py-0.5 rounded bg-surface-secondary dark:bg-surface-secondary-dark">
+																	{v.type}
+																</span>
+																<span>{v.reason}</span>
+															</div>
+															<div className="grid grid-cols-[auto_1fr_auto] gap-2 items-center font-mono text-xs bg-surface dark:bg-surface-dark border border-border dark:border-border-dark rounded p-2">
+																<span className="text-text-muted dark:text-text-muted-dark">
+																	{t('dnsName')}
+																</span>
+																<span className="truncate">
+																	{v.domain}
+																</span>
+																<button
+																	onClick={() => copyToClipboard(v.domain)}
+																	className="p-1 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark rounded"
+																	title={t('copyButton')}
+																>
+																	<Copy className="w-3 h-3" />
+																</button>
+																<span className="text-text-muted dark:text-text-muted-dark">
+																	{t('dnsValue')}
+																</span>
+																<span className="truncate">
+																	{v.value}
+																</span>
+																<button
+																	onClick={() => copyToClipboard(v.value)}
+																	className="p-1 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark rounded"
+																	title={t('copyButton')}
+																>
+																	<Copy className="w-3 h-3" />
+																</button>
+															</div>
+														</div>
+													))}
+												</div>
+											</div>
+										)}
+								</div>
+							))}
+						</div>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/directories/detail/deploy/DomainManagement.tsx
+++ b/apps/web/src/components/directories/detail/deploy/DomainManagement.tsx
@@ -38,17 +38,27 @@ export function DomainManagement({ directory }: DomainManagementProps) {
     const router = useRouter();
     const [domains, setDomains] = useState<DeploymentDomain[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [loadError, setLoadError] = useState<string | null>(null);
     const [newDomain, setNewDomain] = useState('');
     const [expandedDomain, setExpandedDomain] = useState<string | null>(null);
 
     useEffect(() => {
+        let cancelled = false;
+        setIsLoading(true);
+        setLoadError(null);
         getDomains(directory.id).then((result) => {
+            if (cancelled) return;
             if (result.success) {
                 setDomains(result.domains);
+            } else {
+                setLoadError(result.error ?? t('loadFailed'));
             }
             setIsLoading(false);
         });
-    }, [directory.id]);
+        return () => {
+            cancelled = true;
+        };
+    }, [directory.id, t]);
 
     const handleAddDomain = () => {
         const domain = newDomain.trim();
@@ -165,7 +175,13 @@ export function DomainManagement({ directory }: DomainManagementProps) {
                             <Loader2 className="w-4 h-4 animate-spin" />
                             {t('loading')}
                         </div>
-                    ) : domains.length > 0 ? (
+                    ) : loadError ? (
+                        <p className="text-sm text-error dark:text-error-dark py-2">{loadError}</p>
+                    ) : domains.length === 0 ? (
+                        <p className="text-sm text-text-secondary dark:text-text-secondary-dark py-2">
+                            {t('noDomains')}
+                        </p>
+                    ) : (
                         <div className="space-y-2">
                             {domains.map((domain) => (
                                 <div
@@ -304,7 +320,7 @@ export function DomainManagement({ directory }: DomainManagementProps) {
                                 </div>
                             ))}
                         </div>
-                    ) : null}
+                    )}
                 </div>
             </div>
         </div>

--- a/apps/web/src/components/directories/detail/deploy/DomainManagement.tsx
+++ b/apps/web/src/components/directories/detail/deploy/DomainManagement.tsx
@@ -8,280 +8,305 @@ import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
 import {
-	getDomains,
-	addDomain as addDomainAction,
-	removeDomain as removeDomainAction,
-	verifyDomain as verifyDomainAction,
+    getDomains,
+    addDomain as addDomainAction,
+    removeDomain as removeDomainAction,
+    verifyDomain as verifyDomainAction,
 } from '@/app/actions/dashboard/deploy';
-import { Globe, Plus, Trash2, CheckCircle2, Clock, ChevronDown, ChevronUp, Copy, RefreshCw, Loader2 } from 'lucide-react';
+import {
+    Globe,
+    Plus,
+    Trash2,
+    CheckCircle2,
+    Clock,
+    ChevronDown,
+    ChevronUp,
+    Copy,
+    RefreshCw,
+    Loader2,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 interface DomainManagementProps {
-	directory: Directory;
+    directory: Directory;
 }
 
 export function DomainManagement({ directory }: DomainManagementProps) {
-	const t = useTranslations('dashboard.directoryDetail.deploy.domains');
-	const [isPending, startTransition] = useTransition();
-	const router = useRouter();
-	const [domains, setDomains] = useState<DeploymentDomain[]>([]);
-	const [isLoading, setIsLoading] = useState(true);
-	const [newDomain, setNewDomain] = useState('');
-	const [expandedDomain, setExpandedDomain] = useState<string | null>(null);
+    const t = useTranslations('dashboard.directoryDetail.deploy.domains');
+    const [isPending, startTransition] = useTransition();
+    const router = useRouter();
+    const [domains, setDomains] = useState<DeploymentDomain[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [newDomain, setNewDomain] = useState('');
+    const [expandedDomain, setExpandedDomain] = useState<string | null>(null);
 
-	useEffect(() => {
-		getDomains(directory.id).then((result) => {
-			if (result.success) {
-				setDomains(result.domains);
-			}
-			setIsLoading(false);
-		});
-	}, [directory.id]);
+    useEffect(() => {
+        getDomains(directory.id).then((result) => {
+            if (result.success) {
+                setDomains(result.domains);
+            }
+            setIsLoading(false);
+        });
+    }, [directory.id]);
 
-	const handleAddDomain = () => {
-		const domain = newDomain.trim();
-		if (!domain) return;
+    const handleAddDomain = () => {
+        const domain = newDomain.trim();
+        if (!domain) return;
 
-		startTransition(async () => {
-			const result = await addDomainAction(directory.id, domain);
-			if (result.success && result.domain) {
-				setDomains((prev) => [...prev, result.domain!]);
-				setNewDomain('');
-				if (result.verified) {
-					toast.success(t('addedAndVerified'));
-					router.refresh();
-				} else {
-					toast.success(t('added'));
-					setExpandedDomain(result.domain.name);
-				}
-			} else {
-				toast.error(result.error || t('addFailed'));
-			}
-		});
-	};
+        startTransition(async () => {
+            const result = await addDomainAction(directory.id, domain);
+            if (result.success && result.domain) {
+                setDomains((prev) => [...prev, result.domain!]);
+                setNewDomain('');
+                if (result.verified) {
+                    toast.success(t('addedAndVerified'));
+                    router.refresh();
+                } else {
+                    toast.success(t('added'));
+                    setExpandedDomain(result.domain.name);
+                }
+            } else {
+                toast.error(result.error || t('addFailed'));
+            }
+        });
+    };
 
-	const handleRemoveDomain = (domain: string) => {
-		startTransition(async () => {
-			const result = await removeDomainAction(directory.id, domain);
-			if (result.success) {
-				setDomains((prev) => prev.filter((d) => d.name !== domain));
-				toast.success(t('removed'));
-				router.refresh();
-			} else {
-				toast.error(result.error || t('removeFailed'));
-			}
-		});
-	};
+    const handleRemoveDomain = (domain: string) => {
+        startTransition(async () => {
+            const result = await removeDomainAction(directory.id, domain);
+            if (result.success) {
+                setDomains((prev) => prev.filter((d) => d.name !== domain));
+                toast.success(t('removed'));
+                router.refresh();
+            } else {
+                toast.error(result.error || t('removeFailed'));
+            }
+        });
+    };
 
-	const handleVerifyDomain = (domain: string) => {
-		startTransition(async () => {
-			const result = await verifyDomainAction(directory.id, domain);
-			if (result.success && result.domain) {
-				setDomains((prev) => prev.map((d) => (d.name === domain ? result.domain! : d)));
-				if (result.domain.verified) {
-					toast.success(t('verified'));
-					router.refresh();
-				} else {
-					toast.info(t('verifyPending'));
-				}
-			} else {
-				toast.error(result.error || t('verifyFailed'));
-			}
-		});
-	};
+    const handleVerifyDomain = (domain: string) => {
+        startTransition(async () => {
+            const result = await verifyDomainAction(directory.id, domain);
+            if (result.success && result.domain) {
+                setDomains((prev) => prev.map((d) => (d.name === domain ? result.domain! : d)));
+                if (result.domain.verified) {
+                    toast.success(t('verified'));
+                    router.refresh();
+                } else {
+                    toast.info(t('verifyPending'));
+                }
+            } else {
+                toast.error(result.error || t('verifyFailed'));
+            }
+        });
+    };
 
-	const copyToClipboard = (text: string) => {
-		navigator.clipboard.writeText(text);
-		toast.success(t('copied'));
-	};
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text);
+        toast.success(t('copied'));
+    };
 
-	const isVercelAutoAssigned = (name: string) => name.endsWith('.vercel.app');
+    const isVercelAutoAssigned = (name: string) => name.endsWith('.vercel.app');
 
-	return (
-		<div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">
-			<div className="flex items-start gap-4">
-				<div
-					className={cn(
-						'shrink-0 w-10 h-10 rounded-full flex items-center justify-center',
-						'bg-primary/10 dark:bg-primary-dark/10',
-					)}
-				>
-					<Globe className="w-5 h-5 text-primary dark:text-primary-dark" />
-				</div>
-				<div className="flex-1">
-					<h3 className="text-lg font-semibold text-text dark:text-text-dark mb-2">
-						{t('title')}
-					</h3>
-					<p className="text-text-secondary dark:text-text-secondary-dark mb-4">
-						{t('description')}
-					</p>
+    return (
+        <div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">
+            <div className="flex items-start gap-4">
+                <div
+                    className={cn(
+                        'shrink-0 w-10 h-10 rounded-full flex items-center justify-center',
+                        'bg-primary/10 dark:bg-primary-dark/10',
+                    )}
+                >
+                    <Globe className="w-5 h-5 text-primary dark:text-primary-dark" />
+                </div>
+                <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-text dark:text-text-dark mb-2">
+                        {t('title')}
+                    </h3>
+                    <p className="text-text-secondary dark:text-text-secondary-dark mb-4">
+                        {t('description')}
+                    </p>
 
-					{/* Add domain form */}
-					<div className="flex gap-2 mb-4">
-						<div className="flex-1">
-							<Input
-								value={newDomain}
-								onChange={(e) => setNewDomain(e.target.value)}
-								placeholder={t('placeholder')}
-								variant="form"
-								disabled={isPending}
-								onKeyDown={(e) => {
-									if (e.key === 'Enter') {
-										e.preventDefault();
-										handleAddDomain();
-									}
-								}}
-							/>
-						</div>
-						<Button
-							onClick={handleAddDomain}
-							disabled={isPending || !newDomain.trim()}
-							size="lg"
-						>
-							{isPending ? (
-								<Loader2 className="w-4 h-4 animate-spin" />
-							) : (
-								<Plus className="w-4 h-4" />
-							)}
-							<span className="ml-1">{t('addButton')}</span>
-						</Button>
-					</div>
+                    {/* Add domain form */}
+                    <div className="flex gap-2 mb-4">
+                        <div className="flex-1">
+                            <Input
+                                value={newDomain}
+                                onChange={(e) => setNewDomain(e.target.value)}
+                                placeholder={t('placeholder')}
+                                variant="form"
+                                disabled={isPending}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        handleAddDomain();
+                                    }
+                                }}
+                            />
+                        </div>
+                        <Button
+                            onClick={handleAddDomain}
+                            disabled={isPending || !newDomain.trim()}
+                            size="lg"
+                        >
+                            {isPending ? (
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                                <Plus className="w-4 h-4" />
+                            )}
+                            <span className="ml-1">{t('addButton')}</span>
+                        </Button>
+                    </div>
 
-					{/* Domain list */}
-					{isLoading ? (
-						<div className="flex items-center gap-2 text-text-secondary dark:text-text-secondary-dark text-sm py-4">
-							<Loader2 className="w-4 h-4 animate-spin" />
-							{t('loading')}
-						</div>
-					) : domains.length > 0 ? (
-						<div className="space-y-2">
-							{domains.map((domain) => (
-								<div
-									key={domain.name}
-									className="border border-border dark:border-border-dark rounded-lg"
-								>
-									<div className="flex items-center justify-between p-3">
-										<div className="flex items-center gap-2 min-w-0">
-											<span className="text-sm text-text dark:text-text-dark font-medium truncate">
-												{domain.name}
-											</span>
-											{isVercelAutoAssigned(domain.name) ? (
-												<span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark">
-													{t('autoAssigned')}
-												</span>
-											) : domain.verified ? (
-												<span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-success/10 dark:bg-success-dark/10 text-success dark:text-success-dark">
-													<CheckCircle2 className="w-3 h-3" />
-													{t('verifiedBadge')}
-												</span>
-											) : (
-												<span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-warning/10 dark:bg-warning-dark/10 text-warning dark:text-warning-dark">
-													<Clock className="w-3 h-3" />
-													{t('pendingBadge')}
-												</span>
-											)}
-										</div>
-										<div className="flex items-center gap-1 shrink-0 ml-2">
-											{!domain.verified && !isVercelAutoAssigned(domain.name) && (
-												<>
-													<button
-														onClick={() => handleVerifyDomain(domain.name)}
-														disabled={isPending}
-														className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
-														title={t('verifyButton')}
-													>
-														<RefreshCw className={cn('w-4 h-4', isPending && 'animate-spin')} />
-													</button>
-													<button
-														onClick={() =>
-															setExpandedDomain(
-																expandedDomain === domain.name ? null : domain.name,
-															)
-														}
-														className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
-														title={t('dnsInstructions')}
-													>
-														{expandedDomain === domain.name ? (
-															<ChevronUp className="w-4 h-4" />
-														) : (
-															<ChevronDown className="w-4 h-4" />
-														)}
-													</button>
-												</>
-											)}
-											{!isVercelAutoAssigned(domain.name) && (
-												<button
-													onClick={() => handleRemoveDomain(domain.name)}
-													disabled={isPending}
-													className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:text-error dark:hover:text-error-dark hover:bg-error/10 dark:hover:bg-error-dark/10 transition-colors"
-													title={t('removeButton')}
-												>
-													<Trash2 className="w-4 h-4" />
-												</button>
-											)}
-										</div>
-									</div>
+                    {/* Domain list */}
+                    {isLoading ? (
+                        <div className="flex items-center gap-2 text-text-secondary dark:text-text-secondary-dark text-sm py-4">
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            {t('loading')}
+                        </div>
+                    ) : domains.length > 0 ? (
+                        <div className="space-y-2">
+                            {domains.map((domain) => (
+                                <div
+                                    key={domain.name}
+                                    className="border border-border dark:border-border-dark rounded-lg"
+                                >
+                                    <div className="flex items-center justify-between p-3">
+                                        <div className="flex items-center gap-2 min-w-0">
+                                            <span className="text-sm text-text dark:text-text-dark font-medium truncate">
+                                                {domain.name}
+                                            </span>
+                                            {isVercelAutoAssigned(domain.name) ? (
+                                                <span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark">
+                                                    {t('autoAssigned')}
+                                                </span>
+                                            ) : domain.verified ? (
+                                                <span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-success/10 dark:bg-success-dark/10 text-success dark:text-success-dark">
+                                                    <CheckCircle2 className="w-3 h-3" />
+                                                    {t('verifiedBadge')}
+                                                </span>
+                                            ) : (
+                                                <span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-warning/10 dark:bg-warning-dark/10 text-warning dark:text-warning-dark">
+                                                    <Clock className="w-3 h-3" />
+                                                    {t('pendingBadge')}
+                                                </span>
+                                            )}
+                                        </div>
+                                        <div className="flex items-center gap-1 shrink-0 ml-2">
+                                            {!domain.verified &&
+                                                !isVercelAutoAssigned(domain.name) && (
+                                                    <>
+                                                        <button
+                                                            onClick={() =>
+                                                                handleVerifyDomain(domain.name)
+                                                            }
+                                                            disabled={isPending}
+                                                            className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+                                                            title={t('verifyButton')}
+                                                        >
+                                                            <RefreshCw
+                                                                className={cn(
+                                                                    'w-4 h-4',
+                                                                    isPending && 'animate-spin',
+                                                                )}
+                                                            />
+                                                        </button>
+                                                        <button
+                                                            onClick={() =>
+                                                                setExpandedDomain(
+                                                                    expandedDomain === domain.name
+                                                                        ? null
+                                                                        : domain.name,
+                                                                )
+                                                            }
+                                                            className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+                                                            title={t('dnsInstructions')}
+                                                        >
+                                                            {expandedDomain === domain.name ? (
+                                                                <ChevronUp className="w-4 h-4" />
+                                                            ) : (
+                                                                <ChevronDown className="w-4 h-4" />
+                                                            )}
+                                                        </button>
+                                                    </>
+                                                )}
+                                            {!isVercelAutoAssigned(domain.name) && (
+                                                <button
+                                                    onClick={() => handleRemoveDomain(domain.name)}
+                                                    disabled={isPending}
+                                                    className="p-1.5 rounded-md text-text-secondary dark:text-text-secondary-dark hover:text-error dark:hover:text-error-dark hover:bg-error/10 dark:hover:bg-error-dark/10 transition-colors"
+                                                    title={t('removeButton')}
+                                                >
+                                                    <Trash2 className="w-4 h-4" />
+                                                </button>
+                                            )}
+                                        </div>
+                                    </div>
 
-									{/* DNS verification instructions */}
-									{expandedDomain === domain.name &&
-										!domain.verified &&
-										domain.verification?.length && (
-											<div className="border-t border-border dark:border-border-dark p-3 bg-surface-secondary/50 dark:bg-surface-secondary-dark/50 rounded-b-lg">
-												<p className="text-sm font-medium text-text dark:text-text-dark mb-2">
-													{t('dnsTitle')}
-												</p>
-												<div className="space-y-2">
-													{domain.verification.map((v, i) => (
-														<div
-															key={i}
-															className="text-sm text-text-secondary dark:text-text-secondary-dark"
-														>
-															<div className="flex items-center gap-2 mb-1">
-																<span className="font-mono text-xs px-1.5 py-0.5 rounded bg-surface-secondary dark:bg-surface-secondary-dark">
-																	{v.type}
-																</span>
-																<span>{v.reason}</span>
-															</div>
-															<div className="grid grid-cols-[auto_1fr_auto] gap-2 items-center font-mono text-xs bg-surface dark:bg-surface-dark border border-border dark:border-border-dark rounded p-2">
-																<span className="text-text-muted dark:text-text-muted-dark">
-																	{t('dnsName')}
-																</span>
-																<span className="truncate">
-																	{v.domain}
-																</span>
-																<button
-																	onClick={() => copyToClipboard(v.domain)}
-																	className="p-1 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark rounded"
-																	title={t('copyButton')}
-																>
-																	<Copy className="w-3 h-3" />
-																</button>
-																<span className="text-text-muted dark:text-text-muted-dark">
-																	{t('dnsValue')}
-																</span>
-																<span className="truncate">
-																	{v.value}
-																</span>
-																<button
-																	onClick={() => copyToClipboard(v.value)}
-																	className="p-1 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark rounded"
-																	title={t('copyButton')}
-																>
-																	<Copy className="w-3 h-3" />
-																</button>
-															</div>
-														</div>
-													))}
-												</div>
-											</div>
-										)}
-								</div>
-							))}
-						</div>
-					) : null}
-				</div>
-			</div>
-		</div>
-	);
+                                    {/* DNS verification instructions */}
+                                    {expandedDomain === domain.name &&
+                                        !domain.verified &&
+                                        domain.verification?.length && (
+                                            <div className="border-t border-border dark:border-border-dark p-3 bg-surface-secondary/50 dark:bg-surface-secondary-dark/50 rounded-b-lg">
+                                                <p className="text-sm font-medium text-text dark:text-text-dark mb-2">
+                                                    {t('dnsTitle')}
+                                                </p>
+                                                <div className="space-y-2">
+                                                    {domain.verification.map((v, i) => (
+                                                        <div
+                                                            key={i}
+                                                            className="text-sm text-text-secondary dark:text-text-secondary-dark"
+                                                        >
+                                                            <div className="flex items-center gap-2 mb-1">
+                                                                <span className="font-mono text-xs px-1.5 py-0.5 rounded bg-surface-secondary dark:bg-surface-secondary-dark">
+                                                                    {v.type}
+                                                                </span>
+                                                                <span>{v.reason}</span>
+                                                            </div>
+                                                            <div className="grid grid-cols-[auto_1fr_auto] gap-2 items-center font-mono text-xs bg-surface dark:bg-surface-dark border border-border dark:border-border-dark rounded p-2">
+                                                                <span className="text-text-muted dark:text-text-muted-dark">
+                                                                    {t('dnsName')}
+                                                                </span>
+                                                                <span className="truncate">
+                                                                    {v.domain}
+                                                                </span>
+                                                                <button
+                                                                    onClick={() =>
+                                                                        copyToClipboard(v.domain)
+                                                                    }
+                                                                    className="p-1 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark rounded"
+                                                                    title={t('copyButton')}
+                                                                >
+                                                                    <Copy className="w-3 h-3" />
+                                                                </button>
+                                                                <span className="text-text-muted dark:text-text-muted-dark">
+                                                                    {t('dnsValue')}
+                                                                </span>
+                                                                <span className="truncate">
+                                                                    {v.value}
+                                                                </span>
+                                                                <button
+                                                                    onClick={() =>
+                                                                        copyToClipboard(v.value)
+                                                                    }
+                                                                    className="p-1 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark rounded"
+                                                                    title={t('copyButton')}
+                                                                >
+                                                                    <Copy className="w-3 h-3" />
+                                                                </button>
+                                                            </div>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
+                                </div>
+                            ))}
+                        </div>
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/apps/web/src/lib/api/plugins-capabilities/deploy.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/deploy.ts
@@ -67,6 +67,36 @@ export type DeploymentCapabilityResponseDto = APIResponse<{
     userHasToken: boolean;
 }>;
 
+export interface DeploymentDomainVerification {
+    type: string;
+    domain: string;
+    value: string;
+    reason: string;
+}
+
+export interface DeploymentDomain {
+    name: string;
+    verified: boolean;
+    verification?: DeploymentDomainVerification[];
+}
+
+export type DomainsResponseDto = APIResponse<{
+    domains: DeploymentDomain[];
+}>;
+
+export type AddDomainResponseDto = APIResponse<{
+    domain: DeploymentDomain;
+    verified: boolean;
+}>;
+
+export type RemoveDomainResponseDto = APIResponse<{
+    removed: boolean;
+}>;
+
+export type VerifyDomainResponseDto = APIResponse<{
+    domain: DeploymentDomain;
+}>;
+
 export const deployAPI = {
     // Get available deployment providers
     getProviders: async () => {
@@ -135,6 +165,49 @@ export const deployAPI = {
     checkDeploymentCapability(directoryId: string) {
         return serverMutation<DeploymentCapabilityResponseDto>({
             endpoint: `/deploy/directories/${directoryId}/check`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * Get domains for a deployed directory
+     */
+    getDomains(directoryId: string) {
+        return serverFetch<DomainsResponseDto>(`/deploy/directories/${directoryId}/domains`);
+    },
+
+    /**
+     * Add a domain to a deployed directory
+     */
+    addDomain(directoryId: string, domain: string) {
+        return serverMutation<AddDomainResponseDto>({
+            endpoint: `/deploy/directories/${directoryId}/domains`,
+            data: { domain },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * Remove a domain from a deployed directory
+     */
+    removeDomain(directoryId: string, domain: string) {
+        return serverMutation<RemoveDomainResponseDto>({
+            endpoint: `/deploy/directories/${encodeURIComponent(directoryId)}/domains/${encodeURIComponent(domain)}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * Verify a domain on a deployed directory
+     */
+    verifyDomain(directoryId: string, domain: string) {
+        return serverMutation<VerifyDomainResponseDto>({
+            endpoint: `/deploy/directories/${directoryId}/domains/${encodeURIComponent(domain)}/verify`,
             data: {},
             method: 'POST',
             wrapInData: false,

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -7,6 +7,7 @@ import {
     User,
     Directory,
     DirectoryAdvancedPrompts,
+    DirectoryCustomDomain,
     DirectoryMember,
     DirectoryGenerationHistory,
     SubscriptionPlan,
@@ -49,6 +50,7 @@ export interface DatabaseConfig extends Omit<TypeOrmModuleOptions, 'type'> {
 export const ENTITIES = [
     Directory,
     DirectoryAdvancedPrompts,
+    DirectoryCustomDomain,
     DirectoryMember,
     User,
     RefreshToken,

--- a/packages/agent/src/database/database.module.ts
+++ b/packages/agent/src/database/database.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { DirectoryRepository } from './repositories/directory.repository';
 import { DirectoryAdvancedPromptsRepository } from './repositories/directory-advanced-prompts.repository';
+import { DirectoryCustomDomainRepository } from './repositories/directory-custom-domain.repository';
 import { DirectoryMemberRepository } from './repositories/directory-member.repository';
 import { RefreshTokenRepository } from './repositories/refresh-token.repository';
 import { OAuthTokenRepository } from './repositories/oauth-token.repository';
@@ -33,6 +34,7 @@ import { NotificationRepository } from './repositories/notification.repository';
     providers: [
         DirectoryRepository,
         DirectoryAdvancedPromptsRepository,
+        DirectoryCustomDomainRepository,
         DirectoryMemberRepository,
         RefreshTokenRepository,
         UserRepository,
@@ -48,6 +50,7 @@ import { NotificationRepository } from './repositories/notification.repository';
         TypeOrmModule,
         DirectoryRepository,
         DirectoryAdvancedPromptsRepository,
+        DirectoryCustomDomainRepository,
         DirectoryMemberRepository,
         UserRepository,
         RefreshTokenRepository,

--- a/packages/agent/src/database/repositories/directory-custom-domain.repository.ts
+++ b/packages/agent/src/database/repositories/directory-custom-domain.repository.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DirectoryCustomDomain } from '../../entities/directory-custom-domain.entity';
+
+@Injectable()
+export class DirectoryCustomDomainRepository {
+    constructor(
+        @InjectRepository(DirectoryCustomDomain)
+        private readonly repository: Repository<DirectoryCustomDomain>,
+    ) {}
+
+    /**
+     * Find all custom domains for a directory.
+     */
+    async findByDirectory(directoryId: string): Promise<DirectoryCustomDomain[]> {
+        return this.repository.find({
+            where: { directoryId },
+            order: { createdAt: 'ASC' },
+        });
+    }
+
+    /**
+     * Find a single domain record by directory and domain name.
+     */
+    async findOne(directoryId: string, domain: string): Promise<DirectoryCustomDomain | null> {
+        return this.repository.findOne({
+            where: { directoryId, domain },
+        });
+    }
+
+    /**
+     * Add a custom domain to a directory.
+     */
+    async addDomain(
+        directoryId: string,
+        domain: string,
+        provider?: string,
+    ): Promise<DirectoryCustomDomain> {
+        const record = this.repository.create({
+            directoryId,
+            domain,
+            verified: false,
+            provider,
+        });
+        return this.repository.save(record);
+    }
+
+    /**
+     * Remove a custom domain from a directory.
+     */
+    async removeDomain(directoryId: string, domain: string): Promise<boolean> {
+        const result = await this.repository.delete({ directoryId, domain });
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Update the verified status of a domain.
+     */
+    async updateVerified(directoryId: string, domain: string, verified: boolean): Promise<void> {
+        await this.repository.update({ directoryId, domain }, { verified });
+    }
+
+    /**
+     * Update the provider that a domain is synced to.
+     */
+    async updateProvider(directoryId: string, domain: string, provider: string): Promise<void> {
+        await this.repository.update({ directoryId, domain }, { provider });
+    }
+}

--- a/packages/agent/src/entities/directory-custom-domain.entity.ts
+++ b/packages/agent/src/entities/directory-custom-domain.entity.ts
@@ -1,0 +1,54 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    ManyToOne,
+    CreateDateColumn,
+    UpdateDateColumn,
+    Unique,
+    JoinColumn,
+} from 'typeorm';
+import { Directory } from './directory.entity';
+import { ClassToObject, DomainEnvironment } from './types';
+
+/**
+ * DirectoryCustomDomain entity stores custom domains associated with a directory.
+ *
+ * The database is the primary source of truth for domain records.
+ * Provider APIs (e.g. Vercel) are used for sync — pushing/removing domains
+ * and fetching DNS verification status.
+ *
+ * If a user switches deployment providers, domain records persist in the DB
+ * and can be re-attached to the new provider.
+ */
+@Entity({ name: 'directory_custom_domains' })
+@Unique(['directoryId', 'domain'])
+export class DirectoryCustomDomain {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    directoryId: string;
+
+    @ManyToOne(() => Directory, (directory) => directory.customDomains, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'directoryId' })
+    directory: ClassToObject<Directory>;
+
+    @Column()
+    domain: string;
+
+    @Column({ type: 'varchar', default: DomainEnvironment.PRODUCTION })
+    environment: DomainEnvironment;
+
+    @Column({ type: 'boolean', default: false })
+    verified: boolean;
+
+    @Column({ nullable: true })
+    provider?: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/directory.entity.ts
+++ b/packages/agent/src/entities/directory.entity.ts
@@ -21,6 +21,7 @@ import type { PRUpdate } from '@src/generators/data-generator';
 import { DirectoryGenerationHistory } from './directory-generation-history.entity';
 import { TimestampColumn } from './_types';
 import { DirectorySchedule } from './directory-schedule.entity';
+import { DirectoryCustomDomain } from './directory-custom-domain.entity';
 import { DirectoryMember } from './directory-member.entity';
 
 @Entity({ name: 'directories' })
@@ -97,6 +98,9 @@ export class Directory {
 
     @OneToMany(() => DirectoryMember, (member) => member.directory)
     members?: ClassToObject<DirectoryMember>[];
+
+    @OneToMany(() => DirectoryCustomDomain, (customDomain) => customDomain.directory)
+    customDomains?: ClassToObject<DirectoryCustomDomain>[];
 
     @Column({ type: 'boolean', default: false })
     scheduledUpdatesEnabled: boolean;

--- a/packages/agent/src/entities/directory.entity.ts
+++ b/packages/agent/src/entities/directory.entity.ts
@@ -112,6 +112,9 @@ export class Directory {
 
     // Deployment FIELDS
     @Column({ nullable: true })
+    deployProjectId?: string;
+
+    @Column({ nullable: true })
     deploymentState?: string;
 
     @TimestampColumn({ nullable: true })

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -1,5 +1,6 @@
 export * from './directory.entity';
 export * from './directory-advanced-prompts.entity';
+export * from './directory-custom-domain.entity';
 export * from './directory-member.entity';
 export * from './user.entity';
 export * from './refresh-token.entity';

--- a/packages/agent/src/entities/types.ts
+++ b/packages/agent/src/entities/types.ts
@@ -68,6 +68,12 @@ export const ASSIGNABLE_MEMBER_ROLES = [
 
 export type AssignableMemberRole = (typeof ASSIGNABLE_MEMBER_ROLES)[number];
 
+export enum DomainEnvironment {
+    PRODUCTION = 'production',
+    STAGING = 'staging',
+    DEVELOPMENT = 'development',
+}
+
 export interface CommunityPrState {
     processedPrNumbers: number[];
     lastProcessedAt?: string;

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -452,7 +452,8 @@ export class DeployFacadeService implements IDeployFacade {
     }
 
     /**
-     * Resolve the Vercel projectId for a directory
+     * Resolve the deployment projectId for a directory.
+     * Uses the cached deployProjectId when available to avoid redundant API calls.
      */
     private async resolveProjectId(
         plugin: IDeploymentPlugin,
@@ -460,10 +461,19 @@ export class DeployFacadeService implements IDeployFacade {
         directory: Directory,
         options: DeployFacadeOptions,
     ): Promise<string> {
+        // Use cached value if available
+        if (directory.deployProjectId) {
+            return directory.deployProjectId;
+        }
+
         const teamScope = await this.getTeamScope(plugin.id, options);
         if (plugin.lookupExistingDeployment) {
             const result = await plugin.lookupExistingDeployment(directory.slug, token, teamScope);
             if (result.found && result.projectId) {
+                // Cache the projectId for future calls
+                await this.directoryRepository.update(directory.id, {
+                    deployProjectId: result.projectId,
+                });
                 return result.projectId;
             }
         }

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -6,6 +6,8 @@ import type {
     DeployFacadeTeam,
     DeployProviderInfo,
     DeploymentLookupResult,
+    DeploymentDomain,
+    AddDomainResult,
 } from '@ever-works/plugin';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
@@ -291,6 +293,99 @@ export class DeployFacadeService implements IDeployFacade {
         return this.resolvePluginAndTokenWithDirectory(options);
     }
 
+    // Domain management methods
+
+    /**
+     * Get domains for a deployed directory
+     */
+    async getDomains(options: DeployFacadeOptions): Promise<DeploymentDomain[]> {
+        const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
+        if (!plugin.getDomains) {
+            throw new DeployFacadeError('Domain management is not supported by this provider', 'getDomains', plugin.id);
+        }
+        const projectId = await this.resolveProjectId(plugin, token, directory, options);
+        const teamScope = await this.getTeamScope(plugin.id, options);
+        return plugin.getDomains(projectId, token, teamScope);
+    }
+
+    /**
+     * Add a domain to a deployed directory
+     */
+    async addDomain(domain: string, options: DeployFacadeOptions): Promise<AddDomainResult> {
+        const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
+        if (!plugin.addDomain) {
+            throw new DeployFacadeError('Domain management is not supported by this provider', 'addDomain', plugin.id);
+        }
+        const projectId = await this.resolveProjectId(plugin, token, directory, options);
+        const teamScope = await this.getTeamScope(plugin.id, options);
+        const result = await plugin.addDomain(projectId, domain, token, teamScope);
+
+        // Update directory.website if verified immediately
+        if (result.verified) {
+            await this.directoryRepository.update(directory.id, {
+                website: `https://${result.domain.name}`,
+            });
+        }
+
+        return result;
+    }
+
+    /**
+     * Remove a domain from a deployed directory
+     */
+    async removeDomain(domain: string, options: DeployFacadeOptions): Promise<boolean> {
+        const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
+        if (!plugin.removeDomain) {
+            throw new DeployFacadeError(
+                'Domain management is not supported by this provider',
+                'removeDomain',
+                plugin.id,
+            );
+        }
+        const projectId = await this.resolveProjectId(plugin, token, directory, options);
+        const teamScope = await this.getTeamScope(plugin.id, options);
+        const removed = await plugin.removeDomain(projectId, domain, token, teamScope);
+
+        // If the removed domain was the current website URL, re-lookup to update
+        if (removed && directory.website === `https://${domain}`) {
+            const projectName = directory.slug;
+            if (plugin.lookupExistingDeployment) {
+                const lookup = await plugin.lookupExistingDeployment(projectName, token, teamScope);
+                await this.directoryRepository.update(directory.id, {
+                    website: lookup.website ?? undefined,
+                });
+            }
+        }
+
+        return removed;
+    }
+
+    /**
+     * Verify a domain on a deployed directory
+     */
+    async verifyDomain(domain: string, options: DeployFacadeOptions): Promise<DeploymentDomain> {
+        const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
+        if (!plugin.verifyDomain) {
+            throw new DeployFacadeError(
+                'Domain management is not supported by this provider',
+                'verifyDomain',
+                plugin.id,
+            );
+        }
+        const projectId = await this.resolveProjectId(plugin, token, directory, options);
+        const teamScope = await this.getTeamScope(plugin.id, options);
+        const result = await plugin.verifyDomain(projectId, domain, token, teamScope);
+
+        // Update directory.website if newly verified
+        if (result.verified) {
+            await this.directoryRepository.update(directory.id, {
+                website: `https://${result.name}`,
+            });
+        }
+
+        return result;
+    }
+
     // Private methods
 
     private async resolvePluginAndToken(options: DeployFacadeOptions): Promise<{
@@ -346,6 +441,41 @@ export class DeployFacadeService implements IDeployFacade {
             token,
             directory,
         };
+    }
+
+    /**
+     * Resolve the Vercel projectId for a directory
+     */
+    private async resolveProjectId(
+        plugin: IDeploymentPlugin,
+        token: string,
+        directory: Directory,
+        options: DeployFacadeOptions,
+    ): Promise<string> {
+        const teamScope = await this.getTeamScope(plugin.id, options);
+        if (plugin.lookupExistingDeployment) {
+            const result = await plugin.lookupExistingDeployment(directory.slug, token, teamScope);
+            if (result.found && result.projectId) {
+                return result.projectId;
+            }
+        }
+        throw new DeployFacadeError(
+            'Could not resolve project ID. Ensure a deployment exists.',
+            'resolveProjectId',
+            plugin.id,
+        );
+    }
+
+    /**
+     * Get team scope from plugin settings
+     */
+    private async getTeamScope(pluginId: string, options: DeployFacadeOptions): Promise<string | undefined> {
+        const settings = await this.settingsService.getSettings(pluginId, {
+            userId: options.userId,
+            directoryId: options.directoryId,
+            includeSecrets: false,
+        });
+        return settings.defaultTeamScope as string | undefined;
     }
 
     /**

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -16,6 +16,7 @@ import { DirectoryPluginRepository } from '../plugins/repositories/directory-plu
 import { DirectoryRepository } from '../database/repositories/directory.repository';
 import { OAuthTokenRepository } from '../database/repositories/oauth-token.repository';
 import { GitFacadeService } from './git.facade';
+import { DirectoryCustomDomainRepository } from '../database/repositories/directory-custom-domain.repository';
 import { FacadeError, NoProviderError, ProviderNotFoundError } from './base.facade';
 import type { Directory } from '../entities/directory.entity';
 import type { User } from '../entities/user.entity';
@@ -82,6 +83,7 @@ export class DeployFacadeService implements IDeployFacade {
         private readonly directoryRepository: DirectoryRepository,
         private readonly gitFacade: GitFacadeService,
         private readonly oauthTokenRepository: OAuthTokenRepository,
+        private readonly domainRepository: DirectoryCustomDomainRepository,
         private readonly directoryPluginRepository?: DirectoryPluginRepository,
     ) {}
 
@@ -294,26 +296,49 @@ export class DeployFacadeService implements IDeployFacade {
     }
 
     // Domain management methods
+    // DB is the primary source of truth; provider APIs are used for sync and verification.
 
     /**
-     * Get domains for a deployed directory
+     * Get domains for a deployed directory.
+     * Reads from DB, enriches with provider verification data when available.
      */
     async getDomains(options: DeployFacadeOptions): Promise<DeploymentDomain[]> {
-        const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
-        if (!plugin.getDomains) {
-            throw new DeployFacadeError(
-                'Domain management is not supported by this provider',
-                'getDomains',
-                plugin.id,
-            );
+        const dbDomains = await this.domainRepository.findByDirectory(options.directoryId);
+
+        // Try to enrich with provider verification data
+        let providerDomains: DeploymentDomain[] = [];
+        try {
+            const { plugin, token, directory } =
+                await this.resolvePluginAndTokenWithDirectory(options);
+            if (plugin.getDomains) {
+                const projectId = await this.resolveProjectId(plugin, token, directory, options);
+                const teamScope = await this.getTeamScope(plugin.id, options);
+                providerDomains = await plugin.getDomains(projectId, token, teamScope);
+            }
+        } catch (error) {
+            this.logger.warn(`Failed to fetch provider domains for enrichment: ${error}`);
         }
-        const projectId = await this.resolveProjectId(plugin, token, directory, options);
-        const teamScope = await this.getTeamScope(plugin.id, options);
-        return plugin.getDomains(projectId, token, teamScope);
+
+        // Build a lookup map from provider data
+        const providerMap = new Map<string, DeploymentDomain>();
+        for (const pd of providerDomains) {
+            providerMap.set(pd.name, pd);
+        }
+
+        // Merge: DB domains with provider verification details
+        return dbDomains.map((dbDomain) => {
+            const providerData = providerMap.get(dbDomain.domain);
+            return {
+                name: dbDomain.domain,
+                verified: providerData?.verified ?? dbDomain.verified,
+                verification: providerData?.verification,
+            };
+        });
     }
 
     /**
-     * Add a domain to a deployed directory
+     * Add a domain to a deployed directory.
+     * Saves to DB first, then pushes to provider.
      */
     async addDomain(domain: string, options: DeployFacadeOptions): Promise<AddDomainResult> {
         const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
@@ -324,12 +349,25 @@ export class DeployFacadeService implements IDeployFacade {
                 plugin.id,
             );
         }
+
+        // Save to DB first (unverified, no provider yet)
+        await this.domainRepository.addDomain(options.directoryId, domain);
+
+        // Push to provider
         const projectId = await this.resolveProjectId(plugin, token, directory, options);
         const teamScope = await this.getTeamScope(plugin.id, options);
-        const result = await plugin.addDomain(projectId, domain, token, teamScope);
+        let result: AddDomainResult;
+        try {
+            result = await plugin.addDomain(projectId, domain, token, teamScope);
+        } catch (error) {
+            // Provider failed — keep DB record so user can retry, but rethrow
+            throw error;
+        }
 
-        // Update directory.website if verified immediately
+        // Update DB with provider and verified status
+        await this.domainRepository.updateProvider(options.directoryId, domain, plugin.id);
         if (result.verified) {
+            await this.domainRepository.updateVerified(options.directoryId, domain, true);
             await this.directoryRepository.update(directory.id, {
                 website: `https://${result.domain.name}`,
             });
@@ -339,37 +377,54 @@ export class DeployFacadeService implements IDeployFacade {
     }
 
     /**
-     * Remove a domain from a deployed directory
+     * Remove a domain from a deployed directory.
+     * Removes from provider first, then from DB.
      */
     async removeDomain(domain: string, options: DeployFacadeOptions): Promise<boolean> {
         const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
-        if (!plugin.removeDomain) {
-            throw new DeployFacadeError(
-                'Domain management is not supported by this provider',
-                'removeDomain',
-                plugin.id,
-            );
-        }
-        const projectId = await this.resolveProjectId(plugin, token, directory, options);
-        const teamScope = await this.getTeamScope(plugin.id, options);
-        const removed = await plugin.removeDomain(projectId, domain, token, teamScope);
 
-        // If the removed domain was the current website URL, re-lookup to update
-        if (removed && directory.website === `https://${domain}`) {
-            const projectName = directory.slug;
-            if (plugin.lookupExistingDeployment) {
-                const lookup = await plugin.lookupExistingDeployment(projectName, token, teamScope);
-                await this.directoryRepository.update(directory.id, {
-                    website: lookup.website ?? undefined,
-                });
+        // If provider supports removal and domain is synced, remove from provider
+        const dbRecord = await this.domainRepository.findOne(options.directoryId, domain);
+        if (dbRecord?.provider && plugin.removeDomain) {
+            try {
+                const projectId = await this.resolveProjectId(plugin, token, directory, options);
+                const teamScope = await this.getTeamScope(plugin.id, options);
+                await plugin.removeDomain(projectId, domain, token, teamScope);
+            } catch (error) {
+                this.logger.warn(
+                    `Failed to remove domain from provider, removing from DB anyway: ${error}`,
+                );
             }
         }
 
-        return removed;
+        // Always remove from DB
+        await this.domainRepository.removeDomain(options.directoryId, domain);
+
+        // If the removed domain was the current website URL, re-lookup to update
+        if (directory.website === `https://${domain}`) {
+            try {
+                const teamScope = await this.getTeamScope(plugin.id, options);
+                if (plugin.lookupExistingDeployment) {
+                    const lookup = await plugin.lookupExistingDeployment(
+                        directory.slug,
+                        token,
+                        teamScope,
+                    );
+                    await this.directoryRepository.update(directory.id, {
+                        website: lookup.website ?? undefined,
+                    });
+                }
+            } catch (error) {
+                this.logger.warn(`Failed to re-lookup website URL after domain removal: ${error}`);
+            }
+        }
+
+        return true;
     }
 
     /**
-     * Verify a domain on a deployed directory
+     * Verify a domain on a deployed directory.
+     * Verifies at provider, updates DB with result.
      */
     async verifyDomain(domain: string, options: DeployFacadeOptions): Promise<DeploymentDomain> {
         const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
@@ -383,6 +438,9 @@ export class DeployFacadeService implements IDeployFacade {
         const projectId = await this.resolveProjectId(plugin, token, directory, options);
         const teamScope = await this.getTeamScope(plugin.id, options);
         const result = await plugin.verifyDomain(projectId, domain, token, teamScope);
+
+        // Update DB with verification result
+        await this.domainRepository.updateVerified(options.directoryId, domain, result.verified);
 
         // Update directory.website if newly verified
         if (result.verified) {

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -301,7 +301,11 @@ export class DeployFacadeService implements IDeployFacade {
     async getDomains(options: DeployFacadeOptions): Promise<DeploymentDomain[]> {
         const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
         if (!plugin.getDomains) {
-            throw new DeployFacadeError('Domain management is not supported by this provider', 'getDomains', plugin.id);
+            throw new DeployFacadeError(
+                'Domain management is not supported by this provider',
+                'getDomains',
+                plugin.id,
+            );
         }
         const projectId = await this.resolveProjectId(plugin, token, directory, options);
         const teamScope = await this.getTeamScope(plugin.id, options);
@@ -314,7 +318,11 @@ export class DeployFacadeService implements IDeployFacade {
     async addDomain(domain: string, options: DeployFacadeOptions): Promise<AddDomainResult> {
         const { plugin, token, directory } = await this.resolvePluginAndTokenWithDirectory(options);
         if (!plugin.addDomain) {
-            throw new DeployFacadeError('Domain management is not supported by this provider', 'addDomain', plugin.id);
+            throw new DeployFacadeError(
+                'Domain management is not supported by this provider',
+                'addDomain',
+                plugin.id,
+            );
         }
         const projectId = await this.resolveProjectId(plugin, token, directory, options);
         const teamScope = await this.getTeamScope(plugin.id, options);
@@ -469,7 +477,10 @@ export class DeployFacadeService implements IDeployFacade {
     /**
      * Get team scope from plugin settings
      */
-    private async getTeamScope(pluginId: string, options: DeployFacadeOptions): Promise<string | undefined> {
+    private async getTeamScope(
+        pluginId: string,
+        options: DeployFacadeOptions,
+    ): Promise<string | undefined> {
         const settings = await this.settingsService.getSettings(pluginId, {
             userId: options.userId,
             directoryId: options.directoryId,

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -350,6 +350,16 @@ export class DeployFacadeService implements IDeployFacade {
             );
         }
 
+        // Check for duplicate before inserting
+        const existing = await this.domainRepository.findOne(options.directoryId, domain);
+        if (existing) {
+            throw new DeployFacadeError(
+                `Domain "${domain}" is already added to this directory`,
+                'addDomain',
+                plugin.id,
+            );
+        }
+
         // Save to DB first (unverified, no provider yet)
         await this.domainRepository.addDomain(options.directoryId, domain);
 
@@ -368,9 +378,13 @@ export class DeployFacadeService implements IDeployFacade {
         await this.domainRepository.updateProvider(options.directoryId, domain, plugin.id);
         if (result.verified) {
             await this.domainRepository.updateVerified(options.directoryId, domain, true);
-            await this.directoryRepository.update(directory.id, {
-                website: `https://${result.domain.name}`,
-            });
+            // Only promote to primary URL if current website is auto-assigned or unset
+            const isAutoAssigned = !directory.website || directory.website.endsWith('.vercel.app');
+            if (isAutoAssigned) {
+                await this.directoryRepository.update(directory.id, {
+                    website: `https://${result.domain.name}`,
+                });
+            }
         }
 
         return result;
@@ -397,11 +411,11 @@ export class DeployFacadeService implements IDeployFacade {
             }
         }
 
-        // Always remove from DB
-        await this.domainRepository.removeDomain(options.directoryId, domain);
+        // Remove from DB
+        const removed = await this.domainRepository.removeDomain(options.directoryId, domain);
 
         // If the removed domain was the current website URL, re-lookup to update
-        if (directory.website === `https://${domain}`) {
+        if (removed && directory.website === `https://${domain}`) {
             try {
                 const teamScope = await this.getTeamScope(plugin.id, options);
                 if (plugin.lookupExistingDeployment) {
@@ -419,7 +433,7 @@ export class DeployFacadeService implements IDeployFacade {
             }
         }
 
-        return true;
+        return removed;
     }
 
     /**
@@ -442,11 +456,14 @@ export class DeployFacadeService implements IDeployFacade {
         // Update DB with verification result
         await this.domainRepository.updateVerified(options.directoryId, domain, result.verified);
 
-        // Update directory.website if newly verified
+        // Only promote to primary URL if current website is auto-assigned or unset
         if (result.verified) {
-            await this.directoryRepository.update(directory.id, {
-                website: `https://${result.name}`,
-            });
+            const isAutoAssigned = !directory.website || directory.website.endsWith('.vercel.app');
+            if (isAutoAssigned) {
+                await this.directoryRepository.update(directory.id, {
+                    website: `https://${result.name}`,
+                });
+            }
         }
 
         return result;

--- a/packages/plugin/src/contracts/capabilities/deployment.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/deployment.interface.ts
@@ -66,6 +66,42 @@ export interface DeploymentProject {
 }
 
 /**
+ * Domain information from deployment provider
+ */
+export interface DeploymentDomain {
+	/** Domain name (e.g. 'example.com') */
+	readonly name: string;
+	/** Whether the domain is verified */
+	readonly verified: boolean;
+	/** Verification challenges if not verified */
+	readonly verification?: readonly DeploymentDomainVerification[];
+}
+
+/**
+ * DNS verification challenge for a domain
+ */
+export interface DeploymentDomainVerification {
+	/** DNS record type (e.g. 'CNAME', 'TXT', 'A') */
+	readonly type: string;
+	/** DNS record name/host */
+	readonly domain: string;
+	/** DNS record value */
+	readonly value: string;
+	/** Human-readable reason for this record */
+	readonly reason: string;
+}
+
+/**
+ * Result of adding a domain
+ */
+export interface AddDomainResult {
+	/** The domain that was added */
+	readonly domain: DeploymentDomain;
+	/** Whether the domain was verified immediately */
+	readonly verified: boolean;
+}
+
+/**
  * Deployment plugin interface
  * Capability: 'deployment'
  */
@@ -121,6 +157,26 @@ export interface IDeploymentPlugin extends IPlugin {
 	 * List all projects
 	 */
 	listProjects?(token: string): Promise<DeploymentProject[]>;
+
+	/**
+	 * Get domains for a project
+	 */
+	getDomains?(projectId: string, token: string, teamScope?: string): Promise<DeploymentDomain[]>;
+
+	/**
+	 * Add a domain to a project
+	 */
+	addDomain?(projectId: string, domain: string, token: string, teamScope?: string): Promise<AddDomainResult>;
+
+	/**
+	 * Remove a domain from a project
+	 */
+	removeDomain?(projectId: string, domain: string, token: string, teamScope?: string): Promise<boolean>;
+
+	/**
+	 * Verify a domain on a project
+	 */
+	verifyDomain?(projectId: string, domain: string, token: string, teamScope?: string): Promise<DeploymentDomain>;
 }
 
 /**

--- a/packages/plugin/src/facades/deploy-facade.interface.ts
+++ b/packages/plugin/src/facades/deploy-facade.interface.ts
@@ -7,6 +7,7 @@
  */
 
 import type { PluginIcon } from '../contracts/plugin-manifest.types.js';
+import type { DeploymentDomain, AddDomainResult } from '../contracts/capabilities/deployment.interface.js';
 
 /**
  * Options for deploy facade operations
@@ -132,4 +133,35 @@ export interface IDeployFacade {
 	 * @returns Deployment lookup result
 	 */
 	lookupExistingDeployment(projectName: string, options: DeployFacadeOptions): Promise<DeploymentLookupResult>;
+
+	/**
+	 * Get domains for a deployed directory
+	 * @param options Facade options with user and directory IDs
+	 * @returns Array of domain information
+	 */
+	getDomains(options: DeployFacadeOptions): Promise<DeploymentDomain[]>;
+
+	/**
+	 * Add a domain to a deployed directory
+	 * @param domain Domain name to add
+	 * @param options Facade options with user and directory IDs
+	 * @returns Result of domain addition
+	 */
+	addDomain(domain: string, options: DeployFacadeOptions): Promise<AddDomainResult>;
+
+	/**
+	 * Remove a domain from a deployed directory
+	 * @param domain Domain name to remove
+	 * @param options Facade options with user and directory IDs
+	 * @returns True if domain was removed
+	 */
+	removeDomain(domain: string, options: DeployFacadeOptions): Promise<boolean>;
+
+	/**
+	 * Verify a domain on a deployed directory
+	 * @param domain Domain name to verify
+	 * @param options Facade options with user and directory IDs
+	 * @returns Updated domain information
+	 */
+	verifyDomain(domain: string, options: DeployFacadeOptions): Promise<DeploymentDomain>;
 }

--- a/packages/plugins/vercel/src/__tests__/vercel-api.service.spec.ts
+++ b/packages/plugins/vercel/src/__tests__/vercel-api.service.spec.ts
@@ -92,4 +92,24 @@ describe('VercelApiService', () => {
 			expect(result.found).toBe(false);
 		});
 	});
+
+	describe('domain management methods', () => {
+		it('should have addProjectDomain method', () => {
+			expect(typeof service.addProjectDomain).toBe('function');
+		});
+
+		it('should have removeProjectDomain method', () => {
+			expect(typeof service.removeProjectDomain).toBe('function');
+		});
+
+		it('should have verifyProjectDomain method', () => {
+			expect(typeof service.verifyProjectDomain).toBe('function');
+		});
+
+		it('should return domains with verification info from getProjectDomains', async () => {
+			// With an invalid token, getProjectDomains returns empty array
+			const result = await service.getProjectDomains('project-id', 'invalid-token');
+			expect(result).toEqual([]);
+		});
+	});
 });

--- a/packages/plugins/vercel/src/__tests__/vercel-api.service.spec.ts
+++ b/packages/plugins/vercel/src/__tests__/vercel-api.service.spec.ts
@@ -106,10 +106,13 @@ describe('VercelApiService', () => {
 			expect(typeof service.verifyProjectDomain).toBe('function');
 		});
 
-		it('should return domains with verification info from getProjectDomains', async () => {
-			// With an invalid token, getProjectDomains returns empty array
-			const result = await service.getProjectDomains('project-id', 'invalid-token');
+		it('should return empty array from getProjectDomains with empty token', async () => {
+			const result = await service.getProjectDomains('project-id', '');
 			expect(result).toEqual([]);
+		});
+
+		it('should throw from getProjectDomains with invalid token', async () => {
+			await expect(service.getProjectDomains('project-id', 'invalid-token')).rejects.toThrow();
 		});
 	});
 });

--- a/packages/plugins/vercel/src/__tests__/vercel.plugin.spec.ts
+++ b/packages/plugins/vercel/src/__tests__/vercel.plugin.spec.ts
@@ -118,4 +118,22 @@ describe('VercelPlugin', () => {
 			expect(typeof apiService.getTeams).toBe('function');
 		});
 	});
+
+	describe('domain management methods', () => {
+		it('should have getDomains method', () => {
+			expect(typeof plugin.getDomains).toBe('function');
+		});
+
+		it('should have addDomain method', () => {
+			expect(typeof plugin.addDomain).toBe('function');
+		});
+
+		it('should have removeDomain method', () => {
+			expect(typeof plugin.removeDomain).toBe('function');
+		});
+
+		it('should have verifyDomain method', () => {
+			expect(typeof plugin.verifyDomain).toBe('function');
+		});
+	});
 });

--- a/packages/plugins/vercel/src/vercel-api.service.ts
+++ b/packages/plugins/vercel/src/vercel-api.service.ts
@@ -128,8 +128,8 @@ export class VercelApiService {
 						}))
 					: undefined
 			}));
-		} catch {
-			return [];
+		} catch (error) {
+			throw error;
 		}
 	}
 

--- a/packages/plugins/vercel/src/vercel-api.service.ts
+++ b/packages/plugins/vercel/src/vercel-api.service.ts
@@ -100,7 +100,7 @@ export class VercelApiService {
 		projectId: string,
 		token: string,
 		teamScope?: string
-	): Promise<Array<{ name: string; verified: boolean }>> {
+	): Promise<Array<{ name: string; verified: boolean; verification?: Array<{ type: string; domain: string; value: string; reason: string }> }>> {
 		if (!token) {
 			return [];
 		}
@@ -110,13 +110,97 @@ export class VercelApiService {
 				idOrName: projectId,
 				slug: teamScope
 			});
-			return response.domains.map((d) => ({
+			return response.domains.map((d: any) => ({
 				name: d.name,
-				verified: d.verified ?? false
+				verified: d.verified ?? false,
+				verification: d.verification?.length
+					? d.verification.map((v: any) => ({
+							type: v.type || 'TXT',
+							domain: v.domain || d.name,
+							value: v.value || '',
+							reason: v.reason || 'Domain verification'
+						}))
+					: undefined
 			}));
 		} catch {
 			return [];
 		}
+	}
+
+	/**
+	 * Add a domain to a project
+	 */
+	async addProjectDomain(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string
+	): Promise<{ name: string; verified: boolean; verification?: Array<{ type: string; domain: string; value: string; reason: string }> }> {
+		const vercel = await this.createSDK(token);
+		const response: any = await vercel.projects.addProjectDomain({
+			idOrName: projectId,
+			slug: teamScope,
+			requestBody: { name: domain }
+		});
+		return {
+			name: response.name,
+			verified: response.verified ?? false,
+			verification: response.verification?.length
+				? response.verification.map((v: any) => ({
+						type: v.type || 'TXT',
+						domain: v.domain || response.name,
+						value: v.value || '',
+						reason: v.reason || 'Domain verification'
+					}))
+				: undefined
+		};
+	}
+
+	/**
+	 * Remove a domain from a project
+	 */
+	async removeProjectDomain(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string
+	): Promise<boolean> {
+		const vercel = await this.createSDK(token);
+		await vercel.projects.removeProjectDomain({
+			idOrName: projectId,
+			domain,
+			slug: teamScope
+		});
+		return true;
+	}
+
+	/**
+	 * Verify a domain on a project
+	 */
+	async verifyProjectDomain(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string
+	): Promise<{ name: string; verified: boolean; verification?: Array<{ type: string; domain: string; value: string; reason: string }> }> {
+		const vercel = await this.createSDK(token);
+		const response: any = await vercel.projects.verifyProjectDomain({
+			idOrName: projectId,
+			domain,
+			slug: teamScope
+		});
+		return {
+			name: response.name,
+			verified: response.verified ?? false,
+			verification: response.verification?.length
+				? response.verification.map((v: any) => ({
+						type: v.type || 'TXT',
+						domain: v.domain || response.name,
+						value: v.value || '',
+						reason: v.reason || 'Domain verification'
+					}))
+				: undefined
+		};
 	}
 
 	/**
@@ -226,6 +310,7 @@ export class VercelApiService {
 		website?: string;
 		deploymentState?: VercelDeploymentState;
 		teamScope?: string;
+		projectId?: string;
 	}> {
 		// Get all teams
 		const teams = await this.getTeams(token);
@@ -266,7 +351,8 @@ export class VercelApiService {
 				found: true,
 				website,
 				deploymentState: latestDeployment?.readyState,
-				teamScope: scope
+				teamScope: scope,
+				projectId: project.id
 			};
 		}
 

--- a/packages/plugins/vercel/src/vercel-api.service.ts
+++ b/packages/plugins/vercel/src/vercel-api.service.ts
@@ -100,7 +100,13 @@ export class VercelApiService {
 		projectId: string,
 		token: string,
 		teamScope?: string
-	): Promise<Array<{ name: string; verified: boolean; verification?: Array<{ type: string; domain: string; value: string; reason: string }> }>> {
+	): Promise<
+		Array<{
+			name: string;
+			verified: boolean;
+			verification?: Array<{ type: string; domain: string; value: string; reason: string }>;
+		}>
+	> {
 		if (!token) {
 			return [];
 		}
@@ -135,7 +141,11 @@ export class VercelApiService {
 		domain: string,
 		token: string,
 		teamScope?: string
-	): Promise<{ name: string; verified: boolean; verification?: Array<{ type: string; domain: string; value: string; reason: string }> }> {
+	): Promise<{
+		name: string;
+		verified: boolean;
+		verification?: Array<{ type: string; domain: string; value: string; reason: string }>;
+	}> {
 		const vercel = await this.createSDK(token);
 		const response: any = await vercel.projects.addProjectDomain({
 			idOrName: projectId,
@@ -159,12 +169,7 @@ export class VercelApiService {
 	/**
 	 * Remove a domain from a project
 	 */
-	async removeProjectDomain(
-		projectId: string,
-		domain: string,
-		token: string,
-		teamScope?: string
-	): Promise<boolean> {
+	async removeProjectDomain(projectId: string, domain: string, token: string, teamScope?: string): Promise<boolean> {
 		const vercel = await this.createSDK(token);
 		await vercel.projects.removeProjectDomain({
 			idOrName: projectId,
@@ -182,7 +187,11 @@ export class VercelApiService {
 		domain: string,
 		token: string,
 		teamScope?: string
-	): Promise<{ name: string; verified: boolean; verification?: Array<{ type: string; domain: string; value: string; reason: string }> }> {
+	): Promise<{
+		name: string;
+		verified: boolean;
+		verification?: Array<{ type: string; domain: string; value: string; reason: string }>;
+	}> {
 		const vercel = await this.createSDK(token);
 		const response: any = await vercel.projects.verifyProjectDomain({
 			idOrName: projectId,

--- a/packages/plugins/vercel/src/vercel.plugin.ts
+++ b/packages/plugins/vercel/src/vercel.plugin.ts
@@ -8,7 +8,9 @@ import type {
 	JsonSchema,
 	DeploymentConfig,
 	DeploymentResult,
-	DeploymentProject
+	DeploymentProject,
+	DeploymentDomain,
+	AddDomainResult
 } from '@ever-works/plugin';
 import { VercelApiService } from './vercel-api.service.js';
 import type { VercelSettings } from './types.js';
@@ -112,7 +114,8 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 		return {
 			found: result.found,
 			website: result.website,
-			deploymentState: result.deploymentState
+			deploymentState: result.deploymentState,
+			projectId: result.projectId
 		};
 	}
 
@@ -152,6 +155,42 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 			id: project.id,
 			name: project.name,
 			createdAt: new Date().toISOString()
+		};
+	}
+
+	// Domain management methods
+
+	async getDomains(projectId: string, token: string, teamScope?: string): Promise<DeploymentDomain[]> {
+		const domains = await this.apiService.getProjectDomains(projectId, token, teamScope);
+		return domains.map((d) => ({
+			name: d.name,
+			verified: d.verified,
+			verification: d.verification
+		}));
+	}
+
+	async addDomain(projectId: string, domain: string, token: string, teamScope?: string): Promise<AddDomainResult> {
+		const result = await this.apiService.addProjectDomain(projectId, domain, token, teamScope);
+		return {
+			domain: {
+				name: result.name,
+				verified: result.verified,
+				verification: result.verification
+			},
+			verified: result.verified
+		};
+	}
+
+	async removeDomain(projectId: string, domain: string, token: string, teamScope?: string): Promise<boolean> {
+		return this.apiService.removeProjectDomain(projectId, domain, token, teamScope);
+	}
+
+	async verifyDomain(projectId: string, domain: string, token: string, teamScope?: string): Promise<DeploymentDomain> {
+		const result = await this.apiService.verifyProjectDomain(projectId, domain, token, teamScope);
+		return {
+			name: result.name,
+			verified: result.verified,
+			verification: result.verification
 		};
 	}
 

--- a/packages/plugins/vercel/src/vercel.plugin.ts
+++ b/packages/plugins/vercel/src/vercel.plugin.ts
@@ -185,7 +185,12 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 		return this.apiService.removeProjectDomain(projectId, domain, token, teamScope);
 	}
 
-	async verifyDomain(projectId: string, domain: string, token: string, teamScope?: string): Promise<DeploymentDomain> {
+	async verifyDomain(
+		projectId: string,
+		domain: string,
+		token: string,
+		teamScope?: string
+	): Promise<DeploymentDomain> {
 		const result = await this.apiService.verifyProjectDomain(projectId, domain, token, teamScope);
 		return {
 			name: result.name,


### PR DESCRIPTION
Allow users to add, remove, verify, and view custom domains for their deployed directory websites without leaving the platform. Domains are managed through the Vercel API (source of truth) with no database storage. The UI renders below the deploy form after a successful deployment exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain management for deployments: list, add, remove, and verify custom domains with status badges and DNS instructions.

* **UI / Localization**
  * Deploy page now shows a Domain Management panel and new user-facing strings for domain workflows and DNS guidance.

* **API / Client**
  * New endpoints and client actions to fetch/add/remove/verify domains and refresh deploy state.

* **Backend**
  * Persistent domain records, DB migrations/repository, and plugin/agent support for provider interactions and verification flows.

* **Tests**
  * Added tests covering domain-related plugin/API behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->