### PR TITLE
test(plugins): unit tests for jina, comparison-generator, brightdata, scrapfly (91 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -35,10 +35,11 @@
 
 ## Done
 
-| Date       | Area                              | PR                                                        | Notes                                                                                                                                                                                                              |
-| ---------- | --------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 2026-05-07 | Search plugins zero-coverage      | [#471](https://github.com/ever-works/ever-works/pull/471) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest. |
-| 2026-05-07 | Search plugins zero-coverage (b2) | (this PR)                                                 | exa (30 tests), perplexity (22), serpapi (22), firecrawl (28) — 102 new unit tests; same coverage shape as batch 1.                                                                                                |
+| Date       | Area                              | PR                                                        | Notes                                                                                                                                                                                                               |
+| ---------- | --------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-07 | Search plugins zero-coverage      | [#471](https://github.com/ever-works/ever-works/pull/471) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest.  |
+| 2026-05-07 | Search plugins zero-coverage (b2) | [#472](https://github.com/ever-works/ever-works/pull/472) | exa (30 tests), perplexity (22), serpapi (22), firecrawl (28) — 102 new unit tests; same coverage shape as batch 1.                                                                                                 |
+| 2026-05-07 | Plugin coverage (b3)              | (this PR)                                                 | jina (25 tests), comparison-generator (12), brightdata (28), scrapfly (26) — 91 new unit tests; covers remaining zero-coverage search plugins plus utility (comparison-generator) and content-extractor (scrapfly). |
 
 ## Pending — High Priority
 
@@ -58,13 +59,13 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 - [x] `perplexity` (SDK `@perplexity-ai/perplexity_ai`, search) — 22 tests, 2026-05-07
 - [x] `serpapi` (fetch-based, search) — 22 tests, 2026-05-07
 - [x] `firecrawl` (SDK `@mendable/firecrawl-js`, search + content-extractor) — 28 tests, 2026-05-07
-- [ ] `jina` (TBD)
-- [ ] `scrapfly` (search + content-extractor + screenshot)
-- [ ] `brightdata` (TBD)
+- [x] `jina` (fetch-based, search + content-extractor) — 25 tests, 2026-05-07
+- [x] `scrapfly` (SDK `scrapfly-sdk`, content-extractor + screenshot) — 26 tests, 2026-05-07
+- [x] `brightdata` (SDK `@brightdata/sdk`, search + content-extractor) — 28 tests, 2026-05-07
 
 ### Other zero-coverage plugins
 
-- [ ] `comparison-generator` (utility category)
+- [x] `comparison-generator` (utility category) — 12 tests, 2026-05-07
 - [ ] `github` (git-provider + OAuth)
 - [ ] `local-content-extractor` (content-extractor — default)
 

--- a/packages/plugins/brightdata/src/__tests__/brightdata.plugin.spec.ts
+++ b/packages/plugins/brightdata/src/__tests__/brightdata.plugin.spec.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const { searchMock, scrapeMock, BdClientCtorMock } = vi.hoisted(() => {
+	const search = vi.fn();
+	const scrape = vi.fn();
+	const ctor = vi.fn().mockImplementation(() => ({ search, scrape }));
+	return { searchMock: search, scrapeMock: scrape, BdClientCtorMock: ctor };
+});
+
+vi.mock('@brightdata/sdk', () => ({
+	bdclient: BdClientCtorMock
+}));
+
+const { BrightDataPlugin } = await import('../brightdata.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'brightdata',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('BrightDataPlugin', () => {
+	let plugin: BrightDataPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new BrightDataPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('brightdata');
+			expect(plugin.name).toBe('Bright Data');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('search');
+			expect(plugin.providerName).toBe('Bright Data');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_BRIGHTDATA_API_KEY');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('throws when apiKey is missing', async () => {
+			await expect(plugin.search({ query: 'hello', settings: {} })).rejects.toThrow(/API key not configured/i);
+			expect(BdClientCtorMock).not.toHaveBeenCalled();
+		});
+
+		it('parses parsed.organic[] and maps results', async () => {
+			searchMock.mockResolvedValueOnce({
+				body: JSON.stringify({
+					organic: [
+						{
+							title: 'Example',
+							url: 'https://www.example.com/post',
+							description: 'snippet'
+						}
+					]
+				})
+			});
+			const r = await plugin.search(opts());
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://www.example.com/post',
+				snippet: 'snippet',
+				position: 1,
+				source: 'www.example.com'
+			});
+		});
+
+		it('falls back to parsed.results then top-level array', async () => {
+			searchMock.mockResolvedValueOnce({
+				body: JSON.stringify({
+					results: [{ title: 'A', link: 'https://a', snippet: 's' }]
+				})
+			});
+			let r = await plugin.search(opts());
+			expect(r.results[0]).toMatchObject({ title: 'A', url: 'https://a', snippet: 's' });
+
+			searchMock.mockResolvedValueOnce({
+				body: JSON.stringify([{ title: 'B', url: 'https://b', description: 's2' }])
+			});
+			r = await plugin.search(opts());
+			expect(r.results[0]).toMatchObject({ title: 'B', url: 'https://b', snippet: 's2' });
+		});
+
+		it('warns and returns empty results when body is non-JSON', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchMock.mockResolvedValueOnce({ body: 'not-json' });
+			const r = await plugin.search(opts());
+			expect(r.results).toEqual([]);
+			expect(ctx.logger.warn).toHaveBeenCalledWith('Bright Data search returned non-JSON body');
+		});
+
+		it('appends site: filters from includeDomains and -site: from excludeDomains', async () => {
+			searchMock.mockResolvedValueOnce({ body: JSON.stringify({ organic: [] }) });
+			await plugin.search(opts({ includeDomains: ['a.com', 'b.com'], excludeDomains: ['c.com'] }));
+			expect(searchMock.mock.calls[0][0]).toBe('hello (site:a.com OR site:b.com) -site:c.com');
+		});
+
+		it('forwards country code from region', async () => {
+			searchMock.mockResolvedValueOnce({ body: JSON.stringify({ organic: [] }) });
+			await plugin.search(opts({ region: 'US' }));
+			expect(searchMock.mock.calls[0][1]).toMatchObject({ country: 'US', format: 'json' });
+		});
+
+		it('caps the result count at the requested limit (default 20)', async () => {
+			const longList = Array.from({ length: 50 }, (_, i) => ({
+				title: `t${i}`,
+				url: `https://x/${i}`
+			}));
+			searchMock.mockResolvedValueOnce({ body: JSON.stringify({ organic: longList }) });
+			let r = await plugin.search(opts());
+			expect(r.results).toHaveLength(20);
+
+			searchMock.mockResolvedValueOnce({ body: JSON.stringify({ organic: longList }) });
+			r = await plugin.search(opts({ limit: 5 }));
+			expect(r.results).toHaveLength(5);
+		});
+
+		it('logs and rethrows on SDK failure', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			searchMock.mockRejectedValueOnce(new Error('boom'));
+			await expect(plugin.search(opts())).rejects.toThrow(/boom/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+		});
+
+		it('returns success when SDK search works', async () => {
+			searchMock.mockResolvedValueOnce({ body: JSON.stringify({ organic: [] }) });
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			searchMock.mockRejectedValueOnce(new Error('bad key'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/bad key/);
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with markdown, wordCount, readingTime', async () => {
+			scrapeMock.mockResolvedValueOnce('one two three four five six');
+			const r = await plugin.extract(opts());
+			expect(scrapeMock).toHaveBeenCalledWith('https://example.com/post', { dataFormat: 'markdown' });
+			expect(r.success).toBe(true);
+			expect(r.markdown).toBe('one two three four five six');
+			expect(r.wordCount).toBe(6);
+			expect(r.readingTime).toBe(1);
+		});
+
+		it('returns failure when scrape returns empty', async () => {
+			scrapeMock.mockResolvedValueOnce('');
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content/);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			scrapeMock.mockRejectedValueOnce(new Error('extract failed'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/extract failed/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('maps batch responses by index, handling Error entries', async () => {
+			const err = new Error('per-url failure');
+			scrapeMock.mockResolvedValueOnce(['one two', err, 'three four five']);
+			const r = await plugin.extractBatch(['https://a', 'https://b', 'https://c'], {
+				settings: { apiKey: 'k' }
+			});
+			expect(r).toHaveLength(3);
+			expect(r[0]).toMatchObject({ success: true, url: 'https://a', wordCount: 2 });
+			expect(r[1]).toMatchObject({ success: false, url: 'https://b', error: 'per-url failure' });
+			expect(r[2]).toMatchObject({ success: true, url: 'https://c', wordCount: 3 });
+		});
+
+		it('returns per-URL failures when batch call throws', async () => {
+			scrapeMock.mockRejectedValueOnce(new Error('batch failed'));
+			const r = await plugin.extractBatch(['https://a', 'https://b'], { settings: { apiKey: 'k' } });
+			expect(r.every((x) => x.success === false)).toBe(true);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+
+		it('exposes text + html + markdown formats', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text', 'html', 'markdown']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Bright Data Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('brightdata');
+			expect(m.category).toBe('search');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/comparison-generator/src/__tests__/comparison-generator.plugin.spec.ts
+++ b/packages/plugins/comparison-generator/src/__tests__/comparison-generator.plugin.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ComparisonGeneratorPlugin } from '../comparison-generator.plugin.js';
+import type { PluginContext } from '@ever-works/plugin';
+
+const buildContext = (): PluginContext =>
+	({
+		pluginId: 'comparison-generator',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue({})
+	}) as unknown as PluginContext;
+
+describe('ComparisonGeneratorPlugin', () => {
+	let plugin: ComparisonGeneratorPlugin;
+
+	beforeEach(() => {
+		plugin = new ComparisonGeneratorPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('comparison-generator');
+			expect(plugin.name).toBe('Comparison Generator');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('utility');
+		});
+
+		it('declares no operational capabilities (utility plugin)', () => {
+			expect(plugin.capabilities).toEqual([]);
+		});
+
+		it('uses hybrid configuration mode', () => {
+			expect(plugin.configurationMode).toBe('hybrid');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('exposes cadence_override enum with sensible default', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.cadence_override.enum).toEqual(['use_work', 'daily', 'weekly', 'monthly']);
+			expect(props.cadence_override.default).toBe('use_work');
+		});
+
+		it('exposes max_comparisons_mode and conditional max_comparisons bounds', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.max_comparisons_mode.enum).toEqual(['custom', 'unlimited']);
+			expect(props.max_comparisons_mode.default).toBe('custom');
+			expect(props.max_comparisons.default).toBe(50);
+			expect(props.max_comparisons.minimum).toBe(1);
+			expect(props.max_comparisons.maximum).toBe(500);
+			expect(props.max_comparisons['x-showIf']).toEqual({
+				field: 'max_comparisons_mode',
+				value: 'custom'
+			});
+		});
+
+		it('exposes min_items_for_comparison bounds', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.min_items_for_comparison.default).toBe(3);
+			expect(props.min_items_for_comparison.minimum).toBe(2);
+			expect(props.min_items_for_comparison.maximum).toBe(20);
+		});
+
+		it('marks AI overrides and custom_prompt + extended_analysis as hidden', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.ai_provider['x-hidden']).toBe(true);
+			expect(props.ai_model['x-hidden']).toBe(true);
+			expect(props.custom_prompt['x-hidden']).toBe(true);
+			expect(props.extended_analysis['x-hidden']).toBe(true);
+			expect(props.extended_analysis.default).toBe(false);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Comparison Generator plugin loaded');
+		});
+
+		it('clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			await expect(plugin.onUnload()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('healthCheck', () => {
+		it('reports healthy with a checkedAt timestamp', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+			expect(h.message).toMatch(/ready/i);
+			expect(typeof h.checkedAt).toBe('number');
+		});
+	});
+
+	describe('manifest', () => {
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('comparison-generator');
+			expect(m.category).toBe('utility');
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(true);
+			expect(m.autoEnable).toBe(false);
+			expect(m.visibility).toBe('public');
+		});
+
+		it('includes a non-empty readme', () => {
+			const m = plugin.getManifest();
+			expect(typeof m.readme).toBe('string');
+			expect((m.readme as string).length).toBeGreaterThan(100);
+		});
+	});
+});

--- a/packages/plugins/jina/src/__tests__/jina.plugin.spec.ts
+++ b/packages/plugins/jina/src/__tests__/jina.plugin.spec.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JinaReaderPlugin } from '../jina.plugin.js';
+import type { PluginContext, SearchOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'jina',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+const okResponse = (body: unknown): Response =>
+	({
+		ok: true,
+		status: 200,
+		statusText: 'OK',
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body))
+	}) as unknown as Response;
+
+const errResponse = (status: number, statusText = 'error'): Response =>
+	({
+		ok: false,
+		status,
+		statusText,
+		json: () => Promise.resolve({}),
+		text: () => Promise.resolve(statusText)
+	}) as unknown as Response;
+
+describe('JinaReaderPlugin', () => {
+	let plugin: JinaReaderPlugin;
+	let fetchMock: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		plugin = new JinaReaderPlugin();
+		fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.clearAllMocks();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('jina');
+			expect(plugin.name).toBe('Jina AI');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('content-extractor');
+			expect(plugin.providerName).toBe('Jina');
+		});
+
+		it('declares both search and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['search', 'content-extractor']);
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_JINA_API_KEY');
+		});
+	});
+
+	describe('search', () => {
+		const opts = (overrides: Partial<SearchOptions> = {}): SearchOptions => ({
+			query: 'hello',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns mapped results with derived hostname source', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okResponse({
+					data: [
+						{
+							title: 'Example',
+							url: 'https://www.example.com/post',
+							description: 'snippet here',
+							date: '2026-01-01'
+						}
+					]
+				})
+			);
+
+			const r = await plugin.search(opts({ limit: 5, region: 'us', language: 'en' }));
+
+			expect(r.results).toHaveLength(1);
+			expect(r.results[0]).toMatchObject({
+				title: 'Example',
+				url: 'https://www.example.com/post',
+				snippet: 'snippet here',
+				position: 1,
+				publishedDate: '2026-01-01',
+				source: 'www.example.com'
+			});
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://s.jina.ai/');
+			expect(init.method).toBe('POST');
+			expect((init.headers as Record<string, string>).Authorization).toBe('Bearer k');
+			const body = JSON.parse(init.body as string);
+			expect(body.q).toBe('hello');
+			expect(body.num).toBe(5);
+			expect(body.gl).toBe('us');
+			expect(body.hl).toBe('en');
+		});
+
+		it('forwards X-Site header for the first includeDomain', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ data: [] }));
+			await plugin.search(opts({ includeDomains: ['a.com', 'b.com'] }));
+			const init = fetchMock.mock.calls[0][1] as RequestInit;
+			expect((init.headers as Record<string, string>)['X-Site']).toBe('a.com');
+		});
+
+		it('handles missing data array safely', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({}));
+			const r = await plugin.search(opts());
+			expect(r.results).toEqual([]);
+			expect(r.totalResults).toBe(0);
+		});
+
+		it('throws and logs on non-OK upstream', async () => {
+			await plugin.onLoad(buildContext());
+			fetchMock.mockResolvedValueOnce(errResponse(503, 'Service Unavailable'));
+			await expect(plugin.search(opts())).rejects.toThrow(/Jina Search API returned 503/);
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns success on a 200 response', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ data: [] }));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+		});
+
+		it('returns failure on a non-OK response', async () => {
+			fetchMock.mockResolvedValueOnce(errResponse(401, 'Unauthorized'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/401/);
+		});
+
+		it('returns failure when fetch throws', async () => {
+			fetchMock.mockRejectedValueOnce(new Error('boom'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/boom/);
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('returns success with title, content, images, links, metadata, wordCount, readingTime', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okResponse({
+					data: {
+						title: 'Title',
+						url: 'https://example.com/post',
+						content: 'one two three four five',
+						description: 'desc',
+						publishedTime: '2026-01-01',
+						images: { 'alt one': 'https://img/1.png' },
+						links: { 'link one': 'https://target.example' },
+						metadata: { lang: 'en' }
+					}
+				})
+			);
+
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(r.title).toBe('Title');
+			expect(r.markdown).toBe('one two three four five');
+			expect(r.wordCount).toBe(5);
+			expect(r.readingTime).toBe(1);
+			expect(r.images).toHaveLength(1);
+			expect(r.images?.[0]).toMatchObject({ src: 'https://img/1.png', alt: 'alt one' });
+			expect(r.links?.[0]).toMatchObject({ href: 'https://target.example', text: 'link one' });
+			expect(r.metadata).toMatchObject({
+				description: 'desc',
+				publishedDate: '2026-01-01',
+				language: 'en'
+			});
+		});
+
+		it('exposes finalUrl when SDK returns a different URL', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okResponse({
+					data: {
+						title: 't',
+						url: 'https://example.com/redirected',
+						content: 'hi'
+					}
+				})
+			);
+			const r = await plugin.extract(opts());
+			expect(r.finalUrl).toBe('https://example.com/redirected');
+		});
+
+		it('returns failure when content is missing', async () => {
+			fetchMock.mockResolvedValueOnce(okResponse({ data: { title: 't', url: 'u' } }));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content/);
+		});
+
+		it('returns failure when upstream returns non-OK', async () => {
+			fetchMock.mockResolvedValueOnce(errResponse(429, 'Too Many Requests'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/429/);
+		});
+
+		it('omits images when includeImages is false', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okResponse({
+					data: {
+						title: 't',
+						url: 'u',
+						content: 'hi',
+						images: { foo: 'https://i' }
+					}
+				})
+			);
+			const r = await plugin.extract(opts({ includeImages: false }));
+			expect(r.images).toBeUndefined();
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('chunks URLs into batches of 5', async () => {
+			const urls = Array.from({ length: 7 }, (_, i) => `https://example.com/${i}`);
+			for (const u of urls) {
+				fetchMock.mockResolvedValueOnce(okResponse({ data: { title: 't', url: u, content: 'a b' } }));
+			}
+			const r = await plugin.extractBatch(urls, { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(7);
+			expect(r.every((x) => x.success === true)).toBe(true);
+			expect(fetchMock).toHaveBeenCalledTimes(7);
+		});
+	});
+
+	describe('canExtract / getSupportedFormats', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+
+		it('exposes text + markdown formats', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text', 'markdown']);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Jina AI Reader Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('jina');
+			expect(m.category).toBe('content-extractor');
+			expect(m.capabilities).toEqual(['search', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/scrapfly/src/__tests__/scrapfly.plugin.spec.ts
+++ b/packages/plugins/scrapfly/src/__tests__/scrapfly.plugin.spec.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PluginContext, ScreenshotOptions, ContentExtractionOptions } from '@ever-works/plugin';
+
+const { scrapeMock, ClientCtorMock, ScrapeConfigCtorMock } = vi.hoisted(() => {
+	const scrape = vi.fn();
+	const client = vi.fn().mockImplementation(() => ({ scrape }));
+	const scrapeConfig = vi.fn().mockImplementation((cfg: unknown) => ({ __cfg: cfg }));
+	return { scrapeMock: scrape, ClientCtorMock: client, ScrapeConfigCtorMock: scrapeConfig };
+});
+
+vi.mock('scrapfly-sdk', () => ({
+	ScrapflyClient: ClientCtorMock,
+	ScrapeConfig: ScrapeConfigCtorMock
+}));
+
+const { ScrapflyPlugin } = await import('../scrapfly.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'scrapfly',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+describe('ScrapflyPlugin', () => {
+	let plugin: ScrapflyPlugin;
+	let fetchMock: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new ScrapflyPlugin();
+		fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('scrapfly');
+			expect(plugin.name).toBe('Scrapfly');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('content-extractor');
+			expect(plugin.providerName).toBe('Scrapfly');
+		});
+
+		it('declares screenshot and content-extractor capabilities', () => {
+			expect(plugin.capabilities).toEqual(['screenshot', 'content-extractor']);
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('requires apiKey and marks it as user-scoped secret', () => {
+			expect(plugin.settingsSchema.required).toContain('apiKey');
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('PLUGIN_SCRAPFLY_API_KEY');
+		});
+	});
+
+	describe('capture (screenshot)', () => {
+		const opts = (overrides: Partial<ScreenshotOptions> = {}): ScreenshotOptions => ({
+			url: 'https://example.com',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('rejects when apiKey is missing (getApiKey runs before try/catch)', async () => {
+			await expect(plugin.capture({ url: 'https://example.com', settings: {} })).rejects.toThrow(
+				/API key not configured/i
+			);
+			expect(ClientCtorMock).not.toHaveBeenCalled();
+		});
+
+		it('returns success with imageUrl, dimensions, and fileSize', async () => {
+			scrapeMock.mockResolvedValueOnce({
+				result: {
+					screenshots: {
+						main: { url: 'https://shot.example/main.png', size: 1234 }
+					}
+				}
+			});
+			const r = await plugin.capture(opts({ viewportWidth: 1920, viewportHeight: 1080 }));
+			expect(ClientCtorMock).toHaveBeenCalledWith({ key: 'k' });
+			expect(r).toMatchObject({
+				success: true,
+				imageUrl: 'https://shot.example/main.png',
+				width: 1920,
+				height: 1080,
+				fileSize: 1234
+			});
+		});
+
+		it('returns failure when no screenshot data is returned', async () => {
+			scrapeMock.mockResolvedValueOnce({ result: { screenshots: {} } });
+			const r = await plugin.capture(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No screenshot data/);
+		});
+
+		it('returns failure and logs when SDK throws', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			scrapeMock.mockRejectedValueOnce(new Error('shot failed'));
+			const r = await plugin.capture(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/shot failed/);
+			expect(ctx.logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe('getScreenshotUrl', () => {
+		it('returns the imageUrl from a successful capture', async () => {
+			scrapeMock.mockResolvedValueOnce({
+				result: { screenshots: { main: { url: 'https://shot.example/main.png' } } }
+			});
+			const url = await plugin.getScreenshotUrl({
+				url: 'https://example.com',
+				settings: { apiKey: 'k' }
+			});
+			expect(url).toBe('https://shot.example/main.png');
+		});
+
+		it('returns null when capture fails', async () => {
+			scrapeMock.mockResolvedValueOnce({ result: { screenshots: {} } });
+			const url = await plugin.getScreenshotUrl({
+				url: 'https://example.com',
+				settings: { apiKey: 'k' }
+			});
+			expect(url).toBeNull();
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false without context', async () => {
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+
+		it('reflects whether settings has an apiKey', async () => {
+			await plugin.onLoad(buildContext({ apiKey: 'k' }));
+			expect(await plugin.isAvailable()).toBe(true);
+
+			await plugin.onLoad(buildContext({}));
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('fails fast without apiKey', async () => {
+			const r = await plugin.validateConnection({});
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/not configured/i);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('returns success on a 200 response', async () => {
+			fetchMock.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' } as Response);
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(true);
+			const url = fetchMock.mock.calls[0][0] as string;
+			expect(url).toContain('https://api.scrapfly.io/account?key=k');
+		});
+
+		it('returns failure on a non-OK response', async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 401,
+				statusText: 'Unauthorized'
+			} as Response);
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/401/);
+		});
+
+		it('returns failure when fetch throws', async () => {
+			fetchMock.mockRejectedValueOnce(new Error('boom'));
+			const r = await plugin.validateConnection({ apiKey: 'k' });
+			expect(r.success).toBe(false);
+			expect(r.message).toMatch(/boom/);
+		});
+	});
+
+	describe('getMaxDimensions', () => {
+		it('returns 4K dimensions', () => {
+			const d = plugin.getMaxDimensions();
+			expect(d).toEqual({ width: 3840, height: 2160 });
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			settings: { apiKey: 'k' },
+			...overrides
+		});
+
+		it('rejects when apiKey is missing (getApiKey runs before try/catch)', async () => {
+			await expect(plugin.extract({ url: 'https://example.com', settings: {} })).rejects.toThrow(
+				/API key not configured/i
+			);
+		});
+
+		it('returns success with markdown, wordCount, readingTime', async () => {
+			scrapeMock.mockResolvedValueOnce({ result: { content: 'one two three four' } });
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(r.markdown).toBe('one two three four');
+			expect(r.wordCount).toBe(4);
+			expect(r.readingTime).toBe(1);
+		});
+
+		it('returns failure when content is empty', async () => {
+			scrapeMock.mockResolvedValueOnce({ result: { content: '' } });
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/No content/);
+		});
+
+		it('returns failure when SDK throws', async () => {
+			scrapeMock.mockRejectedValueOnce(new Error('extract failed'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/extract failed/);
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('chunks URLs into batches of 5', async () => {
+			const urls = Array.from({ length: 6 }, (_, i) => `https://example.com/${i}`);
+			for (let i = 0; i < urls.length; i++) {
+				scrapeMock.mockResolvedValueOnce({ result: { content: 'a b' } });
+			}
+			const r = await plugin.extractBatch(urls, { settings: { apiKey: 'k' } });
+			expect(r).toHaveLength(6);
+			expect(r.every((x) => x.success === true)).toBe(true);
+			expect(scrapeMock).toHaveBeenCalledTimes(6);
+		});
+	});
+
+	describe('canExtract', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Scrapfly Plugin loaded');
+			await plugin.onUnload();
+			expect(await plugin.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('scrapfly');
+			expect(m.category).toBe('content-extractor');
+			expect(m.capabilities).toEqual(['screenshot', 'content-extractor']);
+			expect(m.builtIn).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Third batch of zero-coverage plugin tests, building on [#471](https://github.com/ever-works/ever-works/pull/471) and [#472](https://github.com/ever-works/ever-works/pull/472). Adds **91 new tests** across 4 plugins.

| Plugin | Tests | Style | Capabilities |
| ------ | ----- | ----- | ------------ |
| `jina` | 25 | fetch mock | `search`, `content-extractor` |
| `comparison-generator` | 12 | none (utility, no external) | `utility` |
| `brightdata` | 28 | SDK mock (`@brightdata/sdk`) | `search`, `content-extractor` |
| `scrapfly` | 26 | SDK mock (`scrapfly-sdk`) | `screenshot`, `content-extractor` |

Combined with #471 and #472, this initiative has now landed **300 new plugin tests across 12 previously-zero-coverage plugins**.

The scrapfly suite additionally covers `capture()`, `getScreenshotUrl()`, and `getMaxDimensions()` since it implements `IScreenshotPlugin`.

Remaining zero-coverage plugins (high priority): `github`, `local-content-extractor`. Tracked in `COVERAGE-TRACKER.md`.

## Test plan

- [x] `pnpm --filter @ever-works/jina-plugin test` — 25/25 passing
- [x] `pnpm --filter @ever-works/comparison-generator-plugin test` — 12/12 passing
- [x] `pnpm --filter @ever-works/brightdata-plugin test` — 28/28 passing
- [x] `pnpm --filter @ever-works/scrapfly-plugin test` — 26/26 passing
- [x] Local prettier check clean on all changed files
- [ ] CI runs full monorepo build/test on develop merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Comprehensive test suites added for jina, brightdata, comparison-generator, and scrapfly plugins, covering plugin metadata, capabilities, configuration, search/extraction functionality, and error handling.

* **Documentation**
  * Test coverage tracker updated to reflect completion of plugin test coverage work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->