### PR TITLE
Add configurable git committer overrides

### DIFF
--- a/apps/api/src/auth/dto/update-profile.dto.ts
+++ b/apps/api/src/auth/dto/update-profile.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, MinLength, IsUrl } from 'class-validator';
+import { IsString, IsOptional, MinLength, IsUrl, IsEmail } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateProfileDto {
@@ -15,4 +15,18 @@ export class UpdateProfileDto {
     @IsUrl()
     @IsOptional()
     avatar?: string;
+
+    @ApiPropertyOptional({
+        description: 'Custom git committer name (overrides username for commits)',
+    })
+    @IsString()
+    @IsOptional()
+    committerName?: string | null;
+
+    @ApiPropertyOptional({
+        description: 'Custom git committer email (overrides account email for commits)',
+    })
+    @IsEmail()
+    @IsOptional()
+    committerEmail?: string | null;
 }

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -475,10 +475,16 @@ export class AuthService {
         };
 
         // Update user profile
-        await this.userRepository.update(userId, {
-            ...(isNotNull(updateData.username) && { username: updateData.username }),
-            ...(isNotNull(updateData.avatar) && { avatar: updateData.avatar }),
-        });
+        const updateFields: Record<string, any> = {};
+        if (isNotNull(updateData.username)) updateFields.username = updateData.username;
+        if (isNotNull(updateData.avatar)) updateFields.avatar = updateData.avatar;
+        // Allow explicitly setting committer fields to null (to clear them)
+        if (updateData.committerName !== undefined)
+            updateFields.committerName = updateData.committerName || null;
+        if (updateData.committerEmail !== undefined)
+            updateFields.committerEmail = updateData.committerEmail || null;
+
+        await this.userRepository.update(userId, updateFields);
 
         // Return updated profile
         return this.getUserProfile(userId);

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -323,7 +323,7 @@ export class DeployService {
                     owner: directory.getRepoOwner(),
                     repo: directory.getWebsiteRepo(),
                     branch: WEBSITE_TEMPLATE_CONFIG.branch,
-                    committer: user.asCommitter(),
+                    committer: directory.resolveCommitter(user),
                 },
                 { userId: directoryOwner.id, providerId: directory.gitProvider },
             );
@@ -340,7 +340,7 @@ export class DeployService {
                 directory.gitProvider,
                 repoDir,
                 `chore: trigger deployment\n\nTriggered by Ever Works platform`,
-                user.asCommitter(),
+                directory.resolveCommitter(user),
             );
             await this.gitFacade.push(
                 { dir: repoDir },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -478,6 +478,12 @@
                     "resend": "Resend",
                     "sent": "Verification email sent. Check your inbox.",
                     "sendFailed": "Failed to send verification email. Please try again."
+                },
+                "committer": {
+                    "title": "Git Committer",
+                    "description": "Override the name and email used in git commits. Leave empty to use your account name ({defaultName}) and email ({defaultEmail}).",
+                    "nameLabel": "Committer Name",
+                    "emailLabel": "Committer Email"
                 }
             },
             "security": {
@@ -1680,6 +1686,15 @@
                             "targetBlank": "New tab"
                         }
                     }
+                },
+                "committer": {
+                    "title": "Git Committer",
+                    "description": "Override the committer name and email for git commits in this directory. Leave empty to use your user-level settings or account defaults.",
+                    "nameLabel": "Committer Name",
+                    "emailLabel": "Committer Email",
+                    "save": "Save Committer",
+                    "saved": "Committer settings saved",
+                    "saveFailed": "Failed to save committer settings"
                 }
             },
             "deploy": {

--- a/apps/web/src/app/actions/dashboard/directories.ts
+++ b/apps/web/src/app/actions/dashboard/directories.ts
@@ -987,3 +987,31 @@ export async function updateCommunityPrSettings(
         };
     }
 }
+
+export async function updateCommitterSettings(
+    directoryId: string,
+    settings: {
+        committerName?: string | null;
+        committerEmail?: string | null;
+    },
+) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await directoryAPI.update(directoryId, settings);
+        revalidatePath(`/directories/${directoryId}/settings`);
+
+        return {
+            success: response.status === 'success',
+        };
+    } catch (error) {
+        console.error('Failed to update committer settings:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to update committer settings',
+        };
+    }
+}

--- a/apps/web/src/app/actions/settings.ts
+++ b/apps/web/src/app/actions/settings.ts
@@ -26,7 +26,11 @@ export async function resendVerificationEmail() {
 }
 
 // Profile Actions
-export async function updateProfile(data: { username: string }) {
+export async function updateProfile(data: {
+    username: string;
+    committerName?: string | null;
+    committerEmail?: string | null;
+}) {
     const t = await getTranslations('actions.settings.profile');
     const tAuth = await getTranslations('validation.auth');
 
@@ -38,6 +42,8 @@ export async function updateProfile(data: { username: string }) {
                 VALIDATION_RULES.USERNAME_MIN_LENGTH,
                 tAuth('username.minLength', { length: VALIDATION_RULES.USERNAME_MIN_LENGTH }),
             ),
+        committerName: z.string().nullable().optional(),
+        committerEmail: z.string().email().nullable().optional().or(z.literal('')),
     });
 
     try {
@@ -55,7 +61,11 @@ export async function updateProfile(data: { username: string }) {
             };
         }
 
-        const result = await authAPI.updateProfile(validation.data);
+        const { committerEmail, ...rest } = validation.data;
+        const result = await authAPI.updateProfile({
+            ...rest,
+            committerEmail: committerEmail === '' ? null : committerEmail,
+        });
         revalidatePath(ROUTES.DASHBOARD_SETTINGS);
 
         return { success: true, data: result };

--- a/apps/web/src/components/directories/detail/settings/CommitterSettings.tsx
+++ b/apps/web/src/components/directories/detail/settings/CommitterSettings.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { useTranslations } from 'next-intl';
+import { useSettings } from './SettingsContext';
+import { Button } from '@/components/ui/button';
+import { updateCommitterSettings } from '@/app/actions/dashboard/directories';
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+export function CommitterSettings() {
+    const t = useTranslations('dashboard.directoryDetail.settings');
+    const { context } = useSettings();
+    const { directory, user } = context;
+
+    const [committerName, setCommitterName] = useState(directory.committerName || '');
+    const [committerEmail, setCommitterEmail] = useState(directory.committerEmail || '');
+    const [isPending, startTransition] = useTransition();
+
+    const handleSave = (e: React.FormEvent) => {
+        e.preventDefault();
+        startTransition(async () => {
+            const result = await updateCommitterSettings(directory.id, {
+                committerName: committerName.trim() || null,
+                committerEmail: committerEmail.trim() || null,
+            });
+            if (result?.success) {
+                toast.success(t('committer.saved'));
+            } else {
+                toast.error(result?.error || t('committer.saveFailed'));
+            }
+        });
+    };
+
+    // Placeholders show the auth defaults (actual fallback includes user-level settings)
+    const defaultName = user.username;
+    const defaultEmail = user.email;
+
+    return (
+        <div
+            className={cn(
+                'rounded-lg border overflow-hidden',
+                'bg-card dark:bg-card-primary-dark/30',
+                'border-card-border dark:border-card-border-dark',
+            )}
+        >
+            <div className="px-5 py-3.5 border-b border-card-border dark:border-card-border-dark">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('committer.title')}
+                </h3>
+            </div>
+
+            <form onSubmit={handleSave} className="px-5 py-4 space-y-4">
+                <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                    {t('committer.description')}
+                </p>
+
+                <Input
+                    label={t('committer.nameLabel')}
+                    type="text"
+                    value={committerName}
+                    onChange={(e) => setCommitterName(e.target.value)}
+                    placeholder={defaultName}
+                    variant="form"
+                />
+
+                <Input
+                    label={t('committer.emailLabel')}
+                    type="email"
+                    value={committerEmail}
+                    onChange={(e) => setCommitterEmail(e.target.value)}
+                    placeholder={defaultEmail}
+                    variant="form"
+                />
+
+                <Button type="submit" disabled={isPending} loading={isPending} variant="primary">
+                    {t('committer.save')}
+                </Button>
+            </form>
+        </div>
+    );
+}

--- a/apps/web/src/components/directories/detail/settings/SettingsContext.tsx
+++ b/apps/web/src/components/directories/detail/settings/SettingsContext.tsx
@@ -42,6 +42,8 @@ export const SettingsProvider = ({
             footer: '',
             overwriteDefaultFooter: false,
         },
+        committerName: directory.committerName ?? null,
+        committerEmail: directory.committerEmail ?? null,
     });
 
     const value = useMemo(() => {

--- a/apps/web/src/components/directories/detail/settings/SettingsForm.tsx
+++ b/apps/web/src/components/directories/detail/settings/SettingsForm.tsx
@@ -12,6 +12,7 @@ import { RepoVisibilitySettings } from './RepoVisibilitySettings';
 import { AdvancedPromptsSettings } from './AdvancedPromptsSettings';
 import { CommunityPrSettings } from './CommunityPrSettings';
 import { WebsiteConfigSettings } from './WebsiteConfigSettings';
+import { CommitterSettings } from './CommitterSettings';
 interface SettingsFormProps {
     directory: Directory;
     user: AuthUser;
@@ -44,6 +45,9 @@ export function SettingsForm({ directory, user, initialRepositories }: SettingsF
 
                 {/* Website Configuration Settings */}
                 <WebsiteConfigSettings directoryId={directory.id} />
+
+                {/* Git Committer Settings */}
+                <CommitterSettings />
 
                 {/* Danger Zone */}
                 <DeleteComponent directory={directory} />

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -14,6 +14,8 @@ interface ProfileSettingsProps {
         username: string;
         email: string;
         emailVerified?: boolean;
+        committerName?: string | null;
+        committerEmail?: string | null;
     };
 }
 
@@ -21,6 +23,8 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
     const [isPending, startTransition] = useTransition();
     const [isResending, startResendTransition] = useTransition();
     const [username, setUsername] = useState(user.username);
+    const [committerName, setCommitterName] = useState(user.committerName || '');
+    const [committerEmail, setCommitterEmail] = useState(user.committerEmail || '');
     const t = useTranslations('dashboard.settings.profile');
 
     const handleResendVerification = () => {
@@ -48,6 +52,8 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
             try {
                 const result = await updateProfile({
                     username: username.trim(),
+                    committerName: committerName.trim() || null,
+                    committerEmail: committerEmail.trim() || null,
                 });
 
                 if (result.success) {
@@ -110,6 +116,35 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
                     disabled
                     helperText={t('fields.emailHelperText')}
                 />
+
+                {/* Git Committer Fields */}
+                <div className="border-t border-border dark:border-border-dark pt-4">
+                    <p className="text-sm font-medium text-text dark:text-text-dark mb-1">
+                        {t('committer.title')}
+                    </p>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark mb-3">
+                        {t('committer.description', {
+                            defaultName: user.username,
+                            defaultEmail: user.email,
+                        })}
+                    </p>
+                    <div className="space-y-3">
+                        <Input
+                            label={t('committer.nameLabel')}
+                            type="text"
+                            value={committerName}
+                            onChange={(e) => setCommitterName(e.target.value)}
+                            placeholder={user.username}
+                        />
+                        <Input
+                            label={t('committer.emailLabel')}
+                            type="email"
+                            value={committerEmail}
+                            onChange={(e) => setCommitterEmail(e.target.value)}
+                            placeholder={user.email}
+                        />
+                    </div>
+                </div>
 
                 {/* Save Button */}
                 <div className="flex justify-end">

--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -27,6 +27,8 @@ export interface UpdatePasswordDto {
 export interface UpdateProfileDto {
     username?: string;
     avatar?: string;
+    committerName?: string | null;
+    committerEmail?: string | null;
 }
 
 // DTOs - Email Verification
@@ -57,6 +59,8 @@ export interface UserProfile {
     email: string;
     avatar?: string;
     emailVerified?: boolean;
+    committerName?: string | null;
+    committerEmail?: string | null;
 }
 
 export interface OAuthUrlResponse {

--- a/apps/web/src/lib/api/directory.ts
+++ b/apps/web/src/lib/api/directory.ts
@@ -64,6 +64,8 @@ export interface UpdateDirectoryDto {
     websiteTemplateUseBeta?: boolean;
     communityPrEnabled?: boolean;
     communityPrAutoClose?: boolean;
+    committerName?: string | null;
+    committerEmail?: string | null;
 }
 
 export interface DeleteDirectoryDto {
@@ -162,6 +164,9 @@ export interface Directory {
     // Import Source FIELDS
     sourceRepository?: SourceRepository;
     repoVisibility?: RepoVisibility;
+    // Git committer overrides
+    committerName?: string | null;
+    committerEmail?: string | null;
 }
 
 export interface DirectoriesResponse {

--- a/packages/agent/src/dto/update-directory.dto.ts
+++ b/packages/agent/src/dto/update-directory.dto.ts
@@ -1,5 +1,12 @@
 import { Type, Transform } from 'class-transformer';
-import { IsOptional, IsString, IsBoolean, IsEmail, ValidateNested, MaxLength } from 'class-validator';
+import {
+    IsOptional,
+    IsString,
+    IsBoolean,
+    IsEmail,
+    ValidateNested,
+    MaxLength,
+} from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { MarkdownReadmeConfigDto } from './create-directory.dto';
 import { sanitizeName, sanitizeDescription } from '../utils/sanitize.util';

--- a/packages/agent/src/dto/update-directory.dto.ts
+++ b/packages/agent/src/dto/update-directory.dto.ts
@@ -1,5 +1,5 @@
 import { Type, Transform } from 'class-transformer';
-import { IsOptional, IsString, IsBoolean, ValidateNested, MaxLength } from 'class-validator';
+import { IsOptional, IsString, IsBoolean, IsEmail, ValidateNested, MaxLength } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { MarkdownReadmeConfigDto } from './create-directory.dto';
 import { sanitizeName, sanitizeDescription } from '../utils/sanitize.util';
@@ -70,7 +70,7 @@ export class UpdateDirectoryDto {
     committerName?: string | null;
 
     @ApiPropertyOptional({ description: 'Custom git committer email for this directory' })
-    @IsString()
+    @IsEmail()
     @IsOptional()
     committerEmail?: string | null;
 }

--- a/packages/agent/src/dto/update-directory.dto.ts
+++ b/packages/agent/src/dto/update-directory.dto.ts
@@ -63,4 +63,14 @@ export class UpdateDirectoryDto {
     @IsOptional()
     @IsBoolean()
     communityPrAutoClose?: boolean;
+
+    @ApiPropertyOptional({ description: 'Custom git committer name for this directory' })
+    @IsString()
+    @IsOptional()
+    committerName?: string | null;
+
+    @ApiPropertyOptional({ description: 'Custom git committer email for this directory' })
+    @IsString()
+    @IsOptional()
+    committerEmail?: string | null;
 }

--- a/packages/agent/src/entities/directory.entity.ts
+++ b/packages/agent/src/entities/directory.entity.ts
@@ -135,10 +135,10 @@ export class Directory {
     itemsCount?: number;
 
     // Git committer overrides at directory level (optional — fallback to user/default)
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     committerName?: string | null;
 
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     committerEmail?: string | null;
 
     // Import Source FIELDS

--- a/packages/agent/src/entities/directory.entity.ts
+++ b/packages/agent/src/entities/directory.entity.ts
@@ -219,8 +219,9 @@ export class Directory {
      * Priority: directory-level override → user-level override → user default (username/email)
      */
     resolveCommitter(user: User): { name: string; email: string } {
-        const name = this.committerName || user.asCommitter().name;
-        const email = this.committerEmail || user.asCommitter().email;
+        const userCommitter = user.asCommitter();
+        const name = this.committerName || userCommitter.name;
+        const email = this.committerEmail || userCommitter.email;
         return { name, email };
     }
 

--- a/packages/agent/src/entities/directory.entity.ts
+++ b/packages/agent/src/entities/directory.entity.ts
@@ -134,6 +134,13 @@ export class Directory {
     @Column({ nullable: true })
     itemsCount?: number;
 
+    // Git committer overrides at directory level (optional — fallback to user/default)
+    @Column({ nullable: true })
+    committerName?: string | null;
+
+    @Column({ nullable: true })
+    committerEmail?: string | null;
+
     // Import Source FIELDS
     @Column('simple-json', { nullable: true })
     sourceRepository?: SourceRepository;
@@ -205,6 +212,16 @@ export class Directory {
 
     getRepoOwner(): string {
         return this.owner || this.user?.username || '';
+    }
+
+    /**
+     * Resolve the git committer for this directory.
+     * Priority: directory-level override → user-level override → user default (username/email)
+     */
+    resolveCommitter(user: User): { name: string; email: string } {
+        const name = this.committerName || user.asCommitter().name;
+        const email = this.committerEmail || user.asCommitter().email;
+        return { name, email };
     }
 
     /**

--- a/packages/agent/src/entities/user.entity.ts
+++ b/packages/agent/src/entities/user.entity.ts
@@ -63,6 +63,13 @@ export class User {
     @Column({ nullable: true })
     passwordResetExpires: Date;
 
+    // Git committer overrides (optional — fallback to username/email if not set)
+    @Column({ nullable: true })
+    committerName?: string | null;
+
+    @Column({ nullable: true })
+    committerEmail?: string | null;
+
     // Timestamps
     @CreateDateColumn()
     createdAt: Date;
@@ -95,6 +102,9 @@ export class User {
     local: boolean = false;
 
     asCommitter(): { name: string; email: string } {
-        return { name: this.username, email: this.email };
+        return {
+            name: this.committerName || this.username,
+            email: this.committerEmail || this.email,
+        };
     }
 }

--- a/packages/agent/src/entities/user.entity.ts
+++ b/packages/agent/src/entities/user.entity.ts
@@ -64,10 +64,10 @@ export class User {
     passwordResetExpires: Date;
 
     // Git committer overrides (optional — fallback to username/email if not set)
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     committerName?: string | null;
 
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     committerEmail?: string | null;
 
     // Timestamps

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -183,7 +183,7 @@ export class DataGeneratorService {
         // Use directory owner's credentials (they set up the repos)
         // but use current user as committer for attribution
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const owner = directory.getRepoOwner();
         const repo = directory.getDataRepo();
 
@@ -364,7 +364,7 @@ export class DataGeneratorService {
                 provider,
                 data.dir,
                 existed ? 'update items' : 'init repository',
-                user.asCommitter(),
+                directory.resolveCommitter(user),
             );
 
             this.logger.debug('files written and committed.');
@@ -469,7 +469,12 @@ export class DataGeneratorService {
                         ? `add ${newItemsCount} new item${newItemsCount > 1 ? 's' : ''}${updatedItemsCount > 0 ? `, update ${updatedItemsCount}` : ''}`
                         : `update ${updatedItemsCount} item${updatedItemsCount > 1 ? 's' : ''}`;
 
-                await this.gitFacade.commit(provider, data.dir, commitMessage, user.asCommitter());
+                await this.gitFacade.commit(
+                    provider,
+                    data.dir,
+                    commitMessage,
+                    directory.resolveCommitter(user),
+                );
 
                 this.logger.debug(`Batch committed ${newItems.length} items`);
             }
@@ -573,7 +578,7 @@ export class DataGeneratorService {
     ): Promise<UpdateMarkdownTemplateResult> {
         // Use directory owner's credentials (they set up the repos)
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const owner = directory.getRepoOwner();
         const repo = directory.getDataRepo();
 
@@ -710,7 +715,7 @@ export class DataGeneratorService {
      */
     async saveCategories(directory: Directory, user: User, categories: Category[]) {
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const repo = directory.getDataRepo();
 
         const dest = await this.gitFacade.cloneOrPull(
@@ -740,7 +745,7 @@ export class DataGeneratorService {
      */
     async saveTags(directory: Directory, user: User, tags: Tag[]) {
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const repo = directory.getDataRepo();
 
         const dest = await this.gitFacade.cloneOrPull(
@@ -765,7 +770,7 @@ export class DataGeneratorService {
      */
     async saveCollections(directory: Directory, user: User, collections: Collection[]) {
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const repo = directory.getDataRepo();
 
         const dest = await this.gitFacade.cloneOrPull(
@@ -885,7 +890,7 @@ export class DataGeneratorService {
         companyWebsite?: string,
     ): Promise<void> {
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
 
         const data = await this.repositoryData(directory, user);
         const currentConfig = await data.getConfig();
@@ -935,7 +940,7 @@ export class DataGeneratorService {
     private async repositoryData(directory: Directory, user: User) {
         // Use directory owner's credentials (they set up the repos)
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
 
         const repo = directory.getDataRepo();
 
@@ -1094,7 +1099,7 @@ export class DataGeneratorService {
      */
     private async getExistingData(directory: Directory, user: User) {
         const directoryOwner = this.getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const repo = directory.getDataRepo();
 
         try {
@@ -1211,7 +1216,7 @@ export class DataGeneratorService {
             };
         },
     ): Promise<InitializeResult> {
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
 
         try {
             // Create the data repository
@@ -1366,7 +1371,7 @@ export class DataGeneratorService {
             commitMessage?: string;
         } = { updateWithPullRequest: true },
     ): Promise<InitializeResult> {
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const repoName = directory.getDataRepo();
         const repoOwner = directory.getRepoOwner();
 

--- a/packages/agent/src/generators/markdown-generator/markdown-generator.service.ts
+++ b/packages/agent/src/generators/markdown-generator/markdown-generator.service.ts
@@ -28,7 +28,7 @@ export class MarkdownGeneratorService {
 
     async initialize(directory: Directory, user: User, options: InitializeOptions = {}) {
         const directoryOwner = getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const description = directory.description;
 
         // Create repository through facade
@@ -180,7 +180,7 @@ export class MarkdownGeneratorService {
                 provider,
                 markdownPath,
                 'sync README.md',
-                user.asCommitter(),
+                directory.resolveCommitter(user),
             );
             await this.gitFacade.push(
                 { dir: markdownPath },
@@ -231,7 +231,7 @@ export class MarkdownGeneratorService {
 
     async removeItemDetail(directory: Directory, user: User, slug: string, branch?: string) {
         const directoryOwner = getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
 
         const markdownPath = await this.gitFacade.cloneOrPull(
             {

--- a/packages/agent/src/generators/website-generator/branch-sync.service.ts
+++ b/packages/agent/src/generators/website-generator/branch-sync.service.ts
@@ -53,7 +53,7 @@ export class BranchSyncService {
                 targetOwner: directory.getRepoOwner(),
                 targetRepo: directory.getWebsiteRepo(),
                 userId: directoryOwner.id,
-                committer: user.asCommitter(),
+                committer: directory.resolveCommitter(user),
                 forcePush: true,
                 branchMapping,
                 providerId: directory.gitProvider,

--- a/packages/agent/src/generators/website-generator/website-generator.service.ts
+++ b/packages/agent/src/generators/website-generator/website-generator.service.ts
@@ -19,7 +19,7 @@ export class WebsiteGeneratorService {
 
     private async duplicate(directory: Directory, user: User) {
         const directoryOwner = getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
 
         await this.cleanup(directory);
 

--- a/packages/agent/src/generators/website-generator/website-update.service.ts
+++ b/packages/agent/src/generators/website-generator/website-update.service.ts
@@ -156,7 +156,7 @@ export class WebsiteUpdateService {
      */
     private async updateFork(directory: Directory, user: User): Promise<boolean> {
         const directoryOwner = getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const websiteRepo = directory.getWebsiteRepo();
 
         try {
@@ -215,7 +215,7 @@ export class WebsiteUpdateService {
                 owner: WEBSITE_TEMPLATE_CONFIG.owner,
                 repo: WEBSITE_TEMPLATE_CONFIG.repo,
                 branch,
-                committer: user.asCommitter(),
+                committer: directory.resolveCommitter(user),
             },
             { userId: directoryOwner.id, providerId: directory.gitProvider },
         );
@@ -256,7 +256,7 @@ export class WebsiteUpdateService {
         branch: string = WEBSITE_TEMPLATE_CONFIG.branch,
     ): Promise<void> {
         const directoryOwner = getDirectoryOwner(directory);
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const websiteRepo = directory.getWebsiteRepo();
 
         // Clone both repositories

--- a/packages/agent/src/import/import-executor.service.ts
+++ b/packages/agent/src/import/import-executor.service.ts
@@ -69,7 +69,7 @@ export class ImportExecutorService {
                 {
                     owner: source.owner,
                     repo: source.repo,
-                    committer: user.asCommitter(),
+                    committer: directory.resolveCommitter(user),
                 },
                 { userId: user.id, providerId: directory.gitProvider, token },
             );
@@ -264,7 +264,7 @@ export class ImportExecutorService {
                 {
                     owner: source.owner,
                     repo: source.repo,
-                    committer: user.asCommitter(),
+                    committer: directory.resolveCommitter(user),
                 },
                 { userId: user.id, providerId: directory.gitProvider, token },
             );

--- a/packages/agent/src/items-generator/item-submission.service.ts
+++ b/packages/agent/src/items-generator/item-submission.service.ts
@@ -38,7 +38,7 @@ export class ItemSubmissionService {
             // Use directory owner's credentials (they set up the repos)
             // but use current user as committer for attribution
             const directoryOwner = directory.user as User;
-            const committer = user.asCommitter();
+            const committer = directory.resolveCommitter(user);
 
             const repo = directory.getDataRepo();
             const owner = directory.getRepoOwner();
@@ -176,7 +176,7 @@ export class ItemSubmissionService {
                 provider,
                 dest,
                 `Add ${itemWithMarkdown.name}`,
-                user.asCommitter(),
+                directory.resolveCommitter(user),
             );
 
             // Push changes
@@ -283,7 +283,7 @@ export class ItemSubmissionService {
             // Use directory owner's credentials (they set up the repos)
             // but use current user as committer for attribution
             const directoryOwner = directory.user as User;
-            const committer = user.asCommitter();
+            const committer = directory.resolveCommitter(user);
 
             const repo = directory.getDataRepo();
             const owner = directory.getRepoOwner();
@@ -362,7 +362,12 @@ export class ItemSubmissionService {
             const commitMessage = removeItemDto.reason
                 ? `Remove ${itemData.name} - ${removeItemDto.reason}`
                 : `Remove ${itemData.name}`;
-            await this.gitFacade.commit(provider, dest, commitMessage, user.asCommitter());
+            await this.gitFacade.commit(
+                provider,
+                dest,
+                commitMessage,
+                directory.resolveCommitter(user),
+            );
 
             // Push changes
             await this.gitFacade.push(
@@ -438,7 +443,7 @@ export class ItemSubmissionService {
             // Use directory owner's credentials (they set up the repos)
             // but use current user as committer for attribution
             const directoryOwner = directory.user as User;
-            const committer = user.asCommitter();
+            const committer = directory.resolveCommitter(user);
 
             const repo = directory.getDataRepo();
             const owner = directory.getRepoOwner();
@@ -530,7 +535,12 @@ export class ItemSubmissionService {
             const commitMessage = sourceUrlChanged
                 ? `Update ${updatedItem.name} source`
                 : `Update ${updatedItem.name} metadata`;
-            await this.gitFacade.commit(provider, dest, commitMessage, user.asCommitter());
+            await this.gitFacade.commit(
+                provider,
+                dest,
+                commitMessage,
+                directory.resolveCommitter(user),
+            );
             await this.gitFacade.push(
                 { dir: dest },
                 { userId: directoryOwner.id, providerId: directory.gitProvider },

--- a/packages/agent/src/services/directory-import.service.ts
+++ b/packages/agent/src/services/directory-import.service.ts
@@ -588,7 +588,7 @@ export class DirectoryImportService {
                 {
                     owner: source.owner,
                     repo: source.repo,
-                    committer: user.asCommitter(),
+                    committer: directory.resolveCommitter(user),
                 },
                 { userId: user.id, providerId: directory.gitProvider },
             );

--- a/packages/agent/src/services/directory-lifecycle.service.ts
+++ b/packages/agent/src/services/directory-lifecycle.service.ts
@@ -130,6 +130,14 @@ export class DirectoryLifecycleService {
                 updateData.communityPrAutoClose = updateDto.communityPrAutoClose;
             }
 
+            // Handle committer overrides (allow null to clear them)
+            if (updateDto.committerName !== undefined) {
+                updateData.committerName = updateDto.committerName || null;
+            }
+            if (updateDto.committerEmail !== undefined) {
+                updateData.committerEmail = updateDto.committerEmail || null;
+            }
+
             const updatedDirectory = await this.directoryRepository.update(id, updateData);
 
             if (!updatedDirectory) {

--- a/packages/agent/src/services/directory-query.service.ts
+++ b/packages/agent/src/services/directory-query.service.ts
@@ -25,7 +25,8 @@ type DirectoryMethods =
     | 'isCreator'
     | 'getMember'
     | 'hasAccess'
-    | 'getUserRole';
+    | 'getUserRole'
+    | 'resolveCommitter';
 
 export type DirectoryWithRole = Omit<Directory, DirectoryMethods> & {
     userRole: DirectoryMemberRole;

--- a/packages/agent/src/services/item-health.service.ts
+++ b/packages/agent/src/services/item-health.service.ts
@@ -162,7 +162,7 @@ export class ItemHealthService {
         options: { trigger: HealthCheckTrigger; itemSlugs?: string[] },
     ): Promise<DirectoryHealthCheckResult> {
         const directoryOwner = directory.user as User;
-        const committer = user.asCommitter();
+        const committer = directory.resolveCommitter(user);
         const repo = directory.getDataRepo();
         const owner = directory.getRepoOwner();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set a Git committer name and email in your profile with validation and save feedback.
  * Define directory-specific committer overrides that take precedence over profile values.
  * New UI sections in profile and directory settings to manage committer name/email, including the ability to clear overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->