### PR TITLE
docs(specs): add Spec Kit feature spec for notifications

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -166,7 +166,7 @@ Cross-check `docs/specs/features/` against actual capabilities. Candidates
 known to lack a Spec Kit feature folder:
 
 - [ ] `auth-jwt-oauth` (JWT issuance, OAuth GitHub/Google flow)
-- [ ] `notifications` (in-app + email delivery, channels)
+- [x] `notifications` (in-app + email delivery, channels) — spec / plan / tasks authored 2026-05-08 at `docs/specs/features/notifications/`. Covers per-user delivery, deduplication via `deduplicationKey` w/ DB-level partial-unique race recovery (Postgres `23505` / MySQL `ER_DUP_ENTRY` / SQLite `SQLITE_CONSTRAINT`), persistent-notification refusal of dismissal, all 6 controller endpoints behind `AuthSessionGuard`, cross-user reject via `findByIdAndUserId`, cleanup cadence (expired / 7-day-dismissed / 30-day) under a `DistributedTaskLockService` lock, and the 5 producer convenience methods.
 - [ ] `subscriptions` (plan/feature gating)
 - [ ] `activity-log` (event taxonomy + persistence)
 - [ ] `mail-providers` (provider abstraction + templates)

--- a/docs/specs/features/notifications/plan.md
+++ b/docs/specs/features/notifications/plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan: Notifications
+
+**Feature ID**: `notifications`
+**Spec**: `./spec.md`
+**Status**: `Done` (Retrospective)
+**Last updated**: 2026-05-08
+
+---
+
+## 1. Architecture
+
+```mermaid
+flowchart TD
+    Producer[NotificationService.notifyXxx] --> Dedup{deduplicationKey?}
+    Dedup -- yes --> Find[findByDeduplicationKey]
+    Find -- exists & !dismissed --> Return[Return existing]
+    Find -- missing --> Insert[repository.create]
+    Dedup -- no --> Insert
+    Insert -- 23505 / dup --> Recover[findByDeduplicationKey]
+    Recover --> Return
+    Insert -- ok --> Persist[(notifications row)]
+    Persist --> Return
+
+    User[Browser] -->|GET /api/notifications| Controller[NotificationsController]
+    Controller -->|filter by userId| Repo[NotificationRepository]
+    Repo --> Persist
+
+    Cron[Cleanup cron] --> Lock[DistributedTaskLockService.runExclusive]
+    Lock -- acquired --> Cleanup[deleteExpired + deleteOlderThan(7d, dismissed) + deleteOlderThan(30d)]
+    Lock -- locked --> Skip[onLocked debug, exit]
+```
+
+## 2. Tech Choices
+
+| Concern             | Choice                                                       | Rationale                                                |
+| ------------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| Storage             | Postgres via TypeORM entity                                  | Same primary store as the rest of the platform           |
+| Deduplication       | Optional `deduplicationKey` + service-side check + DB unique constraint | Defence in depth against in-process and cross-process races |
+| Mutual exclusion    | `DistributedTaskLockService.runExclusive`                    | Constitution Principle IV; cleanup only                  |
+| Cron                | Per-instance scheduled service (`@Cron`) + lock              | Multiple replicas safe; cleanup runs once per window     |
+| API                 | NestJS REST controller behind `AuthSessionGuard`             | Matches the rest of the platform                         |
+| Persistent banner   | `isPersistent` flag + dedicated `/persistent` endpoint        | UI can render a global banner without scanning the list  |
+
+## 3. Data Model
+
+```ts
+@Entity('notifications')
+class Notification {
+    id: string;
+    userId: string; // FK -> users
+    type: 'info' | 'warning' | 'error' | 'success';
+    category: 'ai_credits' | 'subscription' | 'generation' | 'system' | 'security';
+    title: string;
+    message: string;
+    actionUrl?: string;
+    actionLabel?: string;
+    metadata?: Record<string, any>; // jsonb
+    isPersistent: boolean; // default false
+    isDismissed: boolean; // default false
+    isRead: boolean; // default false
+    expiresAt?: Date;
+    deduplicationKey?: string;
+    createdAt: Date;
+}
+```
+
+Indexes (additive, non-breaking migration):
+
+- `(userId, createdAt desc)` — primary list query.
+- `(userId, isPersistent)` partial — persistent banner query.
+- Partial unique `(userId, deduplicationKey) WHERE deduplicationKey IS NOT NULL` — enforces dedup at the DB layer.
+
+## 4. API Surface
+
+| Method | Endpoint                              | Description                                                              |
+| ------ | ------------------------------------- | ------------------------------------------------------------------------ |
+| `GET`  | `/api/notifications`                  | List w/ `unreadOnly`/`limit`/`offset`/`category`. `limit` capped at 100. |
+| `GET`  | `/api/notifications/unread-count`     | `{count}` envelope.                                                      |
+| `GET`  | `/api/notifications/persistent`       | Returns only `isPersistent=true` rows for the current user.              |
+| `POST` | `/api/notifications/:id/read`         | Mark single notification read; 400 if cross-user / missing.              |
+| `POST` | `/api/notifications/read-all`         | Mark all current-user notifications read.                                |
+| `POST` | `/api/notifications/:id/dismiss`      | Dismiss; 400 with explanation if `isPersistent=true`.                    |
+
+All endpoints return JSON envelopes:
+
+- List endpoints: `{ notifications: Notification[] }`.
+- Mutation endpoints: `{ success: true }` (or 400 with `BadRequestException` body).
+
+## 5. Plugin / Web / CLI
+
+- **Plugin**: no plugin surface — internal cross-cutting service.
+- **Web**: header bell icon polling `/unread-count` every 30s; full
+  panel uses `/api/notifications`; persistent banner subscribes to
+  `/persistent`. Dismissal is optimistic; on 400 the row is restored
+  and the error toast is shown.
+- **CLI**: not exposed (CLI is for the work / generator surface).
+
+## 6. Background Jobs
+
+`NotificationCleanupService` runs every 60 minutes (configurable per
+deployment). Each invocation:
+
+1. Calls `DistributedTaskLockService.runExclusive('notifications:cleanup', {ttlMs: 5 * 60_000, onLocked: () => debug log})`.
+2. Inside the lock: `service.cleanup()` → 3 deletes:
+    - `deleteExpired()`
+    - `deleteOlderThan({ olderThanDays: 7, isDismissed: true })`
+    - `deleteOlderThan({ olderThanDays: 30 })`
+3. Logs a single line with the three counts.
+4. On error: swallowed and logged; the next window retries.
+
+## 7. Security & Permissions
+
+- All endpoints behind `AuthSessionGuard`.
+- All mutations route through `findByIdAndUserId(id, userId)` so a user
+  cannot dismiss / read / target another user's notifications.
+- Producer methods take only safe strings (provider name, work name,
+  free-form error message) — no API keys, tokens, or PII other than
+  the user-supplied workName.
+
+## 8. Observability
+
+- Producer log on create: `Created notification <id> for user <userId>: <title>`.
+- Cleanup log: `Notification cleanup: <expired> expired, <dismissed> dismissed (>7d), <old> old (>30d)`.
+- Dedup race log (debug): `Race condition detected for deduplication key <key>, fetching existing`.
+
+## 9. Risks & Mitigations
+
+| Risk                                            | Mitigation                                                                |
+| ----------------------------------------------- | ------------------------------------------------------------------------- |
+| Notification flood from a stuck error loop      | `deduplicationKey` collapses repeated emissions to a single row           |
+| Cleanup running on multiple replicas            | `DistributedTaskLockService` lock                                         |
+| User dismisses a critical security notification | `isPersistent=true` notifications refuse dismissal w/ explanatory message |
+| Race condition on parallel inserts of same key  | Catch unique-constraint code (`23505` / `ER_DUP_ENTRY` / `SQLITE_CONSTRAINT`) and recover |
+| Notification table unbounded growth             | 30-day expiry sweep + 7-day dismissed sweep                               |
+| Cleanup error wedges the next window            | Outer try/catch logs and swallows; lock TTL caps held lock to 5 min       |
+
+## 10. Constitution Reconciliation
+
+See `spec.md` §9.
+
+## 11. References
+
+- Spec: `./spec.md`
+- Service: `packages/agent/src/notifications/notification.service.ts`
+- Controller: `apps/api/src/notifications/notifications.controller.ts`
+- Cleanup worker: `apps/api/src/notifications/notification-cleanup.service.ts`
+- Tests: `apps/api/src/notifications/{notifications.controller.spec.ts,notification-cleanup.service.spec.ts}`
+- Lock service:
+  `packages/agent/src/cache/distributed-task-lock.service.ts`

--- a/docs/specs/features/notifications/spec.md
+++ b/docs/specs/features/notifications/spec.md
@@ -1,0 +1,204 @@
+# Feature Specification: Notifications
+
+**Feature ID**: `notifications`
+**Status**: `Retrospective`
+**Created**: 2026-05-08
+**Last updated**: 2026-05-08
+**Owner**: Ever Works Team
+
+---
+
+## 1. Overview
+
+The notifications system delivers in-app, per-user messages that surface
+asynchronous events (AI credit depletion, generation failures, schedule
+pauses, expired Git auth, security alerts, etc.) to users without
+relying on email. Notifications are persisted in Postgres, retrieved via
+authenticated REST endpoints, deduplicated by an optional
+`deduplicationKey`, and cleaned up on a schedule. A subset of
+notifications are marked **persistent** — these surface as a global
+banner in the UI and cannot be dismissed by the user until the
+underlying issue is resolved.
+
+## 2. User Scenarios
+
+### 2.1 Primary scenarios
+
+- **Given** my AI provider's credits are exhausted, **when** the
+  generator hits a 402, **then** a persistent `ai_credits_depleted_<provider>`
+  notification surfaces in my account header until I top up.
+- **Given** I have several unread notifications, **when** I open the
+  notification panel, **then** I see them sorted newest-first, paginated
+  at 50 per request (max 100).
+- **Given** I dismiss a non-persistent notification, **when** I refresh,
+  **then** it no longer appears and is purged 7 days later by the cleanup
+  job.
+- **Given** the same error condition fires repeatedly, **when** the
+  service emits the notification with the same `deduplicationKey`,
+  **then** only one row is materialised — subsequent calls return the
+  existing row.
+
+### 2.2 Edge cases & failures
+
+- **Given** two concurrent requests race to create a notification with
+  the same dedup key, **when** the second hits the unique constraint,
+  **then** the service catches `23505` / `ER_DUP_ENTRY` /
+  `SQLITE_CONSTRAINT` and returns the row created by the first request.
+- **Given** a notification is marked `isPersistent=true`, **when** I
+  call `POST /api/notifications/:id/dismiss`, **then** the request
+  returns 400 with the message _"Persistent notifications cannot be
+  dismissed. Please resolve the underlying issue first."_
+- **Given** the cleanup job is already running when the cron fires
+  again, **when** the second invocation tries to acquire its lock,
+  **then** it logs an `onLocked` debug message and exits cleanly.
+- **Given** a cleanup pass throws mid-run, **when** the error reaches
+  the listener, **then** the error is swallowed and logged so the next
+  cleanup window is unaffected.
+- **Given** the user requests `limit=500`, **when** the controller
+  caps the request via `Math.min(limit, 100)`, **then** at most 100 rows
+  are returned regardless of input.
+
+## 3. Functional Requirements
+
+- **FR-1** Each notification MUST belong to a single `userId` (no
+  broadcast notifications) and MUST carry a `type`
+  (`info` / `warning` / `error` / `success`) and a `category`
+  (`ai_credits` / `subscription` / `generation` / `system` /
+  `security`).
+- **FR-2** When `deduplicationKey` is supplied, the service MUST return
+  the existing non-dismissed notification rather than creating a
+  duplicate.
+- **FR-3** The service MUST treat unique-constraint violations
+  (Postgres `23505`, MySQL `ER_DUP_ENTRY`, SQLite `SQLITE_CONSTRAINT`)
+  as a deduplication race and return the existing row.
+- **FR-4** `GET /api/notifications` MUST accept `unreadOnly`, `limit`
+  (capped at 100), `offset`, and `category` query params and MUST
+  default to `unreadOnly=false`, `limit=50`, `offset=0`.
+- **FR-5** `GET /api/notifications/unread-count` MUST return
+  `{count: number}`.
+- **FR-6** `GET /api/notifications/persistent` MUST return only
+  notifications where `isPersistent=true`.
+- **FR-7** `POST /api/notifications/:id/read` and
+  `POST /api/notifications/read-all` MUST mark the targeted rows as
+  read for the authenticated user only.
+- **FR-8** `POST /api/notifications/:id/dismiss` MUST refuse persistent
+  notifications with `BadRequestException` and MUST refuse missing /
+  cross-user notifications with `BadRequestException("Notification not
+  found")`.
+- **FR-9** A `clearByDeduplicationKey(userId, key)` operation MUST be
+  available so producers can clear a notification when the underlying
+  issue resolves.
+- **FR-10** A periodic cleanup MUST delete:
+    - all notifications past their `expiresAt`, **and**
+    - dismissed notifications older than 7 days, **and**
+    - all notifications older than 30 days.
+- **FR-11** The cleanup task MUST hold a single-instance lock
+  (`notifications:cleanup`) so two cron firings cannot duplicate work.
+- **FR-12** Convenience producers MUST be available for the most
+  common cases:
+  `notifyAiCreditsDepleted`, `notifyAiProviderError`,
+  `notifyGenerationAccountError`, `notifySchedulePaused`,
+  `notifyGitAuthExpired`. Each MUST set a stable
+  `deduplicationKey`, an `actionUrl`, and an `actionLabel`.
+
+## 4. Non-Functional Requirements
+
+- **Performance**: list queries are indexed on `(userId, createdAt
+  desc)` and `(userId, isPersistent)`; cap at 100 rows per request keeps
+  the panel snappy.
+- **Reliability**: distributed lock + idempotent dedup keys mean
+  cleanup and producer code are safe to retry.
+- **Security**: all endpoints sit behind `AuthSessionGuard`; row-level
+  filtering is enforced via `findByIdAndUserId` on every mutation
+  before any state change.
+- **Observability**: cleanup emits a single log line per run with
+  `expired / dismissed / old` counts; producer methods log on creation
+  with the notification id.
+- **Cost**: no external delivery channel — all notifications are local
+  Postgres rows. Expansion to email / push is out of scope (see §6).
+
+## 5. Key Entities & Domain Concepts
+
+| Entity / concept              | Description                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `Notification`                | TypeORM entity. Fields: `id, userId, type, category, title, message, actionUrl, actionLabel, metadata, isPersistent, isDismissed, isRead, expiresAt, deduplicationKey, createdAt`. |
+| `NotificationType`            | Enum: `info / warning / error / success`.                                                                            |
+| `NotificationCategory`        | Enum: `ai_credits / subscription / generation / system / security`.                                                  |
+| `NotificationService`         | `packages/agent/src/notifications/notification.service.ts` — create / dedup / list / read / dismiss / cleanup.       |
+| `NotificationCleanupService`  | `apps/api/src/notifications/notification-cleanup.service.ts` — distributed-lock-guarded cron worker.                 |
+| Per-cleanup lock key          | `notifications:cleanup` (single-instance, 5-min ttl).                                                                |
+| Deduplication key conventions | `ai_credits_depleted_<provider>`, `ai_provider_error_<provider>`, `generation_error_<workId>`, `schedule_paused_<workId>`, `git_auth_expired_<provider>`. |
+
+## 6. Out of Scope
+
+- Email or push delivery (handled by `mail-providers` for transactional
+  email; push not yet implemented).
+- Per-organisation or broadcast notifications (notifications are
+  strictly per-user).
+- User-configurable notification preferences (mute by category, quiet
+  hours, etc.) — currently all notifications are delivered regardless
+  of preference.
+- Internationalisation of notification copy — strings are emitted in
+  English by the service.
+
+## 7. Acceptance Criteria
+
+- [x] `POST` and `GET` endpoints all sit behind `AuthSessionGuard` and
+      filter by the authenticated user's id.
+- [x] `deduplicationKey` race condition (two concurrent inserts) does
+      NOT produce two rows — second writer recovers the first writer's
+      row.
+- [x] `POST /api/notifications/:id/dismiss` returns 400 for persistent
+      notifications with the resolve-underlying-issue message.
+- [x] Cleanup deletes expired + dismissed (>7d) + old (>30d) and
+      reports the counts in a single log line.
+- [x] Two cleanup invocations under the same lock collapse to one
+      effective run (`onLocked` debug logged on the loser).
+- [x] Tests cover all controller endpoints (10) and the cleanup
+      service (4) — see `apps/api/src/notifications/__tests__`.
+
+## 8. Open Questions
+
+_None on develop._
+
+## 9. Constitution Gates
+
+- [x] **I**: producer-side notifications are emitted from facades and
+      services, not directly from controllers.
+- [x] **II**: capability-driven — only the agent module exports
+      `NotificationService`; the API consumes it as a black box.
+- [x] **III**: notifications are stored in Postgres (a database
+      concern), but the per-user filtering keeps multi-tenant isolation
+      on every read.
+- [x] **IV**: cleanup runs as a `DistributedTaskLockService`-guarded
+      worker so multiple instances cannot duplicate work.
+- [x] **V**: schema additions are additive (new columns can default to
+      `null`); deduplication is enforced by a partial unique index on
+      `(userId, deduplicationKey)` where `deduplicationKey IS NOT NULL`.
+- [x] **VI**: covered by `apps/api/src/notifications/*.spec.ts`
+      (controller + cleanup) — 14 unit tests, [#490](https://github.com/ever-works/ever-works/pull/490).
+- [x] **VII**: no secrets in notifications; producer methods take only
+      user-visible strings (provider name, work name, free-form error
+      message).
+- [x] **VIII**: N/A — no plugin surface.
+- [x] **IX**: this spec describes user-observable behaviour.
+- [x] **X**: schema changes are additive; older clients that ignore
+      `isPersistent` simply never render the persistent banner.
+
+## 10. References
+
+- Implementation:
+    - Service: `packages/agent/src/notifications/notification.service.ts`
+    - Controller: `apps/api/src/notifications/notifications.controller.ts`
+    - Cleanup worker: `apps/api/src/notifications/notification-cleanup.service.ts`
+    - Entity / enums: `packages/agent/src/entities/notification.entity.ts`,
+      `packages/agent/src/entities/notification.types.ts`
+- Tests:
+    - `apps/api/src/notifications/notifications.controller.spec.ts` (10)
+    - `apps/api/src/notifications/notification-cleanup.service.spec.ts` (4)
+- Related specs:
+    - [`../activity-log/spec.md`](../activity-log/spec.md) — separate
+      audit-trail surface (notifications are user-facing, activity log
+      is owner-facing).
+- Lock primitive:
+  [`../../../agent-services/distributed-task-lock.md`](../../../agent-services/distributed-task-lock.md)

--- a/docs/specs/features/notifications/tasks.md
+++ b/docs/specs/features/notifications/tasks.md
@@ -1,0 +1,78 @@
+# Task Breakdown: Notifications
+
+**Feature ID**: `notifications`
+**Status**: `Done` (Retrospective)
+**Last updated**: 2026-05-08
+
+---
+
+## Phase 1 — Schema
+
+- [x] T1. Add `notifications` entity + repository
+      (`packages/agent/src/entities/notification.entity.ts`,
+      `packages/agent/src/database/repositories/notification.repository.ts`).
+- [x] T2. Add type / category enums
+      (`packages/agent/src/entities/notification.types.ts`).
+- [x] T3. Indexes: `(userId, createdAt desc)`,
+      `(userId, isPersistent)`, partial unique on `(userId,
+      deduplicationKey)`.
+
+## Phase 2 — Service
+
+- [x] T4. `NotificationService.create` w/ `deduplicationKey` short-circuit.
+- [x] T5. Race-condition recovery on Postgres `23505` / MySQL `ER_DUP_ENTRY` / SQLite `SQLITE_CONSTRAINT`.
+- [x] T6. List / unread-count / persistent / mark-as-read / dismiss methods.
+- [x] T7. Producer convenience methods:
+      `notifyAiCreditsDepleted`, `notifyAiProviderError`,
+      `notifyGenerationAccountError`, `notifySchedulePaused`,
+      `notifyGitAuthExpired`.
+- [x] T8. `clearByDeduplicationKey` so producers can clear on resolve.
+- [x] T9. `cleanup()` returning `{expired, dismissed, old}`.
+
+## Phase 3 — API
+
+- [x] T10. `NotificationsController` (6 endpoints) behind `AuthSessionGuard`.
+- [x] T11. `Math.min(limit, 100)` cap on list endpoint.
+- [x] T12. 400 on dismissing persistent notifications.
+- [x] T13. Cross-user reject via `findByIdAndUserId`.
+
+## Phase 4 — Background Jobs
+
+- [x] T14. `NotificationCleanupService` cron worker.
+- [x] T15. `DistributedTaskLockService.runExclusive('notifications:cleanup', …)` guard.
+- [x] T16. Outer error swallow + log so a failed window does not wedge later runs.
+
+## Phase 5 — Web / CLI
+
+- [x] T17. Web: header bell + panel + persistent banner consume the API.
+- [ ] T18. CLI: not in scope — CLI is for work / generator surface.
+
+## Phase 6 — Tests
+
+- [x] T19. `NotificationsController` unit tests (10) — limit cap, persistent refusal, cross-user reject.
+- [x] T20. `NotificationCleanupService` unit tests (4) — happy path, locked branch, error swallow.
+- [ ] T21. **Follow-up**: producer / cleanup integration tests in `packages/agent` (Jest) hitting the real repository against a Postgres test container. Currently only the API-side controller + cleanup worker are covered by unit tests — see [#490](https://github.com/ever-works/ever-works/pull/490).
+
+## Phase 7 — Docs
+
+- [x] T22. This Spec Kit folder (spec / plan / tasks).
+- [ ] T23. **Follow-up**: user-facing doc at `docs/features/notifications.md`
+      describing what shows up in the bell and how to clear it.
+
+## Definition of Done
+
+- [x] Service implemented; all controller endpoints behind auth guard.
+- [x] Race-condition recovery and persistent-dismissal protections in place.
+- [x] Cleanup cron lock-guarded and error-tolerant.
+- [x] Unit tests cover the API surface.
+- [x] Spec / plan / tasks documents authored.
+
+## Follow-ups discovered
+
+- **T21**: integration tests for producer dedup race against a real DB
+  would catch any drift between in-process check and the partial-unique
+  index. Currently only unit tests cover the dedup-recovery branch.
+- **T23**: user-facing doc — bell icon, persistent banner behaviour,
+  what categories exist, how to clear them.
+- **Notification preferences UI** — if user feedback asks for muting
+  by category or quiet hours, this is the spec to amend.


### PR DESCRIPTION
## Summary

Closes one of the Pending Medium-Priority entries in
`COVERAGE-TRACKER.md` — adds a Spec Kit feature folder for the
notifications module under `docs/specs/features/notifications/`,
following the existing `community-pr-processing` pattern.

### Captures

- Per-user delivery (no broadcast).
- Deduplication via `deduplicationKey` w/ in-process check **and** DB
  partial-unique race recovery (Postgres `23505` / MySQL
  `ER_DUP_ENTRY` / SQLite `SQLITE_CONSTRAINT`).
- Persistent-notification refusal of dismissal (400 with
  resolve-underlying-issue message).
- All 6 controller endpoints behind `AuthSessionGuard` with
  cross-user reject via `findByIdAndUserId`.
- Cleanup cadence (expired / 7d-dismissed / 30d) under a
  `DistributedTaskLockService` lock with 5-min ttl.
- The 5 producer convenience methods
  (`notifyAiCreditsDepleted` / `notifyAiProviderError` /
  `notifyGenerationAccountError` / `notifySchedulePaused` /
  `notifyGitAuthExpired`).
- Constitution gates I–X enumerated against the existing
  implementation.

### Open follow-ups (in `tasks.md`)

- Producer / cleanup integration tests against a real Postgres test
  container (currently only unit tests cover the dedup-recovery branch).
- User-facing doc at `docs/features/notifications.md` describing the
  bell icon, persistent banner behaviour, categories, and how to
  clear them.

## Test plan

- [x] `spec.md` / `plan.md` / `tasks.md` authored
- [x] Tracker updated: notifications row moved to Done
- [x] No code changes — pure docs PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added feature specification, implementation plan, and task breakdown for the notifications feature
  * Updated feature completion tracker to mark notifications as completed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->