### PR TITLE
fix(greptile): tighten activity log queries and trim unused backgroun…

### DIFF
--- a/apps/web/src/lib/hooks/use-background-activity.tsx
+++ b/apps/web/src/lib/hooks/use-background-activity.tsx
@@ -5,10 +5,6 @@ import { usePathname } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 
 interface BackgroundActivityState {
-    /** At least one directory is currently generating */
-    isGeneratingDirectory: boolean;
-    /** User has visited /directories since the last generation started */
-    hasVisitedDirectoriesPage: boolean;
     /** Show the sidebar indicator? */
     showDirectoryIndicator: boolean;
     /** Call when a generation starts (or is detected) */
@@ -50,19 +46,11 @@ export function BackgroundActivityProvider({ children }: { children: React.React
 
     const value = useMemo(
         () => ({
-            isGeneratingDirectory,
-            hasVisitedDirectoriesPage,
             showDirectoryIndicator,
             markGenerating,
             clearGenerating,
         }),
-        [
-            isGeneratingDirectory,
-            hasVisitedDirectoriesPage,
-            showDirectoryIndicator,
-            markGenerating,
-            clearGenerating,
-        ],
+        [showDirectoryIndicator, markGenerating, clearGenerating],
     );
 
     return (

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -87,7 +87,7 @@ export class ActivityLogService {
 
     async findLatestByUserDirectoryActionStatus(params: {
         userId: string;
-        directoryId?: string;
+        directoryId: string;
         actionType: ActivityActionType;
         status: ActivityStatus;
     }): Promise<ActivityLog | null> {

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -42,7 +42,7 @@ export class ActivityLogRepository {
 
     async findLatestByUserDirectoryActionStatus(params: {
         userId: string;
-        directoryId?: string;
+        directoryId: string;
         actionType: ActivityActionType;
         status: ActivityStatus;
     }): Promise<ActivityLog | null> {
@@ -131,7 +131,7 @@ export class ActivityLogRepository {
             .groupBy('activity.status')
             .getRawMany<{ status: ActivityStatus; count: string }>();
 
-        const counts = {
+        let counts = {
             pending: 0,
             in_progress: 0,
             completed: 0,


### PR DESCRIPTION
…d context

Make the activity-log repository/service require directoryId for latest-entry lookups, align the mutable status-count accumulator with project style, and remove unused public fields from the background activity context while keeping the sidebar indicator behavior unchanged.