### PR TITLE
test(plugins): unit tests for brave, linkup, tavily, valyu (107 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -13,30 +13,30 @@
 
 1. Read this tracker first.
 2. Pick the next item from "Pending — High Priority", or fall back to the next
-    "Pending — Medium / Low" item if all high-priority is in flight.
+   "Pending — Medium / Low" item if all high-priority is in flight.
 3. Open a feature branch, ship in one PR, merge to `develop` (no waiting for
-    review — the scheduled task is authorized to merge per the task spec).
+   review — the scheduled task is authorized to merge per the task spec).
 4. Update this file in the same PR (move the item to "Done", add the PR link,
-    record any follow-ups discovered).
+   record any follow-ups discovered).
 
 ## Inventory snapshot (2026-05-07)
 
 - **Spec files (`*.spec.ts`)**: ~419 across `apps/` + `packages/`
 - **Playwright e2e suites**: 31 in `apps/web/e2e/`
 - **API source spec count**: only **9** specs inside `apps/api/src/` —
-   most modules rely on e2e + agent-package tests instead.
+  most modules rely on e2e + agent-package tests instead.
 - **Spec Kit features (`docs/specs/features/`)**: 24 directories.
 - **Plugins with ZERO unit tests (14)**:
-   `brave`, `brightdata`, `comparison-generator`, `exa`, `firecrawl`, `github`,
-   `jina`, `linkup`, `local-content-extractor`, `perplexity`, `scrapfly`,
-   `serpapi`, `tavily`, `valyu`.
+  `brave`, `brightdata`, `comparison-generator`, `exa`, `firecrawl`, `github`,
+  `jina`, `linkup`, `local-content-extractor`, `perplexity`, `scrapfly`,
+  `serpapi`, `tavily`, `valyu`.
 - **Internal packages with ZERO tests**: `contracts`, `monitoring`,
-   `cli-shared`, `tasks`.
+  `cli-shared`, `tasks`.
 
 ## Done
 
-| Date | Area | PR | Notes |
-| ---- | ---- | -- | ----- |
+| Date       | Area                         | PR        | Notes                                                                                                                                                                                                              |
+| ---------- | ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 2026-05-07 | Search plugins zero-coverage | (this PR) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest. |
 
 ## Pending — High Priority
@@ -70,7 +70,7 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 ### Internal-package coverage
 
 - [ ] `packages/contracts` — pure types; add type-test fixtures via
-       `expectTypeOf` so breaking changes are caught.
+      `expectTypeOf` so breaking changes are caught.
 - [ ] `packages/monitoring` — mock Sentry + PostHog SDKs and assert wiring.
 - [ ] `packages/cli-shared` — pure helpers, easy to unit test.
 - [ ] `packages/tasks` — Trigger.dev jobs; mock `@trigger.dev/sdk` v3.
@@ -104,20 +104,20 @@ known to lack a Spec Kit feature folder:
 - [ ] `ai-conversation` (chat-style conversations against works)
 - [ ] `integrations-twenty-crm`, `integrations-github-app`
 - [ ] `plugins-capabilities` (AI/Search/Deploy/Screenshot/Content-Extractor
-       facades)
+      facades)
 - [ ] `community-pr-processing` already exists — verify it is still accurate
-       after #460/#462/#464 (k8s + activity-log changes).
+      after #460/#462/#464 (k8s + activity-log changes).
 
 ### Docs gaps to audit
 
 - [ ] `docs/packages/*` — every plugin now has a README (PR landed); audit
-       that each one mentions: settings, env vars, capabilities, example
-       configuration, troubleshooting.
+      that each one mentions: settings, env vars, capabilities, example
+      configuration, troubleshooting.
 - [ ] `docs/api/*` — endpoint reference; cross-check against
-       `apps/api/src/**/controllers/*.controller.ts`.
+      `apps/api/src/**/controllers/*.controller.ts`.
 - [ ] `docs/architecture/*` — confirm diagrams are current after
-       Directory→Work rename (PR #436) and works.yml standardization
-       (PR #456).
+      Directory→Work rename (PR #436) and works.yml standardization
+      (PR #456).
 - [ ] `docs/devops/*` — kind-cluster e2e CI just landed (#464); add runbook.
 
 ## Pending — Low Priority
@@ -133,19 +133,19 @@ known to lack a Spec Kit feature folder:
 
 - **Per-plugin spec lives in** `packages/plugins/<id>/src/__tests__/<id>.plugin.spec.ts`.
 - **Mocking style**: prefer mocking the upstream SDK or `global.fetch`
-   over network round-trips. No `nock`, no live calls.
+  over network round-trips. No `nock`, no live calls.
 - **Assert at minimum**: id/name/version/category/capabilities, settings
-   schema (required keys, secret/envVar markers), happy-path search/extract,
-   error path (missing API key, non-OK HTTP), lifecycle (`onLoad`/`onUnload`),
-   `healthCheck`, `getManifest`.
+  schema (required keys, secret/envVar markers), happy-path search/extract,
+  error path (missing API key, non-OK HTTP), lifecycle (`onLoad`/`onUnload`),
+  `healthCheck`, `getManifest`.
 - **Run locally** with `pnpm --filter @ever-works/<id>-plugin test` before
-   committing.
+  committing.
 - **Branch naming**: `tests/<area>-<short-slug>` (e.g.
-   `tests/search-plugins-zero-coverage`).
+  `tests/search-plugins-zero-coverage`).
 - **PR title**: conventional `test(<scope>): <summary>`. Body: list of
-   plugins/modules covered + a one-line summary of mocked surfaces.
+  plugins/modules covered + a one-line summary of mocked surfaces.
 - **Always merge to `develop`** without waiting for human review (the
-   scheduled-task spec authorizes this).
+  scheduled-task spec authorizes this).
 
 ## Follow-ups discovered
 

--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -1,0 +1,152 @@
+# Coverage Tracker — Tests, Docs, Specs
+
+> **Purpose**: track 100%-coverage progress for the Ever Works platform across
+> tests (unit/e2e), docs, and specs. Maintained by the hourly
+> `platform-tests-and-docs` scheduled task so successive runs do not duplicate
+> work and nothing is missed.
+>
+> **Source of truth ordering**: this file > existing CLAUDE.md > AGENTS.md.
+> When a task is shipped (PR merged), the corresponding row is moved to the
+> "Done" section with the merged PR link.
+
+## How an hourly run uses this file
+
+1. Read this tracker first.
+2. Pick the next item from "Pending — High Priority", or fall back to the next
+    "Pending — Medium / Low" item if all high-priority is in flight.
+3. Open a feature branch, ship in one PR, merge to `develop` (no waiting for
+    review — the scheduled task is authorized to merge per the task spec).
+4. Update this file in the same PR (move the item to "Done", add the PR link,
+    record any follow-ups discovered).
+
+## Inventory snapshot (2026-05-07)
+
+- **Spec files (`*.spec.ts`)**: ~419 across `apps/` + `packages/`
+- **Playwright e2e suites**: 31 in `apps/web/e2e/`
+- **API source spec count**: only **9** specs inside `apps/api/src/` —
+   most modules rely on e2e + agent-package tests instead.
+- **Spec Kit features (`docs/specs/features/`)**: 24 directories.
+- **Plugins with ZERO unit tests (14)**:
+   `brave`, `brightdata`, `comparison-generator`, `exa`, `firecrawl`, `github`,
+   `jina`, `linkup`, `local-content-extractor`, `perplexity`, `scrapfly`,
+   `serpapi`, `tavily`, `valyu`.
+- **Internal packages with ZERO tests**: `contracts`, `monitoring`,
+   `cli-shared`, `tasks`.
+
+## Done
+
+| Date | Area | PR | Notes |
+| ---- | ---- | -- | ----- |
+| 2026-05-07 | Search plugins zero-coverage | (this PR) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest. |
+
+## Pending — High Priority
+
+These zero-coverage areas yield the biggest coverage % per PR.
+
+### Search-plugin unit tests (per plugin)
+
+The pattern is established by `groq` / `screenshotone` / `urlbox`: vitest +
+fetch-or-SDK mock, ~10–20 tests asserting metadata, settingsSchema shape,
+search/extract success + error paths, lifecycle, healthCheck, manifest.
+
+- [x] `brave` (fetch-based, search only) — 25 tests, 2026-05-07
+- [x] `linkup` (fetch-based, search + content-extractor) — 27 tests, 2026-05-07
+- [x] `tavily` (SDK `@tavily/core`, search + content-extractor) — 26 tests, 2026-05-07
+- [x] `valyu` (SDK `valyu-js`, search + content-extractor) — 29 tests, 2026-05-07
+- [ ] `exa` (TBD — inspect SDK)
+- [ ] `perplexity` (TBD — inspect SDK)
+- [ ] `serpapi` (TBD — inspect SDK)
+- [ ] `firecrawl` (TBD — inspect SDK)
+- [ ] `jina` (TBD)
+- [ ] `scrapfly` (search + content-extractor + screenshot)
+- [ ] `brightdata` (TBD)
+
+### Other zero-coverage plugins
+
+- [ ] `comparison-generator` (utility category)
+- [ ] `github` (git-provider + OAuth)
+- [ ] `local-content-extractor` (content-extractor — default)
+
+### Internal-package coverage
+
+- [ ] `packages/contracts` — pure types; add type-test fixtures via
+       `expectTypeOf` so breaking changes are caught.
+- [ ] `packages/monitoring` — mock Sentry + PostHog SDKs and assert wiring.
+- [ ] `packages/cli-shared` — pure helpers, easy to unit test.
+- [ ] `packages/tasks` — Trigger.dev jobs; mock `@trigger.dev/sdk` v3.
+
+### API module unit tests
+
+`apps/api/src/` modules currently rely heavily on e2e for coverage. Add
+service-level unit tests (Jest + `@nestjs/testing`) for:
+
+- [ ] `account`, `activity-log`, `ai-conversation`
+- [ ] `auth/services/*` (jwt, password, oauth)
+- [ ] `config`, `events`, `integrations/*`
+- [ ] `mail/providers/*`
+- [ ] `notifications`, `onboarding`
+- [ ] `subscriptions`, `templates`, `trigger`
+- [ ] `works/*` (largest surface — split by sub-module)
+
+## Pending — Medium Priority
+
+### Spec Kit features that need a spec
+
+Cross-check `docs/specs/features/` against actual capabilities. Candidates
+known to lack a Spec Kit feature folder:
+
+- [ ] `auth-jwt-oauth` (JWT issuance, OAuth GitHub/Google flow)
+- [ ] `notifications` (in-app + email delivery, channels)
+- [ ] `subscriptions` (plan/feature gating)
+- [ ] `activity-log` (event taxonomy + persistence)
+- [ ] `mail-providers` (provider abstraction + templates)
+- [ ] `templates-catalog` (PR #459 just landed — needs spec backfill)
+- [ ] `ai-conversation` (chat-style conversations against works)
+- [ ] `integrations-twenty-crm`, `integrations-github-app`
+- [ ] `plugins-capabilities` (AI/Search/Deploy/Screenshot/Content-Extractor
+       facades)
+- [ ] `community-pr-processing` already exists — verify it is still accurate
+       after #460/#462/#464 (k8s + activity-log changes).
+
+### Docs gaps to audit
+
+- [ ] `docs/packages/*` — every plugin now has a README (PR landed); audit
+       that each one mentions: settings, env vars, capabilities, example
+       configuration, troubleshooting.
+- [ ] `docs/api/*` — endpoint reference; cross-check against
+       `apps/api/src/**/controllers/*.controller.ts`.
+- [ ] `docs/architecture/*` — confirm diagrams are current after
+       Directory→Work rename (PR #436) and works.yml standardization
+       (PR #456).
+- [ ] `docs/devops/*` — kind-cluster e2e CI just landed (#464); add runbook.
+
+## Pending — Low Priority
+
+- [ ] CLI (`apps/cli`) — add command-level snapshot tests via esbuild + node.
+- [ ] Internal CLI (`apps/internal-cli`) — `nest-commander` testing module.
+- [ ] Admin app (`apps/admin`) — once routes stabilize.
+- [ ] MCP server (`apps/mcp`) — already has 7 spec files; audit edge cases.
+- [ ] Performance / load tests for the standard pipeline (15 steps).
+- [ ] Visual-regression for marketing pages once those settle.
+
+## Conventions for new tests added by this task
+
+- **Per-plugin spec lives in** `packages/plugins/<id>/src/__tests__/<id>.plugin.spec.ts`.
+- **Mocking style**: prefer mocking the upstream SDK or `global.fetch`
+   over network round-trips. No `nock`, no live calls.
+- **Assert at minimum**: id/name/version/category/capabilities, settings
+   schema (required keys, secret/envVar markers), happy-path search/extract,
+   error path (missing API key, non-OK HTTP), lifecycle (`onLoad`/`onUnload`),
+   `healthCheck`, `getManifest`.
+- **Run locally** with `pnpm --filter @ever-works/<id>-plugin test` before
+   committing.
+- **Branch naming**: `tests/<area>-<short-slug>` (e.g.
+   `tests/search-plugins-zero-coverage`).
+- **PR title**: conventional `test(<scope>): <summary>`. Body: list of
+   plugins/modules covered + a one-line summary of mocked surfaces.
+- **Always merge to `develop`** without waiting for human review (the
+   scheduled-task spec authorizes this).
+
+## Follow-ups discovered
+
+(Empty — populated as the task surfaces them.)

--- a/packages/plugins/brave/src/__tests__/brave.plugin.spec.ts
+++ b/packages/plugins/brave/src/__tests__/brave.plugin.spec.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BraveSearchPlugin } from '../brave.plugin.js';
+import type { PluginContext, SearchOptions } from '@ever-works/plugin';
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'brave',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+const okResponse = (body: unknown): Response =>
+	({
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body))
+	}) as unknown as Response;
+
+const errResponse = (status: number, body = 'rate limited'): Response =>
+	({
+		ok: false,
+		status,
+		json: () => Promise.resolve({ error: body }),
+		text: () => Promise.resolve(body)
+	}) as unknown as Response;
+
+describe('BraveSearchPlugin', () => {
+	let plugin: BraveSearchPlugin;
+	let fetchMock: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		plugin = new BraveSearchPlugin();
+		fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.clearAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('brave');
+			expect(plugin.name).toBe('Brave Search');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Brave');
+		});
+
+		it('declares only the search capability', () => {
+			expect(plugin.capabilities).toEqual(['search']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as a user-scoped secret', () => {
+			expect(plugin.settingsSchema.type).toBe('object');
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-scope']).toBe('user');
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_BRAVE_API_KEY');
+		});
+
+		it('exposes a maxResults setting with sane defaults and bounds', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.maxResults.type).toBe('number');
+			expect(props.maxResults.default).toBe(10);
+			expect(props.maxResults.minimum).toBe(1);
+			expect(props.maxResults.maximum).toBe(20);
+		});
+	});
+
+	describe('search', () => {
+		const searchPayload = {
+			web: {
+				results: [
+					{
+						title: 'Example',
+						url: 'https://example.com',
+						description: 'Example domain',
+						favicon: 'https://example.com/favicon.ico',
+						age: '2026-01-01',
+						language: 'en',
+						family_friendly: true
+					}
+				]
+			},
+			query: { more_results_available: true }
+		};
+
+		it('throws when apiKey is missing', async () => {
+			const opts: SearchOptions = { query: 'test', settings: {} };
+			await expect(plugin.search(opts)).rejects.toThrow(/API key not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns mapped results on success and propagates pagination', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse(searchPayload));
+			const result = await plugin.search({
+				query: 'hello',
+				limit: 5,
+				settings: { apiKey: 'k' }
+			});
+
+			expect(result.results).toHaveLength(1);
+			expect(result.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Example domain',
+				faviconUrl: 'https://example.com/favicon.ico',
+				position: 1
+			});
+			expect(result.hasMore).toBe(true);
+			expect(result.nextPage).toBe(2);
+			expect(typeof result.duration).toBe('number');
+
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('q')).toBe('hello');
+			expect(url.searchParams.get('count')).toBe('5');
+		});
+
+		it('caps the result count at MAX_RESULTS_LIMIT (20)', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			await plugin.search({ query: 'x', limit: 999, settings: { apiKey: 'k' } });
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('count')).toBe('20');
+		});
+
+		it('encodes pagination via offset', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			await plugin.search({ query: 'x', limit: 10, page: 3, settings: { apiKey: 'k' } });
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('offset')).toBe('20');
+		});
+
+		it('clamps offset at MAX_PAGE_OFFSET (9)', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			await plugin.search({ query: 'x', limit: 10, page: 50, settings: { apiKey: 'k' } });
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('offset')).toBe('90');
+		});
+
+		it('forwards region, language, safeSearch, and timeRange filters', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			await plugin.search({
+				query: 'x',
+				region: 'US',
+				language: 'en',
+				safeSearch: 'strict',
+				timeRange: 'week',
+				settings: { apiKey: 'k' }
+			});
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('country')).toBe('US');
+			expect(url.searchParams.get('search_lang')).toBe('en');
+			expect(url.searchParams.get('safesearch')).toBe('strict');
+			expect(url.searchParams.get('freshness')).toBe('pw');
+		});
+
+		it('skips freshness when timeRange is "all"', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			await plugin.search({ query: 'x', timeRange: 'all', settings: { apiKey: 'k' } });
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.has('freshness')).toBe(false);
+		});
+
+		it('sends X-Subscription-Token header with the apiKey', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			await plugin.search({ query: 'x', settings: { apiKey: 'super-secret' } });
+			const init = fetchMock.mock.calls[0][1] as RequestInit;
+			expect((init.headers as Record<string, string>)['X-Subscription-Token']).toBe('super-secret');
+		});
+
+		it('throws and logs when the upstream returns non-OK', async () => {
+			await plugin.onLoad(buildContext());
+			fetchMock.mockResolvedValueOnce(errResponse(429, 'rate limited'));
+			await expect(plugin.search({ query: 'x', settings: { apiKey: 'k' } })).rejects.toThrow(
+				/Brave Search request failed \(429\)/
+			);
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false when context is missing', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('returns true when settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+		});
+
+		it('returns false when settings has no apiKey', async () => {
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('returns failure when apiKey is missing', async () => {
+			const result = await plugin.validateConnection({});
+			expect(result.success).toBe(false);
+			expect(result.message).toMatch(/not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns success on a 200 response', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ web: { results: [] } }));
+			const result = await plugin.validateConnection({ apiKey: 'k' });
+			expect(result.success).toBe(true);
+		});
+
+		it('returns failure on a non-OK response', async () => {
+			fetchMock.mockResolvedValueOnce(errResponse(401, 'unauthorized'));
+			const result = await plugin.validateConnection({ apiKey: 'k' });
+			expect(result.success).toBe(false);
+			expect(result.message).toMatch(/401/);
+		});
+
+		it('returns failure when fetch throws', async () => {
+			fetchMock.mockRejectedValueOnce(new Error('boom'));
+			const result = await plugin.validateConnection({ apiKey: 'k' });
+			expect(result.success).toBe(false);
+			expect(result.message).toMatch(/boom/);
+		});
+	});
+
+	describe('getRateLimitInfo', () => {
+		it('returns sentinel values when not exposed by Brave', async () => {
+			const info = await plugin.getRateLimitInfo();
+			expect(info.remaining).toBe(-1);
+			expect(info.limit).toBe(-1);
+			expect(info.period).toBe('month');
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs a load message and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Brave Search Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+			expect(h.checkedAt).toBeTypeOf('number');
+		});
+
+		it('returns a manifest matching plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('brave');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search']);
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(false);
+			expect(m.autoEnable).toBe(false);
+			expect(m.icon?.type).toBe('svg');
+		});
+	});
+});

--- a/packages/plugins/linkup/src/__tests__/linkup.plugin.spec.ts
+++ b/packages/plugins/linkup/src/__tests__/linkup.plugin.spec.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LinkupSearchPlugin } from '../linkup.plugin.js';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'linkup',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+const okResponse = (body: unknown): Response =>
+	({
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body))
+	}) as unknown as Response;
+
+const errResponse = (status: number, body = 'error'): Response =>
+	({
+		ok: false,
+		status,
+		json: () => Promise.resolve({ error: body }),
+		text: () => Promise.resolve(body)
+	}) as unknown as Response;
+
+describe('LinkupSearchPlugin', () => {
+	let plugin: LinkupSearchPlugin;
+	let fetchMock: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		plugin = new LinkupSearchPlugin();
+		fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.clearAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('linkup');
+			expect(plugin.name).toBe('Linkup');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Linkup');
+			expect(plugin.version).toBe('1.0.0');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as a user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-scope']).toBe('user');
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_LINKUP_API_KEY');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(
+				/API key not configured/i
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns mapped results from data.results on success', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okResponse({
+					results: [
+						{ name: 'Result A', url: 'https://a.example', content: 'snippet a' },
+						{ name: 'Result B', url: 'https://b.example', content: 'snippet b' }
+					]
+				})
+			);
+			const r = await plugin.search(opts());
+			expect(r.results).toHaveLength(2);
+			expect(r.results[0]).toMatchObject({
+				title: 'Result A',
+				url: 'https://a.example',
+				snippet: 'snippet a',
+				position: 1
+			});
+			expect(r.totalResults).toBe(2);
+			expect(r.hasMore).toBe(false);
+			expect(typeof r.duration).toBe('number');
+		});
+
+		it('falls back to data.sources when results is missing', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okResponse({
+					sources: [{ name: 'Source A', url: 'https://s.example', snippet: 'src snippet' }]
+				})
+			);
+			const r = await plugin.search(opts());
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Source A',
+				url: 'https://s.example',
+				snippet: 'src snippet'
+			});
+		});
+
+		it('forwards Bearer apiKey and JSON body with includeDomains/excludeDomains', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ results: [] }));
+			await plugin.search(
+				opts({
+					includeDomains: ['a.com'],
+					excludeDomains: ['b.com']
+				})
+			);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://api.linkup.so/v1/search');
+			expect(init.method).toBe('POST');
+			expect((init.headers as Record<string, string>).Authorization).toBe('Bearer k');
+			const body = JSON.parse(init.body as string);
+			expect(body.q).toBe('hello');
+			expect(body.depth).toBe('deep');
+			expect(body.outputType).toBe('searchResults');
+			expect(body.includeDomains).toEqual(['a.com']);
+			expect(body.excludeDomains).toEqual(['b.com']);
+		});
+
+		it('throws and logs when the upstream returns non-OK', async () => {
+			await plugin.onLoad(buildContext());
+			fetchMock.mockResolvedValueOnce(errResponse(500, 'oops'));
+			await expect(plugin.search(opts())).rejects.toThrow(/Linkup search failed with status 500/);
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without an apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns success on a 200 response', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ results: [] }));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure on a non-OK response', async () => {
+			fetchMock.mockResolvedValueOnce(errResponse(401, 'unauthorized'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/401/);
+		});
+
+		it('returns failure when fetch throws', async () => {
+			fetchMock.mockRejectedValueOnce(new Error('network down'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/network down/);
+		});
+	});
+
+	describe('getRateLimitInfo', () => {
+		it('reports the documented Linkup rate limit', async () => {
+			const info = await plugin.getRateLimitInfo();
+			expect(info.remaining).toBe(-1);
+			expect(info.limit).toBe(10);
+			expect(info.period).toBe('second');
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with markdown and word count', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ markdown: 'one two three' }));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(r.url).toBe('https://example.com/post');
+			expect(r.markdown).toBe('one two three');
+			expect(r.wordCount).toBe(3);
+		});
+
+		it('returns failure when markdown is missing', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({}));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content extracted/);
+		});
+
+		it('returns failure on a non-OK fetch response', async () => {
+			fetchMock.mockResolvedValueOnce(errResponse(503, 'unavailable'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/Linkup fetch failed with status 503/);
+		});
+
+		it('returns failure when fetch throws', async () => {
+			fetchMock.mockRejectedValueOnce(new Error('boom'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/boom/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('runs each URL through extract', async () => {
+			fetchMock
+				.mockResolvedValueOnce(okResponse({ markdown: 'a' }))
+				.mockResolvedValueOnce(okResponse({ markdown: 'b' }));
+			const r = await plugin.extractBatch(['https://a', 'https://b'], { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(2);
+			expect(r[0].success).toBe(true);
+			expect(r[1].success).toBe(true);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('not a url')).toBe(false);
+		});
+
+		it('exposes text + markdown formats', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text', 'markdown']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Linkup Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('linkup');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(false);
+			expect(m.autoEnable).toBe(false);
+		});
+	});
+});

--- a/packages/plugins/linkup/src/__tests__/linkup.plugin.spec.ts
+++ b/packages/plugins/linkup/src/__tests__/linkup.plugin.spec.ts
@@ -82,9 +82,7 @@ describe('LinkupSearchPlugin', () => {
 		});
 
 		it('throws when apiKey is missing', async () => {
-			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(
-				/API key not configured/i
-			);
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
 			expect(fetchMock).not.toHaveBeenCalled();
 		});
 

--- a/packages/plugins/tavily/src/__tests__/tavily.plugin.spec.ts
+++ b/packages/plugins/tavily/src/__tests__/tavily.plugin.spec.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TavilySearchPlugin } from '../tavily.plugin.js';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const searchMock = vi.fn();
+const extractMock = vi.fn();
+const tavilyFactoryMock = vi.fn(() => ({
+	search: searchMock,
+	extract: extractMock
+}));
+
+vi.mock('@tavily/core', () => ({
+	tavily: (opts: { apiKey: string }) => tavilyFactoryMock(opts)
+}));
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'tavily',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('TavilySearchPlugin', () => {
+	let plugin: TavilySearchPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new TavilySearchPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('tavily');
+			expect(plugin.name).toBe('Tavily');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Tavily');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as a user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-scope']).toBe('user');
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_TAVILY_API_KEY');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(
+				/API key not configured/i
+			);
+			expect(tavilyFactoryMock).not.toHaveBeenCalled();
+		});
+
+		it('maps SDK results to SearchResult shape', async () => {
+			searchMock.mockResolvedValueOnce({
+				results: [
+					{
+						title: 'Example',
+						url: 'https://example.com',
+						content: 'content snippet',
+						score: 0.9,
+						publishedDate: '2026-01-01',
+						rawContent: 'raw'
+					}
+				]
+			});
+			const r = await plugin.search(opts());
+
+			expect(tavilyFactoryMock).toHaveBeenCalledWith({ apiKey: 'k' });
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'content snippet',
+				position: 1,
+				publishedDate: '2026-01-01'
+			});
+			expect(r.results[0].metadata).toMatchObject({ score: 0.9, rawContent: 'raw' });
+			expect(r.totalResults).toBe(1);
+			expect(r.hasMore).toBe(false);
+			expect(typeof r.duration).toBe('number');
+		});
+
+		it('forwards limit (default 20), include/excludeDomains, and advanced depth', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(
+				opts({
+					limit: 5,
+					includeDomains: ['a.com'],
+					excludeDomains: ['b.com']
+				})
+			);
+			expect(searchMock).toHaveBeenCalledWith('hello', {
+				searchDepth: 'advanced',
+				maxResults: 5,
+				includeDomains: ['a.com'],
+				excludeDomains: ['b.com']
+			});
+		});
+
+		it('uses default maxResults=20 when limit is omitted', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts());
+			expect(searchMock.mock.calls[0][1]).toMatchObject({ maxResults: 20 });
+		});
+
+		it('logs and rethrows on SDK failure', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchMock.mockRejectedValueOnce(new Error('boom'));
+			await expect(plugin.search(opts())).rejects.toThrow(/boom/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+		});
+
+		it('returns success when SDK search works', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure when SDK search rejects', async () => {
+			searchMock.mockRejectedValueOnce(new Error('bad key'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/bad key/);
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with markdown and word count', async () => {
+			extractMock.mockResolvedValueOnce({
+				results: [{ url: 'https://example.com/post', rawContent: 'one two three four' }]
+			});
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(r.markdown).toBe('one two three four');
+			expect(r.wordCount).toBe(4);
+		});
+
+		it('exposes finalUrl when SDK returns a different URL', async () => {
+			extractMock.mockResolvedValueOnce({
+				results: [{ url: 'https://example.com/redirected', rawContent: 'body' }]
+			});
+			const r = await plugin.extract(opts());
+			expect(r.finalUrl).toBe('https://example.com/redirected');
+		});
+
+		it('returns failure when no results are produced', async () => {
+			extractMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content extracted/);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			extractMock.mockRejectedValueOnce(new Error('extract failed'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/extract failed/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('maps results back to requested URLs by index', async () => {
+			extractMock.mockResolvedValueOnce({
+				results: [
+					{ url: 'https://a.example', rawContent: 'one two' },
+					{ url: 'https://b.example', rawContent: 'three four five' }
+				]
+			});
+			const r = await plugin.extractBatch(['https://a.example', 'https://b.example'], {
+				settings: { apiKey: 'k' }
+			});
+			expect(r).toHaveLength(2);
+			expect(r[0]).toMatchObject({ success: true, url: 'https://a.example', wordCount: 2 });
+			expect(r[1]).toMatchObject({ success: true, url: 'https://b.example', wordCount: 3 });
+		});
+
+		it('returns per-URL failures when the batch call throws', async () => {
+			extractMock.mockRejectedValueOnce(new Error('batch failed'));
+			const r = await plugin.extractBatch(['https://a.example', 'https://b.example'], {
+				settings: { apiKey: 'k' }
+			});
+			expect(r).toHaveLength(2);
+			expect(r.every((x) => x.success === false)).toBe(true);
+			expect(r[0].error).toMatch(/batch failed/);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+
+		it('exposes text + markdown formats', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text', 'markdown']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Tavily Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('tavily');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(true);
+			expect(m.autoEnable).toBe(true);
+			expect(m.defaultForCapabilities).toContain('search');
+		});
+	});
+});

--- a/packages/plugins/tavily/src/__tests__/tavily.plugin.spec.ts
+++ b/packages/plugins/tavily/src/__tests__/tavily.plugin.spec.ts
@@ -69,9 +69,7 @@ describe('TavilySearchPlugin', () => {
 		});
 
 		it('throws when apiKey is missing', async () => {
-			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(
-				/API key not configured/i
-			);
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
 			expect(tavilyFactoryMock).not.toHaveBeenCalled();
 		});
 

--- a/packages/plugins/valyu/src/__tests__/valyu.plugin.spec.ts
+++ b/packages/plugins/valyu/src/__tests__/valyu.plugin.spec.ts
@@ -71,9 +71,7 @@ describe('ValyuSearchPlugin', () => {
 		});
 
 		it('throws when apiKey is missing', async () => {
-			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(
-				/API key not configured/i
-			);
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
 			expect(ValyuCtorMock).not.toHaveBeenCalled();
 		});
 

--- a/packages/plugins/valyu/src/__tests__/valyu.plugin.spec.ts
+++ b/packages/plugins/valyu/src/__tests__/valyu.plugin.spec.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const { searchMock, contentsMock, ValyuCtorMock } = vi.hoisted(() => {
+	const search = vi.fn();
+	const contents = vi.fn();
+	const ctor = vi.fn().mockImplementation(() => ({ search, contents }));
+	return { searchMock: search, contentsMock: contents, ValyuCtorMock: ctor };
+});
+
+vi.mock('valyu-js', () => ({
+	Valyu: ValyuCtorMock
+}));
+
+const { ValyuSearchPlugin } = await import('../valyu.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'valyu',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('ValyuSearchPlugin', () => {
+	let plugin: ValyuSearchPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new ValyuSearchPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('valyu');
+			expect(plugin.name).toBe('Valyu');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Valyu');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and exposes a responseLength enum', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_VALYU_API_KEY');
+			expect(props.responseLength.default).toBe('medium');
+			expect(props.responseLength.enum).toEqual(['short', 'medium', 'large', 'max']);
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(
+				/API key not configured/i
+			);
+			expect(ValyuCtorMock).not.toHaveBeenCalled();
+		});
+
+		it('maps SDK results to SearchResult shape', async () => {
+			searchMock.mockResolvedValueOnce({
+				results: [
+					{
+						title: 'Example',
+						url: 'https://example.com',
+						content: 'snippet text',
+						relevance_score: 0.7,
+						source: 'web',
+						description: 'desc',
+						publication_date: '2026-01-01'
+					}
+				]
+			});
+			const r = await plugin.search(opts());
+
+			expect(ValyuCtorMock).toHaveBeenCalledWith('k');
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'snippet text',
+				position: 1,
+				publishedDate: '2026-01-01'
+			});
+			expect(r.results[0].metadata).toMatchObject({
+				relevanceScore: 0.7,
+				source: 'web',
+				description: 'desc'
+			});
+			expect(r.totalResults).toBe(1);
+			expect(r.hasMore).toBe(false);
+		});
+
+		it('coerces non-string content to string', async () => {
+			searchMock.mockResolvedValueOnce({
+				results: [{ title: 't', url: 'https://e', content: { foo: 'bar' } }]
+			});
+			const r = await plugin.search(opts());
+			expect(typeof r.results[0].snippet).toBe('string');
+		});
+
+		it('forwards limit, responseLength, and country code', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(
+				opts({
+					limit: 7,
+					region: 'us',
+					settings: { apiKey: 'k', responseLength: 'large' }
+				})
+			);
+			expect(searchMock).toHaveBeenCalledWith(
+				'hello',
+				expect.objectContaining({
+					searchType: 'all',
+					maxNumResults: 7,
+					responseLength: 'large',
+					countryCode: 'US'
+				})
+			);
+		});
+
+		it('uses includedSources when includeDomains is set', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ includeDomains: ['a.com'] }));
+			expect(searchMock.mock.calls[0][1]).toMatchObject({ includedSources: ['a.com'] });
+		});
+
+		it('uses excludeSources when only excludeDomains is set', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ excludeDomains: ['b.com'] }));
+			expect(searchMock.mock.calls[0][1]).toMatchObject({ excludeSources: ['b.com'] });
+		});
+
+		it('translates timeRange into start/end ISO date strings', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ timeRange: 'week' }));
+			const call = searchMock.mock.calls[0][1];
+			expect(call.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(call.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		});
+
+		it('skips date filters when timeRange is "all"', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ timeRange: 'all' }));
+			const call = searchMock.mock.calls[0][1];
+			expect(call.startDate).toBeUndefined();
+			expect(call.endDate).toBeUndefined();
+		});
+
+		it('logs and rethrows on SDK failure', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchMock.mockRejectedValueOnce(new Error('boom'));
+			await expect(plugin.search(opts())).rejects.toThrow(/boom/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+		});
+
+		it('returns success when SDK search works', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure when SDK search rejects', async () => {
+			searchMock.mockRejectedValueOnce(new Error('bad key'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/bad key/);
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with markdown and word count', async () => {
+			contentsMock.mockResolvedValueOnce({
+				results: [
+					{
+						url: 'https://example.com/post',
+						title: 'Title',
+						content: 'one two three'
+					}
+				]
+			});
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(r.title).toBe('Title');
+			expect(r.markdown).toBe('one two three');
+			expect(r.wordCount).toBe(3);
+		});
+
+		it('returns failure when no results are produced', async () => {
+			contentsMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content extracted/);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			contentsMock.mockRejectedValueOnce(new Error('extract failed'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/extract failed/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('chunks URLs into batches of 10 and aggregates results', async () => {
+			const urls = Array.from({ length: 12 }, (_, i) => `https://example.com/${i}`);
+			contentsMock
+				.mockResolvedValueOnce({
+					results: urls.slice(0, 10).map((u) => ({ url: u, title: 't', content: 'a b' }))
+				})
+				.mockResolvedValueOnce({
+					results: urls.slice(10).map((u) => ({ url: u, title: 't', content: 'c d e' }))
+				});
+
+			const r = await plugin.extractBatch(urls, { settings: { apiKey: 'k' } });
+			expect(contentsMock).toHaveBeenCalledTimes(2);
+			expect(r).toHaveLength(12);
+			expect(r[0]).toMatchObject({ success: true, wordCount: 2 });
+			expect(r[10]).toMatchObject({ success: true, wordCount: 3 });
+		});
+
+		it('returns per-URL failures when the batch call throws', async () => {
+			contentsMock.mockRejectedValueOnce(new Error('batch failed'));
+			const r = await plugin.extractBatch(['https://a', 'https://b'], { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(2);
+			expect(r.every((x) => x.success === false)).toBe(true);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+
+		it('exposes text + markdown formats', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text', 'markdown']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Valyu Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('valyu');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(false);
+			expect(m.autoEnable).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Brings four previously zero-coverage search plugins under unit test, contributing **107 new tests**.

| Plugin | Tests | Style | Capabilities |
| ------ | ----- | ----- | ------------ |
| `brave` | 25 | fetch mock | `search` |
| `linkup` | 27 | fetch mock | `search`, `content-extractor` |
| `tavily` | 26 | SDK mock (`@tavily/core`) | `search`, `content-extractor` |
| `valyu` | 29 | SDK mock (`valyu-js`) | `search`, `content-extractor` |

Each suite follows the `groq` / `screenshotone` / `urlbox` pattern and asserts:

- plugin metadata (id/name/version/category/capabilities/configurationMode)
- `settingsSchema` (required keys, `x-secret`, `x-envVar`, defaults)
- `search()` happy + error paths (missing key, non-OK upstream, SDK throw)
- `extract()` / `extractBatch()` happy + error paths (where applicable)
- `validateConnection()` with and without API key
- `isAvailable()` reflects context + settings
- lifecycle: `onLoad` logs, `onUnload` clears context
- `healthCheck` and `getManifest` shape

Also adds `COVERAGE-TRACKER.md` at the repo root. The hourly
`platform-tests-and-docs` scheduled task uses it as a persistent backlog
of tests/docs/specs gaps so successive runs do not duplicate work.

## Test plan

- [x] `pnpm --filter @ever-works/brave-plugin test` — 25/25 passing
- [x] `pnpm --filter @ever-works/linkup-plugin test` — 27/27 passing
- [x] `pnpm --filter @ever-works/tavily-plugin test` — 26/26 passing
- [x] `pnpm --filter @ever-works/valyu-plugin test` — 29/29 passing
- [ ] CI runs full monorepo build/test on develop merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests for multiple search plugins (Brave, Linkup, Tavily, Valyu), covering metadata, settings validation, search/results mapping, extraction, error handling, connectivity, lifecycle, and health checks.

* **Documentation**
  * Added a Coverage Tracker detailing current test inventory, a dated snapshot, prioritized pending work, conventions for new tests, and a record of this PR’s completed tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->