### PR TITLE
test(tasks): scaffold vitest and add 61 unit tests

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -46,6 +46,7 @@
 | 2026-05-07 | cli-shared prompt services        | [#477](https://github.com/ever-works/ever-works/pull/477) | Adds 64 unit tests for `BasePromptService` (45) and `WorkPromptService` (19). Base covers display helpers and all validators (URL, email, git username, API key, model name, slug, temperature, max tokens, git name, slugifyName). Work covers generateIncrementedSlug, formatRoleLabel, formatSelectedWork, promptWorkSelection, promptSlugConflictResolution, promptGitProviderSelection, promptDeployProviderSelection, promptWorkCreation — inquirer mocked via vi.mock. |
 | 2026-05-07 | monitoring first coverage         | [#478](https://github.com/ever-works/ever-works/pull/478) | Scaffolds jest in `packages/monitoring` and adds 72 unit tests across PostHog/Sentry config, services, and interceptors. PostHog config (9), Sentry config (12), AnalyticsService (15), SentryService (20), SentryInterceptor (8), PostHogInterceptor (5). Sentry SDK and posthog-node are mocked at module scope; production-vs-dev sample rates and the /auth filter on `beforeSend`/`beforeSendTransaction` are both covered. |
 | 2026-05-07 | contracts first coverage          | [#479](https://github.com/ever-works/ever-works/pull/479) | Scaffolds vitest in `packages/contracts` (with `typecheck` mode for `.spec-d.ts` fixtures) and adds 57 tests: github runtime helper `parseGitHubRepositoryUrl` (10), `isTerminalOnboardingStatus` + `ONBOARDING_TERMINAL_STATUSES` (10), `DomainType` enum (2), and a 35-assertion type-level fixture using `expectTypeOf` that pins the public surface (item / domain / form / github / api/onboarding) so accidental contract regressions fail at type-check. |
+| 2026-05-07 | tasks first coverage              | (this PR)                                                 | Scaffolds vitest in `packages/tasks` and adds 61 tests across 4 suites: `LocalPluginStore` (16) — in-memory CRUD/upsert/findEnabled; `TriggerLogger` (18) — message/context/Error/data extraction across log/error/warn/debug/verbose/fatal + setLogLevels no-op; `TriggerService` (19) — dispatchWorkGeneration / cancelWorkGeneration / dispatchWorkImport with `@trigger.dev/sdk` configure+runs+task mocked, supported-machine matrix; `collectPluginDependencies` (8) — fs-mocked manifest discovery, workspace/@ever-works skip rules, dedup + sort. Excludes spec files and `vitest.config.ts` from the tsc build. |
 
 ## Pending — High Priority
 
@@ -83,7 +84,14 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
       and the `DomainType` enum (2026-05-07).
 - [x] `packages/monitoring` — Sentry + PostHog SDKs mocked, 72 tests across config, services, interceptors (2026-05-07).
 - [x] `packages/cli-shared` — utils + prompt services fully covered (116 tests across slug, validation, config-check, generator-steps, base-prompt.service, work-prompt.service).
-- [ ] `packages/tasks` — Trigger.dev jobs; mock `@trigger.dev/sdk` v3.
+- [x] `packages/tasks` — vitest scaffolded; 61 tests across `LocalPluginStore`,
+      `TriggerLogger`, `TriggerService`, and `collectPluginDependencies`
+      (`@trigger.dev/sdk` and `@ever-works/agent/config` mocked).
+      Follow-ups: `TriggerInternalApiClient` (HTTP retry), `worker-context` /
+      `task-context` utilities, and the four task entrypoints
+      (`work-generation` / `work-import` / `work-onboarding` /
+      `work-schedule-dispatcher`) — these need NestFactory mocked and are
+      best done as a dedicated follow-up.
 
 ### API module unit tests
 

--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -21,7 +21,10 @@
         "prepare:plugins": "node scripts/prepare-plugins.js",
         "dev:trigger": "npx --yes trigger.dev@4.4.5 dev",
         "predeploy:trigger": "pnpm prepare:plugins",
-        "deploy:trigger": "npx trigger.dev@4.4.5 deploy"
+        "deploy:trigger": "npx trigger.dev@4.4.5 deploy",
+        "test": "vitest run --passWithNoTests",
+        "test:watch": "vitest",
+        "test:coverage": "vitest run --coverage"
     },
     "dependencies": {
         "@ever-works/agent": "workspace:*",
@@ -41,6 +44,7 @@
     "devDependencies": {
         "@trigger.dev/build": "^4.4.5",
         "@types/node": "^22.19.3",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
     }
 }

--- a/packages/tasks/src/__tests__/collect-plugin-deps.spec.ts
+++ b/packages/tasks/src/__tests__/collect-plugin-deps.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+
+const { fsMock } = vi.hoisted(() => ({
+    fsMock: {
+        existsSync: vi.fn(),
+        readdirSync: vi.fn(),
+        readFileSync: vi.fn()
+    }
+}));
+
+vi.mock('fs', () => fsMock);
+
+import { collectPluginDependencies } from '../build/collect-plugin-deps';
+
+const PLUGINS_DIR = path.resolve(__dirname, '../../../../packages/plugins');
+
+describe('collectPluginDependencies', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        logSpy.mockRestore();
+    });
+
+    it('returns [] and warns when the plugins directory is missing', () => {
+        fsMock.existsSync.mockReturnValue(false);
+
+        const result = collectPluginDependencies();
+
+        expect(result).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[collectPluginDeps] Plugin source not found:',
+            PLUGINS_DIR
+        );
+    });
+
+    it('skips entries that are not directories', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'README.md', isDirectory: () => false }
+        ]);
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual([]);
+    });
+
+    it('skips directories without package.json', () => {
+        fsMock.existsSync.mockImplementation((p: any) => {
+            return typeof p === 'string' && p === PLUGINS_DIR;
+        });
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'pluginA', isDirectory: () => true }
+        ]);
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual([]);
+    });
+
+    it('skips packages without an everworks.plugin manifest', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'pluginA', isDirectory: () => true }
+        ]);
+        fsMock.readFileSync.mockReturnValue(
+            JSON.stringify({ name: 'pluginA', dependencies: { axios: '^1.0.0' } })
+        );
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual([]);
+    });
+
+    it('skips workspace: dependencies and @ever-works/* packages', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'pluginA', isDirectory: () => true }
+        ]);
+        fsMock.readFileSync.mockReturnValue(
+            JSON.stringify({
+                name: 'pluginA',
+                everworks: { plugin: { id: 'pluginA' } },
+                dependencies: {
+                    axios: '^1.0.0',
+                    '@ever-works/plugin': 'workspace:*',
+                    '@ever-works/contracts': '^1.0.0',
+                    '@some-vendor/sdk': 'workspace:^1.0.0'
+                }
+            })
+        );
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual(['axios@^1.0.0']);
+    });
+
+    it('aggregates dependencies and peerDependencies and dedupes across plugins', () => {
+        const pkgA = {
+            everworks: { plugin: { id: 'a' } },
+            dependencies: { axios: '^1.0.0', lodash: '^4.0.0' }
+        };
+        const pkgB = {
+            everworks: { plugin: { id: 'b' } },
+            dependencies: { axios: '^1.0.0' },
+            peerDependencies: { 'date-fns': '^3.0.0' }
+        };
+
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'a', isDirectory: () => true },
+            { name: 'b', isDirectory: () => true }
+        ]);
+        fsMock.readFileSync.mockImplementation((p: any) => {
+            const str = String(p).replace(/\\/g, '/');
+            if (str.endsWith('/a/package.json')) return JSON.stringify(pkgA);
+            return JSON.stringify(pkgB);
+        });
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual(['axios@^1.0.0', 'date-fns@^3.0.0', 'lodash@^4.0.0']);
+    });
+
+    it('logs the dependency count via console.log', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'a', isDirectory: () => true }
+        ]);
+        fsMock.readFileSync.mockReturnValue(
+            JSON.stringify({
+                everworks: { plugin: { id: 'a' } },
+                dependencies: { axios: '^1.0.0' }
+            })
+        );
+
+        collectPluginDependencies();
+        expect(logSpy).toHaveBeenCalledWith('[collectPluginDeps] Found 1 plugin dependencies');
+    });
+
+    it('returns sorted alphabetically', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'a', isDirectory: () => true }
+        ]);
+        fsMock.readFileSync.mockReturnValue(
+            JSON.stringify({
+                everworks: { plugin: { id: 'a' } },
+                dependencies: { zlib: '^1.0.0', alpha: '^1.0.0', mu: '^1.0.0' }
+            })
+        );
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual(['alpha@^1.0.0', 'mu@^1.0.0', 'zlib@^1.0.0']);
+    });
+});

--- a/packages/tasks/src/__tests__/local-plugin-store.spec.ts
+++ b/packages/tasks/src/__tests__/local-plugin-store.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LocalPluginStore } from '../trigger/worker/services/local-plugin-store';
+
+describe('LocalPluginStore', () => {
+    let store: LocalPluginStore;
+
+    beforeEach(() => {
+        store = new LocalPluginStore();
+    });
+
+    describe('create', () => {
+        it('writes a new entity keyed by pluginId', async () => {
+            const entity = await store.create({ pluginId: 'foo', name: 'Foo' } as any);
+
+            expect(entity.id).toBe('foo');
+            expect(entity.pluginId).toBe('foo');
+            expect(entity.name).toBe('Foo');
+            expect(await store.exists('foo')).toBe(true);
+        });
+
+        it('overwrites an existing entry on subsequent create', async () => {
+            await store.create({ pluginId: 'foo', name: 'First' } as any);
+            await store.create({ pluginId: 'foo', name: 'Second' } as any);
+
+            const all = await store.findAll();
+            expect(all).toHaveLength(1);
+            expect(all[0].name).toBe('Second');
+        });
+    });
+
+    describe('upsert', () => {
+        it('inserts when not present', async () => {
+            const entity = await store.upsert({ pluginId: 'a', name: 'A' } as any);
+
+            expect(entity.pluginId).toBe('a');
+            expect((entity as any).id).toBe('a');
+        });
+
+        it('merges into the existing entity instead of replacing', async () => {
+            const first = await store.upsert({ pluginId: 'a', name: 'A', enabled: true } as any);
+            const second = await store.upsert({ pluginId: 'a', name: 'A2' } as any);
+
+            expect(second).toBe(first);
+            expect((second as any).name).toBe('A2');
+            expect((second as any).enabled).toBe(true);
+        });
+    });
+
+    describe('update', () => {
+        it('returns null when the id is unknown', async () => {
+            const result = await store.update('missing', { name: 'X' } as any);
+            expect(result).toBeNull();
+        });
+
+        it('mutates the existing entity in place', async () => {
+            await store.create({ pluginId: 'p', name: 'A' } as any);
+            const updated = await store.update('p', { name: 'B' } as any);
+
+            expect(updated).not.toBeNull();
+            expect((updated as any).name).toBe('B');
+            const fromStore = (await store.findAll())[0];
+            expect((fromStore as any).name).toBe('B');
+        });
+    });
+
+    describe('delete / deleteByPluginId', () => {
+        it('returns false when nothing was deleted', async () => {
+            expect(await store.delete('missing')).toBe(false);
+            expect(await store.deleteByPluginId('missing')).toBe(false);
+        });
+
+        it('removes the entity and reports true', async () => {
+            await store.create({ pluginId: 'p' } as any);
+            expect(await store.delete('p')).toBe(true);
+            expect(await store.exists('p')).toBe(false);
+        });
+
+        it('deleteByPluginId is an alias for delete by id', async () => {
+            await store.create({ pluginId: 'p' } as any);
+            expect(await store.deleteByPluginId('p')).toBe(true);
+        });
+    });
+
+    describe('updateState', () => {
+        it('returns null when the plugin is unknown', async () => {
+            const out = await store.updateState('missing', 'enabled' as any);
+            expect(out).toBeNull();
+        });
+
+        it('updates state without touching lastError when not provided', async () => {
+            await store.create({ pluginId: 'p', state: 'disabled', lastError: 'old' } as any);
+            const out = await store.updateState('p', 'enabled' as any);
+
+            expect((out as any).state).toBe('enabled');
+            expect((out as any).lastError).toBe('old');
+        });
+
+        it('updates lastError when provided', async () => {
+            await store.create({ pluginId: 'p', state: 'enabled' } as any);
+            const out = await store.updateState('p', 'failed' as any, 'boom');
+
+            expect((out as any).state).toBe('failed');
+            expect((out as any).lastError).toBe('boom');
+        });
+    });
+
+    describe('updateByPluginId', () => {
+        it('returns null when the plugin is unknown', async () => {
+            const out = await store.updateByPluginId('missing', { foo: 1 });
+            expect(out).toBeNull();
+        });
+
+        it('merges arbitrary fields into the entity', async () => {
+            await store.create({ pluginId: 'p', name: 'A' } as any);
+            const out = await store.updateByPluginId('p', { name: 'B', extra: 1 });
+
+            expect((out as any).name).toBe('B');
+            expect((out as any).extra).toBe(1);
+        });
+    });
+
+    describe('findAll / findEnabled', () => {
+        it('findAll returns all stored entities', async () => {
+            await store.create({ pluginId: 'a' } as any);
+            await store.create({ pluginId: 'b' } as any);
+
+            const all = await store.findAll();
+            expect(all.map((e) => e.pluginId).sort()).toEqual(['a', 'b']);
+        });
+
+        it('findEnabled filters by enabled flag', async () => {
+            await store.create({ pluginId: 'a', enabled: true } as any);
+            await store.create({ pluginId: 'b', enabled: false } as any);
+            await store.create({ pluginId: 'c', enabled: true } as any);
+
+            const enabled = await store.findEnabled();
+            expect(enabled.map((e) => e.pluginId).sort()).toEqual(['a', 'c']);
+        });
+    });
+});

--- a/packages/tasks/src/__tests__/trigger-logger.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-logger.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { triggerLoggerMock } = vi.hoisted(() => ({
+    triggerLoggerMock: {
+        log: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        trace: vi.fn()
+    }
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+    logger: triggerLoggerMock
+}));
+
+import { TriggerLogger, createTriggerLogger } from '../trigger/worker/trigger-logger';
+
+describe('TriggerLogger', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('createTriggerLogger', () => {
+        it('returns an instance with the supplied context', () => {
+            const logger = createTriggerLogger('Boot');
+            expect(logger).toBeInstanceOf(TriggerLogger);
+
+            logger.log('hello');
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('[Boot] hello', {});
+        });
+
+        it('returns an instance with no context when omitted', () => {
+            const logger = createTriggerLogger();
+            logger.log('hello');
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('hello', {});
+        });
+    });
+
+    describe('setContext', () => {
+        it('updates the context used in subsequent calls', () => {
+            const logger = new TriggerLogger('Initial');
+            logger.setContext('Updated');
+
+            logger.log('msg');
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('[Updated] msg', {});
+        });
+    });
+
+    describe('log', () => {
+        it('forwards a plain message to triggerLogger.log with empty data', () => {
+            const logger = new TriggerLogger();
+            logger.log('hi');
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('hi', {});
+        });
+
+        it('extracts a string optionalParam as override context', () => {
+            const logger = new TriggerLogger('Default');
+            logger.log('hi', 'Override');
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('[Override] hi', {});
+        });
+
+        it('merges object optionalParams into data payload', () => {
+            const logger = new TriggerLogger();
+            logger.log('hi', { foo: 1, bar: 2 });
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('hi', { foo: 1, bar: 2 });
+        });
+
+        it('flattens Error objects into message + stack', () => {
+            const logger = new TriggerLogger();
+            const err = new Error('boom');
+            logger.log('hi', err);
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith(
+                'hi',
+                expect.objectContaining({ error: 'boom', stack: expect.any(String) })
+            );
+        });
+
+        it('coerces non-string messages via String()', () => {
+            const logger = new TriggerLogger();
+            logger.log({ toString: () => 'object-msg' });
+            expect(triggerLoggerMock.log).toHaveBeenCalledWith('object-msg', {});
+        });
+    });
+
+    describe('error', () => {
+        it('forwards to triggerLogger.error', () => {
+            const logger = new TriggerLogger('Ctx');
+            logger.error('bad');
+            expect(triggerLoggerMock.error).toHaveBeenCalledWith('[Ctx] bad', {});
+        });
+
+        it('captures Error info when provided', () => {
+            const logger = new TriggerLogger();
+            logger.error('failed', new Error('nope'));
+            expect(triggerLoggerMock.error).toHaveBeenCalledWith(
+                'failed',
+                expect.objectContaining({ error: 'nope', stack: expect.any(String) })
+            );
+        });
+    });
+
+    describe('warn', () => {
+        it('forwards to triggerLogger.warn', () => {
+            const logger = new TriggerLogger();
+            logger.warn('careful', { code: 42 });
+            expect(triggerLoggerMock.warn).toHaveBeenCalledWith('careful', { code: 42 });
+        });
+    });
+
+    describe('debug', () => {
+        it('forwards to triggerLogger.debug with empty data when none given', () => {
+            const logger = new TriggerLogger();
+            logger.debug?.('checking');
+            expect(triggerLoggerMock.debug).toHaveBeenCalledWith('checking', {});
+        });
+
+        it('forwards data when present', () => {
+            const logger = new TriggerLogger();
+            logger.debug?.('checking', { a: 1 });
+            expect(triggerLoggerMock.debug).toHaveBeenCalledWith('checking', { a: 1 });
+        });
+    });
+
+    describe('verbose', () => {
+        it('routes through triggerLogger.debug with verbose level marker', () => {
+            const logger = new TriggerLogger();
+            logger.verbose?.('detail');
+            expect(triggerLoggerMock.debug).toHaveBeenCalledWith('detail', { level: 'verbose' });
+        });
+
+        it('merges verbose level with provided data', () => {
+            const logger = new TriggerLogger();
+            logger.verbose?.('detail', { a: 1 });
+            expect(triggerLoggerMock.debug).toHaveBeenCalledWith('detail', {
+                level: 'verbose',
+                a: 1
+            });
+        });
+    });
+
+    describe('fatal', () => {
+        it('routes through triggerLogger.error with fatal level marker', () => {
+            const logger = new TriggerLogger();
+            logger.fatal?.('die');
+            expect(triggerLoggerMock.error).toHaveBeenCalledWith('die', { level: 'fatal' });
+        });
+
+        it('merges fatal level with provided data', () => {
+            const logger = new TriggerLogger();
+            logger.fatal?.('die', { reason: 'oom' });
+            expect(triggerLoggerMock.error).toHaveBeenCalledWith('die', {
+                level: 'fatal',
+                reason: 'oom'
+            });
+        });
+    });
+
+    describe('setLogLevels', () => {
+        it('is a no-op (trigger.dev does not support runtime level changes)', () => {
+            const logger = new TriggerLogger();
+            expect(() => logger.setLogLevels?.(['log', 'error'])).not.toThrow();
+        });
+    });
+});

--- a/packages/tasks/src/__tests__/trigger.service.spec.ts
+++ b/packages/tasks/src/__tests__/trigger.service.spec.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+    configureMock,
+    runsCancelMock,
+    workGenTriggerMock,
+    workImportTriggerMock,
+    triggerConfig,
+    subscriptionsConfig
+} = vi.hoisted(() => {
+    return {
+        configureMock: vi.fn(),
+        runsCancelMock: vi.fn(),
+        workGenTriggerMock: vi.fn(),
+        workImportTriggerMock: vi.fn(),
+        triggerConfig: {
+            shouldUseTrigger: vi.fn(),
+            getSecretKey: vi.fn(),
+            getApiUrl: vi.fn(),
+            getMachine: vi.fn(),
+            getInternalBaseUrl: vi.fn(),
+            getInternalSecret: vi.fn()
+        },
+        subscriptionsConfig: { getDispatchIntervalMinutes: vi.fn(() => 5) }
+    };
+});
+
+vi.mock('@trigger.dev/sdk', () => ({
+    configure: configureMock,
+    runs: { cancel: runsCancelMock },
+    task: vi.fn().mockImplementation(() => ({ id: 'mock-task' })),
+    schedules: { task: vi.fn().mockImplementation(() => ({ id: 'mock-schedule-task' })) },
+    logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+vi.mock('@ever-works/agent/config', () => ({
+    config: {
+        trigger: triggerConfig,
+        subscriptions: subscriptionsConfig
+    }
+}));
+
+vi.mock('@ever-works/agent/tasks', () => ({
+    WORK_GENERATION_DISPATCHER: Symbol('WORK_GENERATION_DISPATCHER'),
+    WORK_IMPORT_DISPATCHER: Symbol('WORK_IMPORT_DISPATCHER')
+}));
+
+vi.mock('../tasks/trigger/work-generation.task', () => ({
+    workGenerationTask: { trigger: workGenTriggerMock }
+}));
+vi.mock('../tasks/trigger/work-import.task', () => ({
+    workImportTask: { trigger: workImportTriggerMock }
+}));
+
+import { TriggerService } from '../trigger/trigger.service';
+
+describe('TriggerService', () => {
+    let service: TriggerService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        triggerConfig.shouldUseTrigger.mockReturnValue(true);
+        triggerConfig.getSecretKey.mockReturnValue('tr_test_secret');
+        triggerConfig.getApiUrl.mockReturnValue('https://api.trigger.test');
+        triggerConfig.getMachine.mockReturnValue('small-1x');
+        service = new TriggerService();
+        // Silence Nest Logger noise from intentional error paths in tests.
+        vi.spyOn((service as any).logger, 'error').mockImplementation(() => {});
+        vi.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('dispatchWorkGeneration', () => {
+        it('returns null when trigger is disabled', async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            const out = await service.dispatchWorkGeneration({
+                workId: 'w1',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+
+            expect(out).toBeNull();
+            expect(configureMock).not.toHaveBeenCalled();
+            expect(workGenTriggerMock).not.toHaveBeenCalled();
+        });
+
+        it('returns null and skips configure when secret key is missing', async () => {
+            triggerConfig.getSecretKey.mockReturnValue('');
+            const out = await service.dispatchWorkGeneration({
+                workId: 'w1',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+
+            expect(out).toBeNull();
+            expect(configureMock).not.toHaveBeenCalled();
+        });
+
+        it('configures the SDK on first dispatch and returns the run id', async () => {
+            workGenTriggerMock.mockResolvedValue({ id: 'run_123' });
+
+            const out = await service.dispatchWorkGeneration({
+                workId: 'w1',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+
+            expect(out).toBe('run_123');
+            expect(configureMock).toHaveBeenCalledWith({
+                accessToken: 'tr_test_secret',
+                baseURL: 'https://api.trigger.test'
+            });
+            expect(workGenTriggerMock).toHaveBeenCalledWith(
+                expect.objectContaining({ workId: 'w1' }),
+                expect.objectContaining({
+                    tags: ['work-generation', 'full', 'w1'],
+                    machine: 'small-1x'
+                })
+            );
+        });
+
+        it('does not reconfigure on subsequent dispatches', async () => {
+            workGenTriggerMock.mockResolvedValue({ id: 'run_a' });
+            await service.dispatchWorkGeneration({
+                workId: 'w1',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+            await service.dispatchWorkGeneration({
+                workId: 'w2',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+
+            expect(configureMock).toHaveBeenCalledTimes(1);
+            expect(workGenTriggerMock).toHaveBeenCalledTimes(2);
+        });
+
+        it('passes machine=undefined when getMachine() returns an unsupported value', async () => {
+            triggerConfig.getMachine.mockReturnValue('giant-99x');
+            workGenTriggerMock.mockResolvedValue({ id: 'run_x' });
+
+            await service.dispatchWorkGeneration({
+                workId: 'w1',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+
+            expect(workGenTriggerMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ machine: undefined })
+            );
+        });
+
+        it('returns null and logs when trigger() throws', async () => {
+            workGenTriggerMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+            const out = await service.dispatchWorkGeneration({
+                workId: 'w1',
+                userId: 'u1',
+                mode: 'full'
+            } as any);
+
+            expect(out).toBeNull();
+        });
+    });
+
+    describe('cancelWorkGeneration', () => {
+        it('returns false when trigger is disabled', async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            const out = await service.cancelWorkGeneration('run_x');
+            expect(out).toBe(false);
+            expect(runsCancelMock).not.toHaveBeenCalled();
+        });
+
+        it('returns true when runs.cancel resolves', async () => {
+            runsCancelMock.mockResolvedValue(undefined);
+            const out = await service.cancelWorkGeneration('run_x');
+            expect(out).toBe(true);
+            expect(runsCancelMock).toHaveBeenCalledWith('run_x');
+        });
+
+        it('returns false when runs.cancel throws', async () => {
+            runsCancelMock.mockRejectedValue(new Error('not found'));
+            const out = await service.cancelWorkGeneration('run_missing');
+            expect(out).toBe(false);
+        });
+    });
+
+    describe('dispatchWorkImport', () => {
+        it('returns null when trigger is disabled', async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            const out = await service.dispatchWorkImport({
+                workId: 'w1',
+                userId: 'u1',
+                sourceType: 'github'
+            } as any);
+
+            expect(out).toBeNull();
+            expect(workImportTriggerMock).not.toHaveBeenCalled();
+        });
+
+        it('returns the run id and tags by sourceType + workId on success', async () => {
+            workImportTriggerMock.mockResolvedValue({ id: 'imp_42' });
+
+            const out = await service.dispatchWorkImport({
+                workId: 'w1',
+                userId: 'u1',
+                sourceType: 'github'
+            } as any);
+
+            expect(out).toBe('imp_42');
+            expect(workImportTriggerMock).toHaveBeenCalledWith(
+                expect.objectContaining({ workId: 'w1', sourceType: 'github' }),
+                expect.objectContaining({
+                    tags: ['work-import', 'github', 'w1'],
+                    machine: 'small-1x'
+                })
+            );
+        });
+
+        it('returns null when import trigger() throws', async () => {
+            workImportTriggerMock.mockRejectedValue(new Error('boom'));
+
+            const out = await service.dispatchWorkImport({
+                workId: 'w1',
+                userId: 'u1',
+                sourceType: 'github'
+            } as any);
+
+            expect(out).toBeNull();
+        });
+    });
+
+    describe('machine selection', () => {
+        it.each([
+            'medium-1x',
+            'micro',
+            'small-1x',
+            'small-2x',
+            'medium-2x',
+            'large-1x',
+            'large-2x'
+        ])('forwards %s as a supported machine', async (machine) => {
+            triggerConfig.getMachine.mockReturnValue(machine);
+            workGenTriggerMock.mockResolvedValue({ id: 'run' });
+
+            await service.dispatchWorkGeneration({
+                workId: 'w',
+                userId: 'u',
+                mode: 'full'
+            } as any);
+
+            expect(workGenTriggerMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ machine })
+            );
+        });
+    });
+});

--- a/packages/tasks/tsconfig.json
+++ b/packages/tasks/tsconfig.json
@@ -23,5 +23,13 @@
             "@src/*": ["./src/*"]
         }
     },
-    "exclude": ["dist", "node_modules", "trigger.config.ts"]
+    "exclude": [
+        "dist",
+        "node_modules",
+        "trigger.config.ts",
+        "vitest.config.ts",
+        "src/**/__tests__/**",
+        "src/**/*.spec.ts",
+        "src/**/*.test.ts"
+    ]
 }

--- a/packages/tasks/vitest.config.ts
+++ b/packages/tasks/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        include: ['src/**/*.{test,spec}.ts'],
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'json', 'html']
+        }
+    }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2033,6 +2033,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
 packages:
 


### PR DESCRIPTION
## Summary

Closes the **packages/tasks** zero-coverage entry from the [COVERAGE-TRACKER.md](./COVERAGE-TRACKER.md) high-priority list. Scaffolds vitest in the package and seeds **61 unit tests** across 4 suites.

## What's covered

- **LocalPluginStore** (16 tests) — in-memory CRUD/upsert/findEnabled, idempotent delete, edge cases for `updateState` (with/without `lastError`) and `updateByPluginId`.
- **TriggerLogger** (18 tests) — context override, Error extraction (message + stack), data merge across `log` / `error` / `warn` / `debug` / `verbose` / `fatal`, and the `setLogLevels` no-op contract.
- **TriggerService** (19 tests) — `dispatchWorkGeneration` / `cancelWorkGeneration` / `dispatchWorkImport` happy + sad paths, with `@trigger.dev/sdk` (`configure`, `runs.cancel`, `task`) and `@ever-works/agent/config` mocked. Verifies single-time `configure()`, supported-machine matrix, unsupported-machine fallback to `undefined`, and the disabled-trigger fast path.
- **collectPluginDependencies** (8 tests) — fs-mocked manifest discovery with `workspace:` and `@ever-works/*` skip rules, deps + peerDeps aggregation, dedupe across plugins, alphabetical sort, and the `[collectPluginDeps] Found N plugin dependencies` console diagnostic.

## Build

- `tsconfig.json` excludes `vitest.config.ts` and `**/__tests__/**` + `**/*.spec.ts` from the tsc build so `dist/` stays clean.
- `package.json` adds `test`, `test:watch`, `test:coverage` scripts and `vitest@^3.0.0` as a devDependency.

## Test plan

- [x] `pnpm --filter @ever-works/trigger-tasks test` → **4 files, 61 tests, 0 failures**
- [x] `pnpm --filter @ever-works/trigger-tasks build` → no diagnostics

## Follow-ups (logged in tracker)

`TriggerInternalApiClient` (HTTP retry with exponential backoff), `worker-context` / `task-context` utilities, and the four task entrypoints (`work-generation` / `work-import` / `work-onboarding` / `work-schedule-dispatcher`) — these need NestFactory mocked and are best done as a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added 61 new unit tests for the task package, covering core services and plugin operations.

* **Chores**
  * Added test runner configuration with automated test scripts (test, test:watch, test:coverage).
  * Updated build configuration to exclude test files and added coverage tracking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->