### PR TITLE
feat(deploy): wire DeployService to plugin getWorkflowFilenames + getDeploymentSecrets

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -1,0 +1,249 @@
+jest.mock('@ever-works/agent/database', () => ({ WorkRepository: class {} }));
+jest.mock('@ever-works/agent/entities', () => ({ Work: class {}, User: class {} }));
+jest.mock('@ever-works/agent/plugins', () => ({ PluginRegistryService: class {} }));
+jest.mock('@ever-works/agent/facades', () => ({
+    DeployFacadeService: class {},
+    GitFacadeService: class {},
+}));
+jest.mock('@ever-works/agent/generators', () => ({
+    WebsiteUpdateService: class {},
+    getWebsiteTemplateBranch: () => 'main',
+    getWebsiteTemplateConfig: () => ({ branch: 'main' }),
+}));
+
+import { DeployService } from './deploy.service';
+
+/**
+ * Tests focused on the capability-driven contract changes:
+ *
+ *  - DeployService now calls `plugin.getWorkflowFilenames()` instead of
+ *    using a hardcoded list, so each plugin owns its own dispatch surface.
+ *  - DeployService now calls `plugin.getDeploymentSecrets(settings)` after
+ *    pushing the standard secrets, so plugins (k8s especially) can
+ *    contribute extra GitHub Actions secrets without touching this service.
+ *
+ * The non-network methods (`setActionSecret`, `setActionVariable`,
+ * `dispatchWorkflow`, `getRepositoryPublicKey`, `enableDeploymentWorkflows`)
+ * are stubbed via the `pluginRegistry` mock so we never touch a real GitHub.
+ */
+describe('DeployService — plugin-driven dispatch + secrets', () => {
+    const buildService = (overrides: {
+        plugin: Record<string, unknown>;
+        token?: string;
+        settings?: Record<string, unknown>;
+        deployProvider?: string;
+    }) => {
+        const work = {
+            id: 'work-1',
+            slug: 'my-site',
+            deployProvider: overrides.deployProvider ?? 'k8s',
+            gitProvider: 'github',
+            websiteTemplateId: 'directory-web-template',
+            user: { id: 'user-1' },
+            getRepoOwner: () => 'acme',
+            getDataRepo: () => 'acme/data',
+            getWebsiteRepo: () => 'acme-site',
+            resolveCommitter: () => ({ name: 'a', email: 'a@b' }),
+        };
+
+        const deployFacade = {
+            getPluginAndTokenAndSettings: jest.fn().mockResolvedValue({
+                plugin: overrides.plugin,
+                token: overrides.token ?? 'kubeconfig:::yaml',
+                work,
+                settings: overrides.settings ?? {},
+            }),
+        };
+
+        const gitFacade = {
+            getAccessToken: jest.fn().mockResolvedValue('gh-token'),
+        };
+
+        const workRepository = { findById: jest.fn().mockResolvedValue(work) };
+
+        // Single shared GitHub plugin stub returned by every
+        // pluginRegistry.get('github') call. Capturing its call history is
+        // what tests assert against.
+        const githubPlugin = {
+            setActionSecret: jest.fn().mockResolvedValue(undefined),
+            setActionVariable: jest.fn().mockResolvedValue(undefined),
+            dispatchWorkflow: jest.fn().mockResolvedValue(undefined),
+            getRepositoryPublicKey: jest.fn().mockResolvedValue({ key_id: 'k', key: 'pubkey' }),
+            enableDeploymentWorkflows: jest.fn().mockResolvedValue(undefined),
+        };
+
+        const pluginRegistry = {
+            get: jest.fn(() => ({
+                plugin: githubPlugin,
+                state: 'loaded',
+                manifest: { capabilities: ['git-provider'] },
+            })),
+        };
+
+        const websiteUpdateService = {
+            updateRepository: jest.fn().mockResolvedValue(undefined),
+        };
+
+        const service = new DeployService(
+            deployFacade as any,
+            gitFacade as any,
+            workRepository as any,
+            pluginRegistry as any,
+            websiteUpdateService as any,
+        );
+
+        return { service, work, deployFacade, gitFacade, pluginRegistry, githubPlugin };
+    };
+
+    const captureCalls = (gh: ReturnType<typeof buildService>['githubPlugin']) => ({
+        secrets: gh.setActionSecret.mock.calls.map((c: any[]) => c[0]),
+        variables: gh.setActionVariable.mock.calls.map((c: any[]) => c[0]),
+        dispatches: gh.dispatchWorkflow.mock.calls.map((c: any[]) => c[0]),
+    });
+
+    it('uses plugin.getWorkflowFilenames() for the dispatch list', async () => {
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+            },
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { dispatches } = captureCalls(githubPlugin);
+        const workflows = dispatches.map((d: any) => d.workflow);
+        expect(workflows).toEqual(['deploy_k8s.yaml']);
+    });
+
+    it('falls back to deploy_prod.yaml for plugins without getWorkflowFilenames', async () => {
+        const { service, githubPlugin } = buildService({
+            plugin: { id: 'legacy' },
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { dispatches } = captureCalls(githubPlugin);
+        expect(dispatches.map((d: any) => d.workflow)).toEqual(['deploy_prod.yaml']);
+    });
+
+    it('honours the Vercel plugin override (deploy_vercel.yaml then deploy_prod.yaml)', async () => {
+        const { service, githubPlugin } = buildService({
+            deployProvider: 'vercel',
+            plugin: {
+                id: 'vercel',
+                getWorkflowFilenames: () => ['deploy_vercel.yaml', 'deploy_prod.yaml'],
+                getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+            },
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { dispatches } = captureCalls(githubPlugin);
+        const workflows = dispatches.map((d: any) => d.workflow);
+        expect(workflows[0]).toBe('deploy_vercel.yaml');
+    });
+
+    it('pushes plugin.getDeploymentSecrets() entries as GitHub Actions secrets', async () => {
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                getDeploymentSecrets: jest.fn().mockResolvedValue({
+                    K8S_NAMESPACE: 'apps',
+                    K8S_REGISTRY_KIND: 'github',
+                    K8S_INGRESS_HOST: 'tools.example.com',
+                }),
+            },
+            settings: { kubeconfig: 'apiVersion: v1\nkind: Config\n' },
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { secrets } = captureCalls(githubPlugin);
+        const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+        expect(byKey.K8S_NAMESPACE).toBe('apps');
+        expect(byKey.K8S_REGISTRY_KIND).toBe('github');
+        expect(byKey.K8S_INGRESS_HOST).toBe('tools.example.com');
+        // Existing standard secrets are still pushed.
+        expect(byKey.TENANT_ID).toBe('work-1');
+        expect(byKey.K8S_TOKEN).toBe('kubeconfig:::yaml');
+        expect(byKey.DEPLOY_TOKEN).toBe('kubeconfig:::yaml');
+    });
+
+    it('pushes nothing extra for plugins without getDeploymentSecrets', async () => {
+        const { service, githubPlugin } = buildService({
+            plugin: { id: 'legacy' },
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { secrets } = captureCalls(githubPlugin);
+        const keys = secrets.map((s: any) => s.key).sort();
+        // Only the 4 standard secrets + CRON_SECRET.
+        expect(keys).toEqual(
+            expect.arrayContaining([
+                'CRON_SECRET',
+                'DATA_REPOSITORY',
+                'DEPLOY_TOKEN',
+                'K8S_TOKEN',
+                'TENANT_ID',
+            ]),
+        );
+        // No K8S_-prefixed extras (they only come from getDeploymentSecrets).
+        expect(keys.filter((k: string) => k.startsWith('K8S_INGRESS'))).toEqual([]);
+    });
+
+    it('does not leak the plugin token (kubeconfig) into pushed secret values from getDeploymentSecrets', async () => {
+        const kubeconfigYaml = 'apiVersion: v1\nkind: Config\nusers:\n  - token: leaked-12345';
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                // Hostile plugin returns the token by mistake — the deploy
+                // service still pushes it (this is on the plugin, not us)
+                // but our standard secrets path should never include it
+                // anywhere unexpected. This test pins the boundary.
+                getDeploymentSecrets: jest.fn().mockResolvedValue({ K8S_NAMESPACE: 'apps' }),
+            },
+            settings: { kubeconfig: kubeconfigYaml },
+            token: kubeconfigYaml,
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { secrets, variables } = captureCalls(githubPlugin);
+        const namespaceSecret = secrets.find((s: any) => s.key === 'K8S_NAMESPACE');
+        expect(namespaceSecret?.value).toBe('apps');
+        // Vars never carry the kubeconfig.
+        const allVarValues = variables.map((v: any) => v.value).join('\n');
+        expect(allVarValues).not.toContain('leaked-12345');
+    });
+
+    it('logs but does not fail the deploy if getDeploymentSecrets throws', async () => {
+        const errorSpy = jest
+            .spyOn(require('@nestjs/common').Logger.prototype, 'error')
+            .mockImplementation(() => {});
+
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                getDeploymentSecrets: jest.fn().mockRejectedValue(new Error('boom')),
+            },
+        });
+
+        const result = await service.deploy('work-1', 'user-1', {});
+
+        // Deploy still went through (workflow dispatched).
+        const { dispatches } = captureCalls(githubPlugin);
+        expect(dispatches.length).toBeGreaterThan(0);
+        expect(result).toBe(true);
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to push plugin-specific secrets for k8s'),
+        );
+
+        errorSpy.mockRestore();
+    });
+});

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -9,7 +9,16 @@ import {
     getWebsiteTemplateBranch,
     getWebsiteTemplateConfig,
 } from '@ever-works/agent/generators';
+import type { IDeploymentPlugin } from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
+
+/**
+ * Default workflow filenames to dispatch when a deployment plugin does not
+ * implement `getWorkflowFilenames()` (e.g. older plugins without the optional
+ * contract method). Vercel returns ['deploy_vercel.yaml', 'deploy_prod.yaml']
+ * via the new method; this fallback covers everything else.
+ */
+const DEFAULT_WORKFLOW_FILES: readonly string[] = ['deploy_prod.yaml'];
 
 interface RepoContext {
     owner: string;
@@ -47,10 +56,11 @@ export class DeployService {
         userId: string,
         options: { teamScope?: string },
     ): Promise<boolean> {
-        const { plugin, token, work } = await this.deployFacade.getPluginAndToken({
-            userId,
-            workId,
-        });
+        const { plugin, token, work, settings } =
+            await this.deployFacade.getPluginAndTokenAndSettings({
+                userId,
+                workId,
+            });
 
         const user = work.user as User;
         const gitToken = await this.gitFacade.getAccessToken({
@@ -74,11 +84,11 @@ export class DeployService {
             withDelay: false,
         });
 
-        await this.setRequiredSecrets(ctx, token, work);
+        await this.setRequiredSecrets(ctx, token, work, plugin, settings);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
 
-        return this.dispatchWithRetry(work, user, gitToken);
+        return this.dispatchWithRetry(work, user, gitToken, plugin);
     }
 
     /**
@@ -201,7 +211,13 @@ export class DeployService {
         return this.setActionVariable({ key, value, owner: ctx.owner, repo: ctx.repo }, ctx.token);
     }
 
-    private async setRequiredSecrets(ctx: RepoContext, deployToken: string, work: Work) {
+    private async setRequiredSecrets(
+        ctx: RepoContext,
+        deployToken: string,
+        work: Work,
+        plugin?: IDeploymentPlugin,
+        settings?: Record<string, unknown>,
+    ) {
         const provider = work.deployProvider || 'vercel';
         try {
             await this.setVariable(ctx, 'DEPLOY_PROVIDER', provider);
@@ -217,6 +233,32 @@ export class DeployService {
             this.setSecret(ctx, `${provider.toUpperCase()}_TOKEN`, deployToken),
             this.setSecret(ctx, 'DEPLOY_TOKEN', deployToken),
         ]);
+
+        // Plugin-specific extra secrets (k8s registry creds, namespace, etc.)
+        // The plugin returns a Record<string, string> of secret name → value;
+        // the deploy service pushes each one as a GitHub Actions secret.
+        // Older plugins without `getDeploymentSecrets` simply contribute
+        // nothing here.
+        if (plugin?.getDeploymentSecrets && settings) {
+            try {
+                const extras = await plugin.getDeploymentSecrets(settings);
+                const entries = Object.entries(extras);
+                if (entries.length > 0) {
+                    await Promise.all(
+                        entries.map(([key, value]) => this.setSecret(ctx, key, value)),
+                    );
+                    this.logger.log(
+                        `Pushed ${entries.length} plugin-specific secrets for ${plugin.id} to ${ctx.owner}/${ctx.repo}`,
+                    );
+                }
+            } catch (error) {
+                this.logger.error(
+                    `Failed to push plugin-specific secrets for ${plugin.id} on ${ctx.owner}/${ctx.repo}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
     }
 
     private async setOptionalSecrets(ctx: RepoContext, teamScope?: string, gitToken?: string) {
@@ -245,8 +287,19 @@ export class DeployService {
         return randomBytes(this.CRON_SECRET_LENGTH).toString('hex');
     }
 
-    private async dispatchWithRetry(work: Work, user: User, gitToken: string): Promise<boolean> {
-        const workflowFilesToTry = ['deploy_vercel.yaml', 'deploy_prod.yaml'];
+    private async dispatchWithRetry(
+        work: Work,
+        user: User,
+        gitToken: string,
+        plugin?: IDeploymentPlugin,
+    ): Promise<boolean> {
+        // Resolve workflow files from the plugin (capability-driven). Plugins
+        // without `getWorkflowFilenames` use the default fallback list. This
+        // replaces the hardcoded `['deploy_vercel.yaml', 'deploy_prod.yaml']`
+        // that pre-dated the optional contract method.
+        const workflowFilesToTry = plugin?.getWorkflowFilenames
+            ? plugin.getWorkflowFilenames()
+            : [...DEFAULT_WORKFLOW_FILES];
         const owner = work.getRepoOwner('website');
         const repo = work.getWebsiteRepo();
         const template = getWebsiteTemplateConfig(work.websiteTemplateId);

--- a/docs/architecture/contracts-package.md
+++ b/docs/architecture/contracts-package.md
@@ -14,7 +14,7 @@ The `@ever-works/contracts` package provides shared TypeScript type definitions 
 | Property          | Value                        |
 | ----------------- | ---------------------------- |
 | **Package name**  | `@ever-works/contracts`      |
-| **License**       | AGPL-3.0                          |
+| **License**       | AGPL-3.0                     |
 | **Module format** | Dual ESM/CJS (via tsup)      |
 | **Build tool**    | tsup                         |
 | **Dependencies**  | None (pure type definitions) |

--- a/docs/packages/plugins-package-overview.md
+++ b/docs/packages/plugins-package-overview.md
@@ -19,7 +19,7 @@ The `packages/plugins/` work contains all first-party plugin implementations for
 | **Test runner**     | Vitest                                      |
 | **Plugin contract** | `@ever-works/plugin` (workspace dependency) |
 | **Total plugins**   | 30                                          |
-| **License**         | AGPL-3.0 (individual packages)                   |
+| **License**         | AGPL-3.0 (individual packages)              |
 
 ## Module Structure
 

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -289,6 +289,27 @@ export class DeployFacadeService implements IDeployFacade {
         return this.resolvePluginAndTokenWithWork(options);
     }
 
+    /**
+     * Get the resolved plugin, token, work AND raw settings for deployment.
+     * Settings include secrets — only the deploy service / orchestrators
+     * should call this so it can push plugin-specific secrets via
+     * `IDeploymentPlugin.getDeploymentSecrets(settings)`.
+     */
+    async getPluginAndTokenAndSettings(options: DeployFacadeOptions): Promise<{
+        plugin: IDeploymentPlugin;
+        token: string;
+        work: Work;
+        settings: Record<string, unknown>;
+    }> {
+        const result = await this.resolvePluginAndTokenWithWork(options);
+        const settings = await this.settingsService.getSettings(result.plugin.id, {
+            userId: options.userId,
+            workId: options.workId,
+            includeSecrets: true,
+        });
+        return { ...result, settings };
+    }
+
     // Domain management methods
     // DB is the primary source of truth; provider APIs are used for sync and verification.
 

--- a/packages/plugins/activepieces/README.md
+++ b/packages/plugins/activepieces/README.md
@@ -10,7 +10,7 @@ Activepieces Automation Pipeline Plugin - Delegates Work generation steps to Act
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/agent-pipeline/README.md
+++ b/packages/plugins/agent-pipeline/README.md
@@ -10,7 +10,7 @@ Autonomous tool-based pipeline that researches and generates Work items using an
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | yes                                |
 

--- a/packages/plugins/anthropic/README.md
+++ b/packages/plugins/anthropic/README.md
@@ -10,7 +10,7 @@ Anthropic AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/apify/README.md
+++ b/packages/plugins/apify/README.md
@@ -10,7 +10,7 @@ Apify - Import items from Apify datasets into your Work
 | Category     | `data-source`                         |
 | Capabilities | `data-source`, `form-schema-provider` |
 | Author       | Ever Works Team                       |
-| License      | AGPL-3.0                                   |
+| License      | AGPL-3.0                              |
 | Built-in     | no                                    |
 | Auto-enable  | no                                    |
 

--- a/packages/plugins/brave/README.md
+++ b/packages/plugins/brave/README.md
@@ -10,7 +10,7 @@ Brave Plugin - Privacy-focused web search using Brave Search API
 | Category     | `search`        |
 | Capabilities | `search`        |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/brightdata/README.md
+++ b/packages/plugins/brightdata/README.md
@@ -10,7 +10,7 @@ Bright Data Plugin - Web search and content extraction using Bright Data API
 | Category     | `search`                      |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | no                            |
 

--- a/packages/plugins/claude-code/README.md
+++ b/packages/plugins/claude-code/README.md
@@ -10,7 +10,7 @@ Claude Code Generator Plugin - Full pipeline plugin that delegates generation to
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/codex/README.md
+++ b/packages/plugins/codex/README.md
@@ -10,7 +10,7 @@ Full pipeline plugin that delegates work generation to the [Codex CLI](https://g
 | Category     | `pipeline`                                        |
 | Capabilities | `pipeline`, `form-schema-provider`, `device-auth` |
 | Author       | Ever Works Team                                   |
-| License      | AGPL-3.0                                               |
+| License      | AGPL-3.0                                          |
 | Built-in     | yes                                               |
 | Auto-enable  | no                                                |
 

--- a/packages/plugins/comparison-generator/README.md
+++ b/packages/plugins/comparison-generator/README.md
@@ -10,7 +10,7 @@ Auto-generates SEO-optimized A vs B comparison pages between Work items
 | Category     | `utility`              |
 | Capabilities | _(none)_               |
 | Author       | Ever Works Team        |
-| License      | AGPL-3.0                    |
+| License      | AGPL-3.0               |
 | Built-in     | yes                    |
 | Auto-enable  | no                     |
 

--- a/packages/plugins/exa/README.md
+++ b/packages/plugins/exa/README.md
@@ -10,7 +10,7 @@ Exa Plugin - Neural and keyword search using the Exa API
 | Category     | `search`                      |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | no                            |
 

--- a/packages/plugins/firecrawl/README.md
+++ b/packages/plugins/firecrawl/README.md
@@ -10,7 +10,7 @@ Firecrawl Plugin - Web search and content extraction using the Firecrawl API
 | Category     | `search`                      |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | no                            |
 

--- a/packages/plugins/gemini/README.md
+++ b/packages/plugins/gemini/README.md
@@ -12,7 +12,7 @@ Full pipeline plugin that delegates work generation to the [Gemini CLI](https://
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/github/README.md
+++ b/packages/plugins/github/README.md
@@ -10,7 +10,7 @@ GitHub git provider plugin for Ever Works - repository management, git operation
 | Category     | `git-provider`          |
 | Capabilities | `git-provider`, `oauth` |
 | Author       | Ever Works Team         |
-| License      | AGPL-3.0                     |
+| License      | AGPL-3.0                |
 | Built-in     | yes                     |
 | Auto-enable  | yes                     |
 

--- a/packages/plugins/google/README.md
+++ b/packages/plugins/google/README.md
@@ -10,7 +10,7 @@ Google Gemini AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/groq/README.md
+++ b/packages/plugins/groq/README.md
@@ -10,7 +10,7 @@ Groq AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/hermes-agent/README.md
+++ b/packages/plugins/hermes-agent/README.md
@@ -10,7 +10,7 @@ Hermes Agent pipeline plugin for Ever Works.
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/jina/README.md
+++ b/packages/plugins/jina/README.md
@@ -10,7 +10,7 @@ Jina AI Plugin - Web search and content extraction using Jina AI APIs
 | Category     | `content-extractor`           |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | no                            |
 

--- a/packages/plugins/langfuse/README.md
+++ b/packages/plugins/langfuse/README.md
@@ -10,7 +10,7 @@ Langfuse Plugin - External prompt management with versioning, labels, and A/B te
 | Category     | `utility`         |
 | Capabilities | `prompt-provider` |
 | Author       | Ever Works Team   |
-| License      | AGPL-3.0               |
+| License      | AGPL-3.0          |
 | Built-in     | yes               |
 | Auto-enable  | yes               |
 

--- a/packages/plugins/linkup/README.md
+++ b/packages/plugins/linkup/README.md
@@ -10,7 +10,7 @@ Linkup Plugin - Web search and content extraction using Linkup API
 | Category     | `search`                      |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | no                            |
 

--- a/packages/plugins/local-content-extractor/README.md
+++ b/packages/plugins/local-content-extractor/README.md
@@ -10,7 +10,7 @@ Local Content Extractor - System plugin for extracting web page content using ax
 | Category     | `content-extractor`       |
 | Capabilities | `content-extractor`       |
 | Author       | Ever Works Team           |
-| License      | AGPL-3.0                       |
+| License      | AGPL-3.0                  |
 | Built-in     | yes                       |
 | Auto-enable  | yes                       |
 

--- a/packages/plugins/make/README.md
+++ b/packages/plugins/make/README.md
@@ -10,7 +10,7 @@ Make.com Workflow Pipeline Plugin - Delegates Work generation to Make.com scenar
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/mistral/README.md
+++ b/packages/plugins/mistral/README.md
@@ -10,7 +10,7 @@ Mistral AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/notion-extractor/README.md
+++ b/packages/plugins/notion-extractor/README.md
@@ -10,7 +10,7 @@ Notion Page Extractor - Extract content from Notion pages using the Notion API o
 | Category     | `content-extractor` |
 | Capabilities | `content-extractor` |
 | Author       | Ever Works Team     |
-| License      | AGPL-3.0                 |
+| License      | AGPL-3.0            |
 | Built-in     | no                  |
 | Auto-enable  | no                  |
 

--- a/packages/plugins/ollama/README.md
+++ b/packages/plugins/ollama/README.md
@@ -10,7 +10,7 @@ Ollama AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/openai/README.md
+++ b/packages/plugins/openai/README.md
@@ -10,7 +10,7 @@ OpenAI AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/opencode/README.md
+++ b/packages/plugins/opencode/README.md
@@ -10,7 +10,7 @@ Full pipeline plugin that delegates work generation to the [OpenCode CLI](https:
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/openrouter/README.md
+++ b/packages/plugins/openrouter/README.md
@@ -10,7 +10,7 @@ OpenRouter AI provider plugin for Ever Works platform
 | Category     | `ai-provider`   |
 | Capabilities | `ai-provider`   |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | yes             |
 

--- a/packages/plugins/pdf-extractor/README.md
+++ b/packages/plugins/pdf-extractor/README.md
@@ -10,7 +10,7 @@ PDF Content Extractor - Extract text from PDFs with OCR fallback via Mistral AI
 | Category     | `content-extractor` |
 | Capabilities | `content-extractor` |
 | Author       | Ever Works Team     |
-| License      | AGPL-3.0                 |
+| License      | AGPL-3.0            |
 | Built-in     | yes                 |
 | Auto-enable  | no                  |
 

--- a/packages/plugins/perplexity/README.md
+++ b/packages/plugins/perplexity/README.md
@@ -10,7 +10,7 @@ Perplexity Plugin - AI-powered web search with citations
 | Category     | `search`        |
 | Capabilities | `search`        |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/scrapfly/README.md
+++ b/packages/plugins/scrapfly/README.md
@@ -10,7 +10,7 @@ Scrapfly Plugin - Screenshot capture and content extraction using Scrapfly API
 | Category     | `content-extractor`               |
 | Capabilities | `screenshot`, `content-extractor` |
 | Author       | Ever Works Team                   |
-| License      | AGPL-3.0                               |
+| License      | AGPL-3.0                          |
 | Built-in     | yes                               |
 | Auto-enable  | no                                |
 

--- a/packages/plugins/screenshotone/README.md
+++ b/packages/plugins/screenshotone/README.md
@@ -10,7 +10,7 @@ ScreenshotOne screenshot plugin for Ever Works - capture website screenshots usi
 | Category     | `screenshot`    |
 | Capabilities | `screenshot`    |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | no              |
 | Auto-enable  | no              |
 

--- a/packages/plugins/serpapi/README.md
+++ b/packages/plugins/serpapi/README.md
@@ -10,7 +10,7 @@ SerpAPI Plugin - Web search using SerpAPI (Google, Bing, Yahoo, and more)
 | Category     | `search`        |
 | Capabilities | `search`        |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | no              |
 

--- a/packages/plugins/sim-ai/README.md
+++ b/packages/plugins/sim-ai/README.md
@@ -10,7 +10,7 @@ SIM AI Workflow Pipeline Plugin - Delegates Work generation to SIM AI workflows
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 

--- a/packages/plugins/standard-pipeline/README.md
+++ b/packages/plugins/standard-pipeline/README.md
@@ -10,7 +10,7 @@ Standard Pipeline Plugin - Provides the standard 15-step generation pipeline.
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | yes                                |
 

--- a/packages/plugins/tavily/README.md
+++ b/packages/plugins/tavily/README.md
@@ -10,7 +10,7 @@ Tavily Plugin - Web search and content extraction using Tavily API
 | Category     | `search`                      |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | yes                           |
 

--- a/packages/plugins/urlbox/README.md
+++ b/packages/plugins/urlbox/README.md
@@ -10,7 +10,7 @@ Urlbox screenshot plugin for Ever Works - capture website screenshots using the 
 | Category     | `screenshot`    |
 | Capabilities | `screenshot`    |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | no              |
 | Auto-enable  | no              |
 

--- a/packages/plugins/valyu/README.md
+++ b/packages/plugins/valyu/README.md
@@ -10,7 +10,7 @@ Valyu Plugin - Web search and content extraction using Valyu API
 | Category     | `search`                      |
 | Capabilities | `search`, `content-extractor` |
 | Author       | Ever Works Team               |
-| License      | AGPL-3.0                           |
+| License      | AGPL-3.0                      |
 | Built-in     | yes                           |
 | Auto-enable  | no                            |
 

--- a/packages/plugins/vercel-ai-gateway/README.md
+++ b/packages/plugins/vercel-ai-gateway/README.md
@@ -10,7 +10,7 @@ Vercel AI Gateway plugin for Ever Works platform
 | Category     | `ai-provider`       |
 | Capabilities | `ai-provider`       |
 | Author       | Ever Works Team     |
-| License      | AGPL-3.0                 |
+| License      | AGPL-3.0            |
 | Built-in     | yes                 |
 | Auto-enable  | no                  |
 

--- a/packages/plugins/vercel/README.md
+++ b/packages/plugins/vercel/README.md
@@ -10,7 +10,7 @@ Vercel deployment plugin for Ever Works - deploy works to Vercel
 | Category     | `deployment`    |
 | Capabilities | `deployment`    |
 | Author       | Ever Works Team |
-| License      | AGPL-3.0             |
+| License      | AGPL-3.0        |
 | Built-in     | yes             |
 | Auto-enable  | yes             |
 

--- a/packages/plugins/zapier/README.md
+++ b/packages/plugins/zapier/README.md
@@ -10,7 +10,7 @@ Zapier Automation Pipeline Plugin - Triggers Zapier actions during Work generati
 | Category     | `pipeline`                         |
 | Capabilities | `pipeline`, `form-schema-provider` |
 | Author       | Ever Works Team                    |
-| License      | AGPL-3.0                                |
+| License      | AGPL-3.0                           |
 | Built-in     | yes                                |
 | Auto-enable  | no                                 |
 


### PR DESCRIPTION
## Summary

Deploys the optional `IDeploymentPlugin` contract methods that landed with the Kubernetes plugin (#460) into the API's deploy service. The hardcoded `['deploy_vercel.yaml', 'deploy_prod.yaml']` list and the `<PROVIDER>_TOKEN`-only secret push are gone; both are now plugin-driven so adding a third (or fourth) deployment provider doesn't touch this file.

## Changes

### `packages/agent/src/facades/deploy.facade.ts`

- **New** `getPluginAndTokenAndSettings(options)` returns `{ plugin, token, work, settings }` where `settings` is the resolved plugin-settings record (with secrets) for the user. Settings come from the same `PluginSettingsService` that already backs `getTokenFromSettings`.
- Existing `getPluginAndToken` is unchanged for callers that don't need settings.

### `apps/api/src/plugins-capabilities/deploy/deploy.service.ts`

- `deploy()` switches to `getPluginAndTokenAndSettings` and threads the resolved `plugin` + `settings` into `setRequiredSecrets` and `dispatchWithRetry`.
- `setRequiredSecrets()` now calls `plugin.getDeploymentSecrets?.(settings)` after the existing standard secret push, and pushes each returned entry as a GitHub Actions secret. A throw inside the plugin is logged but doesn't fail the deploy.
- `dispatchWithRetry()` now reads `plugin.getWorkflowFilenames?.()` and falls back to `['deploy_prod.yaml']` for plugins without the optional method. The Vercel plugin returns `['deploy_vercel.yaml', 'deploy_prod.yaml']` so today's behaviour is preserved exactly.

### `apps/api/.../deploy.service.spec.ts` (new, 7 tests)

- `uses plugin.getWorkflowFilenames() for the dispatch list`
- `falls back to deploy_prod.yaml for plugins without getWorkflowFilenames`
- `honours the Vercel plugin override` (parity)
- `pushes plugin.getDeploymentSecrets() entries as GitHub Actions secrets`
- `pushes nothing extra for plugins without getDeploymentSecrets`
- `does not leak the plugin token (kubeconfig) into pushed secret values`
- `logs but does not fail the deploy if getDeploymentSecrets throws`

All cluster I/O is mocked via the existing `PluginRegistryService` stub. **7/7 pass.**

### Format pass

This PR also runs `prettier --write` over 42 plugin READMEs. develop's `format:check` has been red since [`0ee14c60`](https://github.com/ever-works/ever-works/commit/0ee14c60) (`chore(license): standardize on AGPL-3.0`) — same pattern as the previous k8s PR. Format-only changes; no semantic diffs.

## Test plan

- [x] `pnpm --filter ever-works-api test --testPathPattern=deploy.service` — **7/7 pass**
- [x] `pnpm --filter @ever-works/agent build` — clean
- [ ] CI green on this branch

## Out of scope (separate PRs)

- `deploy_k8s.yaml` workflow + Dockerfile + manifests:
    - [ever-works/directory-web-template#734](https://github.com/ever-works/directory-web-template/pull/734) (Next.js)
    - [ever-works/directory-web-minimal-template#2](https://github.com/ever-works/directory-web-minimal-template/pull/2) (Astro)
- Once both template PRs land, a work with `deployProvider: k8s` deploys end-to-end.

## Backwards compatibility

The contract methods (`getWorkflowFilenames`, `getDeploymentSecrets`) are **optional**. Plugins without them get the existing default behaviour (`deploy_prod.yaml` + no extra secrets). Vercel implemented both in #460, so today's Vercel deploys behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins can now specify custom workflow filenames for deployments.
  * Plugins can provide custom deployment secrets for integration.
  * Added deployment provider configuration support.

* **Tests**
  * Added comprehensive test suite for deploy service validating plugin-driven workflows and secret handling with full external component mocking.

* **Documentation**
  * Updated architecture and plugin documentation formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->