### PR TITLE
fixed the chat color and UI

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -432,7 +432,7 @@ export function DashboardLayoutClient({
                                 </button>
                                 <div
                                     onPointerDown={startDrag}
-                                    className="w-2.5 h-5 -ml-1 my-1.5 flex text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-white items-center justify-center cursor-col-resize dark:bg-surface-dark"
+                                    className="w-2.5 h-5 -ml-1 my-1.5 flex text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-white items-center justify-center cursor-col-resize bg-white dark:bg-surface-dark rounded"
                                     title={tChat('resizeChat')}
                                 >
                                     <GripVertical className="w-full h-4 text-text-muted/70" />

--- a/apps/web/src/app/[locale]/globals.css
+++ b/apps/web/src/app/[locale]/globals.css
@@ -154,7 +154,7 @@ body {
 }
 
 .dark * {
-    scrollbar-color: rgba(71, 85, 105, 0.5) transparent;
+    scrollbar-color: rgba(56, 56, 56, 0.5) transparent;
 }
 
 ::-webkit-scrollbar {

--- a/apps/web/src/components/ai/ChatHistory.tsx
+++ b/apps/web/src/components/ai/ChatHistory.tsx
@@ -104,8 +104,8 @@ export function ChatHistory({ onClose }: ChatHistoryProps) {
                                         'flex items-center gap-2 w-full px-3 py-2.5 rounded-lg text-left group',
                                         'transition-colors duration-75 cursor-pointer',
                                         isActive
-                                            ? 'bg-primary/8 dark:bg-primary/12'
-                                            : 'hover:bg-surface-secondary dark:hover:bg-white/[0.04]',
+                                            ? 'bg-primary/8 dark:bg-white/4'
+                                            : 'hover:bg-surface-secondary dark:hover:bg-white/4',
                                         isDeleting && 'opacity-50 pointer-events-none',
                                     )}
                                 >

--- a/apps/web/src/components/ai/ChatMessages.tsx
+++ b/apps/web/src/components/ai/ChatMessages.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils/cn';
 import { useStickToBottom } from 'use-stick-to-bottom';
 import { useTranslations } from 'next-intl';
@@ -16,6 +16,7 @@ interface ChatMessagesProps {
 export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
     const t = useTranslations('dashboard.aiChat');
     const { scrollRef, contentRef, isAtBottom, scrollToBottom } = useStickToBottom();
+    const [isAtTop, setIsAtTop] = useState(true);
 
     const lastMessage = messages[messages.length - 1];
     const isWaitingForResponse = isStreaming && lastMessage?.role === 'user';
@@ -29,8 +30,32 @@ export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
         prevCountRef.current = messages.length;
     }, [messages.length, scrollToBottom]);
 
+    // Track scroll position to detect if at top
+    useEffect(() => {
+        const scrollElement = scrollRef.current;
+        if (!scrollElement) return;
+
+        const checkScrollTop = () => {
+            setIsAtTop(scrollElement.scrollTop <= 10);
+        };
+
+        checkScrollTop();
+        scrollElement.addEventListener('scroll', checkScrollTop);
+        return () => scrollElement.removeEventListener('scroll', checkScrollTop);
+    }, [scrollRef]);
+
     return (
         <div className="flex-1 min-h-0 relative">
+            {/* Top gradient - only show when not at top */}
+            {!isAtTop && (
+                <div className="absolute top-0 left-0 right-0 h-24 bg-gradient-to-b from-white dark:from-surface-dark to-transparent pointer-events-none z-10 transition-opacity duration-200" />
+            )}
+            
+            {/* Bottom gradient - only show when not at bottom */}
+            {!isAtBottom && (
+                <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-surface-dark to-transparent pointer-events-none z-10 transition-opacity duration-200" />
+            )}
+            
             <div ref={scrollRef} className="h-full overflow-y-auto">
                 <div ref={contentRef} className="px-4 py-3 space-y-3">
                     {messages.map((message, index) => {
@@ -58,8 +83,8 @@ export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
                 <button
                     onClick={() => scrollToBottom()}
                     className={cn(
-                        'absolute bottom-3 left-1/2 -translate-x-1/2 z-10',
-                        'flex items-center justify-center w-8 h-8 rounded-full',
+                        'absolute bottom-3 left-1/2 -translate-x-1/2 z-20',
+                        'flex items-center justify-center w-6 h-6 rounded-full',
                         'bg-white dark:bg-surface-dark',
                         'border border-border dark:border-white/10',
                         'text-text-muted dark:text-text-muted-dark',
@@ -67,7 +92,7 @@ export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
                         'shadow-md transition-all cursor-pointer',
                     )}
                 >
-                    <ArrowDown className="w-3.5 h-3.5" />
+                    <ArrowDown className="w-3 h-3" />
                 </button>
             )}
         </div>
@@ -77,7 +102,7 @@ export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
 function StreamingIndicator({ label }: { label: string }) {
     return (
         <div className="flex justify-start">
-            <div className="rounded-lg px-3 py-2.5 bg-surface-secondary dark:bg-surface-tertiary-dark/50">
+            <div className="rounded-lg px-3 py-2.5 bg-surface-secondary dark:bg-white/4">
                 <div className="flex items-center gap-1.5">
                     <div className="flex space-x-1">
                         <span className="w-1.5 h-1.5 bg-text-muted dark:bg-text-muted-dark rounded-full animate-bounce" />

--- a/apps/web/src/components/ai/ChatMessages.tsx
+++ b/apps/web/src/components/ai/ChatMessages.tsx
@@ -46,15 +46,23 @@ export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
 
     return (
         <div className="flex-1 min-h-0 relative">
-            {/* Top gradient - only show when not at top */}
-            {!isAtTop && (
-                <div className="absolute top-0 left-0 right-0 h-24 bg-gradient-to-b from-white dark:from-surface-dark to-transparent pointer-events-none z-10 transition-opacity duration-200" />
-            )}
+            {/* Top gradient - fade in/out based on scroll position */}
+            <div
+                className={cn(
+                    'absolute top-0 left-0 right-0 h-16 bg-gradient-to-b from-white dark:from-surface-dark to-transparent pointer-events-none z-10',
+                    'transition-opacity duration-200',
+                    isAtTop ? 'opacity-0' : 'opacity-100',
+                )}
+            />
 
-            {/* Bottom gradient - only show when not at bottom */}
-            {!isAtBottom && (
-                <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-surface-dark to-transparent pointer-events-none z-10 transition-opacity duration-200" />
-            )}
+            {/* Bottom gradient - fade in/out based on scroll position */}
+            <div
+                className={cn(
+                    'absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-white dark:from-surface-dark to-transparent pointer-events-none z-10',
+                    'transition-opacity duration-200',
+                    isAtBottom ? 'opacity-0' : 'opacity-100',
+                )}
+            />
 
             <div ref={scrollRef} className="h-full overflow-y-auto">
                 <div ref={contentRef} className="px-4 py-3 space-y-3">

--- a/apps/web/src/components/ai/ChatMessages.tsx
+++ b/apps/web/src/components/ai/ChatMessages.tsx
@@ -50,12 +50,12 @@ export function ChatMessages({ messages, isStreaming }: ChatMessagesProps) {
             {!isAtTop && (
                 <div className="absolute top-0 left-0 right-0 h-24 bg-gradient-to-b from-white dark:from-surface-dark to-transparent pointer-events-none z-10 transition-opacity duration-200" />
             )}
-            
+
             {/* Bottom gradient - only show when not at bottom */}
             {!isAtBottom && (
                 <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-surface-dark to-transparent pointer-events-none z-10 transition-opacity duration-200" />
             )}
-            
+
             <div ref={scrollRef} className="h-full overflow-y-auto">
                 <div ref={contentRef} className="px-4 py-3 space-y-3">
                     {messages.map((message, index) => {

--- a/apps/web/src/components/ai/ChatPanel.tsx
+++ b/apps/web/src/components/ai/ChatPanel.tsx
@@ -47,7 +47,7 @@ export function ChatPanel({
                     open ? 'opacity-100' : 'opacity-0 pointer-events-none',
                 )}
             >
-                <div className="flex-1 flex flex-col min-h-0 w-full">
+                <div className="flex-1 flex flex-col min-h-0 w-full max-w-[60rem] mx-auto">
                     <ChatInterface />
                 </div>
             </div>

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -101,7 +101,11 @@ export function DashboardSidebar({
 
     const navigation = [
         { name: t('navigation.dashboard'), href: ROUTES.DASHBOARD, icon: Home },
-        {name: t('navigation.directories'), href: ROUTES.DASHBOARD_DIRECTORIES,icon: FolderClosed,},
+        {
+            name: t('navigation.directories'),
+            href: ROUTES.DASHBOARD_DIRECTORIES,
+            icon: FolderClosed,
+        },
         { name: t('navigation.plugins'), href: ROUTES.DASHBOARD_PLUGINS, icon: Plug },
         { name: t('navigation.activity'), href: ROUTES.DASHBOARD_ACTIVITY, icon: Activity },
         { name: t('navigation.settings'), href: ROUTES.DASHBOARD_SETTINGS, icon: Settings },
@@ -415,7 +419,10 @@ export function DashboardSidebar({
                                         disabled={isPending}
                                         className="text-danger hover:bg-danger/10 cursor-pointer px-3"
                                     >
-                                        <LogOut className="w-4 h-4 mr-2 shrink-0" strokeWidth={1.3} />
+                                        <LogOut
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.3}
+                                        />
                                         {isPending ? t('signingOut') : t('signOut')}
                                     </DropdownMenuItem>
                                 </DropdownMenuContent>

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -9,7 +9,7 @@ import { ROUTES, getSiteConfig } from '@/lib/constants';
 import { Link, usePathname, useRouter } from '@/i18n/navigation';
 import {
     Home,
-    Folder,
+    FolderClosed,
     Settings,
     LogOut,
     Plus,
@@ -101,7 +101,7 @@ export function DashboardSidebar({
 
     const navigation = [
         { name: t('navigation.dashboard'), href: ROUTES.DASHBOARD, icon: Home },
-        { name: t('navigation.directories'), href: ROUTES.DASHBOARD_DIRECTORIES, icon: Folder },
+        {name: t('navigation.directories'), href: ROUTES.DASHBOARD_DIRECTORIES,icon: FolderClosed,},
         { name: t('navigation.plugins'), href: ROUTES.DASHBOARD_PLUGINS, icon: Plug },
         { name: t('navigation.activity'), href: ROUTES.DASHBOARD_ACTIVITY, icon: Activity },
         { name: t('navigation.settings'), href: ROUTES.DASHBOARD_SETTINGS, icon: Settings },
@@ -167,9 +167,15 @@ export function DashboardSidebar({
                                             )}
                                         >
                                             {isCollapsed ? (
-                                                <PanelLeftOpen className="w-4 h-4" />
+                                                <PanelLeftOpen
+                                                    className="w-4 h-4"
+                                                    strokeWidth={1.3}
+                                                />
                                             ) : (
-                                                <PanelLeftClose className="w-4 h-4" />
+                                                <PanelLeftClose
+                                                    className="w-4 h-4"
+                                                    strokeWidth={1.3}
+                                                />
                                             )}
                                         </button>
                                     </Tooltip>
@@ -182,7 +188,7 @@ export function DashboardSidebar({
                                     size="icon"
                                     className="xl:hidden text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark"
                                 >
-                                    <X className="w-5 h-5" />
+                                    <X className="w-5 h-5" strokeWidth={1.3} />
                                 </Button>
                             )}
                         </div>
@@ -202,7 +208,7 @@ export function DashboardSidebar({
                                 className="w-8 h-8 shadow-sm rounded-xl"
                                 onClick={() => onInteraction?.()}
                             >
-                                <Plus className="w-5 h-5" />
+                                <Plus className="w-5 h-5" strokeWidth={1.3} />
                             </Button>
                         </ConditionalTooltip>
                     ) : (
@@ -214,7 +220,7 @@ export function DashboardSidebar({
                             className="shadow-s dark:border"
                             onClick={() => onInteraction?.()}
                         >
-                            <Plus className="w-5 h-5" />
+                            <Plus className="w-5 h-5" strokeWidth={1.3} />
                             <span className="font-medium">{t('newDirectory')}</span>
                         </Button>
                     )}
@@ -253,7 +259,7 @@ export function DashboardSidebar({
                                             )}
                                         >
                                             <span className="shrink-0 inline-flex">
-                                                <item.icon className="w-5 h-5" />
+                                                <item.icon className="w-5 h-5" strokeWidth={1.3} />
                                             </span>
                                             {!isCollapsed && (
                                                 <span className="text-sm">{item.name}</span>
@@ -351,7 +357,10 @@ export function DashboardSidebar({
                                         }}
                                         className="cursor-pointer px-3 rounded-md hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark"
                                     >
-                                        <Settings className="w-4 h-4 mr-2 shrink-0" />
+                                        <Settings
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.5}
+                                        />
                                         {t('profileMenu.accountSettings')}
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
@@ -361,7 +370,10 @@ export function DashboardSidebar({
                                         }}
                                         className="cursor-pointer px-3 rounded-sm hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark"
                                     >
-                                        <HelpCircle className="w-4 h-4 mr-2 shrink-0" />
+                                        <HelpCircle
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.5}
+                                        />
                                         {t('profileMenu.helpDocs')}
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
@@ -374,7 +386,10 @@ export function DashboardSidebar({
                                         }}
                                         className="cursor-pointer px-3 rounded-md hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark"
                                     >
-                                        <MessageSquare className="w-4 h-4 mr-2 shrink-0" />
+                                        <MessageSquare
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.5}
+                                        />
                                         {t('profileMenu.support')}
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
@@ -385,7 +400,10 @@ export function DashboardSidebar({
                                         disabled={!onOpenHelp}
                                         className="cursor-pointer px-3 rounded-md hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark"
                                     >
-                                        <Keyboard className="w-4 h-4 mr-2 shrink-0" />
+                                        <Keyboard
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.3}
+                                        />
                                         {t('profileMenu.keyboardShortcuts')}
                                     </DropdownMenuItem>
                                     <DropdownMenuSeparator />
@@ -397,7 +415,7 @@ export function DashboardSidebar({
                                         disabled={isPending}
                                         className="text-danger hover:bg-danger/10 cursor-pointer px-3"
                                     >
-                                        <LogOut className="w-4 h-4 mr-2 shrink-0" />
+                                        <LogOut className="w-4 h-4 mr-2 shrink-0" strokeWidth={1.3} />
                                         {isPending ? t('signingOut') : t('signOut')}
                                     </DropdownMenuItem>
                                 </DropdownMenuContent>

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -224,7 +224,7 @@ export function DashboardSidebar({
                             className="shadow-s dark:border"
                             onClick={() => onInteraction?.()}
                         >
-                            <Plus className="w-5 h-5"/>
+                            <Plus className="w-5 h-5" />
                             <span className="font-medium">{t('newDirectory')}</span>
                         </Button>
                     )}

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -258,8 +258,8 @@ export function DashboardSidebar({
                                                     ? 'justify-center w-8 h-8 px-0'
                                                     : 'gap-3 px-4 py-2',
                                                 isActive
-                                                    ? 'border bg-surface-secondary border-surface-tertiary dark:border-transparent dark:bg-card-secondary-dark text-text dark:text-text-dark'
-                                                    : 'text-text dark:text-text-secondary-dark/70 hover:bg-surface-secondary dark:hover:bg-card-primary-dark hover:text-text dark:hover:text-text-dark',
+                                                    ? 'border bg-surface-secondary border-surface-tertiary dark:border-transparent dark:bg-card-secondary-dark text-text dark:text-gray-300'
+                                                    : 'text-text dark:text-gray-500 hover:bg-surface-secondary dark:hover:bg-card-primary-dark hover:text-text dark:hover:text-text-dark',
                                             )}
                                         >
                                             <span className="shrink-0 inline-flex">

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -224,7 +224,7 @@ export function DashboardSidebar({
                             className="shadow-s dark:border"
                             onClick={() => onInteraction?.()}
                         >
-                            <Plus className="w-5 h-5" strokeWidth={1.3} />
+                            <Plus className="w-5 h-5"/>
                             <span className="font-medium">{t('newDirectory')}</span>
                         </Button>
                     )}
@@ -258,12 +258,12 @@ export function DashboardSidebar({
                                                     ? 'justify-center w-8 h-8 px-0'
                                                     : 'gap-3 px-4 py-2',
                                                 isActive
-                                                    ? 'border bg-surface-secondary border-surface-tertiary dark:border-transparent dark:bg-card-secondary-dark text-text dark:text-gray-300'
-                                                    : 'text-text dark:text-gray-500 hover:bg-surface-secondary dark:hover:bg-card-primary-dark hover:text-text dark:hover:text-text-dark',
+                                                    ? 'border bg-surface-secondary border-surface-tertiary dark:border-transparent dark:bg-card-secondary-dark text-text dark:text-text-dark'
+                                                    : 'text-text dark:text-text-secondary-dark/70 hover:bg-surface-secondary dark:hover:bg-card-primary-dark hover:text-text dark:hover:text-text-dark',
                                             )}
                                         >
                                             <span className="shrink-0 inline-flex">
-                                                <item.icon className="w-5 h-5" strokeWidth={1.3} />
+                                                <item.icon className="w-5 h-5" strokeWidth={1.5} />
                                             </span>
                                             {!isCollapsed && (
                                                 <span className="text-sm">{item.name}</span>

--- a/apps/web/src/components/dashboard/StatsOverview.tsx
+++ b/apps/web/src/components/dashboard/StatsOverview.tsx
@@ -20,7 +20,7 @@ export function StatsOverview({
     const statCards: Array<{
         title: string;
         value: string | number;
-         icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+        icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
         change: string;
         changeType: 'positive' | 'negative' | 'neutral';
         iconColor?: string;
@@ -40,7 +40,7 @@ export function StatsOverview({
             value: totalItems,
             icon: ListTodo,
             iconColor: 'text-violet-500',
-             dotColor: 'bg-violet-500',
+            dotColor: 'bg-violet-500',
             change: '+23%',
             changeType: 'positive',
         },
@@ -61,9 +61,9 @@ export function StatsOverview({
                 <div
                     key={stat.title}
                     className={cn(
-                            'group relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
-                            'border border-card-border dark:border-border-dark',
-                        )}
+                        'group relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
+                        'border border-card-border dark:border-border-dark',
+                    )}
                 >
                     <div
                         className={cn(
@@ -76,41 +76,43 @@ export function StatsOverview({
                         <div className="card-top-accent pointer-events-none absolute left-1/2 -translate-x-1/2 top-0 w-1/2 h-px z-20 opacity-40 rounded-full" />
 
                         <div className="flex items-end space-x-2">
-                        <div
-                            className={cn(
-                                'rounded-md w-8 h-8 flex items-center justify-center',
-                                'bg-surface dark:bg-white/6',
-                            )}
-                        >
-                            <stat.icon
-                                className={cn('w-4.5 h-4.5', stat.iconColor)}
-                                strokeWidth={1.3}
-                            />
+                            <div
+                                className={cn(
+                                    'rounded-md w-8 h-8 flex items-center justify-center',
+                                    'bg-surface dark:bg-white/6',
+                                )}
+                            >
+                                <stat.icon
+                                    className={cn('w-4.5 h-4.5', stat.iconColor)}
+                                    strokeWidth={1.3}
+                                />
+                            </div>
+                            <p className="text-3xl text-text dark:text-text-dark truncate">
+                                {stat.value}
+                            </p>
                         </div>
-                        <p className="text-3xl text-text dark:text-text-dark truncate">{stat.value}</p>
-                    </div>
-                    <div className="mt-1 flex items-center space-x-2">
-                        <div className={cn('w-1 h-1 rounded-full mt-0.5', stat.dotColor)} />
-                        <p className="text-xs text-gray-500 dark:text-text-muted-dark">
-                            {stat.title}
-                        </p>
-                    </div>
-                    <div className="mt-4 items-center hidden">
-                        <span
-                            className={cn(
-                                'text-sm font-medium',
-                                stat.changeType === 'positive' && 'text-success',
-                                stat.changeType === 'negative' && 'text-danger',
-                                stat.changeType === 'neutral' &&
-                                    'text-text-muted dark:text-text-muted-dark',
-                            )}
-                        >
-                            {stat.change}
-                        </span>
-                        <span className="text-sm text-text-muted dark:text-text-muted-dark ml-2">
-                            {t('fromLastMonth')}
-                        </span>
-                    </div>
+                        <div className="mt-1 flex items-center space-x-2">
+                            <div className={cn('w-1 h-1 rounded-full mt-0.5', stat.dotColor)} />
+                            <p className="text-xs text-gray-500 dark:text-text-muted-dark">
+                                {stat.title}
+                            </p>
+                        </div>
+                        <div className="mt-4 items-center hidden">
+                            <span
+                                className={cn(
+                                    'text-sm font-medium',
+                                    stat.changeType === 'positive' && 'text-success',
+                                    stat.changeType === 'negative' && 'text-danger',
+                                    stat.changeType === 'neutral' &&
+                                        'text-text-muted dark:text-text-muted-dark',
+                                )}
+                            >
+                                {stat.change}
+                            </span>
+                            <span className="text-sm text-text-muted dark:text-text-muted-dark ml-2">
+                                {t('fromLastMonth')}
+                            </span>
+                        </div>
                     </div>
                 </div>
             ))}

--- a/apps/web/src/components/dashboard/StatsOverview.tsx
+++ b/apps/web/src/components/dashboard/StatsOverview.tsx
@@ -20,11 +20,11 @@ export function StatsOverview({
     const statCards: Array<{
         title: string;
         value: string | number;
-        icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+         icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
         change: string;
         changeType: 'positive' | 'negative' | 'neutral';
-        iconColor: string;
-        dotColor: string;
+        iconColor?: string;
+        dotColor?: string;
     }> = [
         {
             title: t('totalDirectories'),
@@ -40,7 +40,7 @@ export function StatsOverview({
             value: totalItems,
             icon: ListTodo,
             iconColor: 'text-violet-500',
-            dotColor: 'bg-violet-500',
+             dotColor: 'bg-violet-500',
             change: '+23%',
             changeType: 'positive',
         },
@@ -56,16 +56,26 @@ export function StatsOverview({
     ];
 
     return (
-        <div className="grid grid-cols-1 dark:bg-white/2 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-6 border border-card-border dark:border-border-dark rounded-lg p-5">
+        <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-6">
             {statCards.map((stat) => (
                 <div
                     key={stat.title}
                     className={cn(
-                        'group relative transition-shadow duration-200 overflow-hidden',
-                        '',
-                    )}
+                            'group relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
+                            'border border-card-border dark:border-border-dark',
+                        )}
                 >
-                    <div className="flex items-end space-x-2">
+                    <div
+                        className={cn(
+                            'group relative rounded-sm p-5 transition-shadow duration-200 overflow-hidden',
+                            'bg-card dark:bg-surface-secondary-dark',
+                            'border border-card-border dark:border-border-dark',
+                        )}
+                    >
+                        {/* Decorative short top border accent with fading edges */}
+                        <div className="card-top-accent pointer-events-none absolute left-1/2 -translate-x-1/2 top-0 w-1/2 h-px z-20 opacity-40 rounded-full" />
+
+                        <div className="flex items-end space-x-2">
                         <div
                             className={cn(
                                 'rounded-md w-8 h-8 flex items-center justify-center',
@@ -77,7 +87,7 @@ export function StatsOverview({
                                 strokeWidth={1.3}
                             />
                         </div>
-                        <p className="text-3xl text-text dark:text-text-dark">{stat.value}</p>
+                        <p className="text-3xl text-text dark:text-text-dark truncate">{stat.value}</p>
                     </div>
                     <div className="mt-1 flex items-center space-x-2">
                         <div className={cn('w-1 h-1 rounded-full mt-0.5', stat.dotColor)} />
@@ -100,6 +110,7 @@ export function StatsOverview({
                         <span className="text-sm text-text-muted dark:text-text-muted-dark ml-2">
                             {t('fromLastMonth')}
                         </span>
+                    </div>
                     </div>
                 </div>
             ))}

--- a/apps/web/src/components/dashboard/StatsOverview.tsx
+++ b/apps/web/src/components/dashboard/StatsOverview.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils/cn';
 import { useTranslations } from 'next-intl';
+import { FolderClosed, ListTodo, Globe } from 'lucide-react';
 
 interface StatsOverviewProps {
     totalDirectories?: number;
@@ -19,139 +20,89 @@ export function StatsOverview({
     const statCards: Array<{
         title: string;
         value: string | number;
-        icon: React.ComponentType<{ className?: string }>;
+        icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
         change: string;
         changeType: 'positive' | 'negative' | 'neutral';
-        iconColor?: string;
+        iconColor: string;
+        dotColor: string;
     }> = [
         {
             title: t('totalDirectories'),
             value: totalDirectories,
-            icon: FolderIcon,
+            icon: FolderClosed,
             iconColor: 'text-blue-500',
+            dotColor: 'bg-blue-500',
             change: '+12%',
             changeType: 'positive',
         },
         {
             title: t('totalItems'),
             value: totalItems,
-            icon: ItemsIcon,
+            icon: ListTodo,
             iconColor: 'text-violet-500',
+            dotColor: 'bg-violet-500',
             change: '+23%',
             changeType: 'positive',
         },
         {
             title: t('activeWebsites'),
             value: activeWebsites,
-            icon: WebsiteIcon,
+            icon: Globe,
             iconColor: 'text-emerald-500',
+            dotColor: 'bg-emerald-500',
             change: '0%',
             changeType: 'neutral',
         },
     ];
 
     return (
-        <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 dark:bg-white/2 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-6 border border-card-border dark:border-border-dark rounded-lg p-5">
             {statCards.map((stat) => (
                 <div
                     key={stat.title}
                     className={cn(
-                        'p-1 rounded-lg space-y-6',
-                        'bg-card/10 dark:bg-card-primary-dark/30',
-                        'border border-card-border dark:border-border-secondary-dark',
+                        'group relative transition-shadow duration-200 overflow-hidden',
+                        '',
                     )}
                 >
-                    <div
-                        className={cn(
-                            'group relative rounded-sm p-5 transition-shadow duration-200 overflow-hidden',
-                            'bg-card dark:bg-surface-secondary-dark',
-                            'border border-card-border dark:border-border-dark',
-                        )}
-                    >
-                        {/* Decorative short top border accent with fading edges */}
-                        <div className="card-top-accent pointer-events-none absolute left-1/2 -translate-x-1/2 top-0 w-1/2 h-px z-20 opacity-50 rounded-full" />
-
-                        <div>
-                            <div>
-                                <p className="text-sm text-text-muted dark:text-text-muted-dark">
-                                    {stat.title}
-                                </p>
-                                <p className="text-2xl font-bold text-text dark:text-text-dark mt-2">
-                                    {stat.value}
-                                </p>
-                            </div>
+                    <div className="flex items-end space-x-2">
+                        <div
+                            className={cn(
+                                'rounded-md w-8 h-8 flex items-center justify-center',
+                                'bg-surface dark:bg-white/6',
+                            )}
+                        >
+                            <stat.icon
+                                className={cn('w-4.5 h-4.5', stat.iconColor)}
+                                strokeWidth={1.3}
+                            />
                         </div>
-
-                        <div className="absolute top-3 right-3">
-                            <div
-                                className={cn(
-                                    'p-3 rounded-lg',
-                                    'bg-surface dark:bg-surface-dark/50',
-                                )}
-                            >
-                                <stat.icon
-                                    className={cn('w-6 h-6', stat.iconColor ?? 'text-primary')}
-                                />
-                            </div>
-                        </div>
-                        <div className="mt-4  items-center hidden">
-                            <span
-                                className={cn(
-                                    'text-sm font-medium',
-                                    stat.changeType === 'positive' && 'text-success',
-                                    stat.changeType === 'negative' && 'text-danger',
-                                    stat.changeType === 'neutral' &&
-                                        'text-text-muted dark:text-text-muted-dark',
-                                )}
-                            >
-                                {stat.change}
-                            </span>
-                            <span className="text-sm text-text-muted dark:text-text-muted-dark ml-2">
-                                {t('fromLastMonth')}
-                            </span>
-                        </div>
+                        <p className="text-3xl text-text dark:text-text-dark">{stat.value}</p>
+                    </div>
+                    <div className="mt-1 flex items-center space-x-2">
+                        <div className={cn('w-1 h-1 rounded-full mt-0.5', stat.dotColor)} />
+                        <p className="text-xs text-gray-500 dark:text-text-muted-dark">
+                            {stat.title}
+                        </p>
+                    </div>
+                    <div className="mt-4 items-center hidden">
+                        <span
+                            className={cn(
+                                'text-sm font-medium',
+                                stat.changeType === 'positive' && 'text-success',
+                                stat.changeType === 'negative' && 'text-danger',
+                                stat.changeType === 'neutral' &&
+                                    'text-text-muted dark:text-text-muted-dark',
+                            )}
+                        >
+                            {stat.change}
+                        </span>
+                        <span className="text-sm text-text-muted dark:text-text-muted-dark ml-2">
+                            {t('fromLastMonth')}
+                        </span>
                     </div>
                 </div>
             ))}
         </div>
-    );
-}
-
-function FolderIcon({ className }: { className?: string }) {
-    return (
-        <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-            />
-        </svg>
-    );
-}
-
-function ItemsIcon({ className }: { className?: string }) {
-    return (
-        <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-            />
-        </svg>
-    );
-}
-
-function WebsiteIcon({ className }: { className?: string }) {
-    return (
-        <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-            />
-        </svg>
     );
 }

--- a/apps/web/src/components/plugins/PluginCard.tsx
+++ b/apps/web/src/components/plugins/PluginCard.tsx
@@ -91,13 +91,13 @@ export function PluginCard({ plugin }: PluginCardProps) {
                     {visibleCaps.slice(0, 2).map((cap) => (
                         <span
                             key={cap}
-                            className="text-[11px] px-1.5 py-0.5 rounded-md bg-surface-tertiary dark:bg-surface-tertiary-dark text-text-muted dark:text-text-muted-dark"
+                            className="text-[11px] px-1.5 py-0.5 rounded-md bg-surface-tertiary dark:bg-white/6 text-text-muted dark:text-text-muted-dark"
                         >
                             {getCapabilityLabel(cap)}
                         </span>
                     ))}
                     {visibleCaps.length > 2 && (
-                        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-surface-tertiary dark:bg-surface-tertiary-dark text-text-muted dark:text-text-muted-dark">
+                        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-surface-tertiary dark:bg-white/4 text-text-muted dark:text-text-muted-dark">
                             +{visibleCaps.length - 2}
                         </span>
                     )}

--- a/apps/web/src/components/plugins/PluginCategoryFilter.tsx
+++ b/apps/web/src/components/plugins/PluginCategoryFilter.tsx
@@ -28,10 +28,10 @@ export function PluginCategoryFilter({
                 <button
                     onClick={() => onSelectCategory(null)}
                     className={cn(
-                        'px-3 py-1 rounded-full text-sm font-medium transition-colors cursor-pointer',
+                        'px-3 py-1 rounded-full text-xs transition-colors cursor-pointer',
                         selectedCategory === null
                             ? 'bg-button-primary dark:bg-button-primary-dark text-white dark:text-black'
-                            : 'bg-surface-secondary dark:bg-surface-secondary-dark/50 text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-surface-tertiary-dark',
+                            : 'bg-surface-secondary dark:bg-white/9 text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-white/20',
                     )}
                 >
                     {t('all')}
@@ -41,7 +41,7 @@ export function PluginCategoryFilter({
                         key={category}
                         onClick={() => onSelectCategory(category)}
                         className={cn(
-                            'px-3 py-1 rounded-full text-sm font-medium transition-colors cursor-pointer',
+                            'px-3 py-1 rounded-full text-xs transition-colors cursor-pointer',
                             selectedCategory === category
                                 ? 'bg-button-primary dark:bg-button-primary-dark text-white dark:text-black'
                                 : 'bg-surface-secondary dark:bg-white/9 text-text-secondary dark:text-text-secondary-dark hover:bg-surface-tertiary dark:hover:bg-white/20',
@@ -52,7 +52,7 @@ export function PluginCategoryFilter({
                 ))}
             </div>
 
-            <label className="flex items-center gap-2 text-sm text-text-secondary dark:text-text-secondary-dark cursor-pointer">
+            <label className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-secondary-dark cursor-pointer">
                 <input
                     type="checkbox"
                     checked={showEnabledOnly}


### PR DESCRIPTION
Before
<img width="1916" height="865" alt="chat-before" src="https://github.com/user-attachments/assets/1b26b505-5e2e-41a6-84f8-593d4a5f3773" />
After
<img width="1917" height="863" alt="chat-after" src="https://github.com/user-attachments/assets/885ad986-3e64-48ed-91d2-1fdb7828535f" />
Before
<img width="1912" height="870" alt="Screenshot 2026-04-29 132354" src="https://github.com/user-attachments/assets/9a27c94c-2790-480c-ba0e-f08daac0296a" />
After
<img width="1916" height="870" alt="Over-after" src="https://github.com/user-attachments/assets/28caa0d7-4dfa-4203-9969-be45821ba4fe" />
Before
<img width="1913" height="857" alt="Screenshot 2026-04-28 223519" src="https://github.com/user-attachments/assets/e37912eb-a928-424d-82c6-d0ee13c23c1b" />
After
<img width="1912" height="862" alt="chat" src="https://github.com/user-attachments/assets/9b208440-10d1-44e9-afcb-5e2ffdc56ad4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scroll-position tracking with a top fade overlay and updated scroll-to-bottom control.

* **Style**
  * Refined dark-mode colors across chat, plugin cards, history, and scrollbar.
  * Tweaked chat resize handle, streaming indicator, and scroll button sizing/z-index.
  * Centered chat panel with a max-width constraint.
  * Updated sidebar and stats icons, icon stroke styling, tag visuals, and plugin filter typography.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->