### PR TITLE
Adjust Button Sizes on Plugin and Settings Pages

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -83,13 +83,13 @@ export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutC
                 key={tab.id}
                 href={tab.href}
                 className={cn(
-                    'w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors',
+                    'w-full flex items-center gap-3 px-4 py-2 rounded-lg text-left transition-colors',
                     isActive(tab.href)
                         ? 'bg-surface-secondary dark:bg-surface-secondary-dark text-text dark:text-text-dark font-medium'
                         : 'text-text-muted dark:text-text-muted-dark hover:bg-surface dark:hover:bg-surface-dark hover:text-text dark:hover:text-text-dark',
                 )}
             >
-                <Icon className="w-5 h-5" />
+                <Icon className="w-4 h-4" />
                 <span>{tab.label}</span>
             </Link>
         );
@@ -105,7 +105,7 @@ export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutC
                 key={category.category}
                 href={categoryHref}
                 className={cn(
-                    'w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors',
+                    'w-full flex items-center gap-3 px-4 py-2 rounded-lg text-left transition-colors',
                     isCategoryActive(category)
                         ? 'bg-surface-secondary dark:bg-surface-secondary-dark text-text dark:text-text-dark font-medium'
                         : 'text-text-muted dark:text-text-muted-dark hover:bg-surface dark:hover:bg-surface-dark hover:text-text dark:hover:text-text-dark',
@@ -141,7 +141,7 @@ export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutC
                         {settingsMenu?.categories && settingsMenu.categories.length > 0 && (
                             <>
                                 <div className="pt-4 pb-2 px-4">
-                                    <span className="text-xs font-medium text-text-muted dark:text-text-muted-dark uppercase tracking-wider">
+                                    <span className="text-xs font-medium text-text-muted dark:text-text-muted-dark/70 uppercase tracking-wider">
                                         Plugins
                                     </span>
                                 </div>

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -74,7 +74,6 @@ export function EverWorksOnboardingWizard({
     );
 
     const shouldOpen = totalDirectories === 0 && !storedState.dismissed;
-    // const shouldOpen = true;
     const activeStep = Math.min(storedState.step, steps.length - 1);
     const isLastStep = activeStep === steps.length - 1;
 

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -74,6 +74,7 @@ export function EverWorksOnboardingWizard({
     );
 
     const shouldOpen = totalDirectories === 0 && !storedState.dismissed;
+    // const shouldOpen = true;
     const activeStep = Math.min(storedState.step, steps.length - 1);
     const isLastStep = activeStep === steps.length - 1;
 

--- a/apps/web/src/components/plugins/PluginCard.tsx
+++ b/apps/web/src/components/plugins/PluginCard.tsx
@@ -62,17 +62,17 @@ export function PluginCard({ plugin }: PluginCardProps) {
                                 {plugin.name}
                             </h3>
                             {plugin.systemPlugin && (
-                                <span className="shrink-0 text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+                                <span className="shrink-0 text-xs px-1.5 py-0.5 rounded bg-primary/5 text-primary">
                                     {t('system')}
                                 </span>
                             )}
                             {plugin.builtIn && !plugin.systemPlugin && (
-                                <span className="shrink-0 text-xs px-1.5 py-0.5 rounded bg-surface-tertiary dark:bg-surface-tertiary-dark text-text-muted dark:text-text-muted-dark">
+                                <span className="shrink-0 text-xs px-1.5 py-0.5 rounded bg-surface-tertiary dark:bg-surface-tertiary-dark/40 text-text-muted dark:text-text-muted-dark">
                                     {t('builtIn')}
                                 </span>
                             )}
                         </div>
-                        <p className="text-sm text-text-muted dark:text-text-muted-dark mt-0.5">
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
                             v{plugin.version}
                         </p>
                     </div>
@@ -84,21 +84,21 @@ export function PluginCard({ plugin }: PluginCardProps) {
                             onClick={handleToggle}
                             disabled={isPending}
                             loading={isPending}
-                            className={cn(
+                            className={cn('px-2 py-1 text-xs rounded-md gap-0.5',
                                 optimisticEnabled &&
                                     'text-danger hover:text-danger hover:bg-danger/10',
                             )}
                         >
                             {optimisticEnabled ? (
                                 <>
-                                    <PowerOff className="w-4 h-4" />
+                                    <PowerOff className="w-3 h-3" />
                                     <span className="sr-only md:not-sr-only md:ml-1">
                                         {t('disable')}
                                     </span>
                                 </>
                             ) : (
                                 <>
-                                    <Power className="w-4 h-4" />
+                                    <Power className="w-3 h-3" />
                                     <span className="sr-only md:not-sr-only md:ml-1">
                                         {t('enable')}
                                     </span>
@@ -109,7 +109,7 @@ export function PluginCard({ plugin }: PluginCardProps) {
                 </div>
 
                 {plugin.description && (
-                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-3 line-clamp-2">
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-5 line-clamp-2">
                         {plugin.description}
                     </p>
                 )}
@@ -145,9 +145,9 @@ export function PluginCard({ plugin }: PluginCardProps) {
                 <div className="flex items-center gap-2 mt-auto pt-3 border-t border-border dark:border-border-dark">
                     <Link
                         href={ROUTES.DASHBOARD_PLUGIN_DETAIL(plugin.pluginId)}
-                        className="text-sm text-primary hover:text-primary-hover flex items-center gap-1"
+                        className="text-xs text-primary hover:text-primary-hover flex items-center gap-1"
                     >
-                        <Settings className="w-4 h-4" />
+                        <Settings className="w-3 h-3" />
                         {t('settings')}
                     </Link>
 
@@ -156,9 +156,9 @@ export function PluginCard({ plugin }: PluginCardProps) {
                             href={plugin.homepage}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-sm text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark flex items-center gap-1 ml-auto"
+                            className="text-xs text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark flex items-center gap-1 ml-auto"
                         >
-                            <ExternalLink className="w-4 h-4" />
+                            <ExternalLink className="w-3 h-3" />
                             {t('docs')}
                         </a>
                     )}

--- a/apps/web/src/components/plugins/PluginCard.tsx
+++ b/apps/web/src/components/plugins/PluginCard.tsx
@@ -84,7 +84,8 @@ export function PluginCard({ plugin }: PluginCardProps) {
                             onClick={handleToggle}
                             disabled={isPending}
                             loading={isPending}
-                            className={cn('px-2 py-1 text-xs rounded-md gap-0.5',
+                            className={cn(
+                                'px-2 py-1 text-xs rounded-md gap-0.5',
                                 optimisticEnabled &&
                                     'text-danger hover:text-danger hover:bg-danger/10',
                             )}

--- a/apps/web/src/components/plugins/PluginCategoryFilter.tsx
+++ b/apps/web/src/components/plugins/PluginCategoryFilter.tsx
@@ -28,10 +28,10 @@ export function PluginCategoryFilter({
                 <button
                     onClick={() => onSelectCategory(null)}
                     className={cn(
-                        'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                        'px-3 py-1 rounded-full text-sm font-medium transition-colors',
                         selectedCategory === null
-                            ? 'bg-primary text-white'
-                            : 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
+                            ? 'bg-primary-500 text-white'
+                            : 'bg-surface-secondary dark:bg-surface-secondary-dark/50 text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
                     )}
                 >
                     {t('all')}
@@ -41,10 +41,10 @@ export function PluginCategoryFilter({
                         key={category}
                         onClick={() => onSelectCategory(category)}
                         className={cn(
-                            'px-3 py-1.5 rounded-full text-sm font-medium transition-colors',
+                            'px-3 py-1 rounded-full text-sm font-medium transition-colors',
                             selectedCategory === category
-                                ? 'bg-primary text-white'
-                                : 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
+                                ? 'bg-primary-500 text-white'
+                                : 'bg-surface-secondary dark:bg-surface-secondary-dark/50 text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
                         )}
                     >
                         {getCategoryLabel(category)}

--- a/apps/web/src/components/plugins/PluginReadme.tsx
+++ b/apps/web/src/components/plugins/PluginReadme.tsx
@@ -10,7 +10,7 @@ interface PluginReadmeProps {
 
 export function PluginReadme({ content }: PluginReadmeProps) {
     return (
-        <div className="prose prose-sm dark:prose-invert prose-a:text-primary hover:prose-a:text-primary-hover max-w-none">
+        <div className="prose prose-sm prose-p:w-5/6 dark:prose-invert prose-a:text-primary hover:prose-a:text-primary-hover max-w-none">
             <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeRaw]}

--- a/apps/web/src/components/plugins/PluginSettings.tsx
+++ b/apps/web/src/components/plugins/PluginSettings.tsx
@@ -171,10 +171,11 @@ export function PluginSettings({ plugin, oauthConnection }: PluginSettingsProps)
                                     <Button
                                         variant={optimisticEnabled ? 'ghost' : 'primary'}
                                         onClick={handleToggle}
+                                        size="sm"
                                         disabled={isPending}
                                         loading={isPending}
                                         className={cn(
-                                            'shrink-0',
+                                            'shrink-0 gap-2',
                                             optimisticEnabled &&
                                                 'text-danger hover:text-danger hover:bg-danger/10',
                                         )}
@@ -403,7 +404,7 @@ export function PluginSettings({ plugin, oauthConnection }: PluginSettingsProps)
                             {t('about')}
                         </h2>
                     </div>
-                    <div className="p-6">
+                    <div className="py-10 pl-12 pr-24">
                         <PluginReadme content={plugin.readme} />
                     </div>
                 </div>

--- a/apps/web/src/components/settings/ApiKeysSettings.tsx
+++ b/apps/web/src/components/settings/ApiKeysSettings.tsx
@@ -124,17 +124,17 @@ export function ApiKeysSettings({ initialKeys }: ApiKeysSettingsProps) {
 
     return (
         <div className="space-y-8">
-            <div>
-                <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+            <div className='flex justify-between items-start'>
+                <div>
+                    <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
                     {t('title')}
-                </h2>
-                <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
-            </div>
+                    </h2>
+                    <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
+                </div>
 
-            {/* Create Button */}
-            <div className="flex justify-end">
-                <Button onClick={() => setShowCreateDialog(true)}>
-                    <Key className="w-4 h-4 mr-2" />
+                {/* Create Button */}
+                <Button onClick={() => setShowCreateDialog(true)} className='text-sm'>
+                    <Key className="w-4 h-4" />
                     {t('create')}
                 </Button>
             </div>
@@ -276,10 +276,10 @@ export function ApiKeysSettings({ initialKeys }: ApiKeysSettingsProps) {
                             </div>
 
                             <DialogFooter>
-                                <Button variant="secondary" onClick={closeCreateDialog}>
+                                <Button size='sm' variant="secondary" onClick={closeCreateDialog}>
                                     {t('dialog.cancel')}
                                 </Button>
-                                <Button onClick={handleCreate} loading={isPending}>
+                                <Button size='sm' onClick={handleCreate} loading={isPending}>
                                     {t('dialog.createButton')}
                                 </Button>
                             </DialogFooter>

--- a/apps/web/src/components/settings/ApiKeysSettings.tsx
+++ b/apps/web/src/components/settings/ApiKeysSettings.tsx
@@ -124,16 +124,18 @@ export function ApiKeysSettings({ initialKeys }: ApiKeysSettingsProps) {
 
     return (
         <div className="space-y-8">
-            <div className='flex justify-between items-start'>
+            <div className="flex justify-between items-start">
                 <div>
                     <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
-                    {t('title')}
+                        {t('title')}
                     </h2>
-                    <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
+                    <p className="text-text-muted dark:text-text-muted-dark text-sm">
+                        {t('subtitle')}
+                    </p>
                 </div>
 
                 {/* Create Button */}
-                <Button onClick={() => setShowCreateDialog(true)} className='text-sm'>
+                <Button onClick={() => setShowCreateDialog(true)} className="text-sm">
                     <Key className="w-4 h-4" />
                     {t('create')}
                 </Button>
@@ -276,10 +278,10 @@ export function ApiKeysSettings({ initialKeys }: ApiKeysSettingsProps) {
                             </div>
 
                             <DialogFooter>
-                                <Button size='sm' variant="secondary" onClick={closeCreateDialog}>
+                                <Button size="sm" variant="secondary" onClick={closeCreateDialog}>
                                     {t('dialog.cancel')}
                                 </Button>
-                                <Button size='sm' onClick={handleCreate} loading={isPending}>
+                                <Button size="sm" onClick={handleCreate} loading={isPending}>
                                     {t('dialog.createButton')}
                                 </Button>
                             </DialogFooter>

--- a/apps/web/src/components/settings/DangerZone.tsx
+++ b/apps/web/src/components/settings/DangerZone.tsx
@@ -129,7 +129,7 @@ export function DangerZone({ user }: DangerZoneProps) {
                                 onClick={handleDeleteAccount}
                                 disabled={isPending || confirmEmail !== user.email}
                                 className={cn(
-                                    'px-6 py-2 rounded-lg font-medium transition-colors',
+                                    'px-6 py-2 rounded-lg font-medium transition-colors text-sm',
                                     'bg-danger text-white',
                                     confirmEmail === user.email
                                         ? 'hover:bg-danger/90'
@@ -145,7 +145,7 @@ export function DangerZone({ user }: DangerZoneProps) {
                                 }}
                                 disabled={isPending}
                                 className={cn(
-                                    'px-6 py-2 rounded-lg font-medium transition-colors',
+                                    'px-6 py-2 rounded-lg font-medium transition-colors text-sm',
                                     'bg-surface-secondary dark:bg-surface-secondary-dark',
                                     'text-text dark:text-text-dark',
                                     'hover:bg-surface dark:hover:bg-surface-dark',

--- a/apps/web/src/components/settings/DataManagement.tsx
+++ b/apps/web/src/components/settings/DataManagement.tsx
@@ -71,7 +71,7 @@ export function DataManagement() {
                 )}
 
                 <Button onClick={handleExport} disabled={isExporting} size="sm">
-                    <Download className="w-4 h-4 mr-2" />
+                    <Download className="w-4 h-4" />
                     {isExporting ? t('exporting') : t('exportButton')}
                 </Button>
             </div>
@@ -89,7 +89,7 @@ export function DataManagement() {
 
                 {!showImport ? (
                     <Button variant="secondary" onClick={() => setShowImport(true)} size="sm">
-                        <Upload className="w-4 h-4 mr-2" />
+                        <Upload className="w-4 h-4" />
                         {t('importButton')}
                     </Button>
                 ) : (

--- a/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
+++ b/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
@@ -128,20 +128,22 @@ export function GitHubOrganizationsSettings({
                 )}
             </div>
 
-            <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="flex flex-col gap-3">
                 <Input
                     value={draftOrganization}
                     onChange={(event) => setDraftOrganization(event.target.value)}
                     placeholder="Add organization by login"
                 />
-                <Button variant="secondary" onClick={addOrganization}>
-                    <Plus className="w-4 h-4" />
-                    Add organization
-                </Button>
-                <Button onClick={saveOrganizations} loading={isPending}>
-                    <Save className="w-4 h-4" />
-                    Save organizations
-                </Button>
+                <div className="flex gap-3 items-center">
+                    <Button variant="secondary" onClick={addOrganization} className='text-sm'>
+                        <Plus className="w-4 h-4" />
+                        Add organization
+                    </Button>
+                    <Button onClick={saveOrganizations} loading={isPending} className='text-sm py-2'>
+                        <Save className="w-4 h-4" />
+                        Save organizations
+                    </Button>
+                </div>
             </div>
 
             {status && (

--- a/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
+++ b/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
@@ -139,11 +139,7 @@ export function GitHubOrganizationsSettings({
                         <Plus className="w-4 h-4" />
                         Add organization
                     </Button>
-                    <Button
-                        onClick={saveOrganizations}
-                        loading={isPending}
-                        size='sm'
-                    >
+                    <Button onClick={saveOrganizations} loading={isPending} size="sm">
                         <Save className="w-4 h-4" />
                         Save organizations
                     </Button>

--- a/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
+++ b/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
@@ -142,7 +142,7 @@ export function GitHubOrganizationsSettings({
                     <Button
                         onClick={saveOrganizations}
                         loading={isPending}
-                        className="text-sm py-2"
+                        size='sm'
                     >
                         <Save className="w-4 h-4" />
                         Save organizations

--- a/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
+++ b/apps/web/src/components/settings/GitHubOrganizationsSettings.tsx
@@ -135,11 +135,15 @@ export function GitHubOrganizationsSettings({
                     placeholder="Add organization by login"
                 />
                 <div className="flex gap-3 items-center">
-                    <Button variant="secondary" onClick={addOrganization} className='text-sm'>
+                    <Button variant="secondary" onClick={addOrganization} className="text-sm">
                         <Plus className="w-4 h-4" />
                         Add organization
                     </Button>
-                    <Button onClick={saveOrganizations} loading={isPending} className='text-sm py-2'>
+                    <Button
+                        onClick={saveOrganizations}
+                        loading={isPending}
+                        className="text-sm py-2"
+                    >
                         <Save className="w-4 h-4" />
                         Save organizations
                     </Button>

--- a/apps/web/src/components/settings/GitHubSync.tsx
+++ b/apps/web/src/components/settings/GitHubSync.tsx
@@ -116,7 +116,7 @@ export function GitHubSync() {
     if (!status.hasOAuth) {
         return (
             <div className="p-4 rounded-lg border border-border dark:border-border-dark">
-                <div className="flex items-center gap-2 mb-2">
+                <div className="flex items-center mb-2">
                     <Github className="w-5 h-5" />
                     <span className="font-medium text-text dark:text-text-dark">
                         {t('connectGitHub')}
@@ -149,7 +149,7 @@ export function GitHubSync() {
             <div className="space-y-4">
                 {!showConfigure ? (
                     <Button variant="secondary" onClick={() => setShowConfigure(true)} size="sm">
-                        <Github className="w-4 h-4 mr-2" />
+                        <Github className="w-4 h-4" />
                         {t('setupSync')}
                     </Button>
                 ) : (

--- a/apps/web/src/components/settings/GitHubSync.tsx
+++ b/apps/web/src/components/settings/GitHubSync.tsx
@@ -116,7 +116,7 @@ export function GitHubSync() {
     if (!status.hasOAuth) {
         return (
             <div className="p-4 rounded-lg border border-border dark:border-border-dark">
-                <div className="flex items-center mb-2">
+                <div className="flex items-center gap-0.5 mb-2">
                     <Github className="w-5 h-5" />
                     <span className="font-medium text-text dark:text-text-dark">
                         {t('connectGitHub')}

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -148,7 +148,7 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
 
                 {/* Save Button */}
                 <div className="flex justify-end">
-                    <Button onClick={handleSaveProfile} loading={isPending} className='text-sm'>
+                    <Button onClick={handleSaveProfile} loading={isPending} className="text-sm">
                         {t('actions.save')}
                     </Button>
                 </div>

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -148,7 +148,7 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
 
                 {/* Save Button */}
                 <div className="flex justify-end">
-                    <Button onClick={handleSaveProfile} loading={isPending}>
+                    <Button onClick={handleSaveProfile} loading={isPending} className='text-sm'>
                         {t('actions.save')}
                     </Button>
                 </div>

--- a/apps/web/src/components/settings/SecuritySettings.tsx
+++ b/apps/web/src/components/settings/SecuritySettings.tsx
@@ -136,7 +136,7 @@ export function SecuritySettings({ user }: SecuritySettingsProps) {
 
                     {/* Update Button */}
                     <div className="flex justify-end">
-                        <Button onClick={handleUpdatePassword} loading={isPending}>
+                        <Button onClick={handleUpdatePassword} loading={isPending} className='text-sm'>
                             {t('changePassword.actions.update')}
                         </Button>
                     </div>

--- a/apps/web/src/components/settings/SecuritySettings.tsx
+++ b/apps/web/src/components/settings/SecuritySettings.tsx
@@ -136,7 +136,11 @@ export function SecuritySettings({ user }: SecuritySettingsProps) {
 
                     {/* Update Button */}
                     <div className="flex justify-end">
-                        <Button onClick={handleUpdatePassword} loading={isPending} className='text-sm'>
+                        <Button
+                            onClick={handleUpdatePassword}
+                            loading={isPending}
+                            className="text-sm"
+                        >
                             {t('changePassword.actions.update')}
                         </Button>
                     </div>

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -59,7 +59,7 @@ const Input = ({
                 // Variant-specific styles
                 variant === 'form' && ['px-4 py-2', 'bg-white dark:bg-input-bg-dark'],
                 variant === 'default' && [
-                    'px-4 py-3',
+                    'px-4 py-2',
                     'bg-white dark:bg-input-bg-dark',
                     'focus:ring-2 focus:ring-primary-800/20',
                     'hover:border-border-secondary dark:hover:border-border-secondary-dark',


### PR DESCRIPTION
Improve the consistency and usability of the UI by adjusting button sizes on the Plugin and Settings pages. Some buttons are currently inconsistent in size, which affects visual hierarchy and user experience.

> | | Before | | Now | |
> |-|---------|-|--------|-|
> | |<img width="1907" height="871" alt="Screenshot 2026-03-25 235002" src="https://github.com/user-attachments/assets/edd8f7d4-4a50-46c2-b930-0506a7549520" />| |<img width="1915" height="875" alt="Screenshot 2026-03-25 234846" src="https://github.com/user-attachments/assets/52cde299-d1a4-4eaf-a4b8-65238d626d98" />| |

> | | Before | | Now | |
> |-|---------|-|--------|-|
> | |<img width="1912" height="872" alt="Screenshot 2026-03-25 234209" src="https://github.com/user-attachments/assets/028f0ac1-3724-4154-81a8-fa3b5d804391" />| |<img width="1916" height="868" alt="Screenshot 2026-03-25 235604" src="https://github.com/user-attachments/assets/d41d9087-3664-4d9e-b111-d82cd0c80075" />| |

> | | Figma template | | Your project | |
> |-|---------|-|--------|-|
> | |<img width="1910" height="862" alt="Screenshot 2026-03-25 234029" src="https://github.com/user-attachments/assets/08d72518-1ef5-4079-aae4-d9fe14ff851e" />| |<img width="1901" height="871" alt="Screenshot 2026-03-26 000151" src="https://github.com/user-attachments/assets/6ae6ebf6-b4a7-49d2-8cbd-20bf4d0a16ae" />| |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined spacing across settings and plugin UIs for a tighter, more compact layout
  * Reduced vertical padding on navigation, category filters, and buttons
  * Decreased icon sizes and trimmed text sizes for buttons, links, and metadata
  * Adjusted container and prose widths/padding for improved layout balance
  * Tuned dark-mode opacity for muted section headers to improve contrast consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->