### PR TITLE
test(tasks): cover TriggerInternalApiClient + task-context + worker-context (39 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -119,14 +119,40 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
       and the `DomainType` enum (2026-05-07).
 - [x] `packages/monitoring` — Sentry + PostHog SDKs mocked, 72 tests across config, services, interceptors (2026-05-07).
 - [x] `packages/cli-shared` — utils + prompt services fully covered (116 tests across slug, validation, config-check, generator-steps, base-prompt.service, work-prompt.service).
-- [x] `packages/tasks` — vitest scaffolded; 61 tests across `LocalPluginStore`,
-      `TriggerLogger`, `TriggerService`, and `collectPluginDependencies`
-      (`@trigger.dev/sdk` and `@ever-works/agent/config` mocked).
-      Follow-ups: `TriggerInternalApiClient` (HTTP retry), `worker-context` /
-      `task-context` utilities, and the four task entrypoints
+- [x] `packages/tasks` — vitest scaffolded; 100 tests across
+      `LocalPluginStore`, `TriggerLogger`, `TriggerService`,
+      `collectPluginDependencies`, `TriggerInternalApiClient`,
+      `task-context.utils`, and `worker-context.utils`
+      (`@trigger.dev/sdk`, `@ever-works/agent/config`, `@nestjs/core`'s
+      `NestFactory.createApplicationContext`, and the trigger logger factory
+      mocked). The 2026-05-08 follow-up adds 39 tests across three new
+      files: `TriggerInternalApiClient` (20 tests covering constructor env
+      guards for `TRIGGER_INTERNAL_API_URL`/`TRIGGER_INTERNAL_SECRET`,
+      URL composition (trailing-slash strip on base + leading-slash strip
+      on path + `URLSearchParams`-encoded `userId`), `fetchWorkContext`
+      GET shape + `x-trigger-secret` header + 204/empty-body → undefined,
+      `callRemote` POST `/remote/call` with SuperJSON args+meta envelope
+      and SuperJSON-deserialized result, retry behaviour: 5xx retries up
+      to 3× with exponential backoff `500/1000/2000ms` pinned via
+      `vi.useFakeTimers` + `advanceTimersByTimeAsync`, 4xx never retries,
+      network errors retry up to 3×, non-Error rejections coerced to
+      Error); `task-context.utils` (9 tests covering hydrator-before-fetch
+      ordering, `fetchWorkContext(workId, userId)` positional shape,
+      `class-transformer` `plainToInstance(Work|User, …)` hydration,
+      `work.user = user` re-attachment, orchestrator resolution AFTER
+      fetch, gitToken passthrough vs undefined-on-omit, hydrator-error
+      short-circuits the fetch, fetchWorkContext-error short-circuits
+      the orchestrator resolve); `worker-context.utils` (10 tests
+      covering default `TriggerWorkerModule` vs caller-supplied module
+      token, `useLogger(createTriggerLogger(name))` ordering before fn,
+      fn return-value passthrough, appContext passed to fn, close-on-
+      success / close-on-fn-throw / close-error-propagation /
+      try-finally close-error-overrides-body-error semantics,
+      `NestFactory` rejection short-circuits fn + close paths).
+      Outstanding follow-up: the four task entrypoints
       (`work-generation` / `work-import` / `work-onboarding` /
-      `work-schedule-dispatcher`) — these need NestFactory mocked and are
-      best done as a dedicated follow-up.
+      `work-schedule-dispatcher`) — these need fuller NestFactory
+      stubbing and are best done as a dedicated follow-up.
 
 ### API module unit tests
 

--- a/packages/tasks/src/__tests__/task-context.utils.spec.ts
+++ b/packages/tasks/src/__tests__/task-context.utils.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { Work, User } = vi.hoisted(() => {
+    class Work {
+        id?: string;
+        slug?: string;
+        user?: any;
+    }
+    class User {
+        id?: string;
+        email?: string;
+    }
+    return { Work, User };
+});
+
+vi.mock('@ever-works/agent/entities', () => ({ Work, User }));
+
+import { createTaskContext } from '../trigger/worker/utils/task-context.utils';
+import { TriggerInternalApiClient } from '../trigger/worker/services/trigger-internal-api.client';
+import { TriggerPluginHydratorService } from '../trigger/worker/services/trigger-plugin-hydrator.service';
+
+class FakeOrchestrator {
+    name = 'fake-orchestrator';
+}
+
+describe('createTaskContext', () => {
+    let hydrator: { initialize: ReturnType<typeof vi.fn> };
+    let apiClient: { fetchWorkContext: ReturnType<typeof vi.fn> };
+    let orchestratorInstance: FakeOrchestrator;
+    let appContext: { get: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        hydrator = { initialize: vi.fn().mockResolvedValue(undefined) };
+        apiClient = { fetchWorkContext: vi.fn() };
+        orchestratorInstance = new FakeOrchestrator();
+        appContext = {
+            get: vi.fn((token: any) => {
+                if (token === TriggerPluginHydratorService) return hydrator;
+                if (token === TriggerInternalApiClient) return apiClient;
+                if (token === FakeOrchestrator) return orchestratorInstance;
+                throw new Error(`Unexpected DI token: ${String(token)}`);
+            }),
+        };
+    });
+
+    it('initializes the plugin hydrator BEFORE fetching work context', async () => {
+        const calls: string[] = [];
+        hydrator.initialize.mockImplementation(async () => {
+            calls.push('hydrate');
+        });
+        apiClient.fetchWorkContext.mockImplementation(async () => {
+            calls.push('fetch');
+            return { user: { id: 'u1' }, work: { id: 'w1' } };
+        });
+
+        await createTaskContext(
+            appContext as any,
+            { workId: 'w1', userId: 'u1' },
+            FakeOrchestrator,
+        );
+
+        expect(calls).toEqual(['hydrate', 'fetch']);
+    });
+
+    it('forwards the workId + userId positionally to fetchWorkContext', async () => {
+        apiClient.fetchWorkContext.mockResolvedValue({
+            user: { id: 'u1' },
+            work: { id: 'w1' },
+        });
+
+        await createTaskContext(
+            appContext as any,
+            { workId: 'work-42', userId: 'user-99' },
+            FakeOrchestrator,
+        );
+
+        expect(apiClient.fetchWorkContext).toHaveBeenCalledWith('work-42', 'user-99');
+    });
+
+    it('hydrates plain objects into Work/User class instances via class-transformer', async () => {
+        apiClient.fetchWorkContext.mockResolvedValue({
+            user: { id: 'u1', email: 'a@b.c' },
+            work: { id: 'w1', slug: 'my-work' },
+        });
+
+        const ctx = await createTaskContext(
+            appContext as any,
+            { workId: 'w1', userId: 'u1' },
+            FakeOrchestrator,
+        );
+
+        expect(ctx.user).toBeInstanceOf(User);
+        expect(ctx.user.id).toBe('u1');
+        expect(ctx.user.email).toBe('a@b.c');
+        expect(ctx.work).toBeInstanceOf(Work);
+        expect(ctx.work.id).toBe('w1');
+        expect(ctx.work.slug).toBe('my-work');
+    });
+
+    it('attaches the hydrated user back onto work.user', async () => {
+        apiClient.fetchWorkContext.mockResolvedValue({
+            user: { id: 'u1' },
+            work: { id: 'w1' },
+        });
+
+        const ctx = await createTaskContext(
+            appContext as any,
+            { workId: 'w1', userId: 'u1' },
+            FakeOrchestrator,
+        );
+
+        expect(ctx.work.user).toBe(ctx.user);
+        expect(ctx.work.user.id).toBe('u1');
+    });
+
+    it('resolves the orchestrator using the supplied class token AFTER fetching context', async () => {
+        const order: string[] = [];
+        apiClient.fetchWorkContext.mockImplementation(async () => {
+            order.push('fetch');
+            return { user: { id: 'u' }, work: { id: 'w' } };
+        });
+        appContext.get.mockImplementation((token: any) => {
+            if (token === TriggerPluginHydratorService) {
+                order.push('get-hydrator');
+                return hydrator;
+            }
+            if (token === TriggerInternalApiClient) {
+                order.push('get-api-client');
+                return apiClient;
+            }
+            if (token === FakeOrchestrator) {
+                order.push('get-orchestrator');
+                return orchestratorInstance;
+            }
+            throw new Error('Unexpected DI token');
+        });
+
+        const ctx = await createTaskContext(
+            appContext as any,
+            { workId: 'w', userId: 'u' },
+            FakeOrchestrator,
+        );
+
+        expect(ctx.orchestrator).toBe(orchestratorInstance);
+        // hydrator + api-client come before the fetch; orchestrator after.
+        expect(order).toEqual(['get-hydrator', 'get-api-client', 'fetch', 'get-orchestrator']);
+    });
+
+    it('forwards the gitToken from the API response (when present)', async () => {
+        apiClient.fetchWorkContext.mockResolvedValue({
+            user: { id: 'u' },
+            work: { id: 'w' },
+            gitToken: 'ghp_xyz',
+        });
+
+        const ctx = await createTaskContext(
+            appContext as any,
+            { workId: 'w', userId: 'u' },
+            FakeOrchestrator,
+        );
+
+        expect(ctx.gitToken).toBe('ghp_xyz');
+    });
+
+    it('leaves gitToken undefined when the API omits it', async () => {
+        apiClient.fetchWorkContext.mockResolvedValue({
+            user: { id: 'u' },
+            work: { id: 'w' },
+        });
+
+        const ctx = await createTaskContext(
+            appContext as any,
+            { workId: 'w', userId: 'u' },
+            FakeOrchestrator,
+        );
+
+        expect(ctx.gitToken).toBeUndefined();
+    });
+
+    it('propagates errors from the hydrator and skips the fetch entirely', async () => {
+        hydrator.initialize.mockRejectedValueOnce(new Error('plugin-load-failed'));
+
+        await expect(
+            createTaskContext(
+                appContext as any,
+                { workId: 'w', userId: 'u' },
+                FakeOrchestrator,
+            ),
+        ).rejects.toThrow('plugin-load-failed');
+
+        expect(apiClient.fetchWorkContext).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors from fetchWorkContext (no orchestrator resolution attempted)', async () => {
+        apiClient.fetchWorkContext.mockRejectedValueOnce(new Error('api-down'));
+
+        await expect(
+            createTaskContext(
+                appContext as any,
+                { workId: 'w', userId: 'u' },
+                FakeOrchestrator,
+            ),
+        ).rejects.toThrow('api-down');
+
+        // appContext.get was called for hydrator + api-client + … but NOT for the orchestrator
+        const tokens = appContext.get.mock.calls.map((c) => c[0]);
+        expect(tokens).toContain(TriggerPluginHydratorService);
+        expect(tokens).toContain(TriggerInternalApiClient);
+        expect(tokens).not.toContain(FakeOrchestrator);
+    });
+});

--- a/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import superjson from 'superjson';
+
+const { triggerConfig } = vi.hoisted(() => ({
+    triggerConfig: {
+        getInternalBaseUrl: vi.fn(),
+        getInternalSecret: vi.fn(),
+    },
+}));
+
+vi.mock('@ever-works/agent/config', () => ({
+    config: {
+        trigger: triggerConfig,
+    },
+}));
+
+import { TriggerInternalApiClient } from '../trigger/worker/services/trigger-internal-api.client';
+
+const okJsonResponse = (status: number, body: unknown): Response =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        text: () => Promise.resolve(JSON.stringify(body)),
+    }) as unknown as Response;
+
+const okEmptyResponse = (status = 204): Response =>
+    ({
+        ok: true,
+        status,
+        text: () => Promise.resolve(''),
+    }) as unknown as Response;
+
+const errorResponse = (status: number, body = 'boom'): Response =>
+    ({
+        ok: false,
+        status,
+        text: () => Promise.resolve(body),
+    }) as unknown as Response;
+
+describe('TriggerInternalApiClient', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com/');
+        triggerConfig.getInternalSecret.mockReturnValue('secret-1');
+
+        fetchSpy = vi.fn();
+        // @ts-expect-error - install fetch on global
+        globalThis.fetch = fetchSpy;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('constructor', () => {
+        it('throws when TRIGGER_INTERNAL_API_URL is not configured', () => {
+            triggerConfig.getInternalBaseUrl.mockReturnValue('');
+            triggerConfig.getInternalSecret.mockReturnValue('s');
+
+            expect(() => new TriggerInternalApiClient()).toThrow(
+                'TRIGGER_INTERNAL_API_URL is not configured',
+            );
+        });
+
+        it('throws when TRIGGER_INTERNAL_API_URL is null/undefined (treated as empty)', () => {
+            triggerConfig.getInternalBaseUrl.mockReturnValue(undefined as unknown as string);
+            triggerConfig.getInternalSecret.mockReturnValue('s');
+
+            expect(() => new TriggerInternalApiClient()).toThrow(
+                'TRIGGER_INTERNAL_API_URL is not configured',
+            );
+        });
+
+        it('throws when TRIGGER_INTERNAL_SECRET is not configured', () => {
+            triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com');
+            triggerConfig.getInternalSecret.mockReturnValue('');
+
+            expect(() => new TriggerInternalApiClient()).toThrow(
+                'TRIGGER_INTERNAL_SECRET is not configured',
+            );
+        });
+
+        it('throws when TRIGGER_INTERNAL_SECRET is null/undefined', () => {
+            triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com');
+            triggerConfig.getInternalSecret.mockReturnValue(undefined as unknown as string);
+
+            expect(() => new TriggerInternalApiClient()).toThrow(
+                'TRIGGER_INTERNAL_SECRET is not configured',
+            );
+        });
+
+        it('constructs successfully when both env values are present', () => {
+            expect(() => new TriggerInternalApiClient()).not.toThrow();
+        });
+    });
+
+    describe('URL composition', () => {
+        it('strips a trailing slash on the base URL and a leading slash on the path', async () => {
+            triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com/');
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            await client.fetchWorkContext('w1', 'u1');
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            const [url] = fetchSpy.mock.calls[0];
+            expect(url).toBe('https://api.example.com/works/w1/context?userId=u1');
+        });
+
+        it('joins paths with no double-slash when base has no trailing slash', async () => {
+            triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com');
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            await client.fetchWorkContext('w1', 'u1');
+
+            const [url] = fetchSpy.mock.calls[0];
+            expect(url).toBe('https://api.example.com/works/w1/context?userId=u1');
+        });
+
+        it('encodes the userId via URLSearchParams (handles characters that need encoding)', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            await client.fetchWorkContext('work-1', 'user with spaces & symbols');
+
+            const [url] = fetchSpy.mock.calls[0];
+            expect(url).toContain(
+                'userId=user+with+spaces+%26+symbols',
+            );
+        });
+    });
+
+    describe('fetchWorkContext', () => {
+        it('issues a GET to /works/:workId/context?userId=:userId with auth header', async () => {
+            const client = new TriggerInternalApiClient();
+            const expected = { user: { id: 'u1' }, work: { id: 'w1' }, gitToken: 'tok' };
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, expected));
+
+            const result = await client.fetchWorkContext('w1', 'u1');
+
+            expect(result).toEqual(expected);
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            const [, init] = fetchSpy.mock.calls[0];
+            expect(init).toMatchObject({
+                method: 'GET',
+                headers: {
+                    'content-type': 'application/json',
+                    'x-trigger-secret': 'secret-1',
+                },
+            });
+            expect(init.body).toBeUndefined();
+        });
+
+        it('returns undefined for a 204 No Content response', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okEmptyResponse(204));
+
+            const result = await client.fetchWorkContext('w1', 'u1');
+
+            expect(result).toBeUndefined();
+        });
+
+        it('returns undefined for a 200 with empty body', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okEmptyResponse(200));
+
+            const result = await client.fetchWorkContext('w1', 'u1');
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('callRemote', () => {
+        it('issues a POST to /remote/call with the SuperJSON args envelope', async () => {
+            const client = new TriggerInternalApiClient();
+
+            // Server returns a SuperJSON-serialized envelope; the client deserializes it.
+            const serverPayload = superjson.serialize({ value: 42, when: new Date('2026-01-01') });
+            fetchSpy.mockResolvedValueOnce(
+                okJsonResponse(200, { result: serverPayload }),
+            );
+
+            const result = await client.callRemote('SomeService', 'doIt', {
+                json: { foo: 'bar' },
+            });
+
+            expect(result).toEqual({ value: 42, when: new Date('2026-01-01') });
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+            const [url, init] = fetchSpy.mock.calls[0];
+            expect(url).toBe('https://api.example.com/remote/call');
+            expect(init.method).toBe('POST');
+            expect(JSON.parse(init.body)).toEqual({
+                name: 'SomeService',
+                method: 'doIt',
+                args: { json: { foo: 'bar' } },
+            });
+        });
+
+        it('forwards SuperJSON meta inside the args envelope', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(
+                okJsonResponse(200, { result: superjson.serialize('ok') }),
+            );
+
+            await client.callRemote('S', 'm', {
+                json: { d: 'pretend-date' },
+                meta: { values: { d: ['Date'] } },
+            });
+
+            const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+            expect(body.args.meta).toEqual({ values: { d: ['Date'] } });
+        });
+
+        it('returns undefined when the server omits a `result` field', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, {}));
+
+            const result = await client.callRemote('S', 'm', { json: null });
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('retry behaviour', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        const flushAll = async () => {
+            // Drain pending microtasks + timers in lock-step so the retry loop can
+            // progress without us having to know the exact backoff schedule.
+            for (let i = 0; i < 10; i++) {
+                await vi.advanceTimersByTimeAsync(2000);
+            }
+        };
+
+        it('retries once on a 5xx response then resolves on success', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy
+                .mockResolvedValueOnce(errorResponse(500, 'down'))
+                .mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            const promise = client.fetchWorkContext('w', 'u');
+            await flushAll();
+            const result = await promise;
+
+            expect(result).toEqual({ ok: true });
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('retries up to 3 times on persistent 5xx and throws the last status/text', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValue(errorResponse(503, 'unavailable'));
+
+            const promise = client.fetchWorkContext('w', 'u');
+            // Swallow the rejection here so the unhandled-rejection plugin in
+            // vitest does not fail the test before we explicitly assert.
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request failed (503): unavailable',
+            );
+            // initial + 3 retries = 4 fetch calls
+            expect(fetchSpy).toHaveBeenCalledTimes(4);
+        });
+
+        it('does NOT retry on 4xx — throws immediately after the first attempt', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockResolvedValueOnce(errorResponse(404, 'not found'));
+
+            const promise = client.fetchWorkContext('w', 'u');
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow(
+                'Trigger internal API request failed (404): not found',
+            );
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('retries on a network error (fetch rejects) up to 3 times', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+
+            const promise = client.fetchWorkContext('w', 'u');
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('ECONNREFUSED');
+            expect(fetchSpy).toHaveBeenCalledTimes(4);
+        });
+
+        it('coerces non-Error fetch rejections into Error instances before the retry loop continues', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy.mockRejectedValue('string-rejection');
+
+            const promise = client.fetchWorkContext('w', 'u');
+            promise.catch(() => undefined);
+            await flushAll();
+
+            await expect(promise).rejects.toThrow('string-rejection');
+            expect(fetchSpy).toHaveBeenCalledTimes(4);
+        });
+
+        it('uses exponential backoff (500ms, 1000ms, 2000ms) between retries', async () => {
+            const client = new TriggerInternalApiClient();
+            fetchSpy
+                .mockResolvedValueOnce(errorResponse(500))
+                .mockResolvedValueOnce(errorResponse(500))
+                .mockResolvedValueOnce(errorResponse(500))
+                .mockResolvedValueOnce(okJsonResponse(200, { ok: true }));
+
+            const promise = client.fetchWorkContext('w', 'u');
+
+            // First attempt fires synchronously
+            await Promise.resolve();
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+            // Backoff before attempt 2 = 500ms
+            await vi.advanceTimersByTimeAsync(499);
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+            // Backoff before attempt 3 = 1000ms
+            await vi.advanceTimersByTimeAsync(999);
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+            // Backoff before attempt 4 = 2000ms
+            await vi.advanceTimersByTimeAsync(1999);
+            expect(fetchSpy).toHaveBeenCalledTimes(3);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(fetchSpy).toHaveBeenCalledTimes(4);
+
+            const result = await promise;
+            expect(result).toEqual({ ok: true });
+        });
+    });
+});

--- a/packages/tasks/src/__tests__/worker-context.utils.spec.ts
+++ b/packages/tasks/src/__tests__/worker-context.utils.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+    createApplicationContextMock,
+    triggerLoggerInstance,
+    createTriggerLoggerMock,
+    StubModule,
+    CustomModule,
+} = vi.hoisted(() => {
+    class StubModule {}
+    class CustomModule {}
+    return {
+        createApplicationContextMock: vi.fn(),
+        triggerLoggerInstance: { __kind: 'trigger-logger' },
+        createTriggerLoggerMock: vi.fn(),
+        StubModule,
+        CustomModule,
+    };
+});
+
+vi.mock('@nestjs/core', () => ({
+    NestFactory: { createApplicationContext: createApplicationContextMock },
+}));
+
+vi.mock('../trigger/worker/trigger-logger', () => ({
+    createTriggerLogger: createTriggerLoggerMock,
+}));
+
+vi.mock('../trigger/worker/modules/trigger-worker.module', () => ({
+    TriggerWorkerModule: StubModule,
+}));
+
+import { withWorkerContext } from '../trigger/worker/utils/worker-context.utils';
+import { TriggerWorkerModule } from '../trigger/worker/modules/trigger-worker.module';
+
+describe('withWorkerContext', () => {
+    let appContext: { useLogger: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        appContext = {
+            useLogger: vi.fn(),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        createApplicationContextMock.mockResolvedValue(appContext);
+        createTriggerLoggerMock.mockReturnValue(triggerLoggerInstance);
+    });
+
+    it('bootstraps using the default TriggerWorkerModule when no module is supplied', async () => {
+        await withWorkerContext('Boot', async () => 'value');
+
+        expect(createApplicationContextMock).toHaveBeenCalledTimes(1);
+        expect(createApplicationContextMock).toHaveBeenCalledWith(TriggerWorkerModule);
+    });
+
+    it('bootstraps using a caller-supplied module token when provided', async () => {
+        await withWorkerContext('Boot', async () => 'value', CustomModule);
+
+        expect(createApplicationContextMock).toHaveBeenCalledWith(CustomModule);
+    });
+
+    it('installs the trigger logger with the supplied loggerName before invoking fn', async () => {
+        const seen: string[] = [];
+        appContext.useLogger.mockImplementation((logger) => {
+            seen.push(`useLogger:${logger.__kind}`);
+        });
+
+        await withWorkerContext('GenerationWorker', async () => {
+            seen.push('fn');
+        });
+
+        expect(createTriggerLoggerMock).toHaveBeenCalledWith('GenerationWorker');
+        expect(seen).toEqual(['useLogger:trigger-logger', 'fn']);
+    });
+
+    it('returns the value resolved by fn', async () => {
+        const result = await withWorkerContext('X', async () => 42);
+        expect(result).toBe(42);
+    });
+
+    it('passes the booted appContext to fn', async () => {
+        const fn = vi.fn().mockResolvedValue('ok');
+        await withWorkerContext('X', fn);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith(appContext);
+    });
+
+    it('always closes the appContext on success', async () => {
+        await withWorkerContext('X', async () => 'ok');
+        expect(appContext.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('always closes the appContext when fn throws — and re-throws the original error', async () => {
+        const err = new Error('boom');
+        await expect(
+            withWorkerContext('X', async () => {
+                throw err;
+            }),
+        ).rejects.toBe(err);
+
+        expect(appContext.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT swallow close() failures (close throws → caller sees that error)', async () => {
+        appContext.close.mockRejectedValueOnce(new Error('close-failed'));
+        await expect(withWorkerContext('X', async () => 'ok')).rejects.toThrow('close-failed');
+    });
+
+    it('propagates close() errors over body errors when both fire (try/finally semantics)', async () => {
+        // try/finally: a throw inside `finally` overrides any pending error from
+        // the try-block. Pin that observable behaviour so a future refactor that
+        // wraps close() in a swallowing try/catch surfaces in CI.
+        const bodyErr = new Error('body-failed');
+        const closeErr = new Error('close-failed');
+        appContext.close.mockRejectedValueOnce(closeErr);
+
+        await expect(
+            withWorkerContext('X', async () => {
+                throw bodyErr;
+            }),
+        ).rejects.toBe(closeErr);
+
+        expect(appContext.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call useLogger or fn if NestFactory.createApplicationContext rejects', async () => {
+        const fn = vi.fn();
+        createApplicationContextMock.mockRejectedValueOnce(new Error('boot-failed'));
+
+        await expect(withWorkerContext('X', fn)).rejects.toThrow('boot-failed');
+        expect(appContext.useLogger).not.toHaveBeenCalled();
+        expect(fn).not.toHaveBeenCalled();
+        expect(appContext.close).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Closes the previously-deferred follow-up from `packages/tasks` (recorded in `COVERAGE-TRACKER.md`): adds **39 vitest unit tests** across three new spec files under `packages/tasks/src/__tests__/`, bringing the package from **61 → 100 tests**.

## Files added

- `packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts` (20 tests)
- `packages/tasks/src/__tests__/task-context.utils.spec.ts` (9 tests)
- `packages/tasks/src/__tests__/worker-context.utils.spec.ts` (10 tests)

## Coverage detail

**TriggerInternalApiClient (20)**
- Constructor env guards (`TRIGGER_INTERNAL_API_URL` and `TRIGGER_INTERNAL_SECRET` each required; blank-string and undefined paths).
- URL composition: trailing-slash strip on base, leading-slash strip on path, `URLSearchParams` encoding for `userId`.
- `fetchWorkContext` GET shape, `x-trigger-secret` header, 204 + empty-body → \`undefined\`.
- `callRemote` POST `/remote/call` with SuperJSON args+meta envelope, SuperJSON-deserialized result, missing-`result` → \`undefined\`.
- Retry behaviour: 5xx retried up to 3× with exponential backoff `500/1000/2000ms` pinned via `vi.useFakeTimers` + `advanceTimersByTimeAsync`; 4xx never retried; network errors retried up to 3×; non-Error rejections coerced to `Error`.

**task-context.utils (9)**
- Hydrator-before-fetch ordering.
- Positional `fetchWorkContext(workId, userId)` shape.
- `class-transformer` `plainToInstance(Work|User, ...)` hydration.
- `work.user = user` re-attachment.
- Orchestrator resolution AFTER fetch.
- `gitToken` passthrough vs \`undefined\`-on-omit.
- Hydrator-error short-circuits the fetch; fetchWorkContext-error short-circuits the orchestrator resolve.

**worker-context.utils (10)**
- Default `TriggerWorkerModule` vs caller-supplied module token.
- `useLogger(createTriggerLogger(name))` ordering before `fn`.
- `fn` return-value passthrough; `appContext` passed to `fn`.
- `close-on-success` / `close-on-fn-throw` / `close-error-propagation` / try/finally close-error-overrides-body-error semantics.
- `NestFactory` rejection short-circuits `fn` + `close`.

## Mocks
- `@ever-works/agent/config` (for `TriggerInternalApiClient`)
- `@nestjs/core`'s `NestFactory.createApplicationContext`, the trigger-logger factory, and the `TriggerWorkerModule` symbol (for `worker-context`)
- `@ever-works/agent/entities` (for `task-context`)
- All references hoisted via `vi.hoisted` to satisfy vitest's `vi.mock` factory hoist-to-top constraint.

## Test plan
- [x] `pnpm --filter @ever-works/trigger-tasks test` → 7 files, 100 tests passing
- [x] `COVERAGE-TRACKER.md` row updated to reflect new total + close the deferred follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)