### PR TITLE
fix: align directory generating status and switcher badges

### DIFF
--- a/apps/web/src/components/dashboard/DirectorySwitcher.tsx
+++ b/apps/web/src/components/dashboard/DirectorySwitcher.tsx
@@ -65,6 +65,21 @@ export function DirectorySwitcher() {
         () => directories.filter((directory) => matchesDirectoryQuery(directory, deferredQuery)),
         [deferredQuery, directories],
     );
+    const currentDirectoryStatus = useMemo(() => {
+        if (!currentDirectory) {
+            return null;
+        }
+
+        const hasWarnings = !!currentDirectory.generateStatus?.warnings?.length;
+        const statusStyle = getGenerationStatusConfig(currentDirectory.generateStatus?.status, {
+            hasWarnings,
+        });
+
+        return {
+            ...statusStyle,
+            label: tStatus(statusStyle.labelKey),
+        };
+    }, [currentDirectory, tStatus]);
 
     useEffect(() => {
         inputRef.current?.blur();
@@ -178,6 +193,16 @@ export function DirectorySwitcher() {
                             placeholder={t('search')}
                         />
 
+                        {currentDirectoryStatus && (
+                            <DirectoryStatusBadge
+                                className="shrink-0"
+                                label={currentDirectoryStatus.label}
+                                badgeClassName={currentDirectoryStatus.badge}
+                                animate={currentDirectoryStatus.animate}
+                                Icon={currentDirectoryStatus.icon}
+                            />
+                        )}
+
                         <ComboboxButton
                             className={cn(
                                 'flex h-6 w-6 shrink-0 items-center justify-center rounded-md',
@@ -218,7 +243,6 @@ export function DirectorySwitcher() {
                                         { hasWarnings },
                                     );
                                     const statusLabel = tStatus(statusStyle.labelKey);
-                                    const StatusIcon = statusStyle.icon;
 
                                     return (
                                         <ComboboxOption
@@ -249,25 +273,12 @@ export function DirectorySwitcher() {
                                                 </div>
 
                                                 <div className="flex shrink-0 items-center gap-2 self-center">
-                                                    <span
-                                                        className={cn(
-                                                            'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium',
-                                                            statusStyle.badge,
-                                                        )}
-                                                    >
-                                                        <StatusIcon
-                                                            className={cn(
-                                                                'h-3 w-3',
-                                                                statusStyle.animate &&
-                                                                    'animate-spin',
-                                                            )}
-                                                        />
-                                                        {statusStyle.animate ? (
-                                                            <ShinyText text={statusLabel} />
-                                                        ) : (
-                                                            statusLabel
-                                                        )}
-                                                    </span>
+                                                    <DirectoryStatusBadge
+                                                        label={statusLabel}
+                                                        badgeClassName={statusStyle.badge}
+                                                        animate={statusStyle.animate}
+                                                        Icon={statusStyle.icon}
+                                                    />
 
                                                     {isCurrentDirectory && (
                                                         <Check className="h-4 w-4 shrink-0 text-primary dark:text-primary-dark" />
@@ -283,5 +294,32 @@ export function DirectorySwitcher() {
                 </div>
             </Combobox>
         </div>
+    );
+}
+
+function DirectoryStatusBadge({
+    label,
+    badgeClassName,
+    animate,
+    Icon,
+    className,
+}: {
+    label: string;
+    badgeClassName: string;
+    animate: boolean;
+    Icon: React.ComponentType<{ className?: string }>;
+    className?: string;
+}) {
+    return (
+        <span
+            className={cn(
+                'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium',
+                badgeClassName,
+                className,
+            )}
+        >
+            <Icon className={cn('h-3 w-3', animate && 'animate-spin')} />
+            {animate ? <ShinyText text={label} /> : label}
+        </span>
     );
 }

--- a/apps/web/src/components/directories/DirectoryCard.tsx
+++ b/apps/web/src/components/directories/DirectoryCard.tsx
@@ -41,9 +41,11 @@ export function DirectoryCard({ directory }: DirectoryCardProps) {
     const isScheduled = directory.scheduledStatus === DirectoryScheduleStatus.ACTIVE;
     const userRole = directory.userRole;
     const isShared = userRole && userRole !== DirectoryMemberRole.OWNER;
+    const shouldShowScheduledSuffix =
+        isScheduled && status !== GenerateStatusType.GENERATING && !isOpening;
     const statusLabel = isOpening
         ? t('status.opening')
-        : isScheduled
+        : shouldShowScheduledSuffix
           ? `${tStatus(statusConfig.labelKey)} - Scheduled`
           : tStatus(statusConfig.labelKey);
     const isGenerating = statusConfig.labelKey === 'generating' || isOpening;

--- a/apps/web/src/components/directories/detail/DirectoryHeader.tsx
+++ b/apps/web/src/components/directories/detail/DirectoryHeader.tsx
@@ -4,7 +4,7 @@ import { Directory } from '@/lib/api/types-only';
 import { cn } from '@/lib/utils/cn';
 import { getGenerationStatusConfig } from '@/lib/utils/generation-status';
 import { useTranslations } from 'next-intl';
-import { DirectoryMemberRole, DirectoryScheduleStatus } from '@/lib/api/enums';
+import { DirectoryMemberRole, DirectoryScheduleStatus, GenerateStatusType } from '@/lib/api/enums';
 import { Link as IconLink, Users, Cog, Github, Clock } from 'lucide-react';
 import { useDirectoryDetail, useDirectoryPermissions } from './DirectoryDetailContext';
 import { getStepText, getItemsProcessedText } from '@/lib/utils/generator-steps';
@@ -32,7 +32,7 @@ export function DirectoryHeader({ directory }: DirectoryHeaderProps) {
     const isScheduled = directory.scheduledStatus === DirectoryScheduleStatus.ACTIVE;
     const StatusIcon = statusStyle.icon;
     const shouldShowScheduledSuffix =
-        isScheduled && directory.generateStatus?.status !== 'generating';
+        isScheduled && directory.generateStatus?.status !== GenerateStatusType.GENERATING;
     const statusLabel = shouldShowScheduledSuffix
         ? `${t(`status.${statusStyle.labelKey}`)} - Scheduled`
         : t(`status.${statusStyle.labelKey}`);

--- a/apps/web/src/components/directories/detail/DirectoryHeader.tsx
+++ b/apps/web/src/components/directories/detail/DirectoryHeader.tsx
@@ -31,7 +31,9 @@ export function DirectoryHeader({ directory }: DirectoryHeaderProps) {
     });
     const isScheduled = directory.scheduledStatus === DirectoryScheduleStatus.ACTIVE;
     const StatusIcon = statusStyle.icon;
-    const statusLabel = isScheduled
+    const shouldShowScheduledSuffix =
+        isScheduled && directory.generateStatus?.status !== 'generating';
+    const statusLabel = shouldShowScheduledSuffix
         ? `${t(`status.${statusStyle.labelKey}`)} - Scheduled`
         : t(`status.${statusStyle.labelKey}`);
     const pathSegments = pathname.split('/').filter(Boolean);

--- a/packages/agent/src/database/repositories/directory.repository.ts
+++ b/packages/agent/src/database/repositories/directory.repository.ts
@@ -413,7 +413,7 @@ export class DirectoryRepository {
                 'activeWebsites',
             )
             .addSelect(
-                'COALESCE(SUM(CASE WHEN directory.generationStartedAt IS NOT NULL AND directory.generationFinishedAt IS NULL THEN 1 ELSE 0 END), 0)',
+                `COALESCE(SUM(CASE WHEN directory.generateStatus LIKE '%"status":"generating"%' THEN 1 ELSE 0 END), 0)`,
                 'generatingCount',
             )
             .getRawOne();

--- a/packages/agent/src/database/repositories/directory.repository.ts
+++ b/packages/agent/src/database/repositories/directory.repository.ts
@@ -413,6 +413,9 @@ export class DirectoryRepository {
                 'activeWebsites',
             )
             .addSelect(
+                // `generateStatus` is stored as TypeORM `simple-json`, so it is persisted as plain text
+                // across the supported databases in this repo. Keep this query portable by matching the
+                // serialized status field instead of using engine-specific JSON operators.
                 `COALESCE(SUM(CASE WHEN directory.generateStatus LIKE '%"status":"generating"%' THEN 1 ELSE 0 END), 0)`,
                 'generatingCount',
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable status badge for consistent directory status display across the UI

* **Improvements**
  * "Scheduled" suffix now only shown when appropriate—hidden during generation and transient opening states for clearer labels
  * Improved generation-status detection for more accurate and reliable status counts and displays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->