### PR TITLE
test(api): add 22 unit tests for github-app controllers

### DIFF
--- a/apps/api/src/integrations/github-app/github-app-webhook.controller.spec.ts
+++ b/apps/api/src/integrations/github-app/github-app-webhook.controller.spec.ts
@@ -1,0 +1,138 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { GitHubAppWebhookController } from './github-app-webhook.controller';
+
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('@ever-works/agent/import', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@src/auth/decorators/public.decorator', () => ({
+    Public: () => () => undefined,
+}));
+
+describe('GitHubAppWebhookController', () => {
+    function createController() {
+        const gitHubAppService = {
+            verifyWebhookSignature: jest.fn(),
+        };
+        const gitHubAppSyncService = {
+            handleWebhook: jest.fn(),
+        };
+        const controller = new GitHubAppWebhookController(
+            gitHubAppService as any,
+            gitHubAppSyncService as any,
+        );
+        return { controller, gitHubAppService, gitHubAppSyncService };
+    }
+
+    function makeReq(rawBody?: string, body: any = { foo: 'bar' }) {
+        return { body, rawBody };
+    }
+
+    describe('handleWebhook (POST /api/github-app/webhooks)', () => {
+        it('throws BadRequestException when x-github-event header is missing', async () => {
+            const { controller, gitHubAppService, gitHubAppSyncService } = createController();
+            await expect(
+                controller.handleWebhook(makeReq('raw') as any, 'sig', undefined),
+            ).rejects.toThrow(BadRequestException);
+            await expect(
+                controller.handleWebhook(makeReq('raw') as any, 'sig', undefined),
+            ).rejects.toThrow('Missing GitHub event header');
+            // Should not even attempt signature verification or dispatch.
+            expect(gitHubAppService.verifyWebhookSignature).not.toHaveBeenCalled();
+            expect(gitHubAppSyncService.handleWebhook).not.toHaveBeenCalled();
+        });
+
+        it('throws BadRequestException when raw body is missing (empty string is also missing)', async () => {
+            const { controller, gitHubAppService, gitHubAppSyncService } = createController();
+            await expect(
+                controller.handleWebhook(makeReq(undefined) as any, 'sig', 'push'),
+            ).rejects.toThrow('Missing raw webhook payload');
+            await expect(
+                controller.handleWebhook(makeReq('') as any, 'sig', 'push'),
+            ).rejects.toThrow('Missing raw webhook payload');
+            expect(gitHubAppService.verifyWebhookSignature).not.toHaveBeenCalled();
+            expect(gitHubAppSyncService.handleWebhook).not.toHaveBeenCalled();
+        });
+
+        it('throws UnauthorizedException when signature verification fails (and does not dispatch)', async () => {
+            const { controller, gitHubAppService, gitHubAppSyncService } = createController();
+            gitHubAppService.verifyWebhookSignature.mockReturnValue(false);
+
+            await expect(
+                controller.handleWebhook(
+                    makeReq('raw-body-here', { action: 'opened' }) as any,
+                    'sig=bad',
+                    'push',
+                ),
+            ).rejects.toThrow(UnauthorizedException);
+            await expect(
+                controller.handleWebhook(
+                    makeReq('raw-body-here', { action: 'opened' }) as any,
+                    'sig=bad',
+                    'push',
+                ),
+            ).rejects.toThrow('Invalid GitHub webhook signature');
+            expect(gitHubAppService.verifyWebhookSignature).toHaveBeenCalledWith(
+                'raw-body-here',
+                'sig=bad',
+            );
+            expect(gitHubAppSyncService.handleWebhook).not.toHaveBeenCalled();
+        });
+
+        it('forwards rawBody + signature to verifyWebhookSignature; signature header may be undefined', async () => {
+            const { controller, gitHubAppService } = createController();
+            gitHubAppService.verifyWebhookSignature.mockReturnValue(false);
+            await expect(
+                controller.handleWebhook(makeReq('rb') as any, undefined, 'push'),
+            ).rejects.toThrow(UnauthorizedException);
+            expect(gitHubAppService.verifyWebhookSignature).toHaveBeenCalledWith('rb', undefined);
+        });
+
+        it('happy path: dispatches via handleWebhook and returns { ok: true }', async () => {
+            const { controller, gitHubAppService, gitHubAppSyncService } = createController();
+            gitHubAppService.verifyWebhookSignature.mockReturnValue(true);
+            gitHubAppSyncService.handleWebhook.mockResolvedValue(undefined);
+
+            const body = { action: 'opened', repository: { id: 1 } };
+            const result = await controller.handleWebhook(
+                makeReq('raw-body', body) as any,
+                'sig=good',
+                'pull_request',
+            );
+
+            expect(gitHubAppService.verifyWebhookSignature).toHaveBeenCalledWith(
+                'raw-body',
+                'sig=good',
+            );
+            expect(gitHubAppSyncService.handleWebhook).toHaveBeenCalledWith(
+                'pull_request',
+                body,
+            );
+            expect(result).toEqual({ ok: true });
+        });
+
+        it('propagates errors from handleWebhook (no envelope on failure)', async () => {
+            const { controller, gitHubAppService, gitHubAppSyncService } = createController();
+            gitHubAppService.verifyWebhookSignature.mockReturnValue(true);
+            gitHubAppSyncService.handleWebhook.mockRejectedValue(new Error('handler boom'));
+            await expect(
+                controller.handleWebhook(
+                    makeReq('raw', {}) as any,
+                    'sig',
+                    'installation',
+                ),
+            ).rejects.toThrow('handler boom');
+        });
+
+        it('the @Public decorator semantics: handler is callable without auth context (smoke check)', async () => {
+            // The @Public decorator only attaches metadata — it does not affect the
+            // controller method's runtime behavior. Confirm no auth-context object is
+            // required for invocation.
+            const { controller, gitHubAppService, gitHubAppSyncService } = createController();
+            gitHubAppService.verifyWebhookSignature.mockReturnValue(true);
+            gitHubAppSyncService.handleWebhook.mockResolvedValue(undefined);
+            await controller.handleWebhook(makeReq('raw', {}) as any, 'sig', 'ping');
+            expect(gitHubAppSyncService.handleWebhook).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/apps/api/src/integrations/github-app/github-app.controller.spec.ts
+++ b/apps/api/src/integrations/github-app/github-app.controller.spec.ts
@@ -1,0 +1,269 @@
+import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { GitHubAppController } from './github-app.controller';
+
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('@ever-works/agent/import', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+// Stub the auth barrel so importing AuthService doesn't pull in the full
+// auth module (which transitively requires the agent runtime tree we
+// can't satisfy in unit tests).
+jest.mock('@src/auth', () => ({}));
+jest.mock('@src/auth/decorators/public.decorator', () => ({
+    Public: () => () => undefined,
+}));
+jest.mock('@src/auth/providers/auth-provider.abstract', () => ({}));
+jest.mock('@src/auth/providers/auth-provider.constants', () => ({
+    AUTH_PROVIDER: 'AUTH_PROVIDER',
+}));
+
+describe('GitHubAppController', () => {
+    function createController() {
+        const onboardingService = {
+            beginSetup: jest.fn(),
+            completeUserAuth: jest.fn(),
+        };
+        const syncService = {
+            listInstallationsForUser: jest.fn(),
+            syncInstallation: jest.fn(),
+            onboardInstallationRepository: jest.fn(),
+        };
+        const authService = {
+            getUser: jest.fn(),
+        };
+        const authProvider = {
+            issueSession: jest.fn(),
+        };
+
+        const controller = new GitHubAppController(
+            onboardingService as any,
+            syncService as any,
+            authService as any,
+            authProvider as any,
+        );
+
+        return { controller, onboardingService, syncService, authService, authProvider };
+    }
+
+    describe('setup (GET /api/github-app/setup)', () => {
+        it('forwards installation_id, setup_action, redirectTo to onboarding.beginSetup', async () => {
+            const { controller, onboardingService } = createController();
+            onboardingService.beginSetup.mockResolvedValue({ status: 'redirect' });
+
+            const result = await controller.setup({
+                installation_id: 'inst-1',
+                setup_action: 'install',
+                redirectTo: '/dashboard',
+            } as any);
+
+            expect(onboardingService.beginSetup).toHaveBeenCalledWith({
+                installationId: 'inst-1',
+                setupAction: 'install',
+                redirectTo: '/dashboard',
+            });
+            expect(result).toEqual({ status: 'redirect' });
+        });
+
+        it('passes through undefined optional query params (setup_action, redirectTo)', async () => {
+            const { controller, onboardingService } = createController();
+            onboardingService.beginSetup.mockResolvedValue({});
+            await controller.setup({ installation_id: 'inst-2' } as any);
+
+            expect(onboardingService.beginSetup).toHaveBeenCalledWith({
+                installationId: 'inst-2',
+                setupAction: undefined,
+                redirectTo: undefined,
+            });
+        });
+
+        it('propagates errors from onboarding.beginSetup', async () => {
+            const { controller, onboardingService } = createController();
+            onboardingService.beginSetup.mockRejectedValue(new Error('beginSetup boom'));
+            await expect(controller.setup({ installation_id: 'x' } as any)).rejects.toThrow(
+                'beginSetup boom',
+            );
+        });
+    });
+
+    describe('callback (GET /api/github-app/callback)', () => {
+        it('runs completeUserAuth → issueSession and merges installationId+redirectTo into the session payload', async () => {
+            const { controller, onboardingService, authProvider } = createController();
+            onboardingService.completeUserAuth.mockResolvedValue({
+                user: { id: 'u1' },
+                installation: { installationId: 'inst-1' },
+                redirectTo: '/post-auth',
+            });
+            authProvider.issueSession.mockResolvedValue({
+                accessToken: 'tok',
+                refreshToken: 'rtok',
+                user: { id: 'u1' },
+            });
+
+            const result = await controller.callback({ code: 'c', state: 's' } as any);
+
+            expect(onboardingService.completeUserAuth).toHaveBeenCalledWith({
+                code: 'c',
+                state: 's',
+            });
+            expect(authProvider.issueSession).toHaveBeenCalledWith('u1');
+            expect(result).toEqual({
+                accessToken: 'tok',
+                refreshToken: 'rtok',
+                user: { id: 'u1' },
+                installationId: 'inst-1',
+                redirectTo: '/post-auth',
+            });
+        });
+
+        it('does not call issueSession when completeUserAuth fails', async () => {
+            const { controller, onboardingService, authProvider } = createController();
+            onboardingService.completeUserAuth.mockRejectedValue(new Error('auth failed'));
+            await expect(
+                controller.callback({ code: 'c', state: 's' } as any),
+            ).rejects.toThrow('auth failed');
+            expect(authProvider.issueSession).not.toHaveBeenCalled();
+        });
+
+        it('propagates redirectTo undefined → undefined (no default)', async () => {
+            const { controller, onboardingService, authProvider } = createController();
+            onboardingService.completeUserAuth.mockResolvedValue({
+                user: { id: 'u1' },
+                installation: { installationId: 'inst-1' },
+                // redirectTo intentionally omitted
+            });
+            authProvider.issueSession.mockResolvedValue({ accessToken: 'a' });
+
+            const result = await controller.callback({ code: 'c', state: 's' } as any);
+            expect(result.redirectTo).toBeUndefined();
+            expect(result.installationId).toBe('inst-1');
+        });
+    });
+
+    describe('listInstallations (GET /api/github-app/installations)', () => {
+        it('forwards req.user.userId to syncService.listInstallationsForUser', async () => {
+            const { controller, syncService } = createController();
+            syncService.listInstallationsForUser.mockResolvedValue([{ id: 'i1' }]);
+
+            const result = await controller.listInstallations({
+                user: { userId: 'u-42' },
+            } as any);
+            expect(syncService.listInstallationsForUser).toHaveBeenCalledWith('u-42');
+            expect(result).toEqual([{ id: 'i1' }]);
+        });
+    });
+
+    describe('syncInstallation (POST /api/github-app/installations/:installationId/sync)', () => {
+        it('returns the installation when syncInstallation resolves with one', async () => {
+            const { controller, syncService } = createController();
+            const fake = { id: 'inst-1', repositories: [] };
+            syncService.syncInstallation.mockResolvedValue(fake);
+
+            const result = await controller.syncInstallation('inst-1', {
+                user: { userId: 'u1' },
+            } as any);
+            expect(syncService.syncInstallation).toHaveBeenCalledWith('inst-1', 'u1');
+            expect(result).toBe(fake);
+        });
+
+        it('throws UnauthorizedException when syncInstallation resolves to null', async () => {
+            const { controller, syncService } = createController();
+            syncService.syncInstallation.mockResolvedValue(null);
+
+            await expect(
+                controller.syncInstallation('inst-1', { user: { userId: 'u1' } } as any),
+            ).rejects.toThrow(UnauthorizedException);
+            await expect(
+                controller.syncInstallation('inst-1', { user: { userId: 'u1' } } as any),
+            ).rejects.toThrow('GitHub App installation not found for this user');
+        });
+
+        it('throws UnauthorizedException when syncInstallation resolves to undefined', async () => {
+            const { controller, syncService } = createController();
+            syncService.syncInstallation.mockResolvedValue(undefined);
+            await expect(
+                controller.syncInstallation('inst-x', { user: { userId: 'u1' } } as any),
+            ).rejects.toThrow(UnauthorizedException);
+        });
+
+        it('propagates errors from syncInstallation', async () => {
+            const { controller, syncService } = createController();
+            syncService.syncInstallation.mockRejectedValue(new Error('sync boom'));
+            await expect(
+                controller.syncInstallation('inst-1', { user: { userId: 'u1' } } as any),
+            ).rejects.toThrow('sync boom');
+        });
+    });
+
+    describe('onboardRepository (POST .../installations/:installationId/repositories/:repositoryId/onboard)', () => {
+        it('happy path: getUser then onboardInstallationRepository, returns success result', async () => {
+            const { controller, authService, syncService } = createController();
+            const user = { id: 'u1', email: 'u@example.com' };
+            authService.getUser.mockResolvedValue(user);
+            const successResult = {
+                status: 'ok',
+                workId: 'w1',
+                repositoryId: 'r1',
+            };
+            syncService.onboardInstallationRepository.mockResolvedValue(successResult);
+
+            const result = await controller.onboardRepository('inst-1', 'r1', {
+                user: { userId: 'u1' },
+            } as any);
+            expect(authService.getUser).toHaveBeenCalledWith('u1');
+            expect(syncService.onboardInstallationRepository).toHaveBeenCalledWith(
+                'inst-1',
+                'r1',
+                user,
+            );
+            expect(result).toBe(successResult);
+        });
+
+        it('throws NotFoundException when onboardInstallationRepository returns falsy', async () => {
+            const { controller, authService, syncService } = createController();
+            authService.getUser.mockResolvedValue({ id: 'u1' });
+            syncService.onboardInstallationRepository.mockResolvedValue(null);
+
+            await expect(
+                controller.onboardRepository('inst-1', 'r1', {
+                    user: { userId: 'u1' },
+                } as any),
+            ).rejects.toThrow(NotFoundException);
+            await expect(
+                controller.onboardRepository('inst-1', 'r1', {
+                    user: { userId: 'u1' },
+                } as any),
+            ).rejects.toThrow('GitHub App repository not found for this user');
+        });
+
+        it('throws BadRequestException with the error message when result.status === "error"', async () => {
+            const { controller, authService, syncService } = createController();
+            authService.getUser.mockResolvedValue({ id: 'u1' });
+            syncService.onboardInstallationRepository.mockResolvedValue({
+                status: 'error',
+                message: 'repo already onboarded',
+            });
+
+            await expect(
+                controller.onboardRepository('inst-1', 'r1', {
+                    user: { userId: 'u1' },
+                } as any),
+            ).rejects.toThrow(BadRequestException);
+            await expect(
+                controller.onboardRepository('inst-1', 'r1', {
+                    user: { userId: 'u1' },
+                } as any),
+            ).rejects.toThrow('repo already onboarded');
+        });
+
+        it('does not call onboardInstallationRepository if getUser fails', async () => {
+            const { controller, authService, syncService } = createController();
+            authService.getUser.mockRejectedValue(new Error('user lookup failed'));
+            await expect(
+                controller.onboardRepository('inst-1', 'r1', {
+                    user: { userId: 'u1' },
+                } as any),
+            ).rejects.toThrow('user lookup failed');
+            expect(syncService.onboardInstallationRepository).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds 22 unit tests across `apps/api/src/integrations/github-app/`:

- **`github-app.controller.spec.ts`** (15) — covers all 5 endpoints:
  - `GET /setup` forwards `installation_id` / `setup_action` /
    `redirectTo` to `onboarding.beginSetup`; undefined optionals
    pass through; errors propagate.
  - `GET /callback` runs `completeUserAuth` → `issueSession` and
    merges `installationId` + `redirectTo` into the session payload;
    does not call `issueSession` when `completeUserAuth` fails;
    `redirectTo` undefined propagates as undefined.
  - `GET /installations` forwards `req.user.userId` to
    `syncService.listInstallationsForUser`.
  - `POST /installations/:id/sync` returns the installation when
    present; throws `UnauthorizedException("GitHub App installation
    not found for this user")` on null/undefined; propagates handler
    errors.
  - `POST .../repositories/:rid/onboard` runs
    `authService.getUser` → `onboardInstallationRepository`;
    throws `NotFoundException` on falsy result; throws
    `BadRequestException` with the message when
    `result.status === 'error'`; does NOT call
    `onboardInstallationRepository` if `getUser` fails.

- **`github-app-webhook.controller.spec.ts`** (7) — covers POST
  `/webhooks`:
  - `BadRequestException` when `x-github-event` header is missing
    (skip verify + dispatch);
  - `BadRequestException` when raw body is missing (undefined / empty
    string), again skipping verify + dispatch;
  - `UnauthorizedException("Invalid GitHub webhook signature")` when
    verification fails (skip dispatch);
  - signature header may be undefined and is forwarded verbatim;
  - happy path: verify → `handleWebhook(eventName, body)` →
    `{ ok: true }`;
  - propagates errors from `handleWebhook`;
  - smoke check that the `@Public`-decorated handler is invocable
    without an auth-context object.

Both specs mock `@ever-works/agent/{database,entities,import,services}`
plus the `@src/auth` barrel and the `@Public` decorator to avoid pulling
in the full auth+agent module graph (matches the pattern in the
existing `github-app-sync.service.spec.ts`).

## Test plan

- [x] `pnpm --filter ever-works-api jest --testPathPattern=\"github-app.*controller\"` — 2 suites, 22 tests, all green.
- [x] No source changes, no test mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for GitHub App webhook handling, including event validation, signature verification, and error scenarios.
  * Added unit tests for GitHub App controller, covering onboarding flow, authentication callbacks, installation management, and repository synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->