### PR TITLE
test(plugins): unit tests for exa, perplexity, serpapi, firecrawl (102 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -35,9 +35,10 @@
 
 ## Done
 
-| Date       | Area                         | PR        | Notes                                                                                                                                                                                                              |
-| ---------- | ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 2026-05-07 | Search plugins zero-coverage | (this PR) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest. |
+| Date       | Area                              | PR                                                        | Notes                                                                                                                                                                                                              |
+| ---------- | --------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-05-07 | Search plugins zero-coverage      | [#471](https://github.com/ever-works/ever-works/pull/471) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest. |
+| 2026-05-07 | Search plugins zero-coverage (b2) | (this PR)                                                 | exa (30 tests), perplexity (22), serpapi (22), firecrawl (28) — 102 new unit tests; same coverage shape as batch 1.                                                                                                |
 
 ## Pending — High Priority
 
@@ -53,10 +54,10 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 - [x] `linkup` (fetch-based, search + content-extractor) — 27 tests, 2026-05-07
 - [x] `tavily` (SDK `@tavily/core`, search + content-extractor) — 26 tests, 2026-05-07
 - [x] `valyu` (SDK `valyu-js`, search + content-extractor) — 29 tests, 2026-05-07
-- [ ] `exa` (TBD — inspect SDK)
-- [ ] `perplexity` (TBD — inspect SDK)
-- [ ] `serpapi` (TBD — inspect SDK)
-- [ ] `firecrawl` (TBD — inspect SDK)
+- [x] `exa` (SDK `exa-js`, search + content-extractor) — 30 tests, 2026-05-07
+- [x] `perplexity` (SDK `@perplexity-ai/perplexity_ai`, search) — 22 tests, 2026-05-07
+- [x] `serpapi` (fetch-based, search) — 22 tests, 2026-05-07
+- [x] `firecrawl` (SDK `@mendable/firecrawl-js`, search + content-extractor) — 28 tests, 2026-05-07
 - [ ] `jina` (TBD)
 - [ ] `scrapfly` (search + content-extractor + screenshot)
 - [ ] `brightdata` (TBD)

--- a/packages/plugins/exa/src/__tests__/exa.plugin.spec.ts
+++ b/packages/plugins/exa/src/__tests__/exa.plugin.spec.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const { searchMock, getContentsMock, ExaCtorMock } = vi.hoisted(() => {
+	const search = vi.fn();
+	const getContents = vi.fn();
+	const ctor = vi.fn().mockImplementation(() => ({ search, getContents }));
+	return { searchMock: search, getContentsMock: getContents, ExaCtorMock: ctor };
+});
+
+vi.mock('exa-js', () => ({
+	Exa: ExaCtorMock
+}));
+
+const { ExaSearchPlugin } = await import('../exa.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'exa',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('ExaSearchPlugin', () => {
+	let plugin: ExaSearchPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new ExaSearchPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('exa');
+			expect(plugin.name).toBe('Exa');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Exa');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_EXA_API_KEY');
+			expect(props.apiKey['x-scope']).toBe('user');
+		});
+
+		it('exposes searchType, maxResults, and category settings with bounds', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.searchType.enum).toEqual(['auto', 'neural', 'keyword']);
+			expect(props.searchType.default).toBe('auto');
+			expect(props.maxResults.default).toBe(10);
+			expect(props.maxResults.minimum).toBe(1);
+			expect(props.maxResults.maximum).toBe(100);
+			expect(props.category.enum).toContain('research paper');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
+			expect(ExaCtorMock).not.toHaveBeenCalled();
+		});
+
+		it('maps SDK results to SearchResult shape', async () => {
+			searchMock.mockResolvedValueOnce({
+				results: [
+					{
+						title: 'Example',
+						url: 'https://example.com',
+						publishedDate: '2026-01-01',
+						author: 'Alice',
+						favicon: 'https://example.com/favicon.ico'
+					}
+				]
+			});
+			const r = await plugin.search(opts());
+
+			expect(ExaCtorMock).toHaveBeenCalledWith('k');
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://example.com',
+				publishedDate: '2026-01-01',
+				source: 'Alice',
+				faviconUrl: 'https://example.com/favicon.ico',
+				position: 1
+			});
+		});
+
+		it('forwards numResults from limit then maxResults setting then default', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ limit: 7 }));
+			expect(searchMock.mock.calls[0][1]).toMatchObject({ numResults: 7, type: 'auto' });
+
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ settings: { apiKey: 'k', maxResults: 25 } }));
+			expect(searchMock.mock.calls[1][1]).toMatchObject({ numResults: 25 });
+
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts());
+			expect(searchMock.mock.calls[2][1]).toMatchObject({ numResults: 10 });
+		});
+
+		it('forwards include/excludeDomains and category', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(
+				opts({
+					includeDomains: ['a.com'],
+					excludeDomains: ['b.com'],
+					settings: { apiKey: 'k', category: 'research paper' }
+				})
+			);
+			expect(searchMock.mock.calls[0][1]).toMatchObject({
+				includeDomains: ['a.com'],
+				excludeDomains: ['b.com'],
+				category: 'research paper'
+			});
+		});
+
+		it('translates timeRange into startPublishedDate ISO string', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ timeRange: 'week' }));
+			const call = searchMock.mock.calls[0][1];
+			expect(call.startPublishedDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		});
+
+		it('skips date filter when timeRange is "all"', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ timeRange: 'all' }));
+			expect(searchMock.mock.calls[0][1].startPublishedDate).toBeUndefined();
+		});
+
+		it('forwards the configured searchType (neural/keyword)', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ settings: { apiKey: 'k', searchType: 'neural' } }));
+			expect(searchMock.mock.calls[0][1]).toMatchObject({ type: 'neural' });
+		});
+
+		it('logs and rethrows on SDK failure', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchMock.mockRejectedValueOnce(new Error('boom'));
+			await expect(plugin.search(opts())).rejects.toThrow(/boom/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+		});
+
+		it('returns success when SDK search works', async () => {
+			searchMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure when SDK search rejects', async () => {
+			searchMock.mockRejectedValueOnce(new Error('bad key'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/bad key/);
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with text and word count', async () => {
+			getContentsMock.mockResolvedValueOnce({
+				results: [{ url: 'https://example.com/post', title: 'Title', text: 'one two three' }]
+			});
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(r.title).toBe('Title');
+			expect(r.content).toBe('one two three');
+			expect(r.wordCount).toBe(3);
+		});
+
+		it('exposes finalUrl when SDK returns a different URL', async () => {
+			getContentsMock.mockResolvedValueOnce({
+				results: [{ url: 'https://example.com/redirected', title: 't', text: 'a' }]
+			});
+			const r = await plugin.extract(opts());
+			expect(r.finalUrl).toBe('https://example.com/redirected');
+		});
+
+		it('returns failure when no results are produced', async () => {
+			getContentsMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content extracted/);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			getContentsMock.mockRejectedValueOnce(new Error('extract failed'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/extract failed/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('maps results back to requested URLs by index', async () => {
+			getContentsMock.mockResolvedValueOnce({
+				results: [
+					{ url: 'https://a.example', title: 'A', text: 'one two' },
+					{ url: 'https://b.example', title: 'B', text: 'three four five' }
+				]
+			});
+			const r = await plugin.extractBatch(['https://a.example', 'https://b.example'], {
+				settings: { apiKey: 'k' }
+			});
+			expect(r).toHaveLength(2);
+			expect(r[0]).toMatchObject({ success: true, url: 'https://a.example', wordCount: 2 });
+			expect(r[1]).toMatchObject({ success: true, url: 'https://b.example', wordCount: 3 });
+		});
+
+		it('returns per-URL failures when the batch call throws', async () => {
+			getContentsMock.mockRejectedValueOnce(new Error('batch failed'));
+			const r = await plugin.extractBatch(['https://a', 'https://b'], { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(2);
+			expect(r.every((x) => x.success === false)).toBe(true);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+
+		it('exposes only the text format', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Exa Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('exa');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/firecrawl/src/__tests__/firecrawl.plugin.spec.ts
+++ b/packages/plugins/firecrawl/src/__tests__/firecrawl.plugin.spec.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const { searchMock, scrapeMock, batchScrapeMock, FirecrawlAppCtorMock } = vi.hoisted(() => {
+	const search = vi.fn();
+	const scrape = vi.fn();
+	const batchScrape = vi.fn();
+	const ctor = vi.fn().mockImplementation(() => ({ search, scrape, batchScrape }));
+	return {
+		searchMock: search,
+		scrapeMock: scrape,
+		batchScrapeMock: batchScrape,
+		FirecrawlAppCtorMock: ctor
+	};
+});
+
+vi.mock('@mendable/firecrawl-js', () => ({
+	default: FirecrawlAppCtorMock
+}));
+
+const { FirecrawlPlugin } = await import('../firecrawl.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'firecrawl',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('FirecrawlPlugin', () => {
+	let plugin: FirecrawlPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new FirecrawlPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('firecrawl');
+			expect(plugin.name).toBe('Firecrawl');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Firecrawl');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_FIRECRAWL_API_KEY');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
+			expect(FirecrawlAppCtorMock).not.toHaveBeenCalled();
+		});
+
+		it('maps web results with description+title and derives source hostname', async () => {
+			searchMock.mockResolvedValueOnce({
+				web: [
+					{
+						title: 'Example',
+						url: 'https://www.example.com/page',
+						description: 'Example description'
+					}
+				]
+			});
+			const r = await plugin.search(opts({ limit: 5 }));
+
+			expect(FirecrawlAppCtorMock).toHaveBeenCalledWith({ apiKey: 'k' });
+			expect(searchMock).toHaveBeenCalledWith('hello', { limit: 5 });
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://www.example.com/page',
+				snippet: 'Example description',
+				position: 1,
+				source: 'www.example.com'
+			});
+		});
+
+		it('falls back to markdown when description is absent', async () => {
+			searchMock.mockResolvedValueOnce({
+				web: [{ title: 't', url: 'https://example.com', markdown: '# header' }]
+			});
+			const r = await plugin.search(opts());
+			expect(r.results[0].snippet).toBe('# header');
+		});
+
+		it('handles missing fields gracefully', async () => {
+			searchMock.mockResolvedValueOnce({ web: [{}] });
+			const r = await plugin.search(opts());
+			expect(r.results[0]).toMatchObject({ title: '', url: '', snippet: '' });
+		});
+
+		it('returns an empty result list when web is missing', async () => {
+			searchMock.mockResolvedValueOnce({});
+			const r = await plugin.search(opts());
+			expect(r.results).toEqual([]);
+		});
+
+		it('logs and rethrows on SDK failure', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchMock.mockRejectedValueOnce(new Error('boom'));
+			await expect(plugin.search(opts())).rejects.toThrow(/boom/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with markdown, title, wordCount, readingTime', async () => {
+			scrapeMock.mockResolvedValueOnce({
+				markdown: 'one two three four five',
+				metadata: { title: 'Title', url: 'https://example.com/post' }
+			});
+			const r = await plugin.extract(opts());
+			expect(scrapeMock).toHaveBeenCalledWith('https://example.com/post', { formats: ['markdown'] });
+			expect(r.success).toBe(true);
+			expect(r.title).toBe('Title');
+			expect(r.markdown).toBe('one two three four five');
+			expect(r.wordCount).toBe(5);
+			expect(r.readingTime).toBe(1);
+		});
+
+		it('exposes finalUrl when metadata.url differs', async () => {
+			scrapeMock.mockResolvedValueOnce({
+				markdown: 'hi',
+				metadata: { title: 't', url: 'https://example.com/redirected' }
+			});
+			const r = await plugin.extract(opts());
+			expect(r.finalUrl).toBe('https://example.com/redirected');
+		});
+
+		it('returns failure when markdown is empty', async () => {
+			scrapeMock.mockResolvedValueOnce({ markdown: '', metadata: {} });
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content extracted/);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			scrapeMock.mockRejectedValueOnce(new Error('extract failed'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/extract failed/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('uses batch API when available', async () => {
+			batchScrapeMock.mockResolvedValueOnce({
+				data: [
+					{ markdown: 'one two', metadata: { title: 'A', url: 'https://a' } },
+					{ markdown: 'three four five', metadata: { title: 'B', url: 'https://b' } }
+				]
+			});
+			const r = await plugin.extractBatch(['https://a', 'https://b'], { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(2);
+			expect(r[0]).toMatchObject({ success: true, url: 'https://a', wordCount: 2 });
+			expect(r[1]).toMatchObject({ success: true, url: 'https://b', wordCount: 3 });
+		});
+
+		it('falls back to sequential extract when batch API throws', async () => {
+			batchScrapeMock.mockRejectedValueOnce(new Error('batch unavailable'));
+			scrapeMock
+				.mockResolvedValueOnce({ markdown: 'one two', metadata: { title: 'A', url: 'https://a' } })
+				.mockResolvedValueOnce({ markdown: 'three', metadata: { title: 'B', url: 'https://b' } });
+
+			const r = await plugin.extractBatch(['https://a', 'https://b'], { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(2);
+			expect(r[0]).toMatchObject({ success: true, wordCount: 2 });
+			expect(r[1]).toMatchObject({ success: true, wordCount: 1 });
+		});
+
+		it('reports per-item failure when batch returns empty markdown', async () => {
+			batchScrapeMock.mockResolvedValueOnce({
+				data: [{ markdown: '', metadata: { url: 'https://a' } }]
+			});
+			const r = await plugin.extractBatch(['https://a'], { settings: { apiKey: 'k' } });
+			expect(r[0].success).toBe(false);
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+		});
+
+		it('returns success when SDK search works', async () => {
+			searchMock.mockResolvedValueOnce({ web: [] });
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			searchMock.mockRejectedValueOnce(new Error('bad key'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+
+		it('exposes only the markdown format', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['markdown']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Firecrawl Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('firecrawl');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/perplexity/src/__tests__/perplexity.plugin.spec.ts
+++ b/packages/plugins/perplexity/src/__tests__/perplexity.plugin.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, SearchOptions } from '@ever-works/plugin';
+
+const { searchCreateMock, PerplexityCtorMock } = vi.hoisted(() => {
+	const create = vi.fn();
+	const ctor = vi.fn().mockImplementation(() => ({ search: { create } }));
+	return { searchCreateMock: create, PerplexityCtorMock: ctor };
+});
+
+vi.mock('@perplexity-ai/perplexity_ai', () => ({
+	default: PerplexityCtorMock
+}));
+
+const { PerplexitySearchPlugin } = await import('../perplexity.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'perplexity',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('PerplexitySearchPlugin', () => {
+	let plugin: PerplexitySearchPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new PerplexitySearchPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('perplexity');
+			expect(plugin.name).toBe('Perplexity');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Perplexity');
+		});
+
+		it('declares only the search capability', () => {
+			expect(plugin.capabilities).toEqual(['search']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_PERPLEXITY_API_KEY');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
+			expect(PerplexityCtorMock).not.toHaveBeenCalled();
+		});
+
+		it('maps SDK results to SearchResult shape with derived hostname source', async () => {
+			searchCreateMock.mockResolvedValueOnce({
+				results: [
+					{
+						title: 'Example',
+						url: 'https://www.example.com/page',
+						snippet: 'Example snippet'
+					}
+				]
+			});
+			const r = await plugin.search(opts());
+
+			expect(PerplexityCtorMock).toHaveBeenCalledWith({ apiKey: 'k' });
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://www.example.com/page',
+				snippet: 'Example snippet',
+				position: 1,
+				source: 'www.example.com'
+			});
+			expect(r.totalResults).toBe(1);
+			expect(r.hasMore).toBe(false);
+		});
+
+		it('handles malformed result URLs without throwing', async () => {
+			searchCreateMock.mockResolvedValueOnce({
+				results: [{ title: 't', url: 'not-a-url', snippet: 's' }]
+			});
+			const r = await plugin.search(opts());
+			expect(r.results[0].source).toBeUndefined();
+		});
+
+		it('forwards limit as max_results', async () => {
+			searchCreateMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ limit: 7 }));
+			expect(searchCreateMock).toHaveBeenCalledWith(expect.objectContaining({ query: 'hello', max_results: 7 }));
+		});
+
+		it('uses search_domain_filter for includeDomains', async () => {
+			searchCreateMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ includeDomains: ['a.com', 'b.com'] }));
+			expect(searchCreateMock.mock.calls[0][0]).toMatchObject({
+				search_domain_filter: ['a.com', 'b.com']
+			});
+		});
+
+		it('uses negated search_domain_filter for excludeDomains when no include is set', async () => {
+			searchCreateMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ excludeDomains: ['c.com'] }));
+			expect(searchCreateMock.mock.calls[0][0]).toMatchObject({
+				search_domain_filter: ['-c.com']
+			});
+		});
+
+		it('forwards search_recency_filter for timeRange', async () => {
+			searchCreateMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ timeRange: 'week' }));
+			expect(searchCreateMock.mock.calls[0][0]).toMatchObject({ search_recency_filter: 'week' });
+		});
+
+		it('omits search_recency_filter for timeRange "all"', async () => {
+			searchCreateMock.mockResolvedValueOnce({ results: [] });
+			await plugin.search(opts({ timeRange: 'all' }));
+			expect(searchCreateMock.mock.calls[0][0].search_recency_filter).toBeUndefined();
+		});
+
+		it('logs and rethrows on SDK failure', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchCreateMock.mockRejectedValueOnce(new Error('boom'));
+			await expect(plugin.search(opts())).rejects.toThrow(/boom/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+		});
+
+		it('returns success when SDK search works', async () => {
+			searchCreateMock.mockResolvedValueOnce({ results: [] });
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure when SDK rejects', async () => {
+			searchCreateMock.mockRejectedValueOnce(new Error('bad key'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/bad key/);
+		});
+	});
+
+	describe('getRateLimitInfo', () => {
+		it('returns minute-period sentinel values', async () => {
+			const info = await plugin.getRateLimitInfo();
+			expect(info.period).toBe('minute');
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Perplexity Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('perplexity');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/serpapi/src/__tests__/serpapi.plugin.spec.ts
+++ b/packages/plugins/serpapi/src/__tests__/serpapi.plugin.spec.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SerpApiSearchPlugin } from '../serpapi.plugin.js';
+import type { PluginContext, SearchOptions } from '@ever-works/plugin';
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'serpapi',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+const okResponse = (body: unknown): Response =>
+	({
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body))
+	}) as unknown as Response;
+
+const errResponse = (status: number, body = 'error'): Response =>
+	({
+		ok: false,
+		status,
+		json: () => Promise.resolve({ error: body }),
+		text: () => Promise.resolve(body)
+	}) as unknown as Response;
+
+describe('SerpApiSearchPlugin', () => {
+	let plugin: SerpApiSearchPlugin;
+	let fetchMock: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		plugin = new SerpApiSearchPlugin();
+		fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.clearAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('serpapi');
+			expect(plugin.name).toBe('SerpAPI');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('SerpAPI');
+		});
+
+		it('declares only the search capability', () => {
+			expect(plugin.capabilities).toEqual(['search']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_SERPAPI_API_KEY');
+		});
+
+		it('exposes engine enum and maxResults bounds', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.engine.enum).toEqual(['google', 'bing', 'yahoo', 'duckduckgo', 'baidu', 'yandex']);
+			expect(props.engine.default).toBe('google');
+			expect(props.maxResults.default).toBe(10);
+			expect(props.maxResults.minimum).toBe(1);
+			expect(props.maxResults.maximum).toBe(100);
+		});
+	});
+
+	const samplePayload = {
+		organic_results: [
+			{
+				title: 'Example',
+				link: 'https://example.com',
+				snippet: 'Example snippet',
+				displayed_link: 'example.com',
+				favicon: 'https://example.com/favicon.ico',
+				source: 'example.com',
+				position: 1,
+				date: '2026-01-01'
+			}
+		],
+		related_searches: [{ query: 'related one' }],
+		serpapi_pagination: { next: 'https://serpapi.com/...' }
+	};
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns mapped results, related searches, and pagination', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse(samplePayload));
+			const r = await plugin.search(opts({ limit: 5 }));
+
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://example.com',
+				snippet: 'Example snippet',
+				displayUrl: 'example.com',
+				faviconUrl: 'https://example.com/favicon.ico',
+				source: 'example.com',
+				position: 1,
+				publishedDate: '2026-01-01'
+			});
+			expect(r.relatedSearches).toEqual(['related one']);
+			expect(r.hasMore).toBe(true);
+			expect(r.nextPage).toBe(2);
+
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('engine')).toBe('google');
+			expect(url.searchParams.get('q')).toBe('hello');
+			expect(url.searchParams.get('api_key')).toBe('k');
+			expect(url.searchParams.get('num')).toBe('5');
+		});
+
+		it('uses configured engine and maxResults from settings', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ organic_results: [] }));
+			await plugin.search(opts({ settings: { apiKey: 'k', engine: 'bing', maxResults: 25 } }));
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('engine')).toBe('bing');
+			expect(url.searchParams.get('num')).toBe('25');
+		});
+
+		it('builds site: and filetype: prefixes into the query', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ organic_results: [] }));
+			await plugin.search(opts({ site: 'example.com', fileType: 'pdf' }));
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('q')).toBe('filetype:pdf site:example.com hello');
+		});
+
+		it('encodes pagination via start parameter', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ organic_results: [] }));
+			await plugin.search(opts({ limit: 10, page: 4 }));
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('start')).toBe('30');
+		});
+
+		it('forwards region (gl), language (hl), and safe-search mapping', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ organic_results: [] }));
+			await plugin.search(
+				opts({
+					region: 'us',
+					language: 'en',
+					safeSearch: 'strict'
+				})
+			);
+			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			expect(url.searchParams.get('gl')).toBe('us');
+			expect(url.searchParams.get('hl')).toBe('en');
+			expect(url.searchParams.get('safe')).toBe('active');
+		});
+
+		it('throws and logs when the upstream returns non-OK', async () => {
+			await plugin.onLoad(buildContext());
+			fetchMock.mockResolvedValueOnce(errResponse(500, 'oops'));
+			await expect(plugin.search(opts())).rejects.toThrow(/SerpAPI request failed \(500\)/);
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns success on a 200 response', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ organic_results: [] }));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure on a non-OK response', async () => {
+			fetchMock.mockResolvedValueOnce(errResponse(401, 'unauthorized'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/401/);
+		});
+
+		it('returns failure when fetch throws', async () => {
+			fetchMock.mockRejectedValueOnce(new Error('boom'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/boom/);
+		});
+	});
+
+	describe('getRateLimitInfo', () => {
+		it('returns sentinel values', async () => {
+			const info = await plugin.getRateLimitInfo();
+			expect(info.remaining).toBe(-1);
+			expect(info.limit).toBe(-1);
+			expect(info.period).toBe('month');
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('SerpAPI Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('serpapi');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Second batch of zero-coverage search plugins, building on [#471](https://github.com/ever-works/ever-works/pull/471). Adds **102 new tests**.

| Plugin | Tests | Style | Capabilities |
| ------ | ----- | ----- | ------------ |
| `exa` | 30 | SDK mock (`exa-js`) | `search`, `content-extractor` |
| `perplexity` | 22 | SDK mock (`@perplexity-ai/perplexity_ai`) | `search` |
| `serpapi` | 22 | fetch mock | `search` |
| `firecrawl` | 28 | SDK mock (`@mendable/firecrawl-js`) | `search`, `content-extractor` |

Same coverage shape as #471. Combined with that PR, this initiative has now landed **209 new plugin tests** across 8 previously-zero-coverage plugins.

Remaining zero-coverage plugins (tracked in `COVERAGE-TRACKER.md`): `jina`, `scrapfly`, `brightdata`, `comparison-generator`, `github`, `local-content-extractor`.

## Test plan

- [x] `pnpm --filter @ever-works/exa-plugin test` — 30/30 passing
- [x] `pnpm --filter @ever-works/perplexity-plugin test` — 22/22 passing
- [x] `pnpm --filter @ever-works/serpapi-plugin test` — 22/22 passing
- [x] `pnpm --filter @ever-works/firecrawl-plugin test` — 28/28 passing
- [x] Local prettier check clean on all changed files
- [ ] CI runs full monorepo build/test on develop merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test coverage added for search plugins (Exa, Firecrawl, Perplexity, SerpAPI), verifying plugin metadata, settings schemas, search behavior, result mapping, extraction functionality, connection validation, and error handling.

* **Documentation**
  * Updated coverage tracking to reflect completed unit test work for zero-coverage search plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->