### PR TITLE
chore(rebrand): rename Directory→Work in console.log/error messages

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/deploy/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/deploy/page.tsx
@@ -35,7 +35,7 @@ export default async function DeployPage({ params }: DeployPageParams) {
         directory = res.directory;
         deploymentCapability = capabilityRes;
     } catch (error) {
-        console.error('Failed to fetch directory or deployment capability:', error);
+        console.error('Failed to fetch Work or deployment capability:', error);
         notFound();
     }
 

--- a/apps/web/src/app/[locale]/(dashboard)/directories/[id]/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/[id]/layout.tsx
@@ -67,7 +67,7 @@ export default async function DirectoryLayout({ params, children }: LayoutParams
             }
         }
     } catch (error) {
-        console.error('Failed to fetch directory:', error);
+        console.error('Failed to fetch Work:', error);
         notFound();
     }
 

--- a/apps/web/src/app/[locale]/(dashboard)/directories/directories-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/directories/directories-client.tsx
@@ -88,7 +88,7 @@ export default function DirectoriesClient({
             } catch (error) {
                 // Only show error if this is still the latest request
                 if (currentRequestId === requestIdRef.current) {
-                    console.error('Failed to search directories:', error);
+                    console.error('Failed to search works:', error);
                     toast.error(t('searchFailed'));
                 }
             } finally {
@@ -112,7 +112,7 @@ export default function DirectoriesClient({
                 });
             }
         } catch (error) {
-            console.error('Failed to refresh directory stats:', error);
+            console.error('Failed to refresh Work stats:', error);
         }
     }, []);
 

--- a/apps/web/src/app/actions/dashboard/directories.ts
+++ b/apps/web/src/app/actions/dashboard/directories.ts
@@ -145,7 +145,7 @@ export async function createDirectory(data: CreateDirectoryDto) {
         validation.data.gitProvider = providerId;
         validation.data.deployProvider = data.deployProvider || undefined;
 
-        console.log('Creating directory:', validation.data);
+        console.log('Creating Work:', validation.data);
 
         // Create the directory with validated data
         const { directory } = await directoryAPI.create(validation.data);
@@ -156,7 +156,7 @@ export async function createDirectory(data: CreateDirectoryDto) {
             message: t('createSuccess'),
         };
     } catch (error) {
-        console.error('Failed to create directory:', error);
+        console.error('Failed to create Work:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : t('createFailed'),
@@ -300,7 +300,7 @@ export async function createDirectoryWithAI(request: AIDirectoryOptions) {
             isGenerating: true,
         };
     } catch (error) {
-        console.error('Failed to create directory with AI:', error);
+        console.error('Failed to create Work with AI:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : t('createFailed'),
@@ -324,7 +324,7 @@ export async function fetchDirectoryGenerationHistory(
             data: response,
         };
     } catch (error) {
-        console.error('Failed to fetch directory generation history:', error);
+        console.error('Failed to fetch Work generation history:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Unknown error',
@@ -389,7 +389,7 @@ export async function updateDirectory(directoryId: string, data: UpdateDirectory
             message: readmeUpdate?.message || t('updateSuccess'),
         };
     } catch (error) {
-        console.error('Failed to update directory:', error);
+        console.error('Failed to update Work:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : t('updateFailed'),
@@ -426,7 +426,7 @@ export async function updateDirectoryTemplate(directoryId: string, websiteTempla
             message: t('updateSuccess'),
         };
     } catch (error) {
-        console.error('Failed to update directory template:', error);
+        console.error('Failed to update Work template:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : t('updateFailed'),
@@ -459,7 +459,7 @@ export async function deleteDirectory(directoryId: string, options?: DeleteDirec
             message: t('deleteSuccess'),
         };
     } catch (error) {
-        console.error('Failed to delete directory:', error);
+        console.error('Failed to delete Work:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : t('deleteFailed'),
@@ -483,7 +483,7 @@ export async function syncDirectoryData(
         }
         return res;
     } catch (error) {
-        console.error('Failed to sync directory data:', error);
+        console.error('Failed to sync Work data:', error);
         return null;
     }
 }
@@ -498,7 +498,7 @@ export async function getDirectoryForStatusRefresh(directoryId: string): Promise
         const { directory } = await directoryAPI.get(directoryId);
         return directory;
     } catch (error) {
-        console.error('Failed to refresh directory status:', error);
+        console.error('Failed to refresh Work status:', error);
         return null;
     }
 }
@@ -525,7 +525,7 @@ export async function getDirectories(params: GetDirectoriesParams = {}) {
             total,
         };
     } catch (error) {
-        console.error('Failed to fetch directories:', error);
+        console.error('Failed to fetch works:', error);
         return {
             success: false,
             directories: [],
@@ -543,7 +543,7 @@ export async function getDirectoryStats() {
             ...stats,
         };
     } catch (error) {
-        console.error('Failed to fetch directory stats:', error);
+        console.error('Failed to fetch Work stats:', error);
         return {
             success: false,
             totalDirectories: 0,
@@ -705,7 +705,7 @@ export async function importDirectory(data: ImportDirectoryRequest) {
             error: result.status === 'error' ? result.message : undefined,
         };
     } catch (error) {
-        console.error('Failed to import directory:', error);
+        console.error('Failed to import Work:', error);
 
         if (error instanceof ApiResponseError) {
             const providerErrors = error.details?.providerErrors;
@@ -833,7 +833,7 @@ export async function updateDirectorySchedule(
             data: result,
         };
     } catch (error) {
-        console.error('Failed to update directory schedule:', error);
+        console.error('Failed to update Work schedule:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to update schedule',

--- a/apps/web/src/app/actions/plugins.ts
+++ b/apps/web/src/app/actions/plugins.ts
@@ -97,7 +97,7 @@ export async function enableDirectoryPlugin(
         revalidatePath(`/directories/${directoryId}/plugins`);
         return { success: true, data: result };
     } catch (error) {
-        console.error('Failed to enable directory plugin:', error);
+        console.error('Failed to enable Work plugin:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to enable directory plugin',
@@ -117,7 +117,7 @@ export async function disableDirectoryPlugin(
         revalidatePath(`/directories/${directoryId}/plugins`);
         return { success: true, data: result };
     } catch (error) {
-        console.error('Failed to disable directory plugin:', error);
+        console.error('Failed to disable Work plugin:', error);
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to disable directory plugin',
@@ -143,7 +143,7 @@ export async function updateDirectoryPluginSettings(
         revalidatePath(`/directories/${directoryId}/plugins`);
         return { success: true, data: result };
     } catch (error) {
-        console.error('Failed to update directory plugin settings:', error);
+        console.error('Failed to update Work plugin settings:', error);
         return {
             success: false,
             error:

--- a/apps/web/src/components/dashboard/DirectorySwitcher.tsx
+++ b/apps/web/src/components/dashboard/DirectorySwitcher.tsx
@@ -153,7 +153,7 @@ export function DirectorySwitcher() {
                 );
             } catch (error) {
                 if (!isCancelled) {
-                    console.error('Failed to load current directory for switcher:', error);
+                    console.error('Failed to load current Work for switcher:', error);
                 }
             }
         };
@@ -233,7 +233,7 @@ export function DirectorySwitcher() {
                 hasLoadedRef.current = true;
             } catch (error) {
                 if (!isCancelled) {
-                    console.error('Failed to load directories for switcher:', error);
+                    console.error('Failed to load Works for switcher:', error);
                     toast.error(t('searchFailed'));
                 }
             } finally {

--- a/apps/web/src/components/directories/DirectoryList.tsx
+++ b/apps/web/src/components/directories/DirectoryList.tsx
@@ -35,7 +35,7 @@ export function DirectoryList({
                 onUpdate?.(response.directories);
             }
         } catch (error) {
-            console.error('Failed to fetch directories:', error);
+            console.error('Failed to fetch works:', error);
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
## Summary

Updates 23 developer-facing `console.log/error` strings across 7 files so log output uses the new vocabulary ("Work / works") instead of the old ("directory / directories"). Pure string swaps — no identifiers, no logic.

## Why a separate PR

These are developer-only logs and never reach the user, so they're kept out of [#419](https://github.com/ever-works/ever-works/pull/419) (user-facing UI). Lets each be reviewed/reverted independently — useful if a log-aggregator dashboard or alert is keying on the old wording.

## Changes

7 files modified — 23 insertions, 23 deletions:
- `components/directories/DirectoryList.tsx`
- `components/dashboard/DirectorySwitcher.tsx`
- `app/actions/plugins.ts`
- `app/actions/dashboard/directories.ts` (12 messages)
- `app/[locale]/(dashboard)/directories/[id]/deploy/page.tsx`
- `app/[locale]/(dashboard)/directories/[id]/layout.tsx`
- `app/[locale]/(dashboard)/directories/directories-client.tsx`

## Test plan

- [ ] `pnpm type-check` succeeds.
- [ ] No log-aggregation alert/dashboard relies on substrings like "Failed to fetch directories" — if any do, update those queries before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal error logging and messaging terminology throughout the dashboard application. References changed from "directory" to "Work" across deployment pages, status refresh operations, plugin management, client-side operations, and directory switcher components. This ensures consistent naming conventions throughout all error messages and console logs for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->