### PR TITLE
(fix): enhance Make.com scenario execution mode to have a hook-URL fallback during generation

### DIFF
--- a/packages/plugins/make/src/__tests__/make.spec.ts
+++ b/packages/plugins/make/src/__tests__/make.spec.ts
@@ -468,6 +468,82 @@ describe('MakePlugin', () => {
 			expect(fetchMock).toHaveBeenCalledTimes(2);
 		});
 
+		it('should invoke the hook URL in scenario mode when a hook ID is configured', async () => {
+			// validate-make: scenario detail
+			fetchMock.mockResolvedValueOnce(
+				mockResponse({ body: { scenario: { id: 42, name: 'My Scenario', isActive: true } } })
+			);
+			// validate-make: pingHook (fire-and-forget, wrapped in try/catch)
+			fetchMock.mockResolvedValueOnce(mockResponse({ body: {} }));
+			// execute-scenario: getHook returns the webhook URL
+			fetchMock.mockResolvedValueOnce(
+				mockResponse({
+					body: { hook: { id: 99, name: 'My Hook', url: 'https://hook.us2.make.com/abc' } }
+				})
+			);
+			// execute-scenario: invokeWebhook returns the output
+			fetchMock.mockResolvedValueOnce(
+				mockResponse({
+					body: {
+						items: [
+							{
+								name: 'Hook-Routed Item',
+								description: 'Fetched via the hook URL fallback',
+								url: 'https://example.com/hook',
+								category: 'Tools'
+							}
+						]
+					}
+				})
+			);
+
+			const result = await plugin.execute(
+				createDirectory(),
+				createRequest({
+					config: {
+						execution_mode: 'scenario',
+						scenario_id: '42',
+						hook_id: '99'
+					}
+				}),
+				createExisting()
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.outputs.items[0].name).toBe('Hook-Routed Item');
+			// REST /run and /executions/{id} must NOT be called on this path.
+			const calledUrls = fetchMock.mock.calls.map((c) => String(c[0]));
+			expect(calledUrls.some((u) => u.includes('/scenarios/42/run'))).toBe(false);
+			expect(calledUrls.some((u) => u.includes('/executions/'))).toBe(false);
+			expect(calledUrls.some((u) => u === 'https://hook.us2.make.com/abc')).toBe(true);
+		});
+
+		it('should fail scenario mode when the configured hook has no URL', async () => {
+			fetchMock.mockResolvedValueOnce(
+				mockResponse({ body: { scenario: { id: 42, name: 'My Scenario', isActive: true } } })
+			);
+			fetchMock.mockResolvedValueOnce(mockResponse({ body: {} }));
+			fetchMock.mockResolvedValueOnce(
+				mockResponse({ body: { hook: { id: 99, name: 'Broken Hook' } } })
+			);
+
+			const result = await plugin.execute(
+				createDirectory(),
+				createRequest({
+					config: {
+						execution_mode: 'scenario',
+						scenario_id: '42',
+						hook_id: '99'
+					}
+				}),
+				createExisting()
+			);
+
+			expect(result.success).toBe(false);
+			const errorMessage = result.error instanceof Error ? result.error.message : String(result.error);
+			expect(errorMessage).toMatch(/does not expose a URL/i);
+		});
+
 		it('should handle cancellation', async () => {
 			const abortController = new AbortController();
 			abortController.abort();

--- a/packages/plugins/make/src/__tests__/make.spec.ts
+++ b/packages/plugins/make/src/__tests__/make.spec.ts
@@ -523,9 +523,7 @@ describe('MakePlugin', () => {
 				mockResponse({ body: { scenario: { id: 42, name: 'My Scenario', isActive: true } } })
 			);
 			fetchMock.mockResolvedValueOnce(mockResponse({ body: {} }));
-			fetchMock.mockResolvedValueOnce(
-				mockResponse({ body: { hook: { id: 99, name: 'Broken Hook' } } })
-			);
+			fetchMock.mockResolvedValueOnce(mockResponse({ body: { hook: { id: 99, name: 'Broken Hook' } } }));
 
 			const result = await plugin.execute(
 				createDirectory(),

--- a/packages/plugins/make/src/make.plugin.ts
+++ b/packages/plugins/make/src/make.plugin.ts
@@ -368,52 +368,73 @@ export class MakePlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvider
 				reportProgress(onProgress, 2, 15, 'Execute Make.com Scenario', `Starting scenario "${scenarioId}"...`);
 
 				const runStart = Date.now();
-				const run = await client.runScenario(scenarioId, payload, signal);
-				const executionId = run.executionId ?? this.extractExecutionId(run as Record<string, unknown>);
 
-				// `POST /scenarios/{id}/run` is invoked with `responsive: true`, so when the
-				// scenario finishes synchronously its final module payload (e.g. a Webhook
-				// Response body) is included inline in the run response. Prefer that output
-				// over the polling endpoint, which only returns execution metadata (status,
-				// operations, transfer) — never the scenario's output bundles.
-				const inlineOutput = extractInlineOutput(run as Record<string, unknown>);
-
-				if (inlineOutput !== undefined) {
+				if (hookId) {
+					// Webhook-triggered scenarios: invoke via the hook URL. It's the only
+					// channel that returns the Webhook Response body inline.
+					reportProgress(onProgress, 2, 30, 'Execute Make.com Scenario', 'Resolving webhook URL...');
+					const hook = await client.getHook(hookId, signal);
+					if (!hook.url) {
+						throw new Error(
+							`Make.com hook "${hookId}" does not expose a URL. Switch to webhook execution ` +
+								`mode and set the webhook URL directly, or remove the hook ID to rely on REST /run.`
+						);
+					}
+					reportProgress(onProgress, 2, 45, 'Execute Make.com Scenario', 'Invoking scenario...');
+					const output = await client.invokeWebhook(hook.url, payload, signal);
 					execResult = {
-						output: inlineOutput,
-						pollingAttempts: 0,
-						makeDuration: Date.now() - runStart,
-						executionId
-					};
-				} else if (executionId) {
-					const { status, attempts } = await client.pollExecution(
-						scenarioId,
-						executionId,
-						makeSettings,
-						(attempt, statusName) => {
-							const percent = Math.min(15 + Math.round((attempt / 60) * 55), 70);
-							reportProgress(
-								onProgress,
-								2,
-								percent,
-								'Execute Make.com Scenario',
-								`Execution ${statusName} (poll #${attempt})...`
-							);
-						},
-						signal
-					);
-					execResult = {
-						output: status.output ?? status.result ?? status.data ?? status,
-						pollingAttempts: attempts,
-						makeDuration: Date.now() - runStart,
-						executionId
-					};
-				} else {
-					execResult = {
-						output: run.output ?? run.result ?? run.data ?? run,
+						output,
 						pollingAttempts: 0,
 						makeDuration: Date.now() - runStart
 					};
+				} else {
+					const run = await client.runScenario(scenarioId, payload, signal);
+					const executionId = run.executionId ?? this.extractExecutionId(run as Record<string, unknown>);
+
+					// `POST /scenarios/{id}/run` is invoked with `responsive: true`, so when the
+					// scenario finishes synchronously its final module payload (e.g. a Webhook
+					// Response body) is included inline in the run response. Prefer that output
+					// over the polling endpoint, which only returns execution metadata (status,
+					// operations, transfer) — never the scenario's output bundles.
+					const inlineOutput = extractInlineOutput(run as Record<string, unknown>);
+
+					if (inlineOutput !== undefined) {
+						execResult = {
+							output: inlineOutput,
+							pollingAttempts: 0,
+							makeDuration: Date.now() - runStart,
+							executionId
+						};
+					} else if (executionId) {
+						const { status, attempts } = await client.pollExecution(
+							scenarioId,
+							executionId,
+							makeSettings,
+							(attempt, statusName) => {
+								const percent = Math.min(15 + Math.round((attempt / 60) * 55), 70);
+								reportProgress(
+									onProgress,
+									2,
+									percent,
+									'Execute Make.com Scenario',
+									`Execution ${statusName} (poll #${attempt})...`
+								);
+							},
+							signal
+						);
+						execResult = {
+							output: status.output ?? status.result ?? status.data ?? status,
+							pollingAttempts: attempts,
+							makeDuration: Date.now() - runStart,
+							executionId
+						};
+					} else {
+						execResult = {
+							output: run.output ?? run.result ?? run.data ?? run,
+							pollingAttempts: 0,
+							makeDuration: Date.now() - runStart
+						};
+					}
 				}
 			} else {
 				reportProgress(onProgress, 2, 15, 'Execute Make.com Scenario', 'Invoking webhook...');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Make plugin supports webhook-based scenario execution when a hook ID is configured, as an alternative to REST-based execution.
* **Bug Fixes**
  * Added validation to ensure configured hooks expose a usable URL and surface a clear error when they do not.
* **Tests**
  * Added positive and negative tests covering webhook execution and missing-hook-URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->