### PR TITLE
fix(activity-log): defer export blob URL revocation for browser compa…

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
@@ -167,7 +167,7 @@ export function ActivityClient({ initialActivities, totalActivities }: ActivityC
             document.body.appendChild(link);
             link.click();
             link.remove();
-            URL.revokeObjectURL(url);
+            setTimeout(() => URL.revokeObjectURL(url), 100);
         } catch {
             toast.error(t('exportFailed'));
         }

--- a/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
@@ -167,7 +167,7 @@ export function ActivityClient({ initialActivities, totalActivities }: ActivityC
             document.body.appendChild(link);
             link.click();
             link.remove();
-            setTimeout(() => URL.revokeObjectURL(url), 100);
+            setTimeout(() => URL.revokeObjectURL(url), 1000); // Let the browser start the download before revoking the blob URL.
         } catch {
             toast.error(t('exportFailed'));
         }


### PR DESCRIPTION
…tibility

Delay revoking the temporary CSV blob URL until after the download has started so Safari and other stricter browsers can complete the export reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of activity export functionality by adjusting the timing of resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->