### PR TITLE
fix(ci): unblock format check and internal CLI build

### DIFF
--- a/apps/internal-cli/build.js
+++ b/apps/internal-cli/build.js
@@ -34,7 +34,7 @@ async function buildCLI() {
     // Then, compile CLI TypeScript with proper decorator support
     try {
         execSync(
-            'npx tsc --project tsconfig.json --outDir temp-build --emitDecoratorMetadata true --experimentalDecorators true --target ES2020 --module Node16 --moduleResolution Node16 --esModuleInterop true --allowSyntheticDefaultImports true --skipLibCheck true',
+            'npx tsc --project tsconfig.build.json --outDir temp-build --emitDecoratorMetadata true --experimentalDecorators true --target ES2020 --module Node16 --moduleResolution Node16 --esModuleInterop true --allowSyntheticDefaultImports true --skipLibCheck true',
             {
                 cwd: __dirname,
                 stdio: 'inherit',

--- a/apps/internal-cli/src/commands/config/__tests__/set.subcommand.spec.ts
+++ b/apps/internal-cli/src/commands/config/__tests__/set.subcommand.spec.ts
@@ -68,7 +68,16 @@ describe('SetSubCommand.run (validation paths)', () => {
     });
 
     it('accepts each documented AI provider value (case-insensitive)', async () => {
-        for (const v of ['openai', 'OpenAI', 'GOOGLE', 'anthropic', 'openrouter', 'ollama', 'groq', 'custom']) {
+        for (const v of [
+            'openai',
+            'OpenAI',
+            'GOOGLE',
+            'anthropic',
+            'openrouter',
+            'ollama',
+            'groq',
+            'custom',
+        ]) {
             stub.saveConfig.mockClear();
             await cmd.run(['AI_DEFAULT_PROVIDER', v], {});
             expect(stub.saveConfig).toHaveBeenCalledTimes(1);

--- a/apps/internal-cli/src/commands/config/ai-providers/__tests__/ai-provider-registry.service.spec.ts
+++ b/apps/internal-cli/src/commands/config/ai-providers/__tests__/ai-provider-registry.service.spec.ts
@@ -91,9 +91,7 @@ describe('AiProviderRegistryService', () => {
         it('includes the displayName + " - " + description in each choice name', () => {
             const choices = service.getProviderChoices();
             const openAi = choices.find((c) => c.value === 'openai');
-            expect(openAi?.name).toBe(
-                'OpenAI - OpenAI GPT models (GPT-5, GPT-4o, o1/o3)',
-            );
+            expect(openAi?.name).toBe('OpenAI - OpenAI GPT models (GPT-5, GPT-4o, o1/o3)');
         });
     });
 

--- a/apps/internal-cli/src/commands/work/__tests__/config-check.service.spec.ts
+++ b/apps/internal-cli/src/commands/work/__tests__/config-check.service.spec.ts
@@ -74,10 +74,9 @@ describe('ConfigCheckService', () => {
         it('returns false and reports the wrapped error when loadConfig throws', async () => {
             stub.loadConfig.mockRejectedValue(new Error('disk error'));
             await expect(service.checkConfiguration()).resolves.toBe(false);
-            expect(displayConfigurationError).toHaveBeenCalledWith(
-                'Failed to load configuration',
-                ['disk error'],
-            );
+            expect(displayConfigurationError).toHaveBeenCalledWith('Failed to load configuration', [
+                'disk error',
+            ]);
         });
     });
 

--- a/packages/agent/src/cache/distributed-task-lock.service.spec.ts
+++ b/packages/agent/src/cache/distributed-task-lock.service.spec.ts
@@ -70,8 +70,10 @@ describe('DistributedTaskLockService', () => {
             await service.runExclusive('task-1', fn);
 
             // First createQueryBuilder call is the cleanup, before insert
-            const firstQB = (cacheEntryRepository.createQueryBuilder as jest.Mock).mock.invocationCallOrder[0];
-            const insertOrder = (cacheEntryRepository.insert as jest.Mock).mock.invocationCallOrder[0];
+            const firstQB = (cacheEntryRepository.createQueryBuilder as jest.Mock).mock
+                .invocationCallOrder[0];
+            const insertOrder = (cacheEntryRepository.insert as jest.Mock).mock
+                .invocationCallOrder[0];
             expect(firstQB).toBeLessThan(insertOrder);
 
             expect(queryBuilder.where).toHaveBeenCalledWith('key = :key', {

--- a/packages/agent/src/community-pr/community-pr-processor.service.spec.ts
+++ b/packages/agent/src/community-pr/community-pr-processor.service.spec.ts
@@ -46,12 +46,14 @@ function makeWork(overrides: Partial<WorkLike> = {}): WorkLike {
     };
 }
 
-function makePr(overrides: Partial<{
-    number: number;
-    title: string;
-    body: string | null;
-    updatedAt: string;
-}> = {}) {
+function makePr(
+    overrides: Partial<{
+        number: number;
+        title: string;
+        body: string | null;
+        updatedAt: string;
+    }> = {},
+) {
     return {
         number: 42,
         title: 'Add new tool',
@@ -78,13 +80,15 @@ function makeDataRepoMock() {
     };
 }
 
-function makeService(overrides: Partial<{
-    gitFacade: any;
-    aiFacade: any;
-    workRepository: any;
-    generationHistoryRepository: any;
-    taskLockService: any;
-}> = {}) {
+function makeService(
+    overrides: Partial<{
+        gitFacade: any;
+        aiFacade: any;
+        workRepository: any;
+        generationHistoryRepository: any;
+        taskLockService: any;
+    }> = {},
+) {
     const gitFacade = overrides.gitFacade ?? {
         listPullRequests: jest.fn().mockResolvedValue([]),
         getPullRequestFiles: jest.fn().mockResolvedValue([]),
@@ -121,7 +125,14 @@ function makeService(overrides: Partial<{
         taskLockService as any,
     );
 
-    return { service, gitFacade, aiFacade, workRepository, generationHistoryRepository, taskLockService };
+    return {
+        service,
+        gitFacade,
+        aiFacade,
+        workRepository,
+        generationHistoryRepository,
+        taskLockService,
+    };
 }
 
 describe('CommunityPrProcessorService', () => {
@@ -226,7 +237,7 @@ describe('CommunityPrProcessorService', () => {
             expect(result.errors).toEqual([{ workId: 'w', error: 'plain-string-failure' }]);
         });
 
-        it('uses the work\'s existing communityPrState when present, otherwise a fresh skeleton', async () => {
+        it("uses the work's existing communityPrState when present, otherwise a fresh skeleton", async () => {
             const seededState: CommunityPrState = {
                 processedPrNumbers: [1, 2],
                 totalItemsAdded: 7,
@@ -429,7 +440,7 @@ describe('CommunityPrProcessorService', () => {
             expect(gitFacade.getPullRequestFiles).not.toHaveBeenCalled();
         });
 
-        it('honours the explicit autoClose argument over the work\'s communityPrAutoClose', async () => {
+        it("honours the explicit autoClose argument over the work's communityPrAutoClose", async () => {
             const pr = makePr();
             const file = { filename: 'data/x.yml', status: 'added', patch: '+ added' };
             const work = makeWork({ communityPrAutoClose: false });
@@ -635,8 +646,20 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'A', description: 'Da', source_url: 'https://a', category: 'AI', tags: [] },
-                            { name: 'B', description: 'Db', source_url: 'https://b', category: 'Dev', tags: ['t'] },
+                            {
+                                name: 'A',
+                                description: 'Da',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
+                            {
+                                name: 'B',
+                                description: 'Db',
+                                source_url: 'https://b',
+                                category: 'Dev',
+                                tags: ['t'],
+                            },
                         ],
                     },
                 }),
@@ -679,7 +702,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'X', description: 'd', source_url: 'https://x', category: 'AI', tags: [] },
+                            {
+                                name: 'X',
+                                description: 'd',
+                                source_url: 'https://x',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -754,8 +783,20 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'A', description: 'd', source_url: 'https://a', category: 'AI', tags: [] },
-                            { name: 'B', description: 'd', source_url: 'https://b', category: 'AI', tags: [] },
+                            {
+                                name: 'A',
+                                description: 'd',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
+                            {
+                                name: 'B',
+                                description: 'd',
+                                source_url: 'https://b',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -796,7 +837,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'A', description: 'd', source_url: 'https://a', category: 'AI', tags: [] },
+                            {
+                                name: 'A',
+                                description: 'd',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1097,9 +1144,21 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Foo Bar', description: 'a', source_url: 'https://a', category: 'AI', tags: [] },
+                            {
+                                name: 'Foo Bar',
+                                description: 'a',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
                             // Same slug after slugify
-                            { name: 'Foo Bar', description: 'a', source_url: 'https://b', category: 'AI', tags: [] },
+                            {
+                                name: 'Foo Bar',
+                                description: 'a',
+                                source_url: 'https://b',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1118,9 +1177,7 @@ describe('CommunityPrProcessorService', () => {
             const work = makeWork();
             const dataRepo = makeDataRepoMock();
             // First item already exists; second is new.
-            dataRepo.itemExists
-                .mockResolvedValueOnce(true)
-                .mockResolvedValueOnce(false);
+            dataRepo.itemExists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
             dataRepoCreateMock.mockResolvedValue(dataRepo);
             const gitFacade = {
                 listPullRequests: jest.fn().mockResolvedValue([pr]),
@@ -1136,8 +1193,20 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Existing', description: 'a', source_url: 'https://a', category: 'AI', tags: [] },
-                            { name: 'Brand New', description: 'a', source_url: 'https://b', category: 'AI', tags: [] },
+                            {
+                                name: 'Existing',
+                                description: 'a',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
+                            {
+                                name: 'Brand New',
+                                description: 'a',
+                                source_url: 'https://b',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1174,7 +1243,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'A', description: 'a', source_url: 'https://a', category: 'AI', tags: [] },
+                            {
+                                name: 'A',
+                                description: 'a',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1220,8 +1295,20 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: '!!!', description: 'a', source_url: 'https://a', category: 'AI', tags: [] },
-                            { name: 'Real Item', description: 'a', source_url: 'https://b', category: 'AI', tags: [] },
+                            {
+                                name: '!!!',
+                                description: 'a',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
+                            {
+                                name: 'Real Item',
+                                description: 'a',
+                                source_url: 'https://b',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1260,7 +1347,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'X', description: 'd', source_url: 'https://x', category: 'AI', tags: [] },
+                            {
+                                name: 'X',
+                                description: 'd',
+                                source_url: 'https://x',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1277,7 +1370,11 @@ describe('CommunityPrProcessorService', () => {
             );
             expect(gitFacade.push).toHaveBeenCalledWith(
                 { dir: '/tmp/clone' },
-                expect.objectContaining({ userId: 'user-1', providerId: 'github', workId: 'work-1' }),
+                expect.objectContaining({
+                    userId: 'user-1',
+                    providerId: 'github',
+                    workId: 'work-1',
+                }),
             );
         });
 
@@ -1301,8 +1398,20 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Item One', description: 'd', source_url: 'https://a', category: 'AI', tags: [] },
-                            { name: 'Item Two', description: 'd', source_url: 'https://b', category: 'AI', tags: [] },
+                            {
+                                name: 'Item One',
+                                description: 'd',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
+                            {
+                                name: 'Item Two',
+                                description: 'd',
+                                source_url: 'https://b',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1348,7 +1457,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Just One', description: 'd', source_url: 'https://a', category: 'AI', tags: [] },
+                            {
+                                name: 'Just One',
+                                description: 'd',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1387,7 +1502,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Item', description: 'd', source_url: 'https://x', category: 'AI', tags: [] },
+                            {
+                                name: 'Item',
+                                description: 'd',
+                                source_url: 'https://x',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1425,8 +1546,20 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Alpha', description: 'd', source_url: 'https://a', category: 'AI', tags: [] },
-                            { name: 'Beta', description: 'd', source_url: 'https://b', category: 'AI', tags: [] },
+                            {
+                                name: 'Alpha',
+                                description: 'd',
+                                source_url: 'https://a',
+                                category: 'AI',
+                                tags: [],
+                            },
+                            {
+                                name: 'Beta',
+                                description: 'd',
+                                source_url: 'https://b',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1467,7 +1600,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'X', description: 'd', source_url: 'https://x', category: 'AI', tags: [] },
+                            {
+                                name: 'X',
+                                description: 'd',
+                                source_url: 'https://x',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1508,7 +1647,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Y', description: 'd', source_url: 'https://y', category: 'AI', tags: [] },
+                            {
+                                name: 'Y',
+                                description: 'd',
+                                source_url: 'https://y',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1540,7 +1685,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Z', description: 'd', source_url: 'https://z', category: 'AI', tags: [] },
+                            {
+                                name: 'Z',
+                                description: 'd',
+                                source_url: 'https://z',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),
@@ -1580,7 +1731,13 @@ describe('CommunityPrProcessorService', () => {
                 askJson: jest.fn().mockResolvedValue({
                     result: {
                         items: [
-                            { name: 'Tool', description: 'A useful tool.', source_url: 'https://tool.example', category: 'AI', tags: [] },
+                            {
+                                name: 'Tool',
+                                description: 'A useful tool.',
+                                source_url: 'https://tool.example',
+                                category: 'AI',
+                                tags: [],
+                            },
                         ],
                     },
                 }),

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -496,14 +496,17 @@ describe('agent/config', () => {
             ['getBetaBranch', 'WEBSITE_TEMPLATE_BETA_BRANCH', 'stage', 'beta'],
             ['getMinimalOwner', 'WEBSITE_TEMPLATE_MINIMAL_OWNER', 'ever-works', 'other-org'],
             ['getMinimalBranch', 'WEBSITE_TEMPLATE_MINIMAL_BRANCH', 'main', 'develop'],
-        ])('%s defaults + override (%s default=%s override=%s)', (getter, envVar, defaultVal, overrideVal) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            expect((config.websiteTemplate as any)[getter]()).toBe(defaultVal);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (process.env as any)[envVar] = overrideVal;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            expect((config.websiteTemplate as any)[getter]()).toBe(overrideVal);
-        });
+        ])(
+            '%s defaults + override (%s default=%s override=%s)',
+            (getter, envVar, defaultVal, overrideVal) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect((config.websiteTemplate as any)[getter]()).toBe(defaultVal);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (process.env as any)[envVar] = overrideVal;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect((config.websiteTemplate as any)[getter]()).toBe(overrideVal);
+            },
+        );
 
         describe('getMinimalRepo', () => {
             it('returns undefined when env is unset (no default — gates the Minimal seed)', () => {

--- a/packages/agent/src/constants/messages.spec.ts
+++ b/packages/agent/src/constants/messages.spec.ts
@@ -1,8 +1,4 @@
-import {
-    GENERATION_CANCELLED,
-    GIT_TOKEN_NOT_AVAILABLE,
-    IMPORT_CANCELLED,
-} from './messages';
+import { GENERATION_CANCELLED, GIT_TOKEN_NOT_AVAILABLE, IMPORT_CANCELLED } from './messages';
 import * as constantsBarrel from './index';
 
 describe('constants/messages.ts', () => {

--- a/packages/agent/src/dto/dto.spec.ts
+++ b/packages/agent/src/dto/dto.spec.ts
@@ -3,10 +3,7 @@ import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 
 import * as dtoBarrel from './index';
-import {
-    CreateWorkDto,
-    MarkdownReadmeConfigDto,
-} from './create-work.dto';
+import { CreateWorkDto, MarkdownReadmeConfigDto } from './create-work.dto';
 import { GenerateDataDto } from './generate-data.dto';
 import {
     AnalyzeRepositoryDto,
@@ -137,18 +134,19 @@ describe('agent/dto submodule', () => {
                 });
                 const errs = await expectValidationErrors(dto);
                 // either Min/Max or IsInt depending on the value
-                expect(
-                    errs.some((e) => ['min', 'max', 'isInt'].includes(e)),
-                ).toBe(true);
+                expect(errs.some((e) => ['min', 'max', 'isInt'].includes(e))).toBe(true);
             },
         );
 
-        it.each([1, 5, 10])('accepts maxFailureBeforePause=%j (in-range integers)', async (value) => {
-            const dto = plainToInstance(UpdateWorkScheduleDto, {
-                maxFailureBeforePause: value,
-            });
-            await expectValid(dto);
-        });
+        it.each([1, 5, 10])(
+            'accepts maxFailureBeforePause=%j (in-range integers)',
+            async (value) => {
+                const dto = plainToInstance(UpdateWorkScheduleDto, {
+                    maxFailureBeforePause: value,
+                });
+                await expectValid(dto);
+            },
+        );
 
         it('rejects an out-of-enum cadence', async () => {
             const dto = plainToInstance(UpdateWorkScheduleDto, { cadence: 'random' });
@@ -176,15 +174,12 @@ describe('agent/dto submodule', () => {
             'categorization',
             'deduplication',
             'sourceValidation',
-        ] as const)(
-            '%s: empty/whitespace-only string is normalised to null',
-            (field) => {
-                for (const value of ['', '   ', '\n\t']) {
-                    const dto = plainToInstance(UpdateWorkAdvancedPromptsDto, { [field]: value });
-                    expect((dto as any)[field]).toBeNull();
-                }
-            },
-        );
+        ] as const)('%s: empty/whitespace-only string is normalised to null', (field) => {
+            for (const value of ['', '   ', '\n\t']) {
+                const dto = plainToInstance(UpdateWorkAdvancedPromptsDto, { [field]: value });
+                expect((dto as any)[field]).toBeNull();
+            }
+        });
 
         it.each([
             'relevanceAssessment',
@@ -617,9 +612,7 @@ describe('agent/dto submodule', () => {
 
         it('SettingsHeaderDto: accepts each documented theme_default literal', async () => {
             for (const theme of ['light', 'dark', 'system']) {
-                await expectValid(
-                    plainToInstance(SettingsHeaderDto, { theme_default: theme }),
-                );
+                await expectValid(plainToInstance(SettingsHeaderDto, { theme_default: theme }));
             }
         });
 

--- a/packages/agent/src/events/events.spec.ts
+++ b/packages/agent/src/events/events.spec.ts
@@ -87,17 +87,11 @@ describe('agent/events submodule', () => {
         it('every published event class extends BaseEvent', () => {
             expect(new WorkCreatedEvent(fakeWork)).toBeInstanceOf(BaseEvent);
             expect(new WorkGenerationCompletedEvent(fakeWork)).toBeInstanceOf(BaseEvent);
+            expect(new WorksConfigSyncRequestedEvent('w', 'u', 'schedule_updated')).toBeInstanceOf(
+                BaseEvent,
+            );
             expect(
-                new WorksConfigSyncRequestedEvent('w', 'u', 'schedule_updated'),
-            ).toBeInstanceOf(BaseEvent);
-            expect(
-                new WorksConfigSyncFailedEvent(
-                    'w',
-                    'u',
-                    'schedule_updated',
-                    'org/repo',
-                    'boom',
-                ),
+                new WorksConfigSyncFailedEvent('w', 'u', 'schedule_updated', 'org/repo', 'boom'),
             ).toBeInstanceOf(BaseEvent);
             const payload: DeploymentEventPayload = {
                 work: fakeWork,
@@ -266,9 +260,7 @@ describe('agent/events submodule', () => {
         it('re-exports every published event class', () => {
             expect(eventsBarrel.WorkCreatedEvent).toBe(WorkCreatedEvent);
             expect(eventsBarrel.WorkGenerationCompletedEvent).toBe(WorkGenerationCompletedEvent);
-            expect(eventsBarrel.WorksConfigSyncRequestedEvent).toBe(
-                WorksConfigSyncRequestedEvent,
-            );
+            expect(eventsBarrel.WorksConfigSyncRequestedEvent).toBe(WorksConfigSyncRequestedEvent);
             expect(eventsBarrel.WorksConfigSyncFailedEvent).toBe(WorksConfigSyncFailedEvent);
             expect(eventsBarrel.DeploymentDispatchedEvent).toBe(DeploymentDispatchedEvent);
             expect(eventsBarrel.DeploymentCompletedEvent).toBe(DeploymentCompletedEvent);

--- a/packages/agent/src/notifications/notification.service.spec.ts
+++ b/packages/agent/src/notifications/notification.service.spec.ts
@@ -312,7 +312,10 @@ describe('NotificationService', () => {
             } as any);
 
             expect(result).toBe(out);
-            expect(repository.findByUserId).toHaveBeenCalledWith('u', { unreadOnly: true, limit: 10 });
+            expect(repository.findByUserId).toHaveBeenCalledWith('u', {
+                unreadOnly: true,
+                limit: 10,
+            });
         });
 
         it('forwards undefined options when caller omits them', async () => {
@@ -386,9 +389,7 @@ describe('NotificationService', () => {
 
         it('refuses to dismiss a persistent notification with the documented error message', async () => {
             const { service, repository } = makeService({
-                findByIdAndUserId: jest
-                    .fn()
-                    .mockResolvedValue({ id: 'n', isPersistent: true }),
+                findByIdAndUserId: jest.fn().mockResolvedValue({ id: 'n', isPersistent: true }),
             });
 
             await expect(service.dismiss('u', 'n')).rejects.toThrow(
@@ -399,9 +400,7 @@ describe('NotificationService', () => {
 
         it('calls repository.dismiss for non-persistent notifications', async () => {
             const { service, repository } = makeService({
-                findByIdAndUserId: jest
-                    .fn()
-                    .mockResolvedValue({ id: 'n', isPersistent: false }),
+                findByIdAndUserId: jest.fn().mockResolvedValue({ id: 'n', isPersistent: false }),
                 dismiss: jest.fn().mockResolvedValue(undefined),
             });
 
@@ -541,9 +540,7 @@ describe('NotificationService', () => {
             expect(args.type).toBe(NotificationType.WARNING);
             expect(args.category).toBe(NotificationCategory.GENERATION);
             expect(args.title).toBe('Schedule Paused');
-            expect(args.message).toBe(
-                'Scheduled updates for "My Work" paused: Quota exhausted',
-            );
+            expect(args.message).toBe('Scheduled updates for "My Work" paused: Quota exhausted');
             expect(args.actionUrl).toBe('/works/w42/generator/schedule');
             expect(args.actionLabel).toBe('View Schedule');
             expect(args.metadata).toEqual({ workId: 'w42', workName: 'My Work' });
@@ -564,9 +561,7 @@ describe('NotificationService', () => {
             expect(args.type).toBe(NotificationType.ERROR);
             expect(args.category).toBe(NotificationCategory.SECURITY);
             expect(args.title).toBe('Git Authentication Expired');
-            expect(args.message).toBe(
-                'Your GitHub authentication has expired. Please reconnect.',
-            );
+            expect(args.message).toBe('Your GitHub authentication has expired. Please reconnect.');
             expect(args.actionUrl).toBe('/settings/oauth');
             expect(args.actionLabel).toBe('Reconnect');
             expect(args.isPersistent).toBe(true);

--- a/packages/agent/src/onboarding/index.spec.ts
+++ b/packages/agent/src/onboarding/index.spec.ts
@@ -24,8 +24,12 @@ describe('agent/onboarding barrel', () => {
 
         it('ONBOARDING_ACCOUNT_UPSERT is Symbol.for("OnboardingAccountUpsert")', () => {
             expect(typeof onboarding.ONBOARDING_ACCOUNT_UPSERT).toBe('symbol');
-            expect(onboarding.ONBOARDING_ACCOUNT_UPSERT.description).toBe('OnboardingAccountUpsert');
-            expect(onboarding.ONBOARDING_ACCOUNT_UPSERT).toBe(Symbol.for('OnboardingAccountUpsert'));
+            expect(onboarding.ONBOARDING_ACCOUNT_UPSERT.description).toBe(
+                'OnboardingAccountUpsert',
+            );
+            expect(onboarding.ONBOARDING_ACCOUNT_UPSERT).toBe(
+                Symbol.for('OnboardingAccountUpsert'),
+            );
         });
 
         it('ONBOARDING_WORK_CREATOR is Symbol.for("OnboardingWorkCreator")', () => {
@@ -49,7 +53,9 @@ describe('agent/onboarding barrel', () => {
             // someone refactored these to bare `Symbol(...)` we would silently
             // break NestJS DI token equality across module boundaries.
             expect(Symbol.for('OnboardingGitProvider')).toBe(onboarding.ONBOARDING_GIT_PROVIDER);
-            expect(Symbol.for('OnboardingAccountUpsert')).toBe(onboarding.ONBOARDING_ACCOUNT_UPSERT);
+            expect(Symbol.for('OnboardingAccountUpsert')).toBe(
+                onboarding.ONBOARDING_ACCOUNT_UPSERT,
+            );
             expect(Symbol.for('OnboardingWorkCreator')).toBe(onboarding.ONBOARDING_WORK_CREATOR);
         });
     });

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -367,10 +367,7 @@ describe('SubscriptionService', () => {
                 1,
                 SubscriptionPlanCode.STANDARD,
             );
-            expect(planRepository.findByCode).toHaveBeenNthCalledWith(
-                2,
-                SubscriptionPlanCode.FREE,
-            );
+            expect(planRepository.findByCode).toHaveBeenNthCalledWith(2, SubscriptionPlanCode.FREE);
         });
 
         it('throws when the configured plan AND the FREE fallback are both missing', async () => {
@@ -412,9 +409,7 @@ describe('SubscriptionService', () => {
             const { service } = makeService(
                 {},
                 {
-                    findActiveByUser: jest
-                        .fn()
-                        .mockResolvedValue({ plan: STANDARD_PLAN }),
+                    findActiveByUser: jest.fn().mockResolvedValue({ plan: STANDARD_PLAN }),
                 },
             );
 
@@ -436,9 +431,7 @@ describe('SubscriptionService', () => {
             ]) {
                 expect(byCadence[cadence].allowed).toBe(false);
                 expect(byCadence[cadence].payPerUse).toBe(true);
-                expect(byCadence[cadence].reason).toBe(
-                    'Upgrade to Premium for this cadence',
-                );
+                expect(byCadence[cadence].reason).toBe('Upgrade to Premium for this cadence');
             }
         });
 
@@ -447,9 +440,7 @@ describe('SubscriptionService', () => {
             const { service } = makeService(
                 {},
                 {
-                    findActiveByUser: jest
-                        .fn()
-                        .mockResolvedValue({ plan: planWithoutCadences }),
+                    findActiveByUser: jest.fn().mockResolvedValue({ plan: planWithoutCadences }),
                 },
             );
 
@@ -508,12 +499,12 @@ describe('SubscriptionService', () => {
 
         it('returns MONTHLY when allowedCadences is nullish', () => {
             const { service } = makeService();
-            expect(
-                service.getDefaultCadence({ allowedCadences: undefined } as any),
-            ).toBe(WorkScheduleCadence.MONTHLY);
-            expect(
-                service.getDefaultCadence({ allowedCadences: null } as any),
-            ).toBe(WorkScheduleCadence.MONTHLY);
+            expect(service.getDefaultCadence({ allowedCadences: undefined } as any)).toBe(
+                WorkScheduleCadence.MONTHLY,
+            );
+            expect(service.getDefaultCadence({ allowedCadences: null } as any)).toBe(
+                WorkScheduleCadence.MONTHLY,
+            );
         });
     });
 
@@ -581,20 +572,14 @@ describe('SubscriptionService', () => {
             process.env.SUBSCRIPTIONS_ENABLED = 'false';
             const { service } = makeService();
             await expect(
-                service.assignPlanToUser(
-                    { id: 'u1' } as any,
-                    SubscriptionPlanCode.PREMIUM,
-                ),
+                service.assignPlanToUser({ id: 'u1' } as any, SubscriptionPlanCode.PREMIUM),
             ).rejects.toThrow(BadRequestException);
         });
 
         it('throws NotFoundException when the requested plan code is not in the DB', async () => {
             const { service } = makeService({ findByCode: jest.fn().mockResolvedValue(null) });
             await expect(
-                service.assignPlanToUser(
-                    { id: 'u1' } as any,
-                    SubscriptionPlanCode.PREMIUM,
-                ),
+                service.assignPlanToUser({ id: 'u1' } as any, SubscriptionPlanCode.PREMIUM),
             ).rejects.toThrow(NotFoundException);
         });
 
@@ -650,9 +635,7 @@ describe('SubscriptionService', () => {
             expect(summary.plan).toBe(STANDARD_PLAN);
             expect(summary.enabled).toBe(true);
             expect(summary.allowances).toHaveLength(7);
-            expect(summary.allowances.map((a) => a.cadence)).toEqual(
-                ALL_CADENCES_IN_PUBLIC_ORDER,
-            );
+            expect(summary.allowances.map((a) => a.cadence)).toEqual(ALL_CADENCES_IN_PUBLIC_ORDER);
         });
 
         it('reflects the kill-switch in `enabled` and resolves the default plan', async () => {

--- a/packages/agent/src/subscriptions/usage-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/usage-ledger.service.spec.ts
@@ -281,9 +281,7 @@ describe('UsageLedgerService', () => {
             const { service } = makeService(
                 { record: jest.fn().mockResolvedValue({ id: 'led-4' }) },
                 {
-                    recordUsageCharge: jest
-                        .fn()
-                        .mockRejectedValue(new Error('stripe down')),
+                    recordUsageCharge: jest.fn().mockRejectedValue(new Error('stripe down')),
                 },
             );
 

--- a/packages/agent/src/tasks/tasks.spec.ts
+++ b/packages/agent/src/tasks/tasks.spec.ts
@@ -10,10 +10,7 @@ import {
     type WorkContextUserDto,
     type WorkGenerationPayload,
 } from './work-generation.types';
-import {
-    WORK_IMPORT_DISPATCHER,
-    type WorkImportDispatcher,
-} from './work-import-dispatcher';
+import { WORK_IMPORT_DISPATCHER, type WorkImportDispatcher } from './work-import-dispatcher';
 import {
     WorkImportErrorCode,
     type WorkImportPayload,

--- a/packages/plugin/src/ai/__tests__/reasoning.utils.spec.ts
+++ b/packages/plugin/src/ai/__tests__/reasoning.utils.spec.ts
@@ -162,9 +162,7 @@ describe('per-provider getter convenience functions', () => {
 	});
 
 	it('getOpenRouterReasoningConfig matches getReasoningConfig("openrouter", …)', () => {
-		expect(getOpenRouterReasoningConfig('openai/gpt-5')).toEqual(
-			getReasoningConfig('openrouter', 'openai/gpt-5')
-		);
+		expect(getOpenRouterReasoningConfig('openai/gpt-5')).toEqual(getReasoningConfig('openrouter', 'openai/gpt-5'));
 		expect(getOpenRouterReasoningConfig('anthropic/claude-sonnet-4')).toEqual({
 			reasoning: { effort: 'none' }
 		});

--- a/packages/plugin/src/ai/__tests__/token-usage.tracker.spec.ts
+++ b/packages/plugin/src/ai/__tests__/token-usage.tracker.spec.ts
@@ -4,10 +4,7 @@ import { TokenUsageTracker } from '../token-usage.tracker.js';
 
 const baseGenerations = [[{ text: 'hi' } as never]];
 
-const result = (
-	llmOutput?: Record<string, unknown>,
-	generationInfo?: Record<string, unknown>
-): LLMResult =>
+const result = (llmOutput?: Record<string, unknown>, generationInfo?: Record<string, unknown>): LLMResult =>
 	({
 		llmOutput,
 		generations: generationInfo ? [[{ text: 'hi', generationInfo }]] : baseGenerations

--- a/packages/tasks/src/__tests__/task-context.utils.spec.ts
+++ b/packages/tasks/src/__tests__/task-context.utils.spec.ts
@@ -181,11 +181,7 @@ describe('createTaskContext', () => {
         hydrator.initialize.mockRejectedValueOnce(new Error('plugin-load-failed'));
 
         await expect(
-            createTaskContext(
-                appContext as any,
-                { workId: 'w', userId: 'u' },
-                FakeOrchestrator,
-            ),
+            createTaskContext(appContext as any, { workId: 'w', userId: 'u' }, FakeOrchestrator),
         ).rejects.toThrow('plugin-load-failed');
 
         expect(apiClient.fetchWorkContext).not.toHaveBeenCalled();
@@ -195,11 +191,7 @@ describe('createTaskContext', () => {
         apiClient.fetchWorkContext.mockRejectedValueOnce(new Error('api-down'));
 
         await expect(
-            createTaskContext(
-                appContext as any,
-                { workId: 'w', userId: 'u' },
-                FakeOrchestrator,
-            ),
+            createTaskContext(appContext as any, { workId: 'w', userId: 'u' }, FakeOrchestrator),
         ).rejects.toThrow('api-down');
 
         // appContext.get was called for hydrator + api-client + … but NOT for the orchestrator

--- a/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
@@ -127,9 +127,7 @@ describe('TriggerInternalApiClient', () => {
             await client.fetchWorkContext('work-1', 'user with spaces & symbols');
 
             const [url] = fetchSpy.mock.calls[0];
-            expect(url).toContain(
-                'userId=user+with+spaces+%26+symbols',
-            );
+            expect(url).toContain('userId=user+with+spaces+%26+symbols');
         });
     });
 
@@ -179,9 +177,7 @@ describe('TriggerInternalApiClient', () => {
 
             // Server returns a SuperJSON-serialized envelope; the client deserializes it.
             const serverPayload = superjson.serialize({ value: 42, when: new Date('2026-01-01') });
-            fetchSpy.mockResolvedValueOnce(
-                okJsonResponse(200, { result: serverPayload }),
-            );
+            fetchSpy.mockResolvedValueOnce(okJsonResponse(200, { result: serverPayload }));
 
             const result = await client.callRemote('SomeService', 'doIt', {
                 json: { foo: 'bar' },

--- a/packages/tasks/src/__tests__/work-generation.task.spec.ts
+++ b/packages/tasks/src/__tests__/work-generation.task.spec.ts
@@ -240,10 +240,7 @@ describe('workGenerationTask', () => {
                     {},
                 );
 
-                expect(scheduleService.markRunFailed).toHaveBeenCalledWith(
-                    'sched-1',
-                    'cancelled',
-                );
+                expect(scheduleService.markRunFailed).toHaveBeenCalledWith('sched-1', 'cancelled');
                 expect(scheduleService.markRunCompleted).not.toHaveBeenCalled();
             });
 


### PR DESCRIPTION
## Summary

- Format 19 spec files that were flagged by `pnpm format:check` on develop ([run 25571109402](https://github.com/ever-works/ever-works/actions/runs/25571109402)).
- Point `apps/internal-cli/build.js` at the existing `tsconfig.build.json` (which already excludes `vitest.config.ts`, `**/__tests__/**`, and `**/*spec.ts`) so the production `tsc` compile no longer fails on test files. Resolves the main-branch ["Build Internal CLI"](https://github.com/ever-works/ever-works/actions/runs/25571039715) failure: `TS2554` in `switch-ai.subcommand.spec.ts` / `unset.subcommand.spec.ts` and `TS1479` from `vitest.config.ts` importing the ESM-only `vitest/config` under Node16 module resolution.

## Test plan

- [x] `pnpm exec prettier --check` on the 19 affected files → "All matched files use Prettier code style!"
- [x] `npx tsc --project tsconfig.build.json …` (matching `build.js` flags) exits 0
- [ ] CI green on this PR (formatting + build:cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated build configuration to use an optimized TypeScript compilation configuration for generating the CLI distribution.
  * Refactored test file formatting and assertion structures across the codebase for improved code readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->