### PR TITLE
feat: add generation cancel controls for directory and activity views

### DIFF
--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -32,6 +32,14 @@ export class ActivityLogController {
         private readonly directoryRepository: DirectoryRepository,
     ) {}
 
+    private async reconcileActivities(userId: string) {
+        try {
+            await this.activityLogService.reconcileStaleGenerationActivities(userId);
+        } catch {
+            // Activity listing should remain available even if stale-state cleanup fails.
+        }
+    }
+
     @Get()
     @ApiOperation({
         summary: 'List activity log entries',
@@ -57,7 +65,7 @@ export class ActivityLogController {
         @Query('limit', new DefaultValuePipe(25), ParseIntPipe) limit?: number,
         @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset?: number,
     ) {
-        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+        await this.reconcileActivities(auth.userId);
 
         const result = await this.activityLogService.findAll({
             userId: auth.userId,
@@ -84,7 +92,7 @@ export class ActivityLogController {
     })
     @ApiResponse({ status: 200, description: 'Running operations count' })
     async getRunningCount(@CurrentUser() auth: AuthenticatedUser) {
-        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+        await this.reconcileActivities(auth.userId);
 
         const count = await this.activityLogService.countRunning(auth.userId);
         return { count };
@@ -97,7 +105,7 @@ export class ActivityLogController {
     })
     @ApiResponse({ status: 200, description: 'Activity summary counts' })
     async getSummary(@CurrentUser() auth: AuthenticatedUser) {
-        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+        await this.reconcileActivities(auth.userId);
 
         const counts = await this.activityLogService.summarizeStatuses(auth.userId);
         return { counts };
@@ -146,7 +154,7 @@ export class ActivityLogController {
     @ApiResponse({ status: 200, description: 'Activity log entry details' })
     @ApiResponse({ status: 404, description: 'Activity not found' })
     async getActivity(@CurrentUser() auth: AuthenticatedUser, @Param('id') id: string) {
-        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+        await this.reconcileActivities(auth.userId);
 
         const activity = await this.activityLogService.findByIdAndUserId(id, auth.userId);
         if (!activity) {

--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -41,8 +41,9 @@ export class ActivityLogController {
             return;
         }
 
-        const reconcilePromise = this.activityLogService
+        const reconcilePromise: Promise<void> = this.activityLogService
             .reconcileStaleGenerationActivities(userId)
+            .then(() => undefined)
             .catch(() => {
                 // Activity listing should remain available even if stale-state cleanup fails.
             })

--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -57,6 +57,8 @@ export class ActivityLogController {
         @Query('limit', new DefaultValuePipe(25), ParseIntPipe) limit?: number,
         @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset?: number,
     ) {
+        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+
         const result = await this.activityLogService.findAll({
             userId: auth.userId,
             actionType: actionType as ActivityActionType,
@@ -82,6 +84,8 @@ export class ActivityLogController {
     })
     @ApiResponse({ status: 200, description: 'Running operations count' })
     async getRunningCount(@CurrentUser() auth: AuthenticatedUser) {
+        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+
         const count = await this.activityLogService.countRunning(auth.userId);
         return { count };
     }
@@ -93,6 +97,8 @@ export class ActivityLogController {
     })
     @ApiResponse({ status: 200, description: 'Activity summary counts' })
     async getSummary(@CurrentUser() auth: AuthenticatedUser) {
+        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+
         const counts = await this.activityLogService.summarizeStatuses(auth.userId);
         return { counts };
     }
@@ -140,6 +146,8 @@ export class ActivityLogController {
     @ApiResponse({ status: 200, description: 'Activity log entry details' })
     @ApiResponse({ status: 404, description: 'Activity not found' })
     async getActivity(@CurrentUser() auth: AuthenticatedUser, @Param('id') id: string) {
+        await this.activityLogService.reconcileStaleGenerationActivities(auth.userId);
+
         const activity = await this.activityLogService.findByIdAndUserId(id, auth.userId);
         if (!activity) {
             throw new NotFoundException('Activity not found');

--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -27,17 +27,33 @@ import type { Response } from 'express';
 @ApiBearerAuth('JWT-auth')
 @Controller('api/activity-log')
 export class ActivityLogController {
+    private readonly reconcileInFlight = new Map<string, Promise<void>>();
+
     constructor(
         private readonly activityLogService: ActivityLogService,
         private readonly directoryRepository: DirectoryRepository,
     ) {}
 
     private async reconcileActivities(userId: string) {
-        try {
-            await this.activityLogService.reconcileStaleGenerationActivities(userId);
-        } catch {
-            // Activity listing should remain available even if stale-state cleanup fails.
+        const existing = this.reconcileInFlight.get(userId);
+        if (existing) {
+            await existing;
+            return;
         }
+
+        const reconcilePromise = this.activityLogService
+            .reconcileStaleGenerationActivities(userId)
+            .catch(() => {
+                // Activity listing should remain available even if stale-state cleanup fails.
+            })
+            .finally(() => {
+                if (this.reconcileInFlight.get(userId) === reconcilePromise) {
+                    this.reconcileInFlight.delete(userId);
+                }
+            });
+
+        this.reconcileInFlight.set(userId, reconcilePromise);
+        await reconcilePromise;
     }
 
     @Get()

--- a/apps/api/src/activity-log/activity-log.listener.ts
+++ b/apps/api/src/activity-log/activity-log.listener.ts
@@ -38,14 +38,17 @@ export class ActivityLogListener {
         try {
             const directory = event.directory;
             const itemCount = directory.itemsCount || 0;
+            const generateStatus = directory.generateStatus?.status;
             const status =
-                directory.generateStatus?.status === 'error'
+                generateStatus === 'error' || generateStatus === 'cancelled'
                     ? ActivityStatus.FAILED
                     : ActivityStatus.COMPLETED;
             const summary =
-                status === ActivityStatus.FAILED
-                    ? `Generation failed for ${directory.name}`
-                    : `Generated ${itemCount} items for ${directory.name}`;
+                generateStatus === 'cancelled'
+                    ? `Generation cancelled for ${directory.name}`
+                    : status === ActivityStatus.FAILED
+                      ? `Generation failed for ${directory.name}`
+                      : `Generated ${itemCount} items for ${directory.name}`;
             const details = {
                 itemsCount: itemCount,
                 generateStatus: directory.generateStatus,

--- a/apps/api/src/directories/directories.controller.ts
+++ b/apps/api/src/directories/directories.controller.ts
@@ -513,6 +513,22 @@ export class DirectoriesController {
         });
     }
 
+    @Post('directories/:id/cancel-generation')
+    @HttpCode(HttpStatus.ACCEPTED)
+    @ApiOperation({
+        summary: 'Cancel generation',
+        description: 'Request cancellation of the active generation for a directory',
+    })
+    @ApiParam({ name: 'id', description: 'Directory ID' })
+    @ApiResponse({ status: 202, description: 'Generation cancellation requested' })
+    async cancelGeneration(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+    ): Promise<{ status: 'success'; message: string; mode: string }> {
+        const user = await this.authService.getUser(auth.userId);
+        return this.directoryGenerationService.cancelGeneration(id, user);
+    }
+
     @Get('directories/:id/schedule')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({

--- a/apps/api/src/directories/tasks/directory-cleanup.service.ts
+++ b/apps/api/src/directories/tasks/directory-cleanup.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { OnEvent } from '@nestjs/event-emitter';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { CacheEntryRepository } from '@ever-works/agent/cache';
@@ -18,6 +19,7 @@ export class DirectoryCleanupService {
         private readonly repository: DirectoryRepository,
         private readonly cacheRepository: CacheEntryRepository,
         private readonly generationHistoryRepository: DirectoryGenerationHistoryRepository,
+        private readonly eventEmitter: EventEmitter2,
     ) {}
 
     // Runs every 10 minutes
@@ -96,5 +98,14 @@ export class DirectoryCleanupService {
         }
 
         await Promise.all(promises);
+
+        const updatedDirectory = await this.repository.findById(directory.id);
+
+        if (updatedDirectory) {
+            this.eventEmitter.emit(
+                DirectoryGenerationCompletedEvent.EVENT_NAME,
+                new DirectoryGenerationCompletedEvent(updatedDirectory),
+            );
+        }
     }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -446,7 +446,11 @@
             },
             "actions": {
                 "export": "Export CSV",
-                "clearFilters": "Clear filters"
+                "clearFilters": "Clear filters",
+                "stop": "Stop",
+                "stopping": "Stopping...",
+                "stopRequested": "Generation cancellation requested",
+                "stopFailed": "Failed to stop generation"
             },
             "empty": {
                 "title": "No activities yet",
@@ -990,7 +994,11 @@
                 "generating": {
                     "title": "Generation in Progress",
                     "description": "Processing your request...",
-                    "processing": "Processing..."
+                    "processing": "Processing...",
+                    "stop": "Stop",
+                    "stopping": "Stopping...",
+                    "stopRequested": "Generation cancellation requested",
+                    "stopFailed": "Failed to stop generation"
                 },
                 "generated": {
                     "title": "Generation Complete",
@@ -2845,8 +2853,10 @@
             "promptRequired": "Prompt is required",
             "nameRequired": "Name is required",
             "generationStartedSuccessfully": "Generation started successfully",
+            "generationCancellationRequested": "Generation cancellation requested",
             "updateStartedSuccessfully": "Update started successfully",
             "failedToGenerateItems": "Failed to generate items",
+            "failedToCancelGeneration": "Failed to cancel generation",
             "failedToUpdateItems": "Failed to update items",
             "markdownRegeneratedSuccessfully": "Markdown regenerated successfully",
             "failedToRegenerateMarkdown": "Failed to regenerate markdown",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1653,7 +1653,8 @@
                 "progress": "Progress",
                 "closeNote": "This may take a few minutes. You can close this page and come back later.",
                 "showLogs": "Show step logs",
-                "hideLogs": "Hide step logs"
+                "hideLogs": "Hide step logs",
+                "waitingForLogs": "Waiting for live logs to arrive..."
             },
             "settings": {
                 "sourceSettings": "Source Repository",

--- a/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx
@@ -226,6 +226,19 @@ export function ActivityClient({ initialActivities, totalActivities }: ActivityC
         }
     };
 
+    const refreshCurrentPage = useCallback(() => {
+        void fetchSummary();
+        void fetchActivities(
+            page,
+            {
+                actionType,
+                status,
+                search: debouncedSearch,
+            },
+            false,
+        );
+    }, [fetchActivities, fetchSummary, page, actionType, status, debouncedSearch]);
+
     const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
     const summaryCards = [
         { key: 'in_progress', count: summary.in_progress, label: t('filters.statuses.inProgress') },
@@ -338,7 +351,11 @@ export function ActivityClient({ initialActivities, totalActivities }: ActivityC
                 />
             ) : (
                 <>
-                    <ActivityTable activities={activities} loading={loading} />
+                    <ActivityTable
+                        activities={activities}
+                        loading={loading}
+                        onStopRequested={refreshCurrentPage}
+                    />
 
                     {totalPages > 1 && (
                         <div className="flex items-center justify-between">

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/generator/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/generator/page.tsx
@@ -18,16 +18,10 @@ export default async function DirectoryGeneratorPage({ params }: Params) {
     const { id } = await params;
 
     let directory;
-    let config;
 
     try {
-        const [directoryRes, configRes] = await Promise.all([
-            directoryAPI.get(id),
-            directoryAPI.getConfig(id).catch(() => ({ config: undefined })),
-        ]);
-
+        const directoryRes = await directoryAPI.get(id);
         directory = directoryRes.directory;
-        config = configRes.config;
     } catch {
         notFound();
     }
@@ -40,6 +34,15 @@ export default async function DirectoryGeneratorPage({ params }: Params) {
     // If currently generating, show progress
     if (directory.generateStatus?.status === GenerateStatusType.GENERATING) {
         return <GenerationProgress directory={directory} />;
+    }
+
+    let config;
+
+    try {
+        const configRes = await directoryAPI.getConfig(id).catch(() => ({ config: undefined }));
+        config = configRes.config;
+    } catch {
+        config = undefined;
     }
 
     return <GeneratorForm directoryId={id} directory={directory} config={config} />;

--- a/apps/web/src/app/[locale]/globals.css
+++ b/apps/web/src/app/[locale]/globals.css
@@ -7,8 +7,9 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-    --font-sans: var(--font-geist-sans);
-    --font-mono: var(--font-geist-mono);
+    --font-sans:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    --font-mono: 'SFMono-Regular', 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
 
     /* Light mode colors (default) */
     --color-background: #ffffff;
@@ -141,13 +142,7 @@ body {
 
 body {
     @apply bg-background text-text dark:bg-background-dark dark:text-text-dark;
-    font-family:
-        var(--font-geist-sans),
-        -apple-system,
-        BlinkMacSystemFont,
-        'Segoe UI',
-        Roboto,
-        sans-serif;
+    font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
 import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
@@ -9,16 +8,6 @@ import './globals.css';
 import { themeInitScript } from '@/lib/theme-init';
 import { TopLoader } from '@/components/ui/top-loader';
 import { APP_NAME } from '@/lib/constants';
-
-const geistSans = Geist({
-    variable: '--font-geist-sans',
-    subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-    variable: '--font-geist-mono',
-    subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
     title: {
@@ -49,10 +38,7 @@ export default async function RootLayout({
             <head>
                 <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
             </head>
-            <body
-                className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-                suppressHydrationWarning
-            >
+            <body className="antialiased" suppressHydrationWarning>
                 <TopLoader />
                 <NextIntlClientProvider>
                     {children}

--- a/apps/web/src/app/actions/dashboard/generator.ts
+++ b/apps/web/src/app/actions/dashboard/generator.ts
@@ -139,6 +139,26 @@ export async function updateItems(directoryId: string, data: UpdateItemsGenerato
     }
 }
 
+export async function cancelGeneration(directoryId: string) {
+    const t = await getTranslations('actions.generator');
+
+    try {
+        const result = await itemsGeneratorAPI.cancel(directoryId);
+
+        return {
+            success: true,
+            data: result,
+            message: result.message || t('generationCancellationRequested'),
+        };
+    } catch (error) {
+        console.error('Failed to cancel generation:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : t('failedToCancelGeneration'),
+        };
+    }
+}
+
 export async function regenerateMarkdown(directoryId: string) {
     const t = await getTranslations('actions.generator');
 

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useEffect, useState, useTransition } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { formatDistanceToNow } from 'date-fns';
 import type { ActivityLogEntry } from '@/lib/api/activity-log';
@@ -176,8 +176,7 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
     const [hydratedActivities, setHydratedActivities] = useState<Record<string, ActivityLogEntry>>(
         {},
     );
-    const [stoppingDirectoryId, setStoppingDirectoryId] = useState<string | null>(null);
-    const [isStopping, startStopping] = useTransition();
+    const [stoppingDirectoryIds, setStoppingDirectoryIds] = useState<string[]>([]);
 
     const toggleExpanded = (id: string) => {
         setExpandedIds((current) =>
@@ -243,28 +242,30 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
         }
     };
 
-    const stopGeneration = (directoryId: string) => {
-        setStoppingDirectoryId(directoryId);
-        startStopping(async () => {
+    const stopGeneration = async (directoryId: string) => {
+        setStoppingDirectoryIds((current) =>
+            current.includes(directoryId) ? current : [...current, directoryId],
+        );
+
+        try {
             const result = await cancelGeneration(directoryId);
 
             if (!result.success) {
                 if (result.error?.includes('is not generating')) {
                     toast.error(result.error);
                     onStopRequested?.();
-                    setStoppingDirectoryId(null);
                     return;
                 }
 
                 toast.error(result.error || t('actions.stopFailed'));
-                setStoppingDirectoryId(null);
                 return;
             }
 
             toast.success(result.message || t('actions.stopRequested'));
             onStopRequested?.();
-            setStoppingDirectoryId(null);
-        });
+        } finally {
+            setStoppingDirectoryIds((current) => current.filter((id) => id !== directoryId));
+        }
     };
 
     return (
@@ -341,6 +342,9 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                             const hasDetails = hasStructuredData(detailsWithoutLiveLogs);
                             const hasMetadata = hasStructuredData(hydratedActivity.metadata);
                             const hasStructuredContent = hasDetails || hasMetadata;
+                            const isStopping = activity.directoryId
+                                ? stoppingDirectoryIds.includes(activity.directoryId)
+                                : false;
 
                             return (
                                 <Fragment key={activity.id}>
@@ -414,18 +418,13 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                                     <Button
                                                         variant="danger"
                                                         size="sm"
-                                                        loading={
-                                                            isStopping &&
-                                                            stoppingDirectoryId ===
-                                                                activity.directoryId
-                                                        }
+                                                        loading={isStopping}
                                                         onClick={(e) => {
                                                             e.stopPropagation();
                                                             stopGeneration(activity.directoryId!);
                                                         }}
                                                     >
-                                                        {isStopping &&
-                                                        stoppingDirectoryId === activity.directoryId
+                                                        {isStopping
                                                             ? t('actions.stopping')
                                                             : t('actions.stop')}
                                                     </Button>

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment, useEffect, useState, useTransition } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { formatDistanceToNow } from 'date-fns';
 import type { ActivityLogEntry } from '@/lib/api/activity-log';
 import { ActivityStatusBadge } from './ActivityStatusBadge';
@@ -15,11 +15,59 @@ import type { GenerationStepLog } from '@/lib/api/types-only';
 import { Button } from '@/components/ui/button';
 import { cancelGeneration } from '@/app/actions/dashboard/generator';
 import { toast } from 'sonner';
+import { useMounted } from '@/lib/hooks/use-mounted';
 
 interface ActivityTableProps {
     activities: ActivityLogEntry[];
     loading: boolean;
     onStopRequested?: () => void;
+}
+
+const dateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function formatActivityDateTime(value: string, locale: string) {
+    if (!dateTimeFormatterCache.has(locale)) {
+        dateTimeFormatterCache.set(
+            locale,
+            new Intl.DateTimeFormat(locale, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+            }),
+        );
+    }
+
+    return dateTimeFormatterCache.get(locale)!.format(new Date(value));
+}
+
+function ActivityTimestamp({
+    value,
+    variant = 'absolute',
+    className,
+}: {
+    value: string;
+    variant?: 'absolute' | 'relative';
+    className?: string;
+}) {
+    const locale = useLocale();
+    const mounted = useMounted();
+
+    if (!mounted) {
+        return <time dateTime={value} className={className} />;
+    }
+
+    const absoluteValue = formatActivityDateTime(value, locale);
+
+    return (
+        <time
+            dateTime={value}
+            title={variant === 'relative' ? absoluteValue : undefined}
+            className={className}
+        >
+            {variant === 'relative'
+                ? formatDistanceToNow(new Date(value), { addSuffix: true })
+                : absoluteValue}
+        </time>
+    );
 }
 
 function hasStructuredData(value?: Record<string, unknown>) {
@@ -201,6 +249,13 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
             const result = await cancelGeneration(directoryId);
 
             if (!result.success) {
+                if (result.error?.includes('is not generating')) {
+                    toast.error(result.error);
+                    onStopRequested?.();
+                    setStoppingDirectoryId(null);
+                    return;
+                }
+
                 toast.error(result.error || t('actions.stopFailed'));
                 setStoppingDirectoryId(null);
                 return;
@@ -323,15 +378,10 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                             <ActivityStatusBadge status={activity.status} />
                                         </td>
                                         <td className="px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
-                                            <span
-                                                title={new Date(
-                                                    activity.createdAt,
-                                                ).toLocaleString()}
-                                            >
-                                                {formatDistanceToNow(new Date(activity.createdAt), {
-                                                    addSuffix: true,
-                                                })}
-                                            </span>
+                                            <ActivityTimestamp
+                                                value={activity.createdAt}
+                                                variant="relative"
+                                            />
                                         </td>
                                         <td className="px-4 py-3 text-xs">
                                             {activity.directory ? (
@@ -426,11 +476,12 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                                                     <span className="font-medium text-text-secondary dark:text-text-secondary-dark">
                                                                         {t('detail.created')}:
                                                                     </span>{' '}
-                                                                    <span className="text-[11px] text-text-muted dark:text-text-muted-dark">
-                                                                        {new Date(
-                                                                            hydratedActivity.createdAt,
-                                                                        ).toLocaleString()}
-                                                                    </span>
+                                                                    <ActivityTimestamp
+                                                                        value={
+                                                                            hydratedActivity.createdAt
+                                                                        }
+                                                                        className="text-[11px] text-text-muted dark:text-text-muted-dark"
+                                                                    />
                                                                 </p>
                                                             </div>
                                                         </div>

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { formatDistanceToNow } from 'date-fns';
 import type { ActivityLogEntry } from '@/lib/api/activity-log';
@@ -12,10 +12,14 @@ import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { TerminalLogViewer } from '@/components/directories/detail/shared/TerminalLogViewer';
 import type { GenerationStepLog } from '@/lib/api/types-only';
+import { Button } from '@/components/ui/button';
+import { cancelGeneration } from '@/app/actions/dashboard/generator';
+import { toast } from 'sonner';
 
 interface ActivityTableProps {
     activities: ActivityLogEntry[];
     loading: boolean;
+    onStopRequested?: () => void;
 }
 
 function hasStructuredData(value?: Record<string, unknown>) {
@@ -118,12 +122,14 @@ function RawJsonPanel({
     );
 }
 
-export function ActivityTable({ activities, loading }: ActivityTableProps) {
+export function ActivityTable({ activities, loading, onStopRequested }: ActivityTableProps) {
     const t = useTranslations('dashboard.activity');
     const [expandedIds, setExpandedIds] = useState<string[]>([]);
     const [hydratedActivities, setHydratedActivities] = useState<Record<string, ActivityLogEntry>>(
         {},
     );
+    const [stoppingDirectoryId, setStoppingDirectoryId] = useState<string | null>(null);
+    const [isStopping, startStopping] = useTransition();
 
     const toggleExpanded = (id: string) => {
         setExpandedIds((current) =>
@@ -187,6 +193,23 @@ export function ActivityTable({ activities, loading }: ActivityTableProps) {
             e.preventDefault();
             toggleExpanded(id);
         }
+    };
+
+    const stopGeneration = (directoryId: string) => {
+        setStoppingDirectoryId(directoryId);
+        startStopping(async () => {
+            const result = await cancelGeneration(directoryId);
+
+            if (!result.success) {
+                toast.error(result.error || t('actions.stopFailed'));
+                setStoppingDirectoryId(null);
+                return;
+            }
+
+            toast.success(result.message || t('actions.stopRequested'));
+            onStopRequested?.();
+            setStoppingDirectoryId(null);
+        });
     };
 
     return (
@@ -331,8 +354,32 @@ export function ActivityTable({ activities, loading }: ActivityTableProps) {
                                             <ActivityTypeBadge actionType={activity.actionType} />
                                         </td>
                                         <td className="px-4 py-3 text-xs text-text dark:text-text-dark max-w-md">
-                                            <div className="line-clamp-3 break-words">
-                                                {activity.summary}
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div className="min-w-0 flex-1 line-clamp-3 break-words">
+                                                    {activity.summary}
+                                                </div>
+                                                {activity.actionType === 'generation' &&
+                                                activity.status === 'in_progress' &&
+                                                activity.directoryId ? (
+                                                    <Button
+                                                        variant="danger"
+                                                        size="sm"
+                                                        loading={
+                                                            isStopping &&
+                                                            stoppingDirectoryId ===
+                                                                activity.directoryId
+                                                        }
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            stopGeneration(activity.directoryId!);
+                                                        }}
+                                                    >
+                                                        {isStopping &&
+                                                        stoppingDirectoryId === activity.directoryId
+                                                            ? t('actions.stopping')
+                                                            : t('actions.stop')}
+                                                    </Button>
+                                                ) : null}
                                             </div>
                                         </td>
                                     </tr>

--- a/apps/web/src/components/directories/detail/DirectoryStatusCard.tsx
+++ b/apps/web/src/components/directories/detail/DirectoryStatusCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { Directory } from '@/lib/api/types-only';
 import { cn } from '@/lib/utils/cn';
 import { getGenerationStatusConfig } from '@/lib/utils/generation-status';
@@ -13,6 +13,8 @@ import { getStepProgress, getStepText, getItemsProcessedText } from '@/lib/utils
 import { Terminal } from 'lucide-react';
 import { TerminalLogViewer } from './shared/TerminalLogViewer';
 import { ShinyText } from '@/components/ui/ShinyText';
+import { cancelGeneration } from '@/app/actions/dashboard/generator';
+import { toast } from 'sonner';
 
 interface DirectoryStatusCardProps {
     directory: Directory;
@@ -23,6 +25,7 @@ export function DirectoryStatusCard({ directory }: DirectoryStatusCardProps) {
     const t = useTranslations('dashboard.directoryDetail.statusCard');
     const tProgress = useTranslations('dashboard.directoryDetail.progress');
     const [showLogs, setShowLogs] = useState(false);
+    const [isCancelling, startCancelling] = useTransition();
 
     const generateStatus = directory.generateStatus;
     const hasWarnings = !!generateStatus?.warnings?.length;
@@ -117,6 +120,30 @@ export function DirectoryStatusCard({ directory }: DirectoryStatusCardProps) {
                                     <div className="gp-shimmer" aria-hidden />
                                 </div>
                             </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Button
+                                variant="danger"
+                                size="sm"
+                                loading={isCancelling}
+                                onClick={() => {
+                                    startCancelling(async () => {
+                                        const result = await cancelGeneration(directory.id);
+
+                                        if (!result.success) {
+                                            toast.error(result.error || t('generating.stopFailed'));
+                                            return;
+                                        }
+
+                                        toast.success(
+                                            result.message || t('generating.stopRequested'),
+                                        );
+                                        router.refresh();
+                                    });
+                                }}
+                            >
+                                {isCancelling ? t('generating.stopping') : t('generating.stop')}
+                            </Button>
                         </div>
                         {logsSection}
                     </div>

--- a/apps/web/src/components/directories/detail/DirectoryStatusCard.tsx
+++ b/apps/web/src/components/directories/detail/DirectoryStatusCard.tsx
@@ -131,6 +131,12 @@ export function DirectoryStatusCard({ directory }: DirectoryStatusCardProps) {
                                         const result = await cancelGeneration(directory.id);
 
                                         if (!result.success) {
+                                            if (result.error?.includes('is not generating')) {
+                                                toast.error(result.error);
+                                                router.refresh();
+                                                return;
+                                            }
+
                                             toast.error(result.error || t('generating.stopFailed'));
                                             return;
                                         }

--- a/apps/web/src/components/directories/detail/generator/GenerationProgress.tsx
+++ b/apps/web/src/components/directories/detail/generator/GenerationProgress.tsx
@@ -135,8 +135,8 @@ export function GenerationProgress({ directory }: GenerationProgressProps) {
     const progressPercentage = getStepProgress(generateStatus);
     const stepText = getStepText(generateStatus, t('steps.processing'));
     const itemsText = getItemsProcessedText(generateStatus);
-    const recentLogs = generateStatus?.recentLogs;
-    const hasLogs = recentLogs && recentLogs.length > 0;
+    const recentLogs = generateStatus?.recentLogs ?? [];
+    const hasLogs = recentLogs.length > 0;
 
     return (
         <div className="gp-enter max-w-2xl mx-auto py-12">
@@ -184,36 +184,37 @@ export function GenerationProgress({ directory }: GenerationProgressProps) {
                     <ProgressBar percentage={progressPercentage} />
                 </div>
 
-                {hasLogs && (
-                    <div className="px-8 pb-4 space-y-3">
-                        <button
-                            type="button"
-                            onClick={() => setShowLogs((prev) => !prev)}
-                            className={cn(
-                                'group inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all duration-200',
-                                showLogs
-                                    ? 'bg-white/6 text-text dark:text-text-dark ring-1 ring-white/15'
-                                    : 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
-                            )}
-                        >
-                            <Terminal className="h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110" />
-                            {showLogs ? t('hideLogs') : t('showLogs')}
-                            {showLogs ? (
-                                <ChevronUp className="h-3 w-3 ml-0.5 opacity-40" />
-                            ) : (
-                                <ChevronDown className="h-3 w-3 ml-0.5 opacity-40" />
-                            )}
-                        </button>
-
-                        {showLogs && (
-                            <TerminalLogViewer
-                                logs={recentLogs!}
-                                title={t('showLogs')}
-                                showCursor
-                            />
+                <div className="px-8 pb-4 space-y-3">
+                    <button
+                        type="button"
+                        onClick={() => setShowLogs((prev) => !prev)}
+                        className={cn(
+                            'group inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all duration-200',
+                            showLogs
+                                ? 'bg-white/6 text-text dark:text-text-dark ring-1 ring-white/15'
+                                : 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
                         )}
-                    </div>
-                )}
+                    >
+                        <Terminal className="h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110" />
+                        {showLogs ? t('hideLogs') : t('showLogs')}
+                        {showLogs ? (
+                            <ChevronUp className="h-3 w-3 ml-0.5 opacity-40" />
+                        ) : (
+                            <ChevronDown className="h-3 w-3 ml-0.5 opacity-40" />
+                        )}
+                    </button>
+
+                    {showLogs && (
+                        <div className="space-y-2">
+                            <TerminalLogViewer logs={recentLogs} title={t('showLogs')} showCursor />
+                            {!hasLogs && (
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t('waitingForLogs')}
+                                </p>
+                            )}
+                        </div>
+                    )}
+                </div>
 
                 <div className="mx-8 mb-6 mt-2 flex items-start gap-2.5 rounded-lg bg-surface-secondary dark:bg-surface-secondary-dark px-4 py-3">
                     <Info className="h-3.5 w-3.5 mt-0.5 shrink-0 text-text-muted dark:text-text-muted-dark" />

--- a/apps/web/src/components/directories/detail/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/directories/detail/generator/GeneratorForm.tsx
@@ -23,10 +23,15 @@ import {
 } from '@/components/ui/dialog';
 import { generateItems, updateItems } from '@/app/actions/dashboard/generator';
 import { useTranslations } from 'next-intl';
-import { GenerationMethod, WebsiteRepositoryCreationMethod } from '@/lib/api/enums';
+import {
+    GenerateStatusType,
+    GenerationMethod,
+    WebsiteRepositoryCreationMethod,
+} from '@/lib/api/enums';
 import { getFormSchema } from '@/app/actions/dashboard/generator-form';
 import { useProviderSelection } from '@/lib/hooks/use-provider-selection';
 import { ProviderSelectionSection } from '@/components/directories/shared/ProviderSelectionSection';
+import { GenerationProgress } from './GenerationProgress';
 
 interface GeneratorFormProps {
     directoryId: string;
@@ -38,6 +43,7 @@ export function GeneratorForm({ directoryId, directory, config }: GeneratorFormP
     const router = useRouter();
     const t = useTranslations('dashboard.directoryDetail.generator');
     const [isPending, startTransition] = useTransition();
+    const [optimisticGenerating, setOptimisticGenerating] = useState(false);
     const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
     const [confirmRecreate, setConfirmRecreate] = useState(false);
     const [formSchema, setFormSchema] = useState<GeneratorFormSchema | null>(null);
@@ -157,6 +163,18 @@ export function GeneratorForm({ directoryId, directory, config }: GeneratorFormP
         setPluginConfig(values);
     }, []);
 
+    const optimisticDirectory: Directory = {
+        ...directory,
+        generateStatus:
+            directory.generateStatus?.status === GenerateStatusType.GENERATING
+                ? directory.generateStatus
+                : {
+                      status: GenerateStatusType.GENERATING,
+                      progress: 0,
+                      recentLogs: [],
+                  },
+    };
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
@@ -219,6 +237,7 @@ export function GeneratorForm({ directoryId, directory, config }: GeneratorFormP
             }
 
             if (result.success) {
+                setOptimisticGenerating(true);
                 toast.success(result.message || t('operationStartedSuccessfully'));
                 router.refresh();
             } else {
@@ -237,6 +256,10 @@ export function GeneratorForm({ directoryId, directory, config }: GeneratorFormP
         }
         return t('updateItems');
     };
+
+    if (optimisticGenerating) {
+        return <GenerationProgress directory={optimisticDirectory} />;
+    }
 
     return (
         <form onSubmit={handleSubmit} className="space-y-6 max-w-4xl">

--- a/apps/web/src/lib/api/items-generator.ts
+++ b/apps/web/src/lib/api/items-generator.ts
@@ -79,7 +79,7 @@ export interface RegenerateMarkdownResponse {
 export interface CancelGenerationResponse {
     status: 'success';
     message: string;
-    mode: 'trigger' | 'in_process' | 'stale';
+    mode: 'trigger' | 'in_process' | 'stale' | 'already_finished';
 }
 
 export const itemsGeneratorAPI = {

--- a/apps/web/src/lib/api/items-generator.ts
+++ b/apps/web/src/lib/api/items-generator.ts
@@ -76,6 +76,12 @@ export interface RegenerateMarkdownResponse {
     message?: string;
 }
 
+export interface CancelGenerationResponse {
+    status: 'success';
+    message: string;
+    mode: 'trigger' | 'in_process' | 'stale';
+}
+
 export const itemsGeneratorAPI = {
     // Generate items
     generate: async (directoryId: string, data: CreateItemsGeneratorDto) => {
@@ -92,6 +98,15 @@ export const itemsGeneratorAPI = {
         return serverMutation<ItemsGeneratorResponse>({
             endpoint: `/directories/${directoryId}/update`,
             data,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    cancel: async (directoryId: string) => {
+        return serverMutation<CancelGenerationResponse>({
+            endpoint: `/directories/${directoryId}/cancel-generation`,
+            data: {},
             method: 'POST',
             wrapInData: false,
         });

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -1,12 +1,14 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { ActivityLogRepository } from '@src/database/repositories/activity-log.repository';
-import type {
-    CreateActivityLogDto,
-    ActivityLogQueryOptions,
+import { DirectoryRepository } from '@src/database/repositories/directory.repository';
+import {
     ActivityActionType,
     ActivityStatus,
+    type CreateActivityLogDto,
+    type ActivityLogQueryOptions,
 } from '../entities/activity-log.types';
 import type { ActivityLog } from '../entities/activity-log.entity';
+import { GenerateStatusType } from '@src/entities/types';
 import {
     ACTIVITY_LOG_ANALYTICS_DISPATCHER,
     type ActivityLogAnalyticsDispatcher,
@@ -18,6 +20,7 @@ export class ActivityLogService {
 
     constructor(
         private readonly repository: ActivityLogRepository,
+        private readonly directoryRepository: DirectoryRepository,
         @Optional()
         @Inject(ACTIVITY_LOG_ANALYTICS_DISPATCHER)
         private readonly analyticsDispatcher?: ActivityLogAnalyticsDispatcher,
@@ -61,6 +64,71 @@ export class ActivityLogService {
             this.dispatchAnalytics(activity);
         }
         return activity;
+    }
+
+    async reconcileStaleGenerationActivities(userId: string): Promise<number> {
+        const activities = await this.repository.findInProgressGenerationsByUserId(userId);
+
+        if (activities.length === 0) {
+            return 0;
+        }
+
+        let reconciledCount = 0;
+
+        for (const activity of activities) {
+            if (!activity.directoryId || activity.actionType !== ActivityActionType.GENERATION) {
+                continue;
+            }
+
+            const directory = await this.directoryRepository.findById(activity.directoryId);
+
+            if (directory?.generateStatus?.status === GenerateStatusType.GENERATING) {
+                continue;
+            }
+
+            const itemCount = directory?.itemsCount || 0;
+            const resolvedStatus =
+                !directory ||
+                directory.generateStatus?.status === GenerateStatusType.ERROR ||
+                directory.generateStatus?.status === GenerateStatusType.CANCELLED
+                    ? ActivityStatus.FAILED
+                    : ActivityStatus.COMPLETED;
+            const summary = !directory
+                ? 'Generation state is no longer available for this directory'
+                : directory.generateStatus?.status === GenerateStatusType.CANCELLED
+                  ? `Generation cancelled for ${directory.name}`
+                  : directory.generateStatus?.status === GenerateStatusType.ERROR
+                    ? `Generation failed for ${directory.name}`
+                    : `Generated ${itemCount} items for ${directory.name}`;
+
+            const updated = await this.updateStatus(
+                activity.id,
+                resolvedStatus,
+                {
+                    ...(activity.details ?? {}),
+                    itemsCount: itemCount,
+                    generateStatus: directory?.generateStatus ?? null,
+                },
+                {
+                    action: 'generation.completed',
+                    summary,
+                },
+            );
+
+            if (updated) {
+                reconciledCount += 1;
+            }
+        }
+
+        if (reconciledCount > 0) {
+            this.logger.debug(
+                `Reconciled ${reconciledCount} stale in-progress generation activit${
+                    reconciledCount === 1 ? 'y' : 'ies'
+                } for user ${userId}`,
+            );
+        }
+
+        return reconciledCount;
     }
 
     async findAll(

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -67,68 +67,92 @@ export class ActivityLogService {
     }
 
     async reconcileStaleGenerationActivities(userId: string): Promise<number> {
-        const activities = await this.repository.findInProgressGenerationsByUserId(userId);
+        try {
+            const activities = await this.repository.findInProgressGenerationsByUserId(userId);
 
-        if (activities.length === 0) {
+            if (activities.length === 0) {
+                return 0;
+            }
+
+            let reconciledCount = 0;
+
+            for (const activity of activities) {
+                try {
+                    if (
+                        !activity.directoryId ||
+                        activity.actionType !== ActivityActionType.GENERATION
+                    ) {
+                        continue;
+                    }
+
+                    const directory = await this.directoryRepository.findById(activity.directoryId);
+
+                    if (directory?.generateStatus?.status === GenerateStatusType.GENERATING) {
+                        continue;
+                    }
+
+                    const itemCount = directory?.itemsCount || 0;
+                    const resolvedStatus =
+                        !directory ||
+                        directory.generateStatus?.status === GenerateStatusType.ERROR ||
+                        directory.generateStatus?.status === GenerateStatusType.CANCELLED
+                            ? ActivityStatus.FAILED
+                            : ActivityStatus.COMPLETED;
+                    const summary = !directory
+                        ? 'Generation state is no longer available for this directory'
+                        : directory.generateStatus?.status === GenerateStatusType.CANCELLED
+                          ? `Generation cancelled for ${directory.name}`
+                          : directory.generateStatus?.status === GenerateStatusType.ERROR
+                            ? `Generation failed for ${directory.name}`
+                            : `Generated ${itemCount} items for ${directory.name}`;
+                    const existingDetails =
+                        activity.details &&
+                        typeof activity.details === 'object' &&
+                        !Array.isArray(activity.details)
+                            ? activity.details
+                            : {};
+
+                    const updated = await this.updateStatus(
+                        activity.id,
+                        resolvedStatus,
+                        {
+                            ...existingDetails,
+                            itemsCount: itemCount,
+                            generateStatus: directory?.generateStatus ?? null,
+                        },
+                        {
+                            action: 'generation.completed',
+                            summary,
+                        },
+                    );
+
+                    if (updated) {
+                        reconciledCount += 1;
+                    }
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    this.logger.warn(
+                        `Failed to reconcile stale generation activity ${activity.id}: ${message}`,
+                    );
+                }
+            }
+
+            if (reconciledCount > 0) {
+                this.logger.debug(
+                    `Reconciled ${reconciledCount} stale in-progress generation activit${
+                        reconciledCount === 1 ? 'y' : 'ies'
+                    } for user ${userId}`,
+                );
+            }
+
+            return reconciledCount;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(
+                `Failed to reconcile stale generation activities for user ${userId}: ${message}`,
+            );
             return 0;
         }
-
-        let reconciledCount = 0;
-
-        for (const activity of activities) {
-            if (!activity.directoryId || activity.actionType !== ActivityActionType.GENERATION) {
-                continue;
-            }
-
-            const directory = await this.directoryRepository.findById(activity.directoryId);
-
-            if (directory?.generateStatus?.status === GenerateStatusType.GENERATING) {
-                continue;
-            }
-
-            const itemCount = directory?.itemsCount || 0;
-            const resolvedStatus =
-                !directory ||
-                directory.generateStatus?.status === GenerateStatusType.ERROR ||
-                directory.generateStatus?.status === GenerateStatusType.CANCELLED
-                    ? ActivityStatus.FAILED
-                    : ActivityStatus.COMPLETED;
-            const summary = !directory
-                ? 'Generation state is no longer available for this directory'
-                : directory.generateStatus?.status === GenerateStatusType.CANCELLED
-                  ? `Generation cancelled for ${directory.name}`
-                  : directory.generateStatus?.status === GenerateStatusType.ERROR
-                    ? `Generation failed for ${directory.name}`
-                    : `Generated ${itemCount} items for ${directory.name}`;
-
-            const updated = await this.updateStatus(
-                activity.id,
-                resolvedStatus,
-                {
-                    ...(activity.details ?? {}),
-                    itemsCount: itemCount,
-                    generateStatus: directory?.generateStatus ?? null,
-                },
-                {
-                    action: 'generation.completed',
-                    summary,
-                },
-            );
-
-            if (updated) {
-                reconciledCount += 1;
-            }
-        }
-
-        if (reconciledCount > 0) {
-            this.logger.debug(
-                `Reconciled ${reconciledCount} stale in-progress generation activit${
-                    reconciledCount === 1 ? 'y' : 'ies'
-                } for user ${userId}`,
-            );
-        }
-
-        return reconciledCount;
     }
 
     async findAll(

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -74,6 +74,15 @@ export class ActivityLogService {
                 return 0;
             }
 
+            const directories = await this.directoryRepository.findByIds(
+                activities
+                    .map((activity) => activity.directoryId)
+                    .filter((directoryId): directoryId is string => !!directoryId),
+            );
+            const directoriesById = new Map(
+                directories.map((directory) => [directory.id, directory]),
+            );
+
             let reconciledCount = 0;
 
             for (const activity of activities) {
@@ -85,7 +94,7 @@ export class ActivityLogService {
                         continue;
                     }
 
-                    const directory = await this.directoryRepository.findById(activity.directoryId);
+                    const directory = directoriesById.get(activity.directoryId);
 
                     if (directory?.generateStatus?.status === GenerateStatusType.GENERATING) {
                         continue;

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -66,7 +66,6 @@ export class ActivityLogRepository {
                 status: 'in_progress' as ActivityStatus,
             },
             order: { createdAt: 'DESC' },
-            relations: ['directory'],
         });
     }
 

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -58,6 +58,18 @@ export class ActivityLogRepository {
         });
     }
 
+    async findInProgressGenerationsByUserId(userId: string): Promise<ActivityLog[]> {
+        return this.repository.find({
+            where: {
+                userId,
+                actionType: 'generation' as ActivityActionType,
+                status: 'in_progress' as ActivityStatus,
+            },
+            order: { createdAt: 'DESC' },
+            relations: ['directory'],
+        });
+    }
+
     async findByUserId(
         options: ActivityLogQueryOptions,
     ): Promise<{ activities: ActivityLog[]; total: number }> {

--- a/packages/agent/src/database/repositories/directory-generation-history.repository.ts
+++ b/packages/agent/src/database/repositories/directory-generation-history.repository.ts
@@ -128,6 +128,18 @@ export class DirectoryGenerationHistoryRepository {
         return this.repository.findOne({ where: { id } });
     }
 
+    async findLatestInProgressByDirectory(
+        directoryId: string,
+    ): Promise<DirectoryGenerationHistory | null> {
+        return this.repository.findOne({
+            where: {
+                directoryId,
+                status: GenerateStatusType.GENERATING,
+            },
+            order: { startedAt: 'DESC', createdAt: 'DESC' },
+        });
+    }
+
     async findLatestPositiveItemCounts(directoryIds: string[]): Promise<Map<string, number>> {
         const uniqueDirectoryIds = Array.from(new Set(directoryIds));
         if (uniqueDirectoryIds.length === 0) {

--- a/packages/agent/src/database/repositories/directory.repository.ts
+++ b/packages/agent/src/database/repositories/directory.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThan, IsNull, Brackets, Raw, LessThanOrEqual } from 'typeorm';
+import { Repository, LessThan, IsNull, Brackets, Raw, LessThanOrEqual, In } from 'typeorm';
 import { Directory } from '../../entities/directory.entity';
 import { User } from '../../entities';
 import { prepareLikeSearchTerm } from '../utils';
@@ -73,6 +73,19 @@ export class DirectoryRepository {
     async findById(id: string): Promise<Directory | null> {
         return this.repository.findOne({
             where: { id },
+            relations: ['user'],
+        });
+    }
+
+    async findByIds(ids: string[]): Promise<Directory[]> {
+        const uniqueIds = [...new Set(ids.filter(Boolean))];
+
+        if (uniqueIds.length === 0) {
+            return [];
+        }
+
+        return this.repository.find({
+            where: { id: In(uniqueIds) },
             relations: ['user'],
         });
     }

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -30,6 +30,7 @@ import type {
 } from '@ever-works/plugin';
 import type { DirectoryHistoryChangeEntry } from '@ever-works/contracts/api';
 import type { GenerationLogCollector } from './generation-log-collector';
+import { GENERATION_CANCELLED } from '@src/constants/messages';
 
 const PARALLEL_WRITE_CONCURRENCY = 10;
 
@@ -96,11 +97,28 @@ export class DataGeneratorService {
         directory: Directory,
         user: User,
         createItemsGeneratorDto: CreateItemsGeneratorDto,
-        options?: { tryResume?: boolean; logCollector?: GenerationLogCollector },
+        options?: {
+            tryResume?: boolean;
+            logCollector?: GenerationLogCollector;
+            signal?: AbortSignal;
+        },
     ): Promise<InitializeResult> {
         this.logger.debug(
             `Initializing data repository for directory: ${JSON.stringify(createItemsGeneratorDto)}`,
         );
+
+        const throwIfCancelled = () => {
+            if (options?.signal?.aborted) {
+                const reason = options.signal.reason;
+                if (reason instanceof Error) {
+                    throw reason;
+                }
+
+                const error = new Error(GENERATION_CANCELLED);
+                error.name = 'AbortError';
+                throw error;
+            }
+        };
 
         let existingData = {
             existingItems: [],
@@ -121,6 +139,8 @@ export class DataGeneratorService {
                 .existingItems;
         }
 
+        throwIfCancelled();
+
         const existed = existingData.existingItems.length > 0;
 
         const logCollector = options?.logCollector;
@@ -136,6 +156,7 @@ export class DataGeneratorService {
             },
             options?.tryResume,
             logCollector ? (entry) => logCollector.log(entry) : undefined,
+            options?.signal,
         );
 
         const warnings = pipelineResult.warnings?.slice();
@@ -155,6 +176,8 @@ export class DataGeneratorService {
                 warnings,
             };
         }
+
+        throwIfCancelled();
 
         // If no items were generated, we don't need to do anything else
         if (!pipelineResult || pipelineResult.outputs.items.length === 0) {
@@ -189,6 +212,8 @@ export class DataGeneratorService {
         const owner = directory.getRepoOwner();
         const repo = directory.getDataRepo();
 
+        throwIfCancelled();
+
         // Creating repository
         const createdRepository = assertCreatedRepositoryTarget(
             await this.gitFacade.createRepository(
@@ -206,6 +231,7 @@ export class DataGeneratorService {
         );
 
         this.logger.log(`Successfully created repository: ${createdRepository.fullName}`);
+        throwIfCancelled();
 
         // Cloning repository
         let dest: string;
@@ -251,6 +277,7 @@ export class DataGeneratorService {
         }
 
         this.logger.log(`Cloned repository to ${dest}`);
+        throwIfCancelled();
 
         try {
             // Ensure directories exist
@@ -366,6 +393,7 @@ export class DataGeneratorService {
 
             // write categories, tags, readme, license, config, markdown template
             await Promise.all(promises);
+            throwIfCancelled();
 
             // Commit changes
             await this.gitFacade.addAll(provider, data.dir);
@@ -470,6 +498,7 @@ export class DataGeneratorService {
                 },
                 { concurrency: PARALLEL_WRITE_CONCURRENCY },
             );
+            throwIfCancelled();
 
             // Batch commit all items at once
             if (newItems.length > 0) {
@@ -1023,6 +1052,7 @@ export class DataGeneratorService {
         onProgress?: (progress: PipelineProgress) => void,
         tryResume?: boolean,
         onLogEntry?: (log: import('@ever-works/contracts/api').GenerationStepLog) => void,
+        signal?: AbortSignal,
     ): Promise<PipelineResult> {
         // Handle existing data reset for RECREATE mode
         let existing = { ...existingData };
@@ -1075,7 +1105,13 @@ export class DataGeneratorService {
 
         this.logger.log(`Executing pipeline for directory "${directory.slug}" (user: ${user.id})`);
 
-        const pipelineOptions = onLogEntry ? { onLogEntry } : undefined;
+        const pipelineOptions =
+            onLogEntry || signal
+                ? {
+                      ...(onLogEntry ? { onLogEntry } : {}),
+                      ...(signal ? { signal } : {}),
+                  }
+                : undefined;
 
         // Execute the pipeline - the orchestrator handles plugin resolution
         return tryResume

--- a/packages/agent/src/services/directory-generation.service.ts
+++ b/packages/agent/src/services/directory-generation.service.ts
@@ -333,7 +333,7 @@ export class DirectoryGenerationService {
     ): Promise<{
         status: 'success';
         message: string;
-        mode: 'trigger' | 'in_process' | 'stale';
+        mode: 'trigger' | 'in_process' | 'stale' | 'already_finished';
     }> {
         const { directory } = await this.ownershipService.ensureCanEdit(directoryId, user.id);
 
@@ -361,6 +361,19 @@ export class DirectoryGenerationService {
                     status: 'success',
                     message: 'Cancellation requested. The generation will stop shortly.',
                     mode: 'trigger',
+                };
+            }
+
+            const refreshedDirectory = await this.directoryRepository.findById(directoryId);
+
+            if (
+                refreshedDirectory?.generateStatus?.status &&
+                refreshedDirectory.generateStatus.status !== GenerateStatusType.GENERATING
+            ) {
+                return {
+                    status: 'success',
+                    message: `Directory "${refreshedDirectory.name}" is no longer generating.`,
+                    mode: 'already_finished',
                 };
             }
 
@@ -1530,11 +1543,7 @@ Only include image URLs that are absolute URLs (starting with http).`;
 
         if (error instanceof Error) {
             const message = error.message.toLowerCase();
-            return (
-                error.name === 'AbortError' ||
-                message === GENERATION_CANCELLED.toLowerCase() ||
-                message.includes('cancelled')
-            );
+            return error.name === 'AbortError' || message === GENERATION_CANCELLED.toLowerCase();
         }
 
         return false;

--- a/packages/agent/src/services/directory-generation.service.ts
+++ b/packages/agent/src/services/directory-generation.service.ts
@@ -1357,7 +1357,6 @@ Only include image URLs that are absolute URLs (starting with http).`;
         } catch (error) {
             generationError = error;
         } finally {
-            this.generationAbortControllers.delete(directory.id);
             try {
                 await logCollector?.dispose();
                 await this.finalizeGeneration({
@@ -1371,6 +1370,8 @@ Only include image URLs that are absolute URLs (starting with http).`;
                 });
             } catch (finalizeError) {
                 this.logger.error('Failed to finalize generation status:', finalizeError);
+            } finally {
+                this.generationAbortControllers.delete(directory.id);
             }
         }
 

--- a/packages/agent/src/services/directory-generation.service.ts
+++ b/packages/agent/src/services/directory-generation.service.ts
@@ -76,6 +76,7 @@ import {
 } from '@ever-works/contracts/api';
 import { buildDirectoryChangelog } from '../utils/directory-changelog.utils';
 import { GenerationLogCollector } from '@src/generators/data-generator/generation-log-collector';
+import { GENERATION_CANCELLED } from '@src/constants/messages';
 
 export interface BulkCaptureImagesDto {
     itemSlugs?: string[];
@@ -117,6 +118,7 @@ export type UpdateItemsGeneratorOptions = {
 @Injectable()
 export class DirectoryGenerationService {
     private readonly logger = new Logger(DirectoryGenerationService.name);
+    private readonly generationAbortControllers = new Map<string, AbortController>();
 
     constructor(
         private readonly dataGenerator: DataGeneratorService,
@@ -322,6 +324,68 @@ export class DirectoryGenerationService {
             parameters: payload,
             message: `Processing update for '${directory.name}'. Check logs or data directory for updates.`,
             historyId: history.id,
+        };
+    }
+
+    async cancelGeneration(
+        directoryId: string,
+        user: User,
+    ): Promise<{
+        status: 'success';
+        message: string;
+        mode: 'trigger' | 'in_process' | 'stale';
+    }> {
+        const { directory } = await this.ownershipService.ensureCanEdit(directoryId, user.id);
+
+        if (directory.generateStatus?.status !== GenerateStatusType.GENERATING) {
+            throw new ConflictException(`Directory "${directory.name}" is not generating`);
+        }
+
+        const history =
+            await this.generationHistoryRepository.findLatestInProgressByDirectory(directoryId);
+
+        if (history?.triggerRunId) {
+            if (!this.generationDispatcher) {
+                throw new BadRequestException({
+                    status: 'error',
+                    message: 'Generation cancellation is not available in this environment.',
+                });
+            }
+
+            const cancelled = await this.generationDispatcher.cancelDirectoryGeneration(
+                history.triggerRunId,
+            );
+
+            if (cancelled) {
+                return {
+                    status: 'success',
+                    message: 'Cancellation requested. The generation will stop shortly.',
+                    mode: 'trigger',
+                };
+            }
+
+            throw new BadRequestException({
+                status: 'error',
+                message: 'Failed to cancel the active generation run. Please try again.',
+            });
+        }
+
+        const controller = this.generationAbortControllers.get(directoryId);
+        if (controller) {
+            controller.abort(this.createGenerationCancelledError());
+            return {
+                status: 'success',
+                message: 'Cancellation requested. The generation will stop shortly.',
+                mode: 'in_process',
+            };
+        }
+
+        await this.finalizeCancelledGeneration(directory.id, history, history?.scheduleId ?? null);
+
+        return {
+            status: 'success',
+            message: 'Generation was marked as cancelled.',
+            mode: 'stale',
         };
     }
 
@@ -1236,8 +1300,10 @@ Only include image URLs that are absolute URLs (starting with http).`;
         context: GenerationTriggerContext = DEFAULT_TRIGGER_CONTEXT,
     ) {
         const startTime = new Date();
+        const abortController = new AbortController();
 
         await this.markGenerationStarted(directory.id, startTime, history);
+        this.generationAbortControllers.set(directory.id, abortController);
 
         const acc: { stats: GenerationStats | null; warnings?: string[] } = {
             stats: null,
@@ -1266,10 +1332,19 @@ Only include image URLs that are absolute URLs (starting with http).`;
             : undefined;
 
         try {
-            await this.executeGenerationPipeline(directory, user, dto, context, acc, logCollector);
+            await this.executeGenerationPipeline(
+                directory,
+                user,
+                dto,
+                context,
+                acc,
+                logCollector,
+                abortController.signal,
+            );
         } catch (error) {
             generationError = error;
         } finally {
+            this.generationAbortControllers.delete(directory.id);
             try {
                 await logCollector?.dispose();
                 await this.finalizeGeneration({
@@ -1313,10 +1388,12 @@ Only include image URLs that are absolute URLs (starting with http).`;
         context: GenerationTriggerContext,
         acc: { stats: GenerationStats | null; warnings?: string[] },
         logCollector?: GenerationLogCollector,
+        signal?: AbortSignal,
     ): Promise<void> {
         const generated = await this.dataGenerator.initialize(directory, user, dto, {
             tryResume: context.triggeredBy === 'schedule',
             logCollector,
+            signal,
         });
 
         acc.warnings = generated.warnings;
@@ -1331,11 +1408,19 @@ Only include image URLs that are absolute URLs (starting with http).`;
         const newItemsCount = generated.stats?.newItemsCount ?? 0;
         const updatedItemsCount = generated.stats?.updatedItemsCount ?? 0;
 
+        if (signal?.aborted) {
+            throw this.createGenerationCancelledError();
+        }
+
         if (newItemsCount > 0 || updatedItemsCount > 0) {
             await this.markdownGenerator.initialize(directory, user, {
                 generation_method: dto.generation_method,
                 pr_update: generated.prUpdate,
             });
+        }
+
+        if (signal?.aborted) {
+            throw this.createGenerationCancelledError();
         }
 
         if (generated.hasExistingItems || newItemsCount > 0) {
@@ -1383,14 +1468,25 @@ Only include image URLs that are absolute URLs (starting with http).`;
         const { directoryId, startTime, history, error, stats, warnings, context } = params;
         const endTime = new Date();
         const durationInSeconds = calculateDurationSeconds(startTime, endTime);
-        const finalStatus = error ? GenerateStatusType.ERROR : GenerateStatusType.GENERATED;
+        const wasCancelled = this.isGenerationCancelledError(error);
+        const finalStatus = wasCancelled
+            ? GenerateStatusType.CANCELLED
+            : error
+              ? GenerateStatusType.ERROR
+              : GenerateStatusType.GENERATED;
 
         // 1. Finalize directory status
         await Promise.all([
             this.directoryRepository.recordGenerationFinishTime(directoryId, endTime),
             this.directoryRepository.updateGenerateStatus(directoryId, {
                 status: finalStatus,
-                ...(error ? { error: normalizeGeneratorError(error) } : { step: null }),
+                ...(error
+                    ? {
+                          error: wasCancelled
+                              ? GENERATION_CANCELLED
+                              : normalizeGeneratorError(error),
+                      }
+                    : { step: null }),
                 warnings,
             }),
         ]);
@@ -1401,7 +1497,13 @@ Only include image URLs that are absolute URLs (starting with http).`;
                 status: finalStatus,
                 finishedAt: endTime,
                 durationInSeconds,
-                ...(error ? { errorMessage: normalizeGeneratorError(error) } : {}),
+                ...(error
+                    ? {
+                          errorMessage: wasCancelled
+                              ? GENERATION_CANCELLED
+                              : normalizeGeneratorError(error),
+                      }
+                    : {}),
                 ...buildStatsUpdate(stats),
             });
         }
@@ -1412,6 +1514,69 @@ Only include image URLs that are absolute URLs (starting with http).`;
                 ? { status: 'failed', reason: normalizeGeneratorError(error) }
                 : { status: 'completed', historyId: history?.id };
             await this.directoryScheduleService.finalizeScheduleRun(context.scheduleId, outcome);
+        }
+    }
+
+    private createGenerationCancelledError(): Error {
+        const error = new Error(GENERATION_CANCELLED);
+        error.name = 'AbortError';
+        return error;
+    }
+
+    private isGenerationCancelledError(error: unknown): boolean {
+        if (!error) {
+            return false;
+        }
+
+        if (error instanceof Error) {
+            const message = error.message.toLowerCase();
+            return (
+                error.name === 'AbortError' ||
+                message === GENERATION_CANCELLED.toLowerCase() ||
+                message.includes('cancelled')
+            );
+        }
+
+        return false;
+    }
+
+    private async finalizeCancelledGeneration(
+        directoryId: string,
+        history?: DirectoryGenerationHistory | null,
+        scheduleId?: string | null,
+    ): Promise<void> {
+        const finishedAt = new Date();
+        const startedAt = history?.startedAt ?? finishedAt;
+
+        await Promise.all([
+            this.directoryRepository.recordGenerationFinishTime(directoryId, finishedAt),
+            this.directoryRepository.updateGenerateStatus(directoryId, {
+                status: GenerateStatusType.CANCELLED,
+                error: GENERATION_CANCELLED,
+                step: null,
+            }),
+            history
+                ? this.generationHistoryRepository.updateEntry(history.id, {
+                      status: GenerateStatusType.CANCELLED,
+                      finishedAt,
+                      durationInSeconds: calculateDurationSeconds(startedAt, finishedAt),
+                      errorMessage: GENERATION_CANCELLED,
+                  })
+                : Promise.resolve(null),
+            scheduleId
+                ? this.directoryScheduleService.finalizeScheduleRun(scheduleId, {
+                      status: 'failed',
+                      reason: GENERATION_CANCELLED,
+                  })
+                : Promise.resolve(),
+        ]);
+
+        const completedDirectory = await this.directoryRepository.findById(directoryId);
+        if (completedDirectory) {
+            this.eventEmitter.emit(
+                DirectoryGenerationCompletedEvent.EVENT_NAME,
+                new DirectoryGenerationCompletedEvent(completedDirectory),
+            );
         }
     }
 

--- a/packages/agent/src/tasks/directory-generation-dispatcher.ts
+++ b/packages/agent/src/tasks/directory-generation-dispatcher.ts
@@ -6,6 +6,12 @@ export interface DirectoryGenerationDispatcher {
      * @returns The trigger run ID if successful, or null if failed/not triggered.
      */
     dispatchDirectoryGeneration(payload: DirectoryGenerationPayload): Promise<string | null>;
+
+    /**
+     * Requests cancellation of a dispatched directory generation task.
+     * @returns True when the cancellation request was accepted.
+     */
+    cancelDirectoryGeneration(runId: string): Promise<boolean>;
 }
 
 export const DIRECTORY_GENERATION_DISPATCHER = Symbol('DIRECTORY_GENERATION_DISPATCHER');

--- a/packages/tasks/src/tasks/trigger/directory-generation.task.ts
+++ b/packages/tasks/src/tasks/trigger/directory-generation.task.ts
@@ -6,7 +6,7 @@ import { TriggerGenerationOrchestrator } from '../../trigger/worker/orchestrator
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 import { createTaskContext } from '../../trigger/worker/utils/task-context.utils';
 
-export const directoryGenerationTask = task({
+export const directoryGenerationTask = task<'directory-generation', DirectoryGenerationPayload>({
     id: 'directory-generation',
     maxDuration: 3600 * 5, // 5 hours
     onFailure: async ({ payload, error }) => {
@@ -68,7 +68,7 @@ export const directoryGenerationTask = task({
             // Best-effort — if we can't boot the context, nothing more we can do
         }
     },
-    run: async (payload: DirectoryGenerationPayload) => {
+    run: async (payload: DirectoryGenerationPayload, { signal }) => {
         return withWorkerContext('DirectoryGeneration', async (appContext) => {
             const { orchestrator, directory, user } = await createTaskContext(
                 appContext,
@@ -78,20 +78,25 @@ export const directoryGenerationTask = task({
             const scheduleService = appContext.get(DirectoryScheduleService);
 
             try {
-                await orchestrator.run({
+                const finalStatus = await orchestrator.run({
                     directory,
                     user,
                     dto: payload.dto,
                     historyId: payload.historyId,
                     historyStartedAt: payload.historyStartedAt,
+                    signal,
                 });
 
                 if (payload.triggerSource === 'schedule' && payload.scheduleId) {
-                    await scheduleService.markRunCompleted({
-                        scheduleId: payload.scheduleId,
-                        historyId: payload.historyId,
-                        status: GenerateStatusType.GENERATED,
-                    });
+                    if (finalStatus === GenerateStatusType.CANCELLED) {
+                        await scheduleService.markRunFailed(payload.scheduleId, 'cancelled');
+                    } else {
+                        await scheduleService.markRunCompleted({
+                            scheduleId: payload.scheduleId,
+                            historyId: payload.historyId,
+                            status: GenerateStatusType.GENERATED,
+                        });
+                    }
                 }
             } catch (error) {
                 // Mark schedule as failed. The onFailure handler also calls markRunFailed,

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { configure } from '@trigger.dev/sdk';
+import { configure, runs } from '@trigger.dev/sdk';
 import { config } from '@ever-works/agent/config';
 import {
     DirectoryGenerationPayload,
@@ -70,6 +70,23 @@ export class TriggerService implements DirectoryGenerationDispatcher, DirectoryI
         } catch (error) {
             this.logger.error('Failed to dispatch directory-generation task', error as Error);
             return null;
+        }
+    }
+
+    async cancelDirectoryGeneration(runId: string): Promise<boolean> {
+        if (!this.ensureConfigured()) {
+            return false;
+        }
+
+        try {
+            await runs.cancel(runId);
+            return true;
+        } catch (error) {
+            this.logger.error(
+                `Failed to cancel directory-generation task ${runId}`,
+                error as Error,
+            );
+            return false;
         }
     }
 

--- a/packages/tasks/src/trigger/worker/orchestrators/trigger-generation.orchestrator.ts
+++ b/packages/tasks/src/trigger/worker/orchestrators/trigger-generation.orchestrator.ts
@@ -14,12 +14,15 @@ import { normalizeGeneratorError } from '@ever-works/agent/services';
 import { calculateDurationSeconds } from '@ever-works/agent/utils';
 import { BaseOrchestrator } from './base-orchestrator';
 
+const GENERATION_CANCELLED = 'Generation cancelled';
+
 export type TriggerGenerationOptions = {
     directory: Directory;
     user: User;
     dto: CreateItemsGeneratorDto;
     historyId: string;
     historyStartedAt?: string;
+    signal?: AbortSignal;
 };
 
 @Injectable()
@@ -38,7 +41,14 @@ export class TriggerGenerationOrchestrator extends BaseOrchestrator {
         super(directoryOperations, notificationService);
     }
 
-    async run({ directory, user, dto, historyId, historyStartedAt }: TriggerGenerationOptions) {
+    async run({
+        directory,
+        user,
+        dto,
+        historyId,
+        historyStartedAt,
+        signal,
+    }: TriggerGenerationOptions): Promise<GenerateStatusType> {
         const startTime = this.resolveStartTime(historyStartedAt);
 
         const logCollector = new GenerationLogCollector(
@@ -69,6 +79,7 @@ export class TriggerGenerationOrchestrator extends BaseOrchestrator {
         try {
             const generated = await this.dataGenerator.initialize(directory, user, dto, {
                 logCollector,
+                signal,
             });
             generationWarnings = generated.warnings;
 
@@ -95,6 +106,10 @@ export class TriggerGenerationOrchestrator extends BaseOrchestrator {
             const newItemsCount = generated.stats?.newItemsCount ?? 0;
             const updatedItemsCount = generated.stats?.updatedItemsCount ?? 0;
 
+            if (signal?.aborted) {
+                throw this.createGenerationCancelledError();
+            }
+
             if (newItemsCount > 0 || updatedItemsCount > 0) {
                 logCollector.message('Markdown generation started', 'info', 'orchestrator');
                 await this.markdownGenerator.initialize(directory, user, {
@@ -102,6 +117,10 @@ export class TriggerGenerationOrchestrator extends BaseOrchestrator {
                     pr_update: generated.prUpdate,
                 });
                 logCollector.message('Markdown generation completed', 'info', 'orchestrator');
+            }
+
+            if (signal?.aborted) {
+                throw this.createGenerationCancelledError();
             }
 
             if (newItemsCount > 0 || generated.hasExistingItems) {
@@ -133,31 +152,46 @@ export class TriggerGenerationOrchestrator extends BaseOrchestrator {
                     ...buildStatsUpdate(generationStats),
                 }),
             ]);
+
+            return GenerateStatusType.GENERATED;
         } catch (error) {
             const endTime = new Date();
+            const wasCancelled = this.isGenerationCancelledError(error) || Boolean(signal?.aborted);
+            const finalStatus = wasCancelled
+                ? GenerateStatusType.CANCELLED
+                : GenerateStatusType.ERROR;
+            const errorMessage = wasCancelled
+                ? GENERATION_CANCELLED
+                : normalizeGeneratorError(error);
 
             logCollector.message(
-                `Generation failed: ${normalizeGeneratorError(error)}`,
-                'error',
+                wasCancelled
+                    ? 'Generation cancelled'
+                    : `Generation failed: ${normalizeGeneratorError(error)}`,
+                wasCancelled ? 'warn' : 'error',
                 'orchestrator',
             );
 
             await Promise.all([
                 this.directoryOperations.recordGenerationFinishTime(directory.id, endTime),
                 this.directoryOperations.updateGenerateStatus(directory.id, {
-                    status: GenerateStatusType.ERROR,
-                    error: normalizeGeneratorError(error),
+                    status: finalStatus,
+                    error: errorMessage,
                     warnings: generationWarnings,
                     recentLogs: logCollector.getRecentLogs(),
                 }),
                 this.directoryOperations.updateGenerationHistory(directory.id, historyId, {
-                    status: GenerateStatusType.ERROR,
+                    status: finalStatus,
                     finishedAt: endTime,
                     durationInSeconds: calculateDurationSeconds(startTime, endTime),
-                    errorMessage: normalizeGeneratorError(error),
+                    errorMessage,
                     ...buildStatsUpdate(generationStats),
                 }),
             ]);
+
+            if (wasCancelled) {
+                return GenerateStatusType.CANCELLED;
+            }
 
             this.logger.error('Generation failed', error as Error);
 
@@ -168,5 +202,22 @@ export class TriggerGenerationOrchestrator extends BaseOrchestrator {
             await logCollector.dispose();
             await this.directoryOperations.emitGenerationCompleted(directory.id);
         }
+    }
+
+    private createGenerationCancelledError(): Error {
+        const error = new Error(GENERATION_CANCELLED);
+        error.name = 'AbortError';
+        return error;
+    }
+
+    private isGenerationCancelledError(error: unknown): boolean {
+        if (!(error instanceof Error)) {
+            return false;
+        }
+
+        return (
+            error.name === 'AbortError' ||
+            error.message.toLowerCase() === GENERATION_CANCELLED.toLowerCase()
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop/cancel in‑progress generation from the UI and via a new API endpoint; UI triggers immediate refresh.
  * Server supports both in‑process and dispatched cancellation paths for generation jobs.

* **Bug Fixes**
  * Reconciliation of stale generation activities runs on activity requests, serialized per user, and no longer blocks responses.
  * Cancelled generations are surfaced distinctly with clear summaries.

* **UI/UX Improvements**
  * "Stop" buttons with per‑item loading, toast feedback, improved timestamps, and new localized cancellation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->