### PR TITLE
fix(activity-log): secure detail access and complete csv export

### DIFF
--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -125,7 +125,7 @@ export class ActivityLogController {
     @ApiResponse({ status: 200, description: 'Activity log entry details' })
     @ApiResponse({ status: 404, description: 'Activity not found' })
     async getActivity(@CurrentUser() auth: AuthenticatedUser, @Param('id') id: string) {
-        const activity = await this.activityLogService.findById(id);
+        const activity = await this.activityLogService.findByIdAndUserId(id, auth.userId);
         if (!activity) {
             throw new NotFoundException('Activity not found');
         }

--- a/apps/api/src/directories/directories.controller.ts
+++ b/apps/api/src/directories/directories.controller.ts
@@ -613,7 +613,7 @@ export class DirectoriesController {
                 directoryId: id,
                 actionType: ActivityActionType.SCHEDULE_EXECUTED,
                 action: 'schedule.executed',
-                status: ActivityStatus.IN_PROGRESS,
+                status: ActivityStatus.COMPLETED,
                 summary: `Triggered scheduled update`,
             })
             .catch(() => {});
@@ -1096,8 +1096,8 @@ export class DirectoriesController {
                 userId: auth.userId,
                 actionType: ActivityActionType.IMPORT,
                 action: 'directory.import_started',
-                status: ActivityStatus.IN_PROGRESS,
-                summary: `Started directory import`,
+                status: ActivityStatus.COMPLETED,
+                summary: `Triggered directory import`,
                 details: {
                     sourceUrl: importDto.sourceUrl,
                     sourceType: importDto.sourceType,

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -173,8 +173,8 @@ export class DeployController {
                 directoryId: id,
                 actionType: ActivityActionType.DEPLOYMENT,
                 action: 'directory.deployed',
-                status: ActivityStatus.IN_PROGRESS,
-                summary: `Deployed ${directory.name} via ${providerName}`,
+                status: ActivityStatus.COMPLETED,
+                summary: `Triggered deployment for ${directory.name} via ${providerName}`,
             })
             .catch(() => {});
 
@@ -391,8 +391,8 @@ export class DeployController {
                 userId: auth.userId,
                 actionType: ActivityActionType.DEPLOYMENT,
                 action: 'deployment.batch_started',
-                status: ActivityStatus.IN_PROGRESS,
-                summary: `Batch deployed ${batchDeployDto.directories.length} directories`,
+                status: ActivityStatus.COMPLETED,
+                summary: `Triggered batch deploy for ${batchDeployDto.directories.length} directories`,
                 details: {
                     directoryIds: batchDeployDto.directories.map((item) => item.directoryId),
                 },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -346,6 +346,7 @@
         "activity": {
             "title": "Activity Log",
             "subtitle": "Track all operations across your directories",
+            "loading": "Loading...",
             "fetchFailed": "Failed to load activities",
             "exportFailed": "Failed to export activity log",
             "showing": "Showing {from} to {to} of {total}",

--- a/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
@@ -144,14 +144,31 @@ export function ActivityClient({ initialActivities, totalActivities }: ActivityC
     };
 
     const handleExport = async () => {
+        const params = new URLSearchParams();
+        if (actionType) params.set('actionType', actionType);
+        if (status) params.set('status', status);
+        if (debouncedSearch) params.set('search', debouncedSearch);
+        const query = params.toString();
+
         try {
-            const params = new URLSearchParams();
-            if (actionType) params.set('actionType', actionType);
-            if (status) params.set('status', status);
-            if (debouncedSearch) params.set('search', debouncedSearch);
-            const query = params.toString();
-            window.open(`/api/activity-log/export${query ? `?${query}` : ''}`, '_blank');
-        } catch (error) {
+            const response = await fetch(`/api/activity-log/export${query ? `?${query}` : ''}`, {
+                method: 'GET',
+            });
+
+            if (!response.ok) {
+                throw new Error('Export failed');
+            }
+
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'activity-log.csv';
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(url);
+        } catch {
             toast.error(t('exportFailed'));
         }
     };

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -111,6 +111,16 @@ export function ActivityTable({ activities, loading }: ActivityTableProps) {
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-border dark:divide-border-dark">
+                        {loading && activities.length === 0 && (
+                            <tr className="bg-card dark:bg-transparent">
+                                <td
+                                    colSpan={6}
+                                    className="px-4 py-10 text-center text-sm text-text-muted dark:text-text-muted-dark"
+                                >
+                                    Loading...
+                                </td>
+                            </tr>
+                        )}
                         {activities.map((activity) => {
                             const isExpanded = expandedIds.includes(activity.id);
                             const hasDetails =

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -117,7 +117,7 @@ export function ActivityTable({ activities, loading }: ActivityTableProps) {
                                     colSpan={6}
                                     className="px-4 py-10 text-center text-sm text-text-muted dark:text-text-muted-dark"
                                 >
-                                    Loading...
+                                    {t('loading')}
                                 </td>
                             </tr>
                         )}

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -47,8 +47,12 @@ export class ActivityLogService {
         return this.repository.findById(id);
     }
 
+    async findByIdAndUserId(id: string, userId: string): Promise<ActivityLog | null> {
+        return this.repository.findByIdAndUserId(id, userId);
+    }
+
     async exportCsv(query: ActivityLogQueryOptions): Promise<string> {
-        const { activities } = await this.repository.findByUserId({
+        const activities = await this.repository.findByUserIdForExport({
             ...query,
             limit: 10000,
             offset: 0,

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -42,6 +42,18 @@ export class ActivityLogRepository {
     async findByUserId(
         options: ActivityLogQueryOptions,
     ): Promise<{ activities: ActivityLog[]; total: number }> {
+        return this.findByUserIdWithLimit(options, true);
+    }
+
+    async findByUserIdForExport(options: ActivityLogQueryOptions): Promise<ActivityLog[]> {
+        const { activities } = await this.findByUserIdWithLimit(options, false);
+        return activities;
+    }
+
+    private async findByUserIdWithLimit(
+        options: ActivityLogQueryOptions,
+        enforceCap: boolean,
+    ): Promise<{ activities: ActivityLog[]; total: number }> {
         const qb = this.repository
             .createQueryBuilder('activity')
             .leftJoinAndSelect('activity.directory', 'directory')
@@ -76,7 +88,8 @@ export class ActivityLogRepository {
             });
         }
 
-        const limit = Math.min(options.limit || 25, 100);
+        const requestedLimit = options.limit || 25;
+        const limit = enforceCap ? Math.min(requestedLimit, 100) : requestedLimit;
         const offset = options.offset || 0;
 
         const [activities, total] = await qb.take(limit).skip(offset).getManyAndCount();


### PR DESCRIPTION
Restrict activity detail reads to the owning user, remove export truncation from the repository query path, and make the dashboard export flow fail safely before starting the download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loading indicator in the activity log table.
  * CSV export now downloads directly and returns full results (no truncation).

* **Bug Fixes**
  * Activity entries are properly scoped to the authenticated user.
  * Activity statuses now reflect COMPLETED (not IN_PROGRESS) where appropriate.
  * Activity summary text refined for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->