### PR TITLE
test(api): add 45 unit tests for works members controller + DTOs

### DIFF
--- a/apps/api/src/works/dto/dto.spec.ts
+++ b/apps/api/src/works/dto/dto.spec.ts
@@ -1,0 +1,278 @@
+jest.mock('@ever-works/agent/entities', () => ({
+    WorkMemberRole: {
+        OWNER: 'owner',
+        MANAGER: 'manager',
+        EDITOR: 'editor',
+        VIEWER: 'viewer',
+    },
+    ASSIGNABLE_MEMBER_ROLES: ['manager', 'editor', 'viewer'],
+}));
+
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { InviteMemberDto } from './invite-member.dto';
+import { UpdateMemberRoleDto } from './update-member-role.dto';
+import { ValidateTokenDto } from './deploy.dto';
+import { BatchDeployDto, BatchDeployItemDto } from './batch-deploy.dto';
+import { GenerateWorkDetailDto } from './generate-detail.dto';
+import { GenerateManualComparisonDto } from './generate-manual-comparison.dto';
+
+const constraintsFor = (errs: any[], property: string) =>
+    errs.find((e) => e.property === property)?.constraints ?? {};
+
+describe('works DTOs validation', () => {
+    describe('InviteMemberDto', () => {
+        it('accepts valid email + assignable role (editor)', async () => {
+            const dto = plainToInstance(InviteMemberDto, {
+                email: 'foo@bar.com',
+                role: 'editor',
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts viewer and manager roles', async () => {
+            for (const role of ['viewer', 'manager']) {
+                const dto = plainToInstance(InviteMemberDto, {
+                    email: 'a@b.com',
+                    role,
+                });
+                expect(await validate(dto)).toHaveLength(0);
+            }
+        });
+
+        it('rejects "owner" role (not in ASSIGNABLE_MEMBER_ROLES)', async () => {
+            const dto = plainToInstance(InviteMemberDto, {
+                email: 'a@b.com',
+                role: 'owner',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'role').isIn).toBe(
+                'Role must be one of: viewer, editor, manager',
+            );
+        });
+
+        it('rejects an invalid email format', async () => {
+            const dto = plainToInstance(InviteMemberDto, {
+                email: 'not-an-email',
+                role: 'viewer',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'email').isEmail).toBeDefined();
+        });
+
+        it('rejects empty / missing role', async () => {
+            const dto = plainToInstance(InviteMemberDto, {
+                email: 'a@b.com',
+                role: '',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'role').isNotEmpty).toBeDefined();
+        });
+
+        it('rejects empty / missing email', async () => {
+            const dto = plainToInstance(InviteMemberDto, { email: '', role: 'editor' });
+            const errs = await validate(dto);
+            expect(errs.find((e) => e.property === 'email')).toBeDefined();
+        });
+    });
+
+    describe('UpdateMemberRoleDto', () => {
+        it('accepts each assignable role', async () => {
+            for (const role of ['viewer', 'editor', 'manager']) {
+                const dto = plainToInstance(UpdateMemberRoleDto, { role });
+                expect(await validate(dto)).toHaveLength(0);
+            }
+        });
+
+        it('rejects unknown role', async () => {
+            const dto = plainToInstance(UpdateMemberRoleDto, { role: 'admin' });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'role').isIn).toBe(
+                'Role must be one of: viewer, editor, manager',
+            );
+        });
+
+        it('rejects empty role', async () => {
+            const dto = plainToInstance(UpdateMemberRoleDto, { role: '' });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'role').isNotEmpty).toBeDefined();
+        });
+    });
+
+    describe('ValidateTokenDto (deploy.dto.ts)', () => {
+        it('accepts a string token', async () => {
+            const dto = plainToInstance(ValidateTokenDto, { token: 'abc123' });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('rejects non-string token', async () => {
+            const dto = plainToInstance(ValidateTokenDto, { token: 123 });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'token').isString).toBeDefined();
+        });
+
+        it('accepts empty string (no IsNotEmpty constraint)', async () => {
+            const dto = plainToInstance(ValidateTokenDto, { token: '' });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+    });
+
+    describe('BatchDeployDto', () => {
+        it('accepts valid array with one item (no teamScope)', async () => {
+            const dto = plainToInstance(BatchDeployDto, {
+                works: [{ workId: 'w-1' }],
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts valid array with multiple items + per-item teamScope + default teamScope', async () => {
+            const dto = plainToInstance(BatchDeployDto, {
+                teamScope: 'team-x',
+                works: [
+                    { workId: 'w-1', teamScope: 'team-y' },
+                    { workId: 'w-2' },
+                ],
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('rejects empty array (ArrayMinSize 1)', async () => {
+            const dto = plainToInstance(BatchDeployDto, { works: [] });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'works').arrayMinSize).toBeDefined();
+        });
+
+        it('rejects when works is not an array', async () => {
+            const dto = plainToInstance(BatchDeployDto, { works: 'not-array' as any });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'works').isArray).toBeDefined();
+        });
+
+        it('rejects nested item with non-string workId', async () => {
+            const dto = plainToInstance(BatchDeployDto, {
+                works: [{ workId: 123 as any }],
+            });
+            const errs = await validate(dto);
+            const worksErr = errs.find((e) => e.property === 'works');
+            const nested = worksErr?.children?.[0];
+            const itemChild = nested?.children?.find((c: any) => c.property === 'workId');
+            expect(itemChild?.constraints?.isString).toBeDefined();
+        });
+
+        it('rejects when default teamScope is non-string', async () => {
+            const dto = plainToInstance(BatchDeployDto, {
+                teamScope: 123 as any,
+                works: [{ workId: 'w-1' }],
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'teamScope').isString).toBeDefined();
+        });
+    });
+
+    describe('BatchDeployItemDto (standalone)', () => {
+        it('accepts workId only', async () => {
+            const dto = plainToInstance(BatchDeployItemDto, { workId: 'w-1' });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts workId + teamScope', async () => {
+            const dto = plainToInstance(BatchDeployItemDto, {
+                workId: 'w-1',
+                teamScope: 'team-x',
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('rejects non-string workId', async () => {
+            const dto = plainToInstance(BatchDeployItemDto, { workId: 1 as any });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'workId').isString).toBeDefined();
+        });
+    });
+
+    describe('GenerateWorkDetailDto', () => {
+        it('accepts valid work_name + prompt without ai_provider', async () => {
+            const dto = plainToInstance(GenerateWorkDetailDto, {
+                work_name: 'My Work',
+                prompt: 'Generate a directory of...',
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts ai_provider when provided', async () => {
+            const dto = plainToInstance(GenerateWorkDetailDto, {
+                work_name: 'My Work',
+                prompt: 'Generate...',
+                ai_provider: 'openai',
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('rejects empty work_name', async () => {
+            const dto = plainToInstance(GenerateWorkDetailDto, {
+                work_name: '',
+                prompt: 'p',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'work_name').isNotEmpty).toBeDefined();
+        });
+
+        it('rejects empty prompt', async () => {
+            const dto = plainToInstance(GenerateWorkDetailDto, {
+                work_name: 'n',
+                prompt: '',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'prompt').isNotEmpty).toBeDefined();
+        });
+
+        it('rejects non-string ai_provider', async () => {
+            const dto = plainToInstance(GenerateWorkDetailDto, {
+                work_name: 'n',
+                prompt: 'p',
+                ai_provider: 123 as any,
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'ai_provider').isString).toBeDefined();
+        });
+    });
+
+    describe('GenerateManualComparisonDto', () => {
+        it('accepts both slugs', async () => {
+            const dto = plainToInstance(GenerateManualComparisonDto, {
+                itemASlug: 'a',
+                itemBSlug: 'b',
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('rejects empty itemASlug', async () => {
+            const dto = plainToInstance(GenerateManualComparisonDto, {
+                itemASlug: '',
+                itemBSlug: 'b',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'itemASlug').isNotEmpty).toBeDefined();
+        });
+
+        it('rejects empty itemBSlug', async () => {
+            const dto = plainToInstance(GenerateManualComparisonDto, {
+                itemASlug: 'a',
+                itemBSlug: '',
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'itemBSlug').isNotEmpty).toBeDefined();
+        });
+
+        it('rejects non-string slugs', async () => {
+            const dto = plainToInstance(GenerateManualComparisonDto, {
+                itemASlug: 1 as any,
+                itemBSlug: {} as any,
+            });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'itemASlug').isString).toBeDefined();
+            expect(constraintsFor(errs, 'itemBSlug').isString).toBeDefined();
+        });
+    });
+});

--- a/apps/api/src/works/members.controller.spec.ts
+++ b/apps/api/src/works/members.controller.spec.ts
@@ -1,0 +1,273 @@
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        MEMBER_ROLE_CHANGED: 'MEMBER_ROLE_CHANGED',
+        MEMBER_REMOVED: 'MEMBER_REMOVED',
+    },
+    ActivityStatus: { COMPLETED: 'COMPLETED' },
+    ASSIGNABLE_MEMBER_ROLES: ['viewer', 'editor', 'manager'],
+}));
+jest.mock('../auth', () => ({
+    AuthService: class {},
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+jest.mock('../config/constants', () => ({
+    config: {
+        webAppUrl: jest.fn(() => 'https://app.example.com'),
+    },
+}));
+
+import { MembersController } from './members.controller';
+import { MemberInvitedEvent } from '../events';
+import { ActivityActionType, ActivityStatus } from '@ever-works/agent/entities';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import type { WorkMemberService } from '@ever-works/agent/services';
+import type { ActivityLogService } from '@ever-works/agent/activity-log';
+import type { AuthService } from '../auth';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
+
+describe('MembersController', () => {
+    let memberService: {
+        listMembers: jest.Mock;
+        getWorkOwnerInfo: jest.Mock;
+        inviteMember: jest.Mock;
+        getMember: jest.Mock;
+        updateMemberRole: jest.Mock;
+        removeMember: jest.Mock;
+        leaveWork: jest.Mock;
+    };
+    let authService: { getUser: jest.Mock };
+    let eventEmitter: { emit: jest.Mock };
+    let activityLogService: { log: jest.Mock };
+    let controller: MembersController;
+    const auth: AuthenticatedUser = { userId: 'auth-1' } as any;
+
+    beforeEach(() => {
+        memberService = {
+            listMembers: jest.fn(),
+            getWorkOwnerInfo: jest.fn(),
+            inviteMember: jest.fn(),
+            getMember: jest.fn(),
+            updateMemberRole: jest.fn(),
+            removeMember: jest.fn(),
+            leaveWork: jest.fn(),
+        };
+        authService = {
+            getUser: jest.fn().mockResolvedValue({ id: 'user-1' }),
+        };
+        eventEmitter = { emit: jest.fn() };
+        activityLogService = { log: jest.fn().mockResolvedValue(undefined) };
+        controller = new MembersController(
+            memberService as unknown as WorkMemberService,
+            authService as unknown as AuthService,
+            eventEmitter as unknown as EventEmitter2,
+            activityLogService as unknown as ActivityLogService,
+        );
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('listMembers', () => {
+        it('returns members + owner with status:success and forwards user.id', async () => {
+            memberService.listMembers.mockResolvedValue([{ id: 'm1' }]);
+            memberService.getWorkOwnerInfo.mockResolvedValue({ id: 'owner' });
+
+            const result = await controller.listMembers(auth, 'w-1');
+
+            expect(authService.getUser).toHaveBeenCalledWith('auth-1');
+            expect(memberService.listMembers).toHaveBeenCalledWith('w-1', 'user-1');
+            expect(memberService.getWorkOwnerInfo).toHaveBeenCalledWith('w-1', 'user-1');
+            expect(result).toEqual({
+                status: 'success',
+                members: [{ id: 'm1' }],
+                owner: { id: 'owner' },
+            });
+        });
+
+        it('propagates errors from authService.getUser', async () => {
+            const err = new Error('user lookup failed');
+            authService.getUser.mockRejectedValue(err);
+            await expect(controller.listMembers(auth, 'w-1')).rejects.toBe(err);
+            expect(memberService.listMembers).not.toHaveBeenCalled();
+        });
+
+        it('propagates errors from memberService.listMembers', async () => {
+            memberService.listMembers.mockRejectedValue(new Error('not authorized'));
+            await expect(controller.listMembers(auth, 'w-1')).rejects.toThrow('not authorized');
+            expect(memberService.getWorkOwnerInfo).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('inviteMember', () => {
+        it('invites the member, emits MemberInvitedEvent with the workUrl, and returns the new member', async () => {
+            const invitee = { id: 'invitee', email: 'foo@bar.com' };
+            const inviter = { id: 'inviter' };
+            const work = { id: 'w-1' };
+            const member = { id: 'm-new', role: 'editor' };
+            memberService.inviteMember.mockResolvedValue({ invitee, inviter, work, member });
+
+            const dto = { email: 'foo@bar.com', role: 'editor' } as any;
+            const result = await controller.inviteMember(auth, 'w-1', dto);
+
+            expect(memberService.inviteMember).toHaveBeenCalledWith('w-1', 'user-1', dto);
+            expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+            const [eventName, eventArg] = eventEmitter.emit.mock.calls[0];
+            expect(eventName).toBe(MemberInvitedEvent.EVENT_NAME);
+            expect(eventArg).toBeInstanceOf(MemberInvitedEvent);
+            expect(eventArg.invitee).toBe(invitee);
+            expect(eventArg.inviter).toBe(inviter);
+            expect(eventArg.work).toBe(work);
+            expect(eventArg.role).toBe('editor');
+            expect(eventArg.workUrl).toBe('https://app.example.com/works/w-1');
+            expect(result).toEqual({ status: 'success', member });
+        });
+
+        it('does not emit when inviteMember throws', async () => {
+            const err = new Error('email taken');
+            memberService.inviteMember.mockRejectedValue(err);
+            await expect(
+                controller.inviteMember(auth, 'w-1', {
+                    email: 'a@b.c',
+                    role: 'viewer',
+                } as any),
+            ).rejects.toBe(err);
+            expect(eventEmitter.emit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getMember', () => {
+        it('forwards workId, user.id, memberId and returns the member', async () => {
+            memberService.getMember.mockResolvedValue({ id: 'm-2' });
+            const result = await controller.getMember(auth, 'w-1', 'm-2');
+            expect(memberService.getMember).toHaveBeenCalledWith('w-1', 'user-1', 'm-2');
+            expect(result).toEqual({ status: 'success', member: { id: 'm-2' } });
+        });
+
+        it('propagates not-found errors from getMember', async () => {
+            memberService.getMember.mockRejectedValue(new Error('not found'));
+            await expect(controller.getMember(auth, 'w-1', 'm-2')).rejects.toThrow('not found');
+        });
+    });
+
+    describe('updateMemberRole', () => {
+        it('updates role, fire-and-forget activity log, returns the member', async () => {
+            memberService.updateMemberRole.mockResolvedValue({ id: 'm-2', role: 'manager' });
+            const dto = { role: 'manager' } as any;
+            const result = await controller.updateMemberRole(auth, 'w-1', 'm-2', dto);
+
+            expect(memberService.updateMemberRole).toHaveBeenCalledWith(
+                'w-1',
+                'user-1',
+                'm-2',
+                dto,
+            );
+            // Wait for the fire-and-forget activity log call
+            await Promise.resolve();
+            expect(activityLogService.log).toHaveBeenCalledWith({
+                userId: 'auth-1',
+                workId: 'w-1',
+                actionType: ActivityActionType.MEMBER_ROLE_CHANGED,
+                action: 'member.role_changed',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Changed member role to manager',
+                details: { memberId: 'm-2', role: 'manager' },
+            });
+            expect(result).toEqual({
+                status: 'success',
+                member: { id: 'm-2', role: 'manager' },
+            });
+        });
+
+        it('still returns success when activityLogService.log rejects (catch swallows)', async () => {
+            memberService.updateMemberRole.mockResolvedValue({ id: 'm-2', role: 'editor' });
+            activityLogService.log.mockRejectedValue(new Error('activity-log down'));
+
+            const result = await controller.updateMemberRole(auth, 'w-1', 'm-2', {
+                role: 'editor',
+            } as any);
+            // ensure swallowed
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(result).toEqual({
+                status: 'success',
+                member: { id: 'm-2', role: 'editor' },
+            });
+        });
+
+        it('propagates errors from updateMemberRole and does not log activity', async () => {
+            memberService.updateMemberRole.mockRejectedValue(new Error('role denied'));
+            await expect(
+                controller.updateMemberRole(auth, 'w-1', 'm-2', {
+                    role: 'manager',
+                } as any),
+            ).rejects.toThrow('role denied');
+            expect(activityLogService.log).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('removeMember', () => {
+        it('removes the member, fire-and-forget activity log, returns success message', async () => {
+            memberService.removeMember.mockResolvedValue(undefined);
+            const result = await controller.removeMember(auth, 'w-1', 'm-2');
+
+            expect(memberService.removeMember).toHaveBeenCalledWith('w-1', 'user-1', 'm-2');
+            await Promise.resolve();
+            expect(activityLogService.log).toHaveBeenCalledWith({
+                userId: 'auth-1',
+                workId: 'w-1',
+                actionType: ActivityActionType.MEMBER_REMOVED,
+                action: 'member.removed',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Removed member from work',
+                details: { memberId: 'm-2' },
+            });
+            expect(result).toEqual({
+                status: 'success',
+                message: 'Member removed successfully',
+            });
+        });
+
+        it('still returns success when activityLogService.log rejects', async () => {
+            memberService.removeMember.mockResolvedValue(undefined);
+            activityLogService.log.mockRejectedValue(new Error('activity-log down'));
+            const result = await controller.removeMember(auth, 'w-1', 'm-2');
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(result).toEqual({
+                status: 'success',
+                message: 'Member removed successfully',
+            });
+        });
+
+        it('propagates errors from removeMember and does not log activity', async () => {
+            memberService.removeMember.mockRejectedValue(new Error('cannot remove owner'));
+            await expect(controller.removeMember(auth, 'w-1', 'm-2')).rejects.toThrow(
+                'cannot remove owner',
+            );
+            expect(activityLogService.log).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('leaveWork', () => {
+        it('forwards workId + user.id and returns success message', async () => {
+            memberService.leaveWork.mockResolvedValue(undefined);
+            const result = await controller.leaveWork(auth, 'w-1');
+            expect(memberService.leaveWork).toHaveBeenCalledWith('w-1', 'user-1');
+            expect(result).toEqual({
+                status: 'success',
+                message: 'Successfully left the work',
+            });
+        });
+
+        it('propagates errors from leaveWork', async () => {
+            memberService.leaveWork.mockRejectedValue(new Error('cannot leave as owner'));
+            await expect(controller.leaveWork(auth, 'w-1')).rejects.toThrow(
+                'cannot leave as owner',
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Adds **45 unit tests** in `apps/api/src/works/`: `members.controller.spec.ts` (15) covers all 6 endpoints, `dto/dto.spec.ts` (30) covers class-validator behavior for all 6 DTOs.
- Continues the `works/*` surface coverage push started in [#504](https://github.com/ever-works/ever-works/pull/504).

## Coverage

### `members.controller.spec.ts` (15)
- `listMembers` — `{members, owner}` envelope, getUser → user.id forwarding, error propagation from both upstream calls.
- `inviteMember` — `inviteMember` forward, workUrl built from `config.webAppUrl()`, `MemberInvitedEvent` emit with positional args, no-event on rejection.
- `getMember` — pass-through + error propagation.
- `updateMemberRole` — `updateMemberRole` forward, fire-and-forget activity log (`MEMBER_ROLE_CHANGED`), `.catch(()=>{})` swallow on activity-log rejection, error propagation.
- `removeMember` — same pattern with `MEMBER_REMOVED`.
- `leaveWork` — pass-through + error propagation.

### `dto/dto.spec.ts` (30)
- `InviteMemberDto` (6) — valid email + assignable role; `owner` rejected via `@IsIn(ASSIGNABLE_MEMBER_ROLES)` with the exact message; bad email; empty role/email.
- `UpdateMemberRoleDto` (3) — each assignable role; unknown role; empty role.
- `ValidateTokenDto` (3) — `IsString` with empty-string allowed (no `@IsNotEmpty`).
- `BatchDeployDto` (6) — `ArrayMinSize`, `@ValidateNested`, `Type(()=>BatchDeployItemDto)`, default `teamScope` validation.
- `BatchDeployItemDto` (3) — workId required, optional teamScope.
- `GenerateWorkDetailDto` (5) — required `work_name`/`prompt`, optional `ai_provider`.
- `GenerateManualComparisonDto` (4) — both slugs required.

## Test plan

- [x] `pnpm --filter ever-works-api exec jest src/works` — 9 suites, 104 tests, all pass (45 new + 59 from #504).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for works management functionality, including validation of data transfer objects, member invitation and role management workflows, token validation, batch deployment operations, and work generation features. Ensures API reliability through comprehensive test suite additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->