### PR TITLE
Preserve nextRunAt for manual runs ahead of schedule (#341)

### DIFF
--- a/packages/agent/src/services/__tests__/directory-schedule.service.spec.ts
+++ b/packages/agent/src/services/__tests__/directory-schedule.service.spec.ts
@@ -1,0 +1,289 @@
+jest.mock('@src/generators/data-generator/data-generator.service', () => ({
+    DataGeneratorService: class DataGeneratorService {},
+}));
+
+import { DirectoryScheduleService } from '../directory-schedule.service';
+import {
+    DirectoryScheduleBillingMode,
+    DirectoryScheduleCadence,
+    DirectoryScheduleStatus,
+    GenerateStatusType,
+} from '@src/entities/types';
+
+describe('DirectoryScheduleService', () => {
+    const user = { id: 'user-1' } as any;
+    const directory = { id: 'dir-1', sourceRepository: null } as any;
+
+    let scheduleRepository: any;
+    let directoryRepository: any;
+    let ownershipService: any;
+    let subscriptionService: any;
+    let usageLedgerService: any;
+    let dataGeneratorService: any;
+    let pluginRegistry: any;
+    let notificationService: any;
+    let service: DirectoryScheduleService;
+
+    beforeEach(() => {
+        scheduleRepository = {
+            findByDirectoryId: jest.fn(),
+            upsert: jest.fn(),
+            findById: jest.fn(),
+            updateById: jest.fn(),
+            countActiveByUser: jest.fn().mockResolvedValue(0),
+        };
+        directoryRepository = {
+            update: jest.fn(),
+            findById: jest.fn(),
+        };
+        ownershipService = {
+            ensureCanEdit: jest.fn().mockResolvedValue({ directory }),
+            ensureCanView: jest.fn().mockResolvedValue({ directory }),
+        };
+        subscriptionService = {
+            isEnabled: jest.fn().mockReturnValue(false),
+            resolvePlanForUser: jest.fn().mockResolvedValue({
+                code: 'free',
+                displayName: 'Free',
+                maxDirectories: 10,
+            }),
+            getCadenceAllowances: jest
+                .fn()
+                .mockResolvedValue([{ cadence: DirectoryScheduleCadence.DAILY, allowed: true }]),
+            getDefaultCadence: jest.fn().mockReturnValue(DirectoryScheduleCadence.DAILY),
+            requiresUsageBilling: jest.fn().mockReturnValue(false),
+        };
+        usageLedgerService = {
+            recordUsage: jest.fn().mockResolvedValue(null),
+        };
+        dataGeneratorService = {
+            getConfig: jest.fn().mockResolvedValue({
+                metadata: {
+                    last_request_data: { prompt: 'hello' },
+                },
+            }),
+        };
+        pluginRegistry = {
+            get: jest.fn(),
+        };
+        notificationService = {
+            notifySchedulePaused: jest.fn(),
+        };
+
+        service = new DirectoryScheduleService(
+            scheduleRepository,
+            directoryRepository,
+            ownershipService,
+            subscriptionService,
+            usageLedgerService,
+            dataGeneratorService,
+            pluginRegistry,
+            notificationService,
+        );
+    });
+
+    it('preserves nextRunAt when saving an already-active schedule without changing cadence', async () => {
+        const nextRunAt = new Date('2026-04-08T12:47:00.000Z');
+        const existing = {
+            id: 'schedule-1',
+            directoryId: directory.id,
+            userId: user.id,
+            cadence: DirectoryScheduleCadence.DAILY,
+            billingMode: DirectoryScheduleBillingMode.SUBSCRIPTION,
+            status: DirectoryScheduleStatus.ACTIVE,
+            nextRunAt,
+            maxFailureBeforePause: 3,
+            alwaysCreatePullRequest: false,
+            providerOverrides: null,
+        };
+
+        scheduleRepository.findByDirectoryId.mockResolvedValue(existing);
+        scheduleRepository.upsert.mockResolvedValue(existing);
+
+        await service.updateSchedule(
+            directory.id,
+            {
+                enable: true,
+                cadence: DirectoryScheduleCadence.DAILY,
+                billingMode: DirectoryScheduleBillingMode.SUBSCRIPTION,
+                maxFailureBeforePause: 5,
+            },
+            user,
+        );
+
+        expect(scheduleRepository.upsert).toHaveBeenCalledWith(
+            directory.id,
+            expect.objectContaining({
+                nextRunAt,
+                maxFailureBeforePause: 5,
+            }),
+        );
+    });
+
+    it('recalculates nextRunAt when the cadence changes on an active schedule', async () => {
+        const nextRunAt = new Date('2026-04-08T12:47:00.000Z');
+        const existing = {
+            id: 'schedule-1',
+            directoryId: directory.id,
+            userId: user.id,
+            cadence: DirectoryScheduleCadence.DAILY,
+            billingMode: DirectoryScheduleBillingMode.SUBSCRIPTION,
+            status: DirectoryScheduleStatus.ACTIVE,
+            nextRunAt,
+            maxFailureBeforePause: 3,
+            alwaysCreatePullRequest: false,
+            providerOverrides: null,
+        };
+        const recalculated = new Date('2026-04-15T12:47:00.000Z');
+
+        jest.spyOn(service, 'calculateNextRun').mockReturnValue(recalculated);
+        scheduleRepository.findByDirectoryId.mockResolvedValue(existing);
+        scheduleRepository.upsert.mockResolvedValue({
+            ...existing,
+            cadence: DirectoryScheduleCadence.WEEKLY,
+            nextRunAt: recalculated,
+        });
+
+        await service.updateSchedule(
+            directory.id,
+            {
+                enable: true,
+                cadence: DirectoryScheduleCadence.WEEKLY,
+                billingMode: DirectoryScheduleBillingMode.SUBSCRIPTION,
+                maxFailureBeforePause: 3,
+            },
+            user,
+        );
+
+        expect(scheduleRepository.upsert).toHaveBeenCalledWith(
+            directory.id,
+            expect.objectContaining({
+                nextRunAt: recalculated,
+                cadence: DirectoryScheduleCadence.WEEKLY,
+            }),
+        );
+    });
+
+    it('keeps the upcoming run when a manual early run completes', async () => {
+        const nextRunAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        const schedule = {
+            id: 'schedule-1',
+            directoryId: directory.id,
+            userId: user.id,
+            cadence: DirectoryScheduleCadence.DAILY,
+            billingMode: DirectoryScheduleBillingMode.USAGE,
+            status: DirectoryScheduleStatus.ACTIVE,
+            nextRunAt,
+            scheduledFor: null,
+            failureCount: 2,
+        };
+
+        scheduleRepository.findById.mockResolvedValue(schedule);
+
+        await service.markRunCompleted({
+            scheduleId: schedule.id,
+            historyId: 'history-1',
+            status: GenerateStatusType.GENERATED,
+        });
+
+        expect(scheduleRepository.updateById).toHaveBeenCalledWith(
+            schedule.id,
+            expect.objectContaining({
+                nextRunAt,
+                failureCount: 0,
+                lastRunStatus: GenerateStatusType.GENERATED,
+            }),
+        );
+        expect(usageLedgerService.recordUsage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                directoryId: directory.id,
+                generationHistoryId: 'history-1',
+            }),
+        );
+    });
+
+    it('keeps the upcoming run and does not increment failures for a manual early failure', async () => {
+        const nextRunAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        const schedule = {
+            id: 'schedule-1',
+            directoryId: directory.id,
+            userId: user.id,
+            cadence: DirectoryScheduleCadence.DAILY,
+            billingMode: DirectoryScheduleBillingMode.SUBSCRIPTION,
+            status: DirectoryScheduleStatus.ACTIVE,
+            nextRunAt,
+            scheduledFor: null,
+            failureCount: 2,
+            maxFailureBeforePause: 3,
+        };
+
+        scheduleRepository.findById.mockResolvedValue(schedule);
+
+        await service.markRunFailed(schedule.id, 'manual test failed');
+
+        expect(scheduleRepository.updateById).toHaveBeenCalledWith(
+            schedule.id,
+            expect.objectContaining({
+                nextRunAt,
+                failureCount: 2,
+                status: DirectoryScheduleStatus.ACTIVE,
+                lastRunStatus: null,
+            }),
+        );
+        expect(directoryRepository.update).toHaveBeenCalledWith(
+            directory.id,
+            expect.objectContaining({
+                scheduledNextRunAt: nextRunAt,
+            }),
+        );
+    });
+
+    it('does not let a manual early failure suppress a later scheduled failure', async () => {
+        const futureNextRunAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        const manualRunSchedule = {
+            id: 'schedule-1',
+            directoryId: directory.id,
+            userId: user.id,
+            cadence: DirectoryScheduleCadence.HOURLY,
+            billingMode: DirectoryScheduleBillingMode.SUBSCRIPTION,
+            status: DirectoryScheduleStatus.ACTIVE,
+            nextRunAt: futureNextRunAt,
+            scheduledFor: null,
+            failureCount: 2,
+            maxFailureBeforePause: 3,
+        };
+        const scheduledRunSchedule = {
+            ...manualRunSchedule,
+            nextRunAt: null,
+            scheduledFor: new Date(Date.now() - 60 * 1000),
+            lastRunStatus: null,
+            lastRunAt: new Date(),
+        };
+
+        scheduleRepository.findById
+            .mockResolvedValueOnce(manualRunSchedule)
+            .mockResolvedValueOnce(scheduledRunSchedule);
+
+        await service.markRunFailed(manualRunSchedule.id, 'manual run failed');
+        await service.markRunFailed(scheduledRunSchedule.id, 'scheduled run failed');
+
+        expect(scheduleRepository.updateById).toHaveBeenNthCalledWith(
+            1,
+            manualRunSchedule.id,
+            expect.objectContaining({
+                failureCount: 2,
+                lastRunStatus: null,
+                nextRunAt: futureNextRunAt,
+            }),
+        );
+        expect(scheduleRepository.updateById).toHaveBeenNthCalledWith(
+            2,
+            scheduledRunSchedule.id,
+            expect.objectContaining({
+                failureCount: 3,
+                lastRunStatus: GenerateStatusType.ERROR,
+                status: DirectoryScheduleStatus.PAUSED,
+            }),
+        );
+    });
+});

--- a/packages/agent/src/services/directory-schedule.service.ts
+++ b/packages/agent/src/services/directory-schedule.service.ts
@@ -163,9 +163,17 @@ export class DirectoryScheduleService {
 
         const status = enable ? DirectoryScheduleStatus.ACTIVE : DirectoryScheduleStatus.PAUSED;
 
+        const shouldRecalculateNextRun =
+            status === DirectoryScheduleStatus.ACTIVE &&
+            (!existing ||
+                existing.status !== DirectoryScheduleStatus.ACTIVE ||
+                existing.cadence !== cadence);
+
         const nextRunAt =
             status === DirectoryScheduleStatus.ACTIVE
-                ? this.calculateNextRun(cadence)
+                ? shouldRecalculateNextRun
+                    ? this.calculateNextRun(cadence)
+                    : (existing?.nextRunAt ?? null)
                 : (existing?.nextRunAt ?? null);
 
         const schedule = await this.scheduleRepository.upsert(directory.id, {
@@ -289,10 +297,12 @@ export class DirectoryScheduleService {
         // scheduledFor is set by tryMarkDispatched before clearing nextRunAt.
         const anchorDate = this.resolveAnchorDate(schedule);
 
-        const nextRunAt =
-            schedule.status === DirectoryScheduleStatus.ACTIVE && schedule.cadence
-                ? this.calculateNextRun(schedule.cadence, 0, anchorDate)
-                : null;
+        const preserveExistingNextRun = this.isManualRunAheadOfSchedule(schedule);
+        const nextRunAt = preserveExistingNextRun
+            ? (schedule.nextRunAt ?? null)
+            : schedule.status === DirectoryScheduleStatus.ACTIVE && schedule.cadence
+              ? this.calculateNextRun(schedule.cadence, 0, anchorDate)
+              : null;
 
         await this.scheduleRepository.updateById(schedule.id, {
             lastRunStatus: options.status,
@@ -330,31 +340,39 @@ export class DirectoryScheduleService {
             return;
         }
 
-        const failureCount = (schedule.failureCount || 0) + 1;
+        const preserveExistingNextRun = this.isManualRunAheadOfSchedule(schedule);
+        const failureCount = preserveExistingNextRun
+            ? schedule.failureCount || 0
+            : (schedule.failureCount || 0) + 1;
         const maxFailures =
             schedule.maxFailureBeforePause || config.subscriptions.getMaxFailureBeforePause();
-        const reachedLimit = failureCount >= maxFailures;
+        const reachedLimit = !preserveExistingNextRun && failureCount >= maxFailures;
 
         const anchorDate = this.resolveAnchorDate(schedule);
+        const nextRunAt = preserveExistingNextRun
+            ? (schedule.nextRunAt ?? null)
+            : reachedLimit
+              ? null
+              : schedule.cadence
+                ? new Date(anchorDate.getTime() + this.RETRY_DELAY_MINUTES * 60 * 1000)
+                : null;
+        const lastRunStatus = preserveExistingNextRun ? null : GenerateStatusType.ERROR;
 
         await this.scheduleRepository.updateById(schedule.id, {
             failureCount,
-            lastRunStatus: GenerateStatusType.ERROR,
+            lastRunStatus,
             lastRunAt: new Date(),
             status: reachedLimit ? DirectoryScheduleStatus.PAUSED : schedule.status,
             scheduledFor: null,
-            nextRunAt: reachedLimit
-                ? null
-                : schedule.cadence
-                  ? new Date(anchorDate.getTime() + this.RETRY_DELAY_MINUTES * 60 * 1000)
-                  : null,
+            nextRunAt,
         });
 
         await this.syncDirectory(schedule.directoryId, {
             ...schedule,
             failureCount,
             status: reachedLimit ? DirectoryScheduleStatus.PAUSED : schedule.status,
-            lastRunStatus: GenerateStatusType.ERROR,
+            lastRunStatus,
+            nextRunAt,
         });
 
         if (reachedLimit) {
@@ -388,12 +406,14 @@ export class DirectoryScheduleService {
 
         // Reschedule using the original cadence — don't penalize the schedule.
         // If the anchor is in the past, use now() to avoid a rapid retry loop.
+        const preserveExistingNextRun = this.isManualRunAheadOfSchedule(schedule);
         const anchorDate = this.resolveAnchorDate(schedule);
         const baseDate = anchorDate.getTime() > Date.now() ? anchorDate : new Date();
-        const nextRunAt =
-            schedule.status === DirectoryScheduleStatus.ACTIVE && schedule.cadence
-                ? new Date(baseDate.getTime() + this.RETRY_DELAY_MINUTES * 60 * 1000)
-                : null;
+        const nextRunAt = preserveExistingNextRun
+            ? (schedule.nextRunAt ?? null)
+            : schedule.status === DirectoryScheduleStatus.ACTIVE && schedule.cadence
+              ? new Date(baseDate.getTime() + this.RETRY_DELAY_MINUTES * 60 * 1000)
+              : null;
 
         await this.scheduleRepository.updateById(schedule.id, {
             lastRunStatus: null,
@@ -448,6 +468,18 @@ export class DirectoryScheduleService {
         }
 
         return new Date();
+    }
+
+    /**
+     * Manual "run now" requests can execute before the scheduled slot is due.
+     * In that case, preserve the existing nextRunAt so we don't skip the upcoming run.
+     */
+    private isManualRunAheadOfSchedule(schedule: DirectorySchedule): boolean {
+        return Boolean(
+            !schedule.scheduledFor &&
+            schedule.nextRunAt &&
+            schedule.nextRunAt.getTime() > Date.now(),
+        );
     }
 
     private isAlreadyMarkedFailed(schedule: DirectorySchedule): boolean {


### PR DESCRIPTION
* Preserve nextRunAt for manual runs ahead of schedule

* Prevent manual early failures from suppressing scheduled ones