### PR TITLE
fix: implement automatic JWT token refresh on expiration

### DIFF
--- a/apps/web/src/lib/api/server-api.ts
+++ b/apps/web/src/lib/api/server-api.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { API_URL, WEB_URL } from '../constants';
 import { headers } from 'next/headers';
 import { getAuthAccessCookie } from '../auth/cookies';
+import { refreshAccessToken } from '../auth/refresh';
 import { getTranslations } from 'next-intl/server';
 
 export async function handleServerError(error: unknown): Promise<never> {
@@ -40,34 +41,40 @@ export async function serverFetch<T>(
     endpoint: string,
     options: ServerFetchOptions = {},
 ): Promise<T> {
-    const token = await getAuthAccessCookie();
     const frontendUrl = await getFrontendUrl();
     const t = await getTranslations('api.errors');
-
     const { rawResponse, ...fetchOptions } = options;
 
-    const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        'X-Frontend-URL': frontendUrl,
-        ...((fetchOptions.headers as Record<string, string>) || {}),
+    const doFetch = async (authToken?: string) => {
+        const reqHeaders: Record<string, string> = {
+            'Content-Type': 'application/json',
+            'X-Frontend-URL': frontendUrl,
+            ...((fetchOptions.headers as Record<string, string>) || {}),
+        };
+
+        if (authToken) {
+            reqHeaders['Authorization'] = `Bearer ${authToken}`;
+        }
+
+        return fetch(`${API_URL}${endpoint}`, {
+            ...fetchOptions,
+            headers: reqHeaders,
+            cache: 'no-store',
+            next: { revalidate: 0 },
+        });
     };
 
-    // Add authentication header if token exists
-    if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-    }
+    const token = await getAuthAccessCookie();
+    let response = await doFetch(token);
 
-    const response = await fetch(`${API_URL}${endpoint}`, {
-        ...fetchOptions,
-        headers,
-        // Enable caching for GET requests by default
-        // next: {
-        //     revalidate: fetchOptions.method === "GET" ? 3600 : 0, // Cache for 1 hour
-        //     tags: [endpoint.split("/")[1] || "api"], // Tag based on resource type
-        // },
-        cache: 'no-store',
-        next: { revalidate: 0 },
-    });
+    // On 401, attempt a single token refresh and retry
+    if (response.status === 401 && token) {
+        const refreshed = await refreshAccessToken();
+        if (refreshed) {
+            const newToken = await getAuthAccessCookie();
+            response = await doFetch(newToken);
+        }
+    }
 
     // Return raw response for streaming
     if (rawResponse) {

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -31,6 +31,11 @@ export async function getAuthFromAPI() {
         if (!refreshed) {
             return null;
         }
+        // Re-verify the refreshed token is valid before making the API call
+        const freshAuth = await getAuthFromRequest();
+        if (!freshAuth.isAuthenticated || freshAuth.isExpired) {
+            return null;
+        }
     }
 
     try {

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,5 +1,6 @@
 import { authAPI } from '../api';
 import { getAuthFromRequest } from './middleware';
+import { refreshAccessToken } from './refresh';
 
 export async function getAuthFromCookie() {
     const auth = await getAuthFromRequest();
@@ -8,8 +9,12 @@ export async function getAuthFromCookie() {
     }
 
     if (auth.isExpired) {
-        console.error('Token expired, NEED TO REFRESH (TODO)');
-        return null;
+        const refreshed = await refreshAccessToken();
+        if (!refreshed) {
+            return null;
+        }
+        const freshAuth = await getAuthFromRequest();
+        return freshAuth.user || null;
     }
 
     return auth.user || null;
@@ -22,8 +27,10 @@ export async function getAuthFromAPI() {
     }
 
     if (auth.isExpired) {
-        console.error('Token expired, NEED TO REFRESH (TODO)');
-        return null;
+        const refreshed = await refreshAccessToken();
+        if (!refreshed) {
+            return null;
+        }
     }
 
     try {
@@ -35,3 +42,4 @@ export async function getAuthFromAPI() {
 
 export * from './middleware';
 export * from './cookies';
+export { refreshAccessToken } from './refresh';

--- a/apps/web/src/lib/auth/refresh.ts
+++ b/apps/web/src/lib/auth/refresh.ts
@@ -1,11 +1,12 @@
 import 'server-only';
+import { cache } from 'react';
 import { API_URL } from '../constants';
 import { getRefreshCookie, setAuthCookies, removeAuthAccessCookies } from './cookies';
 
-// Deduplicate concurrent refresh attempts within the same request lifecycle.
-// Multiple server actions or fetches hitting an expired token simultaneously
-// will share a single in-flight refresh call instead of racing.
-let pendingRefresh: Promise<boolean> | null = null;
+// React.cache() scopes this per-request in Next.js App Router, so concurrent
+// server components within the same render share one refresh call without
+// leaking state across different users' requests.
+const getRefreshState = cache(() => ({ pending: null as Promise<boolean> | null }));
 
 /**
  * Attempts to refresh the access token using the stored refresh token.
@@ -15,16 +16,17 @@ let pendingRefresh: Promise<boolean> | null = null;
  * Returns true if refresh succeeded, false otherwise.
  */
 export async function refreshAccessToken(): Promise<boolean> {
-    if (pendingRefresh) {
-        return pendingRefresh;
+    const state = getRefreshState();
+    if (state.pending) {
+        return state.pending;
     }
 
-    pendingRefresh = doRefresh();
+    state.pending = doRefresh();
 
     try {
-        return await pendingRefresh;
+        return await state.pending;
     } finally {
-        pendingRefresh = null;
+        state.pending = null;
     }
 }
 
@@ -57,8 +59,10 @@ async function doRefresh(): Promise<boolean> {
 
         await setAuthCookies(data.access_token, data.refresh_token);
         return true;
-    } catch {
-        await removeAuthAccessCookies();
+    } catch (error) {
+        // Only log on transient/network errors — leave cookies intact so the
+        // user is not forced to re-authenticate on a temporary failure.
+        console.error('Token refresh failed unexpectedly:', error);
         return false;
     }
 }

--- a/apps/web/src/lib/auth/refresh.ts
+++ b/apps/web/src/lib/auth/refresh.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+import { API_URL } from '../constants';
+import { getRefreshCookie, setAuthCookies, removeAuthAccessCookies } from './cookies';
+
+// Deduplicate concurrent refresh attempts within the same request lifecycle.
+// Multiple server actions or fetches hitting an expired token simultaneously
+// will share a single in-flight refresh call instead of racing.
+let pendingRefresh: Promise<boolean> | null = null;
+
+/**
+ * Attempts to refresh the access token using the stored refresh token.
+ * Calls the API refresh endpoint directly (bypasses serverFetch to avoid
+ * circular dependency) and updates both auth cookies on success.
+ *
+ * Returns true if refresh succeeded, false otherwise.
+ */
+export async function refreshAccessToken(): Promise<boolean> {
+    if (pendingRefresh) {
+        return pendingRefresh;
+    }
+
+    pendingRefresh = doRefresh();
+
+    try {
+        return await pendingRefresh;
+    } finally {
+        pendingRefresh = null;
+    }
+}
+
+async function doRefresh(): Promise<boolean> {
+    try {
+        const refreshToken = await getRefreshCookie();
+        if (!refreshToken) {
+            await removeAuthAccessCookies();
+            return false;
+        }
+
+        const response = await fetch(`${API_URL}/auth/refresh`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ refreshToken }),
+            cache: 'no-store',
+        });
+
+        if (!response.ok) {
+            await removeAuthAccessCookies();
+            return false;
+        }
+
+        const data = await response.json();
+
+        if (!data.access_token || !data.refresh_token) {
+            await removeAuthAccessCookies();
+            return false;
+        }
+
+        await setAuthCookies(data.access_token, data.refresh_token);
+        return true;
+    } catch {
+        await removeAuthAccessCookies();
+        return false;
+    }
+}


### PR DESCRIPTION
Add server-side token refresh that seamlessly renews expired access tokens using the existing refresh token endpoint. Concurrent refresh attempts are deduplicated via a shared promise, and serverFetch retries once on 401 before propagating the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds automatic token refresh to recover sessions when access tokens expire, reducing interruptions.

* **Bug Fixes**
  * API requests that fail due to expired tokens are retried once after a successful refresh, improving reliability and reducing unexpected sign-outs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->