### PR TITLE
chore(rebrand): rename Directory→Work in plugin package descriptions

### DIFF
--- a/packages/plugins/activepieces/package.json
+++ b/packages/plugins/activepieces/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/activepieces-plugin",
 	"version": "1.0.0",
-	"description": "Activepieces Automation Pipeline Plugin - Delegates directory generation steps to Activepieces flows",
+	"description": "Activepieces Automation Pipeline Plugin - Delegates Work generation steps to Activepieces flows",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -46,7 +46,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Pipeline plugin that delegates directory generation steps to Activepieces flows",
+			"description": "Pipeline plugin that delegates Work generation steps to Activepieces flows",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/agent-pipeline/package.json
+++ b/packages/plugins/agent-pipeline/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/agent-pipeline-plugin",
 	"version": "1.0.0",
-	"description": "Autonomous tool-based pipeline that researches and generates directory items using an AI agent",
+	"description": "Autonomous tool-based pipeline that researches and generates Work items using an AI agent",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -58,7 +58,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Autonomous tool-based pipeline that researches and generates directory items using an AI agent",
+			"description": "Autonomous tool-based pipeline that researches and generates Work items using an AI agent",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/apify/package.json
+++ b/packages/plugins/apify/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/apify-plugin",
 	"version": "1.0.0",
-	"description": "Apify - Import items from Apify datasets into your directory",
+	"description": "Apify - Import items from Apify datasets into your Work",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/plugins/claude-managed-agent/package.json
+++ b/packages/plugins/claude-managed-agent/package.json
@@ -47,7 +47,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Hosted Claude Managed Agent pipeline for directory generation in Ever Works",
+			"description": "Hosted Claude Managed Agent pipeline for Work generation in Ever Works",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/comparison-generator/package.json
+++ b/packages/plugins/comparison-generator/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/comparison-generator-plugin",
 	"version": "1.0.0",
-	"description": "Auto-generates SEO-optimized A vs B comparison pages between directory items",
+	"description": "Auto-generates SEO-optimized A vs B comparison pages between Work items",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -41,7 +41,7 @@
 			"version": "1.0.0",
 			"category": "utility",
 			"capabilities": [],
-			"description": "Auto-generates SEO-optimized A vs B comparison pages between directory items. Runs on a schedule, generating one high-quality comparison per pass. Also supports manual item-to-item comparison.",
+			"description": "Auto-generates SEO-optimized A vs B comparison pages between Work items. Runs on a schedule, generating one high-quality comparison per pass. Also supports manual item-to-item comparison.",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/hermes-agent/package.json
+++ b/packages/plugins/hermes-agent/package.json
@@ -46,7 +46,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Self-managed pipeline plugin that delegates directory generation to Hermes Agent",
+			"description": "Self-managed pipeline plugin that delegates Work generation to Hermes Agent",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/make/package.json
+++ b/packages/plugins/make/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/make-plugin",
 	"version": "1.0.0",
-	"description": "Make.com Workflow Pipeline Plugin - Delegates directory generation to Make.com scenarios and webhooks",
+	"description": "Make.com Workflow Pipeline Plugin - Delegates Work generation to Make.com scenarios and webhooks",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -47,7 +47,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Pipeline plugin that delegates directory generation to Make.com scenarios and webhooks",
+			"description": "Pipeline plugin that delegates Work generation to Make.com scenarios and webhooks",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/sim-ai/package.json
+++ b/packages/plugins/sim-ai/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/sim-ai-plugin",
 	"version": "1.0.0",
-	"description": "SIM AI Workflow Pipeline Plugin - Delegates directory generation to SIM AI workflows",
+	"description": "SIM AI Workflow Pipeline Plugin - Delegates Work generation to SIM AI workflows",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -49,7 +49,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Pipeline plugin that delegates directory generation to SIM AI workflows",
+			"description": "Pipeline plugin that delegates Work generation to SIM AI workflows",
 			"author": {
 				"name": "Ever Works Team"
 			},

--- a/packages/plugins/zapier/package.json
+++ b/packages/plugins/zapier/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/zapier-plugin",
 	"version": "1.0.0",
-	"description": "Zapier Automation Pipeline Plugin - Triggers Zapier actions during directory generation",
+	"description": "Zapier Automation Pipeline Plugin - Triggers Zapier actions during Work generation",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -50,7 +50,7 @@
 				"pipeline",
 				"form-schema-provider"
 			],
-			"description": "Pipeline plugin that triggers Zapier actions during directory generation",
+			"description": "Pipeline plugin that triggers Zapier actions during Work generation",
 			"author": {
 				"name": "Ever Works Team"
 			},


### PR DESCRIPTION
## Summary

Updates the `description` field in 9 plugin `package.json` manifests to use "Work generation" / "Work items" instead of "directory generation" / "directory items", so plugin metadata aligns with the new Ever Works branding (see [#419](https://github.com/ever-works/ever-works/pull/419) for the main copy rename).

## Changes

`description` field only — touched in:
- `activepieces`, `agent-pipeline`, `apify`, `claude-managed-agent`, `comparison-generator`, `hermes-agent`, `make`, `sim-ai`, `zapier`

## Out of scope

Plugin **contract field names** (`id`, `name`, `category`, `capabilities`, JSON Schema field names like `directoryId`, etc.) are untouched — those will be part of the larger code-identifier rename PR.

## Test plan

- [ ] `pnpm build:plugins` succeeds
- [ ] No JSON syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)