### PR TITLE
feat: add live progress tracking to comparison generation

### DIFF
--- a/apps/api/src/directories/directories.controller.ts
+++ b/apps/api/src/directories/directories.controller.ts
@@ -1059,6 +1059,21 @@ export class DirectoriesController {
         return { count };
     }
 
+    @Get('directories/:id/comparisons/generation-status')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Get comparison generation status',
+        description: 'Check the current progress of an in-flight comparison generation',
+    })
+    @ApiParam({ name: 'id', description: 'Directory ID' })
+    async getComparisonGenerationStatus(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+    ) {
+        await this.authService.getUser(auth.userId);
+        return this.comparisonGenerationService.getGenerationStatus(id);
+    }
+
     @Get('directories/:id/comparisons/:slug')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Get comparison', description: 'Get a single comparison by slug' })

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -915,7 +915,14 @@
                     "generating": "Generating comparisons: {completed} / {total} complete",
                     "error": "{count, plural, one {# error} other {# errors}}",
                     "stopped": "Stopped. Generated {count, plural, one {# comparison} other {# comparisons}} with {errors, plural, one {# error} other {# errors}}.",
-                    "done": "Done! Generated {count, plural, one {# comparison} other {# comparisons}}."
+                    "done": "Done! Generated {count, plural, one {# comparison} other {# comparisons}}.",
+                    "stages": {
+                        "researching": "Researching {itemA} vs {itemB}...",
+                        "analyzing": "Analyzing comparison data...",
+                        "writing": "Writing comparison article...",
+                        "writing_extended": "Writing extended analysis...",
+                        "saving": "Saving and publishing..."
+                    }
                 },
                 "pagination": {
                     "showing": "Showing {from}–{to} of {total}"

--- a/apps/web/src/app/actions/dashboard/comparisons.ts
+++ b/apps/web/src/app/actions/dashboard/comparisons.ts
@@ -35,6 +35,20 @@ export async function getRemainingComparisonCount(directoryId: string) {
     }
 }
 
+export async function getComparisonGenerationStatus(directoryId: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        return await directoryAPI.getComparisonGenerationStatus(directoryId);
+    } catch (error) {
+        console.error('Get comparison generation status error:', error);
+        return { generating: false };
+    }
+}
+
 export async function generateNextComparison(directoryId: string) {
     const user = await getAuthFromCookie();
     if (!user) {

--- a/apps/web/src/app/api/directories/[id]/comparisons/generation-status/route.ts
+++ b/apps/web/src/app/api/directories/[id]/comparisons/generation-status/route.ts
@@ -4,14 +4,14 @@ import { directoryAPI } from '@/lib/api';
 export const dynamic = 'force-dynamic';
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-	const { id } = await params;
+    const { id } = await params;
 
-	try {
-		const status = await directoryAPI.getComparisonGenerationStatus(id);
-		return NextResponse.json(status, {
-			headers: { 'Cache-Control': 'no-store' },
-		});
-	} catch {
-		return NextResponse.json({ generating: false }, { status: 200 });
-	}
+    try {
+        const status = await directoryAPI.getComparisonGenerationStatus(id);
+        return NextResponse.json(status, {
+            headers: { 'Cache-Control': 'no-store' },
+        });
+    } catch {
+        return NextResponse.json({ generating: false }, { status: 200 });
+    }
 }

--- a/apps/web/src/app/api/directories/[id]/comparisons/generation-status/route.ts
+++ b/apps/web/src/app/api/directories/[id]/comparisons/generation-status/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { directoryAPI } from '@/lib/api';
+import { getAuthFromCookie } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     const { id } = await params;
 
     try {

--- a/apps/web/src/app/api/directories/[id]/comparisons/generation-status/route.ts
+++ b/apps/web/src/app/api/directories/[id]/comparisons/generation-status/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { directoryAPI } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+	const { id } = await params;
+
+	try {
+		const status = await directoryAPI.getComparisonGenerationStatus(id);
+		return NextResponse.json(status, {
+			headers: { 'Cache-Control': 'no-store' },
+		});
+	} catch {
+		return NextResponse.json({ generating: false }, { status: 200 });
+	}
+}

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
-import { getComparisonGenerationStatus } from '@/app/actions/dashboard/comparisons';
 
 const STAGES = ['researching', 'analyzing', 'writing', 'writing_extended', 'saving'] as const;
 
@@ -39,8 +38,15 @@ export function ComparisonGenerationProgress({
 
         const poll = async () => {
             try {
-                const result = await getComparisonGenerationStatus(directoryId);
-                setStatus(result);
+                // Use direct fetch to Route Handler instead of server action
+                // to avoid Next.js server action serialization (which would
+                // block this call while the generation server action is running)
+                const res = await fetch(
+                    `/api/directories/${directoryId}/comparisons/generation-status`,
+                );
+                if (res.ok) {
+                    setStatus(await res.json());
+                }
             } catch {
                 // Silently ignore polling errors
             }

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { getComparisonGenerationStatus } from '@/app/actions/dashboard/comparisons';
+
+const STAGES = ['researching', 'analyzing', 'writing', 'writing_extended', 'saving'] as const;
+
+type Stage = (typeof STAGES)[number];
+
+interface ComparisonGenerationProgressProps {
+	directoryId: string;
+	isGenerating: boolean;
+}
+
+export function ComparisonGenerationProgress({
+	directoryId,
+	isGenerating,
+}: ComparisonGenerationProgressProps) {
+	const t = useTranslations('dashboard.directoryDetail.comparisons');
+	const [status, setStatus] = useState<{
+		generating: boolean;
+		stage?: string;
+		itemAName?: string;
+		itemBName?: string;
+	}>({ generating: false });
+	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	useEffect(() => {
+		if (!isGenerating) {
+			setStatus({ generating: false });
+			if (intervalRef.current) {
+				clearInterval(intervalRef.current);
+				intervalRef.current = null;
+			}
+			return;
+		}
+
+		const poll = async () => {
+			try {
+				const result = await getComparisonGenerationStatus(directoryId);
+				setStatus(result);
+			} catch {
+				// Silently ignore polling errors
+			}
+		};
+
+		// Poll immediately, then every 1.5s
+		poll();
+		intervalRef.current = setInterval(poll, 1500);
+
+		return () => {
+			if (intervalRef.current) {
+				clearInterval(intervalRef.current);
+				intervalRef.current = null;
+			}
+		};
+	}, [isGenerating, directoryId]);
+
+	if (!isGenerating) return null;
+
+	const currentStage = status.stage as Stage | undefined;
+	const currentStageIndex = currentStage ? STAGES.indexOf(currentStage) : -1;
+
+	// Only show stages up to writing_extended if it's active; otherwise hide it
+	const visibleStages = STAGES.filter(
+		(s) => s !== 'writing_extended' || currentStage === 'writing_extended',
+	);
+
+	return (
+		<div className="rounded-lg border border-border dark:border-border-dark p-4 space-y-3">
+			<div className="flex items-center gap-3">
+				<div className="relative h-4 w-4 shrink-0">
+					<div className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
+					<div className="absolute inset-0.5 rounded-full bg-primary" />
+				</div>
+				<div className="min-w-0">
+					<p className="text-sm font-medium text-text dark:text-text-dark truncate">
+						{currentStage && status.itemAName && status.itemBName
+							? t(`progress.stages.${currentStage}`, {
+									itemA: status.itemAName,
+									itemB: status.itemBName,
+								})
+							: t('actions.generating')}
+					</p>
+					{status.itemAName && status.itemBName && (
+						<p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+							{status.itemAName} vs {status.itemBName}
+						</p>
+					)}
+				</div>
+			</div>
+
+			{/* Step indicators */}
+			{currentStageIndex >= 0 && (
+				<div className="flex items-center gap-1.5">
+					{visibleStages.map((stage) => {
+						const stageIndex = STAGES.indexOf(stage);
+						const isCompleted = stageIndex < currentStageIndex;
+						const isCurrent = stageIndex === currentStageIndex;
+
+						return (
+							<div key={stage} className="flex items-center gap-1.5 flex-1">
+								<div
+									className={cn(
+										'h-1.5 rounded-full flex-1 transition-all duration-500',
+										isCompleted && 'bg-primary',
+										isCurrent && 'bg-primary/60 animate-pulse',
+										!isCompleted && !isCurrent && 'bg-surface-hover dark:bg-surface-hover-dark',
+									)}
+								/>
+							</div>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
@@ -10,111 +10,113 @@ const STAGES = ['researching', 'analyzing', 'writing', 'writing_extended', 'savi
 type Stage = (typeof STAGES)[number];
 
 interface ComparisonGenerationProgressProps {
-	directoryId: string;
-	isGenerating: boolean;
+    directoryId: string;
+    isGenerating: boolean;
 }
 
 export function ComparisonGenerationProgress({
-	directoryId,
-	isGenerating,
+    directoryId,
+    isGenerating,
 }: ComparisonGenerationProgressProps) {
-	const t = useTranslations('dashboard.directoryDetail.comparisons');
-	const [status, setStatus] = useState<{
-		generating: boolean;
-		stage?: string;
-		itemAName?: string;
-		itemBName?: string;
-	}>({ generating: false });
-	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const t = useTranslations('dashboard.directoryDetail.comparisons');
+    const [status, setStatus] = useState<{
+        generating: boolean;
+        stage?: string;
+        itemAName?: string;
+        itemBName?: string;
+    }>({ generating: false });
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-	useEffect(() => {
-		if (!isGenerating) {
-			setStatus({ generating: false });
-			if (intervalRef.current) {
-				clearInterval(intervalRef.current);
-				intervalRef.current = null;
-			}
-			return;
-		}
+    useEffect(() => {
+        if (!isGenerating) {
+            setStatus({ generating: false });
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+            return;
+        }
 
-		const poll = async () => {
-			try {
-				const result = await getComparisonGenerationStatus(directoryId);
-				setStatus(result);
-			} catch {
-				// Silently ignore polling errors
-			}
-		};
+        const poll = async () => {
+            try {
+                const result = await getComparisonGenerationStatus(directoryId);
+                setStatus(result);
+            } catch {
+                // Silently ignore polling errors
+            }
+        };
 
-		// Poll immediately, then every 1.5s
-		poll();
-		intervalRef.current = setInterval(poll, 1500);
+        // Poll immediately, then every 1.5s
+        poll();
+        intervalRef.current = setInterval(poll, 1500);
 
-		return () => {
-			if (intervalRef.current) {
-				clearInterval(intervalRef.current);
-				intervalRef.current = null;
-			}
-		};
-	}, [isGenerating, directoryId]);
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        };
+    }, [isGenerating, directoryId]);
 
-	if (!isGenerating) return null;
+    if (!isGenerating) return null;
 
-	const currentStage = status.stage as Stage | undefined;
-	const currentStageIndex = currentStage ? STAGES.indexOf(currentStage) : -1;
+    const currentStage = status.stage as Stage | undefined;
+    const currentStageIndex = currentStage ? STAGES.indexOf(currentStage) : -1;
 
-	// Only show stages up to writing_extended if it's active; otherwise hide it
-	const visibleStages = STAGES.filter(
-		(s) => s !== 'writing_extended' || currentStage === 'writing_extended',
-	);
+    // Only show stages up to writing_extended if it's active; otherwise hide it
+    const visibleStages = STAGES.filter(
+        (s) => s !== 'writing_extended' || currentStage === 'writing_extended',
+    );
 
-	return (
-		<div className="rounded-lg border border-border dark:border-border-dark p-4 space-y-3">
-			<div className="flex items-center gap-3">
-				<div className="relative h-4 w-4 shrink-0">
-					<div className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
-					<div className="absolute inset-0.5 rounded-full bg-primary" />
-				</div>
-				<div className="min-w-0">
-					<p className="text-sm font-medium text-text dark:text-text-dark truncate">
-						{currentStage && status.itemAName && status.itemBName
-							? t(`progress.stages.${currentStage}`, {
-									itemA: status.itemAName,
-									itemB: status.itemBName,
-								})
-							: t('actions.generating')}
-					</p>
-					{status.itemAName && status.itemBName && (
-						<p className="text-xs text-text-secondary dark:text-text-secondary-dark">
-							{status.itemAName} vs {status.itemBName}
-						</p>
-					)}
-				</div>
-			</div>
+    return (
+        <div className="rounded-lg border border-border dark:border-border-dark p-4 space-y-3">
+            <div className="flex items-center gap-3">
+                <div className="relative h-4 w-4 shrink-0">
+                    <div className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
+                    <div className="absolute inset-0.5 rounded-full bg-primary" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-sm font-medium text-text dark:text-text-dark truncate">
+                        {currentStage && status.itemAName && status.itemBName
+                            ? t(`progress.stages.${currentStage}`, {
+                                  itemA: status.itemAName,
+                                  itemB: status.itemBName,
+                              })
+                            : t('actions.generating')}
+                    </p>
+                    {status.itemAName && status.itemBName && (
+                        <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                            {status.itemAName} vs {status.itemBName}
+                        </p>
+                    )}
+                </div>
+            </div>
 
-			{/* Step indicators */}
-			{currentStageIndex >= 0 && (
-				<div className="flex items-center gap-1.5">
-					{visibleStages.map((stage) => {
-						const stageIndex = STAGES.indexOf(stage);
-						const isCompleted = stageIndex < currentStageIndex;
-						const isCurrent = stageIndex === currentStageIndex;
+            {/* Step indicators */}
+            {currentStageIndex >= 0 && (
+                <div className="flex items-center gap-1.5">
+                    {visibleStages.map((stage) => {
+                        const stageIndex = STAGES.indexOf(stage);
+                        const isCompleted = stageIndex < currentStageIndex;
+                        const isCurrent = stageIndex === currentStageIndex;
 
-						return (
-							<div key={stage} className="flex items-center gap-1.5 flex-1">
-								<div
-									className={cn(
-										'h-1.5 rounded-full flex-1 transition-all duration-500',
-										isCompleted && 'bg-primary',
-										isCurrent && 'bg-primary/60 animate-pulse',
-										!isCompleted && !isCurrent && 'bg-surface-hover dark:bg-surface-hover-dark',
-									)}
-								/>
-							</div>
-						);
-					})}
-				</div>
-			)}
-		</div>
-	);
+                        return (
+                            <div key={stage} className="flex items-center gap-1.5 flex-1">
+                                <div
+                                    className={cn(
+                                        'h-1.5 rounded-full flex-1 transition-all duration-500',
+                                        isCompleted && 'bg-primary',
+                                        isCurrent && 'bg-primary/60 animate-pulse',
+                                        !isCompleted &&
+                                            !isCurrent &&
+                                            'bg-surface-hover dark:bg-surface-hover-dark',
+                                    )}
+                                />
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
 }

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonGenerationProgress.tsx
@@ -70,8 +70,10 @@ export function ComparisonGenerationProgress({
     const currentStageIndex = currentStage ? STAGES.indexOf(currentStage) : -1;
 
     // Only show stages up to writing_extended if it's active; otherwise hide it
+    // Keep writing_extended visible once it has started or completed,
+    // so the progress bar doesn't shrink when transitioning to saving
     const visibleStages = STAGES.filter(
-        (s) => s !== 'writing_extended' || currentStage === 'writing_extended',
+        (s) => s !== 'writing_extended' || currentStageIndex >= STAGES.indexOf('writing_extended'),
     );
 
     return (

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
@@ -478,10 +478,7 @@ export function ComparisonsPageClient({
             )}
 
             {/* Single generation progress */}
-            <ComparisonGenerationProgress
-                directoryId={directoryId}
-                isGenerating={isPending}
-            />
+            <ComparisonGenerationProgress directoryId={directoryId} isGenerating={isPending} />
 
             {/* Generate All progress bar */}
             {isGeneratingAll && (

--- a/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
+++ b/apps/web/src/components/directories/detail/comparisons/ComparisonsPageClient.tsx
@@ -50,7 +50,9 @@ import {
     getRemainingComparisonCount,
     saveComparisonAiConfig,
     getAiProviderModels,
+    listComparisons,
 } from '@/app/actions/dashboard/comparisons';
+import { ComparisonGenerationProgress } from './ComparisonGenerationProgress';
 
 interface ComparisonsPageClientProps {
     directoryId: string;
@@ -147,14 +149,23 @@ export function ComparisonsPageClient({
         .filter((item) => item.slug !== selectedItemA)
         .filter((item) => queryB === '' || item.name.toLowerCase().includes(queryB.toLowerCase()));
 
+    const refreshComparisons = async () => {
+        try {
+            const updated = await listComparisons(directoryId);
+            setComparisons(updated);
+        } catch {
+            // Fallback: reload if fetch fails
+            window.location.reload();
+        }
+    };
+
     const handleGenerateNext = () => {
         startTransition(async () => {
             const result = await generateNextComparison(directoryId);
 
             if (result.status === 'success') {
                 toast.success(result.message);
-                // Refresh comparisons list
-                window.location.reload();
+                await refreshComparisons();
             } else if (result.status === 'skipped') {
                 toast.info(result.message);
             } else {
@@ -183,7 +194,7 @@ export function ComparisonsPageClient({
 
             if (result.status === 'success') {
                 toast.success(result.message);
-                window.location.reload();
+                await refreshComparisons();
             } else if (result.status === 'skipped') {
                 toast.info(result.message);
             } else {
@@ -264,7 +275,7 @@ export function ComparisonsPageClient({
             toast.success(t('progress.done', { count: completed }));
         }
 
-        window.location.reload();
+        await refreshComparisons();
     }, [directoryId, remainingCount]);
 
     const handleStopGenerateAll = () => {
@@ -465,6 +476,12 @@ export function ComparisonsPageClient({
                     )}
                 </div>
             )}
+
+            {/* Single generation progress */}
+            <ComparisonGenerationProgress
+                directoryId={directoryId}
+                isGenerating={isPending}
+            />
 
             {/* Generate All progress bar */}
             {isGeneratingAll && (

--- a/apps/web/src/lib/api/directory.ts
+++ b/apps/web/src/lib/api/directory.ts
@@ -873,6 +873,16 @@ export const directoryAPI = {
         return serverFetch<{ count: number }>(`/directories/${id}/comparisons/remaining-count`);
     },
 
+    getComparisonGenerationStatus: async (id: string) => {
+        return serverFetch<{
+            generating: boolean;
+            stage?: string;
+            itemAName?: string;
+            itemBName?: string;
+            startedAt?: string;
+        }>(`/directories/${id}/comparisons/generation-status`);
+    },
+
     generateNextComparison: async (id: string) => {
         return serverMutation<ComparisonResult>({
             endpoint: `/directories/${id}/comparisons/generate`,

--- a/packages/agent/src/comparison-generator/comparison-generation.service.ts
+++ b/packages/agent/src/comparison-generator/comparison-generation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
 import { z } from 'zod';
 import { AiFacadeService } from '../facades/ai.facade';
 import { SearchFacadeService } from '../facades/search.facade';
@@ -12,6 +12,7 @@ import type { Directory } from '../entities/directory.entity';
 import type { ComparisonData } from '@ever-works/contracts';
 import type { FacadeOptions } from '@ever-works/plugin';
 import { DataRepository, type IDataConfig } from '../generators/data-generator/data-repository';
+import { CACHE_MANAGER, type Cache } from '../cache';
 import { GenerateStatusType } from '../entities/types';
 import {
     DEFAULT_COMPARISON_SETTINGS,
@@ -25,6 +26,9 @@ import {
     type ResearchDependencies,
     type ComparisonAiDependencies,
     type ComparisonPromptOptions,
+    type ComparisonProgressStage,
+    type ComparisonProgressInfo,
+    type ComparisonProgressCallback,
 } from './comparison';
 import {
     DirectoryHistoryActivityType,
@@ -68,7 +72,46 @@ export class ComparisonGenerationService {
         private readonly directoryRepository: DirectoryRepository,
         private readonly generationHistoryRepository: DirectoryGenerationHistoryRepository,
         private readonly directoryPluginRepository: DirectoryPluginRepository,
+        @Optional() @Inject(CACHE_MANAGER) private readonly cacheManager?: Cache,
     ) {}
+
+    private static readonly PROGRESS_CACHE_TTL = 120_000; // 2 minutes
+
+    private progressCacheKey(directoryId: string): string {
+        return `comparison-progress-${directoryId}`;
+    }
+
+    private async setProgress(
+        directoryId: string,
+        stage: ComparisonProgressStage,
+        itemAName: string,
+        itemBName: string,
+        startedAt: string,
+    ): Promise<void> {
+        if (!this.cacheManager) return;
+        const info: ComparisonProgressInfo = { stage, itemAName, itemBName, startedAt };
+        await this.cacheManager.set(
+            this.progressCacheKey(directoryId),
+            info,
+            ComparisonGenerationService.PROGRESS_CACHE_TTL,
+        );
+    }
+
+    private async clearProgress(directoryId: string): Promise<void> {
+        if (!this.cacheManager) return;
+        await this.cacheManager.del(this.progressCacheKey(directoryId));
+    }
+
+    async getGenerationStatus(
+        directoryId: string,
+    ): Promise<{ generating: boolean } & Partial<ComparisonProgressInfo>> {
+        if (!this.cacheManager) return { generating: false };
+        const info = await this.cacheManager.get<ComparisonProgressInfo>(
+            this.progressCacheKey(directoryId),
+        );
+        if (!info) return { generating: false };
+        return { generating: true, ...info };
+    }
 
     private async recordComparisonHistory(params: {
         directoryId: string;
@@ -403,130 +446,148 @@ export class ComparisonGenerationService {
         },
         gitOptions: GitFacadeOptions,
     ): Promise<ComparisonResult> {
-        const pluginSettings = await this.getComparisonPluginSettings(directory.id);
-        const facadeOptions: FacadeOptions = {
-            userId: gitOptions.userId!,
-            directoryId: directory.id,
-            providerOverride: pluginSettings.ai_provider,
-        };
-
-        // 1. Research the pair
-        const researchDeps: ResearchDependencies = {
-            search: async (query: string, limit: number) => {
-                const results = await this.searchFacade.search(
-                    query,
-                    { maxResults: limit },
-                    facadeOptions,
-                );
-                return results.map((r) => ({ url: r.url, snippet: r.title || '' }));
-            },
-            extractContent: async (url: string) => {
-                const result = await this.contentExtractorFacade.extractContent(
-                    url,
-                    undefined,
-                    facadeOptions,
-                );
-                return result?.rawContent ?? null;
-            },
-        };
-
-        this.logger.log(`Researching comparison: ${pair.itemA.name} vs ${pair.itemB.name}`);
-        const research = await researchPair(pair, researchDeps);
-
-        // 2. Generate comparison via AI
-        const aiDeps: ComparisonAiDependencies = {
-            askJson: async <T>(prompt: string, _schema: Record<string, unknown>) => {
-                const response = await this.aiFacade.askJson(
-                    prompt,
-                    comparisonStructureSchema,
-                    pluginSettings.ai_model
-                        ? { routing: { modelOverride: pluginSettings.ai_model } }
-                        : undefined,
-                    facadeOptions,
-                );
-                return response.result as T;
-            },
-            askText: async (prompt: string) => {
-                const response = await this.aiFacade.createChatCompletion(
-                    {
-                        messages: [{ role: 'user', content: prompt }],
-                        model: pluginSettings.ai_model,
-                    },
-                    facadeOptions,
-                );
-                const content = response.choices[0]?.message?.content;
-                return typeof content === 'string' ? content : '';
-            },
-        };
-
-        this.logger.log(`Generating comparison: ${pair.itemA.name} vs ${pair.itemB.name}`);
-        const promptOptions: ComparisonPromptOptions = {
-            promptFacade: this.promptFacade,
-            facadeOptions,
-        };
-        const result = await generateComparison(
-            pair,
-            research,
-            aiDeps,
-            {
-                name: directory.name,
-                description: directory.description,
-                customPrompt: pluginSettings.custom_prompt,
-                extendedAnalysis: pluginSettings.extended_analysis,
-            },
-            promptOptions,
-        );
-
-        // 3. Write to data repo
-        await dataRepo.writeComparison(result.comparison);
-        await dataRepo.writeComparisonMarkdown(result.comparison.slug, result.markdown);
-        if (result.extendedAnalysisMarkdown) {
-            await dataRepo.writeComparisonExtendedMarkdown(
-                result.comparison.slug,
-                result.extendedAnalysisMarkdown,
+        const startedAt = new Date().toISOString();
+        const onProgress: ComparisonProgressCallback = (stage) => {
+            this.setProgress(directory.id, stage, pair.itemA.name, pair.itemB.name, startedAt).catch(
+                () => {},
             );
-        }
-
-        // 4. Update comparison state
-        comparisonState.generated_pairs.push(result.comparison.slug);
-        comparisonState.last_generated_at = new Date().toISOString();
-        comparisonState.total_generated += 1;
-
-        await dataRepo.mergeConfig({
-            settings: { comparisons_enabled: true },
-            metadata: { ...config.metadata, comparison_state: comparisonState },
-        });
-
-        // 5. Commit and push
-        await this.gitFacade.add(directory.gitProvider, dataRepo.dir, '.');
-        await this.gitFacade.commit(
-            directory.gitProvider,
-            dataRepo.dir,
-            `chore: add comparison - ${pair.itemA.name} vs ${pair.itemB.name}`,
-        );
-        await this.gitFacade.push({ dir: dataRepo.dir }, gitOptions);
-
-        this.logger.log(`Comparison generated: ${result.comparison.slug}`);
-
-        await this.recordComparisonHistory({
-            directoryId: directory.id,
-            userId: gitOptions.userId!,
-            activityType: DirectoryHistoryActivityType.COMPARISON_ADDED,
-            entries: [
-                {
-                    entityType: 'comparison',
-                    action: 'added',
-                    name: result.comparison.title,
-                    slug: result.comparison.slug,
-                },
-            ],
-            summary: `Comparison generated: ${pair.itemA.name} vs ${pair.itemB.name}`,
-        });
-
-        return {
-            status: 'success',
-            slug: result.comparison.slug,
-            message: `Generated comparison: ${pair.itemA.name} vs ${pair.itemB.name}`,
         };
+
+        try {
+            const pluginSettings = await this.getComparisonPluginSettings(directory.id);
+            const facadeOptions: FacadeOptions = {
+                userId: gitOptions.userId!,
+                directoryId: directory.id,
+                providerOverride: pluginSettings.ai_provider,
+            };
+
+            // 1. Research the pair
+            onProgress('researching');
+            const researchDeps: ResearchDependencies = {
+                search: async (query: string, limit: number) => {
+                    const results = await this.searchFacade.search(
+                        query,
+                        { maxResults: limit },
+                        facadeOptions,
+                    );
+                    return results.map((r) => ({ url: r.url, snippet: r.title || '' }));
+                },
+                extractContent: async (url: string) => {
+                    const result = await this.contentExtractorFacade.extractContent(
+                        url,
+                        undefined,
+                        facadeOptions,
+                    );
+                    return result?.rawContent ?? null;
+                },
+            };
+
+            this.logger.log(
+                `Researching comparison: ${pair.itemA.name} vs ${pair.itemB.name}`,
+            );
+            const research = await researchPair(pair, researchDeps);
+
+            // 2. Generate comparison via AI
+            const aiDeps: ComparisonAiDependencies = {
+                askJson: async <T>(prompt: string, _schema: Record<string, unknown>) => {
+                    const response = await this.aiFacade.askJson(
+                        prompt,
+                        comparisonStructureSchema,
+                        pluginSettings.ai_model
+                            ? { routing: { modelOverride: pluginSettings.ai_model } }
+                            : undefined,
+                        facadeOptions,
+                    );
+                    return response.result as T;
+                },
+                askText: async (prompt: string) => {
+                    const response = await this.aiFacade.createChatCompletion(
+                        {
+                            messages: [{ role: 'user', content: prompt }],
+                            model: pluginSettings.ai_model,
+                        },
+                        facadeOptions,
+                    );
+                    const content = response.choices[0]?.message?.content;
+                    return typeof content === 'string' ? content : '';
+                },
+            };
+
+            this.logger.log(
+                `Generating comparison: ${pair.itemA.name} vs ${pair.itemB.name}`,
+            );
+            const promptOptions: ComparisonPromptOptions = {
+                promptFacade: this.promptFacade,
+                facadeOptions,
+            };
+            const result = await generateComparison(
+                pair,
+                research,
+                aiDeps,
+                {
+                    name: directory.name,
+                    description: directory.description,
+                    customPrompt: pluginSettings.custom_prompt,
+                    extendedAnalysis: pluginSettings.extended_analysis,
+                },
+                promptOptions,
+                onProgress,
+            );
+
+            // 3. Write to data repo
+            onProgress('saving');
+            await dataRepo.writeComparison(result.comparison);
+            await dataRepo.writeComparisonMarkdown(result.comparison.slug, result.markdown);
+            if (result.extendedAnalysisMarkdown) {
+                await dataRepo.writeComparisonExtendedMarkdown(
+                    result.comparison.slug,
+                    result.extendedAnalysisMarkdown,
+                );
+            }
+
+            // 4. Update comparison state
+            comparisonState.generated_pairs.push(result.comparison.slug);
+            comparisonState.last_generated_at = new Date().toISOString();
+            comparisonState.total_generated += 1;
+
+            await dataRepo.mergeConfig({
+                settings: { comparisons_enabled: true },
+                metadata: { ...config.metadata, comparison_state: comparisonState },
+            });
+
+            // 5. Commit and push
+            await this.gitFacade.add(directory.gitProvider, dataRepo.dir, '.');
+            await this.gitFacade.commit(
+                directory.gitProvider,
+                dataRepo.dir,
+                `chore: add comparison - ${pair.itemA.name} vs ${pair.itemB.name}`,
+            );
+            await this.gitFacade.push({ dir: dataRepo.dir }, gitOptions);
+
+            this.logger.log(`Comparison generated: ${result.comparison.slug}`);
+
+            await this.recordComparisonHistory({
+                directoryId: directory.id,
+                userId: gitOptions.userId!,
+                activityType: DirectoryHistoryActivityType.COMPARISON_ADDED,
+                entries: [
+                    {
+                        entityType: 'comparison',
+                        action: 'added',
+                        name: result.comparison.title,
+                        slug: result.comparison.slug,
+                    },
+                ],
+                summary: `Comparison generated: ${pair.itemA.name} vs ${pair.itemB.name}`,
+            });
+
+            return {
+                status: 'success',
+                slug: result.comparison.slug,
+                message: `Generated comparison: ${pair.itemA.name} vs ${pair.itemB.name}`,
+            };
+        } finally {
+            await this.clearProgress(directory.id);
+        }
     }
 }

--- a/packages/agent/src/comparison-generator/comparison-generation.service.ts
+++ b/packages/agent/src/comparison-generator/comparison-generation.service.ts
@@ -448,9 +448,13 @@ export class ComparisonGenerationService {
     ): Promise<ComparisonResult> {
         const startedAt = new Date().toISOString();
         const onProgress: ComparisonProgressCallback = (stage) => {
-            this.setProgress(directory.id, stage, pair.itemA.name, pair.itemB.name, startedAt).catch(
-                () => {},
-            );
+            this.setProgress(
+                directory.id,
+                stage,
+                pair.itemA.name,
+                pair.itemB.name,
+                startedAt,
+            ).catch(() => {});
         };
 
         try {
@@ -482,9 +486,7 @@ export class ComparisonGenerationService {
                 },
             };
 
-            this.logger.log(
-                `Researching comparison: ${pair.itemA.name} vs ${pair.itemB.name}`,
-            );
+            this.logger.log(`Researching comparison: ${pair.itemA.name} vs ${pair.itemB.name}`);
             const research = await researchPair(pair, researchDeps);
 
             // 2. Generate comparison via AI
@@ -513,9 +515,7 @@ export class ComparisonGenerationService {
                 },
             };
 
-            this.logger.log(
-                `Generating comparison: ${pair.itemA.name} vs ${pair.itemB.name}`,
-            );
+            this.logger.log(`Generating comparison: ${pair.itemA.name} vs ${pair.itemB.name}`);
             const promptOptions: ComparisonPromptOptions = {
                 promptFacade: this.promptFacade,
                 facadeOptions,

--- a/packages/agent/src/comparison-generator/comparison/__tests__/comparison-writer.spec.ts
+++ b/packages/agent/src/comparison-generator/comparison/__tests__/comparison-writer.spec.ts
@@ -311,4 +311,62 @@ describe('generateComparison', () => {
         expect(extendedPrompt).toContain('Vercel');
         expect(extendedPrompt).toContain('Netlify');
     });
+
+    it('should call onProgress at each generation stage', async () => {
+        const ai = makeAi();
+        const onProgress = jest.fn();
+
+        await generateComparison(pair, research, ai, { name: 'Test' }, undefined, onProgress);
+
+        expect(onProgress).toHaveBeenCalledWith('analyzing');
+        expect(onProgress).toHaveBeenCalledWith('writing');
+
+        // Verify order: analyzing before writing
+        const calls = onProgress.mock.calls.map((c: unknown[]) => c[0]);
+        expect(calls.indexOf('analyzing')).toBeLessThan(calls.indexOf('writing'));
+    });
+
+    it('should call onProgress with writing_extended when extended analysis is enabled', async () => {
+        const ai = makeAi();
+        const onProgress = jest.fn();
+
+        await generateComparison(
+            pair,
+            research,
+            ai,
+            { name: 'Test', extendedAnalysis: true },
+            undefined,
+            onProgress,
+        );
+
+        expect(onProgress).toHaveBeenCalledWith('analyzing');
+        expect(onProgress).toHaveBeenCalledWith('writing');
+        expect(onProgress).toHaveBeenCalledWith('writing_extended');
+    });
+
+    it('should not call onProgress with writing_extended when extended analysis is disabled', async () => {
+        const ai = makeAi();
+        const onProgress = jest.fn();
+
+        await generateComparison(
+            pair,
+            research,
+            ai,
+            { name: 'Test', extendedAnalysis: false },
+            undefined,
+            onProgress,
+        );
+
+        expect(onProgress).not.toHaveBeenCalledWith('writing_extended');
+    });
+
+    it('should work without onProgress callback', async () => {
+        const ai = makeAi();
+
+        // Should not throw when no onProgress is provided
+        const result = await generateComparison(pair, research, ai);
+
+        expect(result.comparison).toBeDefined();
+        expect(result.markdown).toBeDefined();
+    });
 });

--- a/packages/agent/src/comparison-generator/comparison/comparison-writer.ts
+++ b/packages/agent/src/comparison-generator/comparison/comparison-writer.ts
@@ -1,7 +1,12 @@
 import type { ComparisonDimension, ComparisonSource } from '@ever-works/contracts';
 import { substituteVariables } from '@ever-works/plugin';
 import type { IPromptFacade, FacadeOptions, TemplateVariables } from '@ever-works/plugin';
-import type { ComparisonPair, ComparisonResearch, ComparisonGenerationResult } from './types';
+import type {
+    ComparisonPair,
+    ComparisonResearch,
+    ComparisonGenerationResult,
+    ComparisonProgressCallback,
+} from './types';
 import { buildPairKey } from './pair-selector';
 import { PROMPT_KEYS } from './prompt-keys';
 
@@ -415,6 +420,7 @@ export async function generateComparison(
         extendedAnalysis?: boolean;
     },
     promptOptions?: ComparisonPromptOptions,
+    onProgress?: ComparisonProgressCallback,
 ): Promise<ComparisonGenerationResult> {
     const { promptFacade, facadeOptions } = promptOptions ?? {};
 
@@ -433,6 +439,7 @@ export async function generateComparison(
         buildStructurePromptVariables(pair, research, directoryContext),
     );
 
+    onProgress?.('analyzing');
     const structure = await ai.askJson<AiComparisonStructure>(
         structurePrompt,
         COMPARISON_JSON_SCHEMA,
@@ -460,6 +467,7 @@ export async function generateComparison(
         ),
     );
 
+    onProgress?.('writing');
     const markdown = await ai.askText(markdownPrompt);
 
     let extendedAnalysisMarkdown: string | undefined;
@@ -483,6 +491,7 @@ export async function generateComparison(
                 directoryContext?.customPrompt,
             ),
         );
+        onProgress?.('writing_extended');
         extendedAnalysisMarkdown = await ai.askText(extendedPrompt);
     }
 

--- a/packages/agent/src/comparison-generator/comparison/index.ts
+++ b/packages/agent/src/comparison-generator/comparison/index.ts
@@ -10,5 +10,8 @@ export type {
     ComparisonResearch,
     ComparisonGenerationResult,
     ComparisonPluginSettings,
+    ComparisonProgressStage,
+    ComparisonProgressCallback,
+    ComparisonProgressInfo,
 } from './types';
 export { DEFAULT_COMPARISON_SETTINGS } from './types';

--- a/packages/agent/src/comparison-generator/comparison/types.ts
+++ b/packages/agent/src/comparison-generator/comparison/types.ts
@@ -41,4 +41,20 @@ export const DEFAULT_COMPARISON_SETTINGS: ComparisonPluginSettings = {
     min_items_for_comparison: 3,
 };
 
+export type ComparisonProgressStage =
+    | 'researching'
+    | 'analyzing'
+    | 'writing'
+    | 'writing_extended'
+    | 'saving';
+
+export type ComparisonProgressCallback = (stage: ComparisonProgressStage) => void;
+
+export interface ComparisonProgressInfo {
+    readonly stage: ComparisonProgressStage;
+    readonly itemAName: string;
+    readonly itemBName: string;
+    readonly startedAt: string;
+}
+
 export type { ComparisonData, ComparisonDimension };


### PR DESCRIPTION
Surface stage-by-stage progress (researching, analyzing, writing, saving) during comparison generation via cache-based status polling, replacing the opaque "Generating..." state with meaningful real-time feedback. Also replaces full page reloads with in-place list updates for smoother UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time progress tracking for comparison generation with staged messages (researching, analyzing, writing, writing_extended, saving) and visual step indicators.
  * Progress UI displays item names and updates without full-page reloads.

* **Bug Fixes / Reliability**
  * More reliable generation status reporting so progress is available during long-running operations.

* **Documentation**
  * Added user-facing progress messages/translations for each generation stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->