### PR TITLE
test(cli-shared): unit tests for base-prompt and work-prompt services (64 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -42,7 +42,8 @@
 | 2026-05-07 | Plugin coverage (b3)              | [#473](https://github.com/ever-works/ever-works/pull/473) | jina (25 tests), comparison-generator (12), brightdata (28), scrapfly (26) — 91 new unit tests; covers remaining zero-coverage search plugins plus utility (comparison-generator) and content-extractor (scrapfly).                                                                                                   |
 | 2026-05-07 | Plugin coverage (b4)              | [#474](https://github.com/ever-works/ever-works/pull/474) | local-content-extractor (20 tests, axios mock), github (20 tests, fetch + libsodium mock for OAuth flow) — 40 new unit tests; closes the high-priority zero-coverage plugin list.                                                                                                                                     |
 | 2026-05-07 | cli-shared first coverage         | [#475](https://github.com/ever-works/ever-works/pull/475) | Scaffolds vitest in `packages/cli-shared` and adds 27 unit tests (slug-utils 13 + validation-utils 14) covering slugify, validateSlug, generateIncrementedSlug, validateUrl, validateEmail, validateGitUsername, validateApiKey, validateModelName.                                                                   |
-| 2026-05-07 | cli-shared utils extended         | (this PR)                                                 | Adds 25 more unit tests in `cli-shared`: config-check (10) covers maskSecret edge cases (incl. <8 char short-circuit and boundary at exactly 8) plus displayConfigurationError/Warnings; generator-steps (15) covers getStepText, getStepProgress, getDynamicStepText, getDynamicStepProgress, getItemsProcessedText. |
+| 2026-05-07 | cli-shared utils extended         | [#476](https://github.com/ever-works/ever-works/pull/476) | Adds 25 more unit tests in `cli-shared`: config-check (10) covers maskSecret edge cases (incl. <8 char short-circuit and boundary at exactly 8) plus displayConfigurationError/Warnings; generator-steps (15) covers getStepText, getStepProgress, getDynamicStepText, getDynamicStepProgress, getItemsProcessedText. |
+| 2026-05-07 | cli-shared prompt services        | (this PR)                                                 | Adds 64 unit tests for `BasePromptService` (45) and `WorkPromptService` (19). Base covers display helpers and all validators (URL, email, git username, API key, model name, slug, temperature, max tokens, git name, slugifyName). Work covers generateIncrementedSlug, formatRoleLabel, formatSelectedWork, promptWorkSelection, promptSlugConflictResolution, promptGitProviderSelection, promptDeployProviderSelection, promptWorkCreation — inquirer mocked via vi.mock. |
 
 ## Pending — High Priority
 
@@ -77,7 +78,7 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 - [ ] `packages/contracts` — pure types; add type-test fixtures via
       `expectTypeOf` so breaking changes are caught.
 - [ ] `packages/monitoring` — mock Sentry + PostHog SDKs and assert wiring.
-- [~] `packages/cli-shared` — utils fully covered (52 tests across slug, validation, config-check, generator-steps). Prompt services (`base-prompt.service.ts`, `work-prompt.service.ts`) still pending.
+- [x] `packages/cli-shared` — utils + prompt services fully covered (116 tests across slug, validation, config-check, generator-steps, base-prompt.service, work-prompt.service).
 - [ ] `packages/tasks` — Trigger.dev jobs; mock `@trigger.dev/sdk` v3.
 
 ### API module unit tests

--- a/packages/cli-shared/src/prompts/__tests__/base-prompt.service.spec.ts
+++ b/packages/cli-shared/src/prompts/__tests__/base-prompt.service.spec.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BasePromptService } from '../base-prompt.service.js';
+
+// Test subclass that exposes protected members so we can exercise them
+// without going through inquirer (interactive prompts are mocked separately).
+class TestPromptService extends BasePromptService {
+	public exposeDisplaySectionHeader = (t: string) => this.displaySectionHeader(t);
+	public exposeDisplayInfo = (m: string) => this.displayInfo(m);
+	public exposeDisplaySuccess = (m: string) => this.displaySuccess(m);
+	public exposeDisplayWarning = (m: string) => this.displayWarning(m);
+	public exposeDisplayError = (m: string) => this.displayError(m);
+
+	public exposeValidateUrl = (u: string) => this.validateUrl(u);
+	public exposeValidateEmail = (e: string) => this.validateEmail(e);
+	public exposeValidateGitUsername = (u: string) => this.validateGitUsername(u);
+	public exposeValidateApiKey = (k: string) => this.validateApiKey(k);
+	public exposeValidateApiKeyWithProvider = (k: string, p: string) => this.validateApiKeyWithProvider(k, p);
+	public exposeValidateModelName = (m: string) => this.validateModelName(m);
+	public exposeValidateSlug = (s: string) => this.validateSlug(s);
+	public exposeValidateTemperature = (t: number) => this.validateTemperature(t);
+	public exposeValidateMaxTokens = (n: number) => this.validateMaxTokens(n);
+	public exposeValidateGitName = (n: string) => this.validateGitName(n);
+	public exposeSlugifyName = (n: string) => this.slugifyName(n);
+}
+
+describe('BasePromptService — display helpers', () => {
+	let svc: TestPromptService;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		svc = new TestPromptService();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it('displaySectionHeader prints the title', () => {
+		svc.exposeDisplaySectionHeader('Auth');
+		const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+		expect(out).toMatch(/Auth/);
+	});
+
+	it('displayInfo / displaySuccess / displayWarning / displayError each call console.log once', () => {
+		svc.exposeDisplayInfo('hello');
+		svc.exposeDisplaySuccess('ok');
+		svc.exposeDisplayWarning('careful');
+		svc.exposeDisplayError('bad');
+		expect(logSpy).toHaveBeenCalledTimes(4);
+		const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+		expect(out).toMatch(/hello/);
+		expect(out).toMatch(/ok/);
+		expect(out).toMatch(/careful/);
+		expect(out).toMatch(/bad/);
+	});
+});
+
+describe('BasePromptService — validateUrl', () => {
+	const svc = new TestPromptService();
+
+	it('accepts http and https URLs', () => {
+		expect(svc.exposeValidateUrl('https://example.com')).toBe(true);
+		expect(svc.exposeValidateUrl('http://example.com/path?q=1')).toBe(true);
+	});
+
+	it('rejects malformed URLs with a helpful message', () => {
+		const r = svc.exposeValidateUrl('not-a-url');
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/valid URL/);
+	});
+
+	it('rejects empty string', () => {
+		expect(svc.exposeValidateUrl('')).not.toBe(true);
+	});
+});
+
+describe('BasePromptService — validateEmail', () => {
+	const svc = new TestPromptService();
+
+	it('accepts a typical email address', () => {
+		expect(svc.exposeValidateEmail('alice@example.com')).toBe(true);
+	});
+
+	it('rejects strings without @ or domain', () => {
+		expect(svc.exposeValidateEmail('alice')).not.toBe(true);
+		expect(svc.exposeValidateEmail('@example.com')).not.toBe(true);
+		expect(svc.exposeValidateEmail('alice@')).not.toBe(true);
+	});
+
+	it('rejects strings missing the dot in domain', () => {
+		expect(svc.exposeValidateEmail('alice@example')).not.toBe(true);
+	});
+});
+
+describe('BasePromptService — validateGitUsername', () => {
+	const svc = new TestPromptService();
+
+	it('accepts typical alphanumeric usernames and hyphens', () => {
+		expect(svc.exposeValidateGitUsername('alice')).toBe(true);
+		expect(svc.exposeValidateGitUsername('alice-bob')).toBe(true);
+		expect(svc.exposeValidateGitUsername('user123')).toBe(true);
+	});
+
+	it('rejects empty username', () => {
+		expect(svc.exposeValidateGitUsername('')).not.toBe(true);
+	});
+
+	it('rejects username with > 39 characters', () => {
+		expect(svc.exposeValidateGitUsername('a'.repeat(40))).not.toBe(true);
+	});
+
+	it('rejects usernames starting or ending with a hyphen', () => {
+		expect(svc.exposeValidateGitUsername('-alice')).not.toBe(true);
+		expect(svc.exposeValidateGitUsername('alice-')).not.toBe(true);
+	});
+
+	it('rejects usernames with disallowed characters', () => {
+		// The regex permits a single trailing _segment ("alice_bob" matches),
+		// but dots and spaces are never allowed.
+		expect(svc.exposeValidateGitUsername('alice.bob')).not.toBe(true);
+		expect(svc.exposeValidateGitUsername('alice bob')).not.toBe(true);
+		expect(svc.exposeValidateGitUsername('alice@home')).not.toBe(true);
+	});
+});
+
+describe('BasePromptService — validateApiKey', () => {
+	const svc = new TestPromptService();
+
+	it('accepts a 32-character key', () => {
+		expect(svc.exposeValidateApiKey('a'.repeat(32))).toBe(true);
+	});
+
+	it('rejects too-short keys (<10 chars)', () => {
+		const r = svc.exposeValidateApiKey('short');
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/too short/);
+	});
+
+	it('rejects too-long keys (>200 chars)', () => {
+		const r = svc.exposeValidateApiKey('a'.repeat(201));
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/too long/);
+	});
+});
+
+describe('BasePromptService — validateApiKeyWithProvider', () => {
+	const svc = new TestPromptService();
+
+	it('accepts a reasonable key for the given provider', () => {
+		expect(svc.exposeValidateApiKeyWithProvider('abcdef12345', 'OpenAI')).toBe(true);
+	});
+
+	it('rejects a key that is too short and includes provider name in the error', () => {
+		const r = svc.exposeValidateApiKeyWithProvider('abcd', 'Anthropic');
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/Anthropic/);
+		expect(r as string).toMatch(/too short/);
+	});
+
+	it('rejects keys containing spaces', () => {
+		const r = svc.exposeValidateApiKeyWithProvider('abcdef abcdef', 'OpenAI');
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/should not contain spaces/);
+	});
+});
+
+describe('BasePromptService — validateModelName', () => {
+	const svc = new TestPromptService();
+
+	it('accepts typical AI model names', () => {
+		expect(svc.exposeValidateModelName('gpt-4')).toBe(true);
+		expect(svc.exposeValidateModelName('claude-3-opus')).toBe(true);
+		expect(svc.exposeValidateModelName('provider/model-name')).toBe(true);
+		expect(svc.exposeValidateModelName('claude.3.5_sonnet')).toBe(true);
+	});
+
+	it('rejects names that are too short', () => {
+		expect(svc.exposeValidateModelName('a')).not.toBe(true);
+	});
+
+	it('rejects names that are too long (>100)', () => {
+		expect(svc.exposeValidateModelName('a'.repeat(101))).not.toBe(true);
+	});
+
+	it('rejects names with disallowed characters', () => {
+		expect(svc.exposeValidateModelName('foo bar')).not.toBe(true);
+		expect(svc.exposeValidateModelName('foo!bar')).not.toBe(true);
+	});
+});
+
+describe('BasePromptService — validateSlug', () => {
+	const svc = new TestPromptService();
+
+	it('accepts a simple slug', () => {
+		expect(svc.exposeValidateSlug('hello-world')).toBe(true);
+		expect(svc.exposeValidateSlug('ab')).toBe(true);
+	});
+
+	it('rejects too-short slugs', () => {
+		const r = svc.exposeValidateSlug('a');
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/at least 2/);
+	});
+
+	it('rejects too-long slugs (>50)', () => {
+		const r = svc.exposeValidateSlug('a'.repeat(51));
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/less than 50/);
+	});
+
+	it('rejects uppercase or non-allowed chars', () => {
+		expect(svc.exposeValidateSlug('Hello-World')).not.toBe(true);
+		expect(svc.exposeValidateSlug('hello_world')).not.toBe(true);
+		expect(svc.exposeValidateSlug('hello world')).not.toBe(true);
+	});
+
+	it('rejects slugs starting/ending with hyphen', () => {
+		expect(svc.exposeValidateSlug('-hello')).not.toBe(true);
+		expect(svc.exposeValidateSlug('hello-')).not.toBe(true);
+	});
+
+	it('rejects slugs with consecutive hyphens', () => {
+		const r = svc.exposeValidateSlug('hello--world');
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/consecutive hyphens/);
+	});
+});
+
+describe('BasePromptService — validateTemperature', () => {
+	const svc = new TestPromptService();
+
+	it('accepts values in the [0, 2] range', () => {
+		expect(svc.exposeValidateTemperature(0)).toBe(true);
+		expect(svc.exposeValidateTemperature(0.7)).toBe(true);
+		expect(svc.exposeValidateTemperature(2)).toBe(true);
+	});
+
+	it('rejects values below 0', () => {
+		expect(svc.exposeValidateTemperature(-0.1)).not.toBe(true);
+	});
+
+	it('rejects values above 2', () => {
+		expect(svc.exposeValidateTemperature(2.5)).not.toBe(true);
+	});
+});
+
+describe('BasePromptService — validateMaxTokens', () => {
+	const svc = new TestPromptService();
+
+	it('accepts integers in the valid range', () => {
+		expect(svc.exposeValidateMaxTokens(1)).toBe(true);
+		expect(svc.exposeValidateMaxTokens(4096)).toBe(true);
+		expect(svc.exposeValidateMaxTokens(200000)).toBe(true);
+	});
+
+	it('rejects values below 1', () => {
+		expect(svc.exposeValidateMaxTokens(0)).not.toBe(true);
+	});
+
+	it('rejects values above 200,000', () => {
+		expect(svc.exposeValidateMaxTokens(200001)).not.toBe(true);
+	});
+
+	it('rejects non-integer values', () => {
+		const r = svc.exposeValidateMaxTokens(4096.5);
+		expect(typeof r).toBe('string');
+		expect(r as string).toMatch(/whole number/);
+	});
+});
+
+describe('BasePromptService — validateGitName', () => {
+	const svc = new TestPromptService();
+
+	it('accepts typical names', () => {
+		expect(svc.exposeValidateGitName('Alice')).toBe(true);
+		expect(svc.exposeValidateGitName("Mary O'Hara")).toBe(true);
+		expect(svc.exposeValidateGitName('Jean-Luc Picard')).toBe(true);
+		expect(svc.exposeValidateGitName('Dr. Watson')).toBe(true);
+	});
+
+	it('rejects names that are too short', () => {
+		expect(svc.exposeValidateGitName('A')).not.toBe(true);
+	});
+
+	it('rejects names that are too long', () => {
+		expect(svc.exposeValidateGitName('A'.repeat(101))).not.toBe(true);
+	});
+
+	it('rejects names with disallowed characters', () => {
+		expect(svc.exposeValidateGitName('Alice123')).not.toBe(true);
+		expect(svc.exposeValidateGitName('Alice@home')).not.toBe(true);
+	});
+});
+
+describe('BasePromptService — slugifyName', () => {
+	const svc = new TestPromptService();
+
+	it('lowercases input and replaces whitespace with hyphens', () => {
+		expect(svc.exposeSlugifyName('Hello World')).toBe('hello-world');
+	});
+
+	it('strips disallowed characters', () => {
+		expect(svc.exposeSlugifyName('Hello, World! 2026?')).toBe('hello-world-2026');
+	});
+
+	it('collapses consecutive hyphens', () => {
+		expect(svc.exposeSlugifyName('hello---world')).toBe('hello-world');
+	});
+
+	it('trims leading and trailing hyphens', () => {
+		expect(svc.exposeSlugifyName('  -- hello -- ')).toBe('hello');
+	});
+
+	it('returns empty string for input with only special characters', () => {
+		expect(svc.exposeSlugifyName('!!!')).toBe('');
+	});
+});

--- a/packages/cli-shared/src/prompts/__tests__/work-prompt.service.spec.ts
+++ b/packages/cli-shared/src/prompts/__tests__/work-prompt.service.spec.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WorkPromptService, WorkMemberRole, type Work } from '../work-prompt.service.js';
+
+// Mock inquirer at the module level so the prompt methods don't try to read
+// from stdin during tests. Each test resets the mock implementation as needed.
+vi.mock('inquirer', () => {
+	const prompt = vi.fn();
+	const Separator = class {
+		constructor(public sep?: string) {}
+	};
+	return {
+		default: { prompt, Separator },
+		prompt,
+		Separator
+	};
+});
+
+import inquirer from 'inquirer';
+
+const mockedPrompt = inquirer.prompt as unknown as ReturnType<typeof vi.fn>;
+
+class TestWorkPromptService extends WorkPromptService {
+	public exposeFormatRoleLabel = (role: WorkMemberRole, isShared: boolean) =>
+		this.formatRoleLabel(role, isShared);
+}
+
+const makeWork = (overrides: Partial<Work> = {}): Work => ({
+	id: 'w1',
+	name: 'My Work',
+	slug: 'my-work',
+	owner: 'alice',
+	organization: false,
+	description: 'Some description',
+	...overrides
+});
+
+describe('WorkPromptService.generateIncrementedSlug', () => {
+	const svc = new WorkPromptService();
+
+	it('appends -N to the base slug', () => {
+		expect(svc.generateIncrementedSlug('hello', 1)).toBe('hello-1');
+		expect(svc.generateIncrementedSlug('a-b', 42)).toBe('a-b-42');
+	});
+
+	it('handles zero / large numbers', () => {
+		expect(svc.generateIncrementedSlug('foo', 0)).toBe('foo-0');
+		expect(svc.generateIncrementedSlug('foo', 9999)).toBe('foo-9999');
+	});
+});
+
+describe('WorkPromptService.formatRoleLabel', () => {
+	const svc = new TestWorkPromptService();
+
+	it('returns the human-readable label name regardless of color', () => {
+		// Strip ANSI escape codes for stable assertions.
+		const strip = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+		expect(strip(svc.exposeFormatRoleLabel(WorkMemberRole.OWNER, false))).toBe('[Owner]');
+		expect(strip(svc.exposeFormatRoleLabel(WorkMemberRole.MANAGER, true))).toBe('[Manager]');
+		expect(strip(svc.exposeFormatRoleLabel(WorkMemberRole.EDITOR, true))).toBe('[Editor]');
+		expect(strip(svc.exposeFormatRoleLabel(WorkMemberRole.VIEWER, false))).toBe('[Viewer]');
+	});
+
+	it('produces a label containing the role name regardless of shared flag', () => {
+		// chalk may strip colors when stdout is not a TTY (vitest pipes output),
+		// so we don't assert color differences — just that the role text is
+		// present in both shared and non-shared paths.
+		const a = svc.exposeFormatRoleLabel(WorkMemberRole.MANAGER, true);
+		const b = svc.exposeFormatRoleLabel(WorkMemberRole.MANAGER, false);
+		expect(a).toMatch(/Manager/);
+		expect(b).toMatch(/Manager/);
+	});
+});
+
+describe('WorkPromptService.formatSelectedWork', () => {
+	const svc = new WorkPromptService();
+	const strip = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+
+	it('includes the work name, slug and the role label', () => {
+		const work = makeWork();
+		const out = strip(svc.formatSelectedWork(work, WorkMemberRole.OWNER, false));
+		expect(out).toContain('My Work');
+		expect(out).toContain('(my-work)');
+		expect(out).toContain('[Owner]');
+	});
+});
+
+describe('WorkPromptService.promptWorkSelection', () => {
+	let svc: WorkPromptService;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		svc = new WorkPromptService();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		mockedPrompt.mockReset();
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it('returns cancelled=true with null work when no works are provided', async () => {
+		const r = await svc.promptWorkSelection([]);
+		expect(r).toEqual({ work: null, cancelled: true });
+
+		const r2 = await svc.promptWorkSelection(undefined);
+		expect(r2).toEqual({ work: null, cancelled: true });
+
+		// Should not have called inquirer because the list short-circuited.
+		expect(mockedPrompt).not.toHaveBeenCalled();
+	});
+
+	it('returns the selected work with OWNER role when userRole is missing', async () => {
+		const work = makeWork({ id: 'w1', slug: 'one' });
+		mockedPrompt.mockResolvedValueOnce({ selectedWork: work });
+
+		const r = await svc.promptWorkSelection([work]);
+		expect(r.work).toBe(work);
+		expect(r.cancelled).toBe(false);
+		expect(r.role).toBe(WorkMemberRole.OWNER);
+		expect(r.isShared).toBe(false);
+	});
+
+	it('marks the selection as shared when userRole is non-OWNER', async () => {
+		const work = makeWork({ id: 'w2', slug: 'two', userRole: WorkMemberRole.MANAGER });
+		mockedPrompt.mockResolvedValueOnce({ selectedWork: work });
+
+		const r = await svc.promptWorkSelection([work]);
+		expect(r.role).toBe(WorkMemberRole.MANAGER);
+		expect(r.isShared).toBe(true);
+	});
+
+	it('returns cancelled=true when the user picks the cancel choice (null)', async () => {
+		const work = makeWork();
+		mockedPrompt.mockResolvedValueOnce({ selectedWork: null });
+
+		const r = await svc.promptWorkSelection([work]);
+		expect(r).toEqual({ work: null, cancelled: true });
+	});
+});
+
+describe('WorkPromptService.promptSlugConflictResolution', () => {
+	let svc: WorkPromptService;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		svc = new WorkPromptService();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		mockedPrompt.mockReset();
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it('returns the suggested slug when user picks "use_suggested"', async () => {
+		mockedPrompt.mockResolvedValueOnce({ value: 'use_suggested' });
+
+		const r = await svc.promptSlugConflictResolution('mine', 'mine-2');
+		expect(r).toEqual({ action: 'use_suggested', finalSlug: 'mine-2' });
+	});
+
+	it('prompts again for a custom slug when user picks "modify"', async () => {
+		mockedPrompt
+			.mockResolvedValueOnce({ value: 'modify' })
+			.mockResolvedValueOnce({ value: 'my-custom-slug' });
+
+		const r = await svc.promptSlugConflictResolution('mine', 'mine-2');
+		expect(r).toEqual({ action: 'modify', finalSlug: 'my-custom-slug' });
+		expect(mockedPrompt).toHaveBeenCalledTimes(2);
+	});
+
+	it('returns cancel without a finalSlug when user picks "cancel"', async () => {
+		mockedPrompt.mockResolvedValueOnce({ value: 'cancel' });
+
+		const r = await svc.promptSlugConflictResolution('mine', 'mine-2');
+		expect(r.action).toBe('cancel');
+		expect(r.finalSlug).toBeUndefined();
+	});
+});
+
+describe('WorkPromptService.promptGitProviderSelection', () => {
+	let svc: WorkPromptService;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		svc = new WorkPromptService();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		mockedPrompt.mockReset();
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it('returns the provider id selected by the user', async () => {
+		mockedPrompt.mockResolvedValueOnce({ value: 'github' });
+
+		const r = await svc.promptGitProviderSelection([
+			{ id: 'github', name: 'GitHub', enabled: true, connected: true, username: 'alice' },
+			{ id: 'gitlab', name: 'GitLab', enabled: true, connected: false }
+		]);
+		expect(r).toBe('github');
+	});
+
+	it('re-prompts when user selects a disabled provider, then accepts a real one', async () => {
+		mockedPrompt
+			.mockResolvedValueOnce({ value: '__disabled__bitbucket' })
+			.mockResolvedValueOnce({ value: 'github' });
+
+		const r = await svc.promptGitProviderSelection([
+			{ id: 'github', name: 'GitHub', enabled: true, connected: true },
+			{ id: 'bitbucket', name: 'Bitbucket', enabled: false, connected: false }
+		]);
+		expect(r).toBe('github');
+		expect(mockedPrompt).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('WorkPromptService.promptDeployProviderSelection', () => {
+	let svc: WorkPromptService;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		svc = new WorkPromptService();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		mockedPrompt.mockReset();
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it('returns null when user picks "None"', async () => {
+		mockedPrompt.mockResolvedValueOnce({ value: '__none__' });
+
+		const r = await svc.promptDeployProviderSelection([
+			{ id: 'vercel', name: 'Vercel', enabled: true }
+		]);
+		expect(r).toBeNull();
+	});
+
+	it('returns the selected provider id when user picks an enabled provider', async () => {
+		mockedPrompt.mockResolvedValueOnce({ value: 'vercel' });
+
+		const r = await svc.promptDeployProviderSelection([
+			{ id: 'vercel', name: 'Vercel', enabled: true }
+		]);
+		expect(r).toBe('vercel');
+	});
+
+	it('re-prompts when user picks a disabled provider, then accepts None', async () => {
+		mockedPrompt
+			.mockResolvedValueOnce({ value: '__disabled__netlify' })
+			.mockResolvedValueOnce({ value: '__none__' });
+
+		const r = await svc.promptDeployProviderSelection([
+			{ id: 'netlify', name: 'Netlify', enabled: false }
+		]);
+		expect(r).toBeNull();
+		expect(mockedPrompt).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('WorkPromptService.promptWorkCreation', () => {
+	let svc: WorkPromptService;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		svc = new WorkPromptService();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		mockedPrompt.mockReset();
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it('returns name/slug/description/owner=undefined when no orgs are provided', async () => {
+		mockedPrompt
+			.mockResolvedValueOnce({ value: 'My Cool Work' }) // name
+			.mockResolvedValueOnce({ value: 'my-cool-work' }) // slug
+			.mockResolvedValueOnce({ value: 'A reasonably long description.' }); // description
+
+		const r = await svc.promptWorkCreation();
+		expect(r).toEqual({
+			name: 'My Cool Work',
+			slug: 'my-cool-work',
+			description: 'A reasonably long description.',
+			owner: undefined
+		});
+		expect(mockedPrompt).toHaveBeenCalledTimes(3);
+	});
+
+	it('returns the selected owner when orgs list is provided', async () => {
+		mockedPrompt
+			.mockResolvedValueOnce({ value: 'My Cool Work' }) // name
+			.mockResolvedValueOnce({ value: 'my-cool-work' }) // slug
+			.mockResolvedValueOnce({ value: 'A reasonably long description.' }) // description
+			.mockResolvedValueOnce({ value: 'org-acme' }); // owner select
+
+		const r = await svc.promptWorkCreation('alice', [
+			{ name: 'Personal', value: 'alice' },
+			{ name: 'Acme Inc.', value: 'org-acme' }
+		]);
+		expect(r.owner).toBe('org-acme');
+		expect(mockedPrompt).toHaveBeenCalledTimes(4);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the `packages/cli-shared` row on the COVERAGE-TRACKER hourly task. Adds 64 new unit tests across the two prompt services that previously had zero coverage:

- **`BasePromptService` (45 tests)** — display helpers (`displaySectionHeader`, `displayInfo`/`Success`/`Warning`/`Error`) and every validator: `validateUrl`, `validateEmail`, `validateGitUsername`, `validateApiKey`, `validateApiKeyWithProvider`, `validateModelName`, `validateSlug`, `validateTemperature`, `validateMaxTokens`, `validateGitName`, `slugifyName`. A test subclass (`TestPromptService`) exposes the protected members so we can exercise them without driving inquirer prompts.
- **`WorkPromptService` (19 tests)** — `generateIncrementedSlug`, `formatRoleLabel`, `formatSelectedWork`, `promptWorkSelection` (empty / OWNER / shared / cancel paths), `promptSlugConflictResolution` (use-suggested / modify / cancel), `promptGitProviderSelection` (incl. re-prompt when user picks a disabled provider), `promptDeployProviderSelection` (None / configured / re-prompt on disabled), `promptWorkCreation` (no orgs vs orgs list). `inquirer` is mocked via `vi.mock` at module scope.

Total `cli-shared` test count is now **116 passing** across utils + prompts.

## Test plan
- [x] `pnpm --filter @ever-works/cli-shared test` — 116/116 pass
- [x] `pnpm --filter @ever-works/cli-shared build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suites for prompt services to improve reliability.

* **Documentation**
  * Updated test coverage tracking documentation to reflect completed test work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->