### PR TITLE
docs(api): add Search + Device Auth capability pages

### DIFF
--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -83,6 +83,8 @@ const sidebars: SidebarsConfig = {
 				'api/deploy-capability',
 				'api/git-provider-capability',
 				'api/oauth-capability',
+				'api/search-capability',
+				'api/device-auth-capability',
 				'api/error-handling',
 				'api/guards-interceptors',
 				'api/websocket-events'

--- a/docs/api/device-auth-capability.md
+++ b/docs/api/device-auth-capability.md
@@ -1,0 +1,217 @@
+---
+id: device-auth-capability
+title: Device Auth Capability
+sidebar_label: Device Auth Capability
+sidebar_position: 23
+---
+
+# Device Auth Capability
+
+The Device Auth capability exposes a thin REST surface for managed
+**device-code** authentication flows on plugins that authenticate via
+the OAuth 2.0 Device Authorization Grant
+([RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)) — for
+example, Claude Code OAuth, GitHub CLI auth, and similar
+copy-the-code-into-your-terminal patterns.
+
+The platform never owns the upstream OAuth provider's UI; instead, the
+plugin is asked for a verification URL + user code, the platform shows
+both to the user, and the user pastes the code into the provider's web
+flow on their own device.
+
+Source: `apps/api/src/plugins-capabilities/device-auth/`
+
+## Architecture
+
+```
+DeviceAuthModule
+  ├── DeviceAuthController        -- REST API endpoints
+  ├── DeviceAuthService           -- Two-method passthrough
+  └── PluginOperationsService     -- From @ever-works/agent/plugins
+```
+
+```typescript
+@Module({
+    imports: [AuthModule, PluginsModule],
+    controllers: [DeviceAuthController],
+    providers: [DeviceAuthService]
+})
+export class DeviceAuthModule {}
+```
+
+`DeviceAuthService` is two two-line methods: `getStatus(userId,
+pluginId)` and `start(userId, pluginId)`. Both forward to
+`PluginOperationsService.{getPluginDeviceAuthStatus,startPluginDeviceAuth}(pluginId,
+userId)`. Errors propagate unwrapped — there is no
+`BadRequestException` shaping at the HTTP layer.
+
+> ⚠️ **Argument order**: the underlying service expects `pluginId`
+> **first**, `userId` **second**. The controller's adapter swaps them
+> back to put `userId` first, but if you call `DeviceAuthService`
+> directly from another module, mind the order.
+
+## API Endpoints
+
+All endpoints are under `/api/device-auth` and require JWT
+authentication via the global `AuthSessionGuard`.
+
+### Get Status
+
+```
+GET /api/device-auth/:pluginId/status
+Authorization: Bearer <jwt-token>
+```
+
+Returns the user-scoped device-auth status for a plugin. Safe to call
+repeatedly (idempotent) — the UI uses this to poll while the user
+completes the device flow on the provider's site.
+
+**Path Parameters:**
+
+| Name       | Type     | Description                                   |
+| ---------- | -------- | --------------------------------------------- |
+| `pluginId` | `string` | The plugin's id (e.g. `claude-code`, `codex`) |
+
+**Response (`DeviceAuthStatus`):**
+
+```json
+{
+    "installed": true,
+    "connected": false,
+    "pending": true,
+    "scope": "user",
+    "flowType": "device-code",
+    "prompt": {
+        "verificationUri": "https://github.com/login/device",
+        "userCode": "ABCD-1234"
+    },
+    "message": "Visit the verification URL and enter the code to complete sign-in."
+}
+```
+
+When the plugin has no in-flight session, `pending` is `false`,
+`prompt` is omitted, and `message` describes the current state (e.g.
+`"Not signed in"`, `"Already connected"`).
+
+### Start
+
+```
+POST /api/device-auth/:pluginId/start
+Authorization: Bearer <jwt-token>
+```
+
+Starts a fresh device-auth flow for the user. The response is the same
+`DeviceAuthStatus` envelope — typically with `pending: true` and a new
+`prompt` payload containing the `verificationUri` + `userCode` to show
+the user.
+
+The plugin is expected to:
+
+1. Request a fresh device code from the upstream provider.
+2. Store the device-code session (server-side) keyed by the user.
+3. Begin polling the upstream provider's token endpoint at the
+   provider-specified interval (typically 5–10 seconds).
+4. Return the verification URI + user code immediately so the platform
+   can display them.
+
+The UI then calls `GET /status` on a timer until `pending` becomes
+`false` and `connected` becomes `true` (or the flow times out / is
+cancelled).
+
+## DeviceAuthStatus Shape
+
+```typescript
+export interface DeviceAuthPrompt {
+    verificationUri: string;
+    userCode: string;
+}
+
+export interface DeviceAuthStatus {
+    installed: boolean;            // Plugin loaded + advertises device-auth
+    connected: boolean;            // User has a valid stored token
+    pending: boolean;              // A device-code flow is in flight
+    scope: 'user';                 // Always per-user (no global device flows)
+    flowType: 'device-code';       // Discriminator for UI rendering
+    prompt?: DeviceAuthPrompt;     // Present iff pending === true
+    message: string;               // Human-readable status line
+}
+```
+
+The `scope: 'user'` and `flowType: 'device-code'` literals are
+intentionally narrow — they let the UI differentiate device-code flows
+from other auth shapes (OAuth web redirect, PAT, etc.) at the type
+level.
+
+## Plugin Contract
+
+To support this capability, a plugin must implement
+[`IDeviceAuthProvider`](https://github.com/ever-works/ever-works/blob/develop/packages/plugin/src/contracts/capabilities/device-auth-provider.interface.ts):
+
+```typescript
+export interface IDeviceAuthProvider {
+    getDeviceAuthStatus(userId: string): Promise<DeviceAuthStatus>;
+    startDeviceAuth(userId: string): Promise<DeviceAuthStatus>;
+    cancelDeviceAuth?(userId: string): Promise<DeviceAuthStatus>;
+}
+```
+
+`cancelDeviceAuth` is optional. When it is implemented, the plugin
+should invalidate the in-flight device-code session and return a
+`DeviceAuthStatus` with `pending: false`. Today there is no HTTP
+endpoint that surfaces `cancelDeviceAuth` — the cancel path is
+internal-only and used by other workflows (e.g. when the user disables
+the plugin mid-flow).
+
+The capability registry detects this contract via `isDeviceAuthProvider`
+(structural duck-typing on `getDeviceAuthStatus` + `startDeviceAuth`).
+
+## Plugins That Use This Capability
+
+| Plugin ID                | Provider                  | Notes                                                                |
+| ------------------------ | ------------------------- | -------------------------------------------------------------------- |
+| `claude-code`            | Claude Code OAuth          | User-scoped; surfaces `verification_uri_complete` + `user_code`     |
+| `claude-managed-agent`   | Claude Code (managed)      | Same flow as `claude-code` but with a managed-agent context wrapper  |
+| `codex`                  | OpenAI Codex CLI           | Device-code flow against the OpenAI auth endpoint                    |
+| `gemini`                 | Gemini CLI                 | Google's device-code flow                                            |
+| `opencode`               | OpenCode CLI               | Device-code flow against the OpenCode auth endpoint                  |
+
+Each of these plugins ships its own settings schema for the resulting
+token storage; the device-auth flow only handles the *acquisition* of
+the token, not its long-term storage shape.
+
+## Error Handling
+
+Errors propagate unwrapped from the underlying `PluginOperationsService`.
+Common failure modes:
+
+| Scenario                              | What happens                                                                |
+| ------------------------------------- | --------------------------------------------------------------------------- |
+| Plugin not installed / unloaded       | `PluginOperationsService` throws; the controller returns the original error |
+| Plugin doesn't implement device-auth  | `PluginOperationsService` throws `Plugin does not support device auth`      |
+| Upstream provider returns 4xx/5xx     | The plugin re-throws; the platform surfaces the message                     |
+
+Unlike the deploy/search/screenshot capabilities, the device-auth
+controller does NOT shape errors into `{status: 'error', message}`
+envelopes — the response either succeeds (`DeviceAuthStatus`) or
+the framework's default error handler returns a 500 with the original
+message.
+
+## Activity-Log Behaviour
+
+No activity-log entries are emitted for device-auth operations. The
+flow is high-frequency (status is polled while the user completes the
+upstream flow) and the audit-volume cost outweighs the visibility gain.
+A successful connection produces a regular `PLUGIN_CONFIGURED` log
+entry indirectly when the resulting token is persisted via the plugin's
+settings hooks (see [`activity-log`
+spec](https://github.com/ever-works/ever-works/tree/develop/docs/specs/features/activity-log)).
+
+## Source Files
+
+| File                                                                       | Purpose                              |
+| -------------------------------------------------------------------------- | ------------------------------------ |
+| `apps/api/src/plugins-capabilities/device-auth/device-auth.module.ts`      | Module definition                    |
+| `apps/api/src/plugins-capabilities/device-auth/device-auth.controller.ts`  | REST API controller                  |
+| `apps/api/src/plugins-capabilities/device-auth/device-auth.service.ts`     | Thin two-method passthrough          |
+| `packages/plugin/src/contracts/capabilities/device-auth-provider.interface.ts` | `DeviceAuthStatus` + `IDeviceAuthProvider` |
+| `packages/agent/src/plugins/plugin-operations.service.ts`                   | `PluginOperationsService` orchestrator |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -59,7 +59,9 @@ All tiers apply simultaneously. If any tier's limit is exceeded, the API returns
 | **AI Conversation** | `/api/ai-conversations`      | Streaming AI chat                                | [AI Conversation](/api/ai-conversation)                                                 |
 | **Git Providers**   | `/api/git-providers`         | Git provider connections, repos, orgs            | [Other Modules](/api/other-modules#git-provider-api)                                    |
 | **Generator Form**  | `/api/generator-form`        | Dynamic pipeline form schemas                    | [Other Modules](/api/other-modules#generator-form-schema)                               |
-| **Screenshot**      | `/api/screenshot`            | Screenshot capture                               | [Other Modules](/api/other-modules#screenshot-api)                                      |
+| **Screenshot**      | `/api/screenshot`            | Screenshot capture                               | [Screenshot Capability](/api/screenshot-capability)                                     |
+| **Search**          | `/api/search`                | Web search via the user's first configured plugin | [Search Capability](/api/search-capability)                                             |
+| **Plugin Device Auth** | `/api/device-auth`        | Per-user device-code OAuth for plugins (CLI tools) | [Device Auth Capability](/api/device-auth-capability)                                  |
 | **Subscriptions**   | `/api/subscriptions`         | Plans, billing, usage tracking                   | [Other Modules](/api/other-modules#subscriptions-api)                                   |
 | **Notifications**   | `/api/notifications`         | User notifications                               | [Other Modules](/api/other-modules#notifications-api)                                   |
 | **Members**         | `/api/works/:id/members`     | Work member management                           | [Works](/api/works)                                                                     |

--- a/docs/api/search-capability.md
+++ b/docs/api/search-capability.md
@@ -1,0 +1,322 @@
+---
+id: search-capability
+title: Search Capability
+sidebar_label: Search Capability
+sidebar_position: 22
+---
+
+# Search Capability
+
+The Search capability exposes a single-call web-search API that delegates
+to the user's first enabled and fully configured search provider plugin
+(Tavily, Brave, Exa, Perplexity, SerpApi, Linkup, Valyu, Firecrawl, Jina,
+or BrightData). It is used by the AI conversation surface, the
+work-generation pipeline, and any other module that needs ad-hoc web
+search without hard-coding a provider.
+
+Source: `apps/api/src/plugins-capabilities/search/`
+
+## Architecture
+
+```
+SearchModule
+  ├── SearchController          -- REST API endpoints
+  ├── SearchFacadeService       -- Plugin resolution (from @ever-works/agent)
+  ├── PluginRegistryService     -- Enabled-plugin enumeration
+  └── PluginSettingsService     -- Settings cascade reader
+```
+
+```typescript
+@Module({
+    imports: [FacadesModule, PluginsModule, AuthModule],
+    controllers: [SearchController]
+})
+export class SearchModule {}
+```
+
+The controller never reaches into a specific search plugin — it asks
+`PluginRegistryService.getEnabledPluginsScoped(SEARCH, undefined,
+userId)` for the user's enabled list, picks the first one whose required
+settings (excluding `x-envVar` and `x-adminOnly` fields) are populated,
+and forwards the call to `SearchFacadeService.search` with the resolved
+provider id passed via `providerOverride`.
+
+## API Endpoints
+
+All endpoints are under the `/api/search` prefix and require JWT
+authentication via the global `AuthSessionGuard`.
+
+### Check Availability
+
+```
+GET /api/search/check-availability
+Authorization: Bearer <jwt-token>
+```
+
+Returns whether the user has at least one fully-configured search
+provider, and which one is active.
+
+**Success Response (available):**
+
+```json
+{
+    "status": "success",
+    "available": true,
+    "activeProvider": {
+        "id": "tavily",
+        "name": "Tavily"
+    }
+}
+```
+
+**Success Response (no provider enabled):**
+
+```json
+{
+    "status": "success",
+    "available": false,
+    "activeProvider": null,
+    "message": "No search provider is enabled. Enable a search plugin (e.g. Tavily, Linkup, Brave, Exa) in settings."
+}
+```
+
+**Success Response (enabled but unconfigured):**
+
+```json
+{
+    "status": "success",
+    "available": false,
+    "activeProvider": null,
+    "message": "Search plugins are enabled but none have all required settings configured (e.g. API key)."
+}
+```
+
+The two unavailable messages are distinct so the UI can render two
+different call-to-action prompts.
+
+### Search
+
+```
+POST /api/search/
+Authorization: Bearer <jwt-token>
+Content-Type: application/json
+```
+
+Searches the web using the user's first enabled and fully-configured
+search provider.
+
+**Request Body (`SearchDto`):**
+
+| Field            | Type       | Required | Validation        | Description                                          |
+| ---------------- | ---------- | -------- | ----------------- | ---------------------------------------------------- |
+| `query`          | `string`   | Yes      | non-empty string  | Free-text search query                               |
+| `maxResults`     | `number`   | No       | `1` ≤ N ≤ `50`    | Cap on the number of results to return               |
+| `includeDomains` | `string[]` | No       | array of hostnames | Restrict results to these domains                    |
+| `excludeDomains` | `string[]` | No       | array of hostnames | Drop results from these domains                      |
+
+**Example Request:**
+
+```json
+{
+    "query": "best project management tools",
+    "maxResults": 10,
+    "includeDomains": ["producthunt.com", "g2.com"],
+    "excludeDomains": ["pinterest.com"]
+}
+```
+
+**Success Response:**
+
+```json
+{
+    "status": "success",
+    "results": [
+        {
+            "title": "...",
+            "url": "...",
+            "snippet": "...",
+            "score": 0.91
+        }
+    ],
+    "provider": "Tavily"
+}
+```
+
+The exact result shape depends on the active plugin — see the per-plugin
+documentation for the canonical fields.
+
+**Error Response (400):**
+
+When no provider is configured:
+
+```json
+{
+    "status": "error",
+    "message": "No search provider with all required settings configured is available."
+}
+```
+
+When the facade rejects with `NoProviderError`:
+
+```json
+{
+    "status": "error",
+    "message": "No search provider configured. Enable a search plugin in settings."
+}
+```
+
+When the upstream provider throws:
+
+```json
+{
+    "status": "error",
+    "message": "<provider error message>"
+}
+```
+
+When a non-Error rejection occurs:
+
+```json
+{
+    "status": "error",
+    "message": "Search failed"
+}
+```
+
+## DTO Validation
+
+The `SearchDto` uses `class-validator` decorators:
+
+```typescript
+export class SearchDto {
+    @IsString()
+    @IsNotEmpty()
+    query: string;
+
+    @IsOptional()
+    @IsNumber()
+    @Min(1)
+    @Max(50)
+    maxResults?: number;
+
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    includeDomains?: string[];
+
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    excludeDomains?: string[];
+}
+```
+
+## Provider Resolution
+
+The controller's private `resolveConfiguredProvider(userId)` helper picks
+the active provider in three steps:
+
+1. Enumerate all enabled SEARCH-capability plugins for the user via
+   `pluginRegistry.getEnabledPluginsScoped(PLUGIN_CAPABILITIES.SEARCH,
+   undefined, userId)`. The cascade respects work → user → admin →
+   environment.
+2. Sort the list with plugins that declare `defaultForCapabilities:
+   ['search']` in their manifest first (e.g. Tavily — the canonical
+   default). Other plugins keep their registration order.
+3. For each plugin in the sorted list, resolve its settings via
+   `pluginSettings.getSettings(pluginId, {userId, includeSecrets: true})`
+   and run `hasAllRequiredSettings(schema, resolved)`. The first plugin
+   that passes the check wins.
+
+`hasAllRequiredSettings` walks the plugin's `settingsSchema.required`
+list and treats `undefined`, `null`, or `''` as missing. Fields flagged
+`x-envVar` (env-var fallback) or `x-adminOnly` (admin-supplied) are
+**skipped** — they are considered always-present from the user's point
+of view.
+
+## Supported Providers
+
+| Plugin ID      | Provider     | Required settings                                                                                |
+| -------------- | ------------ | ------------------------------------------------------------------------------------------------ |
+| `tavily`       | Tavily       | `apiKey` (env-var fallback `PLUGIN_TAVILY_API_KEY`)                                              |
+| `brave`        | Brave Search | `apiKey` (env-var fallback `PLUGIN_BRAVE_API_KEY`)                                               |
+| `exa`          | Exa.ai       | `apiKey` (env-var fallback `PLUGIN_EXA_API_KEY`)                                                 |
+| `perplexity`   | Perplexity   | `apiKey` (env-var fallback `PLUGIN_PERPLEXITY_API_KEY`)                                          |
+| `serpapi`      | SerpApi      | `apiKey` (env-var fallback `PLUGIN_SERPAPI_API_KEY`)                                             |
+| `linkup`       | Linkup       | `apiKey` (env-var fallback `PLUGIN_LINKUP_API_KEY`)                                              |
+| `valyu`        | Valyu        | `apiKey` (env-var fallback `PLUGIN_VALYU_API_KEY`)                                               |
+| `firecrawl`    | Firecrawl    | `apiKey` (env-var fallback `PLUGIN_FIRECRAWL_API_KEY`)                                           |
+| `jina`         | Jina AI      | `apiKey` (env-var fallback `PLUGIN_JINA_API_KEY`)                                                |
+| `brightdata`   | BrightData   | `apiToken` + `customerId` (env-var fallbacks `PLUGIN_BRIGHTDATA_API_TOKEN`/`PLUGIN_BRIGHTDATA_CUSTOMER_ID`) |
+
+`tavily` is the canonical default — it ships in the platform's
+`built-in-plugins.md` catalogue with `defaultForCapabilities:
+['search']`. To override, enable any other plugin with `default: true`
+in your settings, or pass `providerOverride` from the calling code path
+(currently only available to the AI facade — the HTTP controller does
+not expose this; see [`plugins-capabilities`
+spec](https://github.com/ever-works/ever-works/tree/develop/docs/specs/features/plugins-capabilities)
+OQ-4).
+
+## Provider Integration
+
+The controller uses `SearchFacadeService` to execute the search:
+
+```typescript
+const results = await this.searchFacade.search(
+    dto.query,
+    {
+        maxResults: dto.maxResults,
+        includeDomains: dto.includeDomains,
+        excludeDomains: dto.excludeDomains
+    },
+    {
+        userId: auth.userId,
+        providerOverride: provider.id
+    }
+);
+```
+
+Passing the resolved provider via `providerOverride` short-circuits the
+facade's own resolution step — the controller and the facade always
+agree on which plugin runs.
+
+## Error Handling
+
+The controller throws `BadRequestException` in two scenarios:
+
+1. **No configured provider**: when `resolveConfiguredProvider` returns
+   `null` BEFORE the facade is even called.
+2. **Search execution failed**: when the facade rejects. `NoProviderError`
+   is remapped to a friendlier message; all other errors surface their
+   `.message` (or coerce to `"Search failed"` for non-Error rejections).
+
+Both cases return the structured envelope:
+
+```json
+{
+    "status": "error",
+    "message": "<descriptive message>"
+}
+```
+
+## Usage in the Platform
+
+Search is consumed by:
+
+- **AI conversation**: tool-call lookups when the chat assistant needs
+  current information.
+- **Work generation pipeline**: source discovery during the standard
+  pipeline's research steps.
+- **Item enrichment**: optional web-search lookups when extracting items
+  from URLs.
+
+## Source Files
+
+| File                                                            | Purpose                 |
+| --------------------------------------------------------------- | ----------------------- |
+| `apps/api/src/plugins-capabilities/search/search.module.ts`     | Module definition       |
+| `apps/api/src/plugins-capabilities/search/search.controller.ts` | REST API controller     |
+| `apps/api/src/plugins-capabilities/search/dto/search.dto.ts`    | Request validation DTO  |
+| `packages/agent/src/facades/search.facade.ts`                   | Plugin-resolving facade |
+| `packages/plugins/<id>/`                                        | Per-provider plugin     |


### PR DESCRIPTION
## Summary

Two `apps/api/src/plugins-capabilities/` sub-modules previously had no dedicated docs page (the others — deploy, screenshot, oauth, git-provider — already do). Pinning their user-facing HTTP contract mirrors the spec backfill in [#539](https://github.com/ever-works/ever-works/pull/539).

- `docs/api/search-capability.md` (sidebar position 22) — documents `GET /api/search/check-availability` (the two distinct unconfigured-vs-not-enabled messages) and `POST /api/search/` (the SearchDto shape, the `resolveConfiguredProvider` three-step resolver, the `defaultForCapabilities`-first sort, the `hasAllRequiredSettings` rule that skips `x-envVar`/`x-adminOnly` fields, the four error envelopes including the `NoProviderError` remap, and the supported-providers table).
- `docs/api/device-auth-capability.md` (sidebar position 23) — documents `GET /api/device-auth/:pluginId/status` and `POST /api/device-auth/:pluginId/start`, the `DeviceAuthStatus` shape, the `IDeviceAuthProvider` plugin contract, the optional `cancelDeviceAuth` extension, and the five plugins that consume this capability (Claude Code, Claude managed agent, Codex, Gemini, OpenCode).

Wires both into `apps/docs/sidebarsPlatform.ts` after `api/oauth-capability` and before `api/error-handling`. Updates the endpoint-groups table in `docs/api/index.md` to add Search + Plugin Device Auth rows pointing at the new pages, and re-points the existing Screenshot row from `other-modules#screenshot-api` to its dedicated capability page.

Closes the per-capability docs gap for the `plugins-capabilities` surface.

## Test plan

- [x] Markdown only — sidebar wiring verified manually
- [x] Cross-references resolve to existing files
- [x] Source paths in each doc match the actual code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Search Capability API documentation covering endpoints, request/response formats, provider selection, and error handling
  * Added Device Auth Capability API documentation including REST endpoints, status checking, and plugin contracts
  * Updated API reference index and sidebar navigation to include new capability documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->