### PR TITLE
fix(local-content-extractor): coerce content-type header to string

### DIFF
--- a/packages/plugins/local-content-extractor/src/local-content-extractor.plugin.ts
+++ b/packages/plugins/local-content-extractor/src/local-content-extractor.plugin.ts
@@ -103,7 +103,16 @@ export class LocalContentExtractorPlugin implements IPlugin, IContentExtractorPl
 				validateStatus: (status) => status >= 200 && status < 400
 			});
 
-			const contentType = response.headers['content-type'] || '';
+			// axios 1.15.2 narrows response.headers values to
+			// `string | number | true | string[] | AxiosHeaders`. Coerce to
+			// string before string-only ops.
+			const rawContentType = response.headers['content-type'];
+			const contentType =
+				typeof rawContentType === 'string'
+					? rawContentType
+					: Array.isArray(rawContentType)
+						? rawContentType.join(', ')
+						: String(rawContentType ?? '');
 			if (
 				!contentType.includes('text/html') &&
 				!contentType.includes('text/plain') &&


### PR DESCRIPTION
## Summary

Fixes the `e2e (22.x)` and `Build all packages` CI failures introduced by the axios 1.15.2 bump (#450). axios narrowed `response.headers[name]` to `string | number | true | string[] | AxiosHeaders`, which broke the direct `.includes()` calls in `local-content-extractor.plugin.ts`.

The handler now coerces the value to string (joining arrays where applicable) before running the includes checks, so build is green again.

## Test plan

- [x] `pnpm --filter @ever-works/local-content-extractor-plugin build` green locally.
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)