### PR TITLE
Preserve message insertion order in appendMessages

### DIFF
--- a/packages/agent/src/database/repositories/conversation.repository.ts
+++ b/packages/agent/src/database/repositories/conversation.repository.ts
@@ -73,8 +73,14 @@ export class ConversationRepository {
     async appendMessages(messages: AppendMessageInput[]): Promise<ConversationMessage[]> {
         if (messages.length === 0) return [];
 
-        const entities = messages.map((m) => this.messageRepo.create(m));
-        const saved = await this.messageRepo.save(entities);
+        // Save messages one by one to guarantee distinct createdAt timestamps
+        // and preserve insertion order. Batch save assigns the same timestamp
+        // to all messages, causing incorrect ordering on reload.
+        const saved: ConversationMessage[] = [];
+        for (const m of messages) {
+            const entity = this.messageRepo.create(m);
+            saved.push(await this.messageRepo.save(entity));
+        }
 
         const conversationId = messages[0].conversationId;
         await this.conversationRepo.update(conversationId, { updatedAt: new Date() });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message timestamp generation in conversations to ensure each message receives a distinct creation time, accurately reflecting the insertion sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->