### PR TITLE
fix(jest): raise per-test timeout to 30s — eliminate the recurring CI flake

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -19,6 +19,11 @@ module.exports = {
     collectCoverageFrom: ['**/*.(t|j)s'],
     coverageDirectory: '../coverage',
     testEnvironment: 'node',
+    // Raise the per-test timeout from Jest's 5s default. ts-jest's first-run
+    // type-checking on shared CI runners can push a fast async test past the
+    // 5s budget; 30s matches the agent package and is the standard ts-jest
+    // recommendation for CI stability.
+    testTimeout: 30000,
     moduleNameMapper: {
         '^@src/generators/(.*)$': '<rootDir>/../../../packages/agent/src/generators/$1/index.ts',
         '^@src/(.*)$': '<rootDir>/$1',

--- a/packages/agent/jest.config.js
+++ b/packages/agent/jest.config.js
@@ -16,6 +16,13 @@ module.exports = {
     collectCoverageFrom: ['**/*.(t|j)s'],
     coverageDirectory: '../coverage',
     testEnvironment: 'node',
+    // Raise the per-test timeout from Jest's 5s default. Some specs that pass
+    // locally in <100ms time out at 5000ms on shared GitHub-Actions runners
+    // because ts-jest's first-run type-checking + the test's own awaited work
+    // race past the budget. 30s is the standard "ts-jest on CI" recommendation
+    // and matches what other NestJS+ts-jest monorepos use; truly slow tests
+    // still surface, just not via spurious timeouts.
+    testTimeout: 30000,
     moduleNameMapper: {
         '^@src/(.*)$': '<rootDir>/$1',
         // Map workspace packages to their source TypeScript files for testing


### PR DESCRIPTION
## Summary

Recurring CI flake — most recently [run 25367790435](https://github.com/ever-works/ever-works/actions/runs/25367790435) on \`main\`, where one spec in \`@ever-works/agent\` timed out at the Jest default of **5000 ms**:

\`\`\`
FAIL src/facades/__tests__/ai.facade.spec.ts
  ● AiFacadeService › askJson › should use plugin.askJson for efficient structured output
    thrown: \"Exceeded timeout of 5000 ms for a test.\"

Test Suites: 1 failed, 70 passed, 71 total
Tests:       1 failed, 1127 passed, 1128 total
\`\`\`

The test itself runs in <100 ms locally — the failure mode is the standard \`ts-jest on a shared GitHub-Actions runner\` problem: ts-jest's first-run TypeScript type-checking + the test's own awaited mock can race past the 5 s budget when the runner is loaded.

## Fix

Add \`testTimeout: 30000\` to the Jest config in **both** packages:

- \`packages/agent/jest.config.js\`
- \`apps/api/jest.config.js\`

30 s is the standard ts-jest-on-CI recommendation. Truly slow tests still surface (a 30 s runtime is still abnormal); 5 s spurious-timeouts no longer do.

## Why config, not test logic

The flake is structural: the test passes; only the timeout decides exit code. Changing the test (adding a per-test \`jest.setTimeout(30_000)\`, retries, or refactoring the mock) would either be noisy across many specs or would hide real flakes. Raising the per-test budget at the runner level is the surgical fix.

## Test plan

- [x] \`pnpm test\` on \`@ever-works/agent\` — green locally including the previously-flaky \`ai.facade.spec.ts\`.
- [ ] CI green on this PR.
- [ ] Develop \`CI\` job stays green for subsequent pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)