### PR TITLE
fix: mask secret values in plugin API responses

### DIFF
--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -183,13 +183,27 @@ export function PluginSettingsField({
         }
 
         // String input (default) - with secret support
+        // For masked values: eye closed = dots, eye open = partial reveal (e.g. sk-p••••n4Xj)
+        // Clicking into the field clears it so the user can enter a new value
+        const displayValue = isMaskedValue
+            ? showSecret
+                ? String(value)
+                : '••••••••••••••••'
+            : String(value ?? schema.default ?? '');
+
         return (
             <div className="relative">
                 <input
-                    type={getInputType()}
-                    value={isMaskedValue ? '' : String(value ?? schema.default ?? '')}
-                    placeholder={isMaskedValue ? String(value) : undefined}
-                    onChange={(e) => onChange(e.target.value)}
+                    type={isMaskedValue ? 'text' : getInputType()}
+                    value={displayValue}
+                    onChange={
+                        isMaskedValue
+                            ? () => {
+                                    /* block direct edits on masked display; cleared via onFocus */
+                              }
+                            : (e) => onChange(e.target.value)
+                    }
+                    onFocus={isMaskedValue ? () => onChange('') : undefined}
                     maxLength={schema.maxLength}
                     required={isMaskedValue ? false : required}
                     className={cn(
@@ -198,6 +212,7 @@ export function PluginSettingsField({
                         'text-text dark:text-text-dark',
                         'focus:outline-none focus:ring-2 focus:ring-primary/50',
                         isSecret && 'pr-10',
+                        isMaskedValue && !showSecret && 'tracking-wider',
                     )}
                 />
                 {isSecret && (

--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -199,7 +199,7 @@ export function PluginSettingsField({
                     onChange={
                         isMaskedValue
                             ? () => {
-                                    /* block direct edits on masked display; cleared via onFocus */
+                                  /* block direct edits on masked display; cleared via onFocus */
                               }
                             : (e) => onChange(e.target.value)
                     }

--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -36,6 +36,9 @@ export function PluginSettingsField({
     const isSecret = schema.secret;
     const primaryType = getPrimaryType(schema.type);
 
+    // Check if the current value is a masked placeholder from the API
+    const isMaskedValue = isSecret && typeof value === 'string' && value.includes('••••');
+
     // Determine input type for string/number inputs
     const getInputType = () => {
         if (isSecret && !showSecret) return 'password';
@@ -184,10 +187,11 @@ export function PluginSettingsField({
             <div className="relative">
                 <input
                     type={getInputType()}
-                    value={String(value ?? schema.default ?? '')}
+                    value={isMaskedValue ? '' : String(value ?? schema.default ?? '')}
+                    placeholder={isMaskedValue ? String(value) : undefined}
                     onChange={(e) => onChange(e.target.value)}
                     maxLength={schema.maxLength}
-                    required={required}
+                    required={isMaskedValue ? false : required}
                     className={cn(
                         'w-full px-3 py-2 rounded-lg border border-border dark:border-border-dark',
                         'bg-surface-secondary dark:bg-surface-secondary-dark',

--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -205,7 +205,11 @@ export function PluginSettingsField({
                         isMaskedValue
                             ? (e) => {
                                   // Only clear when user actually types a character, not on Tab/Shift/etc
-                                  if (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Delete') {
+                                  if (
+                                      e.key.length === 1 ||
+                                      e.key === 'Backspace' ||
+                                      e.key === 'Delete'
+                                  ) {
                                       onChange('');
                                   }
                               }

--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -196,14 +196,21 @@ export function PluginSettingsField({
                 <input
                     type={isMaskedValue ? 'text' : getInputType()}
                     value={displayValue}
-                    onChange={
+                    onChange={(e) => {
+                        if (!isMaskedValue) {
+                            onChange(e.target.value);
+                        }
+                    }}
+                    onKeyDown={
                         isMaskedValue
-                            ? () => {
-                                  /* block direct edits on masked display; cleared via onFocus */
+                            ? (e) => {
+                                  // Only clear when user actually types a character, not on Tab/Shift/etc
+                                  if (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Delete') {
+                                      onChange('');
+                                  }
                               }
-                            : (e) => onChange(e.target.value)
+                            : undefined
                     }
-                    onFocus={isMaskedValue ? () => onChange('') : undefined}
                     maxLength={schema.maxLength}
                     required={isMaskedValue ? false : required}
                     className={cn(

--- a/apps/web/src/lib/hooks/use-plugin-settings.ts
+++ b/apps/web/src/lib/hooks/use-plugin-settings.ts
@@ -188,14 +188,16 @@ export function usePluginSettings({
                 });
             }
             if (sanitizedSecretSettings) {
-                // Update secretSettings state
+                // Replace saved secret values with a masked placeholder immediately
+                // so the full value is never visible in state after save.
+                // The actual masked value from the API will replace this on router.refresh().
                 setSecretSettings((prev) => {
                     const updated = { ...prev };
                     for (const [key, value] of Object.entries(sanitizedSecretSettings)) {
                         if (value === null) {
                             delete updated[key];
                         } else {
-                            updated[key] = value;
+                            updated[key] = '••••••••';
                         }
                     }
                     return updated;

--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -164,8 +164,8 @@ describe('PluginOperationsService', () => {
     });
 
     describe('secret settings in API response', () => {
-        describe('x-secret fields return real values', () => {
-            it('should return real secret values for x-secret fields', async () => {
+        describe('x-secret fields are masked in responses', () => {
+            it('should return masked secret values for x-secret fields', async () => {
                 const registered = createRegisteredPlugin();
                 jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
                 jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue({
@@ -185,11 +185,12 @@ describe('PluginOperationsService', () => {
                 const result = await service.getPlugin('test-plugin', 'user-1');
 
                 expect(result.settings).toBeDefined();
-                expect(result.settings!.secretField).toBe('real-secret-value');
+                // Secret field should be masked (first 4 + •••• + last 4)
+                expect(result.settings!.secretField).toBe('real••••alue');
                 expect(result.settings!.normalSetting).toBe('should-appear');
             });
 
-            it('should return real secret values in directory plugin response', async () => {
+            it('should return masked secret values in directory plugin response', async () => {
                 const registered = createRegisteredPlugin();
                 jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
                 jest.spyOn(pluginRegistryService, 'getAll').mockReturnValue([registered]);
@@ -227,7 +228,8 @@ describe('PluginOperationsService', () => {
                 const plugin = result.plugins.find((p) => p.pluginId === 'test-plugin');
                 expect(plugin).toBeDefined();
                 expect(plugin!.directorySettings).toBeDefined();
-                expect(plugin!.directorySettings!.secretField).toBe('real-dir-secret');
+                // Secret field should be masked (first 4 + •••• + last 4)
+                expect(plugin!.directorySettings!.secretField).toBe('real••••cret');
                 expect(plugin!.directorySettings!.normalSetting).toBe('should-appear');
             });
         });
@@ -260,7 +262,7 @@ describe('PluginOperationsService', () => {
         });
 
         describe('combined settings and secretSettings merge', () => {
-            it('should return all fields with real values', async () => {
+            it('should return masked secret fields and real non-secret fields', async () => {
                 const registered = createRegisteredPlugin();
                 jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
                 jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue({
@@ -283,10 +285,10 @@ describe('PluginOperationsService', () => {
                 const result = await service.getPlugin('test-plugin', 'user-1');
 
                 expect(result.settings).toBeDefined();
-                // Secret fields return real values
-                expect(result.settings!.clientSecret).toBe('secret-env-var');
-                expect(result.settings!.secretField).toBe('secret-value');
-                // Non-secret fields pass through
+                // Secret fields are masked (first 4 + •••• + last 4)
+                expect(result.settings!.clientSecret).toBe('secr••••-var');
+                expect(result.settings!.secretField).toBe('secr••••alue');
+                // Non-secret fields pass through unchanged
                 expect(result.settings!.clientId).toBe('env-var-field');
                 expect(result.settings!.apiBaseUrl).toBe('https://custom.api.com');
                 expect(result.settings!.normalSetting).toBe('normal');

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -1030,13 +1030,15 @@ export class PluginOperationsService {
             hasDirectoryContext: false,
         });
 
+        const mergedSettings = userPlugin
+            ? { ...userPlugin.settings, ...userPlugin.secretSettings }
+            : undefined;
+
         return {
             ...baseResponse,
             installed: !!userPlugin || enabled,
             enabled,
-            settings: userPlugin
-                ? { ...userPlugin.settings, ...userPlugin.secretSettings }
-                : undefined,
+            settings: this.maskSecretSettings(mergedSettings, registered.plugin.settingsSchema),
             userPluginId: userPlugin?.id,
             autoEnableForDirectories: userPlugin?.autoEnableForDirectories ?? false,
         };
@@ -1065,9 +1067,12 @@ export class PluginOperationsService {
                 hasDirectoryContext: true,
             }),
             activeCapability: directoryPlugin?.activeCapability,
-            directorySettings: directoryPlugin
-                ? { ...directoryPlugin.settings, ...directoryPlugin.secretSettings }
-                : undefined,
+            directorySettings: this.maskSecretSettings(
+                directoryPlugin
+                    ? { ...directoryPlugin.settings, ...directoryPlugin.secretSettings }
+                    : undefined,
+                registered.plugin.settingsSchema,
+            ),
             directoryPluginId: directoryPlugin?.id,
             priority: directoryPlugin?.priority,
         };
@@ -1081,6 +1086,33 @@ export class PluginOperationsService {
         if (!icon) return undefined;
 
         return { ...icon };
+    }
+
+    /**
+     * Mask secret values in settings for API responses.
+     * Shows first 4 + '••••' + last 4 chars (or first 2 + '••••' + last 2 for short values).
+     */
+    private maskSecretSettings(
+        settings: Record<string, unknown> | undefined,
+        schema: JsonSchema | undefined,
+    ): Record<string, unknown> | undefined {
+        if (!settings || !schema?.properties) return settings;
+
+        const masked: Record<string, unknown> = { ...settings };
+        for (const [key, value] of Object.entries(masked)) {
+            const propSchema = schema.properties[key];
+            if (propSchema?.['x-secret'] && typeof value === 'string' && value.length > 0) {
+                masked[key] = this.partialReveal(value);
+            }
+        }
+        return masked;
+    }
+
+    private partialReveal(value: string): string {
+        if (value.length <= 8) {
+            return value.slice(0, 2) + '••••' + value.slice(-2);
+        }
+        return value.slice(0, 4) + '••••' + value.slice(-4);
     }
 
     /**

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -1098,7 +1098,7 @@ export class PluginOperationsService {
     ): Record<string, unknown> | undefined {
         if (!settings || !schema?.properties) return settings;
 
-        const masked: Record<string, unknown> = { ...settings };
+        let masked: Record<string, unknown> = { ...settings };
         for (const [key, value] of Object.entries(masked)) {
             const propSchema = schema.properties[key];
             if (propSchema?.['x-secret'] && typeof value === 'string' && value.length > 0) {
@@ -1109,10 +1109,12 @@ export class PluginOperationsService {
     }
 
     private partialReveal(value: string): string {
-        if (value.length <= 8) {
-            return value.slice(0, 2) + '••••' + value.slice(-2);
+        const prefixLen = value.length <= 8 ? 2 : 4;
+        const suffixLen = prefixLen;
+        if (prefixLen + suffixLen >= value.length) {
+            return '••••••••';
         }
-        return value.slice(0, 4) + '••••' + value.slice(-4);
+        return value.slice(0, prefixLen) + '••••' + value.slice(-suffixLen);
     }
 
     /**

--- a/packages/agent/src/plugins/services/plugin-settings.service.ts
+++ b/packages/agent/src/plugins/services/plugin-settings.service.ts
@@ -687,6 +687,7 @@ export class PluginSettingsService {
 
     /**
      * Strip masked placeholder values from settings based on schema x-secret fields.
+     * Recognizes both the full mask ('********') and partial-reveal format ('sk-p••••n4Xj').
      */
     private stripMaskedPlaceholders(
         settings: Record<string, unknown>,
@@ -697,9 +698,11 @@ export class PluginSettingsService {
         const filtered: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(settings)) {
             const propSchema = schema.properties[key] as JsonSchema | undefined;
-            if (propSchema?.['x-secret'] && value === MASKED_SECRET_PLACEHOLDER) {
-                this.logger.debug(`Stripping masked placeholder for field "${key}"`);
-                continue;
+            if (propSchema?.['x-secret'] && typeof value === 'string') {
+                if (value === MASKED_SECRET_PLACEHOLDER || value.includes('••••')) {
+                    this.logger.debug(`Stripping masked placeholder for field "${key}"`);
+                    continue;
+                }
             }
             filtered[key] = value;
         }


### PR DESCRIPTION
Plugin secret settings (API keys, tokens, credentials) were returned in full by the API. Now all x-secret fields are partially redacted in responses (first 4 + ···· + last 4 chars). The save flow recognizes masked values and skips overwriting stored secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret fields show masked placeholders (••••) with an eye toggle; typing clears masked content to allow re-entry and masked inputs render for editing.
  * Masked state adjusts input behavior (suppresses live change until unmasked) and visual styling for clarity.

* **Security**
  * Secret values are stored and displayed in masked form after saving; partial-prefix/suffix reveal may appear instead of full secrets.

* **Tests**
  * Tests updated to expect masked secret formats in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->