### PR TITLE
test(plugins): unit tests for local-content-extractor and github (40 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -39,7 +39,8 @@
 | ---------- | --------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-05-07 | Search plugins zero-coverage      | [#471](https://github.com/ever-works/ever-works/pull/471) | brave (25 tests), linkup (27), tavily (26), valyu (29) — 107 new unit tests; mock fetch / SDK; cover metadata, settings, search, extract (where applicable), validateConnection, lifecycle, healthCheck, manifest.  |
 | 2026-05-07 | Search plugins zero-coverage (b2) | [#472](https://github.com/ever-works/ever-works/pull/472) | exa (30 tests), perplexity (22), serpapi (22), firecrawl (28) — 102 new unit tests; same coverage shape as batch 1.                                                                                                 |
-| 2026-05-07 | Plugin coverage (b3)              | (this PR)                                                 | jina (25 tests), comparison-generator (12), brightdata (28), scrapfly (26) — 91 new unit tests; covers remaining zero-coverage search plugins plus utility (comparison-generator) and content-extractor (scrapfly). |
+| 2026-05-07 | Plugin coverage (b3)              | [#473](https://github.com/ever-works/ever-works/pull/473) | jina (25 tests), comparison-generator (12), brightdata (28), scrapfly (26) — 91 new unit tests; covers remaining zero-coverage search plugins plus utility (comparison-generator) and content-extractor (scrapfly). |
+| 2026-05-07 | Plugin coverage (b4)              | (this PR)                                                 | local-content-extractor (20 tests, axios mock), github (20 tests, fetch + libsodium mock for OAuth flow) — 40 new unit tests; closes the high-priority zero-coverage plugin list.                                   |
 
 ## Pending — High Priority
 
@@ -66,8 +67,8 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 ### Other zero-coverage plugins
 
 - [x] `comparison-generator` (utility category) — 12 tests, 2026-05-07
-- [ ] `github` (git-provider + OAuth)
-- [ ] `local-content-extractor` (content-extractor — default)
+- [x] `github` (git-provider + OAuth) — 20 tests, 2026-05-07
+- [x] `local-content-extractor` (content-extractor — default) — 20 tests, 2026-05-07
 
 ### Internal-package coverage
 

--- a/packages/plugins/github/src/__tests__/github.plugin.spec.ts
+++ b/packages/plugins/github/src/__tests__/github.plugin.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PluginContext } from '@ever-works/plugin';
+
+// libsodium-wrappers loads native modules that vitest cannot resolve under
+// Node ESM in the test runner. The plugin only uses it via the actions service
+// for secret encryption, which is exercised in integration tests, not here.
+vi.mock('libsodium-wrappers', () => ({
+	default: {
+		ready: Promise.resolve(),
+		from_base64: vi.fn(),
+		crypto_box_seal: vi.fn(),
+		to_base64: vi.fn()
+	}
+}));
+
+const { GitHubPlugin } = await import('../github.plugin.js');
+
+const buildContext = (settings: Record<string, unknown> = {}): PluginContext =>
+	({
+		pluginId: 'github',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue(settings)
+	}) as unknown as PluginContext;
+
+const okJsonResponse = (body: unknown): Response =>
+	({
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body))
+	}) as unknown as Response;
+
+describe('GitHubPlugin', () => {
+	let plugin: GitHubPlugin;
+
+	beforeEach(() => {
+		plugin = new GitHubPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('github');
+			expect(plugin.name).toBe('GitHub');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('git-provider');
+			expect(plugin.providerName).toBe('github');
+		});
+
+		it('declares git-provider and oauth capabilities', () => {
+			expect(plugin.capabilities).toEqual(['git-provider', 'oauth']);
+		});
+
+		it('uses admin-only configuration mode', () => {
+			expect(plugin.configurationMode).toBe('admin-only');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('exposes clientId, clientSecret, and apiBaseUrl', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.clientId['x-envVar']).toBe('PLUGIN_GITHUB_CLIENT_ID');
+			expect(props.clientId['x-adminOnly']).toBe(true);
+			expect(props.clientSecret['x-secret']).toBe(true);
+			expect(props.clientSecret['x-envVar']).toBe('PLUGIN_GITHUB_CLIENT_SECRET');
+			expect(props.apiBaseUrl.default).toBe('https://api.github.com');
+			expect(props.apiBaseUrl['x-hidden']).toBe(true);
+		});
+	});
+
+	describe('IGitProviderPlugin pure helpers', () => {
+		it('getAuth returns x-access-token + token tuple', () => {
+			const auth = plugin.getAuth('tok123');
+			expect(auth).toEqual({ username: 'x-access-token', password: 'tok123' });
+		});
+
+		it('getCloneUrl builds the canonical https clone URL', () => {
+			expect(plugin.getCloneUrl('octo', 'repo')).toBe('https://github.com/octo/repo.git');
+		});
+
+		it('getWebUrl builds the canonical web URL', () => {
+			expect(plugin.getWebUrl('octo', 'repo')).toBe('https://github.com/octo/repo');
+		});
+
+		it('getRawFileUrl delegates through to a github.com style URL', () => {
+			const url = plugin.getRawFileUrl('octo', 'repo', 'main', 'README.md');
+			expect(url).toContain('octo');
+			expect(url).toContain('repo');
+			expect(url).toContain('main');
+			expect(url).toContain('README.md');
+		});
+	});
+
+	describe('IOAuthPlugin — getAuthorizationUrl', () => {
+		it('throws when clientId is missing', () => {
+			expect(() => plugin.getAuthorizationUrl('state')).toThrow(/client ID not configured/i);
+		});
+
+		it('builds the canonical GitHub OAuth URL with state, scope, redirect', () => {
+			const url = plugin.getAuthorizationUrl('xyz', {
+				clientId: 'cid',
+				redirectUri: 'https://app/cb',
+				scopes: ['repo', 'user:email']
+			});
+			expect(url.startsWith('https://github.com/login/oauth/authorize?')).toBe(true);
+			const u = new URL(url);
+			expect(u.searchParams.get('client_id')).toBe('cid');
+			expect(u.searchParams.get('redirect_uri')).toBe('https://app/cb');
+			expect(u.searchParams.get('state')).toBe('xyz');
+			expect(u.searchParams.get('scope')).toBe('repo user:email');
+		});
+
+		it('appends prompt=consent when forceConsent is true', () => {
+			const url = plugin.getAuthorizationUrl('s', {
+				clientId: 'cid',
+				redirectUri: 'https://r',
+				scopes: ['repo'],
+				forceConsent: true
+			});
+			expect(new URL(url).searchParams.get('prompt')).toBe('consent');
+		});
+
+		it('falls back to GITHUB_SCOPES default when no scopes are passed', () => {
+			const url = plugin.getAuthorizationUrl('s', { clientId: 'cid', redirectUri: 'https://r' });
+			const scope = new URL(url).searchParams.get('scope');
+			expect(typeof scope).toBe('string');
+			expect((scope as string).length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('IOAuthPlugin — exchangeCodeForToken', () => {
+		const originalFetch = globalThis.fetch;
+		let fetchMock: ReturnType<typeof vi.fn>;
+
+		beforeEach(() => {
+			fetchMock = vi.fn();
+			globalThis.fetch = fetchMock as unknown as typeof fetch;
+		});
+
+		afterEach(() => {
+			globalThis.fetch = originalFetch;
+		});
+
+		it('throws when clientId or clientSecret is missing', async () => {
+			await expect(plugin.exchangeCodeForToken('code')).rejects.toThrow(/credentials not configured/i);
+			await expect(plugin.exchangeCodeForToken('code', { clientId: 'cid' })).rejects.toThrow(
+				/credentials not configured/i
+			);
+		});
+
+		it('exchanges code for an access token on success', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okJsonResponse({
+					access_token: 'tok',
+					token_type: 'bearer',
+					scope: 'repo,user:email',
+					refresh_token: 'rtok'
+				})
+			);
+			const t = await plugin.exchangeCodeForToken('code', {
+				clientId: 'cid',
+				clientSecret: 'csec',
+				redirectUri: 'https://r'
+			});
+			expect(t).toEqual({
+				accessToken: 'tok',
+				tokenType: 'bearer',
+				scope: 'repo,user:email',
+				refreshToken: 'rtok'
+			});
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://github.com/login/oauth/access_token');
+			const body = JSON.parse(init.body as string);
+			expect(body).toMatchObject({
+				client_id: 'cid',
+				client_secret: 'csec',
+				code: 'code',
+				redirect_uri: 'https://r'
+			});
+		});
+
+		it('throws when GitHub returns an error payload', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okJsonResponse({ error: 'bad_verification_code', error_description: 'Code invalid' })
+			);
+			await expect(plugin.exchangeCodeForToken('bad', { clientId: 'cid', clientSecret: 'csec' })).rejects.toThrow(
+				/Code invalid/
+			);
+		});
+
+		it('defaults tokenType to "bearer" when missing', async () => {
+			fetchMock.mockResolvedValueOnce(okJsonResponse({ access_token: 'tok' }));
+			const t = await plugin.exchangeCodeForToken('code', {
+				clientId: 'cid',
+				clientSecret: 'csec'
+			});
+			expect(t.tokenType).toBe('bearer');
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('GitHub Plugin loaded');
+			await plugin.onUnload();
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+			expect(h.checkedAt).toBeTypeOf('number');
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('github');
+			expect(m.category).toBe('git-provider');
+			expect(m.capabilities).toEqual(['git-provider', 'oauth']);
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(true);
+			expect(m.autoEnable).toBe(true);
+			expect(m.visibility).toBe('user-only');
+		});
+
+		it('exposes onboarding ui hints', () => {
+			const m = plugin.getManifest();
+			expect(m.uiHints?.includeInOnboarding).toBe(true);
+			expect(m.uiHints?.organizationSettings).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/local-content-extractor/src/__tests__/local-content-extractor.plugin.spec.ts
+++ b/packages/plugins/local-content-extractor/src/__tests__/local-content-extractor.plugin.spec.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, ContentExtractionOptions } from '@ever-works/plugin';
+
+const { axiosGetMock, axiosDefaultMock } = vi.hoisted(() => {
+	const get = vi.fn();
+	return { axiosGetMock: get, axiosDefaultMock: { get } };
+});
+
+vi.mock('axios', () => ({
+	default: axiosDefaultMock
+}));
+
+const { LocalContentExtractorPlugin } = await import('../local-content-extractor.plugin.js');
+
+const buildContext = (): PluginContext =>
+	({
+		pluginId: 'local-content-extractor',
+		logger: {
+			log: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn()
+		},
+		getSettings: vi.fn().mockResolvedValue({})
+	}) as unknown as PluginContext;
+
+const buildHtml = (body: string, head = ''): string =>
+	`<!DOCTYPE html><html lang="en"><head><title>Test Page</title>${head}</head><body>${body}</body></html>`;
+
+const articleHtml = buildHtml(
+	`<article>
+		<h1>The Title</h1>
+		<p>${'word '.repeat(120)}</p>
+		<img src="/img.png" alt="Sample">
+		<a href="https://external.example.com/page" rel="nofollow">External link</a>
+		<a href="/internal" title="Internal">Internal link</a>
+	</article>`,
+	`<meta name="description" content="An article description for testing.">
+	 <meta name="author" content="Alice">
+	 <meta property="og:title" content="OG Title">`
+);
+
+const okHtmlResponse = (html: string, finalUrl?: string) =>
+	({
+		data: html,
+		headers: { 'content-type': 'text/html; charset=utf-8' },
+		request: finalUrl ? { res: { responseUrl: finalUrl } } : undefined
+	}) as unknown;
+
+describe('LocalContentExtractorPlugin', () => {
+	let plugin: InstanceType<typeof LocalContentExtractorPlugin>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new LocalContentExtractorPlugin();
+	});
+
+	describe('metadata', () => {
+		it('exposes stable identity fields', () => {
+			expect(plugin.id).toBe('local-content-extractor');
+			expect(plugin.name).toBe('Local Content Processor');
+			expect(plugin.version).toBe('1.0.0');
+			expect(plugin.category).toBe('content-extractor');
+			expect(plugin.providerName).toBe('Local (Readability)');
+		});
+
+		it('declares only the content-extractor capability', () => {
+			expect(plugin.capabilities).toEqual(['content-extractor']);
+		});
+
+		it('flags itself as a system plugin', () => {
+			expect(plugin.systemPlugin).toBe(true);
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('exposes timeout, minContentLength, and userAgent with defaults and bounds', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.timeout.default).toBe(15000);
+			expect(props.timeout.minimum).toBe(1000);
+			expect(props.timeout.maximum).toBe(60000);
+			expect(props.minContentLength.default).toBe(200);
+			expect(typeof props.userAgent.default).toBe('string');
+			expect(props.timeout['x-hidden']).toBe(true);
+			expect(props.userAgent['x-hidden']).toBe(true);
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('always returns true (no API key needed)', async () => {
+			expect(await plugin.isAvailable()).toBe(true);
+		});
+	});
+
+	describe('canExtract', () => {
+		it('accepts http and https URLs', async () => {
+			expect(await plugin.canExtract('https://example.com')).toBe(true);
+			expect(await plugin.canExtract('http://example.com')).toBe(true);
+		});
+
+		it('rejects non-http schemes and invalid URLs', async () => {
+			expect(await plugin.canExtract('ftp://example.com')).toBe(false);
+			expect(await plugin.canExtract('garbage')).toBe(false);
+		});
+	});
+
+	describe('getSupportedFormats', () => {
+		it('exposes text + html + markdown', () => {
+			expect(plugin.getSupportedFormats()).toEqual(['text', 'html', 'markdown']);
+		});
+	});
+
+	describe('extract', () => {
+		const opts = (overrides: Partial<ContentExtractionOptions> = {}): ContentExtractionOptions => ({
+			url: 'https://example.com/post',
+			...overrides
+		});
+
+		it('returns success with content + metadata + word count for a typical article', async () => {
+			axiosGetMock.mockResolvedValueOnce(okHtmlResponse(articleHtml));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+			expect(typeof r.content).toBe('string');
+			expect((r.content as string).length).toBeGreaterThan(0);
+			expect(typeof r.markdown).toBe('string');
+			expect(r.wordCount).toBeGreaterThan(50);
+			expect(r.readingTime).toBeGreaterThanOrEqual(1);
+			expect(r.metadata?.description).toBe('An article description for testing.');
+		});
+
+		it('rejects non-supported content types early', async () => {
+			axiosGetMock.mockResolvedValueOnce({
+				data: 'PDF binary',
+				headers: { 'content-type': 'application/pdf' },
+				request: undefined
+			});
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/Unsupported content type: application\/pdf/);
+		});
+
+		it('falls back to meta description when Readability content is too short', async () => {
+			const html = buildHtml(
+				'<p>tiny</p>',
+				'<meta name="description" content="A reasonably long description with more than fifty characters of content here.">'
+			);
+			axiosGetMock.mockResolvedValueOnce(okHtmlResponse(html));
+			const r = await plugin.extract(opts({ settings: { minContentLength: 9999 } }));
+			expect(r.success).toBe(true);
+			expect(r.content).toMatch(/reasonably long description/);
+		});
+
+		it('exposes finalUrl when the response was redirected', async () => {
+			axiosGetMock.mockResolvedValueOnce(okHtmlResponse(articleHtml, 'https://example.com/redirected'));
+			const r = await plugin.extract(opts());
+			expect(r.finalUrl).toBe('https://example.com/redirected');
+		});
+
+		it('returns failure when axios throws (HTTP error)', async () => {
+			const err = Object.assign(new Error('Request failed'), {
+				response: { status: 404 },
+				message: 'Not Found'
+			});
+			axiosGetMock.mockRejectedValueOnce(err);
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/HTTP 404/);
+		});
+
+		it('returns failure when axios throws (network error)', async () => {
+			axiosGetMock.mockRejectedValueOnce(new Error('ENOTFOUND'));
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(false);
+			expect(r.error).toMatch(/ENOTFOUND/);
+		});
+
+		it('handles array Content-Type header gracefully', async () => {
+			axiosGetMock.mockResolvedValueOnce({
+				data: articleHtml,
+				headers: { 'content-type': ['text/html; charset=utf-8', 'extra'] },
+				request: undefined
+			});
+			const r = await plugin.extract(opts());
+			expect(r.success).toBe(true);
+		});
+
+		it('forwards configured timeout, userAgent, and headers', async () => {
+			axiosGetMock.mockResolvedValueOnce(okHtmlResponse(articleHtml));
+			await plugin.extract(opts({ settings: { timeout: 5000, userAgent: 'CustomAgent/1.0' } }));
+			const [, config] = axiosGetMock.mock.calls[0];
+			expect(config.timeout).toBe(5000);
+			expect(config.headers['User-Agent']).toBe('CustomAgent/1.0');
+		});
+	});
+
+	describe('extractBatch', () => {
+		it('runs each URL through extract and aggregates results', async () => {
+			axiosGetMock
+				.mockResolvedValueOnce(okHtmlResponse(articleHtml))
+				.mockResolvedValueOnce(okHtmlResponse(articleHtml));
+			const r = await plugin.extractBatch(['https://a.example', 'https://b.example']);
+			expect(r).toHaveLength(2);
+			expect(r.every((x) => x.success === true)).toBe(true);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('logs on load and clears context on unload without error', async () => {
+			const ctx = buildContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('Local Content Processor Plugin loaded');
+			await expect(plugin.onUnload()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('healthCheck + manifest', () => {
+		it('reports healthy', async () => {
+			const h = await plugin.healthCheck();
+			expect(h.status).toBe('healthy');
+			expect(h.message).toMatch(/ready/i);
+		});
+
+		it('returns a manifest aligned with plugin metadata', () => {
+			const m = plugin.getManifest();
+			expect(m.id).toBe('local-content-extractor');
+			expect(m.category).toBe('content-extractor');
+			expect(m.builtIn).toBe(true);
+			expect(m.systemPlugin).toBe(true);
+			expect(m.autoEnable).toBe(true);
+			expect(m.defaultForCapabilities).toContain('content-extractor');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fourth batch of zero-coverage plugin tests, closing the high-priority list. Adds **40 new tests** across 2 plugins:

| Plugin | Tests | Style | Capabilities |
| ------ | ----- | ----- | ------------ |
| `local-content-extractor` | 20 | axios mock | `content-extractor` (default) |
| `github` | 20 | fetch + libsodium-wrappers mock | `git-provider`, `oauth` |

Combined with #471, #472, and #473 this initiative has now landed **340 new unit tests across 14 previously-zero-coverage plugins**.

Notable coverage:
- `local-content-extractor`: full Readability flow including content-type filtering, meta-description fallback, redirect handling, axios HTTP/network error mapping, array Content-Type headers, and configured timeout + userAgent forwarding.
- `github`: OAuth `getAuthorizationUrl` (forceConsent, default scopes) and `exchangeCodeForToken` (success / error payload / missing creds / default tokenType), plus the pure git-helpers (`getAuth`, `getCloneUrl`, `getWebUrl`, `getRawFileUrl`).

Next focus per `COVERAGE-TRACKER.md`: internal-package coverage (`contracts`, `monitoring`, `cli-shared`, `tasks`) and per-API-module unit tests.

## Test plan

- [x] \`pnpm --filter @ever-works/local-content-extractor-plugin test\` — 20/20 passing
- [x] \`pnpm --filter @ever-works/github-plugin test\` — 20/20 passing
- [x] Local prettier check clean on all changed files
- [ ] CI runs full monorepo build/test on develop merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for the GitHub and Local Content Extractor plugins, covering plugin metadata, capabilities, authentication flows, token exchange, URL formatting, content extraction, and lifecycle management.

* **Documentation**
  * Updated coverage tracking documentation to record completion of plugin coverage work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->