### PR TITLE
fix: remove sensitive data from logs and hardcoded JWT secret fallback

### DIFF
--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -1,5 +1,11 @@
 export const jwtConstants = {
-    secret: () => process.env.JWT_SECRET || 'aesh4Dai_secret_key_here',
+    secret: () => {
+        const secret = process.env.JWT_SECRET;
+        if (!secret) {
+            throw new Error('JWT_SECRET environment variable is required');
+        }
+        return secret;
+    },
     accessTokenExpiration: (): any => {
         const expiration = process.env.JWT_ACCESS_TOKEN_EXPIRATION;
         // Return undefined to disable expiration

--- a/apps/api/src/integrations/twenty-crm/services/twenty-crm.service.ts
+++ b/apps/api/src/integrations/twenty-crm/services/twenty-crm.service.ts
@@ -57,7 +57,7 @@ export class TwentyCrmService {
             const config = this.configService.twentyCrmConfig;
             const url = schema ? `${this.metadataUrl}${endpoint}` : `${this.baseUrl}${endpoint}`;
 
-            this.logger.debug(`Making ${method} request to ${url}`, { data, params });
+            this.logger.debug(`Making ${method} request to ${url}`);
 
             const response = await firstValueFrom(
                 this.httpService.request({

--- a/apps/api/src/integrations/twenty-crm/twenty-crm.module.ts
+++ b/apps/api/src/integrations/twenty-crm/twenty-crm.module.ts
@@ -14,7 +14,6 @@ import { CompaniesController } from './controllers/companies.service';
 @Module({})
 export class TwentyCrmModule {
     static forRoot(config?: Partial<CrmConfigService>) {
-        console.log('forRoot', config?.twentyCrmConfig.apiKey);
         return {
             module: TwentyCrmModule,
             global: true,

--- a/apps/api/src/mail/providers/faker-mailer.service.ts
+++ b/apps/api/src/mail/providers/faker-mailer.service.ts
@@ -6,6 +6,6 @@ export class FakerMailerService {
     private readonly logger = new Logger(FakerMailerService.name);
 
     async sendMail(data: SendMailOptions): Promise<void> {
-        this.logger.debug('FakerMailerService:sendMail', data);
+        this.logger.debug(`FakerMailerService:sendMail to=${data.to} subject="${data.subject}"`);
     }
 }


### PR DESCRIPTION
Remove console.log that leaked Twenty CRM API key on module init. Strip request body/params from CRM debug logs. Sanitize faker mailer logs to only show recipient and subject. Replace hardcoded JWT secret fallback with a required environment variable check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API now requires JWT_SECRET environment variable; missing configuration will cause startup failures.

* **Chores**
  * Refined debug logging to remove sensitive information.
  * Improved log message clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->