### PR TITLE
test(api): add 59 unit tests for works/tasks schedulers

### DIFF
--- a/apps/api/src/works/tasks/community-pr-scheduler.service.spec.ts
+++ b/apps/api/src/works/tasks/community-pr-scheduler.service.spec.ts
@@ -1,0 +1,118 @@
+jest.mock('@ever-works/agent/community-pr', () => ({}));
+jest.mock('@ever-works/agent/cache', () => ({}));
+
+import { CommunityPrSchedulerService } from './community-pr-scheduler.service';
+import type { CommunityPrProcessorService } from '@ever-works/agent/community-pr';
+import type { DistributedTaskLockService } from '@ever-works/agent/cache';
+
+describe('CommunityPrSchedulerService', () => {
+    let processor: { processAllWorks: jest.Mock };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: CommunityPrSchedulerService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        processor = { processAllWorks: jest.fn() };
+        taskLockService = { runExclusive: jest.fn() };
+        service = new CommunityPrSchedulerService(
+            processor as unknown as CommunityPrProcessorService,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runExclusive uses works:community-pr-scheduler key, 1h ttlMs, and a debug onLocked', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+
+        await service.handleCommunityPrProcessing();
+
+        const [key, work, opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:community-pr-scheduler');
+        expect(typeof work).toBe('function');
+        expect(opts.ttlMs).toBe(60 * 60 * 1000);
+        expect(typeof opts.onLocked).toBe('function');
+
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping community PR processing because another instance holds the task lock',
+        );
+    });
+
+    it('runs the inner work, logs start + completion with processed and error counts', async () => {
+        processor.processAllWorks.mockResolvedValue({
+            processed: 7,
+            errors: ['e1', 'e2'],
+        });
+
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleCommunityPrProcessing();
+
+        expect(processor.processAllWorks).toHaveBeenCalledTimes(1);
+        expect(logSpy).toHaveBeenCalledWith('Starting community PR processing');
+        expect(logSpy).toHaveBeenCalledWith(
+            'Community PR processing completed: 7 processed, 2 errors',
+        );
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs an error stack when processor throws Error and swallows the failure', async () => {
+        const boom = new Error('boom');
+        processor.processAllWorks.mockRejectedValue(boom);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await expect(service.handleCommunityPrProcessing()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error during community PR processing',
+            boom.stack,
+        );
+    });
+
+    it('logs error with String(error) when thrown value is not an Error', async () => {
+        processor.processAllWorks.mockRejectedValue('plain string failure');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleCommunityPrProcessing();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error during community PR processing',
+            'plain string failure',
+        );
+    });
+
+    it('does not run inner work when runExclusive returns without invoking it (locked branch)', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+        await service.handleCommunityPrProcessing();
+        expect(processor.processAllWorks).not.toHaveBeenCalled();
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('handles zero processed and zero errors', async () => {
+        processor.processAllWorks.mockResolvedValue({ processed: 0, errors: [] });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleCommunityPrProcessing();
+        expect(logSpy).toHaveBeenCalledWith(
+            'Community PR processing completed: 0 processed, 0 errors',
+        );
+    });
+});

--- a/apps/api/src/works/tasks/comparison-scheduler.service.spec.ts
+++ b/apps/api/src/works/tasks/comparison-scheduler.service.spec.ts
@@ -1,0 +1,159 @@
+jest.mock('@ever-works/agent/comparison-generator', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/cache', () => ({}));
+
+import { ComparisonSchedulerService } from './comparison-scheduler.service';
+import type { ComparisonGenerationService } from '@ever-works/agent/comparison-generator';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { DistributedTaskLockService } from '@ever-works/agent/cache';
+
+describe('ComparisonSchedulerService', () => {
+    let comparisonService: { generateNextComparison: jest.Mock };
+    let workRepository: { findWithComparisonsEnabled: jest.Mock };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: ComparisonSchedulerService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        comparisonService = { generateNextComparison: jest.fn() };
+        workRepository = { findWithComparisonsEnabled: jest.fn() };
+        taskLockService = { runExclusive: jest.fn() };
+        service = new ComparisonSchedulerService(
+            comparisonService as unknown as ComparisonGenerationService,
+            workRepository as unknown as WorkRepository,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runExclusive uses works:comparison-scheduler key, 1h ttl, debug onLocked', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+
+        await service.handleComparisonGeneration();
+
+        const [key, work, opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:comparison-scheduler');
+        expect(typeof work).toBe('function');
+        expect(opts.ttlMs).toBe(60 * 60 * 1000);
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping scheduled comparison generation because another instance holds the task lock',
+        );
+    });
+
+    it('returns early with zero counts when there are no eligible works', async () => {
+        workRepository.findWithComparisonsEnabled.mockResolvedValue([]);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleComparisonGeneration();
+        expect(comparisonService.generateNextComparison).not.toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith('Starting scheduled comparison generation');
+        expect(logSpy).toHaveBeenCalledWith(
+            'Comparison generation completed: 0 generated, 0 skipped, 0 errors',
+        );
+    });
+
+    it('counts generated/skipped/errors and forwards { respectCadence: true }', async () => {
+        const works = [
+            { id: 'w1', userId: 'u1' },
+            { id: 'w2', userId: 'u2' },
+            { id: 'w3', userId: 'u3' },
+            { id: 'w4', userId: 'u4' },
+        ];
+        workRepository.findWithComparisonsEnabled.mockResolvedValue(works);
+
+        comparisonService.generateNextComparison
+            .mockResolvedValueOnce({ status: 'success', slug: 'foo-vs-bar' })
+            .mockResolvedValueOnce({ status: 'skipped' })
+            .mockResolvedValueOnce({ status: 'success', slug: 'baz-vs-qux' })
+            .mockRejectedValueOnce(new Error('per-work failure'));
+
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleComparisonGeneration();
+
+        expect(comparisonService.generateNextComparison).toHaveBeenCalledTimes(4);
+        works.forEach((work) => {
+            expect(comparisonService.generateNextComparison).toHaveBeenCalledWith(
+                work.id,
+                work.userId,
+                { respectCadence: true },
+            );
+        });
+
+        expect(logSpy).toHaveBeenCalledWith('Generated comparison for work w1: foo-vs-bar');
+        expect(logSpy).toHaveBeenCalledWith('Generated comparison for work w3: baz-vs-qux');
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Failed to generate comparison for work w4: per-work failure',
+        );
+        expect(logSpy).toHaveBeenCalledWith(
+            'Comparison generation completed: 2 generated, 1 skipped, 1 errors',
+        );
+    });
+
+    it('treats a non-Error rejection as String(error) in the per-work error log', async () => {
+        workRepository.findWithComparisonsEnabled.mockResolvedValue([{ id: 'w1', userId: 'u1' }]);
+        comparisonService.generateNextComparison.mockRejectedValue('rate limit');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleComparisonGeneration();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Failed to generate comparison for work w1: rate limit',
+        );
+    });
+
+    it('does not increment generated/skipped on unknown status values', async () => {
+        workRepository.findWithComparisonsEnabled.mockResolvedValue([{ id: 'w1', userId: 'u1' }]);
+        comparisonService.generateNextComparison.mockResolvedValue({ status: 'pending' });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleComparisonGeneration();
+        expect(logSpy).toHaveBeenCalledWith(
+            'Comparison generation completed: 0 generated, 0 skipped, 0 errors',
+        );
+    });
+
+    it('logs error stack when findWithComparisonsEnabled throws Error', async () => {
+        const boom = new Error('db unavailable');
+        workRepository.findWithComparisonsEnabled.mockRejectedValue(boom);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await expect(service.handleComparisonGeneration()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith('Error during comparison generation', boom.stack);
+    });
+
+    it('logs error with String(error) when outer rejection is not an Error', async () => {
+        workRepository.findWithComparisonsEnabled.mockRejectedValue('outer-string');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleComparisonGeneration();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error during comparison generation',
+            'outer-string',
+        );
+    });
+});

--- a/apps/api/src/works/tasks/item-source-validation-scheduler.service.spec.ts
+++ b/apps/api/src/works/tasks/item-source-validation-scheduler.service.spec.ts
@@ -1,0 +1,137 @@
+jest.mock('@ever-works/agent/cache', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+
+import { ItemSourceValidationCronService } from './item-source-validation-scheduler.service';
+import type {
+    CacheEntryRepository,
+    DistributedTaskLockService,
+} from '@ever-works/agent/cache';
+import type { ItemSourceValidationSchedulerService } from '@ever-works/agent/services';
+import {
+    WORK_CATEGORIES_TAGS_CACHE_KEY_PREFIX,
+    WORK_CONFIG_CACHE_KEY_PREFIX,
+    WORK_COUNT_CACHE_KEY_PREFIX,
+    WORK_ITEMS_CACHE_KEY_PREFIX,
+} from '../work-cache.constants';
+
+describe('ItemSourceValidationCronService', () => {
+    let scheduler: { processDueSchedules: jest.Mock };
+    let cacheEntryRepository: { typeormAdapter: { deleteUnscopedEntriesLike: jest.Mock } };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: ItemSourceValidationCronService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        scheduler = { processDueSchedules: jest.fn() };
+        cacheEntryRepository = {
+            typeormAdapter: { deleteUnscopedEntriesLike: jest.fn().mockResolvedValue(undefined) },
+        };
+        taskLockService = { runExclusive: jest.fn() };
+        service = new ItemSourceValidationCronService(
+            scheduler as unknown as ItemSourceValidationSchedulerService,
+            cacheEntryRepository as unknown as CacheEntryRepository,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runExclusive uses works:item-source-validation-scheduler key, 1h ttl, debug onLocked', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+
+        await service.handleScheduledSourceValidation();
+
+        const [key, work, opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:item-source-validation-scheduler');
+        expect(typeof work).toBe('function');
+        expect(opts.ttlMs).toBe(60 * 60 * 1000);
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping scheduled item source validation because another instance holds the task lock',
+        );
+    });
+
+    it('processes schedules, deletes the four work cache prefixes in parallel, logs counts', async () => {
+        scheduler.processDueSchedules.mockResolvedValue({
+            processed: 3,
+            skipped: 1,
+            itemsChecked: 12,
+            itemsChanged: 5,
+            errors: ['err-a'],
+        });
+
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleScheduledSourceValidation();
+
+        expect(scheduler.processDueSchedules).toHaveBeenCalledTimes(1);
+        expect(cacheEntryRepository.typeormAdapter.deleteUnscopedEntriesLike).toHaveBeenCalledTimes(
+            4,
+        );
+        const calls = cacheEntryRepository.typeormAdapter.deleteUnscopedEntriesLike.mock.calls.map(
+            (c) => c[0],
+        );
+        expect(calls).toEqual(
+            expect.arrayContaining([
+                WORK_ITEMS_CACHE_KEY_PREFIX,
+                WORK_CONFIG_CACHE_KEY_PREFIX,
+                WORK_COUNT_CACHE_KEY_PREFIX,
+                WORK_CATEGORIES_TAGS_CACHE_KEY_PREFIX,
+            ]),
+        );
+        expect(logSpy).toHaveBeenCalledWith('Starting scheduled item source validation');
+        expect(logSpy).toHaveBeenCalledWith(
+            'Scheduled item source validation completed: 3 processed, 1 skipped, 12 items checked, 5 items changed, 1 errors',
+        );
+    });
+
+    it('logs the error stack when processDueSchedules throws Error and swallows', async () => {
+        const boom = new Error('process failed');
+        scheduler.processDueSchedules.mockRejectedValue(boom);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await expect(service.handleScheduledSourceValidation()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error during scheduled item source validation',
+            boom.stack,
+        );
+        expect(cacheEntryRepository.typeormAdapter.deleteUnscopedEntriesLike).not.toHaveBeenCalled();
+    });
+
+    it('logs error with String(error) when thrown value is not an Error', async () => {
+        scheduler.processDueSchedules.mockRejectedValue('boom');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleScheduledSourceValidation();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error during scheduled item source validation',
+            'boom',
+        );
+    });
+
+    it('does not invoke processDueSchedules or cache deletes when locked branch skips', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+        await service.handleScheduledSourceValidation();
+        expect(scheduler.processDueSchedules).not.toHaveBeenCalled();
+        expect(
+            cacheEntryRepository.typeormAdapter.deleteUnscopedEntriesLike,
+        ).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/works/tasks/website-template-scheduler.service.spec.ts
+++ b/apps/api/src/works/tasks/website-template-scheduler.service.spec.ts
@@ -1,0 +1,284 @@
+jest.mock('@ever-works/agent/cache', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('@ever-works/agent/generators', () => ({}));
+jest.mock('@ever-works/agent/config', () => ({
+    config: {
+        websiteTemplate: {
+            autoUpdateEnabled: jest.fn(),
+        },
+    },
+}));
+
+import { config } from '@ever-works/agent/config';
+import { WebsiteTemplateSchedulerService } from './website-template-scheduler.service';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { Work } from '@ever-works/agent/entities';
+import type { WebsiteUpdateService } from '@ever-works/agent/generators';
+import type { DistributedTaskLockService } from '@ever-works/agent/cache';
+
+describe('WebsiteTemplateSchedulerService', () => {
+    let workRepository: {
+        findWithWebsiteAutoUpdateEnabled: jest.Mock;
+        update: jest.Mock;
+    };
+    let websiteUpdateService: {
+        checkForUpdate: jest.Mock;
+        updateRepository: jest.Mock;
+    };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: WebsiteTemplateSchedulerService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+    const autoUpdateEnabled = (config as any).websiteTemplate.autoUpdateEnabled as jest.Mock;
+
+    beforeEach(() => {
+        workRepository = {
+            findWithWebsiteAutoUpdateEnabled: jest.fn(),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        websiteUpdateService = {
+            checkForUpdate: jest.fn(),
+            updateRepository: jest.fn(),
+        };
+        taskLockService = { runExclusive: jest.fn() };
+        service = new WebsiteTemplateSchedulerService(
+            workRepository as unknown as WorkRepository,
+            websiteUpdateService as unknown as WebsiteUpdateService,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+        autoUpdateEnabled.mockReturnValue(true);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runExclusive uses works:website-template-scheduler key, 1h ttl, debug onLocked', async () => {
+        // override default
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+        await service.handleScheduledTemplateUpdates();
+        const [key, work, opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:website-template-scheduler');
+        expect(typeof work).toBe('function');
+        expect(opts.ttlMs).toBe(60 * 60 * 1000);
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping website template scheduler because another instance holds the task lock',
+        );
+    });
+
+    it('returns early when feature is disabled', async () => {
+        autoUpdateEnabled.mockReturnValue(false);
+        await service.handleScheduledTemplateUpdates();
+        expect(workRepository.findWithWebsiteAutoUpdateEnabled).not.toHaveBeenCalled();
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns early when no eligible works are found', async () => {
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([]);
+        await service.handleScheduledTemplateUpdates();
+        expect(websiteUpdateService.checkForUpdate).not.toHaveBeenCalled();
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs the count then performs an update for each work and logs completion', async () => {
+        const work1 = {
+            id: 'w1',
+            slug: 's1',
+            user: { id: 'u1' },
+        } as unknown as Work;
+        const work2 = {
+            id: 'w2',
+            slug: 's2',
+            user: { id: 'u2' },
+        } as unknown as Work;
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([work1, work2]);
+
+        websiteUpdateService.checkForUpdate
+            .mockResolvedValueOnce({
+                error: null,
+                updateAvailable: true,
+                branch: 'main',
+                currentCommit: 'abc',
+                latestCommit: 'def',
+            })
+            .mockResolvedValueOnce({
+                error: null,
+                updateAvailable: false,
+                branch: 'main',
+            });
+
+        websiteUpdateService.updateRepository.mockResolvedValueOnce({
+            commitSha: 'def',
+            method: 'merge',
+        });
+
+        await service.handleScheduledTemplateUpdates();
+
+        expect(logSpy).toHaveBeenCalledWith('Checking 2 works for website template updates');
+        expect(logSpy).toHaveBeenCalledWith('Update available for s1: abc -> def');
+        expect(logSpy).toHaveBeenCalledWith('Successfully updated s1 using merge method');
+        expect(debugSpy).toHaveBeenCalledWith(
+            'No update available for work s2 (branch: main)',
+        );
+        expect(logSpy).toHaveBeenCalledWith('Website template update check completed');
+
+        // Update calls: lastChecked for both, success-update for w1
+        const updateCalls = workRepository.update.mock.calls;
+        // w1 lastChecked
+        expect(updateCalls[0][0]).toBe('w1');
+        expect(updateCalls[0][1]).toEqual({ websiteTemplateLastCheckedAt: expect.any(Date) });
+        // w1 success
+        expect(workRepository.update).toHaveBeenCalledWith('w1', {
+            websiteTemplateLastCommit: 'def',
+            websiteTemplateLastUpdatedAt: expect.any(Date),
+            websiteTemplateLastError: null,
+        });
+        // w2 lastChecked only
+        expect(workRepository.update).toHaveBeenCalledWith('w2', {
+            websiteTemplateLastCheckedAt: expect.any(Date),
+        });
+
+        expect(websiteUpdateService.updateRepository).toHaveBeenCalledTimes(1);
+        expect(websiteUpdateService.updateRepository).toHaveBeenCalledWith(
+            work1,
+            work1.user,
+            { branch: 'main' },
+        );
+    });
+
+    it('falls back to updateCheck.latestCommit when result.commitSha is missing', async () => {
+        const work = {
+            id: 'w1',
+            slug: 's1',
+            user: { id: 'u1' },
+        } as unknown as Work;
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([work]);
+        websiteUpdateService.checkForUpdate.mockResolvedValue({
+            updateAvailable: true,
+            branch: 'main',
+            currentCommit: null,
+            latestCommit: 'fallback-sha',
+        });
+        websiteUpdateService.updateRepository.mockResolvedValue({ method: 'rebase' });
+
+        await service.handleScheduledTemplateUpdates();
+
+        expect(workRepository.update).toHaveBeenCalledWith('w1', {
+            websiteTemplateLastCommit: 'fallback-sha',
+            websiteTemplateLastUpdatedAt: expect.any(Date),
+            websiteTemplateLastError: null,
+        });
+        expect(logSpy).toHaveBeenCalledWith('Update available for s1: none -> fallback-sha');
+    });
+
+    it('records updateCheck.error and skips update when checkForUpdate reports error', async () => {
+        const work = {
+            id: 'w1',
+            slug: 's1',
+            user: { id: 'u1' },
+        } as unknown as Work;
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([work]);
+        websiteUpdateService.checkForUpdate.mockResolvedValue({
+            error: 'token expired',
+            updateAvailable: false,
+        });
+
+        await service.handleScheduledTemplateUpdates();
+
+        expect(workRepository.update).toHaveBeenCalledWith('w1', {
+            websiteTemplateLastError: 'token expired',
+        });
+        expect(warnSpy).toHaveBeenCalledWith('Cannot check updates for s1: token expired');
+        expect(websiteUpdateService.updateRepository).not.toHaveBeenCalled();
+    });
+
+    it('skips update when workOwner (work.user) is not loaded', async () => {
+        const work = { id: 'w1', slug: 's1', user: null } as unknown as Work;
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([work]);
+        websiteUpdateService.checkForUpdate.mockResolvedValue({
+            updateAvailable: true,
+            branch: 'main',
+            currentCommit: 'a',
+            latestCommit: 'b',
+        });
+
+        await service.handleScheduledTemplateUpdates();
+
+        expect(websiteUpdateService.updateRepository).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith('Work s1 has no user loaded, skipping update');
+    });
+
+    it('records error message when updateRepository throws Error', async () => {
+        const work = {
+            id: 'w1',
+            slug: 's1',
+            user: { id: 'u1' },
+        } as unknown as Work;
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([work]);
+        websiteUpdateService.checkForUpdate.mockResolvedValue({
+            updateAvailable: true,
+            branch: 'main',
+            currentCommit: 'a',
+            latestCommit: 'b',
+        });
+        websiteUpdateService.updateRepository.mockRejectedValue(new Error('git push failed'));
+
+        await service.handleScheduledTemplateUpdates();
+
+        expect(workRepository.update).toHaveBeenCalledWith('w1', {
+            websiteTemplateLastError: 'git push failed',
+        });
+        expect(errorSpy).toHaveBeenCalledWith('Failed to update template for work s1: git push failed');
+    });
+
+    it('records "Unknown error during template update" when non-Error is thrown', async () => {
+        const work = {
+            id: 'w1',
+            slug: 's1',
+            user: { id: 'u1' },
+        } as unknown as Work;
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockResolvedValue([work]);
+        websiteUpdateService.checkForUpdate.mockResolvedValue({
+            updateAvailable: true,
+            branch: 'main',
+            currentCommit: 'a',
+            latestCommit: 'b',
+        });
+        websiteUpdateService.updateRepository.mockRejectedValue('weird');
+
+        await service.handleScheduledTemplateUpdates();
+
+        expect(workRepository.update).toHaveBeenCalledWith('w1', {
+            websiteTemplateLastError: 'Unknown error during template update',
+        });
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Failed to update template for work s1: Unknown error during template update',
+        );
+    });
+
+    it('logs the outer error stack when findWithWebsiteAutoUpdateEnabled throws', async () => {
+        const boom = new Error('repo down');
+        workRepository.findWithWebsiteAutoUpdateEnabled.mockRejectedValue(boom);
+
+        await service.handleScheduledTemplateUpdates();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error during scheduled template update check',
+            boom.stack,
+        );
+    });
+});

--- a/apps/api/src/works/tasks/work-cache-warmup.service.spec.ts
+++ b/apps/api/src/works/tasks/work-cache-warmup.service.spec.ts
@@ -1,0 +1,306 @@
+jest.mock('@ever-works/agent/cache', () => ({
+    CACHE_MANAGER: 'CACHE_MANAGER',
+}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({
+    GenerateStatusType: {
+        GENERATING: 'GENERATING',
+        COMPLETED: 'COMPLETED',
+        ERROR: 'ERROR',
+    },
+}));
+
+import { WorkCacheWarmupService } from './work-cache-warmup.service';
+import type { Cache } from '@ever-works/agent/cache';
+import type {
+    DistributedTaskLockService,
+} from '@ever-works/agent/cache';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { WorkQueryService } from '@ever-works/agent/services';
+import {
+    getWorkCategoriesTagsCacheKey,
+    getWorkConfigCacheKey,
+    getWorkCountCacheKey,
+    getWorkItemsCacheKey,
+    WORK_CACHE_TTL_MS,
+} from '../work-cache.constants';
+
+describe('WorkCacheWarmupService', () => {
+    let cacheManager: { get: jest.Mock; set: jest.Mock };
+    let workRepository: {
+        countForDetailCacheWarmup: jest.Mock;
+        findForDetailCacheWarmup: jest.Mock;
+    };
+    let workQueryService: {
+        workItems: jest.Mock;
+        workConfig: jest.Mock;
+        workCount: jest.Mock;
+        workCategoriesTags: jest.Mock;
+    };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: WorkCacheWarmupService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        cacheManager = {
+            get: jest.fn(),
+            set: jest.fn().mockResolvedValue(undefined),
+        };
+        workRepository = {
+            countForDetailCacheWarmup: jest.fn(),
+            findForDetailCacheWarmup: jest.fn(),
+        };
+        workQueryService = {
+            workItems: jest.fn(),
+            workConfig: jest.fn(),
+            workCount: jest.fn(),
+            workCategoriesTags: jest.fn(),
+        };
+        taskLockService = { runExclusive: jest.fn() };
+        service = new WorkCacheWarmupService(
+            cacheManager as unknown as Cache,
+            workRepository as unknown as WorkRepository,
+            workQueryService as unknown as WorkQueryService,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runExclusive uses works:cache-warmup key, 9-min ttl, debug onLocked', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+        await service.warmWorkCaches();
+        const [key, , opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:cache-warmup');
+        expect(opts.ttlMs).toBe(9 * 60 * 1000);
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping work cache warm-up because another instance holds the task lock',
+        );
+    });
+
+    it('returns early when totalEligible is zero', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(0);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+        await service.warmWorkCaches();
+        expect(workRepository.findForDetailCacheWarmup).not.toHaveBeenCalled();
+        expect(cacheManager.set).not.toHaveBeenCalled();
+    });
+
+    it('warms a single work and sets all four cache entries with WORK_CACHE_TTL_MS', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(1);
+        const work = {
+            id: 'w1',
+            generateStatus: { status: 'COMPLETED' },
+            user: { id: 'u1' },
+        };
+        workRepository.findForDetailCacheWarmup.mockResolvedValueOnce([work]);
+        workQueryService.workItems.mockResolvedValue('items');
+        workQueryService.workConfig.mockResolvedValue('config');
+        workQueryService.workCount.mockResolvedValue('count');
+        workQueryService.workCategoriesTags.mockResolvedValue('cats');
+
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+        await service.warmWorkCaches();
+
+        expect(workRepository.findForDetailCacheWarmup).toHaveBeenCalledWith(25, 0);
+        expect(cacheManager.set).toHaveBeenCalledWith(
+            getWorkItemsCacheKey('w1', 'u1'),
+            'items',
+            WORK_CACHE_TTL_MS,
+        );
+        expect(cacheManager.set).toHaveBeenCalledWith(
+            getWorkConfigCacheKey('w1', 'u1'),
+            'config',
+            WORK_CACHE_TTL_MS,
+        );
+        expect(cacheManager.set).toHaveBeenCalledWith(
+            getWorkCountCacheKey('w1', 'u1'),
+            'count',
+            WORK_CACHE_TTL_MS,
+        );
+        expect(cacheManager.set).toHaveBeenCalledWith(
+            getWorkCategoriesTagsCacheKey('w1', 'u1'),
+            'cats',
+            WORK_CACHE_TTL_MS,
+        );
+        // total-eligible<=BATCH so cursor is set to 0 with the 30-day TTL
+        const cursorTtl = 1000 * 60 * 60 * 24 * 30;
+        expect(cacheManager.set).toHaveBeenCalledWith(
+            'work-cache-warmup-offset',
+            0,
+            cursorTtl,
+        );
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Work detail cache warm-up completed: 1 warmed, 0 skipped, 0 errors',
+            ),
+        );
+    });
+
+    it('skips works with status=GENERATING and works without user.id', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(2);
+        workRepository.findForDetailCacheWarmup.mockResolvedValue([
+            { id: 'gen', generateStatus: { status: 'GENERATING' }, user: { id: 'u1' } },
+            { id: 'noUser', generateStatus: { status: 'COMPLETED' }, user: null },
+        ]);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.warmWorkCaches();
+        expect(workQueryService.workItems).not.toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('0 warmed, 2 skipped'),
+        );
+    });
+
+    it('counts errors when query services throw, logs the per-work warning', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(1);
+        workRepository.findForDetailCacheWarmup.mockResolvedValue([
+            { id: 'w1', generateStatus: { status: 'COMPLETED' }, user: { id: 'u1' } },
+        ]);
+        workQueryService.workItems.mockRejectedValue(new Error('items down'));
+        workQueryService.workConfig.mockResolvedValue('c');
+        workQueryService.workCount.mockResolvedValue('c2');
+        workQueryService.workCategoriesTags.mockResolvedValue('c3');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.warmWorkCaches();
+        expect(warnSpy).toHaveBeenCalledWith('Failed to warm detail cache for work w1: items down');
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('0 warmed, 0 skipped, 1 errors'),
+        );
+    });
+
+    it('handles non-Error rejection in per-work warm path with String(error) in warn', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(1);
+        workRepository.findForDetailCacheWarmup.mockResolvedValue([
+            { id: 'w1', generateStatus: { status: 'COMPLETED' }, user: { id: 'u1' } },
+        ]);
+        workQueryService.workItems.mockRejectedValue('network');
+        workQueryService.workConfig.mockResolvedValue('c');
+        workQueryService.workCount.mockResolvedValue('c2');
+        workQueryService.workCategoriesTags.mockResolvedValue('c3');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.warmWorkCaches();
+        expect(warnSpy).toHaveBeenCalledWith('Failed to warm detail cache for work w1: network');
+    });
+
+    it('uses cached cursor and advances offset when totalEligible exceeds batch size', async () => {
+        // totalEligible=30, batch=25, currentOffset=10 from cache
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(30);
+        cacheManager.get.mockResolvedValue(10);
+        const works = Array.from({ length: 20 }, (_, i) => ({
+            id: `w${i}`,
+            generateStatus: { status: 'COMPLETED' },
+            user: { id: 'u' },
+        }));
+        const wrapped = Array.from({ length: 5 }, (_, i) => ({
+            id: `wr${i}`,
+            generateStatus: { status: 'COMPLETED' },
+            user: { id: 'u' },
+        }));
+        workRepository.findForDetailCacheWarmup
+            .mockResolvedValueOnce(works) // first batch with offset=10, returned 20 (less than 25)
+            .mockResolvedValueOnce(wrapped); // wrap-around second batch from offset 0, remainder 5
+        workQueryService.workItems.mockResolvedValue('i');
+        workQueryService.workConfig.mockResolvedValue('c');
+        workQueryService.workCount.mockResolvedValue('cnt');
+        workQueryService.workCategoriesTags.mockResolvedValue('t');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.warmWorkCaches();
+
+        // Verify two repo calls: the first with (25, 10), then wrap with (5, 0)
+        expect(workRepository.findForDetailCacheWarmup).toHaveBeenNthCalledWith(1, 25, 10);
+        expect(workRepository.findForDetailCacheWarmup).toHaveBeenNthCalledWith(2, 5, 0);
+
+        // nextOffset = (10 + 25) % 30 = 5
+        const cursorTtl = 1000 * 60 * 60 * 24 * 30;
+        expect(cacheManager.set).toHaveBeenCalledWith('work-cache-warmup-offset', 5, cursorTtl);
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('25 warmed, 0 skipped, 0 errors, offset 10 -> 5'),
+        );
+    });
+
+    it('coerces invalid cursor (string-non-numeric) to currentOffset=0', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(30);
+        cacheManager.get.mockResolvedValue('not-a-number');
+        workRepository.findForDetailCacheWarmup.mockResolvedValueOnce([
+            { id: 'w1', generateStatus: { status: 'COMPLETED' }, user: { id: 'u' } },
+        ]);
+        workRepository.findForDetailCacheWarmup.mockResolvedValueOnce([]);
+        workQueryService.workItems.mockResolvedValue('i');
+        workQueryService.workConfig.mockResolvedValue('c');
+        workQueryService.workCount.mockResolvedValue('cnt');
+        workQueryService.workCategoriesTags.mockResolvedValue('t');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+        await service.warmWorkCaches();
+        expect(workRepository.findForDetailCacheWarmup).toHaveBeenNthCalledWith(1, 25, 0);
+    });
+
+    it('resets cursor to 0 when current window yields zero works', async () => {
+        workRepository.countForDetailCacheWarmup.mockResolvedValue(30);
+        cacheManager.get.mockResolvedValue(0);
+        workRepository.findForDetailCacheWarmup.mockResolvedValue([]);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.warmWorkCaches();
+        const cursorTtl = 1000 * 60 * 60 * 24 * 30;
+        expect(cacheManager.set).toHaveBeenCalledWith('work-cache-warmup-offset', 0, cursorTtl);
+        expect(logSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('Work detail cache warm-up completed'),
+        );
+    });
+
+    it('logs the outer error stack and swallows when countForDetailCacheWarmup throws', async () => {
+        const boom = new Error('count failed');
+        workRepository.countForDetailCacheWarmup.mockRejectedValue(boom);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await expect(service.warmWorkCaches()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith('Error during work detail cache warm-up', boom.stack);
+    });
+
+    it('outer error handler uses String(error) for non-Error', async () => {
+        workRepository.countForDetailCacheWarmup.mockRejectedValue('weird');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.warmWorkCaches();
+        expect(errorSpy).toHaveBeenCalledWith('Error during work detail cache warm-up', 'weird');
+    });
+});

--- a/apps/api/src/works/tasks/work-cleanup.service.spec.ts
+++ b/apps/api/src/works/tasks/work-cleanup.service.spec.ts
@@ -1,0 +1,276 @@
+jest.mock('@ever-works/agent/cache', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({
+    GenerateStatusType: {
+        GENERATING: 'GENERATING',
+        COMPLETED: 'COMPLETED',
+        ERROR: 'ERROR',
+    },
+}));
+jest.mock('@ever-works/agent/events', () => ({
+    WorkGenerationCompletedEvent: class WorkGenerationCompletedEvent {
+        static EVENT_NAME = 'work.generation.completed';
+        constructor(public readonly work: any) {}
+    },
+}));
+jest.mock('@src/config/constants', () => ({
+    config: {
+        work: {
+            staleTimeoutHours: jest.fn(() => 2),
+        },
+    },
+}));
+
+import { WorkCleanupService } from './work-cleanup.service';
+import {
+    WorkGenerationCompletedEvent,
+    // type-side import
+} from '@ever-works/agent/events';
+import { GenerateStatusType } from '@ever-works/agent/entities';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
+import type {
+    CacheEntryRepository,
+    DistributedTaskLockService,
+} from '@ever-works/agent/cache';
+import type {
+    WorkRepository,
+    WorkGenerationHistoryRepository,
+} from '@ever-works/agent/database';
+
+describe('WorkCleanupService', () => {
+    let workRepository: {
+        getUnfinishedGenerations: jest.Mock;
+        recordGenerationFinishTime: jest.Mock;
+        updateGenerateStatus: jest.Mock;
+        findById: jest.Mock;
+    };
+    let cacheRepository: {
+        typeormAdapter: { deleteUnscopedEntriesLike: jest.Mock };
+    };
+    let generationHistoryRepository: {
+        findOrphanedGenerating: jest.Mock;
+        updateEntry: jest.Mock;
+    };
+    let eventEmitter: { emit: jest.Mock };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: WorkCleanupService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        workRepository = {
+            getUnfinishedGenerations: jest.fn().mockResolvedValue([]),
+            recordGenerationFinishTime: jest.fn().mockResolvedValue(undefined),
+            updateGenerateStatus: jest.fn().mockResolvedValue(undefined),
+            findById: jest.fn().mockResolvedValue(null),
+        };
+        cacheRepository = {
+            typeormAdapter: { deleteUnscopedEntriesLike: jest.fn() },
+        };
+        generationHistoryRepository = {
+            findOrphanedGenerating: jest.fn().mockResolvedValue([]),
+            updateEntry: jest.fn().mockResolvedValue(undefined),
+        };
+        eventEmitter = { emit: jest.fn() };
+        taskLockService = { runExclusive: jest.fn() };
+
+        service = new WorkCleanupService(
+            workRepository as unknown as WorkRepository,
+            cacheRepository as unknown as CacheEntryRepository,
+            generationHistoryRepository as unknown as WorkGenerationHistoryRepository,
+            eventEmitter as unknown as EventEmitter2,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runExclusive uses works:cleanup key, 9-min ttl, debug onLocked', async () => {
+        taskLockService.runExclusive.mockResolvedValue(undefined);
+        await service.handleStalledGenerations();
+        const [key, , opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:cleanup');
+        expect(opts.ttlMs).toBe(9 * 60 * 1000);
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping work cleanup because another instance holds the task lock',
+        );
+    });
+
+    it('uses staleTimeoutHours config to compute the staleThreshold passed to repository', async () => {
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+        const before = Date.now();
+        await service.handleStalledGenerations();
+        const after = Date.now();
+        expect(workRepository.getUnfinishedGenerations).toHaveBeenCalledTimes(1);
+        const arg = workRepository.getUnfinishedGenerations.mock.calls[0][0] as Date;
+        expect(arg).toBeInstanceOf(Date);
+        const diffMs = before - arg.getTime();
+        // staleTimeoutHours mock returns 2 → threshold ≈ now - 2h
+        const expectedMs = 2 * 60 * 60 * 1000;
+        expect(diffMs).toBeGreaterThanOrEqual(expectedMs - 1000);
+        expect(diffMs).toBeLessThanOrEqual(after - arg.getTime());
+    });
+
+    it('does not log when there are no stalled works and no orphaned history records', async () => {
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+        await service.handleStalledGenerations();
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('marks GENERATING stalled works as ERROR, finishes them, refetches, and emits event', async () => {
+        const stalled = {
+            id: 'w-gen',
+            generateStatus: { status: GenerateStatusType.GENERATING },
+        };
+        workRepository.getUnfinishedGenerations.mockResolvedValue([stalled]);
+        const updatedWork = { id: 'w-gen', generateStatus: { status: GenerateStatusType.ERROR } };
+        workRepository.findById.mockResolvedValue(updatedWork);
+
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+        await service.handleStalledGenerations();
+
+        expect(workRepository.recordGenerationFinishTime).toHaveBeenCalledWith(
+            'w-gen',
+            expect.any(Date),
+        );
+        expect(workRepository.updateGenerateStatus).toHaveBeenCalledWith('w-gen', {
+            status: GenerateStatusType.ERROR,
+            error: 'Generation stalled',
+        });
+        expect(workRepository.findById).toHaveBeenCalledWith('w-gen');
+        const [eventName, eventArg] = eventEmitter.emit.mock.calls[0];
+        expect(eventName).toBe('work.generation.completed');
+        expect(eventArg).toBeInstanceOf(WorkGenerationCompletedEvent);
+        expect((eventArg as WorkGenerationCompletedEvent).work).toBe(updatedWork);
+        expect(logSpy).toHaveBeenCalledWith('Found 1 stalled generation(s)');
+        expect(logSpy).toHaveBeenCalledWith('Stalled generation check completed');
+    });
+
+    it('does not call updateGenerateStatus for stalled works that are not GENERATING', async () => {
+        const stalled = {
+            id: 'w-error',
+            generateStatus: { status: GenerateStatusType.ERROR },
+        };
+        workRepository.getUnfinishedGenerations.mockResolvedValue([stalled]);
+        workRepository.findById.mockResolvedValue(stalled);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleStalledGenerations();
+        expect(workRepository.recordGenerationFinishTime).toHaveBeenCalledWith(
+            'w-error',
+            expect.any(Date),
+        );
+        expect(workRepository.updateGenerateStatus).not.toHaveBeenCalled();
+        expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit when refetched work is null', async () => {
+        const stalled = {
+            id: 'w1',
+            generateStatus: { status: GenerateStatusType.GENERATING },
+        };
+        workRepository.getUnfinishedGenerations.mockResolvedValue([stalled]);
+        workRepository.findById.mockResolvedValue(null);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleStalledGenerations();
+        expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('recovers orphaned history records by marking them ERROR', async () => {
+        generationHistoryRepository.findOrphanedGenerating.mockResolvedValue([
+            { id: 'h1' },
+            { id: 'h2' },
+        ]);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleStalledGenerations();
+        expect(logSpy).toHaveBeenCalledWith(
+            'Found 2 orphaned history record(s), marking as error',
+        );
+        expect(generationHistoryRepository.updateEntry).toHaveBeenCalledTimes(2);
+        const firstUpdate = generationHistoryRepository.updateEntry.mock.calls[0];
+        expect(firstUpdate[0]).toBe('h1');
+        expect(firstUpdate[1]).toEqual({
+            status: GenerateStatusType.ERROR,
+            errorMessage: 'Generation stalled — automatically recovered',
+            finishedAt: expect.any(Date),
+        });
+    });
+
+    it('logs error stack when getUnfinishedGenerations throws Error and swallows', async () => {
+        const boom = new Error('db down');
+        workRepository.getUnfinishedGenerations.mockRejectedValue(boom);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await expect(service.handleStalledGenerations()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith('Error checking stalled generations', boom.stack);
+    });
+
+    it('logs String(error) when thrown value is not an Error', async () => {
+        workRepository.getUnfinishedGenerations.mockRejectedValue({
+            // no `stack`
+            details: 'hello',
+        });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.handleStalledGenerations();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error checking stalled generations',
+            '[object Object]',
+        );
+    });
+
+    describe('clearWorkCache (event handler)', () => {
+        it('deletes cache entries by work id and logs success', async () => {
+            cacheRepository.typeormAdapter.deleteUnscopedEntriesLike.mockResolvedValue(undefined);
+            const event = new WorkGenerationCompletedEvent({ id: 'w42' } as any);
+            service.clearWorkCache(event);
+            // wait microtasks so the .then() runs
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(
+                cacheRepository.typeormAdapter.deleteUnscopedEntriesLike,
+            ).toHaveBeenCalledWith('w42');
+            expect(logSpy).toHaveBeenCalledWith('Cache cleared for work w42');
+        });
+
+        it('logs error when cache clear fails', async () => {
+            const err = new Error('redis down');
+            cacheRepository.typeormAdapter.deleteUnscopedEntriesLike.mockRejectedValue(err);
+            const event = new WorkGenerationCompletedEvent({ id: 'w99' } as any);
+            service.clearWorkCache(event);
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(errorSpy).toHaveBeenCalledWith('Failed to clear cache:', err);
+        });
+    });
+});

--- a/apps/api/src/works/tasks/work-schedule-dispatcher-cron.service.spec.ts
+++ b/apps/api/src/works/tasks/work-schedule-dispatcher-cron.service.spec.ts
@@ -1,0 +1,183 @@
+jest.mock('@ever-works/agent/cache', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/agent/config', () => ({
+    config: {
+        subscriptions: {
+            scheduledUpdatesEnabled: jest.fn(),
+            getDispatchIntervalMinutes: jest.fn(),
+        },
+        trigger: {
+            shouldUseTrigger: jest.fn(),
+        },
+    },
+}));
+
+import { config } from '@ever-works/agent/config';
+import { WorkScheduleDispatcherCronService } from './work-schedule-dispatcher-cron.service';
+import type { WorkScheduleDispatcherService } from '@ever-works/agent/services';
+import type { DistributedTaskLockService } from '@ever-works/agent/cache';
+
+describe('WorkScheduleDispatcherCronService', () => {
+    let dispatcher: { dispatchDue: jest.Mock };
+    let taskLockService: { runExclusive: jest.Mock };
+    let service: WorkScheduleDispatcherCronService;
+    let logSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+    const scheduledUpdatesEnabled = (config as any).subscriptions
+        .scheduledUpdatesEnabled as jest.Mock;
+    const getDispatchIntervalMinutes = (config as any).subscriptions
+        .getDispatchIntervalMinutes as jest.Mock;
+    const shouldUseTrigger = (config as any).trigger.shouldUseTrigger as jest.Mock;
+    let dateSpy: jest.SpyInstance | undefined;
+
+    beforeEach(() => {
+        dispatcher = { dispatchDue: jest.fn() };
+        taskLockService = { runExclusive: jest.fn() };
+        service = new WorkScheduleDispatcherCronService(
+            dispatcher as unknown as WorkScheduleDispatcherService,
+            taskLockService as unknown as DistributedTaskLockService,
+        );
+        logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        errorSpy = jest
+            .spyOn((service as any).logger, 'error')
+            .mockImplementation(() => undefined);
+        debugSpy = jest
+            .spyOn((service as any).logger, 'debug')
+            .mockImplementation(() => undefined);
+        // Defaults: feature ON, no trigger
+        scheduledUpdatesEnabled.mockReturnValue(true);
+        shouldUseTrigger.mockReturnValue(false);
+        getDispatchIntervalMinutes.mockReturnValue(1);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        dateSpy?.mockRestore();
+    });
+
+    it('returns early when scheduledUpdatesEnabled() is false', async () => {
+        scheduledUpdatesEnabled.mockReturnValue(false);
+        await service.dispatchDueSchedules();
+        expect(taskLockService.runExclusive).not.toHaveBeenCalled();
+    });
+
+    it('returns early when trigger should be used (delegates dispatch elsewhere)', async () => {
+        shouldUseTrigger.mockReturnValue(true);
+        await service.dispatchDueSchedules();
+        expect(taskLockService.runExclusive).not.toHaveBeenCalled();
+    });
+
+    it('skips when current minute is not aligned with the dispatch interval', async () => {
+        // interval=5 → run only at minutes divisible by 5
+        getDispatchIntervalMinutes.mockReturnValue(5);
+        // 5 mins after epoch = 60_000 * 5 = epochMinute 5 (5 % 5 === 0). Pick a non-aligned: 6.
+        const sixMins = new Date(60_000 * 6);
+        dateSpy = jest.spyOn(global, 'Date').mockImplementation(() => sixMins as any);
+
+        await service.dispatchDueSchedules();
+        expect(taskLockService.runExclusive).not.toHaveBeenCalled();
+    });
+
+    it('runs dispatcher when minute is aligned, with ttlMs = max(intervalMinutes*60_000, 60_000)', async () => {
+        getDispatchIntervalMinutes.mockReturnValue(5);
+        // epochMinute 5 is aligned
+        const fiveMins = new Date(60_000 * 5);
+        dateSpy = jest.spyOn(global, 'Date').mockImplementation(() => fiveMins as any);
+        dispatcher.dispatchDue.mockResolvedValue({
+            dispatched: 3,
+            skipped: 1,
+            failed: 0,
+            dueCount: 4,
+        });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.dispatchDueSchedules();
+        const [key, , opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(key).toBe('works:schedule-dispatcher');
+        expect(opts.ttlMs).toBe(5 * 60 * 1000);
+        opts.onLocked();
+        expect(debugSpy).toHaveBeenCalledWith(
+            'Skipping work schedule dispatch because another instance holds the task lock',
+        );
+        expect(dispatcher.dispatchDue).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith(
+            'Work schedule dispatch completed: 3 dispatched, 1 skipped, 0 failed (4 due)',
+        );
+    });
+
+    it('does not log completion when both dueCount and failed are zero', async () => {
+        getDispatchIntervalMinutes.mockReturnValue(1);
+        dispatcher.dispatchDue.mockResolvedValue({
+            dispatched: 0,
+            skipped: 0,
+            failed: 0,
+            dueCount: 0,
+        });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.dispatchDueSchedules();
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs completion when only failed count is non-zero', async () => {
+        getDispatchIntervalMinutes.mockReturnValue(1);
+        dispatcher.dispatchDue.mockResolvedValue({
+            dispatched: 0,
+            skipped: 0,
+            failed: 2,
+            dueCount: 0,
+        });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.dispatchDueSchedules();
+        expect(logSpy).toHaveBeenCalledWith(
+            'Work schedule dispatch completed: 0 dispatched, 0 skipped, 2 failed (0 due)',
+        );
+    });
+
+    it('clamps ttlMs to a minimum of 60_000 ms when interval=0', async () => {
+        getDispatchIntervalMinutes.mockReturnValue(0); // private getter clamps to >=1
+        dispatcher.dispatchDue.mockResolvedValue({
+            dispatched: 0,
+            skipped: 0,
+            failed: 0,
+            dueCount: 0,
+        });
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.dispatchDueSchedules();
+        // private getDispatchIntervalMinutes returns max(1, 0) = 1, so ttl = 60_000
+        const [, , opts] = taskLockService.runExclusive.mock.calls[0];
+        expect(opts.ttlMs).toBe(60_000);
+    });
+
+    it('logs error stack when dispatchDue throws Error and swallows', async () => {
+        const boom = new Error('dispatch failed');
+        dispatcher.dispatchDue.mockRejectedValue(boom);
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await expect(service.dispatchDueSchedules()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith('Work schedule dispatch failed', boom.stack);
+    });
+
+    it('logs String(error) when dispatcher rejects with non-Error', async () => {
+        dispatcher.dispatchDue.mockRejectedValue('boom');
+        taskLockService.runExclusive.mockImplementation(async (_k, w) => {
+            await w();
+        });
+
+        await service.dispatchDueSchedules();
+        expect(errorSpy).toHaveBeenCalledWith('Work schedule dispatch failed', 'boom');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds **59 unit tests** across 7 spec files in `apps/api/src/works/tasks/`, closing the entire `works/tasks` schedulers surface.
- Each scheduler test asserts the `runExclusive` lock key + ttl + `onLocked` debug, the happy path, the error paths (Error.stack vs String(error)), and the relevant configuration gates.
- Mocks `@ever-works/agent/{cache,community-pr,comparison-generator,config,database,entities,events,generators,services}` and `@src/config/constants` so the agent runtime tree is not pulled in.

## Coverage breakdown

| File | Tests | Notes |
|---|---:|---|
| `community-pr-scheduler.service.spec.ts` | 6 | `works:community-pr-scheduler` key, processed/errors log, locked-branch no-op |
| `comparison-scheduler.service.spec.ts` | 7 | per-work `respectCadence:true` forward, unknown-status not counted, outer + inner error variants |
| `item-source-validation-scheduler.service.spec.ts` | 5 | 4 cache-prefix deletes in parallel, outer error path |
| `website-template-scheduler.service.spec.ts` | 10 | `autoUpdateEnabled()` gate, missing user skip, fallback `latestCommit`, "Unknown error" fallback |
| `work-cache-warmup.service.spec.ts` | 11 | cursor advance + wrap-around (totalEligible > BATCH), invalid-cursor coercion, GENERATING/no-user skip |
| `work-cleanup.service.spec.ts` | 11 | stale GENERATING → ERROR + emit, orphaned history recovery, `clearWorkCache` `@OnEvent` handler |
| `work-schedule-dispatcher-cron.service.spec.ts` | 9 | `scheduledUpdatesEnabled` + `!shouldUseTrigger` gates, `isDispatchMinute`, `ttlMs` clamp |

## Test plan

- [x] `pnpm --filter ever-works-api exec jest src/works/tasks` — 7 suites, 59 tests, all pass.
- [x] Pre-existing API tsc + 2-suite jest failures from stale `@ever-works/agent` `dist` are unchanged (documented in COVERAGE-TRACKER follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)