### PR TITLE
Prevents auto-navigate for replayed tool results

### DIFF
--- a/apps/web/src/components/ai/ChatToolResult.tsx
+++ b/apps/web/src/components/ai/ChatToolResult.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { useRouter, usePathname, Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
@@ -129,9 +129,15 @@ export function ChatToolResult({ toolName, state, output, errorText }: ChatToolR
     const isDone = state === 'output-available';
     const isError = state === 'output-error';
 
-    // Auto-navigate or reload
+    // Track whether this tool was live (seen running) vs loaded from history.
+    // Only auto-navigate/reload for live tool executions, not replayed results.
+    const wasLive = useRef(false);
+    if (isRunning) {
+        wasLive.current = true;
+    }
+
     useEffect(() => {
-        if (!isDone || !output) return;
+        if (!isDone || !output || !wasLive.current) return;
         if (toolName === 'navigate') {
             const data = output as NavigateOutput;
             if (data.url && data.url.startsWith('/')) router.push(data.url);

--- a/apps/web/src/components/ai/ChatToolResult.tsx
+++ b/apps/web/src/components/ai/ChatToolResult.tsx
@@ -132,9 +132,11 @@ export function ChatToolResult({ toolName, state, output, errorText }: ChatToolR
     // Track whether this tool was live (seen running) vs loaded from history.
     // Only auto-navigate/reload for live tool executions, not replayed results.
     const wasLive = useRef(false);
-    if (isRunning) {
-        wasLive.current = true;
-    }
+    useEffect(() => {
+        if (isRunning) {
+            wasLive.current = true;
+        }
+    }, [isRunning]);
 
     useEffect(() => {
         if (!isDone || !output || !wasLive.current) return;

--- a/apps/web/src/lib/ai/tools/search.tools.ts
+++ b/apps/web/src/lib/ai/tools/search.tools.ts
@@ -11,7 +11,9 @@ export const webSearch = tool({
         'Use natural language queries — do NOT use search operators like site: or inurl:.',
     ].join(' '),
     inputSchema: z.object({
-        query: z.string().describe('Natural language search query. Do not use site: or other search operators.'),
+        query: z
+            .string()
+            .describe('Natural language search query. Do not use site: or other search operators.'),
         maxResults: z.number().optional().describe('Maximum number of results (default: 10)'),
     }),
     execute: async ({ query, maxResults }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page redirects and refreshes that incorrectly occurred when replaying historical AI tool results. These actions now only happen during active live tool executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->