### PR TITLE
fix: add error handling to dashboard API calls to prevent page crashes

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -314,7 +314,8 @@
             "subtitle": "Manage your AI-powered directories and track their performance",
             "notifications": {
                 "title": "Notifications",
-                "empty": "No new notifications"
+                "empty": "No new notifications",
+                "fetchFailed": "Failed to load notifications"
             },
             "help": {
                 "title": "Help & Resources",
@@ -350,6 +351,7 @@
             "search": "Search directories...",
             "create": "Create Directory",
             "showing": "Showing {current} of {total} directories",
+            "searchFailed": "Failed to search directories. Please try again.",
             "pagination": {
                 "previous": "Previous",
                 "next": "Next"
@@ -2344,6 +2346,7 @@
             "inputPlaceholder": "Describe the directory you want to create...",
             "sendButton": "Send",
             "sendHint": "Enter to send · Shift+Enter for new line",
+            "providersError": "Failed to load AI providers. Chat may not work correctly.",
             "providerNotConfigured": "This provider is not configured. Set it up in Plugins.",
             "editMessage": "Edit message",
             "saveEdit": "Save & Submit",

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
@@ -17,8 +17,17 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Dashboard() {
     const [user, directoriesResponse, statsResponse, pluginsResponse] = await Promise.all([
         getAuthFromCookie(),
-        getDirectories({ limit: GET_DIRECTORY_LIST_LIMIT }),
-        getDirectoryStats(),
+        getDirectories({ limit: GET_DIRECTORY_LIST_LIMIT }).catch(() => ({
+            success: false,
+            directories: [],
+            total: 0,
+        })),
+        getDirectoryStats().catch(() => ({
+            success: false,
+            totalDirectories: 0,
+            totalItems: 0,
+            activeWebsites: 0,
+        })),
         pluginsAPI.list().catch(() => ({ plugins: [] as UserPlugin[], total: 0 })),
     ]);
 

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/generator/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/generator/page.tsx
@@ -17,13 +17,20 @@ type Params = { params: Promise<{ id: string }> };
 export default async function DirectoryGeneratorPage({ params }: Params) {
     const { id } = await params;
 
-    const [directoryRes, configRes] = await Promise.all([
-        directoryAPI.get(id),
-        directoryAPI.getConfig(id).catch(() => ({ config: undefined })),
-    ]);
+    let directory;
+    let config;
 
-    const directory = directoryRes.directory;
-    const config = configRes.config;
+    try {
+        const [directoryRes, configRes] = await Promise.all([
+            directoryAPI.get(id),
+            directoryAPI.getConfig(id).catch(() => ({ config: undefined })),
+        ]);
+
+        directory = directoryRes.directory;
+        config = configRes.config;
+    } catch {
+        notFound();
+    }
 
     // Server-side permission check: only editors+ can access generator
     if (!canGenerate(directory.userRole)) {

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/members/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/members/page.tsx
@@ -15,12 +15,20 @@ type Params = { params: Promise<{ id: string }> };
 export default async function DirectoryMembersPage({ params }: Params) {
     const { id } = await params;
 
-    const [directoryRes, membersRes] = await Promise.all([
-        directoryAPI.get(id),
-        membersAPI.list(id),
-    ]);
+    let directory;
+    let membersRes;
 
-    const directory = directoryRes.directory;
+    try {
+        const [directoryResult, membersResult] = await Promise.all([
+            directoryAPI.get(id),
+            membersAPI.list(id),
+        ]);
+
+        directory = directoryResult.directory;
+        membersRes = membersResult;
+    } catch {
+        notFound();
+    }
 
     if (!canManageMembers(directory.userRole)) {
         notFound();

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/page.tsx
@@ -6,6 +6,7 @@ import { DirectoryInfo } from '@/components/directories/detail/overview/Director
 import { DirectoryStats } from '@/components/directories/detail/overview/DirectoryStats';
 import { DirectoryConfig } from '@/components/directories/detail/overview/DirectoryConfig';
 import { GenerateStatusType } from '@/lib/api/enums';
+import { notFound } from 'next/navigation';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('metadata.pages');
@@ -17,16 +18,25 @@ type Params = { params: Promise<{ id: string }> };
 export default async function DirectoryOverviewPage({ params }: Params) {
     const { id } = await params;
 
-    const [directoryRes, configRes, countRes] = await Promise.all([
-        directoryAPI.get(id),
-        directoryAPI.getConfig(id).catch(() => ({ config: null })),
-        directoryAPI
-            .getCount(id)
-            .catch(() => ({ items: 0, categories: 0, tags: 0, comparisons: 0 })),
-    ]);
+    let directory;
+    let config = null;
+    let countRes = { items: 0, categories: 0, tags: 0, comparisons: 0 };
 
-    const directory = directoryRes.directory;
-    const config = configRes.config;
+    try {
+        const [directoryRes, configResult, countResult] = await Promise.all([
+            directoryAPI.get(id),
+            directoryAPI.getConfig(id).catch(() => ({ config: null })),
+            directoryAPI
+                .getCount(id)
+                .catch(() => ({ items: 0, categories: 0, tags: 0, comparisons: 0 })),
+        ]);
+
+        directory = directoryRes.directory;
+        config = configResult.config;
+        countRes = countResult;
+    } catch {
+        notFound();
+    }
 
     const showStatusCard =
         !directory.generateStatus?.status ||

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/plugins/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/plugins/page.tsx
@@ -16,15 +16,25 @@ export default async function DirectoryPluginsPage({ params }: Params) {
     const { id } = await params;
     const t = await getTranslations('dashboard.directoryPlugins');
 
-    const res = await directoryAPI.get(id);
-    const directory = res.directory;
+    let directory;
+    let pluginsData;
+
+    try {
+        const [res, pluginsResult] = await Promise.all([
+            directoryAPI.get(id),
+            pluginsAPI.listForDirectory(id),
+        ]);
+
+        directory = res.directory;
+        pluginsData = pluginsResult;
+    } catch {
+        notFound();
+    }
 
     // Server-side permission check: only managers and owners can access settings
     if (!canAccessSettings(directory.userRole)) {
         notFound();
     }
-
-    const pluginsData = await pluginsAPI.listForDirectory(id);
 
     return (
         <div className="w-full">

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/schedule/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/schedule/page.tsx
@@ -57,12 +57,14 @@ export default async function DirectorySchedulePage({ params }: Params) {
     let configRes;
 
     try {
-        const [directoryResult, scheduleResult, formSchemaResult, configResult] = await Promise.all([
-            directoryAPI.get(id),
-            directoryAPI.getSchedule(id).catch(() => null),
-            itemsGeneratorAPI.getFormSchema(id).catch(() => null),
-            directoryAPI.getConfig(id).catch(() => null),
-        ]);
+        const [directoryResult, scheduleResult, formSchemaResult, configResult] = await Promise.all(
+            [
+                directoryAPI.get(id),
+                directoryAPI.getSchedule(id).catch(() => null),
+                itemsGeneratorAPI.getFormSchema(id).catch(() => null),
+                directoryAPI.getConfig(id).catch(() => null),
+            ],
+        );
 
         directory = directoryResult.directory;
         scheduleRes = scheduleResult;

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/schedule/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/schedule/page.tsx
@@ -51,14 +51,26 @@ function resolveActiveProviders(
 export default async function DirectorySchedulePage({ params }: Params) {
     const { id } = await params;
 
-    const [directoryRes, scheduleRes, formSchema, configRes] = await Promise.all([
-        directoryAPI.get(id),
-        directoryAPI.getSchedule(id).catch(() => null),
-        itemsGeneratorAPI.getFormSchema(id).catch(() => null),
-        directoryAPI.getConfig(id).catch(() => null),
-    ]);
+    let directory;
+    let scheduleRes;
+    let formSchema;
+    let configRes;
 
-    const directory = directoryRes.directory;
+    try {
+        const [directoryResult, scheduleResult, formSchemaResult, configResult] = await Promise.all([
+            directoryAPI.get(id),
+            directoryAPI.getSchedule(id).catch(() => null),
+            itemsGeneratorAPI.getFormSchema(id).catch(() => null),
+            directoryAPI.getConfig(id).catch(() => null),
+        ]);
+
+        directory = directoryResult.directory;
+        scheduleRes = scheduleResult;
+        formSchema = formSchemaResult;
+        configRes = configResult;
+    } catch {
+        notFound();
+    }
 
     if (!canManageSchedule(directory.userRole)) {
         notFound();

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/settings/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/settings/page.tsx
@@ -18,8 +18,14 @@ export default async function DirectorySettingsPage({ params }: Params) {
     const { id } = await params;
 
     const user = await getAuthFromCookie();
-    const res = await directoryAPI.get(id);
-    const directory = res.directory;
+
+    let directory;
+    try {
+        const res = await directoryAPI.get(id);
+        directory = res.directory;
+    } catch {
+        notFound();
+    }
 
     // Server-side permission check: only managers and owners can access settings
     if (!canAccessSettings(directory.userRole)) {

--- a/apps/web/src/app/[locale]/(dashboard)/directories/directories-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/directories-client.tsx
@@ -10,6 +10,7 @@ import { Link, useRouter } from '@/i18n/navigation';
 import { getDirectories } from '@/app/actions/dashboard/directories';
 import { cn } from '@/lib/utils/cn';
 import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 
 const MIN_SEARCH_CHARS = 3;
 const DEBOUNCE_MS = 300;
@@ -69,9 +70,10 @@ export default function DirectoriesClient({
                     setTotal(response.total);
                 }
             } catch (error) {
-                // Only log error if this is still the latest request
+                // Only show error if this is still the latest request
                 if (currentRequestId === requestIdRef.current) {
                     console.error('Failed to search directories:', error);
+                    toast.error(t('searchFailed'));
                 }
             } finally {
                 // Only clear loading if this is still the latest request

--- a/apps/web/src/app/[locale]/(dashboard)/directories/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/page.tsx
@@ -10,7 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function DirectoriesPage() {
     // Fetch all directories with pagination
-    const response = await getDirectories({ limit: 20, offset: 0 });
+    const response = await getDirectories({ limit: 20, offset: 0 }).catch(() => ({
+        success: false,
+        directories: [],
+        total: 0,
+    }));
 
     return (
         <DirectoriesClient

--- a/apps/web/src/app/[locale]/(dashboard)/plugins/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/plugins/page.tsx
@@ -10,7 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function PluginsPage() {
     const t = await getTranslations('dashboard.plugins');
-    const pluginsData = await pluginsAPI.list();
+    const pluginsData = await pluginsAPI.list().catch(() => ({
+        plugins: [],
+        categories: [],
+        capabilities: [],
+    }));
 
     return (
         <div className="w-full">

--- a/apps/web/src/components/ai/ChatProvider.tsx
+++ b/apps/web/src/components/ai/ChatProvider.tsx
@@ -12,7 +12,6 @@ interface ChatContextValue extends UseChatHistoryValue {
     providers: ProviderOption[];
     selectedProvider: string | null;
     setSelectedProvider: (id: string | null) => void;
-    providersError: boolean;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
@@ -22,8 +21,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     const chatHistory = useChatHistory({ initialMessage: t('welcomeMessage') });
     const [providers, setProviders] = useState<ProviderOption[]>([]);
     const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
-    const [providersError, setProvidersError] = useState(false);
-
     useEffect(() => {
         let cancelled = false;
 
@@ -41,13 +38,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
                         setSelectedProvider(defaultProvider.id);
                     }
                 } else {
-                    setProvidersError(true);
                     toast.error(t('providersError'));
                 }
             } catch (error) {
                 if (cancelled) return;
                 console.error('Failed to load AI providers:', error);
-                setProvidersError(true);
                 toast.error(t('providersError'));
             }
         }
@@ -68,7 +63,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         providers,
         selectedProvider,
         setSelectedProvider: handleSetSelectedProvider,
-        providersError,
     };
 
     return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;

--- a/apps/web/src/components/ai/ChatProvider.tsx
+++ b/apps/web/src/components/ai/ChatProvider.tsx
@@ -6,11 +6,13 @@ import { useChatHistory, UseChatHistoryValue } from '@/lib/hooks/use-chat-histor
 import type { ProviderOption } from '@/lib/api/types-only';
 import { getGlobalFormSchema } from '@/app/actions/dashboard/generator-form';
 import { resolveEffectiveDefault } from '@ever-works/plugin';
+import { toast } from 'sonner';
 
 interface ChatContextValue extends UseChatHistoryValue {
     providers: ProviderOption[];
     selectedProvider: string | null;
     setSelectedProvider: (id: string | null) => void;
+    providersError: boolean;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
@@ -20,22 +22,33 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     const chatHistory = useChatHistory({ initialMessage: t('welcomeMessage') });
     const [providers, setProviders] = useState<ProviderOption[]>([]);
     const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+    const [providersError, setProvidersError] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
 
         async function fetchProviders() {
-            const result = await getGlobalFormSchema();
-            if (cancelled) return;
+            try {
+                const result = await getGlobalFormSchema();
+                if (cancelled) return;
 
-            if (result.success && result.data) {
-                const aiProviders = result.data.providers.ai ?? [];
-                setProviders(aiProviders);
+                if (result.success && result.data) {
+                    const aiProviders = result.data.providers.ai ?? [];
+                    setProviders(aiProviders);
 
-                const defaultProvider = resolveEffectiveDefault(aiProviders);
-                if (defaultProvider) {
-                    setSelectedProvider(defaultProvider.id);
+                    const defaultProvider = resolveEffectiveDefault(aiProviders);
+                    if (defaultProvider) {
+                        setSelectedProvider(defaultProvider.id);
+                    }
+                } else {
+                    setProvidersError(true);
+                    toast.error(t('providersError'));
                 }
+            } catch (error) {
+                if (cancelled) return;
+                console.error('Failed to load AI providers:', error);
+                setProvidersError(true);
+                toast.error(t('providersError'));
             }
         }
 
@@ -44,7 +57,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         return () => {
             cancelled = true;
         };
-    }, []);
+    }, [t]);
 
     const handleSetSelectedProvider = useCallback((id: string | null) => {
         setSelectedProvider(id);
@@ -55,6 +68,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         providers,
         selectedProvider,
         setSelectedProvider: handleSetSelectedProvider,
+        providersError,
     };
 
     return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;

--- a/apps/web/src/components/dashboard/NotificationDropdown.tsx
+++ b/apps/web/src/components/dashboard/NotificationDropdown.tsx
@@ -13,8 +13,8 @@ import {
     dismissNotification,
 } from '@/app/actions/notifications';
 import { useRouter } from 'next/navigation';
-import { formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
+import { formatDistanceToNow } from 'date-fns';
 import { Bell, X } from 'lucide-react';
 
 interface NotificationDropdownProps {
@@ -128,8 +128,9 @@ export function NotificationDropdown({ className }: NotificationDropdownProps) {
             }
         } catch (error) {
             console.error('Failed to fetch notifications:', error);
+            toast.error(t('notifications.fetchFailed'));
         }
-    }, []);
+    }, [t]);
 
     const fetchUnreadCount = useCallback(async () => {
         try {


### PR DESCRIPTION
Server component pages with unhandled directoryAPI.get() calls now use try/catch with notFound() fallback. Home and directories list pages use .catch() for graceful degradation with empty data. Client components (ChatProvider, NotificationDropdown, DirectoriesClient) now surface errors via toast notifications instead of failing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-facing error toasts for notifications, directory search, and AI chat provider failures.

* **Bug Fixes**
  * Improved error handling across dashboard pages: API failures now produce safe fallbacks or redirect to Not Found instead of crashing.

* **Localization**
  * Added new UI strings for notification fetch failure, directory search failure, and AI provider load error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->