### PR TITLE
fix: add directory metadata to schedule dispatcher runs

### DIFF
--- a/apps/web/src/lib/api/items-generator.ts
+++ b/apps/web/src/lib/api/items-generator.ts
@@ -44,7 +44,7 @@ export type {
 export interface ItemsGeneratorResponse {
     id: string;
     slug: string;
-    status: string;
+    status: 'success' | 'error' | 'pending' | 'skipped';
     message?: string;
 }
 

--- a/packages/agent/src/items-generator/dto/items-generator-response.dto.ts
+++ b/packages/agent/src/items-generator/dto/items-generator-response.dto.ts
@@ -13,7 +13,7 @@ export interface ItemsGeneratorMetrics {
 }
 
 export interface ItemsGeneratorResponseDto {
-    status: 'success' | 'error' | 'pending';
+    status: 'success' | 'error' | 'pending' | 'skipped';
     slug: string;
     message: string;
     metrics?: ItemsGeneratorMetrics;

--- a/packages/agent/src/services/directory-generation.service.ts
+++ b/packages/agent/src/services/directory-generation.service.ts
@@ -946,7 +946,9 @@ Only include image URLs that are absolute URLs (starting with http).`;
         }
     }
 
-    async runScheduledUpdate(schedule: DirectorySchedule) {
+    async runScheduledUpdate(
+        schedule: DirectorySchedule,
+    ): Promise<ItemsGeneratorResponseDto | void> {
         let user: User | null = null;
         try {
             user = (schedule.user as User) || (await this.userRepository.findById(schedule.userId));
@@ -967,7 +969,11 @@ Only include image URLs that are absolute URLs (starting with http).`;
                     status: 'skipped',
                     reason: 'Entitlement check failed — schedule paused',
                 });
-                return;
+                return {
+                    slug: schedule.directory?.slug ?? schedule.directoryId,
+                    status: 'skipped',
+                    message: 'Entitlement check failed — schedule paused',
+                };
             }
 
             const directory =

--- a/packages/agent/src/services/directory-schedule-dispatcher.service.ts
+++ b/packages/agent/src/services/directory-schedule-dispatcher.service.ts
@@ -55,7 +55,7 @@ export class DirectoryScheduleDispatcherService {
         await this.directoryScheduleService.recoverStuckSchedules();
 
         const schedules = await this.scheduleRepository.findDue(limit);
-        const summary: DirectoryScheduleDispatchSummary = {
+        let summary: DirectoryScheduleDispatchSummary = {
             limit,
             dueCount: schedules.length,
             dispatched: 0,

--- a/packages/agent/src/services/directory-schedule-dispatcher.service.ts
+++ b/packages/agent/src/services/directory-schedule-dispatcher.service.ts
@@ -3,6 +3,28 @@ import { config } from '@src/config';
 import { DirectoryScheduleRepository } from '@src/database/repositories/directory-schedule.repository';
 import { DirectoryGenerationService } from './directory-generation.service';
 import { DirectoryScheduleService } from './directory-schedule.service';
+import type { DirectorySchedule } from '@src/entities/directory-schedule.entity';
+
+export interface DirectoryScheduleDispatchEntry {
+    scheduleId: string;
+    directoryId: string;
+    directoryName: string;
+    directorySlug: string;
+    directoryOwner: string;
+    scheduledFor: string | null;
+    outcome: 'dispatched' | 'skipped' | 'failed';
+    message?: string;
+    historyId?: string;
+}
+
+export interface DirectoryScheduleDispatchSummary {
+    limit: number;
+    dueCount: number;
+    dispatched: number;
+    skipped: number;
+    failed: number;
+    entries: DirectoryScheduleDispatchEntry[];
+}
 
 @Injectable()
 export class DirectoryScheduleDispatcherService {
@@ -14,17 +36,33 @@ export class DirectoryScheduleDispatcherService {
         private readonly directoryScheduleService: DirectoryScheduleService,
     ) {}
 
-    async dispatchDue(limit = config.subscriptions.getMaxBatch()): Promise<number> {
+    async dispatchDue(
+        limit = config.subscriptions.getMaxBatch(),
+    ): Promise<DirectoryScheduleDispatchSummary> {
         if (!config.subscriptions.scheduledUpdatesEnabled()) {
             this.logger.warn('Scheduled updates disabled, skipping dispatch');
-            return 0;
+            return {
+                limit,
+                dueCount: 0,
+                dispatched: 0,
+                skipped: 0,
+                failed: 0,
+                entries: [],
+            };
         }
 
         // Step 0: Cleanup zombies
         await this.directoryScheduleService.recoverStuckSchedules();
 
         const schedules = await this.scheduleRepository.findDue(limit);
-        let dispatched = 0;
+        const summary: DirectoryScheduleDispatchSummary = {
+            limit,
+            dueCount: schedules.length,
+            dispatched: 0,
+            skipped: 0,
+            failed: 0,
+            entries: [],
+        };
 
         for (const schedule of schedules) {
             try {
@@ -33,24 +71,81 @@ export class DirectoryScheduleDispatcherService {
 
                 if (!reservedSchedule) {
                     this.logger.warn(`Schedule ${schedule.id} was already dispatched, skipping`);
+                    summary.skipped += 1;
+                    summary.entries.push(
+                        this.buildEntry(schedule, {
+                            outcome: 'skipped',
+                            message: 'Schedule was already dispatched by another worker',
+                        }),
+                    );
                     continue;
                 }
 
-                await this.directoryGenerationService.runScheduledUpdate(reservedSchedule);
-                dispatched += 1;
+                const result =
+                    await this.directoryGenerationService.runScheduledUpdate(reservedSchedule);
+                const resultData = result && typeof result === 'object' ? result : null;
+
+                if (resultData?.status === 'skipped') {
+                    summary.skipped += 1;
+                    summary.entries.push(
+                        this.buildEntry(reservedSchedule, {
+                            outcome: 'skipped',
+                            message: resultData.message,
+                            historyId: resultData.historyId,
+                        }),
+                    );
+                    continue;
+                }
+
+                summary.dispatched += 1;
+                summary.entries.push(
+                    this.buildEntry(reservedSchedule, {
+                        outcome: 'dispatched',
+                        message: resultData?.message,
+                        historyId: resultData?.historyId,
+                    }),
+                );
             } catch (error) {
                 // Schedule finalization (markRunFailed) is handled by the inner methods:
                 // - finalizeGeneration (for generation errors)
                 // - handleSyncFailure (for sync errors)
                 // - updateItemsGenerator early-exit (for config errors)
                 // We only log here to avoid double-counting failures.
+                const message = error instanceof Error ? error.message : String(error);
                 this.logger.error(
                     `Failed to dispatch scheduled update for directory ${schedule.directoryId}`,
                     error as Error,
                 );
+                summary.failed += 1;
+                summary.entries.push(
+                    this.buildEntry(schedule, {
+                        outcome: 'failed',
+                        message,
+                    }),
+                );
             }
         }
 
-        return dispatched;
+        return summary;
+    }
+
+    private buildEntry(
+        schedule: DirectorySchedule,
+        details: Pick<DirectoryScheduleDispatchEntry, 'outcome' | 'message' | 'historyId'>,
+    ): DirectoryScheduleDispatchEntry {
+        const directory = schedule.directory;
+
+        return {
+            scheduleId: schedule.id,
+            directoryId: schedule.directoryId,
+            directoryName: directory?.name ?? schedule.directoryId,
+            directorySlug: directory?.slug ?? '',
+            directoryOwner: directory?.getRepoOwner?.() ?? directory?.owner ?? '',
+            scheduledFor:
+                schedule.scheduledFor?.toISOString() ?? schedule.nextRunAt?.toISOString() ?? null,
+            outcome: details.outcome,
+            message: details.message,
+            historyId: details.historyId,
+        };
     }
 }

--- a/packages/tasks/src/tasks/trigger/directory-schedule-dispatcher.task.ts
+++ b/packages/tasks/src/tasks/trigger/directory-schedule-dispatcher.task.ts
@@ -19,11 +19,11 @@ export const directoryScheduleDispatcherTask = schedules.task({
 
         try {
             const dispatcher = appContext.get(DirectoryScheduleDispatcherService);
-            const dispatched = await dispatcher.dispatchDue();
+            const summary = await dispatcher.dispatchDue();
 
             return {
-                dispatched,
                 intervalMinutes: interval,
+                ...summary,
             };
         } finally {
             await appContext.close();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added explicit "skipped" status for item-generation responses.
  * Dispatch operations now return detailed summaries with totals (dispatched, skipped, failed) and per-item outcome records.
  * Scheduled run behavior now returns an explicit skipped response when a run is not eligible.
  * Task responses now include merged summary metrics alongside interval information for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->