### PR TITLE
chore(web):downgrade the seclect button to fix the build conflict error

### DIFF
--- a/apps/web/src/components/directories/detail/history/DirectoryHistoryPageClient.tsx
+++ b/apps/web/src/components/directories/detail/history/DirectoryHistoryPageClient.tsx
@@ -202,19 +202,18 @@ export function DirectoryHistoryPageClient({
             </div>
 
             <div className="max-w-xs">
-                <Select value={activityFilter} onValueChange={handleFilterChange}>
-                    <SelectTrigger aria-label={t('filters.label')}>
-                        <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="all">{t('filters.all')}</SelectItem>
-                        <SelectItem value="generation">{t('filters.generation')}</SelectItem>
-                        <SelectItem value="items">{t('filters.items')}</SelectItem>
-                        <SelectItem value="comparisons">{t('filters.comparisons')}</SelectItem>
-                        <SelectItem value="taxonomy">{t('filters.taxonomy')}</SelectItem>
-                        <SelectItem value="community_pr">{t('filters.community_pr')}</SelectItem>
-                    </SelectContent>
-                </Select>
+                <select
+                    value={activityFilter}
+                    onChange={(e) => handleFilterChange(e.target.value)}
+                    aria-label={t('filters.label')}
+                >
+                    <option value="all">{t('filters.all')}</option>
+                    <option value="generation">{t('filters.generation')}</option>
+                    <option value="items">{t('filters.items')}</option>
+                    <option value="comparisons">{t('filters.comparisons')}</option>
+                    <option value="taxonomy">{t('filters.taxonomy')}</option>
+                    <option value="community_pr">{t('filters.community_pr')}</option>
+                </select>
             </div>
 
             {entries.length === 0 ? (


### PR DESCRIPTION
The build error in this [PR](https://github.com/ever-works/ever-works/pull/261), it is because, I made changes /components/ui/select'; , so I think it a build conflict on `workflows`
so I made this `PR` to downgrade the code.
so if we merge this `PR`, I think it'll fix the current build error.
then after merge, I'll push the upgrade select styles the same as in this [PR](https://github.com/ever-works/ever-works/pull/261).

### There no mansion, on github that we have a github conflict
<img width="1067" height="516" alt="Screenshot 2026-03-14 145239" src="https://github.com/user-attachments/assets/7d98d3d6-f4df-4612-8ba3-cc1c68fee976" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the filter dropdown component on the directory history page for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->