### PR TITLE
fix: wire dashboard stats to real data (Total Items and Active Websites)

### DIFF
--- a/apps/api/src/directories/directories.controller.ts
+++ b/apps/api/src/directories/directories.controller.ts
@@ -146,7 +146,8 @@ export class DirectoriesController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: 'Get directory stats',
-        description: 'Get aggregated stats (total directories, total items, active websites) for the authenticated user',
+        description:
+            'Get aggregated stats (total directories, total items, active websites) for the authenticated user',
     })
     @ApiResponse({ status: 200, description: 'Directory stats' })
     async getDirectoryStats(@CurrentUser() auth: AuthenticatedUser) {

--- a/apps/api/src/directories/directories.controller.ts
+++ b/apps/api/src/directories/directories.controller.ts
@@ -142,6 +142,18 @@ export class DirectoriesController {
         );
     }
 
+    @Get('directories/stats')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Get directory stats',
+        description: 'Get aggregated stats (total directories, total items, active websites) for the authenticated user',
+    })
+    @ApiResponse({ status: 200, description: 'Directory stats' })
+    async getDirectoryStats(@CurrentUser() auth: AuthenticatedUser) {
+        const user = await this.authService.getUser(auth.userId);
+        return this.directoryQueryService.getStats(user);
+    }
+
     @Post('directories')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Create directory', description: 'Create a new directory' })

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
@@ -13,12 +13,16 @@ interface DashboardClientProps {
     user: AuthUser;
     initialDirectories: Directory[];
     totalDirectories: number;
+    totalItems: number;
+    activeWebsites: number;
 }
 
 export default function DashboardClient({
     user,
     initialDirectories,
     totalDirectories,
+    totalItems,
+    activeWebsites,
 }: DashboardClientProps) {
     const router = useRouter();
     const t = useTranslations('dashboard');
@@ -35,7 +39,11 @@ export default function DashboardClient({
                 </p>
             </div>
 
-            <StatsOverview totalDirectories={totalDirectories} />
+            <StatsOverview
+                totalDirectories={totalDirectories}
+                totalItems={totalItems}
+                activeWebsites={activeWebsites}
+            />
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-8">
                 <div className="lg:col-span-3">

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { getAuthFromCookie } from '@/lib/auth';
 import DashboardClient from './dashboard-client';
-import { getDirectories } from '@/app/actions/dashboard/directories';
+import { getDirectories, getDirectoryStats } from '@/app/actions/dashboard/directories';
 import { GET_DIRECTORY_LIST_LIMIT } from '@/lib/constants';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -13,13 +13,18 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Dashboard() {
     const user = await getAuthFromCookie();
 
-    const directoriesResponse = await getDirectories({ limit: GET_DIRECTORY_LIST_LIMIT });
+    const [directoriesResponse, statsResponse] = await Promise.all([
+        getDirectories({ limit: GET_DIRECTORY_LIST_LIMIT }),
+        getDirectoryStats(),
+    ]);
 
     return (
         <DashboardClient
             user={user!}
             initialDirectories={directoriesResponse.directories}
-            totalDirectories={directoriesResponse.total}
+            totalDirectories={statsResponse.totalDirectories}
+            totalItems={statsResponse.totalItems}
+            activeWebsites={statsResponse.activeWebsites}
         />
     );
 }

--- a/apps/web/src/app/actions/dashboard/directories.ts
+++ b/apps/web/src/app/actions/dashboard/directories.ts
@@ -477,6 +477,24 @@ export async function getDirectories(params: GetDirectoriesParams = {}) {
     }
 }
 
+export async function getDirectoryStats() {
+    try {
+        const stats = await directoryAPI.getStats();
+        return {
+            success: true,
+            ...stats,
+        };
+    } catch (error) {
+        console.error('Failed to fetch directory stats:', error);
+        return {
+            success: false,
+            totalDirectories: 0,
+            totalItems: 0,
+            activeWebsites: 0,
+        };
+    }
+}
+
 // Import actions
 
 export async function analyzeRepository(sourceUrl: string, providerId?: string) {

--- a/apps/web/src/components/dashboard/StatsOverview.tsx
+++ b/apps/web/src/components/dashboard/StatsOverview.tsx
@@ -1,39 +1,21 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { cn } from '@/lib/utils/cn';
 import { useTranslations } from 'next-intl';
 
-interface Stats {
-    totalDirectories: number;
-    totalItems: number;
-    apiCalls: number;
-    activeWebsites: number;
-}
-
 interface StatsOverviewProps {
     totalDirectories?: number;
+    totalItems?: number;
+    activeWebsites?: number;
 }
 
-export function StatsOverview({ totalDirectories = 0 }: StatsOverviewProps) {
+export function StatsOverview({
+    totalDirectories = 0,
+    totalItems = 0,
+    activeWebsites = 0,
+}: StatsOverviewProps) {
     const t = useTranslations('dashboard.stats');
-    const [stats, setStats] = useState<Stats>({
-        totalDirectories: totalDirectories,
-        totalItems: 0,
-        apiCalls: 0,
-        activeWebsites: 0,
-    });
-
-    useEffect(() => {
-        // TODO: Fetch other stats from API
-        setStats({
-            totalDirectories: totalDirectories,
-            totalItems: 0,
-            apiCalls: 0,
-            activeWebsites: 0,
-        });
-    }, [totalDirectories]);
 
     const statCards: Array<{
         title: string;
@@ -45,7 +27,7 @@ export function StatsOverview({ totalDirectories = 0 }: StatsOverviewProps) {
     }> = [
         {
             title: t('totalDirectories'),
-            value: stats.totalDirectories,
+            value: totalDirectories,
             icon: FolderIcon,
             iconColor: 'text-blue-500',
             change: '+12%',
@@ -53,7 +35,7 @@ export function StatsOverview({ totalDirectories = 0 }: StatsOverviewProps) {
         },
         {
             title: t('totalItems'),
-            value: stats.totalItems,
+            value: totalItems,
             icon: ItemsIcon,
             iconColor: 'text-violet-500',
             change: '+23%',
@@ -61,7 +43,7 @@ export function StatsOverview({ totalDirectories = 0 }: StatsOverviewProps) {
         },
         {
             title: t('activeWebsites'),
-            value: stats.activeWebsites,
+            value: activeWebsites,
             icon: WebsiteIcon,
             iconColor: 'text-emerald-500',
             change: '0%',

--- a/apps/web/src/lib/api/directory.ts
+++ b/apps/web/src/lib/api/directory.ts
@@ -163,6 +163,12 @@ export interface DirectoriesResponse {
     offset?: number;
 }
 
+export interface DirectoryStatsResponse {
+    totalDirectories: number;
+    totalItems: number;
+    activeWebsites: number;
+}
+
 export interface DeleteDirectoryResponse {
     status: 'success' | 'error' | 'pending';
     slug: string;
@@ -488,6 +494,11 @@ export const directoryAPI = {
         const query = params.toString() ? `?${params.toString()}` : '';
 
         return serverFetch<DirectoriesResponse>(`/directories${query}`);
+    },
+
+    // Get aggregated stats for the current user's directories
+    getStats: async () => {
+        return serverFetch<DirectoryStatsResponse>(`/directories/stats`);
     },
 
     // Get a directory by ID

--- a/packages/agent/src/database/repositories/directory.repository.ts
+++ b/packages/agent/src/database/repositories/directory.repository.ts
@@ -394,7 +394,7 @@ export class DirectoryRepository {
             .select('COUNT(*)', 'totalDirectories')
             .addSelect('COALESCE(SUM(directory.itemsCount), 0)', 'totalItems')
             .addSelect(
-                'SUM(CASE WHEN directory.website IS NOT NULL AND directory.website != \'\' THEN 1 ELSE 0 END)',
+                "SUM(CASE WHEN directory.website IS NOT NULL AND directory.website != '' THEN 1 ELSE 0 END)",
                 'activeWebsites',
             )
             .getRawOne();

--- a/packages/agent/src/database/repositories/directory.repository.ts
+++ b/packages/agent/src/database/repositories/directory.repository.ts
@@ -363,6 +363,50 @@ export class DirectoryRepository {
     }
 
     /**
+     * Get aggregated stats for all directories accessible to a user.
+     */
+    async getAccessibleStats(options: {
+        userId: string;
+        memberDirectoryIds?: string[];
+    }): Promise<{ totalDirectories: number; totalItems: number; activeWebsites: number }> {
+        const { userId, memberDirectoryIds = [] } = options;
+
+        if (!userId) {
+            return { totalDirectories: 0, totalItems: 0, activeWebsites: 0 };
+        }
+
+        const queryBuilder = this.repository.createQueryBuilder('directory');
+
+        if (memberDirectoryIds.length > 0) {
+            queryBuilder.where(
+                new Brackets((qb) => {
+                    qb.where('directory.userId = :userId', { userId }).orWhere(
+                        'directory.id IN (:...memberDirectoryIds)',
+                        { memberDirectoryIds },
+                    );
+                }),
+            );
+        } else {
+            queryBuilder.where('directory.userId = :userId', { userId });
+        }
+
+        const result = await queryBuilder
+            .select('COUNT(*)', 'totalDirectories')
+            .addSelect('COALESCE(SUM(directory.itemsCount), 0)', 'totalItems')
+            .addSelect(
+                'SUM(CASE WHEN directory.website IS NOT NULL AND directory.website != \'\' THEN 1 ELSE 0 END)',
+                'activeWebsites',
+            )
+            .getRawOne();
+
+        return {
+            totalDirectories: parseInt(result.totalDirectories, 10) || 0,
+            totalItems: parseInt(result.totalItems, 10) || 0,
+            activeWebsites: parseInt(result.activeWebsites, 10) || 0,
+        };
+    }
+
+    /**
      * Find a directory by ID with members relation loaded.
      */
     async findByIdWithMembers(id: string): Promise<Directory | null> {

--- a/packages/agent/src/services/directory-query.service.ts
+++ b/packages/agent/src/services/directory-query.service.ts
@@ -112,6 +112,20 @@ export class DirectoryQueryService {
         }
     }
 
+    async getStats(user: User) {
+        try {
+            const memberDirectoryIds =
+                await this.directoryMemberRepository.getAccessibleDirectoryIds(user.id);
+
+            return await this.directoryRepository.getAccessibleStats({
+                userId: user.id,
+                memberDirectoryIds,
+            });
+        } catch (error) {
+            rethrowAsNormalized(error, this.logger, 'getting directory stats');
+        }
+    }
+
     async getDirectory(id: string, user: User) {
         try {
             const accessResult = await this.ownershipService.ensureAccess(id, user.id);


### PR DESCRIPTION
Add GET /api/directories/stats endpoint that returns totalDirectories, totalItems (sum of itemsCount), and activeWebsites (directories with a website URL) in a single query. Update StatsOverview to display real values instead of hardcoded zeros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays expanded directory statistics including total items and active websites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->