### PR TITLE
fix(e2e): use real endpoint paths for /api/screenshot, /api/deploy, /api/git-providers

### DIFF
--- a/apps/web/e2e/git-providers.spec.ts
+++ b/apps/web/e2e/git-providers.spec.ts
@@ -8,21 +8,22 @@ import { API_BASE, registerUserViaAPI, authedHeaders } from './helpers/api';
  */
 
 test.describe('Git providers — API contract', () => {
-    test('GET /api/git-providers without auth → 401', async ({ request }) => {
-        const res = await request.get(`${API_BASE}/api/git-providers`);
+    test('GET /api/git-providers/github/connection without auth → 401', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/git-providers/github/connection`);
         expect(res.status()).toBe(401);
     });
 
-    test('GET /api/git-providers with auth returns provider list', async ({ request }) => {
+    test('GET /api/git-providers/github/connection with auth returns connection info', async ({
+        request,
+    }) => {
         const u = await registerUserViaAPI(request);
-        const res = await request.get(`${API_BASE}/api/git-providers`, {
+        const res = await request.get(`${API_BASE}/api/git-providers/github/connection`, {
             headers: authedHeaders(u.access_token),
         });
         expect(res.status(), `status was ${res.status()}`).toBe(200);
         const body = await res.json();
-        const providers = Array.isArray(body)
-            ? body
-            : (body?.providers ?? body?.data ?? body?.items ?? []);
-        expect(Array.isArray(providers), 'providers is array').toBe(true);
+        // Without OAuth set up this is { connected: false } or similar; we
+        // just verify the endpoint shape.
+        expect(typeof body, 'connection response is an object').toBe('object');
     });
 });

--- a/apps/web/e2e/screenshot-and-deploy.spec.ts
+++ b/apps/web/e2e/screenshot-and-deploy.spec.ts
@@ -7,21 +7,28 @@ import { API_BASE } from './helpers/api';
  * just verify the routes exist and reject unauth cleanly.
  */
 
-const protectedReadEndpoints = ['/api/screenshot', '/api/deploy', '/api/search/check-availability'];
+// Real endpoint paths exposed by these capability controllers (verified
+// against source). Each is auth-required; the goal is to confirm the
+// route exists and rejects unauth (not 404, not 5xx).
+const protectedReadEndpoints = [
+    '/api/screenshot/check-availability',
+    '/api/deploy/providers',
+    '/api/search/check-availability',
+];
 
 test.describe('Plugins-capabilities — protected endpoints reject unauth', () => {
     for (const path of protectedReadEndpoints) {
         test(`GET ${path} → 401 (no auth)`, async ({ request }) => {
             const res = await request.get(`${API_BASE}${path}`);
-            // These all live behind AuthGuard. 401 expected; 404 means we
-            // wired the wrong path; >=500 means something broke server-side.
+            // 401 expected; 404 means we wired the wrong path; >=500 means
+            // something broke server-side.
             expect(res.status(), `${path} returned ${res.status()}`).not.toBe(404);
             expect(res.status()).toBeLessThan(500);
         });
     }
 
-    test('POST /api/search without auth → 401', async ({ request }) => {
-        const res = await request.post(`${API_BASE}/api/search`, { data: {} });
+    test('POST /api/search/ without auth → 401 (auth-protected)', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/search/`, { data: {} });
         expect(res.status(), `status: ${res.status()}`).not.toBe(404);
         expect(res.status()).toBeLessThan(500);
     });


### PR DESCRIPTION
Follow-up to #439. New specs assumed bare GET /api/{screenshot,deploy,git-providers} existed; controllers expose sub-routes only. Switched to verified paths. 359/361 e2e tests passed on parent PR; this fixes the remaining 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests for Git provider authentication endpoints to verify proper authorization behavior.
  * Refined authentication checks for screenshot and deploy capability endpoints with specific route validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->