### PR TITLE
test(api): add 22 unit tests for subscriptions + trigger controllers

### DIFF
--- a/apps/api/src/subscriptions/subscriptions.controller.spec.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.spec.ts
@@ -1,0 +1,195 @@
+jest.mock('@ever-works/agent/subscriptions', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({
+    SubscriptionPlanCode: {
+        FREE: 'free',
+        STARTER: 'starter',
+        PRO: 'pro',
+        ENTERPRISE: 'enterprise',
+    },
+}));
+// Stub the auth barrel — we never exercise the guard / decorator at the
+// unit-test layer (the controller is constructed manually below) and we want
+// to avoid pulling in @ever-works/agent/database transitively.
+jest.mock('../auth', () => ({
+    AuthSessionGuard: class AuthSessionGuard {},
+    AuthService: class AuthService {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { SubscriptionsController } from './subscriptions.controller';
+import type { SubscriptionService } from '@ever-works/agent/subscriptions';
+import type { AuthService } from '../auth';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+describe('SubscriptionsController', () => {
+    let subscriptionService: jest.Mocked<
+        Pick<SubscriptionService, 'summarizePlan' | 'isEnabled' | 'assignPlanToUser'>
+    >;
+    let authService: jest.Mocked<Pick<AuthService, 'getUser'>>;
+    let controller: SubscriptionsController;
+
+    const auth: AuthenticatedUser = {
+        userId: 'user-1',
+        email: 'u@e.test',
+        username: 'u',
+        provider: 'local',
+        emailVerified: true,
+        isActive: true,
+        avatar: null,
+        iat: 0,
+        iss: '',
+        aud: '',
+    };
+
+    const user = { id: 'user-1', email: 'u@e.test' } as any;
+
+    beforeEach(() => {
+        subscriptionService = {
+            summarizePlan: jest.fn(),
+            isEnabled: jest.fn(),
+            assignPlanToUser: jest.fn(),
+        } as any;
+        authService = {
+            getUser: jest.fn().mockResolvedValue(user),
+        } as any;
+        controller = new SubscriptionsController(
+            subscriptionService as unknown as SubscriptionService,
+            authService as unknown as AuthService,
+        );
+    });
+
+    describe('getPlan', () => {
+        it('returns enabled=false envelope when subscriptions are disabled', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: false,
+                plan: null,
+                allowances: [],
+            } as any);
+
+            const result = await controller.getPlan(auth);
+
+            expect(authService.getUser).toHaveBeenCalledWith('user-1');
+            expect(subscriptionService.summarizePlan).toHaveBeenCalledWith(user);
+            expect(result).toEqual({ status: 'success', enabled: false, plan: null });
+        });
+
+        it('returns plan envelope mapping code/displayName/allowances when enabled', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                plan: { code: 'pro', displayName: 'Pro' },
+                allowances: ['daily', 'weekly'],
+            } as any);
+
+            const result = await controller.getPlan(auth);
+
+            expect(result).toEqual({
+                status: 'success',
+                enabled: true,
+                plan: {
+                    code: 'pro',
+                    name: 'Pro',
+                    allowedCadences: ['daily', 'weekly'],
+                },
+            });
+        });
+
+        it('propagates AuthService errors (user not found)', async () => {
+            authService.getUser.mockRejectedValue(new Error('User not found'));
+
+            await expect(controller.getPlan(auth)).rejects.toThrow('User not found');
+            expect(subscriptionService.summarizePlan).not.toHaveBeenCalled();
+        });
+
+        it('propagates SubscriptionService.summarizePlan errors', async () => {
+            subscriptionService.summarizePlan.mockRejectedValue(new Error('boom'));
+
+            await expect(controller.getPlan(auth)).rejects.toThrow('boom');
+        });
+    });
+
+    describe('updatePlan', () => {
+        it('throws BadRequestException when subscriptions are disabled (and never calls getUser/assignPlanToUser)', async () => {
+            subscriptionService.isEnabled.mockReturnValue(false);
+
+            await expect(
+                controller.updatePlan(auth, { planCode: 'pro' as any }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                controller.updatePlan(auth, { planCode: 'pro' as any }),
+            ).rejects.toThrow('Subscriptions are disabled');
+            expect(authService.getUser).not.toHaveBeenCalled();
+            expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+        });
+
+        it('assigns plan and returns mapped envelope when enabled', async () => {
+            subscriptionService.isEnabled.mockReturnValue(true);
+            subscriptionService.assignPlanToUser.mockResolvedValue({
+                code: 'starter',
+                displayName: 'Starter',
+            } as any);
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                plan: { code: 'starter', displayName: 'Starter' },
+                allowances: ['daily'],
+            } as any);
+
+            const result = await controller.updatePlan(auth, { planCode: 'starter' as any });
+
+            expect(authService.getUser).toHaveBeenCalledWith('user-1');
+            expect(subscriptionService.assignPlanToUser).toHaveBeenCalledWith(user, 'starter');
+            expect(subscriptionService.summarizePlan).toHaveBeenCalledWith(user);
+            expect(result).toEqual({
+                status: 'success',
+                enabled: true,
+                plan: {
+                    code: 'starter',
+                    name: 'Starter',
+                    allowedCadences: ['daily'],
+                },
+            });
+        });
+
+        it('uses the assignPlanToUser response (not summarizePlan) for code/name', async () => {
+            subscriptionService.isEnabled.mockReturnValue(true);
+            subscriptionService.assignPlanToUser.mockResolvedValue({
+                code: 'pro',
+                displayName: 'Pro Plan',
+            } as any);
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                // a different plan in the summary — controller must trust assignPlanToUser
+                plan: { code: 'free', displayName: 'Free' },
+                allowances: ['weekly'],
+            } as any);
+
+            const result = await controller.updatePlan(auth, { planCode: 'pro' as any });
+
+            expect(result.plan).toEqual({
+                code: 'pro',
+                name: 'Pro Plan',
+                allowedCadences: ['weekly'],
+            });
+        });
+
+        it('propagates assignPlanToUser errors', async () => {
+            subscriptionService.isEnabled.mockReturnValue(true);
+            subscriptionService.assignPlanToUser.mockRejectedValue(new Error('plan not found'));
+
+            await expect(
+                controller.updatePlan(auth, { planCode: 'unknown' as any }),
+            ).rejects.toThrow('plan not found');
+            expect(subscriptionService.summarizePlan).not.toHaveBeenCalled();
+        });
+
+        it('propagates AuthService errors (user resolution before assignment)', async () => {
+            subscriptionService.isEnabled.mockReturnValue(true);
+            authService.getUser.mockRejectedValue(new Error('User not found'));
+
+            await expect(
+                controller.updatePlan(auth, { planCode: 'pro' as any }),
+            ).rejects.toThrow('User not found');
+            expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -1,0 +1,310 @@
+jest.mock('@ever-works/agent/database', () => ({
+    WorkRepository: class WorkRepository {},
+    AuthAccountRepository: class AuthAccountRepository {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('@ever-works/agent/cache', () => ({
+    CACHE_MANAGER: 'CACHE_MANAGER',
+}));
+jest.mock('@ever-works/agent/work-operations', () => ({
+    WorkOperationsService: class WorkOperationsService {},
+}));
+jest.mock('@ever-works/agent/tasks', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({
+    WorkOwnershipService: class WorkOwnershipService {},
+    WorkScheduleDispatcherService: class WorkScheduleDispatcherService {},
+    WorkScheduleService: class WorkScheduleService {},
+}));
+jest.mock('@ever-works/agent/notifications', () => ({
+    NotificationService: class NotificationService {},
+}));
+jest.mock('@ever-works/agent/facades', () => ({
+    GitFacadeService: class GitFacadeService {},
+}));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginRepository: class PluginRepository {},
+    UserPluginRepository: class UserPluginRepository {},
+    WorkPluginRepository: class WorkPluginRepository {},
+}));
+
+const getInternalSecretMock = jest.fn<string | undefined, []>();
+jest.mock('@ever-works/agent/config', () => ({
+    config: {
+        trigger: {
+            getInternalSecret: () => getInternalSecretMock(),
+        },
+    },
+}));
+
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import superjson from 'superjson';
+import { TriggerInternalController } from './trigger-internal.controller';
+
+describe('TriggerInternalController', () => {
+    const VALID_SECRET = 'super-secret-token';
+
+    let workRepository: any;
+    let ownershipService: any;
+    let workOperationsService: any;
+    let cacheManager: any;
+    let scheduleDispatcher: any;
+    let workScheduleService: any;
+    let notificationService: any;
+    let gitFacade: any;
+    let pluginRepository: any;
+    let userPluginRepository: any;
+    let workPluginRepository: any;
+    let authAccountRepository: any;
+    let controller: TriggerInternalController;
+
+    const buildController = () => {
+        const c = new TriggerInternalController(
+            workRepository,
+            ownershipService,
+            workOperationsService,
+            cacheManager,
+            scheduleDispatcher,
+            workScheduleService,
+            notificationService,
+            gitFacade,
+            pluginRepository,
+            userPluginRepository,
+            workPluginRepository,
+            authAccountRepository,
+        );
+        c.onModuleInit();
+        return c;
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        getInternalSecretMock.mockReturnValue(VALID_SECRET);
+
+        workRepository = { name: 'WorkRepository' };
+        ownershipService = { ensureAccess: jest.fn() };
+        workOperationsService = { name: 'WorkOperationsService' };
+        cacheManager = { name: 'CacheManager' };
+        scheduleDispatcher = { name: 'WorkScheduleDispatcherService' };
+        workScheduleService = { name: 'WorkScheduleService' };
+        notificationService = { name: 'NotificationService' };
+        gitFacade = { getAccessToken: jest.fn() };
+        pluginRepository = { name: 'PluginRepository', echo: jest.fn((v: string) => `echo:${v}`) };
+        userPluginRepository = { name: 'UserPluginRepository' };
+        workPluginRepository = { name: 'WorkPluginRepository' };
+        authAccountRepository = { name: 'AuthAccountRepository' };
+
+        controller = buildController();
+    });
+
+    describe('getWorkContext', () => {
+        const baseUser = { id: 'user-1', password: 'hashed-secret', email: 'u@e.test' };
+        const baseWork = {
+            id: 'work-1',
+            gitProvider: 'github',
+            user: baseUser,
+            description: 'A work',
+        };
+
+        it('returns context with stripped relations and stripped user password + git token', async () => {
+            (ownershipService.ensureAccess as jest.Mock).mockResolvedValue({
+                work: { ...baseWork },
+            });
+            (gitFacade.getAccessToken as jest.Mock).mockResolvedValue('gh-token');
+
+            const result = await controller.getWorkContext(VALID_SECRET, 'work-1', 'user-1');
+
+            expect(ownershipService.ensureAccess).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(gitFacade.getAccessToken).toHaveBeenCalledWith({
+                userId: 'user-1',
+                providerId: 'github',
+                workId: 'work-1',
+            });
+            // user relation stripped from work
+            expect((result.work as any).user).toBeUndefined();
+            expect((result.work as any).id).toBe('work-1');
+            // password stripped from user
+            expect((result.user as any).password).toBeUndefined();
+            expect((result.user as any).id).toBe('user-1');
+            expect(result.gitToken).toBe('gh-token');
+        });
+
+        it('returns gitToken=undefined when GitFacade returns null', async () => {
+            (ownershipService.ensureAccess as jest.Mock).mockResolvedValue({
+                work: { ...baseWork },
+            });
+            (gitFacade.getAccessToken as jest.Mock).mockResolvedValue(null);
+
+            const result = await controller.getWorkContext(VALID_SECRET, 'work-1', 'user-1');
+
+            expect(result.gitToken).toBeUndefined();
+        });
+
+        it('throws BadRequestException when userId is missing', async () => {
+            await expect(
+                controller.getWorkContext(VALID_SECRET, 'work-1', undefined as any),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                controller.getWorkContext(VALID_SECRET, 'work-1', ''),
+            ).rejects.toThrow('Missing userId');
+            expect(ownershipService.ensureAccess).not.toHaveBeenCalled();
+        });
+
+        it('throws ForbiddenException when secret is missing or wrong', async () => {
+            await expect(
+                controller.getWorkContext('', 'work-1', 'user-1'),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+            await expect(
+                controller.getWorkContext('wrong', 'work-1', 'user-1'),
+            ).rejects.toThrow('Invalid trigger secret');
+            expect(ownershipService.ensureAccess).not.toHaveBeenCalled();
+        });
+
+        it('throws ForbiddenException when no internal secret is configured', async () => {
+            getInternalSecretMock.mockReturnValue(undefined);
+
+            await expect(
+                controller.getWorkContext(VALID_SECRET, 'work-1', 'user-1'),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+            await expect(
+                controller.getWorkContext(VALID_SECRET, 'work-1', 'user-1'),
+            ).rejects.toThrow('Trigger internal secret is not configured');
+        });
+
+        it('does not strip non-user relations', async () => {
+            (ownershipService.ensureAccess as jest.Mock).mockResolvedValue({
+                work: { ...baseWork, items: [{ id: 'i1' }] },
+            });
+            (gitFacade.getAccessToken as jest.Mock).mockResolvedValue(undefined);
+
+            const result = await controller.getWorkContext(VALID_SECRET, 'work-1', 'user-1');
+
+            expect((result.work as any).items).toEqual([{ id: 'i1' }]);
+            expect(result.gitToken).toBeUndefined();
+        });
+    });
+
+    describe('callRemote', () => {
+        const buildBody = (overrides: Partial<{
+            name: string;
+            method: string;
+            args: unknown[];
+        }> = {}) => {
+            const args = overrides.args ?? [];
+            return {
+                name: overrides.name ?? 'PluginRepository',
+                method: overrides.method ?? 'echo',
+                args: superjson.serialize(args) as any,
+            };
+        };
+
+        it('dispatches to the registered remote target/method and returns superjson-serialized result', async () => {
+            const echoSpy = jest.spyOn(pluginRepository, 'echo');
+
+            const out = await controller.callRemote(
+                VALID_SECRET,
+                buildBody({ args: ['hello'] }),
+            );
+
+            expect(echoSpy).toHaveBeenCalledWith('hello');
+            const deserialized = superjson.deserialize(out.result as any);
+            expect(deserialized).toBe('echo:hello');
+        });
+
+        it('preserves rich types via superjson (Date round-trip)', async () => {
+            const fixedDate = new Date('2026-05-07T12:00:00.000Z');
+            (pluginRepository as any).withDate = jest.fn(async (d: Date) => {
+                expect(d).toBeInstanceOf(Date);
+                expect(d.toISOString()).toBe(fixedDate.toISOString());
+                return d;
+            });
+
+            const out = await controller.callRemote(
+                VALID_SECRET,
+                {
+                    name: 'PluginRepository',
+                    method: 'withDate',
+                    args: superjson.serialize([fixedDate]) as any,
+                },
+            );
+
+            const deserialized = superjson.deserialize(out.result as any) as Date;
+            expect(deserialized).toBeInstanceOf(Date);
+            expect(deserialized.toISOString()).toBe(fixedDate.toISOString());
+        });
+
+        it('throws BadRequestException for unknown remote target', async () => {
+            await expect(
+                controller.callRemote(
+                    VALID_SECRET,
+                    buildBody({ name: 'NotARealTarget' }),
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                controller.callRemote(
+                    VALID_SECRET,
+                    buildBody({ name: 'NotARealTarget' }),
+                ),
+            ).rejects.toThrow('Unknown remote target: NotARealTarget');
+        });
+
+        it('throws BadRequestException for unknown method on a known target', async () => {
+            await expect(
+                controller.callRemote(
+                    VALID_SECRET,
+                    buildBody({ name: 'PluginRepository', method: 'doesNotExist' }),
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                controller.callRemote(
+                    VALID_SECRET,
+                    buildBody({ name: 'PluginRepository', method: 'doesNotExist' }),
+                ),
+            ).rejects.toThrow('Unknown method: doesNotExist');
+        });
+
+        it('throws ForbiddenException with wrong secret (and never invokes the remote)', async () => {
+            const echoSpy = jest.spyOn(pluginRepository, 'echo');
+
+            await expect(
+                controller.callRemote('wrong', buildBody({ args: ['x'] })),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+            expect(echoSpy).not.toHaveBeenCalled();
+        });
+
+        it('exposes all 10 expected remote targets after onModuleInit', async () => {
+            const expectedTargets = [
+                'AuthAccountRepository',
+                'PluginRepository',
+                'UserPluginRepository',
+                'WorkPluginRepository',
+                'WorkOperationsService',
+                'NotificationService',
+                'WorkRepository',
+                'CacheManager',
+                'WorkScheduleDispatcherService',
+                'WorkScheduleService',
+            ];
+
+            for (const target of expectedTargets) {
+                await expect(
+                    controller.callRemote(
+                        VALID_SECRET,
+                        {
+                            name: target,
+                            method: 'doesNotExist',
+                            args: superjson.serialize([]) as any,
+                        },
+                    ),
+                ).rejects.toThrow('Unknown method: doesNotExist');
+            }
+        });
+
+        it('builds remoteMap fresh on each onModuleInit (no shared state across instances)', async () => {
+            const second = buildController();
+            (second as any).pluginRepository = { name: 'second' };
+            // each controller instance has its own remoteMap pointing at its own injections
+            expect((controller as any).remoteMap).not.toBe((second as any).remoteMap);
+            expect((controller as any).remoteMap.PluginRepository).toBe(pluginRepository);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds Jest unit tests for two zero-coverage `apps/api/src/` modules
flagged in `COVERAGE-TRACKER.md`'s "API module unit tests" section.

- **`subscriptions/subscriptions.controller`** — 9 tests
  - `getPlan`: enabled=false envelope, enabled mapping (`code/displayName` → `code/name + allowances`), AuthService.getUser propagation, summarizePlan error propagation.
  - `updatePlan`: `BadRequestException` when subscriptions disabled (no getUser/assignPlanToUser side effects), happy path mapping, plan envelope uses `assignPlanToUser` response (not `summarizePlan`), error propagation from `assignPlanToUser` and `getUser`.

- **`trigger/trigger-internal.controller`** — 13 tests
  - `getWorkContext`: secret + userId guards (`Forbidden` / `BadRequest` / "secret not configured"), `gitToken=undefined` when GitFacade returns null, `user.password` + `work.user` relation stripped, non-user relations preserved, dispatches with correct args to `ownership.ensureAccess` + `gitFacade.getAccessToken`.
  - `callRemote`: superjson serialize/deserialize round-trip including Date, `BadRequest` for unknown target / unknown method, `Forbidden` with wrong secret short-circuits before invocation, all 10 expected remote targets registered after `onModuleInit`, no shared state across instances.

Mocks `@ever-works/agent/{database,entities,cache,work-operations,tasks,services,notifications,facades,plugins,config,subscriptions}` at module scope to avoid pulling in the agent runtime tree, plus the `../auth` barrel for the subscriptions controller (matches the pattern already used by `notifications.controller.spec.ts`).

Per `COVERAGE-TRACKER.md`, the scheduled task is authorized to merge to develop without waiting for human review.

## Test plan

- [x] subscriptions: 9/9 passing
- [x] trigger: 13/13 passing
- [x] Full API suite: 350 passing (the 2 pre-existing failures in template-catalog.controller and plugins-capabilities/deploy.service are unrelated TS errors from a stale dist/ of @ever-works/agent and exist on develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for subscription management, covering plan retrieval and updates across various scenarios
  * Added comprehensive unit tests for internal trigger controller operations, including access validation and remote call handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->