### PR TITLE
test(contracts): scaffold vitest and add 57 tests incl. type-level fixtures

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -44,7 +44,8 @@
 | 2026-05-07 | cli-shared first coverage         | [#475](https://github.com/ever-works/ever-works/pull/475) | Scaffolds vitest in `packages/cli-shared` and adds 27 unit tests (slug-utils 13 + validation-utils 14) covering slugify, validateSlug, generateIncrementedSlug, validateUrl, validateEmail, validateGitUsername, validateApiKey, validateModelName.                                                                   |
 | 2026-05-07 | cli-shared utils extended         | [#476](https://github.com/ever-works/ever-works/pull/476) | Adds 25 more unit tests in `cli-shared`: config-check (10) covers maskSecret edge cases (incl. <8 char short-circuit and boundary at exactly 8) plus displayConfigurationError/Warnings; generator-steps (15) covers getStepText, getStepProgress, getDynamicStepText, getDynamicStepProgress, getItemsProcessedText. |
 | 2026-05-07 | cli-shared prompt services        | [#477](https://github.com/ever-works/ever-works/pull/477) | Adds 64 unit tests for `BasePromptService` (45) and `WorkPromptService` (19). Base covers display helpers and all validators (URL, email, git username, API key, model name, slug, temperature, max tokens, git name, slugifyName). Work covers generateIncrementedSlug, formatRoleLabel, formatSelectedWork, promptWorkSelection, promptSlugConflictResolution, promptGitProviderSelection, promptDeployProviderSelection, promptWorkCreation — inquirer mocked via vi.mock. |
-| 2026-05-07 | monitoring first coverage         | (this PR)                                                 | Scaffolds jest in `packages/monitoring` and adds 72 unit tests across PostHog/Sentry config, services, and interceptors. PostHog config (9), Sentry config (12), AnalyticsService (15), SentryService (20), SentryInterceptor (8), PostHogInterceptor (5). Sentry SDK and posthog-node are mocked at module scope; production-vs-dev sample rates and the /auth filter on `beforeSend`/`beforeSendTransaction` are both covered. |
+| 2026-05-07 | monitoring first coverage         | [#478](https://github.com/ever-works/ever-works/pull/478) | Scaffolds jest in `packages/monitoring` and adds 72 unit tests across PostHog/Sentry config, services, and interceptors. PostHog config (9), Sentry config (12), AnalyticsService (15), SentryService (20), SentryInterceptor (8), PostHogInterceptor (5). Sentry SDK and posthog-node are mocked at module scope; production-vs-dev sample rates and the /auth filter on `beforeSend`/`beforeSendTransaction` are both covered. |
+| 2026-05-07 | contracts first coverage          | (this PR)                                                 | Scaffolds vitest in `packages/contracts` (with `typecheck` mode for `.spec-d.ts` fixtures) and adds 57 tests: github runtime helper `parseGitHubRepositoryUrl` (10), `isTerminalOnboardingStatus` + `ONBOARDING_TERMINAL_STATUSES` (10), `DomainType` enum (2), and a 35-assertion type-level fixture using `expectTypeOf` that pins the public surface (item / domain / form / github / api/onboarding) so accidental contract regressions fail at type-check. |
 
 ## Pending — High Priority
 
@@ -76,8 +77,10 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 
 ### Internal-package coverage
 
-- [ ] `packages/contracts` — pure types; add type-test fixtures via
-      `expectTypeOf` so breaking changes are caught.
+- [x] `packages/contracts` — vitest scaffolded; 57 tests including
+      a 35-assertion type-level fixture via `expectTypeOf` plus runtime
+      tests for `parseGitHubRepositoryUrl`, `isTerminalOnboardingStatus`,
+      and the `DomainType` enum (2026-05-07).
 - [x] `packages/monitoring` — Sentry + PostHog SDKs mocked, 72 tests across config, services, interceptors (2026-05-07).
 - [x] `packages/cli-shared` — utils + prompt services fully covered (116 tests across slug, validation, config-check, generator-steps, base-prompt.service, work-prompt.service).
 - [ ] `packages/tasks` — Trigger.dev jobs; mock `@trigger.dev/sdk` v3.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -47,12 +47,16 @@
 		"build": "tsup",
 		"dev": "tsup --watch",
 		"clean": "rm -rf dist",
-		"type-check": "tsc --noEmit"
+		"type-check": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
 	},
 	"devDependencies": {
 		"@types/node": "^22.19.3",
 		"tsup": "^8.0.0",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"vitest": "^3.0.0"
 	},
 	"peerDependencies": {},
 	"dependencies": {}

--- a/packages/contracts/src/__tests__/types.spec-d.ts
+++ b/packages/contracts/src/__tests__/types.spec-d.ts
@@ -1,0 +1,301 @@
+// Type-level fixtures. These tests run via vitest's `typecheck` mode and fail
+// at compile time if a contract changes shape. They exist to catch breaking
+// changes — adding a property is fine, removing or retyping a load-bearing
+// one is what we want to surface.
+
+import { expectTypeOf, describe, it } from 'vitest';
+// Note: this file is consumed by vitest's `typecheck` mode (filename pattern
+// `*.spec-d.ts`). It contains TYPE assertions only — no runtime expectations.
+import type {
+	// item
+	Identifiable,
+	Category,
+	Tag,
+	Collection,
+	Brand,
+	Badge,
+	ItemBadges,
+	BadgeEvaluationResult,
+	ItemHealth,
+	ItemHealthStatus,
+	ItemSourceReachabilityStatus,
+	ItemSourceAccuracyStatus,
+	ItemSourceValidation,
+	ItemData,
+	MutableItemData,
+	ComparisonDimension,
+	ComparisonSource,
+	ComparisonData,
+	// domain
+	DomainAnalysis,
+	WebPageData,
+	RelevanceAssessment,
+	// form
+	FormFieldType,
+	FormFieldOption,
+	FormFieldValidation,
+	FormFieldCondition,
+	FormFieldDefinition,
+	FormFieldGroup,
+	FormSchema,
+	// github
+	ParsedGitHubRepository
+} from '../index.js';
+
+import { DomainType } from '../domain/index.js';
+import type {
+	OnboardingStatus,
+	WebhookEvent,
+	WebhookEventTerminal,
+	WebhookEventManifestChanged,
+	WebhookEventDeployFailed
+} from '../api/onboarding/index.js';
+
+describe('item contracts (type)', () => {
+	it('Identifiable has readonly id and name strings', () => {
+		expectTypeOf<Identifiable>().toEqualTypeOf<{
+			readonly id: string;
+			readonly name: string;
+		}>();
+	});
+
+	it('Category extends Identifiable shape with optional metadata', () => {
+		expectTypeOf<Category>().toMatchTypeOf<{ readonly id: string; readonly name: string }>();
+		expectTypeOf<Category['description']>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<Category['priority']>().toEqualTypeOf<number | undefined>();
+	});
+
+	it('Tag is the minimal id+name shape', () => {
+		expectTypeOf<Tag>().toEqualTypeOf<{ readonly id: string; readonly name: string }>();
+	});
+
+	it('Collection mirrors Category (without category-specific extensions)', () => {
+		expectTypeOf<Collection>().toMatchTypeOf<{ readonly id: string; readonly name: string }>();
+		expectTypeOf<Collection['icon_url']>().toEqualTypeOf<string | undefined>();
+	});
+
+	it('Brand fields are well-typed', () => {
+		expectTypeOf<Brand['logo_url']>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<Brand['website']>().toEqualTypeOf<string | undefined>();
+	});
+
+	it('Badge.value is required and details may be null', () => {
+		expectTypeOf<Badge['value']>().toBeString();
+		expectTypeOf<Badge['details']>().toEqualTypeOf<string | null | undefined>();
+	});
+
+	it('ItemBadges is Record<string, Badge>', () => {
+		expectTypeOf<ItemBadges>().toEqualTypeOf<Record<string, Badge>>();
+	});
+
+	it('BadgeEvaluationResult.evaluated_at is a (ISO-) string', () => {
+		expectTypeOf<BadgeEvaluationResult['evaluated_at']>().toBeString();
+		expectTypeOf<BadgeEvaluationResult['badges']>().toEqualTypeOf<ItemBadges>();
+	});
+
+	it('ItemHealthStatus is the closed union of 5 known states', () => {
+		expectTypeOf<ItemHealthStatus>().toEqualTypeOf<
+			'unchecked' | 'healthy' | 'unknown' | 'warning' | 'broken'
+		>();
+	});
+
+	it('ItemSourceReachabilityStatus / ItemSourceAccuracyStatus are closed unions', () => {
+		expectTypeOf<ItemSourceReachabilityStatus>().toEqualTypeOf<
+			'reachable' | 'broken' | 'unknown'
+		>();
+		expectTypeOf<ItemSourceAccuracyStatus>().toEqualTypeOf<
+			'accurate' | 'generic' | 'weak' | 'unknown'
+		>();
+	});
+
+	it('ItemHealth optional metadata can be null where stated', () => {
+		expectTypeOf<ItemHealth['status_code']>().toEqualTypeOf<number | null | undefined>();
+		expectTypeOf<ItemHealth['message']>().toEqualTypeOf<string | null | undefined>();
+		expectTypeOf<ItemHealth['checked_via']>().toEqualTypeOf<'manual' | 'schedule' | undefined>();
+	});
+
+	it('ItemSourceValidation flags are typed as boolean | undefined', () => {
+		expectTypeOf<ItemSourceValidation['is_relevant']>().toEqualTypeOf<boolean | undefined>();
+		expectTypeOf<ItemSourceValidation['is_specific']>().toEqualTypeOf<boolean | undefined>();
+		expectTypeOf<ItemSourceValidation['is_official']>().toEqualTypeOf<boolean | undefined>();
+	});
+
+	it('ItemData.category accepts string OR readonly string[]', () => {
+		expectTypeOf<ItemData['category']>().toEqualTypeOf<string | readonly string[]>();
+	});
+
+	it('ItemData.tags accepts readonly string[] OR readonly Tag[]', () => {
+		expectTypeOf<ItemData['tags']>().toEqualTypeOf<readonly string[] | readonly Tag[]>();
+	});
+
+	it('ItemData required fields exist', () => {
+		// These will fail to compile if any required field is removed or made optional.
+		const sample: ItemData = {
+			name: 'n',
+			description: 'd',
+			source_url: 'https://x',
+			category: 'cat',
+			tags: ['t']
+		};
+		expectTypeOf(sample).toMatchTypeOf<ItemData>();
+	});
+
+	it('MutableItemData is the writable counterpart to ItemData', () => {
+		// MutableItemData fields are writable (no `readonly`); the assignment
+		// below would be a type error if any of these were marked readonly.
+		const mut: MutableItemData = {
+			name: 'n',
+			description: 'd',
+			source_url: 'https://x',
+			category: ['a'],
+			tags: []
+		};
+		mut.name = 'updated';
+		expectTypeOf(mut.name).toBeString();
+	});
+
+	it('Comparison verdict_winner is the closed union "item_a" | "item_b" | "tie"', () => {
+		expectTypeOf<ComparisonData['verdict_winner']>().toEqualTypeOf<
+			'item_a' | 'item_b' | 'tie' | undefined
+		>();
+		expectTypeOf<ComparisonDimension['winner']>().toEqualTypeOf<
+			'item_a' | 'item_b' | 'tie' | undefined
+		>();
+	});
+
+	it('ComparisonData.dimensions / sources are readonly arrays', () => {
+		expectTypeOf<ComparisonData['dimensions']>().toEqualTypeOf<readonly ComparisonDimension[]>();
+		expectTypeOf<ComparisonData['sources']>().toEqualTypeOf<readonly ComparisonSource[]>();
+	});
+});
+
+describe('domain contracts (type)', () => {
+	it('DomainType members are typed as the four expected literal strings', () => {
+		expectTypeOf<typeof DomainType.SOFTWARE>().toEqualTypeOf<DomainType.SOFTWARE>();
+		expectTypeOf<typeof DomainType.ECOMMERCE>().toEqualTypeOf<DomainType.ECOMMERCE>();
+		expectTypeOf<typeof DomainType.SERVICES>().toEqualTypeOf<DomainType.SERVICES>();
+		expectTypeOf<typeof DomainType.GENERAL>().toEqualTypeOf<DomainType.GENERAL>();
+	});
+
+	it('DomainAnalysis confidence is a number, optional arrays are readonly string[]', () => {
+		expectTypeOf<DomainAnalysis['confidence']>().toBeNumber();
+		expectTypeOf<DomainAnalysis['expected_attributes']>().toEqualTypeOf<
+			readonly string[] | undefined
+		>();
+		expectTypeOf<DomainAnalysis['official_source_patterns']>().toEqualTypeOf<
+			readonly string[] | undefined
+		>();
+	});
+
+	it('WebPageData has the three core fields', () => {
+		expectTypeOf<WebPageData>().toEqualTypeOf<{
+			readonly source_url: string;
+			readonly retrieved_at: string;
+			readonly raw_content: string;
+		}>();
+	});
+
+	it('RelevanceAssessment requires relevant + relevance_score + reason', () => {
+		expectTypeOf<RelevanceAssessment>().toEqualTypeOf<{
+			readonly relevant: boolean;
+			readonly relevance_score: number;
+			readonly reason: string;
+		}>();
+	});
+});
+
+describe('form contracts (type)', () => {
+	it('FormFieldType has at least the well-known scalars', () => {
+		// Spot-check that the specific names still exist in the union.
+		expectTypeOf<'text'>().toMatchTypeOf<FormFieldType>();
+		expectTypeOf<'number'>().toMatchTypeOf<FormFieldType>();
+		expectTypeOf<'boolean'>().toMatchTypeOf<FormFieldType>();
+		expectTypeOf<'select'>().toMatchTypeOf<FormFieldType>();
+		expectTypeOf<'multiselect'>().toMatchTypeOf<FormFieldType>();
+		expectTypeOf<'password'>().toMatchTypeOf<FormFieldType>();
+		expectTypeOf<'hidden'>().toMatchTypeOf<FormFieldType>();
+	});
+
+	it('FormFieldOption.value is the union string | number | boolean', () => {
+		expectTypeOf<FormFieldOption['value']>().toEqualTypeOf<string | number | boolean>();
+	});
+
+	it('FormFieldValidation fields are all optional', () => {
+		const empty: FormFieldValidation = {};
+		expectTypeOf(empty).toMatchTypeOf<FormFieldValidation>();
+	});
+
+	it('FormFieldCondition.operator is the closed union of comparison operators', () => {
+		expectTypeOf<FormFieldCondition['operator']>().toEqualTypeOf<
+			'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains' | 'not_contains'
+		>();
+	});
+
+	it('FormFieldDefinition.showIf accepts a single condition or an array', () => {
+		expectTypeOf<FormFieldDefinition['showIf']>().toEqualTypeOf<
+			FormFieldCondition | readonly FormFieldCondition[] | undefined
+		>();
+	});
+
+	it('FormFieldGroup is collapsible-aware', () => {
+		expectTypeOf<FormFieldGroup['collapsible']>().toEqualTypeOf<boolean | undefined>();
+		expectTypeOf<FormFieldGroup['collapsed']>().toEqualTypeOf<boolean | undefined>();
+	});
+
+	it('FormSchema.fields is a readonly FormFieldDefinition[]', () => {
+		expectTypeOf<FormSchema['fields']>().toEqualTypeOf<readonly FormFieldDefinition[]>();
+		expectTypeOf<FormSchema['groups']>().toEqualTypeOf<readonly FormFieldGroup[] | undefined>();
+	});
+});
+
+describe('github contracts (type)', () => {
+	it('ParsedGitHubRepository has owner/repo/canonicalUrl as strings', () => {
+		expectTypeOf<ParsedGitHubRepository>().toEqualTypeOf<{
+			owner: string;
+			repo: string;
+			canonicalUrl: string;
+		}>();
+	});
+});
+
+describe('api/onboarding contracts (type)', () => {
+	it('OnboardingStatus is the closed union of 8 states', () => {
+		expectTypeOf<OnboardingStatus>().toEqualTypeOf<
+			| 'received'
+			| 'validating'
+			| 'validated'
+			| 'queued'
+			| 'generating'
+			| 'deployed'
+			| 'failed'
+			| 'rejected'
+		>();
+	});
+
+	it('WebhookEventTerminal.status is restricted to terminal statuses only', () => {
+		expectTypeOf<WebhookEventTerminal['status']>().toEqualTypeOf<
+			'deployed' | 'failed' | 'rejected'
+		>();
+	});
+
+	it('WebhookEvent is a discriminated union over `event`', () => {
+		expectTypeOf<WebhookEvent['event']>().toEqualTypeOf<
+			'onboarding.terminal' | 'work.regenerated' | 'work.deploy_failed'
+		>();
+	});
+
+	it('WebhookEventManifestChanged has commitSha and workId, no status', () => {
+		expectTypeOf<WebhookEventManifestChanged>().toMatchTypeOf<{
+			event: 'work.regenerated';
+			deliveryId: string;
+			occurredAt: string;
+			workId: string;
+			commitSha: string;
+		}>();
+	});
+
+	it('WebhookEventDeployFailed requires failureCode and failureMessage', () => {
+		expectTypeOf<WebhookEventDeployFailed['failureCode']>().toBeString();
+		expectTypeOf<WebhookEventDeployFailed['failureMessage']>().toBeString();
+	});
+});

--- a/packages/contracts/src/api/onboarding/__tests__/onboarding-status.spec.ts
+++ b/packages/contracts/src/api/onboarding/__tests__/onboarding-status.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+	ONBOARDING_TERMINAL_STATUSES,
+	isTerminalOnboardingStatus,
+	type OnboardingStatus
+} from '../onboarding-status.js';
+
+describe('ONBOARDING_TERMINAL_STATUSES', () => {
+	it('contains exactly the three terminal statuses (deployed, failed, rejected)', () => {
+		expect([...ONBOARDING_TERMINAL_STATUSES].sort()).toEqual(['deployed', 'failed', 'rejected']);
+	});
+});
+
+describe('isTerminalOnboardingStatus', () => {
+	it.each(['deployed', 'failed', 'rejected'] as const)('returns true for %s', (s) => {
+		expect(isTerminalOnboardingStatus(s)).toBe(true);
+	});
+
+	it.each(['received', 'validating', 'validated', 'queued', 'generating'] as const)(
+		'returns false for %s',
+		(s) => {
+			expect(isTerminalOnboardingStatus(s)).toBe(false);
+		}
+	);
+
+	it('every OnboardingStatus value is classified as either terminal or non-terminal', () => {
+		const all: OnboardingStatus[] = [
+			'received',
+			'validating',
+			'validated',
+			'queued',
+			'generating',
+			'deployed',
+			'failed',
+			'rejected'
+		];
+		for (const s of all) {
+			const terminal = isTerminalOnboardingStatus(s);
+			expect(typeof terminal).toBe('boolean');
+		}
+	});
+});

--- a/packages/contracts/src/domain/__tests__/domain.spec.ts
+++ b/packages/contracts/src/domain/__tests__/domain.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { DomainType } from '../index.js';
+
+describe('DomainType enum', () => {
+	it('exposes the four expected string values', () => {
+		expect(DomainType.SOFTWARE).toBe('software');
+		expect(DomainType.ECOMMERCE).toBe('ecommerce');
+		expect(DomainType.SERVICES).toBe('services');
+		expect(DomainType.GENERAL).toBe('general');
+	});
+
+	it('has exactly 4 members (catches accidental additions/removals)', () => {
+		// String enums emit one entry per member; no reverse-mapping noise.
+		expect(Object.keys(DomainType)).toEqual(
+			expect.arrayContaining(['SOFTWARE', 'ECOMMERCE', 'SERVICES', 'GENERAL'])
+		);
+		expect(Object.keys(DomainType)).toHaveLength(4);
+	});
+});

--- a/packages/contracts/src/github/__tests__/github.spec.ts
+++ b/packages/contracts/src/github/__tests__/github.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseGitHubRepositoryUrl, type ParsedGitHubRepository } from '../index.js';
+
+describe('parseGitHubRepositoryUrl', () => {
+	it('parses a canonical https://github.com/<owner>/<repo> URL', () => {
+		const r = parseGitHubRepositoryUrl('https://github.com/ever-works/ever-works');
+		expect(r).toEqual({
+			owner: 'ever-works',
+			repo: 'ever-works',
+			canonicalUrl: 'https://github.com/ever-works/ever-works'
+		} satisfies ParsedGitHubRepository);
+	});
+
+	it('lower-cases the owner and repo', () => {
+		const r = parseGitHubRepositoryUrl('https://github.com/Ever-Works/Ever-Works');
+		expect(r?.owner).toBe('ever-works');
+		expect(r?.repo).toBe('ever-works');
+		expect(r?.canonicalUrl).toBe('https://github.com/ever-works/ever-works');
+	});
+
+	it('strips a trailing .git suffix from the repo segment', () => {
+		const r = parseGitHubRepositoryUrl('https://github.com/ever-works/ever-works.git');
+		expect(r?.repo).toBe('ever-works');
+		expect(r?.canonicalUrl).toBe('https://github.com/ever-works/ever-works');
+	});
+
+	it('ignores extra path segments past <owner>/<repo>', () => {
+		const r = parseGitHubRepositoryUrl(
+			'https://github.com/ever-works/ever-works/tree/main/packages/contracts'
+		);
+		expect(r?.owner).toBe('ever-works');
+		expect(r?.repo).toBe('ever-works');
+	});
+
+	it('accepts http:// in addition to https://', () => {
+		const r = parseGitHubRepositoryUrl('http://github.com/foo/bar');
+		expect(r?.owner).toBe('foo');
+		expect(r?.repo).toBe('bar');
+	});
+
+	it('accepts mixed-case hostname', () => {
+		const r = parseGitHubRepositoryUrl('https://GitHub.com/foo/bar');
+		expect(r?.owner).toBe('foo');
+		expect(r?.repo).toBe('bar');
+	});
+
+	it('returns null for non-github hostnames', () => {
+		expect(parseGitHubRepositoryUrl('https://gitlab.com/foo/bar')).toBeNull();
+		expect(parseGitHubRepositoryUrl('https://example.com/foo/bar')).toBeNull();
+	});
+
+	it('returns null for ssh / git protocols (only http/https supported)', () => {
+		expect(parseGitHubRepositoryUrl('git@github.com:foo/bar.git')).toBeNull();
+		expect(parseGitHubRepositoryUrl('ssh://git@github.com/foo/bar')).toBeNull();
+		expect(parseGitHubRepositoryUrl('git://github.com/foo/bar')).toBeNull();
+	});
+
+	it('returns null when the URL has fewer than 2 path segments', () => {
+		expect(parseGitHubRepositoryUrl('https://github.com')).toBeNull();
+		expect(parseGitHubRepositoryUrl('https://github.com/')).toBeNull();
+		expect(parseGitHubRepositoryUrl('https://github.com/owner-only')).toBeNull();
+	});
+
+	it('returns null for an unparseable URL', () => {
+		expect(parseGitHubRepositoryUrl('not a url')).toBeNull();
+		expect(parseGitHubRepositoryUrl('')).toBeNull();
+	});
+});

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		typecheck: {
+			enabled: true,
+			include: ['src/**/*.spec-d.ts']
+		},
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 1.10.4(@jitsu/protocols@1.10.4)(@types/dlv@1.1.5)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -191,16 +191,16 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -431,10 +431,10 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -767,13 +767,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -865,6 +865,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/monitoring:
     dependencies:
@@ -895,7 +898,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -17819,6 +17822,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -17840,6 +17854,16 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -20653,7 +20677,7 @@ snapshots:
   '@fig/complete-commander@3.2.0(commander@11.1.0)':
     dependencies:
       commander: 11.1.0
-      prettier: 3.8.1
+      prettier: 3.8.3
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -21838,7 +21862,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -21855,7 +21879,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.25.7
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -21882,7 +21906,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -21901,6 +21925,35 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21)))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
@@ -21932,7 +21985,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -21961,7 +22014,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -22063,6 +22116,17 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
+
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -24407,6 +24471,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.2
+      semver: 7.7.4
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -32457,13 +32540,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## Summary

Closes the `packages/contracts` row on the COVERAGE-TRACKER. Previously the package had no tests despite shipping two runtime helpers (`parseGitHubRepositoryUrl`, `isTerminalOnboardingStatus`) and a public type surface that other packages depend on.

This PR scaffolds **vitest** with `typecheck` mode enabled so `.spec-d.ts` files run as type assertions. Coverage:

- **github (10)** — `parseGitHubRepositoryUrl`: canonical URLs, lower-casing, `.git` suffix stripping, extra path segments, http/https acceptance, mixed-case hostnames, non-github hostnames, ssh/git protocol rejection, fewer than 2 path segments, unparseable input.
- **api/onboarding (10)** — `ONBOARDING_TERMINAL_STATUSES` shape, every terminal and non-terminal value, exhaustive classification check.
- **domain (2)** — `DomainType` enum has exactly 4 expected values.
- **types.spec-d.ts (35 type assertions)** — pins the public surface so accidental contract regressions fail at type-check:
  - item: `Identifiable`, `Category`, `Tag`, `Collection`, `Brand`, `Badge`, `ItemBadges`, `BadgeEvaluationResult`, `ItemHealthStatus` + reachability/accuracy closed unions, `ItemHealth`, `ItemSourceValidation`, `ItemData`, `MutableItemData`, `Comparison*` (`verdict_winner`, `dimensions`, `sources`).
  - domain: `DomainType` member literal types, `DomainAnalysis`, `WebPageData`, `RelevanceAssessment`.
  - form: `FormFieldType`, `FormFieldOption.value` union, `FormFieldValidation`, `FormFieldCondition.operator`, `FormFieldDefinition`, `FormFieldGroup`, `FormSchema`.
  - github: `ParsedGitHubRepository`.
  - api/onboarding: `OnboardingStatus`, `WebhookEventTerminal.status` restricted to terminal-only, the `WebhookEvent` discriminated union over `event`.

## Test plan

- [x] `pnpm --filter @ever-works/contracts test` — 57/57 pass (4 test files)
- [x] `pnpm --filter @ever-works/contracts type-check` — clean
- [x] `pnpm --filter @ever-works/contracts build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)