### PR TITLE
test(api): add 41 unit tests for plugins-capabilities search + screenshot controllers

### DIFF
--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
@@ -1,0 +1,567 @@
+jest.mock('@ever-works/agent/facades', () => ({
+    ScreenshotFacadeService: class {},
+    NoProviderError: class NoProviderError extends Error {
+        constructor(capability?: string) {
+            super(`No provider for ${capability ?? 'unknown'}`);
+            this.name = 'NoProviderError';
+        }
+    },
+}));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginRegistryService: class {},
+    PluginSettingsService: class {},
+}));
+jest.mock('../../auth', () => ({
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { ScreenshotController } from './screenshot.controller';
+import { NoProviderError } from '@ever-works/agent/facades';
+import type { ScreenshotFacadeService } from '@ever-works/agent/facades';
+import type { PluginRegistryService, PluginSettingsService } from '@ever-works/agent/plugins';
+import type { AuthenticatedUser } from '../../auth/types/auth.types';
+
+describe('ScreenshotController', () => {
+    let screenshotFacade: { capture: jest.Mock; getScreenshotUrl: jest.Mock };
+    let pluginRegistry: {
+        getEnabledPluginsScoped: jest.Mock;
+        getDefaultForCapabilityScoped: jest.Mock;
+    };
+    let pluginSettings: { getSettings: jest.Mock };
+    let controller: ScreenshotController;
+    const auth: AuthenticatedUser = { userId: 'user-1' } as any;
+
+    beforeEach(() => {
+        screenshotFacade = { capture: jest.fn(), getScreenshotUrl: jest.fn() };
+        pluginRegistry = {
+            getEnabledPluginsScoped: jest.fn(),
+            getDefaultForCapabilityScoped: jest.fn(),
+        };
+        pluginSettings = { getSettings: jest.fn() };
+        controller = new ScreenshotController(
+            screenshotFacade as unknown as ScreenshotFacadeService,
+            pluginRegistry as unknown as PluginRegistryService,
+            pluginSettings as unknown as PluginSettingsService,
+        );
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const registered = (
+        id: string,
+        opts: {
+            name?: string;
+            description?: string;
+            icon?: string;
+            isDefault?: boolean;
+            systemPlugin?: boolean;
+            requiredSettings?: string[];
+            schemaProperties?: Record<string, Record<string, unknown>>;
+        } = {},
+    ) => ({
+        plugin: {
+            id,
+            name: opts.name ?? id,
+            settingsSchema: opts.requiredSettings
+                ? {
+                      type: 'object',
+                      required: opts.requiredSettings,
+                      properties: opts.schemaProperties ?? {},
+                  }
+                : undefined,
+        },
+        manifest: {
+            description: opts.description,
+            icon: opts.icon,
+            defaultForCapabilities: opts.isDefault ? ['screenshot'] : undefined,
+            systemPlugin: opts.systemPlugin,
+        },
+    });
+
+    describe('checkAvailability', () => {
+        it('returns available:true when at least one provider is configured', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                registered('screenshotone', { name: 'ScreenshotOne' }),
+            ]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(pluginRegistry.getEnabledPluginsScoped).toHaveBeenCalledWith(
+                'screenshot',
+                undefined,
+                'user-1',
+            );
+            expect(pluginRegistry.getDefaultForCapabilityScoped).toHaveBeenCalledWith(
+                'screenshot',
+                undefined,
+                'user-1',
+            );
+            expect(result).toEqual(
+                expect.objectContaining({
+                    status: 'success',
+                    available: true,
+                }),
+            );
+            expect(result.providers).toHaveLength(1);
+            expect(result.providers[0]).toEqual(
+                expect.objectContaining({
+                    id: 'screenshotone',
+                    name: 'ScreenshotOne',
+                    configured: true,
+                }),
+            );
+        });
+
+        it('returns available:false when all providers lack required settings', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                registered('screenshotone', {
+                    requiredSettings: ['apiKey'],
+                    schemaProperties: { apiKey: { type: 'string' } },
+                }),
+            ]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.available).toBe(false);
+            expect(result.providers[0].configured).toBe(false);
+        });
+
+        it('forwards workId to both registry calls and pluginSettings.getSettings', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            await controller.checkAvailability(auth, 'work-42');
+
+            expect(pluginRegistry.getEnabledPluginsScoped).toHaveBeenCalledWith(
+                'screenshot',
+                'work-42',
+                'user-1',
+            );
+            expect(pluginRegistry.getDefaultForCapabilityScoped).toHaveBeenCalledWith(
+                'screenshot',
+                'work-42',
+                'user-1',
+            );
+            expect(pluginSettings.getSettings).toHaveBeenCalledWith('p', {
+                userId: 'user-1',
+                workId: 'work-42',
+                includeSecrets: true,
+            });
+        });
+
+        it('marks the active provider returned by getDefaultForCapabilityScoped as isDefault=true', async () => {
+            const a = registered('a', { name: 'A' });
+            const b = registered('b', { name: 'B' });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([a, b]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(b);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            const provB = result.providers.find((p) => p.id === 'b')!;
+            const provA = result.providers.find((p) => p.id === 'a')!;
+            expect(provB.isDefault).toBe(true);
+            expect(provA.isDefault).toBe(false);
+            expect(result.activeProvider?.id).toBe('b');
+        });
+
+        it('falls back to manifest.defaultForCapabilities when no active provider', async () => {
+            const nonDefault = registered('a', { name: 'A' });
+            const defaultPlugin = registered('b', { name: 'B', isDefault: true });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([nonDefault, defaultPlugin]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            const provB = result.providers.find((p) => p.id === 'b')!;
+            expect(provB.isDefault).toBe(true);
+            // activeProvider falls back to first isDefault when no active id
+            expect(result.activeProvider?.id).toBe('b');
+        });
+
+        it('falls back to manifest.systemPlugin when no defaultForCapabilities and no active provider', async () => {
+            const sysPlugin = registered('local', { systemPlugin: true });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([sysPlugin]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.providers[0].isDefault).toBe(true);
+        });
+
+        it('sorts providers: default first, configured second, name alphabetical third', async () => {
+            // Two non-default plugins, both configured: alphabetical
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                registered('zeta', { name: 'Zeta' }),
+                registered('alpha', { name: 'Alpha' }),
+            ]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.providers.map((p) => p.id)).toEqual(['alpha', 'zeta']);
+        });
+
+        it('sorts default-for-capability before non-default even when non-default is alphabetically first', async () => {
+            const def = registered('zeta', { name: 'Zeta', isDefault: true });
+            const nondef = registered('alpha', { name: 'Alpha' });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([nondef, def]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.providers.map((p) => p.id)).toEqual(['zeta', 'alpha']);
+        });
+
+        it('sorts configured before unconfigured when default-rank ties', async () => {
+            const unconfigured = registered('a', {
+                name: 'A',
+                requiredSettings: ['apiKey'],
+                schemaProperties: { apiKey: { type: 'string' } },
+            });
+            const configured = registered('b', { name: 'B' });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([unconfigured, configured]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockImplementation(async (id: string) =>
+                id === 'a' ? {} : { random: 'ok' },
+            );
+
+            const result = await controller.checkAvailability(auth);
+
+            // both same default rank (neither isDefault), so configured first
+            expect(result.providers.map((p) => p.id)).toEqual(['b', 'a']);
+        });
+
+        it('returns activeProvider:null when no providers exist', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.providers).toEqual([]);
+            expect(result.activeProvider).toBeNull();
+            expect(result.available).toBe(false);
+        });
+
+        it('exposes manifest.description and manifest.icon on each ProviderOption', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                registered('p', {
+                    description: 'a screenshot tool',
+                    icon: 'https://x/icon.png',
+                }),
+            ]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.providers[0]).toEqual(
+                expect.objectContaining({
+                    description: 'a screenshot tool',
+                    icon: 'https://x/icon.png',
+                }),
+            );
+        });
+    });
+
+    describe('capture', () => {
+        const dto = {
+            url: 'https://example.com',
+            workId: 'work-1',
+            providerOverride: 'screenshotone',
+            viewportWidth: 1280,
+            viewportHeight: 720,
+            format: 'png' as const,
+            fullPage: true,
+            delay: 500,
+            blockAds: true,
+            blockTrackers: false,
+            blockCookieBanners: true,
+        };
+
+        it('throws BadRequestException with "No screenshot provider configured" when none configured', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+
+            try {
+                await controller.capture(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'No screenshot provider configured',
+                });
+            }
+            expect(screenshotFacade.capture).not.toHaveBeenCalled();
+        });
+
+        it('forwards options + context to screenshotFacade.capture and returns success envelope (cacheUrl over imageUrl)', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('screenshotone')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            screenshotFacade.capture.mockResolvedValue({
+                success: true,
+                imageUrl: 'https://primary/img.png',
+                cacheUrl: 'https://cache/img.png',
+                imageBuffer: undefined,
+            });
+
+            const result = await controller.capture(auth, dto);
+
+            expect(screenshotFacade.capture).toHaveBeenCalledWith(
+                {
+                    url: dto.url,
+                    viewportWidth: dto.viewportWidth,
+                    viewportHeight: dto.viewportHeight,
+                    format: dto.format,
+                    fullPage: dto.fullPage,
+                    delay: dto.delay,
+                    blockAds: dto.blockAds,
+                    blockTrackers: dto.blockTrackers,
+                    blockCookieBanners: dto.blockCookieBanners,
+                },
+                {
+                    userId: 'user-1',
+                    workId: 'work-1',
+                    providerOverride: 'screenshotone',
+                },
+            );
+
+            expect(result).toEqual({
+                status: 'success',
+                imageUrl: 'https://cache/img.png',
+                cacheUrl: 'https://cache/img.png',
+                imageBase64: null,
+            });
+        });
+
+        it('falls back to imageUrl when cacheUrl missing', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            screenshotFacade.capture.mockResolvedValue({
+                success: true,
+                imageUrl: 'https://primary/img.png',
+                cacheUrl: undefined,
+            });
+
+            const result = await controller.capture(auth, dto);
+
+            expect(result.imageUrl).toBe('https://primary/img.png');
+            expect(result.cacheUrl).toBeUndefined();
+        });
+
+        it('encodes imageBuffer as base64 when present', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const buffer = Buffer.from('fake-png-bytes', 'utf8');
+            screenshotFacade.capture.mockResolvedValue({
+                success: true,
+                imageUrl: 'https://x/i.png',
+                imageBuffer: buffer,
+            });
+
+            const result = await controller.capture(auth, dto);
+
+            expect(result.imageBase64).toBe(buffer.toString('base64'));
+        });
+
+        it('wraps NoProviderError in BadRequestException with "configured or available" message', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            screenshotFacade.capture.mockRejectedValue(new NoProviderError('screenshot'));
+
+            try {
+                await controller.capture(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'No screenshot provider configured or available',
+                });
+            }
+        });
+
+        it('rethrows non-NoProviderError errors unchanged', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            const err = new Error('upstream blew up');
+            screenshotFacade.capture.mockRejectedValue(err);
+
+            await expect(controller.capture(auth, dto)).rejects.toBe(err);
+        });
+
+        it('throws BadRequestException with result.error when result.success=false', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            screenshotFacade.capture.mockResolvedValue({
+                success: false,
+                error: 'site blocked us',
+            });
+
+            try {
+                await controller.capture(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'site blocked us',
+                });
+            }
+        });
+
+        it('falls back to "Failed to capture screenshot" when result.error missing', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            screenshotFacade.capture.mockResolvedValue({ success: false });
+
+            try {
+                await controller.capture(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'Failed to capture screenshot',
+                });
+            }
+        });
+    });
+
+    describe('getScreenshotUrl', () => {
+        const dto = {
+            url: 'https://example.com',
+            workId: 'work-1',
+            providerOverride: 'urlbox',
+            viewportWidth: 1280,
+            viewportHeight: 720,
+            format: 'png' as const,
+            fullPage: false,
+            delay: 0,
+            blockAds: false,
+            blockTrackers: false,
+            blockCookieBanners: false,
+        };
+
+        it('throws BadRequestException with "No screenshot provider configured" when none configured', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+
+            try {
+                await controller.getScreenshotUrl(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'No screenshot provider configured',
+                });
+            }
+            expect(screenshotFacade.getScreenshotUrl).not.toHaveBeenCalled();
+        });
+
+        it('forwards options + context to screenshotFacade.getScreenshotUrl and returns { status, imageUrl }', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            screenshotFacade.getScreenshotUrl.mockResolvedValue('https://shot.test/img.png');
+
+            const result = await controller.getScreenshotUrl(auth, dto);
+
+            expect(screenshotFacade.getScreenshotUrl).toHaveBeenCalledWith(
+                {
+                    url: dto.url,
+                    viewportWidth: dto.viewportWidth,
+                    viewportHeight: dto.viewportHeight,
+                    format: dto.format,
+                    fullPage: dto.fullPage,
+                    delay: dto.delay,
+                    blockAds: dto.blockAds,
+                    blockTrackers: dto.blockTrackers,
+                    blockCookieBanners: dto.blockCookieBanners,
+                },
+                {
+                    userId: 'user-1',
+                    workId: 'work-1',
+                    providerOverride: 'urlbox',
+                },
+            );
+            expect(result).toEqual({
+                status: 'success',
+                imageUrl: 'https://shot.test/img.png',
+            });
+        });
+
+        it('wraps NoProviderError in BadRequestException with "configured or available" message', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            screenshotFacade.getScreenshotUrl.mockRejectedValue(new NoProviderError('screenshot'));
+
+            try {
+                await controller.getScreenshotUrl(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'No screenshot provider configured or available',
+                });
+            }
+        });
+
+        it('rethrows non-NoProviderError errors unchanged', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            const err = new Error('signing failure');
+            screenshotFacade.getScreenshotUrl.mockRejectedValue(err);
+
+            await expect(controller.getScreenshotUrl(auth, dto)).rejects.toBe(err);
+        });
+
+        it('throws BadRequestException "Failed to generate screenshot URL" when imageUrl is null/empty', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            for (const value of [null, '', undefined]) {
+                screenshotFacade.getScreenshotUrl.mockResolvedValue(value);
+                try {
+                    await controller.getScreenshotUrl(auth, dto);
+                    fail('expected throw');
+                } catch (e: any) {
+                    expect(e).toBeInstanceOf(BadRequestException);
+                    expect(e.getResponse()).toEqual({
+                        status: 'error',
+                        message: 'Failed to generate screenshot URL',
+                    });
+                }
+            }
+        });
+    });
+});

--- a/apps/api/src/plugins-capabilities/search/search.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/search/search.controller.spec.ts
@@ -1,0 +1,385 @@
+jest.mock('@ever-works/agent/facades', () => ({
+    SearchFacadeService: class {},
+    NoProviderError: class NoProviderError extends Error {
+        constructor(capability?: string) {
+            super(`No provider for ${capability ?? 'unknown'}`);
+            this.name = 'NoProviderError';
+        }
+    },
+}));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginRegistryService: class {},
+    PluginSettingsService: class {},
+}));
+jest.mock('../../auth', () => ({
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { NoProviderError } from '@ever-works/agent/facades';
+import type { SearchFacadeService } from '@ever-works/agent/facades';
+import type { PluginRegistryService, PluginSettingsService } from '@ever-works/agent/plugins';
+import type { AuthenticatedUser } from '../../auth/types/auth.types';
+
+describe('SearchController', () => {
+    let searchFacade: { search: jest.Mock };
+    let pluginRegistry: { getEnabledPluginsScoped: jest.Mock };
+    let pluginSettings: { getSettings: jest.Mock };
+    let controller: SearchController;
+    const auth: AuthenticatedUser = { userId: 'user-1' } as any;
+
+    beforeEach(() => {
+        searchFacade = { search: jest.fn() };
+        pluginRegistry = { getEnabledPluginsScoped: jest.fn() };
+        pluginSettings = { getSettings: jest.fn() };
+        controller = new SearchController(
+            searchFacade as unknown as SearchFacadeService,
+            pluginRegistry as unknown as PluginRegistryService,
+            pluginSettings as unknown as PluginSettingsService,
+        );
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    // Helper to build a registered plugin shape
+    const registered = (
+        id: string,
+        opts: {
+            name?: string;
+            isDefault?: boolean;
+            requiredSettings?: string[];
+            schemaProperties?: Record<string, Record<string, unknown>>;
+        } = {},
+    ) => ({
+        plugin: {
+            id,
+            name: opts.name ?? id,
+            settingsSchema: opts.requiredSettings
+                ? {
+                      type: 'object',
+                      required: opts.requiredSettings,
+                      properties: opts.schemaProperties ?? {},
+                  }
+                : undefined,
+        },
+        manifest: {
+            defaultForCapabilities: opts.isDefault ? ['search'] : undefined,
+        },
+    });
+
+    describe('checkAvailability', () => {
+        it('returns available:false with "No search provider is enabled" when no plugins enabled', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(pluginRegistry.getEnabledPluginsScoped).toHaveBeenCalledWith(
+                'search',
+                undefined,
+                'user-1',
+            );
+            expect(result).toEqual({
+                status: 'success',
+                available: false,
+                activeProvider: null,
+                message:
+                    'No search provider is enabled. Enable a search plugin (e.g. Tavily, Linkup, Brave, Exa) in settings.',
+            });
+        });
+
+        it('returns available:false with "enabled but unconfigured" message when plugin enabled but missing required setting', async () => {
+            const plugin = registered('tavily', {
+                requiredSettings: ['apiKey'],
+                schemaProperties: { apiKey: { type: 'string' } },
+            });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({}); // no apiKey
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result).toEqual({
+                status: 'success',
+                available: false,
+                activeProvider: null,
+                message:
+                    'Search plugins are enabled but none have all required settings configured (e.g. API key).',
+            });
+        });
+
+        it('returns available:true with first configured provider', async () => {
+            const plugin = registered('tavily', { name: 'Tavily' });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result).toEqual({
+                status: 'success',
+                available: true,
+                activeProvider: { id: 'tavily', name: 'Tavily' },
+            });
+        });
+
+        it('passes resolved settings (4-level merge incl. secrets) by setting includeSecrets:true + userId', async () => {
+            const plugin = registered('tavily');
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            await controller.checkAvailability(auth);
+
+            expect(pluginSettings.getSettings).toHaveBeenCalledWith('tavily', {
+                userId: 'user-1',
+                includeSecrets: true,
+            });
+        });
+
+        it('treats null/undefined/empty-string as missing required setting', async () => {
+            for (const value of [null, undefined, '']) {
+                pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                    registered('p', {
+                        requiredSettings: ['apiKey'],
+                        schemaProperties: { apiKey: { type: 'string' } },
+                    }),
+                ]);
+                pluginSettings.getSettings.mockResolvedValue({ apiKey: value });
+
+                const result = await controller.checkAvailability(auth);
+                expect(result.available).toBe(false);
+            }
+        });
+
+        it('skips fields marked with x-envVar in required check', async () => {
+            const plugin = registered('p', {
+                requiredSettings: ['envSecret', 'apiKey'],
+                schemaProperties: {
+                    envSecret: { type: 'string', 'x-envVar': 'PLUGIN_SECRET' },
+                    apiKey: { type: 'string' },
+                },
+            });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({ apiKey: 'real-key' });
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    available: true,
+                    activeProvider: { id: 'p', name: 'p' },
+                }),
+            );
+        });
+
+        it('skips fields marked with x-adminOnly in required check', async () => {
+            const plugin = registered('p', {
+                requiredSettings: ['adminThing', 'apiKey'],
+                schemaProperties: {
+                    adminThing: { type: 'string', 'x-adminOnly': true },
+                    apiKey: { type: 'string' },
+                },
+            });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({ apiKey: 'k' });
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.available).toBe(true);
+        });
+
+        it('returns available:true when settingsSchema is undefined (no required check)', async () => {
+            const plugin = registered('no-schema');
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.available).toBe(true);
+        });
+
+        it('returns available:true when schema has required but no properties (continue-skips field)', async () => {
+            const plugin = {
+                plugin: {
+                    id: 'p',
+                    name: 'P',
+                    settingsSchema: {
+                        type: 'object',
+                        required: ['nope'],
+                        // properties intentionally absent
+                    },
+                },
+                manifest: {},
+            };
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([plugin]);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.available).toBe(true);
+        });
+
+        it('sorts default-for-capability plugin first, returning it before non-default', async () => {
+            const nonDefault = registered('brave', { name: 'Brave' });
+            const defaultPlugin = registered('tavily', { name: 'Tavily', isDefault: true });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([nonDefault, defaultPlugin]);
+            pluginSettings.getSettings.mockResolvedValue({});
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.activeProvider).toEqual({ id: 'tavily', name: 'Tavily' });
+        });
+
+        it('falls back to non-default when default plugin lacks required settings', async () => {
+            const fallback = registered('brave', { name: 'Brave' });
+            const defaultButUnconfigured = registered('tavily', {
+                name: 'Tavily',
+                isDefault: true,
+                requiredSettings: ['apiKey'],
+                schemaProperties: { apiKey: { type: 'string' } },
+            });
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                fallback,
+                defaultButUnconfigured,
+            ]);
+            pluginSettings.getSettings.mockImplementation(async (id: string) =>
+                id === 'tavily' ? {} : { random: 'whatever' },
+            );
+
+            const result = await controller.checkAvailability(auth);
+
+            expect(result.activeProvider).toEqual({ id: 'brave', name: 'Brave' });
+        });
+    });
+
+    describe('search', () => {
+        it('throws BadRequestException with "No search provider..." when no provider configured', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+
+            const dto = { query: 'hello' } as any;
+
+            await expect(controller.search(auth, dto)).rejects.toBeInstanceOf(BadRequestException);
+            try {
+                await controller.search(auth, dto);
+            } catch (e: any) {
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'No search provider with all required settings configured is available.',
+                });
+            }
+            expect(searchFacade.search).not.toHaveBeenCalled();
+        });
+
+        it('forwards (query, options, context) to searchFacade.search and returns success envelope', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([
+                registered('tavily', { name: 'Tavily' }),
+            ]);
+            pluginSettings.getSettings.mockResolvedValue({});
+            searchFacade.search.mockResolvedValue([{ url: 'r1' }]);
+
+            const dto = {
+                query: 'hello',
+                maxResults: 5,
+                includeDomains: ['github.com'],
+                excludeDomains: ['pinterest.com'],
+            } as any;
+
+            const result = await controller.search(auth, dto);
+
+            expect(searchFacade.search).toHaveBeenCalledWith(
+                'hello',
+                {
+                    maxResults: 5,
+                    includeDomains: ['github.com'],
+                    excludeDomains: ['pinterest.com'],
+                },
+                {
+                    userId: 'user-1',
+                    providerOverride: 'tavily',
+                },
+            );
+            expect(result).toEqual({
+                status: 'success',
+                results: [{ url: 'r1' }],
+                provider: 'Tavily',
+            });
+        });
+
+        it('passes undefined for optional dto fields when omitted', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('tavily')]);
+            pluginSettings.getSettings.mockResolvedValue({});
+            searchFacade.search.mockResolvedValue([]);
+
+            const dto = { query: 'q' } as any;
+
+            await controller.search(auth, dto);
+
+            expect(searchFacade.search).toHaveBeenCalledWith(
+                'q',
+                {
+                    maxResults: undefined,
+                    includeDomains: undefined,
+                    excludeDomains: undefined,
+                },
+                expect.any(Object),
+            );
+        });
+
+        it('wraps NoProviderError in BadRequestException with "Enable a search plugin" message', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('tavily')]);
+            pluginSettings.getSettings.mockResolvedValue({});
+            searchFacade.search.mockRejectedValue(new NoProviderError('search'));
+
+            const dto = { query: 'q' } as any;
+
+            await expect(controller.search(auth, dto)).rejects.toBeInstanceOf(BadRequestException);
+            try {
+                await controller.search(auth, dto);
+            } catch (e: any) {
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'No search provider configured. Enable a search plugin in settings.',
+                });
+            }
+        });
+
+        it('wraps generic Error rejection in BadRequestException with the original message', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('tavily')]);
+            pluginSettings.getSettings.mockResolvedValue({});
+            searchFacade.search.mockRejectedValue(new Error('rate limited'));
+
+            const dto = { query: 'q' } as any;
+
+            try {
+                await controller.search(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'rate limited',
+                });
+            }
+        });
+
+        it('wraps non-Error rejection with generic "Search failed" message', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('tavily')]);
+            pluginSettings.getSettings.mockResolvedValue({});
+            searchFacade.search.mockRejectedValue('boom');
+
+            const dto = { query: 'q' } as any;
+
+            try {
+                await controller.search(auth, dto);
+                fail('expected throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect(e.getResponse()).toEqual({
+                    status: 'error',
+                    message: 'Search failed',
+                });
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Adds 41 unit tests across `apps/api/src/plugins-capabilities/`:
  - **search (17)**: `SearchController` covers `checkAvailability` (no-plugins-enabled message, enabled-but-unconfigured message, configured-provider envelope, `pluginSettings.getSettings` `{includeSecrets:true, userId}` shape, all null/undefined/empty-string variants treated as missing required setting, `x-envVar` and `x-adminOnly` skip semantics, undefined `settingsSchema` short-circuits the required check, `required`-without-`properties` short-circuits at the field level, `defaultForCapabilities`-first sort order, fallback to non-default when default plugin lacks required settings); `search` (no-provider `BadRequestException` with `{status:"error", message}` envelope, `searchFacade.search(query, options, context)` positional forwarding incl. `providerOverride`, undefined-passthrough for optional dto fields, `NoProviderError` → BadRequest with "Enable a search plugin" message, generic Error → BadRequest with original message, non-Error → generic "Search failed" message).
  - **screenshot (24)**: `ScreenshotController` covers `checkAvailability` (available:true when at least one configured, available:false when none, workId forwarding to BOTH `getEnabledPluginsScoped` + `getDefaultForCapabilityScoped` + `pluginSettings.getSettings`, active provider from `getDefaultForCapabilityScoped` flagged as `isDefault=true`, fallback to `manifest.defaultForCapabilities`, fallback to `manifest.systemPlugin`, three-tier sort: default-first → configured-second → name alphabetical-third, activeProvider:null when no providers, manifest description/icon exposed on each ProviderOption); `capture` (no-provider BadRequest before facade call, full positional forwarding to `screenshotFacade.capture(options, context)`, cacheUrl-over-imageUrl preference in response, fallback to imageUrl when cacheUrl missing, imageBuffer base64 encoding, `NoProviderError` wrapped in BadRequest with "configured or available" message, non-NoProviderError errors rethrown unchanged, `result.success=false` → BadRequest with `result.error` or "Failed to capture screenshot" fallback); `getScreenshotUrl` (same no-provider/`NoProviderError`/non-NoProviderError patterns, full positional forwarding to `screenshotFacade.getScreenshotUrl(options, context)`, `{status:"success", imageUrl}` envelope on success, null/empty/undefined imageUrl → BadRequest "Failed to generate screenshot URL").

All 41 tests pass. Mocks `@ever-works/agent/{facades,plugins}` plus `../../auth` (re-exporting `NoProviderError` from the facades mock so `instanceof` checks in the controller still match against test-thrown errors).

## Test plan

- [x] `cd apps/api && npx jest --testPathPattern='plugins-capabilities/(search|screenshot)'` — 2 suites pass, 41/41 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for screenshot and search controller capabilities, including availability verification, provider selection, error handling, and request workflows.

**Note:** This release contains testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->