### PR TITLE
chore(tracker): pin PR #565 link for packages/tasks worker services + utils row

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -123,6 +123,7 @@ search/extract success + error paths, lifecycle, healthCheck, manifest.
       `LocalPluginStore`, `TriggerLogger`, `TriggerService`,
       `collectPluginDependencies`, `TriggerInternalApiClient`,
       `task-context.utils`, and `worker-context.utils`
+      ([#565](https://github.com/ever-works/ever-works/pull/565))
       (`@trigger.dev/sdk`, `@ever-works/agent/config`, `@nestjs/core`'s
       `NestFactory.createApplicationContext`, and the trigger logger factory
       mocked). The 2026-05-08 follow-up adds 39 tests across three new


### PR DESCRIPTION
Pins the PR link for #565 (39 new tests across TriggerInternalApiClient + task-context.utils + worker-context.utils) into the packages/tasks row of COVERAGE-TRACKER.md, matching the established convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)