### PR TITLE
feat(activity-log): add Jitsu event dispatch for activity entries

### DIFF
--- a/.env.compose
+++ b/.env.compose
@@ -71,6 +71,10 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL="${WEB_URL}/api/oauth/google/callback"
 
+# Jitsu Analytics
+JITSU_HOST=
+JITSU_WRITE_KEY=
+
 # =============================================================================
 # Trigger.dev configuration
 # =============================================================================
@@ -222,4 +226,3 @@ PLUGIN_OPENROUTER_DEFAULT_MODEL='openai/gpt-5-nano'
 PLUGIN_OPENROUTER_SIMPLE_MODEL='openai/gpt-5-nano'
 PLUGIN_OPENROUTER_MEDIUM_MODEL='moonshotai/kimi-k2.5'
 PLUGIN_OPENROUTER_COMPLEX_MODEL='moonshotai/kimi-k2.5'
-

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -45,6 +45,10 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL="${WEB_URL}/api/oauth/google/callback"
 
+# Jitsu Analytics
+JITSU_HOST=
+JITSU_WRITE_KEY=
+
 # =============================================================================
 # Trigger.dev configuration
 # =============================================================================
@@ -204,4 +208,3 @@ PLUGIN_OPENROUTER_DEFAULT_MODEL='openai/gpt-5-nano'
 PLUGIN_OPENROUTER_SIMPLE_MODEL='openai/gpt-5-nano'
 PLUGIN_OPENROUTER_MEDIUM_MODEL='moonshotai/kimi-k2.5'
 PLUGIN_OPENROUTER_COMPLEX_MODEL='moonshotai/kimi-k2.5'
-

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
         "@ever-works/monitoring": "workspace:*",
         "@ever-works/plugin": "workspace:*",
         "@ever-works/trigger-tasks": "workspace:*",
+        "@jitsu/js": "^1.10.4",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.1.13",

--- a/apps/api/src/activity-log/activity-log.module.ts
+++ b/apps/api/src/activity-log/activity-log.module.ts
@@ -3,9 +3,10 @@ import { ActivityLogModule as AgentActivityLogModule } from '@ever-works/agent/a
 import { DatabaseModule } from '@ever-works/agent/database';
 import { ActivityLogController } from './activity-log.controller';
 import { ActivityLogListener } from './activity-log.listener';
+import { JitsuModule } from './jitsu.module';
 
 @Module({
-    imports: [AgentActivityLogModule, DatabaseModule],
+    imports: [JitsuModule, AgentActivityLogModule, DatabaseModule],
     controllers: [ActivityLogController],
     providers: [ActivityLogListener],
     exports: [AgentActivityLogModule],

--- a/apps/api/src/activity-log/jitsu.module.ts
+++ b/apps/api/src/activity-log/jitsu.module.ts
@@ -1,0 +1,16 @@
+import { Global, Module } from '@nestjs/common';
+import { ACTIVITY_LOG_ANALYTICS_DISPATCHER } from '@ever-works/agent/activity-log';
+import { JitsuService } from './jitsu.service';
+
+@Global()
+@Module({
+    providers: [
+        JitsuService,
+        {
+            provide: ACTIVITY_LOG_ANALYTICS_DISPATCHER,
+            useExisting: JitsuService,
+        },
+    ],
+    exports: [JitsuService, ACTIVITY_LOG_ANALYTICS_DISPATCHER],
+})
+export class JitsuModule {}

--- a/apps/api/src/activity-log/jitsu.service.ts
+++ b/apps/api/src/activity-log/jitsu.service.ts
@@ -37,6 +37,7 @@ export class JitsuService implements ActivityLogAnalyticsDispatcher {
                 : {};
 
         await this.client.track(activity.action, {
+            ...metadata,
             activityId: activity.id,
             userId: activity.userId,
             directoryId: activity.directoryId ?? undefined,
@@ -46,7 +47,6 @@ export class JitsuService implements ActivityLogAnalyticsDispatcher {
             summary: activity.summary,
             details: activity.details ?? undefined,
             createdAt: activity.createdAt.toISOString(),
-            ...metadata,
         });
     }
 }

--- a/apps/api/src/activity-log/jitsu.service.ts
+++ b/apps/api/src/activity-log/jitsu.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { jitsuAnalytics, type AnalyticsInterface } from '@jitsu/js';
+import type { ActivityLogAnalyticsDispatcher } from '@ever-works/agent/activity-log';
+import type { ActivityLog } from '@ever-works/agent/entities';
+
+@Injectable()
+export class JitsuService implements ActivityLogAnalyticsDispatcher {
+    private readonly logger = new Logger(JitsuService.name);
+    private readonly client: AnalyticsInterface | null;
+
+    constructor() {
+        const host = process.env.JITSU_HOST;
+        const writeKey = process.env.JITSU_WRITE_KEY;
+
+        if (!host || !writeKey) {
+            this.client = null;
+            this.logger.log('Jitsu analytics disabled: missing JITSU_HOST or JITSU_WRITE_KEY');
+            return;
+        }
+
+        this.client = jitsuAnalytics({
+            host,
+            writeKey,
+        });
+    }
+
+    async track(activity: ActivityLog): Promise<void> {
+        if (!this.client) {
+            return;
+        }
+
+        const metadata =
+            activity.metadata && typeof activity.metadata === 'object' && !Array.isArray(activity.metadata)
+                ? activity.metadata
+                : {};
+
+        await this.client.track(activity.action, {
+            activityId: activity.id,
+            userId: activity.userId,
+            directoryId: activity.directoryId ?? undefined,
+            actionType: activity.actionType,
+            action: activity.action,
+            status: activity.status,
+            summary: activity.summary,
+            details: activity.details ?? undefined,
+            createdAt: activity.createdAt.toISOString(),
+            ...metadata,
+        });
+    }
+}

--- a/apps/api/src/activity-log/jitsu.service.ts
+++ b/apps/api/src/activity-log/jitsu.service.ts
@@ -30,7 +30,9 @@ export class JitsuService implements ActivityLogAnalyticsDispatcher {
         }
 
         const metadata =
-            activity.metadata && typeof activity.metadata === 'object' && !Array.isArray(activity.metadata)
+            activity.metadata &&
+            typeof activity.metadata === 'object' &&
+            !Array.isArray(activity.metadata)
                 ? activity.metadata
                 : {};
 

--- a/apps/web/src/components/directories/detail/DirectoryLayoutClient.tsx
+++ b/apps/web/src/components/directories/detail/DirectoryLayoutClient.tsx
@@ -29,10 +29,12 @@ export function DirectoryLayoutClient({
     const t = useTranslations('dashboard.directoryDetail');
     const isGenerating = directory.generateStatus?.status === GenerateStatusType.GENERATING;
     const lastGenerateStatus = useRef(directory.generateStatus?.status);
+    const previousGenerateStatus = lastGenerateStatus.current;
+    const hasSyncedOnMount = useRef(false);
     const generateStatus = directory.generateStatus?.status;
 
     useEffect(() => {
-        const lastStatus = lastGenerateStatus.current;
+        const lastStatus = previousGenerateStatus;
         const currentStatus = directory.generateStatus?.status;
 
         if (lastStatus !== currentStatus && currentStatus === GenerateStatusType.ERROR) {
@@ -54,7 +56,7 @@ export function DirectoryLayoutClient({
         }
 
         lastGenerateStatus.current = directory.generateStatus?.status;
-    }, [generateStatus]);
+    }, [directory.generateStatus?.status, previousGenerateStatus, t]);
 
     useEffect(() => {
         if (isGenerating) {
@@ -64,12 +66,26 @@ export function DirectoryLayoutClient({
     }, [isGenerating, router]);
 
     useEffect(() => {
+        if (hasSyncedOnMount.current) {
+            return;
+        }
+
+        hasSyncedOnMount.current = true;
         syncDirectoryData(directory.id).catch(() => {
             // Silent fail; best effort
         });
+    }, [directory.id]);
 
-        // we want also sync when generateStatus changes
-    }, [directory.id, generateStatus, router]);
+    useEffect(() => {
+        if (
+            previousGenerateStatus === GenerateStatusType.GENERATING &&
+            generateStatus === GenerateStatusType.GENERATED
+        ) {
+            syncDirectoryData(directory.id).catch(() => {
+                // Silent fail; best effort
+            });
+        }
+    }, [directory.id, generateStatus, previousGenerateStatus]);
 
     return (
         <DirectoryDetailProvider

--- a/packages/agent/src/activity-log/activity-log-analytics-dispatcher.ts
+++ b/packages/agent/src/activity-log/activity-log-analytics-dispatcher.ts
@@ -1,0 +1,7 @@
+import type { ActivityLog } from '../entities/activity-log.entity';
+
+export const ACTIVITY_LOG_ANALYTICS_DISPATCHER = 'ACTIVITY_LOG_ANALYTICS_DISPATCHER';
+
+export interface ActivityLogAnalyticsDispatcher {
+    track(activity: ActivityLog): Promise<void>;
+}

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { ActivityLogRepository } from '@src/database/repositories/activity-log.repository';
 import type {
     CreateActivityLogDto,
@@ -6,15 +6,36 @@ import type {
     ActivityStatus,
 } from '../entities/activity-log.types';
 import type { ActivityLog } from '../entities/activity-log.entity';
+import {
+    ACTIVITY_LOG_ANALYTICS_DISPATCHER,
+    type ActivityLogAnalyticsDispatcher,
+} from './activity-log-analytics-dispatcher';
 
 @Injectable()
 export class ActivityLogService {
     private readonly logger = new Logger(ActivityLogService.name);
 
-    constructor(private readonly repository: ActivityLogRepository) {}
+    constructor(
+        private readonly repository: ActivityLogRepository,
+        @Optional()
+        @Inject(ACTIVITY_LOG_ANALYTICS_DISPATCHER)
+        private readonly analyticsDispatcher?: ActivityLogAnalyticsDispatcher,
+    ) {}
+
+    private dispatchAnalytics(activity: ActivityLog) {
+        if (!this.analyticsDispatcher) {
+            return;
+        }
+
+        this.analyticsDispatcher.track(activity).catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Activity analytics dispatch failed: ${message}`);
+        });
+    }
 
     async log(entry: CreateActivityLogDto): Promise<ActivityLog> {
         const activity = await this.repository.create(entry);
+        this.dispatchAnalytics(activity);
         this.logger.debug(
             `Activity logged: [${entry.actionType}] ${entry.summary} (user: ${entry.userId})`,
         );
@@ -30,7 +51,11 @@ export class ActivityLogService {
         if (details) {
             updateData.details = details;
         }
-        return this.repository.update(id, updateData);
+        const activity = await this.repository.update(id, updateData);
+        if (activity) {
+            this.dispatchAnalytics(activity);
+        }
+        return activity;
     }
 
     async findAll(

--- a/packages/agent/src/activity-log/index.ts
+++ b/packages/agent/src/activity-log/index.ts
@@ -1,2 +1,3 @@
 export { ActivityLogModule } from './activity-log.module';
 export { ActivityLogService } from './activity-log.service';
+export * from './activity-log-analytics-dispatcher';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@ever-works/trigger-tasks':
         specifier: workspace:*
         version: link:../../packages/tasks
+      '@jitsu/js':
+        specifier: ^1.10.4
+        version: 1.10.4(@jitsu/protocols@1.10.4)(@types/dlv@1.1.5)
       '@nestjs-modules/mailer':
         specifier: ^2.0.2
         version: 2.0.2(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.13)(nodemailer@8.0.4)
@@ -1688,6 +1691,27 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@analytics/cookie-utils@0.2.14':
+    resolution: {integrity: sha512-x51x2cLqvP5Fb1ydgNvTCX+SVv0ALK/yTNwp/53++yk4kLhxb850krWtQ4aASN0612oXrIGotwfmdJIttnLiPQ==}
+
+  '@analytics/core@0.12.17':
+    resolution: {integrity: sha512-GMxRm5Dp3Wam/w5NNvqNKMO6zWecozbVv21Kn4WhftCx6OjJI7zMlVtiLpjGjxa0RRZfVG80YhupF0Qh9XL2gw==}
+
+  '@analytics/global-storage-utils@0.1.9':
+    resolution: {integrity: sha512-+xm6CDnWsVOQIKkqbPRPRdYDXKk3PNgr/bCZWSI+7tEDT5PCDgI0QSBZe+FqCVkCRtTkgOrjFOY7wOM8Gq+ndA==}
+
+  '@analytics/localstorage-utils@0.1.12':
+    resolution: {integrity: sha512-BL3vuZUwWgMqdkQsE0GKsED5SPLC6daI4K4LE0a/BkKv+4Cae5JLLqpO5gju2HUGOjJxIvw8U/G5EcglNY5+1w==}
+
+  '@analytics/session-storage-utils@0.0.9':
+    resolution: {integrity: sha512-fhP9QCpyq45rZKsXaAxyz+VTmOUWljIW08CWSkFzpwOHkDM4Xy5tymc1YcWqSBBaLjHldo3HlY4qfqEIS4Aj1A==}
+
+  '@analytics/storage-utils@0.4.4':
+    resolution: {integrity: sha512-873P4wDIunbOnBqADc2AhTVsLbluUv1dP6k9UrK8FIeV8WXv5+fG12HdwwaniUIxq6QLgZJfKEaCwtWSKrrV0g==}
+
+  '@analytics/type-utils@0.6.4':
+    resolution: {integrity: sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw==}
+
   '@angular-devkit/core@19.2.17':
     resolution: {integrity: sha512-Ah008x2RJkd0F+NLKqIpA34/vUGwjlprRCkvddjDopAWRzYn6xCkz1Tqwuhn0nR1Dy47wTLKYD999TYl5ONOAQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -2973,6 +2997,14 @@ packages:
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jitsu/js@1.10.4':
+    resolution: {integrity: sha512-FTMIH7TnfzK+o+wODV/TQ37VeTIKigMqkoWE7iOnEKmBscToYsaEfXShBOcrTq/O//ENujcy/J8no+COuC/bqw==}
+    peerDependencies:
+      '@jitsu/protocols': 1.10.4
+
+  '@jitsu/protocols@1.10.4':
+    resolution: {integrity: sha512-eOjIObyovCLbOMp7IK+MNnkYwpkPBmYVqU0y7JQkMLsnzFpbD9micAsLs1zAwAUuQ4oqBdYOIsumz0KesI55bQ==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -5495,6 +5527,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dlv@1.1.5':
+    resolution: {integrity: sha512-JHOWNfiWepAhfwlSw17kiWrWrk6od2dEQgHltJw9AS0JPFoLZJBge5+Dnil2NfdjAvJ/+vGSX60/BRW20PpUXw==}
+
   '@types/ejs@3.1.5':
     resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
 
@@ -6057,6 +6092,14 @@ packages:
   amdefine@1.0.1:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
     engines: {node: '>=0.4.2'}
+
+  analytics-utils@1.1.1:
+    resolution: {integrity: sha512-nRybjTpRAcHVhWb1cvYaOLJaI3R79r8XjMbu5c0wd2jKmANNqSrYwybiU0X3mp+CQQdm4YiAggTXb2cIA8XhUg==}
+    peerDependencies:
+      '@types/dlv': ^1.0.0
+
+  analytics@0.8.9:
+    resolution: {integrity: sha512-oTbUzQpncMTslakqfK70GgB6bopk5hY+uuekwnadMkDyqNLgcD02KRzteTnO7q5Ko6wDECVtT8xi/6OuAMZykA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -11897,6 +11940,40 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@analytics/cookie-utils@0.2.14':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+
+  '@analytics/core@0.12.17(@types/dlv@1.1.5)':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+      '@analytics/type-utils': 0.6.4
+      analytics-utils: 1.1.1(@types/dlv@1.1.5)
+    transitivePeerDependencies:
+      - '@types/dlv'
+
+  '@analytics/global-storage-utils@0.1.9':
+    dependencies:
+      '@analytics/type-utils': 0.6.4
+
+  '@analytics/localstorage-utils@0.1.12':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+
+  '@analytics/session-storage-utils@0.0.9':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+
+  '@analytics/storage-utils@0.4.4':
+    dependencies:
+      '@analytics/cookie-utils': 0.2.14
+      '@analytics/global-storage-utils': 0.1.9
+      '@analytics/localstorage-utils': 0.1.12
+      '@analytics/session-storage-utils': 0.0.9
+      '@analytics/type-utils': 0.6.4
+
+  '@analytics/type-utils@0.6.4': {}
+
   '@angular-devkit/core@19.2.17(chokidar@4.0.3)':
     dependencies:
       ajv: 8.17.1
@@ -13237,6 +13314,15 @@ snapshots:
       '@types/node': 22.19.11
       '@types/yargs': 17.0.35
       chalk: 4.1.2
+
+  '@jitsu/js@1.10.4(@jitsu/protocols@1.10.4)(@types/dlv@1.1.5)':
+    dependencies:
+      '@jitsu/protocols': 1.10.4
+      analytics: 0.8.9(@types/dlv@1.1.5)
+    transitivePeerDependencies:
+      - '@types/dlv'
+
+  '@jitsu/protocols@1.10.4': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -15938,6 +16024,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/dlv@1.1.5': {}
+
   '@types/ejs@3.1.5':
     optional: true
 
@@ -16692,6 +16780,19 @@ snapshots:
     optional: true
 
   amdefine@1.0.1: {}
+
+  analytics-utils@1.1.1(@types/dlv@1.1.5):
+    dependencies:
+      '@analytics/type-utils': 0.6.4
+      '@types/dlv': 1.1.5
+      dlv: 1.1.3
+
+  analytics@0.8.9(@types/dlv@1.1.5):
+    dependencies:
+      '@analytics/core': 0.12.17(@types/dlv@1.1.5)
+      '@analytics/storage-utils': 0.4.4
+    transitivePeerDependencies:
+      - '@types/dlv'
 
   ansi-colors@4.1.3: {}
 
@@ -20357,7 +20458,7 @@ snapshots:
 
   minimatch@5.1.6:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
     optional: true
 
   minimatch@9.0.1:


### PR DESCRIPTION
Send activity log records to Jitsu alongside the existing database write, using a provider hook in the shared activity log service and an API-side Jitsu integration that can be enabled through env configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for activity logs to capture user actions and system events.

* **Bug Fixes**
  * Prevented duplicate directory synchronization on initial page load, reducing redundant network requests and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->