### PR TITLE
fix(docker): use turbo directly in mcp Dockerfile to avoid !./apps/docs filter

### DIFF
--- a/.deploy/docker/api/Dockerfile
+++ b/.deploy/docker/api/Dockerfile
@@ -32,8 +32,11 @@ COPY --from=pruner /app/out/full/ .
 COPY packages/plugins/ packages/plugins/
 COPY scripts/prepare-docker-plugins.js scripts/prepare-docker-plugins.js
 
-RUN pnpm build --filter=ever-works-api...
-RUN pnpm build --filter="./packages/plugins/*"
+# Use turbo directly to bypass the root `pnpm build` script's
+# `--filter=!./apps/docs` which fails in the pruned workspace where
+# apps/docs is not present.
+RUN pnpm exec turbo build --filter=ever-works-api...
+RUN pnpm exec turbo build --filter="./packages/plugins/*"
 RUN pnpm deploy --filter=ever-works-api --prod --legacy /app/deploy
 RUN node scripts/prepare-docker-plugins.js
 

--- a/.deploy/docker/mcp/Dockerfile
+++ b/.deploy/docker/mcp/Dockerfile
@@ -20,7 +20,10 @@ RUN echo "shamefully-hoist=true" > .npmrc
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
-RUN pnpm build --filter=ever-works-mcp...
+# Use turbo directly to bypass the root `pnpm build` script's
+# `--filter=!./apps/docs` which fails in the pruned workspace where
+# apps/docs is not present.
+RUN pnpm exec turbo build --filter=ever-works-mcp...
 RUN pnpm deploy --filter=ever-works-mcp --prod --legacy /app/deploy
 
 #-- Production


### PR DESCRIPTION
## Why

After merging #419 (Directory→Work rename), the `Build and Publish Docker Images MCP Dev` workflow on develop fails with:

```
x Directory '/app/apps/docs' specified in filter does not exist
ERROR: process "/bin/sh -c pnpm build --filter=ever-works-mcp..." did not complete successfully: exit code: 1
```

This is a pre-existing latent issue: the root `package.json` `build` script uses `turbo build --filter=!./apps/docs` to skip the docs site in normal builds. The mcp Dockerfile then runs `pnpm build --filter=ever-works-mcp...`, which combines both filters. Since `turbo prune --scope=ever-works-mcp` doesn't include `apps/docs` in the pruned workspace, turbo errors out.

## What

Bypass the root `pnpm build` script and call turbo directly with only the mcp filter:

```diff
- RUN pnpm build --filter=ever-works-mcp...
+ RUN pnpm exec turbo build --filter=ever-works-mcp...
```

## Test plan

- [ ] `Build and Publish Docker Images MCP Dev` workflow succeeds on this PR
- [ ] `Deploy MCP to DO Dev` workflow (chained) succeeds on develop after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process to invoke build tooling directly and explicitly prepare plugins, improving reliability and consistency for trimmed/pruned workspaces during image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->