### PR TITLE
fix: preserve directory item counts in failed states

### DIFF
--- a/packages/agent/src/database/repositories/__tests__/directory-generation-history.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/directory-generation-history.repository.spec.ts
@@ -1,0 +1,80 @@
+import type { Repository } from 'typeorm';
+import { DirectoryGenerationHistoryRepository } from '../directory-generation-history.repository';
+import { DirectoryGenerationHistory } from '@src/entities/directory-generation-history.entity';
+
+describe('DirectoryGenerationHistoryRepository', () => {
+    let repository: jest.Mocked<Pick<Repository<DirectoryGenerationHistory>, 'find'>>;
+    let service: DirectoryGenerationHistoryRepository;
+
+    beforeEach(() => {
+        repository = {
+            find: jest.fn(),
+        };
+
+        service = new DirectoryGenerationHistoryRepository(
+            repository as unknown as Repository<DirectoryGenerationHistory>,
+        );
+    });
+
+    it('returns early for an empty directory list', async () => {
+        await expect(service.findLatestPositiveItemCounts([])).resolves.toEqual(new Map());
+        expect(repository.find).not.toHaveBeenCalled();
+    });
+
+    it('fetches history in bounded pages until every directory has a count', async () => {
+        repository.find
+            .mockResolvedValueOnce(
+                Array.from({ length: 20 }, (_, index) => ({
+                    directoryId: 'dir-a',
+                    totalItemsCount: 100 - index,
+                })) as DirectoryGenerationHistory[],
+            )
+            .mockResolvedValueOnce([
+                {
+                    directoryId: 'dir-b',
+                    totalItemsCount: 42,
+                },
+            ] as DirectoryGenerationHistory[]);
+
+        const result = await service.findLatestPositiveItemCounts(['dir-a', 'dir-b']);
+
+        expect(repository.find).toHaveBeenNthCalledWith(1, {
+            where: expect.any(Object),
+            order: { startedAt: 'DESC', createdAt: 'DESC' },
+            take: 20,
+            skip: 0,
+        });
+        expect(repository.find).toHaveBeenNthCalledWith(2, {
+            where: expect.any(Object),
+            order: { startedAt: 'DESC', createdAt: 'DESC' },
+            take: 20,
+            skip: 20,
+        });
+        expect(result).toEqual(
+            new Map([
+                ['dir-a', 100],
+                ['dir-b', 42],
+            ]),
+        );
+    });
+
+    it('deduplicates requested directory ids before querying', async () => {
+        repository.find.mockResolvedValueOnce([
+            {
+                directoryId: 'dir-a',
+                totalItemsCount: 7,
+            },
+        ] as DirectoryGenerationHistory[]);
+
+        await service.findLatestPositiveItemCounts(['dir-a', 'dir-a']);
+
+        expect(repository.find).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                directoryId: expect.anything(),
+            }),
+            order: { startedAt: 'DESC', createdAt: 'DESC' },
+            take: 10,
+            skip: 0,
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/directory-generation-history.repository.ts
+++ b/packages/agent/src/database/repositories/directory-generation-history.repository.ts
@@ -44,6 +44,8 @@ type HistoryUpdateParams = {
     logs?: GenerationStepLog[] | null;
 };
 
+const LATEST_POSITIVE_ITEM_COUNTS_BATCH_MULTIPLIER = 10;
+
 @Injectable()
 export class DirectoryGenerationHistoryRepository {
     constructor(
@@ -127,24 +129,44 @@ export class DirectoryGenerationHistoryRepository {
     }
 
     async findLatestPositiveItemCounts(directoryIds: string[]): Promise<Map<string, number>> {
-        if (directoryIds.length === 0) {
+        const uniqueDirectoryIds = Array.from(new Set(directoryIds));
+        if (uniqueDirectoryIds.length === 0) {
             return new Map();
         }
 
-        const records = await this.repository.find({
-            where: {
-                directoryId: In(directoryIds),
-                totalItemsCount: MoreThan(0),
-            },
-            order: { startedAt: 'DESC', createdAt: 'DESC' },
-        });
-
         const counts = new Map<string, number>();
+        const batchSize = Math.max(
+            uniqueDirectoryIds.length * LATEST_POSITIVE_ITEM_COUNTS_BATCH_MULTIPLIER,
+            uniqueDirectoryIds.length,
+        );
+        let skip = 0;
 
-        for (const record of records) {
-            if (!counts.has(record.directoryId)) {
-                counts.set(record.directoryId, record.totalItemsCount);
+        while (counts.size < uniqueDirectoryIds.length) {
+            const records = await this.repository.find({
+                where: {
+                    directoryId: In(uniqueDirectoryIds),
+                    totalItemsCount: MoreThan(0),
+                },
+                order: { startedAt: 'DESC', createdAt: 'DESC' },
+                take: batchSize,
+                skip,
+            });
+
+            if (records.length === 0) {
+                break;
             }
+
+            for (const record of records) {
+                if (!counts.has(record.directoryId)) {
+                    counts.set(record.directoryId, record.totalItemsCount);
+                }
+            }
+
+            if (records.length < batchSize) {
+                break;
+            }
+
+            skip += records.length;
         }
 
         return counts;

--- a/packages/agent/src/database/repositories/directory-generation-history.repository.ts
+++ b/packages/agent/src/database/repositories/directory-generation-history.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, MoreThan, Repository } from 'typeorm';
 import { DirectoryGenerationHistory, GenerationMetrics } from '@src/entities';
 import { GenerateStatusType } from '@src/entities/types';
 import {
@@ -124,6 +124,30 @@ export class DirectoryGenerationHistoryRepository {
 
     async findById(id: string): Promise<DirectoryGenerationHistory | null> {
         return this.repository.findOne({ where: { id } });
+    }
+
+    async findLatestPositiveItemCounts(directoryIds: string[]): Promise<Map<string, number>> {
+        if (directoryIds.length === 0) {
+            return new Map();
+        }
+
+        const records = await this.repository.find({
+            where: {
+                directoryId: In(directoryIds),
+                totalItemsCount: MoreThan(0),
+            },
+            order: { startedAt: 'DESC', createdAt: 'DESC' },
+        });
+
+        const counts = new Map<string, number>();
+
+        for (const record of records) {
+            if (!counts.has(record.directoryId)) {
+                counts.set(record.directoryId, record.totalItemsCount);
+            }
+        }
+
+        return counts;
     }
 
     async appendLogs(id: string, newLogs: GenerationStepLog[]): Promise<void> {

--- a/packages/agent/src/services/__tests__/directory-query.service.spec.ts
+++ b/packages/agent/src/services/__tests__/directory-query.service.spec.ts
@@ -1,0 +1,100 @@
+jest.mock('@src/generators/data-generator/data-generator.service', () => ({
+    DataGeneratorService: class DataGeneratorService {},
+}));
+
+import { DirectoryQueryService } from '../directory-query.service';
+import { DirectoryMemberRole, GenerateStatusType } from '@src/entities/types';
+
+describe('DirectoryQueryService', () => {
+    const user = { id: 'user-1' } as any;
+
+    let directoryRepository: any;
+    let directoryMemberRepository: any;
+    let dataGenerator: any;
+    let generationHistoryRepository: any;
+    let ownershipService: any;
+    let service: DirectoryQueryService;
+
+    beforeEach(() => {
+        directoryRepository = {
+            findAllAccessible: jest.fn(),
+            countAllAccessible: jest.fn(),
+        };
+        directoryMemberRepository = {
+            getAccessibleDirectoryIds: jest.fn(),
+            getMemberRolesForDirectories: jest.fn(),
+        };
+        dataGenerator = {};
+        generationHistoryRepository = {
+            findLatestPositiveItemCounts: jest.fn(),
+        };
+        ownershipService = {};
+
+        service = new DirectoryQueryService(
+            directoryRepository,
+            directoryMemberRepository,
+            dataGenerator as any,
+            generationHistoryRepository,
+            ownershipService as any,
+        );
+    });
+
+    it('recovers the last known positive items count for errored directories', async () => {
+        const directory = {
+            id: 'dir-1',
+            userId: user.id,
+            owner: 'ever-works',
+            itemsCount: 0,
+            generateStatus: { status: GenerateStatusType.ERROR },
+            getRepoOwner: jest.fn().mockReturnValue('ever-works'),
+        } as any;
+
+        directoryMemberRepository.getAccessibleDirectoryIds.mockResolvedValue([]);
+        directoryRepository.findAllAccessible.mockResolvedValue([directory]);
+        directoryRepository.countAllAccessible.mockResolvedValue(1);
+        directoryMemberRepository.getMemberRolesForDirectories.mockResolvedValue(new Map());
+        generationHistoryRepository.findLatestPositiveItemCounts.mockResolvedValue(
+            new Map([['dir-1', 42]]),
+        );
+
+        const result = await service.getDirectories({}, user);
+
+        expect(generationHistoryRepository.findLatestPositiveItemCounts).toHaveBeenCalledWith([
+            'dir-1',
+        ]);
+        expect(result.directories[0]).toEqual(
+            expect.objectContaining({
+                id: 'dir-1',
+                itemsCount: 42,
+                userRole: DirectoryMemberRole.OWNER,
+            }),
+        );
+    });
+
+    it('does not override zero counts for completed directories', async () => {
+        const directory = {
+            id: 'dir-2',
+            userId: user.id,
+            owner: 'ever-works',
+            itemsCount: 0,
+            generateStatus: { status: GenerateStatusType.GENERATED },
+            getRepoOwner: jest.fn().mockReturnValue('ever-works'),
+        } as any;
+
+        directoryMemberRepository.getAccessibleDirectoryIds.mockResolvedValue([]);
+        directoryRepository.findAllAccessible.mockResolvedValue([directory]);
+        directoryRepository.countAllAccessible.mockResolvedValue(1);
+        directoryMemberRepository.getMemberRolesForDirectories.mockResolvedValue(new Map());
+        generationHistoryRepository.findLatestPositiveItemCounts.mockResolvedValue(new Map());
+
+        const result = await service.getDirectories({}, user);
+
+        expect(generationHistoryRepository.findLatestPositiveItemCounts).toHaveBeenCalledWith([]);
+        expect(result.directories[0]).toEqual(
+            expect.objectContaining({
+                id: 'dir-2',
+                itemsCount: 0,
+            }),
+        );
+    });
+});

--- a/packages/agent/src/services/directory-query.service.ts
+++ b/packages/agent/src/services/directory-query.service.ts
@@ -5,7 +5,7 @@ import { DirectoryGenerationHistoryRepository } from '@src/database/repositories
 import { DataGeneratorService } from '@src/generators/data-generator/data-generator.service';
 import { User } from '@src/entities/user.entity';
 import { Directory } from '@src/entities/directory.entity';
-import { DirectoryMemberRole } from '@src/entities/types';
+import { DirectoryMemberRole, GenerateStatusType } from '@src/entities/types';
 import { DirectoryOwnershipService } from './directory-ownership.service';
 import { normalizeGeneratorError, rethrowAsNormalized } from './utils/error.utils';
 import {
@@ -69,6 +69,15 @@ export class DirectoryQueryService {
                 search: sanitizedSearch,
             });
 
+            const directoryIdsNeedingRecoveredCounts = directories
+                .filter((dir) => this.shouldRecoverItemsCount(dir))
+                .map((dir) => dir.id);
+
+            const recoveredItemCounts =
+                await this.generationHistoryRepository.findLatestPositiveItemCounts(
+                    directoryIdsNeedingRecoveredCounts,
+                );
+
             // Separate directories into owned vs member-accessed for role computation
             const nonOwnedDirectoryIds = directories
                 .filter((dir) => dir.userId !== user.id)
@@ -84,6 +93,12 @@ export class DirectoryQueryService {
             const directoriesWithRoles: DirectoryWithRole[] = directories.map((dir) => {
                 dir.owner = dir.getRepoOwner();
 
+                const recoveredItemsCount = recoveredItemCounts.get(dir.id);
+                const itemsCount =
+                    (dir.itemsCount ?? 0) > 0
+                        ? dir.itemsCount
+                        : (recoveredItemsCount ?? dir.itemsCount);
+
                 // Creator is always OWNER, otherwise look up member role
                 const userRole =
                     dir.userId === user.id
@@ -92,6 +107,7 @@ export class DirectoryQueryService {
 
                 return {
                     ...dir,
+                    itemsCount,
                     userRole,
                 } as DirectoryWithRole;
             });
@@ -112,6 +128,19 @@ export class DirectoryQueryService {
         } catch (error) {
             rethrowAsNormalized(error, this.logger, 'getting directories');
         }
+    }
+
+    private shouldRecoverItemsCount(directory: Directory): boolean {
+        if ((directory.itemsCount ?? 0) > 0) {
+            return false;
+        }
+
+        const status = directory.generateStatus?.status;
+        return (
+            status === GenerateStatusType.GENERATING ||
+            status === GenerateStatusType.ERROR ||
+            status === GenerateStatusType.CANCELLED
+        );
     }
 
     async getStats(user: User) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directories now recover the most recent positive item count when generation is interrupted, errored, or cancelled, preventing incorrect zero counts from being shown; directories already fully generated are unchanged.
* **Tests**
  * Added unit tests covering the recovery behavior and the history-lookup logic to ensure accurate and paginated retrieval of latest positive counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->