### PR TITLE
Adds global pipeline default preference with optional enforcement

### DIFF
--- a/apps/api/src/plugins/dto/update-plugin-settings.dto.ts
+++ b/apps/api/src/plugins/dto/update-plugin-settings.dto.ts
@@ -132,7 +132,8 @@ export class SetGlobalPipelineDefaultDto {
     pluginId?: string | null;
 
     @ApiProperty({
-        description: 'When true, this pipeline is enforced in the generator form (cannot be overridden)',
+        description:
+            'When true, this pipeline is enforced in the generator form (cannot be overridden)',
         example: false,
     })
     @IsBoolean()

--- a/apps/api/src/plugins/dto/update-plugin-settings.dto.ts
+++ b/apps/api/src/plugins/dto/update-plugin-settings.dto.ts
@@ -117,3 +117,24 @@ export class UpdateDirectoryPluginPriorityDto {
     @Min(0)
     priority: number;
 }
+
+/**
+ * DTO for setting the user's global pipeline default
+ */
+export class SetGlobalPipelineDefaultDto {
+    @ApiPropertyOptional({
+        description: 'Pipeline plugin ID to set as global default, or null to clear',
+        example: 'standard-pipeline',
+        nullable: true,
+    })
+    @IsString()
+    @IsOptional()
+    pluginId?: string | null;
+
+    @ApiProperty({
+        description: 'When true, this pipeline is enforced in the generator form (cannot be overridden)',
+        example: false,
+    })
+    @IsBoolean()
+    enforce: boolean;
+}

--- a/apps/api/src/plugins/plugins.controller.ts
+++ b/apps/api/src/plugins/plugins.controller.ts
@@ -27,6 +27,7 @@ import {
     EnableDirectoryPluginDto,
     SetActiveCapabilityDto,
     SettingsMenuResponseDto,
+    SetGlobalPipelineDefaultDto,
 } from './dto';
 import { PluginValidationService } from './plugin-validation.service';
 
@@ -174,6 +175,25 @@ export class PluginsController {
             dto.settings,
             dto.secretSettings,
             dto.metadata,
+        );
+    }
+
+    @Post('plugins/pipeline-default')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Set global pipeline default',
+        description:
+            'Set or clear the global default pipeline for the current user. Optionally enforce it so the generator form cannot override it.',
+    })
+    @ApiResponse({ status: 200, description: 'Global pipeline default updated' })
+    async setGlobalPipelineDefault(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() dto: SetGlobalPipelineDefaultDto,
+    ): Promise<void> {
+        await this.pluginsService.setGlobalPipelineDefault(
+            auth.userId,
+            dto.pluginId ?? null,
+            dto.enforce,
         );
     }
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -448,7 +448,16 @@
                 "configure": "Configure",
                 "noPluginsInCategory": "No plugins in this category",
                 "requiredSettingsMissing": "Required settings not configured",
-                "backToCategory": "Back to {category}"
+                "backToCategory": "Back to {category}",
+                "pipelineDefault": {
+                    "title": "Default Pipeline",
+                    "description": "Choose which pipeline is used by default when generating directory items.",
+                    "autoLabel": "Auto",
+                    "autoDescription": "Use the system-resolved pipeline for each directory",
+                    "enforceLabel": "Enforce this default",
+                    "enforceDescription": "The selected pipeline will be pre-selected in the generator form across all directories.",
+                    "saveFailed": "Failed to save pipeline default"
+                }
             },
             "profile": {
                 "title": "Profile Settings",

--- a/apps/web/src/app/[locale]/(dashboard)/settings/plugins/[category]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/plugins/[category]/page.tsx
@@ -6,6 +6,7 @@ import { getTranslations } from 'next-intl/server';
 import { getCategoryLabel } from '@/lib/utils/plugin-category-icons';
 import { isPluginCategory } from '@ever-works/plugin';
 import { PluginSettingsInline } from '@/components/settings/PluginSettingsInline';
+import { PipelineDefaultSelector } from '@/components/settings/PipelineDefaultSelector';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('metadata.pages');
@@ -69,6 +70,11 @@ export default async function PluginCategoryPage({ params }: PageProps) {
                     {t('plugins.configure')} {categoryLabel.toLowerCase()}
                 </p>
             </div>
+
+            {/* Default pipeline selector — shown only for the pipeline category */}
+            {category === 'pipeline' && plugins.length > 1 && (
+                <PipelineDefaultSelector plugins={plugins} />
+            )}
 
             <div className="space-y-3">
                 {pluginsWithOAuth.map(({ plugin, oauthConnection }) => (

--- a/apps/web/src/app/actions/plugins.ts
+++ b/apps/web/src/app/actions/plugins.ts
@@ -203,3 +203,23 @@ export async function setActiveCapability(
         };
     }
 }
+
+/**
+ * Set or clear the global default pipeline for the current user
+ */
+export async function setGlobalPipelineDefault(
+    pluginId: string | null,
+    enforce: boolean,
+): Promise<ActionResult> {
+    try {
+        await pluginsAPI.setGlobalPipelineDefault(pluginId, enforce);
+        revalidatePath('/settings/plugins/pipeline');
+        return { success: true };
+    } catch (error) {
+        console.error('Failed to set global pipeline default:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to set global pipeline default',
+        };
+    }
+}

--- a/apps/web/src/components/settings/PipelineDefaultSelector.tsx
+++ b/apps/web/src/components/settings/PipelineDefaultSelector.tsx
@@ -25,20 +25,30 @@ export function PipelineDefaultSelector({ plugins }: PipelineDefaultSelectorProp
 
     const handleSelect = (pluginId: string | null) => {
         const newEnforce = pluginId === null ? false : enforce;
+        const prevId = selectedId;
+        const prevEnforce = enforce;
         setSelectedId(pluginId);
         if (pluginId === null) setEnforce(false);
-        save(pluginId, newEnforce);
+        save(pluginId, newEnforce, prevId, prevEnforce);
     };
 
     const handleEnforceToggle = (value: boolean) => {
+        const prevEnforce = enforce;
         setEnforce(value);
-        save(selectedId, value);
+        save(selectedId, value, selectedId, prevEnforce);
     };
 
-    const save = (pluginId: string | null, enforceValue: boolean) => {
+    const save = (
+        pluginId: string | null,
+        enforceValue: boolean,
+        prevId: string | null,
+        prevEnforce: boolean,
+    ) => {
         startTransition(async () => {
             const result = await setGlobalPipelineDefault(pluginId, enforceValue);
             if (!result.success) {
+                setSelectedId(prevId);
+                setEnforce(prevEnforce);
                 toast.error(result.error ?? t('saveFailed'));
             }
         });

--- a/apps/web/src/components/settings/PipelineDefaultSelector.tsx
+++ b/apps/web/src/components/settings/PipelineDefaultSelector.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import type { UserPlugin } from '@/lib/api/plugins';
+import { PluginIcon } from '@/components/plugins/PluginIcon';
+import { setGlobalPipelineDefault } from '@/app/actions/plugins';
+import { toast } from 'sonner';
+import { Shuffle, Lock } from 'lucide-react';
+
+interface PipelineDefaultSelectorProps {
+    plugins: UserPlugin[];
+}
+
+export function PipelineDefaultSelector({ plugins }: PipelineDefaultSelectorProps) {
+    const t = useTranslations('dashboard.settings.plugins.pipelineDefault');
+    const [isPending, startTransition] = useTransition();
+
+    // Determine current state from plugin metadata
+    const currentDefault = plugins.find((p) => p.metadata?.isGlobalPipelineDefault === true);
+    const currentEnforce = currentDefault?.metadata?.globalPipelineDefaultEnforce === true;
+
+    const [selectedId, setSelectedId] = useState<string | null>(currentDefault?.pluginId ?? null);
+    const [enforce, setEnforce] = useState<boolean>(currentEnforce);
+
+    const handleSelect = (pluginId: string | null) => {
+        const newEnforce = pluginId === null ? false : enforce;
+        setSelectedId(pluginId);
+        if (pluginId === null) setEnforce(false);
+        save(pluginId, newEnforce);
+    };
+
+    const handleEnforceToggle = (value: boolean) => {
+        setEnforce(value);
+        save(selectedId, value);
+    };
+
+    const save = (pluginId: string | null, enforceValue: boolean) => {
+        startTransition(async () => {
+            const result = await setGlobalPipelineDefault(pluginId, enforceValue);
+            if (!result.success) {
+                toast.error(result.error ?? t('saveFailed'));
+            }
+        });
+    };
+
+    return (
+        <div className="rounded-xl border border-border dark:border-border-dark bg-card dark:bg-card-primary-dark/30 overflow-hidden">
+            <div className="px-5 py-4 border-b border-border dark:border-border-dark">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                    {t('description')}
+                </p>
+            </div>
+
+            <div className="p-4 space-y-2">
+                {/* Auto option */}
+                <label
+                    className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer border transition-colors ${
+                        selectedId === null
+                            ? 'border-primary bg-primary/5 dark:bg-primary/10'
+                            : 'border-transparent hover:bg-surface dark:hover:bg-surface-dark'
+                    }`}
+                >
+                    <input
+                        type="radio"
+                        name="pipeline-default"
+                        checked={selectedId === null}
+                        onChange={() => handleSelect(null)}
+                        disabled={isPending}
+                        className="accent-primary"
+                    />
+                    <div className="flex items-center gap-2 flex-1 min-w-0">
+                        <div className="w-8 h-8 rounded-lg bg-surface-secondary dark:bg-surface-secondary-dark flex items-center justify-center shrink-0">
+                            <Shuffle className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                        </div>
+                        <div className="min-w-0">
+                            <p className="text-sm font-medium text-text dark:text-text-dark">
+                                {t('autoLabel')}
+                            </p>
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('autoDescription')}
+                            </p>
+                        </div>
+                    </div>
+                </label>
+
+                {/* Pipeline options */}
+                {plugins.map((plugin) => (
+                    <label
+                        key={plugin.pluginId}
+                        className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer border transition-colors ${
+                            selectedId === plugin.pluginId
+                                ? 'border-primary bg-primary/5 dark:bg-primary/10'
+                                : 'border-transparent hover:bg-surface dark:hover:bg-surface-dark'
+                        }`}
+                    >
+                        <input
+                            type="radio"
+                            name="pipeline-default"
+                            checked={selectedId === plugin.pluginId}
+                            onChange={() => handleSelect(plugin.pluginId)}
+                            disabled={isPending}
+                            className="accent-primary"
+                        />
+                        <div className="flex items-center gap-2 flex-1 min-w-0">
+                            <PluginIcon
+                                icon={plugin.icon}
+                                name={plugin.name}
+                                size={32}
+                                className="rounded-lg shrink-0"
+                            />
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium text-text dark:text-text-dark">
+                                    {plugin.name}
+                                </p>
+                                {plugin.description && (
+                                    <p className="text-xs text-text-muted dark:text-text-muted-dark line-clamp-1">
+                                        {plugin.description}
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+                    </label>
+                ))}
+            </div>
+
+            {/* Enforce toggle — only shown when a pipeline is selected */}
+            {selectedId !== null && (
+                <div className="px-5 py-4 border-t border-border dark:border-border-dark bg-surface/50 dark:bg-surface-dark/30">
+                    <label className="flex items-start gap-3 cursor-pointer">
+                        <div className="relative mt-0.5">
+                            <input
+                                type="checkbox"
+                                checked={enforce}
+                                onChange={(e) => handleEnforceToggle(e.target.checked)}
+                                disabled={isPending}
+                                className="peer sr-only"
+                            />
+                            <div className="w-9 h-5 bg-border dark:bg-border-dark rounded-full peer-checked:bg-primary transition-colors" />
+                            <div className="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform peer-checked:translate-x-4" />
+                        </div>
+                        <div>
+                            <div className="flex items-center gap-1.5">
+                                <Lock className="w-3.5 h-3.5 text-text-secondary dark:text-text-secondary-dark" />
+                                <p className="text-sm font-medium text-text dark:text-text-dark">
+                                    {t('enforceLabel')}
+                                </p>
+                            </div>
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
+                                {t('enforceDescription')}
+                            </p>
+                        </div>
+                    </label>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/plugins.ts
+++ b/apps/web/src/lib/api/plugins.ts
@@ -227,10 +227,7 @@ export const pluginsAPI = {
     /**
      * Set or clear the global default pipeline for the current user
      */
-    setGlobalPipelineDefault: async (
-        pluginId: string | null,
-        enforce: boolean,
-    ): Promise<void> => {
+    setGlobalPipelineDefault: async (pluginId: string | null, enforce: boolean): Promise<void> => {
         await serverMutation<void>({
             endpoint: '/plugins/pipeline-default',
             data: { pluginId, enforce },

--- a/apps/web/src/lib/api/plugins.ts
+++ b/apps/web/src/lib/api/plugins.ts
@@ -225,6 +225,21 @@ export const pluginsAPI = {
     },
 
     /**
+     * Set or clear the global default pipeline for the current user
+     */
+    setGlobalPipelineDefault: async (
+        pluginId: string | null,
+        enforce: boolean,
+    ): Promise<void> => {
+        await serverMutation<void>({
+            endpoint: '/plugins/pipeline-default',
+            data: { pluginId, enforce },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
      * Set active capability for a directory plugin
      */
     setActiveCapability: async (

--- a/apps/web/src/lib/api/server-api.ts
+++ b/apps/web/src/lib/api/server-api.ts
@@ -117,10 +117,12 @@ export async function serverFetch<T>(
         throw new Error(errorMessage || apiErro);
     }
 
+    const text = await response.text();
+    if (!text) return undefined as T;
     try {
-        return await response.json();
-    } catch (error) {
-        return (await response.text()) as T;
+        return JSON.parse(text) as T;
+    } catch {
+        return text as T;
     }
 }
 

--- a/packages/agent/src/database/repositories/api-key.repository.ts
+++ b/packages/agent/src/database/repositories/api-key.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThan, MoreThan, IsNull } from 'typeorm';
+import { Repository, MoreThan, IsNull } from 'typeorm';
 import { ApiKey } from '../../entities/api-key.entity';
 
 @Injectable()
@@ -54,9 +54,12 @@ export class ApiKeyRepository {
     }
 
     async deleteExpiredKeys(): Promise<number> {
-        const result = await this.repository.delete({
-            expiresAt: LessThan(new Date()),
-        });
+        const result = await this.repository
+            .createQueryBuilder('k')
+            .delete()
+            .where('k.expiresAt IS NOT NULL')
+            .andWhere('k.expiresAt < :now', { now: Date.now() })
+            .execute();
         return result.affected ?? 0;
     }
 }

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -580,7 +580,9 @@ export class PluginOperationsService {
             globalPipelineDefaultEnforce: enforce,
         };
         await this.userPluginRepository.save(userPlugin);
-        this.logger.log(`Global pipeline default set to "${pluginId}" (enforce=${enforce}) for user "${userId}"`);
+        this.logger.log(
+            `Global pipeline default set to "${pluginId}" (enforce=${enforce}) for user "${userId}"`,
+        );
     }
 
     // ============================================

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -527,15 +527,13 @@ export class PluginOperationsService {
         pluginId: string | null,
         enforce: boolean,
     ): Promise<void> {
-        const pipelines = this.pluginRegistryService.getByCapability(PLUGIN_CAPABILITIES.PIPELINE);
-
-        // Clear the flag from all pipeline plugins for this user
-        for (const registered of pipelines) {
-            const existing = await this.userPluginRepository.findOne({
-                where: { userId, pluginId: registered.plugin.id },
-            });
-            if (existing && existing.metadata?.isGlobalPipelineDefault) {
-                const newMeta = { ...existing.metadata };
+        // Clear the flag from all user plugins in the DB that have it set.
+        // Querying the DB directly (rather than the registry) ensures stale flags from
+        // previously-registered-but-now-unloaded plugins are also removed.
+        const flaggedPlugins = await this.userPluginRepository.find({ where: { userId } });
+        for (const existing of flaggedPlugins) {
+            if (existing.metadata?.isGlobalPipelineDefault) {
+                let newMeta = { ...existing.metadata };
                 delete newMeta.isGlobalPipelineDefault;
                 delete newMeta.globalPipelineDefaultEnforce;
                 await this.userPluginRepository.save({ ...existing, metadata: newMeta });

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -13,6 +13,7 @@ import {
     type JsonSchema,
     type PluginManifest,
     toPluginSettingsSchemaProperty,
+    PLUGIN_CAPABILITIES,
 } from '@ever-works/plugin';
 import type {
     PluginResponse,
@@ -509,6 +510,77 @@ export class PluginOperationsService {
         this.logger.log(`Plugin "${pluginId}" settings updated for user "${userId}"`);
 
         return this.toUserPluginResponse(registered, userPlugin);
+    }
+
+    /**
+     * Set or clear the user's global pipeline default preference.
+     *
+     * Clears `isGlobalPipelineDefault` from all pipeline plugins for this user,
+     * then marks the given plugin (if any) as the global default.
+     *
+     * @param userId - The user to update
+     * @param pluginId - Plugin to set as default, or null to clear
+     * @param enforce - When true, this pipeline is forced in the generator form
+     */
+    async setGlobalPipelineDefault(
+        userId: string,
+        pluginId: string | null,
+        enforce: boolean,
+    ): Promise<void> {
+        const pipelines = this.pluginRegistryService.getByCapability(PLUGIN_CAPABILITIES.PIPELINE);
+
+        // Clear the flag from all pipeline plugins for this user
+        for (const registered of pipelines) {
+            const existing = await this.userPluginRepository.findOne({
+                where: { userId, pluginId: registered.plugin.id },
+            });
+            if (existing && existing.metadata?.isGlobalPipelineDefault) {
+                const newMeta = { ...existing.metadata };
+                delete newMeta.isGlobalPipelineDefault;
+                delete newMeta.globalPipelineDefaultEnforce;
+                await this.userPluginRepository.save({ ...existing, metadata: newMeta });
+            }
+        }
+
+        if (!pluginId) return;
+
+        // Ensure the target plugin exists
+        const target = this.pluginRegistryService.get(pluginId);
+        if (!target) {
+            throw new NotFoundException(`Plugin "${pluginId}" not found`);
+        }
+        if (!target.plugin.capabilities.includes(PLUGIN_CAPABILITIES.PIPELINE)) {
+            throw new BadRequestException(`Plugin "${pluginId}" is not a pipeline plugin`);
+        }
+
+        // Find or create the user plugin record for the target
+        let userPlugin = await this.userPluginRepository.findOne({
+            where: { userId, pluginId },
+        });
+
+        if (!userPlugin) {
+            const pluginEntity = await this.pluginRepository.findOne({ where: { pluginId } });
+            if (!pluginEntity) {
+                throw new NotFoundException(`Plugin entity "${pluginId}" not found`);
+            }
+            userPlugin = this.userPluginRepository.create({
+                userId,
+                pluginId,
+                pluginEntityId: pluginEntity.id,
+                enabled: true,
+                settings: {},
+                secretSettings: {},
+                metadata: {},
+            });
+        }
+
+        userPlugin.metadata = {
+            ...userPlugin.metadata,
+            isGlobalPipelineDefault: true,
+            globalPipelineDefaultEnforce: enforce,
+        };
+        await this.userPluginRepository.save(userPlugin);
+        this.logger.log(`Global pipeline default set to "${pluginId}" (enforce=${enforce}) for user "${userId}"`);
     }
 
     // ============================================

--- a/packages/agent/src/plugins/services/plugin-settings.service.ts
+++ b/packages/agent/src/plugins/services/plugin-settings.service.ts
@@ -716,4 +716,23 @@ export class PluginSettingsService {
         }
         return filtered;
     }
+
+    /**
+     * Get the user's global pipeline default preference.
+     * Returns the pluginId and enforce flag if set, or null if not configured.
+     */
+    async getUserGlobalPipelineDefault(
+        userId: string,
+    ): Promise<{ pluginId: string; enforce: boolean } | null> {
+        const userPlugins = await this.userPluginRepository.findByUser(userId);
+        for (const up of userPlugins) {
+            if (up.metadata?.isGlobalPipelineDefault === true) {
+                return {
+                    pluginId: up.pluginId,
+                    enforce: up.metadata.globalPipelineDefaultEnforce === true,
+                };
+            }
+        }
+        return null;
+    }
 }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -114,8 +114,19 @@ export class GeneratorFormSchemaService {
             defaultValues = { ...defaultValues, ...dsFields.defaultValues };
         }
 
+        // Determine if the pipeline is enforced by the user's global default
+        let isPipelineEnforced = false;
+        if (options?.userId && this.pluginSettingsService) {
+            const globalDefault =
+                await this.pluginSettingsService.getUserGlobalPipelineDefault(options.userId);
+            if (globalDefault?.enforce) {
+                isPipelineEnforced = true;
+            }
+        }
+
         return {
             resolvedPipelineId: pipelinePlugin?.plugin.id,
+            isPipelineEnforced,
             providers,
             pluginFields,
             pluginGroups,
@@ -590,6 +601,21 @@ export class GeneratorFormSchemaService {
         pipelineId?: string,
         options?: FormSchemaOptions,
     ): Promise<RegisteredPlugin | undefined> {
+        // Resolve user's global pipeline default (if any)
+        let userGlobalDefault: { pluginId: string; enforce: boolean } | null = null;
+        if (options?.userId && this.pluginSettingsService) {
+            userGlobalDefault =
+                await this.pluginSettingsService.getUserGlobalPipelineDefault(options.userId);
+        }
+
+        // 0. Enforced user global default — overrides everything including explicit form selection
+        if (userGlobalDefault?.enforce) {
+            const registered = this.pluginRegistry.get(userGlobalDefault.pluginId);
+            if (registered && registered.state === 'loaded') {
+                return registered;
+            }
+        }
+
         // 1. Explicit pipelineId — use it directly
         if (pipelineId) {
             const registered = this.pluginRegistry.get(pipelineId);
@@ -597,6 +623,14 @@ export class GeneratorFormSchemaService {
                 return registered;
             }
             this.logger.warn(`Pipeline plugin not found or not enabled: ${pipelineId}`);
+        }
+
+        // 1.5. Non-enforced user global default — preferred over directory/manifest defaults
+        if (userGlobalDefault && !userGlobalDefault.enforce) {
+            const registered = this.pluginRegistry.get(userGlobalDefault.pluginId);
+            if (registered && registered.state === 'loaded') {
+                return registered;
+            }
         }
 
         // 2. Directory's activeCapability for 'pipeline'

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -117,8 +117,9 @@ export class GeneratorFormSchemaService {
         // Determine if the pipeline is enforced by the user's global default
         let isPipelineEnforced = false;
         if (options?.userId && this.pluginSettingsService) {
-            const globalDefault =
-                await this.pluginSettingsService.getUserGlobalPipelineDefault(options.userId);
+            const globalDefault = await this.pluginSettingsService.getUserGlobalPipelineDefault(
+                options.userId,
+            );
             if (globalDefault?.enforce) {
                 isPipelineEnforced = true;
             }
@@ -604,8 +605,9 @@ export class GeneratorFormSchemaService {
         // Resolve user's global pipeline default (if any)
         let userGlobalDefault: { pluginId: string; enforce: boolean } | null = null;
         if (options?.userId && this.pluginSettingsService) {
-            userGlobalDefault =
-                await this.pluginSettingsService.getUserGlobalPipelineDefault(options.userId);
+            userGlobalDefault = await this.pluginSettingsService.getUserGlobalPipelineDefault(
+                options.userId,
+            );
         }
 
         // 0. Enforced user global default — overrides everything including explicit form selection

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -63,8 +63,14 @@ export class GeneratorFormSchemaService {
         pipelineId?: string,
         options?: FormSchemaOptions,
     ): Promise<GeneratorFormSchema> {
+        // Fetch the user's global pipeline default once and share with resolvePipelinePlugin
+        const userGlobalDefault =
+            options?.userId && this.pluginSettingsService
+                ? await this.pluginSettingsService.getUserGlobalPipelineDefault(options.userId)
+                : null;
+
         // Resolve the selected pipeline plugin
-        const pipelinePlugin = await this.resolvePipelinePlugin(pipelineId, options);
+        const pipelinePlugin = await this.resolvePipelinePlugin(pipelineId, options, userGlobalDefault);
 
         // Get available providers for each capability category (filtered by enable status)
         const providers = await this.getAvailableProviders(options);
@@ -114,16 +120,10 @@ export class GeneratorFormSchemaService {
             defaultValues = { ...defaultValues, ...dsFields.defaultValues };
         }
 
-        // Determine if the pipeline is enforced by the user's global default
-        let isPipelineEnforced = false;
-        if (options?.userId && this.pluginSettingsService) {
-            const globalDefault = await this.pluginSettingsService.getUserGlobalPipelineDefault(
-                options.userId,
-            );
-            if (globalDefault?.enforce) {
-                isPipelineEnforced = true;
-            }
-        }
+        // Only enforce if the stored enforced plugin was actually resolved and loaded
+        const isPipelineEnforced =
+            userGlobalDefault?.enforce === true &&
+            pipelinePlugin?.plugin.id === userGlobalDefault.pluginId;
 
         return {
             resolvedPipelineId: pipelinePlugin?.plugin.id,
@@ -601,10 +601,10 @@ export class GeneratorFormSchemaService {
     private async resolvePipelinePlugin(
         pipelineId?: string,
         options?: FormSchemaOptions,
+        userGlobalDefault?: { pluginId: string; enforce: boolean } | null,
     ): Promise<RegisteredPlugin | undefined> {
-        // Resolve user's global pipeline default (if any)
-        let userGlobalDefault: { pluginId: string; enforce: boolean } | null = null;
-        if (options?.userId && this.pluginSettingsService) {
+        // Resolve user's global pipeline default — use pre-fetched value if provided
+        if (userGlobalDefault === undefined && options?.userId && this.pluginSettingsService) {
             userGlobalDefault = await this.pluginSettingsService.getUserGlobalPipelineDefault(
                 options.userId,
             );

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -70,7 +70,11 @@ export class GeneratorFormSchemaService {
                 : null;
 
         // Resolve the selected pipeline plugin
-        const pipelinePlugin = await this.resolvePipelinePlugin(pipelineId, options, userGlobalDefault);
+        const pipelinePlugin = await this.resolvePipelinePlugin(
+            pipelineId,
+            options,
+            userGlobalDefault,
+        );
 
         // Get available providers for each capability category (filtered by enable status)
         const providers = await this.getAvailableProviders(options);

--- a/packages/plugin/src/contracts/capabilities/form-schema-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/form-schema-provider.interface.ts
@@ -83,6 +83,11 @@ export function isFormSchemaProvider(plugin: IPlugin): plugin is IFormSchemaProv
 export interface GeneratorFormSchema {
 	/** Pipeline plugin ID the server resolved for this schema */
 	resolvedPipelineId?: string;
+	/**
+	 * When true, the user has configured a global default pipeline with "enforce" mode.
+	 * The frontend should lock the pipeline selector and not allow changes.
+	 */
+	isPipelineEnforced?: boolean;
 	/** Available providers for each capability category (derived from SELECTABLE_PROVIDER_CATEGORIES) */
 	providers: FormSchemaProvidersType;
 	pluginFields: FormFieldDefinition[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global default pipeline selector in plugin settings with an "Auto" option and per-option Enforce toggle.
  * Frontend and backend support to save a user-level pipeline default.
  * Generator form now indicates when a pipeline is enforced so the UI can lock selection.

* **Localization**
  * Added localized copy for the pipeline default UI and related error message.

* **Bug Fixes**
  * Improved server response parsing for more reliable API handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->