### PR TITLE
Update API URL in k8s manifest for dev environment

### DIFF
--- a/.deploy/k8s/k8s-manifest.mcp.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.dev.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: EVER_WORKS_API_URL
-              value: "http://ever-works-api-dev:3100"
+              value: "https://apidev.ever.works"
             - name: EVER_WORKS_API_KEY
               value: "$EVER_WORKS_MCP_API_KEY"
             - name: EVER_WORKS_MCP_PORT

--- a/.deploy/k8s/k8s-manifest.mcp.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.prod.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: EVER_WORKS_API_URL
-              value: "http://ever-works-api:3100"
+              value: "https://api.ever.works"
             - name: EVER_WORKS_API_KEY
               value: "$EVER_WORKS_MCP_API_KEY"
             - name: EVER_WORKS_MCP_PORT

--- a/.deploy/k8s/k8s-manifest.mcp.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.stage.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: EVER_WORKS_API_URL
-              value: "http://ever-works-api-stage:3100"
+              value: "https://apistage.ever.works"
             - name: EVER_WORKS_API_KEY
               value: "$EVER_WORKS_MCP_API_KEY"
             - name: EVER_WORKS_MCP_PORT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated MCP development environment API endpoint to the external HTTPS address (apidev.ever.works).
  * Updated MCP staging environment API endpoint to the external HTTPS address (apistage.ever.works).
  * Updated MCP production environment API endpoint to the external HTTPS address (api.ever.works).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->