### PR TITLE
test(api/activity-log): add 34 unit tests for jitsu + listener

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -46,7 +46,8 @@
 | 2026-05-07 | cli-shared prompt services        | [#477](https://github.com/ever-works/ever-works/pull/477) | Adds 64 unit tests for `BasePromptService` (45) and `WorkPromptService` (19). Base covers display helpers and all validators (URL, email, git username, API key, model name, slug, temperature, max tokens, git name, slugifyName). Work covers generateIncrementedSlug, formatRoleLabel, formatSelectedWork, promptWorkSelection, promptSlugConflictResolution, promptGitProviderSelection, promptDeployProviderSelection, promptWorkCreation — inquirer mocked via vi.mock. |
 | 2026-05-07 | monitoring first coverage         | [#478](https://github.com/ever-works/ever-works/pull/478) | Scaffolds jest in `packages/monitoring` and adds 72 unit tests across PostHog/Sentry config, services, and interceptors. PostHog config (9), Sentry config (12), AnalyticsService (15), SentryService (20), SentryInterceptor (8), PostHogInterceptor (5). Sentry SDK and posthog-node are mocked at module scope; production-vs-dev sample rates and the /auth filter on `beforeSend`/`beforeSendTransaction` are both covered. |
 | 2026-05-07 | contracts first coverage          | [#479](https://github.com/ever-works/ever-works/pull/479) | Scaffolds vitest in `packages/contracts` (with `typecheck` mode for `.spec-d.ts` fixtures) and adds 57 tests: github runtime helper `parseGitHubRepositoryUrl` (10), `isTerminalOnboardingStatus` + `ONBOARDING_TERMINAL_STATUSES` (10), `DomainType` enum (2), and a 35-assertion type-level fixture using `expectTypeOf` that pins the public surface (item / domain / form / github / api/onboarding) so accidental contract regressions fail at type-check. |
-| 2026-05-07 | tasks first coverage              | (this PR)                                                 | Scaffolds vitest in `packages/tasks` and adds 61 tests across 4 suites: `LocalPluginStore` (16) — in-memory CRUD/upsert/findEnabled; `TriggerLogger` (18) — message/context/Error/data extraction across log/error/warn/debug/verbose/fatal + setLogLevels no-op; `TriggerService` (19) — dispatchWorkGeneration / cancelWorkGeneration / dispatchWorkImport with `@trigger.dev/sdk` configure+runs+task mocked, supported-machine matrix; `collectPluginDependencies` (8) — fs-mocked manifest discovery, workspace/@ever-works skip rules, dedup + sort. Excludes spec files and `vitest.config.ts` from the tsc build. |
+| 2026-05-07 | tasks first coverage              | [#481](https://github.com/ever-works/ever-works/pull/481) | Scaffolds vitest in `packages/tasks` and adds 61 tests across 4 suites: `LocalPluginStore` (16) — in-memory CRUD/upsert/findEnabled; `TriggerLogger` (18) — message/context/Error/data extraction across log/error/warn/debug/verbose/fatal + setLogLevels no-op; `TriggerService` (19) — dispatchWorkGeneration / cancelWorkGeneration / dispatchWorkImport with `@trigger.dev/sdk` configure+runs+task mocked, supported-machine matrix; `collectPluginDependencies` (8) — fs-mocked manifest discovery, workspace/@ever-works skip rules, dedup + sort. Excludes spec files and `vitest.config.ts` from the tsc build. |
+| 2026-05-07 | api activity-log first coverage   | (this PR)                                                 | Adds 34 unit tests for `apps/api/src/activity-log/`: `JitsuService` (9) — env-driven enable/disable, object/array/null metadata handling, optional `workId`/`details`; `ActivityLogListener` (25) — every `@OnEvent` handler (work-created, generation-completed with new/in-progress entry branches and history fallback, works-config sync failure, user signup, user confirmed with provider fallback, password changed, member invited, deployment dispatched/completed/failed with URL fallback and CANCELED→cancelled mapping). Mocks `@ever-works/agent/{activity-log,database,events,entities}` plus `../events` to avoid the agent runtime tree. |
 
 ## Pending — High Priority
 
@@ -98,7 +99,11 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
 `apps/api/src/` modules currently rely heavily on e2e for coverage. Add
 service-level unit tests (Jest + `@nestjs/testing`) for:
 
-- [ ] `account`, `activity-log`, `ai-conversation`
+- [ ] `account`, `ai-conversation`
+- [x] `activity-log` — `JitsuService` (9 tests, mocks `@jitsu/js`,
+      env-driven enable/disable + payload mapping) and
+      `ActivityLogListener` (25 tests covering all 9 `@OnEvent`
+      handlers, both happy + error paths) — see (this PR)
 - [ ] `auth/services/*` (jwt, password, oauth)
 - [ ] `config`, `events`, `integrations/*`
 - [ ] `mail/providers/*`

--- a/apps/api/src/activity-log/activity-log.listener.spec.ts
+++ b/apps/api/src/activity-log/activity-log.listener.spec.ts
@@ -1,0 +1,485 @@
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/events', () => {
+    class WorkCreatedEvent {
+        static EVENT_NAME = 'work.created';
+    }
+    class WorkGenerationCompletedEvent {
+        static EVENT_NAME = 'work.generation_completed';
+    }
+    class WorksConfigSyncFailedEvent {
+        static EVENT_NAME = 'works_config.sync_failed';
+    }
+    class DeploymentDispatchedEvent {
+        static EVENT_NAME = 'deployment.dispatched';
+    }
+    class DeploymentCompletedEvent {
+        static EVENT_NAME = 'deployment.completed';
+    }
+    class DeploymentFailedEvent {
+        static EVENT_NAME = 'deployment.failed';
+    }
+    return {
+        WorkCreatedEvent,
+        WorkGenerationCompletedEvent,
+        WorksConfigSyncFailedEvent,
+        DeploymentDispatchedEvent,
+        DeploymentCompletedEvent,
+        DeploymentFailedEvent,
+    };
+});
+
+jest.mock('../events', () => {
+    class UserCreatedEvent {
+        static EVENT_NAME = 'user.created';
+    }
+    class UserConfirmedEvent {
+        static EVENT_NAME = 'user.confirmed';
+    }
+    class UserPasswordChangedEvent {
+        static EVENT_NAME = 'user.password_changed';
+    }
+    class MemberInvitedEvent {
+        static EVENT_NAME = 'work.member_invited';
+    }
+    return {
+        UserCreatedEvent,
+        UserConfirmedEvent,
+        UserPasswordChangedEvent,
+        MemberInvitedEvent,
+    };
+});
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        WORK_CREATED: 'WORK_CREATED',
+        GENERATION: 'GENERATION',
+        WORKS_CONFIG_SYNC: 'WORKS_CONFIG_SYNC',
+        USER_SIGNUP: 'USER_SIGNUP',
+        USER_LOGIN: 'USER_LOGIN',
+        PASSWORD_CHANGED: 'PASSWORD_CHANGED',
+        MEMBER_INVITED: 'MEMBER_INVITED',
+        DEPLOYMENT: 'DEPLOYMENT',
+    },
+    ActivityStatus: {
+        COMPLETED: 'completed',
+        FAILED: 'failed',
+        IN_PROGRESS: 'in_progress',
+        CANCELLED: 'cancelled',
+    },
+}));
+
+import { ActivityLogListener } from './activity-log.listener';
+import { ActivityActionType, ActivityStatus } from '@ever-works/agent/entities';
+
+// The event-class types are only used as TypeScript shapes here; the runtime
+// objects we hand to the listener satisfy the same field surface but carry no
+// real prototype, so we cast through `any`. Keeping the imports as type-only
+// avoids dragging in the agent/events runtime tree (entity modules, etc.).
+import type {
+    UserCreatedEvent,
+    UserConfirmedEvent,
+    UserPasswordChangedEvent,
+    MemberInvitedEvent,
+} from '../events';
+import type {
+    WorkCreatedEvent,
+    WorkGenerationCompletedEvent,
+    WorksConfigSyncFailedEvent,
+    DeploymentDispatchedEvent,
+    DeploymentCompletedEvent,
+    DeploymentFailedEvent,
+} from '@ever-works/agent/events';
+
+describe('ActivityLogListener', () => {
+    let activityLogService: any;
+    let generationHistoryRepository: any;
+    let listener: ActivityLogListener;
+    let loggerErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        activityLogService = {
+            log: jest.fn().mockResolvedValue(undefined),
+            updateStatus: jest.fn().mockResolvedValue(undefined),
+            findLatestByUserWorkActionStatus: jest.fn().mockResolvedValue(null),
+            resolveGenerationActivityStatus: jest.fn().mockReturnValue(ActivityStatus.COMPLETED),
+            formatGenerationCompletionSummary: jest
+                .fn()
+                .mockReturnValue('Generated 12 items'),
+        };
+        generationHistoryRepository = {
+            findLatestCompletedByWork: jest.fn().mockResolvedValue(null),
+        };
+        listener = new ActivityLogListener(activityLogService, generationHistoryRepository);
+
+        loggerErrorSpy = jest
+            .spyOn((listener as any).logger, 'error')
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('onWorkCreated', () => {
+        it('logs a WORK_CREATED activity with the correct fields', async () => {
+            const work: any = { id: 'w1', userId: 'u1', name: 'My Work' };
+            await listener.onWorkCreated({ work } as WorkCreatedEvent);
+
+            expect(activityLogService.log).toHaveBeenCalledWith({
+                userId: 'u1',
+                workId: 'w1',
+                actionType: ActivityActionType.WORK_CREATED,
+                action: 'work.created',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Created work: My Work',
+            });
+        });
+
+        it('swallows and logs errors from the service', async () => {
+            activityLogService.log.mockRejectedValue(new Error('db error'));
+            await expect(
+                listener.onWorkCreated({ work: { id: 'w', userId: 'u', name: 'n' } } as any),
+            ).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onGenerationCompleted', () => {
+        const work: any = {
+            id: 'w1',
+            userId: 'u1',
+            itemsCount: 12,
+            generateStatus: { code: 'GENERATED' },
+        };
+
+        it('updates an existing in-progress entry when one exists', async () => {
+            activityLogService.findLatestByUserWorkActionStatus.mockResolvedValue({ id: 'a-old' });
+            generationHistoryRepository.findLatestCompletedByWork.mockResolvedValue({
+                totalItemsCount: 15,
+                newItemsCount: 3,
+                updatedItemsCount: 5,
+            });
+            activityLogService.resolveGenerationActivityStatus.mockReturnValue(
+                ActivityStatus.COMPLETED,
+            );
+
+            await listener.onGenerationCompleted({ work } as WorkGenerationCompletedEvent);
+
+            expect(activityLogService.updateStatus).toHaveBeenCalledWith(
+                'a-old',
+                ActivityStatus.COMPLETED,
+                expect.objectContaining({
+                    itemsCount: 15,
+                    newItemsCount: 3,
+                    updatedItemsCount: 5,
+                    generateStatus: work.generateStatus,
+                }),
+                expect.objectContaining({
+                    action: 'generation.completed',
+                    summary: 'Generated 12 items',
+                }),
+            );
+            expect(activityLogService.log).not.toHaveBeenCalled();
+        });
+
+        it('creates a new entry when no in-progress entry exists', async () => {
+            activityLogService.findLatestByUserWorkActionStatus.mockResolvedValue(null);
+            generationHistoryRepository.findLatestCompletedByWork.mockResolvedValue(null);
+
+            await listener.onGenerationCompleted({ work } as WorkGenerationCompletedEvent);
+
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    workId: 'w1',
+                    actionType: ActivityActionType.GENERATION,
+                    action: 'generation.completed',
+                    status: ActivityStatus.COMPLETED,
+                }),
+            );
+            expect(activityLogService.updateStatus).not.toHaveBeenCalled();
+        });
+
+        it('falls back to work.itemsCount when there is no completed history row', async () => {
+            generationHistoryRepository.findLatestCompletedByWork.mockResolvedValue(null);
+            await listener.onGenerationCompleted({ work } as WorkGenerationCompletedEvent);
+
+            const details = activityLogService.log.mock.calls[0][0].details;
+            expect(details.itemsCount).toBe(12);
+            expect(details.newItemsCount).toBe(0);
+            expect(details.updatedItemsCount).toBe(0);
+        });
+
+        it('swallows errors thrown anywhere in the handler', async () => {
+            generationHistoryRepository.findLatestCompletedByWork.mockRejectedValue(
+                new Error('repo down'),
+            );
+            await expect(
+                listener.onGenerationCompleted({ work } as WorkGenerationCompletedEvent),
+            ).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onWorksConfigSyncFailed', () => {
+        const event: any = {
+            userId: 'u1',
+            workId: 'w1',
+            repository: 'org/repo',
+            reason: 'permission_denied',
+            errorMessage: 'No access token',
+        };
+
+        it('logs a WORKS_CONFIG_SYNC failure activity', async () => {
+            await listener.onWorksConfigSyncFailed(event as WorksConfigSyncFailedEvent);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    actionType: ActivityActionType.WORKS_CONFIG_SYNC,
+                    action: 'works_config.sync_failed',
+                    status: ActivityStatus.FAILED,
+                    summary: 'Failed to sync works.yml to org/repo',
+                    details: {
+                        reason: 'permission_denied',
+                        repository: 'org/repo',
+                        error: 'No access token',
+                    },
+                }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('boom'));
+            await expect(
+                listener.onWorksConfigSyncFailed(event as WorksConfigSyncFailedEvent),
+            ).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onUserCreated', () => {
+        it('logs a USER_SIGNUP activity', async () => {
+            await listener.onUserCreated({
+                user: { id: 'u1' },
+            } as UserCreatedEvent);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    actionType: ActivityActionType.USER_SIGNUP,
+                    action: 'user.signup',
+                    status: ActivityStatus.COMPLETED,
+                    summary: 'Account created',
+                }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(
+                listener.onUserCreated({ user: { id: 'u1' } } as any),
+            ).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onUserConfirmed', () => {
+        it('uses the registration provider when present', async () => {
+            await listener.onUserConfirmed({
+                user: { id: 'u1', registrationProvider: 'github' },
+            } as UserConfirmedEvent);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    summary: 'Signed in via github',
+                    actionType: ActivityActionType.USER_LOGIN,
+                    action: 'user.confirmed',
+                }),
+            );
+        });
+
+        it('falls back to "email" when registration provider is missing', async () => {
+            await listener.onUserConfirmed({
+                user: { id: 'u1', registrationProvider: null },
+            } as any);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({ summary: 'Signed in via email' }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(
+                listener.onUserConfirmed({ user: { id: 'u1' } } as any),
+            ).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onPasswordChanged', () => {
+        it('logs a PASSWORD_CHANGED activity with the IP address', async () => {
+            await listener.onPasswordChanged({
+                user: { id: 'u1' },
+                ipAddress: '127.0.0.1',
+            } as UserPasswordChangedEvent);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    actionType: ActivityActionType.PASSWORD_CHANGED,
+                    action: 'user.password_changed',
+                    status: ActivityStatus.COMPLETED,
+                    summary: 'Password changed',
+                    ipAddress: '127.0.0.1',
+                }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(
+                listener.onPasswordChanged({ user: { id: 'u1' } } as any),
+            ).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onMemberInvited', () => {
+        const event = {
+            inviter: { id: 'inviter' },
+            invitee: { email: 'new@example.com' },
+            work: { id: 'w1', name: 'My Work' },
+            role: 'editor',
+        } as any as MemberInvitedEvent;
+
+        it('logs a MEMBER_INVITED activity', async () => {
+            await listener.onMemberInvited(event);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'inviter',
+                    workId: 'w1',
+                    actionType: ActivityActionType.MEMBER_INVITED,
+                    action: 'member.invited',
+                    status: ActivityStatus.COMPLETED,
+                    summary: 'Invited new@example.com as editor to My Work',
+                    details: { inviteeEmail: 'new@example.com', role: 'editor' },
+                }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(listener.onMemberInvited(event)).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onDeploymentDispatched', () => {
+        const event = {
+            payload: {
+                work: { id: 'w1', name: 'My Work' },
+                userId: 'u1',
+                providerId: 'vercel',
+                providerName: 'Vercel',
+            },
+        } as DeploymentDispatchedEvent;
+
+        it('logs an IN_PROGRESS deployment activity', async () => {
+            await listener.onDeploymentDispatched(event);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    workId: 'w1',
+                    actionType: ActivityActionType.DEPLOYMENT,
+                    action: 'deployment.dispatched',
+                    status: ActivityStatus.IN_PROGRESS,
+                    summary: 'Dispatched deployment workflow for My Work via Vercel',
+                    details: { providerId: 'vercel', providerName: 'Vercel' },
+                }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(listener.onDeploymentDispatched(event)).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onDeploymentCompleted', () => {
+        const baseEvent = {
+            payload: {
+                work: { id: 'w1', name: 'My Work' },
+                userId: 'u1',
+                providerId: 'vercel',
+                providerName: 'Vercel',
+                url: 'https://my-work.vercel.app',
+            },
+        } as DeploymentCompletedEvent;
+
+        it('uses the URL in the summary when available', async () => {
+            await listener.onDeploymentCompleted(baseEvent);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'deployment.succeeded',
+                    status: ActivityStatus.COMPLETED,
+                    summary: 'Deployed My Work to https://my-work.vercel.app',
+                }),
+            );
+        });
+
+        it('falls back to provider name when URL is missing', async () => {
+            const eventNoUrl = {
+                payload: { ...baseEvent.payload, url: undefined },
+            } as DeploymentCompletedEvent;
+            await listener.onDeploymentCompleted(eventNoUrl);
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({ summary: 'Deployed My Work via Vercel' }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(listener.onDeploymentCompleted(baseEvent)).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('onDeploymentFailed', () => {
+        const buildEvent = (terminalState: 'FAILED' | 'CANCELED' = 'FAILED') =>
+            ({
+                payload: {
+                    work: { id: 'w1', name: 'My Work' },
+                    userId: 'u1',
+                    providerId: 'vercel',
+                    providerName: 'Vercel',
+                    terminalState,
+                    error: 'Build failed',
+                },
+            }) as DeploymentFailedEvent;
+
+        it('uses cancelled action+status when terminalState is CANCELED', async () => {
+            await listener.onDeploymentFailed(buildEvent('CANCELED'));
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'deployment.cancelled',
+                    status: ActivityStatus.CANCELLED,
+                    summary: 'Deployment canceled for My Work via Vercel',
+                }),
+            );
+        });
+
+        it('uses failed action+status when terminalState is FAILED', async () => {
+            await listener.onDeploymentFailed(buildEvent('FAILED'));
+            expect(activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'deployment.failed',
+                    status: ActivityStatus.FAILED,
+                    summary: 'Deployment failed for My Work via Vercel',
+                }),
+            );
+        });
+
+        it('swallows service errors', async () => {
+            activityLogService.log.mockRejectedValue(new Error('x'));
+            await expect(listener.onDeploymentFailed(buildEvent())).resolves.toBeUndefined();
+            expect(loggerErrorSpy).toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/activity-log/jitsu.service.spec.ts
+++ b/apps/api/src/activity-log/jitsu.service.spec.ts
@@ -1,0 +1,150 @@
+import { JitsuService } from './jitsu.service';
+
+const trackMock = jest.fn();
+const jitsuAnalyticsMock = jest.fn((_config: unknown) => ({ track: trackMock }));
+
+jest.mock('@jitsu/js', () => ({
+    jitsuAnalytics: (config: unknown) => jitsuAnalyticsMock(config),
+}));
+
+describe('JitsuService', () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        delete process.env.JITSU_HOST;
+        delete process.env.JITSU_WRITE_KEY;
+    });
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV;
+    });
+
+    describe('constructor', () => {
+        it('logs and disables itself when JITSU_HOST is missing', () => {
+            process.env.JITSU_WRITE_KEY = 'wk';
+            const service = new JitsuService();
+            expect(jitsuAnalyticsMock).not.toHaveBeenCalled();
+            // Internal client is null — verified through track() being a no-op.
+            expect((service as any).client).toBeNull();
+        });
+
+        it('logs and disables itself when JITSU_WRITE_KEY is missing', () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            const service = new JitsuService();
+            expect(jitsuAnalyticsMock).not.toHaveBeenCalled();
+            expect((service as any).client).toBeNull();
+        });
+
+        it('initializes the client when both env vars are set', () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            process.env.JITSU_WRITE_KEY = 'wk-123';
+            const service = new JitsuService();
+            expect(jitsuAnalyticsMock).toHaveBeenCalledWith({
+                host: 'jitsu.example.com',
+                writeKey: 'wk-123',
+            });
+            expect((service as any).client).toBeDefined();
+        });
+    });
+
+    describe('track', () => {
+        function buildActivity(overrides: Record<string, unknown> = {}) {
+            return {
+                id: 'a1',
+                userId: 'u1',
+                workId: 'w1',
+                actionType: 'GENERATION',
+                action: 'generation.completed',
+                status: 'completed',
+                summary: 'Done',
+                details: { foo: 'bar' },
+                metadata: { source: 'web' },
+                createdAt: new Date('2026-05-07T12:34:56.000Z'),
+                ...overrides,
+            } as any;
+        }
+
+        it('is a no-op when the client is disabled', async () => {
+            const service = new JitsuService();
+            await service.track(buildActivity());
+            expect(trackMock).not.toHaveBeenCalled();
+        });
+
+        it('forwards activity fields with object metadata merged in', async () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            process.env.JITSU_WRITE_KEY = 'wk';
+            const service = new JitsuService();
+
+            await service.track(buildActivity());
+
+            expect(trackMock).toHaveBeenCalledWith(
+                'generation.completed',
+                expect.objectContaining({
+                    source: 'web',
+                    activityId: 'a1',
+                    userId: 'u1',
+                    workId: 'w1',
+                    actionType: 'GENERATION',
+                    action: 'generation.completed',
+                    status: 'completed',
+                    summary: 'Done',
+                    details: { foo: 'bar' },
+                    createdAt: '2026-05-07T12:34:56.000Z',
+                }),
+            );
+        });
+
+        it('treats array metadata as an empty object (no spread of indices)', async () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            process.env.JITSU_WRITE_KEY = 'wk';
+            const service = new JitsuService();
+
+            await service.track(buildActivity({ metadata: ['a', 'b'] }));
+
+            const payload = trackMock.mock.calls[0][1];
+            expect(payload['0']).toBeUndefined();
+            expect(payload['1']).toBeUndefined();
+            expect(payload.activityId).toBe('a1');
+        });
+
+        it('treats null metadata as empty object', async () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            process.env.JITSU_WRITE_KEY = 'wk';
+            const service = new JitsuService();
+
+            await service.track(buildActivity({ metadata: null }));
+
+            expect(trackMock).toHaveBeenCalledWith(
+                'generation.completed',
+                expect.objectContaining({ activityId: 'a1' }),
+            );
+        });
+
+        it('passes workId=undefined when activity has no work', async () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            process.env.JITSU_WRITE_KEY = 'wk';
+            const service = new JitsuService();
+
+            await service.track(buildActivity({ workId: null }));
+
+            expect(trackMock).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({ workId: undefined }),
+            );
+        });
+
+        it('passes details=undefined when activity has none', async () => {
+            process.env.JITSU_HOST = 'jitsu.example.com';
+            process.env.JITSU_WRITE_KEY = 'wk';
+            const service = new JitsuService();
+
+            await service.track(buildActivity({ details: null }));
+
+            expect(trackMock).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({ details: undefined }),
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Closes the **activity-log** row in the API-module coverage section of [COVERAGE-TRACKER.md](./COVERAGE-TRACKER.md).

Adds **34 unit tests** across two files in [apps/api/src/activity-log](./apps/api/src/activity-log):

### JitsuService (9 tests)
- Constructor disables itself when ${'`'}JITSU_HOST${'`'} or ${'`'}JITSU_WRITE_KEY${'`'} is missing; initializes the ${'`'}@jitsu/js${'`'} client when both are set.
- ${'`'}track()${'`'} is a no-op while disabled; otherwise forwards activity fields with object metadata merged in.
- Treats array / null metadata as empty (no leakage of array indices), and passes ${'`'}workId${'`'} / ${'`'}details${'`'} = ${'`'}undefined${'`'} when absent.

### ActivityLogListener (25 tests)
Every ${'`'}@OnEvent${'`'} handler is covered with **both** a happy path and an error path that asserts ${'`'}logger.error${'`'} is invoked but the listener still resolves cleanly.

- ${'`'}onWorkCreated${'`'}, ${'`'}onUserCreated${'`'}, ${'`'}onUserConfirmed${'`'} (registration provider + ${'`'}'email'${'`'} fallback), ${'`'}onPasswordChanged${'`'}, ${'`'}onMemberInvited${'`'}, ${'`'}onWorksConfigSyncFailed${'`'}
- ${'`'}onGenerationCompleted${'`'}: new entry, in-progress-entry update, fallback to ${'`'}work.itemsCount${'`'} when history is missing, swallowed errors
- ${'`'}onDeploymentDispatched${'`'}, ${'`'}onDeploymentCompleted${'`'} (URL vs provider-name fallback), ${'`'}onDeploymentFailed${'`'} (FAILED vs CANCELED → cancelled action+status mapping)

### Mocking strategy
Mocks ${'`'}@ever-works/agent/{activity-log,database,events,entities}${'`'} and ${'`'}../events${'`'} to avoid loading the agent runtime tree. Follows the pattern established by ${'`'}onboarding.service.spec.ts${'`'}.

## Test plan
- [x] ${'`'}cd apps/api && npx jest --testPathPattern='activity-log/'${'`'} → **2 files, 34 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for activity logging functionality, covering work lifecycle events, user authentication events, password changes, member invitations, and deployment status tracking.
  * Added unit tests for analytics event tracking with environment-based configuration validation.

* **Documentation**
  * Updated test coverage tracker with new test coverage entries for activity logging and analytics modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->