### PR TITLE
test(api/activity-log): cover ActivityLogController (33 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -19,20 +19,20 @@
 4. Update this file in the same PR (move the item to "Done", add the PR link,
    record any follow-ups discovered).
 
-## Inventory snapshot (2026-05-07, refreshed 2026-05-08)
+## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~442 across `apps/` + `packages/` (was 439
-  earlier on 2026-05-08; +3 apps/api auth provider specs landed
-  2026-05-08 — `auth-provider.service.spec.ts`, `auth-sync.service.spec.ts`,
-  `request-headers.spec.ts`, in addition to the auth controller + guard
-  batch and several other PRs in the intervening hours — see `Done` for
-  the running ledger).
+- **Spec files (`*.spec.ts`)**: ~443 across `apps/` + `packages/` (was 442
+  earlier on 2026-05-08; +1 apps/api `activity-log.controller.spec.ts`
+  landed 2026-05-09 closing the only remaining ActivityLog-module gap —
+  see `Done` for the running ledger).
 - **Playwright e2e suites**: 31 in `apps/web/e2e/`
-- **API source spec count**: **75** specs inside `apps/api/src/` (was 72 on
-  2026-05-08; the per-module audit landed across multiple 2026-05-07/08 PRs
-  and the auth-providers PR added the three newest entries — every file
-  under `apps/api/src/auth/` except the abstract base and types declarations
-  now has a unit suite).
+- **API source spec count**: **80** specs inside `apps/api/src/` (was 75 on
+  2026-05-08; the four new entries in the intervening hours are the
+  auth-controllers + guard batch — `auth.controller.spec.ts`,
+  `oauth.controller.spec.ts`, `api-keys.controller.spec.ts`,
+  `auth-session.guard.spec.ts` — the deploy-controller suite
+  (`deploy.controller.spec.ts`), and the activity-log controller suite
+  (`activity-log.controller.spec.ts`).
 - **Spec Kit features (`docs/specs/features/`)**: 33 directories (was 24 on
   2026-05-07; +9 retrospective specs authored on 2026-05-08).
 - **Plugins with ZERO unit tests (14)**: ALL closed as of 2026-05-07 —
@@ -236,6 +236,36 @@ service-level unit tests (Jest + `@nestjs/testing`) for:
       env-driven enable/disable + payload mapping) and
       `ActivityLogListener` (25 tests covering all 9 `@OnEvent`
       handlers, both happy + error paths) — [#482](https://github.com/ever-works/ever-works/pull/482).
+      `ActivityLogController` covered 2026-05-09 — 33 tests in
+      `activity-log.controller.spec.ts` covering all five endpoints
+      (`getActivities`/`getRunningCount`/`getSummary`/`exportCsv`/`getActivity`)
+      plus the private `reconcileActivities` helper observable through
+      the endpoints. Pins: in-flight `Map` per-user dedup (two concurrent
+      callers run reconcile once), 5-second `ACTIVITY_RECONCILE_TTL_MS`
+      cache (call within 5s skips, call past 5.001s retries), reconcile
+      rejection swallowed AND completedAt NOT cached so the next call
+      retries (vs. successful runs that ARE cached for 5s), per-user
+      isolation (different `userId`s run independently and forward the
+      correct positional arg), reconcile-before-service ordering pinned
+      via shared `order` array on every endpoint; `getActivities` query
+      forwarding (every filter forwarded, ISO `dateFrom`/`dateTo` parsed
+      to `Date`, `Math.min(limit, 100)` cap incl. boundary `limit=100`,
+      `{activities, total}` envelope shape so service-side extras don't
+      leak); `getRunningCount` `{count}` envelope; `getSummary` `{counts}`
+      envelope; `exportCsv` filter forwarding + `Content-Type: text/csv`
+      and `Content-Disposition: attachment; filename=activity-log.csv`
+      headers + body via `res.send`, error path skips both header writes
+      and `send`; `getActivity` `NotFoundException` on null lookup
+      (cross-user safety via composite-key `findByIdAndUserId`),
+      `details ?? {}` default coercion when activity has no details,
+      live-logs override behaviour (status===`'in_progress'` AND
+      `workId` AND `work.generateStatus.recentLogs.length>0` →
+      override; otherwise preserve `activity.details.liveLogs`; null
+      work / no `generateStatus` / empty `recentLogs` / missing `workId`
+      all preserve original; no `liveLogs` key injected when activity
+      had none and override path didn't fire). Mocks
+      `@ever-works/agent/{activity-log,database,entities}` so the
+      transitive TypeORM/agent runtime trees aren't pulled in.
 - [x] `auth/services/api-key.service` (15 tests, 2026-05-07) — `ApiKeyService` covering create (10-key cap, expiresAt-in-past rejection, ew*live* prefix + sha256 hashing, future expiresAt, unique-key generation), list/revoke, and validate (sha256 lookup, null-when-missing, null-when-expired, null-expiresAt = never-expiring, fire-and-forget updateLastUsed swallowing failure).
 - [x] `auth/services/auth.service` (45 tests, 2026-05-07) — `AuthService` covering assertCanRegister, validateSocialUser (new user creation with trusted-email emit, unverified-email gating, suspended-account rejection, provider-link bypass, upsertProviderAccount field mapping), sendVerificationEmail (24h expiry, callback URL token-append vs default), verifyEmail, forgotPassword (1h expiry, callback URL handling, generic-message safety), getUserByPasswordResetToken, consumePasswordResetToken, getUser, getUserProfile (sensitive-field stripping, github repo-scope gating, expired-token filtering), updateUserProfile (selective field updates, committer-field clearing semantics), validateEmailVerificationToken, validatePasswordResetToken.
 - [x] `auth/services/social-auth.service` (37 tests, 2026-05-07) — `SocialAuthService` covering all four OAuth providers (GitHub/Google/Facebook/LinkedIn): `getAuthorizationUrl` (default vs override callback+state, Google access_type=offline+prompt=consent, Facebook comma scope separator, LinkedIn default space separator, unknown provider + missing client id rejection); `getProviderDisplayName` for all four + unknown; `getConfiguredProviders` (full env, missing client id/secret, empty); `authenticate` (GitHub full flow w/o `grant_type` + `/user` + `/user/emails` resolution via `resolveGitHubAccountEmail`, displayName fallback chain login→email-local-part; Google emailVerified default-true vs explicit false, expires_in→expiresAt computation; Facebook always-false emailVerified, picture nesting; LinkedIn OIDC userinfo + given/family fallback + locale metadata; missing access_token, missing email per provider, missing client id/secret, unknown provider; readNumber/readOptionalString edge cases). HttpService mocked with rxjs `of()`.

--- a/apps/api/src/activity-log/activity-log.controller.spec.ts
+++ b/apps/api/src/activity-log/activity-log.controller.spec.ts
@@ -1,0 +1,631 @@
+// Mock the agent-package barrels first so importing the controller does not
+// pull the real ActivityLogService / WorkRepository runtime trees (TypeORM,
+// nest entities, etc.). Mirrors the convention in
+// `notifications.controller.spec.ts` and `activity-log.listener.spec.ts`.
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        WORK_CREATED: 'WORK_CREATED',
+        GENERATION: 'GENERATION',
+        DEPLOYMENT: 'DEPLOYMENT',
+    },
+    ActivityStatus: {
+        IN_PROGRESS: 'in_progress',
+        COMPLETED: 'completed',
+        FAILED: 'failed',
+        CANCELLED: 'cancelled',
+    },
+}));
+
+import { NotFoundException } from '@nestjs/common';
+import { ActivityLogController } from './activity-log.controller';
+import type { ActivityLogService } from '@ever-works/agent/activity-log';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+describe('ActivityLogController', () => {
+    let activityLogService: jest.Mocked<
+        Pick<
+            ActivityLogService,
+            | 'reconcileStaleGenerationActivities'
+            | 'findAll'
+            | 'countRunning'
+            | 'summarizeStatuses'
+            | 'exportCsv'
+            | 'findByIdAndUserId'
+        >
+    >;
+    let workRepository: jest.Mocked<Pick<WorkRepository, 'findById'>>;
+    let controller: ActivityLogController;
+
+    const auth = {
+        userId: 'user-1',
+        email: 'u@e.test',
+        username: 'u',
+        provider: 'local',
+        emailVerified: true,
+        isActive: true,
+        avatar: null,
+        iat: 0,
+        iss: '',
+        aud: '',
+    } as AuthenticatedUser;
+
+    const buildController = () => {
+        controller = new ActivityLogController(
+            activityLogService as unknown as ActivityLogService,
+            workRepository as unknown as WorkRepository,
+        );
+    };
+
+    beforeEach(() => {
+        activityLogService = {
+            reconcileStaleGenerationActivities: jest.fn().mockResolvedValue(0),
+            findAll: jest.fn(),
+            countRunning: jest.fn(),
+            summarizeStatuses: jest.fn(),
+            exportCsv: jest.fn(),
+            findByIdAndUserId: jest.fn(),
+        } as any;
+        workRepository = {
+            findById: jest.fn(),
+        } as any;
+        buildController();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    describe('reconcileActivities (private behaviour observable through endpoints)', () => {
+        it('runs reconcile exactly once for two concurrent calls (in-flight dedup)', async () => {
+            // Hold the first reconcile open until we explicitly resolve it,
+            // so the second call observes the in-flight Map entry and awaits
+            // the same promise rather than starting a new run.
+            let resolveFirst: () => void = () => undefined;
+            activityLogService.reconcileStaleGenerationActivities.mockImplementationOnce(
+                () =>
+                    new Promise<number>((resolve) => {
+                        resolveFirst = () => resolve(0);
+                    }),
+            );
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+
+            const first = controller.getActivities(auth);
+            const second = controller.getActivities(auth);
+
+            // Resolve the in-flight reconcile so the queued requests can finish.
+            resolveFirst();
+            await Promise.all([first, second]);
+
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        it('skips reconcile a second time if the first completed within the 5-second TTL', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+
+            await controller.getActivities(auth);
+            // Advance time but still within 5-second TTL.
+            jest.setSystemTime(new Date('2026-01-01T00:00:04Z'));
+            await controller.getActivities(auth);
+
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        it('runs reconcile a second time once the 5-second TTL elapses', async () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+
+            await controller.getActivities(auth);
+            // Advance past TTL boundary (>= 5000 ms). Use 5001 to be safe.
+            jest.setSystemTime(new Date('2026-01-01T00:00:05.001Z'));
+            await controller.getActivities(auth);
+
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenCalledTimes(2);
+        });
+
+        it('still serves the request when reconcile rejects (failure is swallowed)', async () => {
+            activityLogService.reconcileStaleGenerationActivities.mockRejectedValueOnce(
+                new Error('reconcile failed'),
+            );
+            activityLogService.findAll.mockResolvedValue({
+                activities: [{ id: 'a1' }],
+                total: 1,
+            } as any);
+
+            const result = await controller.getActivities(auth);
+
+            expect(result).toEqual({ activities: [{ id: 'a1' }], total: 1 });
+        });
+
+        it('does NOT cache completion when reconcile rejected — next call retries', async () => {
+            activityLogService.reconcileStaleGenerationActivities
+                .mockRejectedValueOnce(new Error('first failed'))
+                .mockResolvedValueOnce(0);
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+
+            await controller.getActivities(auth);
+            await controller.getActivities(auth);
+
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenCalledTimes(2);
+        });
+
+        it('isolates the in-flight Map per user (different userIds run independently)', async () => {
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+            const otherAuth = { ...auth, userId: 'user-2' } as AuthenticatedUser;
+
+            await Promise.all([
+                controller.getActivities(auth),
+                controller.getActivities(otherAuth),
+            ]);
+
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenCalledTimes(2);
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenNthCalledWith(1, 'user-1');
+            expect(
+                activityLogService.reconcileStaleGenerationActivities,
+            ).toHaveBeenNthCalledWith(2, 'user-2');
+        });
+
+        it('reconciles before invoking findAll (ordering pinned)', async () => {
+            const order: string[] = [];
+            activityLogService.reconcileStaleGenerationActivities.mockImplementationOnce(
+                async () => {
+                    order.push('reconcile');
+                    return 0;
+                },
+            );
+            activityLogService.findAll.mockImplementationOnce(async () => {
+                order.push('findAll');
+                return { activities: [], total: 0 } as any;
+            });
+
+            await controller.getActivities(auth);
+
+            expect(order).toEqual(['reconcile', 'findAll']);
+        });
+    });
+
+    describe('getActivities', () => {
+        it('forwards every filter + caps limit at 100 + parses ISO dates', async () => {
+            activityLogService.findAll.mockResolvedValue({
+                activities: [{ id: 'a1' }],
+                total: 1,
+            } as any);
+
+            const result = await controller.getActivities(
+                auth,
+                'WORK_CREATED',
+                'work-77',
+                'completed',
+                '2026-01-01T00:00:00Z',
+                '2026-01-31T23:59:59Z',
+                'search-term',
+                250, // capped to 100
+                40,
+            );
+
+            expect(activityLogService.findAll).toHaveBeenCalledTimes(1);
+            const call = activityLogService.findAll.mock.calls[0]![0]!;
+            expect(call.userId).toBe('user-1');
+            expect(call.actionType).toBe('WORK_CREATED');
+            expect(call.workId).toBe('work-77');
+            expect(call.status).toBe('completed');
+            expect(call.dateFrom).toBeInstanceOf(Date);
+            expect(call.dateFrom!.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+            expect(call.dateTo).toBeInstanceOf(Date);
+            expect(call.dateTo!.toISOString()).toBe('2026-01-31T23:59:59.000Z');
+            expect(call.search).toBe('search-term');
+            expect(call.limit).toBe(100);
+            expect(call.offset).toBe(40);
+
+            expect(result).toEqual({ activities: [{ id: 'a1' }], total: 1 });
+        });
+
+        it('passes through limit when below cap and forwards undefined dates', async () => {
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+
+            await controller.getActivities(
+                auth,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                25,
+                0,
+            );
+
+            const call = activityLogService.findAll.mock.calls[0]![0]!;
+            expect(call.limit).toBe(25);
+            expect(call.offset).toBe(0);
+            expect(call.dateFrom).toBeUndefined();
+            expect(call.dateTo).toBeUndefined();
+            expect(call.actionType).toBeUndefined();
+            expect(call.workId).toBeUndefined();
+            expect(call.status).toBeUndefined();
+            expect(call.search).toBeUndefined();
+        });
+
+        it('treats limit equal to cap (100) as 100', async () => {
+            activityLogService.findAll.mockResolvedValue({ activities: [], total: 0 } as any);
+
+            await controller.getActivities(
+                auth,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                100,
+                0,
+            );
+
+            const call = activityLogService.findAll.mock.calls[0]![0]!;
+            expect(call.limit).toBe(100);
+        });
+
+        it('returns the {activities, total} envelope (other service fields are not leaked)', async () => {
+            activityLogService.findAll.mockResolvedValue({
+                activities: [{ id: 'a1' }],
+                total: 9,
+                // Hypothetical extra fields the service might add later — must not leak.
+                cursor: 'should-not-leak',
+            } as any);
+
+            const result = await controller.getActivities(auth);
+
+            expect(result).toEqual({ activities: [{ id: 'a1' }], total: 9 });
+        });
+
+        it('propagates service errors after reconcile completes', async () => {
+            activityLogService.findAll.mockRejectedValueOnce(new Error('db down'));
+
+            await expect(controller.getActivities(auth)).rejects.toThrow('db down');
+        });
+    });
+
+    describe('getRunningCount', () => {
+        it('returns count from service wrapped in {count}', async () => {
+            activityLogService.countRunning.mockResolvedValue(3);
+
+            const result = await controller.getRunningCount(auth);
+
+            expect(activityLogService.countRunning).toHaveBeenCalledWith('user-1');
+            expect(result).toEqual({ count: 3 });
+        });
+
+        it('propagates service errors', async () => {
+            activityLogService.countRunning.mockRejectedValueOnce(new Error('boom'));
+
+            await expect(controller.getRunningCount(auth)).rejects.toThrow('boom');
+        });
+
+        it('runs reconcile before countRunning', async () => {
+            const order: string[] = [];
+            activityLogService.reconcileStaleGenerationActivities.mockImplementationOnce(
+                async () => {
+                    order.push('reconcile');
+                    return 0;
+                },
+            );
+            activityLogService.countRunning.mockImplementationOnce(async () => {
+                order.push('countRunning');
+                return 0;
+            });
+
+            await controller.getRunningCount(auth);
+
+            expect(order).toEqual(['reconcile', 'countRunning']);
+        });
+    });
+
+    describe('getSummary', () => {
+        it('returns counts from service wrapped in {counts}', async () => {
+            const counts = {
+                in_progress: 1,
+                completed: 4,
+                failed: 0,
+                cancelled: 0,
+            };
+            activityLogService.summarizeStatuses.mockResolvedValue(counts as any);
+
+            const result = await controller.getSummary(auth);
+
+            expect(activityLogService.summarizeStatuses).toHaveBeenCalledWith('user-1');
+            expect(result).toEqual({ counts });
+        });
+
+        it('runs reconcile before summarizeStatuses', async () => {
+            const order: string[] = [];
+            activityLogService.reconcileStaleGenerationActivities.mockImplementationOnce(
+                async () => {
+                    order.push('reconcile');
+                    return 0;
+                },
+            );
+            activityLogService.summarizeStatuses.mockImplementationOnce(async () => {
+                order.push('summarizeStatuses');
+                return {} as any;
+            });
+
+            await controller.getSummary(auth);
+
+            expect(order).toEqual(['reconcile', 'summarizeStatuses']);
+        });
+
+        it('propagates service errors', async () => {
+            activityLogService.summarizeStatuses.mockRejectedValueOnce(new Error('agg failed'));
+
+            await expect(controller.getSummary(auth)).rejects.toThrow('agg failed');
+        });
+    });
+
+    describe('exportCsv', () => {
+        let res: { setHeader: jest.Mock; send: jest.Mock };
+
+        beforeEach(() => {
+            res = { setHeader: jest.fn(), send: jest.fn() };
+        });
+
+        it('forwards filters + writes Content-Type + Content-Disposition headers + body', async () => {
+            activityLogService.exportCsv.mockResolvedValue('id,summary\nrow1,foo');
+
+            await controller.exportCsv(
+                auth,
+                res as any,
+                'GENERATION',
+                'work-1',
+                'failed',
+                '2026-01-01T00:00:00Z',
+                '2026-01-31T23:59:59Z',
+            );
+
+            expect(activityLogService.exportCsv).toHaveBeenCalledTimes(1);
+            const call = activityLogService.exportCsv.mock.calls[0]![0]!;
+            expect(call.userId).toBe('user-1');
+            expect(call.actionType).toBe('GENERATION');
+            expect(call.workId).toBe('work-1');
+            expect(call.status).toBe('failed');
+            expect(call.dateFrom).toBeInstanceOf(Date);
+            expect(call.dateFrom!.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+            expect(call.dateTo).toBeInstanceOf(Date);
+            expect(call.dateTo!.toISOString()).toBe('2026-01-31T23:59:59.000Z');
+
+            expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
+            expect(res.setHeader).toHaveBeenCalledWith(
+                'Content-Disposition',
+                'attachment; filename=activity-log.csv',
+            );
+            expect(res.send).toHaveBeenCalledWith('id,summary\nrow1,foo');
+        });
+
+        it('forwards undefined filters + dates when not provided', async () => {
+            activityLogService.exportCsv.mockResolvedValue('id,summary');
+
+            await controller.exportCsv(auth, res as any);
+
+            const call = activityLogService.exportCsv.mock.calls[0]![0]!;
+            expect(call.actionType).toBeUndefined();
+            expect(call.workId).toBeUndefined();
+            expect(call.status).toBeUndefined();
+            expect(call.dateFrom).toBeUndefined();
+            expect(call.dateTo).toBeUndefined();
+            expect(res.send).toHaveBeenCalledWith('id,summary');
+        });
+
+        it('runs reconcile BEFORE the CSV is generated (so the export never sees stale rows)', async () => {
+            const order: string[] = [];
+            activityLogService.reconcileStaleGenerationActivities.mockImplementationOnce(
+                async () => {
+                    order.push('reconcile');
+                    return 0;
+                },
+            );
+            activityLogService.exportCsv.mockImplementationOnce(async () => {
+                order.push('exportCsv');
+                return '';
+            });
+
+            await controller.exportCsv(auth, res as any);
+
+            expect(order).toEqual(['reconcile', 'exportCsv']);
+        });
+
+        it('propagates service errors and does NOT touch the response', async () => {
+            activityLogService.exportCsv.mockRejectedValueOnce(new Error('csv failed'));
+
+            await expect(controller.exportCsv(auth, res as any)).rejects.toThrow('csv failed');
+            expect(res.setHeader).not.toHaveBeenCalled();
+            expect(res.send).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getActivity', () => {
+        it('throws NotFoundException when service returns null', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce(null);
+
+            await expect(controller.getActivity(auth, 'a1')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(activityLogService.findByIdAndUserId).toHaveBeenCalledWith('a1', 'user-1');
+            // No work lookup when activity is missing.
+            expect(workRepository.findById).not.toHaveBeenCalled();
+        });
+
+        it('returns activity wrapped in {activity} (details preserved when no liveLogs override)', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'completed',
+                workId: 'work-1',
+                details: { existing: true },
+            } as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(result).toEqual({
+                activity: {
+                    id: 'a1',
+                    status: 'completed',
+                    workId: 'work-1',
+                    details: { existing: true },
+                },
+            });
+            // Live-logs path is NOT exercised when status !== 'in_progress'.
+            expect(workRepository.findById).not.toHaveBeenCalled();
+        });
+
+        it('keeps details intact when activity has no details object (defaults to {})', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'completed',
+                workId: 'work-1',
+            } as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(result.activity.details).toEqual({});
+        });
+
+        it('overrides liveLogs from work.generateStatus.recentLogs when status is in_progress AND work has logs', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'in_progress',
+                workId: 'work-1',
+                details: { liveLogs: ['stale-1'], other: 'kept' },
+            } as any);
+            workRepository.findById.mockResolvedValueOnce({
+                generateStatus: { recentLogs: ['fresh-1', 'fresh-2'] },
+            } as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(workRepository.findById).toHaveBeenCalledWith('work-1');
+            expect(result.activity.details).toEqual({
+                liveLogs: ['fresh-1', 'fresh-2'],
+                other: 'kept',
+            });
+        });
+
+        it('preserves activity.details.liveLogs when status is in_progress but work has no recentLogs', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'in_progress',
+                workId: 'work-1',
+                details: { liveLogs: ['existing'], other: 'kept' },
+            } as any);
+            workRepository.findById.mockResolvedValueOnce({
+                generateStatus: { recentLogs: [] },
+            } as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(result.activity.details).toEqual({
+                liveLogs: ['existing'],
+                other: 'kept',
+            });
+        });
+
+        it('preserves activity.details.liveLogs when status is in_progress but work is null', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'in_progress',
+                workId: 'work-1',
+                details: { liveLogs: ['existing'] },
+            } as any);
+            workRepository.findById.mockResolvedValueOnce(null as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(result.activity.details).toEqual({ liveLogs: ['existing'] });
+        });
+
+        it('preserves activity.details.liveLogs when status is in_progress but work has no generateStatus', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'in_progress',
+                workId: 'work-1',
+                details: { liveLogs: ['existing'] },
+            } as any);
+            workRepository.findById.mockResolvedValueOnce({} as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(result.activity.details).toEqual({ liveLogs: ['existing'] });
+        });
+
+        it('does NOT call workRepository.findById when status is in_progress but workId is missing', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'in_progress',
+                workId: null,
+                details: {},
+            } as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(workRepository.findById).not.toHaveBeenCalled();
+            // No liveLogs property added because activity.details.liveLogs was undefined.
+            expect(result.activity.details).toEqual({});
+        });
+
+        it('does NOT inject liveLogs key when activity has no liveLogs and override is empty', async () => {
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce({
+                id: 'a1',
+                status: 'completed',
+                workId: 'work-1',
+                details: { foo: 'bar' },
+            } as any);
+
+            const result = await controller.getActivity(auth, 'a1');
+
+            expect(result.activity.details).toEqual({ foo: 'bar' });
+            expect(result.activity.details).not.toHaveProperty('liveLogs');
+        });
+
+        it('runs reconcile before the lookup (ordering pinned)', async () => {
+            const order: string[] = [];
+            activityLogService.reconcileStaleGenerationActivities.mockImplementationOnce(
+                async () => {
+                    order.push('reconcile');
+                    return 0;
+                },
+            );
+            activityLogService.findByIdAndUserId.mockImplementationOnce(async () => {
+                order.push('findByIdAndUserId');
+                return { id: 'a1', status: 'completed', workId: 'w1', details: {} } as any;
+            });
+
+            await controller.getActivity(auth, 'a1');
+
+            expect(order).toEqual(['reconcile', 'findByIdAndUserId']);
+        });
+
+        it('cross-user lookup returns null → 404 (composite-key safety)', async () => {
+            // findByIdAndUserId is the composite-key safety surface — returning
+            // null when the activity belongs to a different user is what
+            // turns into a 404 here.
+            activityLogService.findByIdAndUserId.mockResolvedValueOnce(null);
+
+            await expect(controller.getActivity(auth, 'someone-elses')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `apps/api/src/activity-log/activity-log.controller.spec.ts` (33 tests) covering all five endpoints (`getActivities` / `getRunningCount` / `getSummary` / `exportCsv` / `getActivity`) plus the private `reconcileActivities` helper observable through them.
- Closes the only remaining gap in the `activity-log` module — listener + Jitsu service had shipped under #482 but the controller itself was untested.
- Updates `COVERAGE-TRACKER.md` (inventory snapshot bumped to 80 API specs; `activity-log` row in *API module unit tests* expanded with the controller batch).

## What's pinned

* **`reconcileActivities` private helper** — in-flight `Map` per-user dedup (two concurrent callers run reconcile exactly once); `ACTIVITY_RECONCILE_TTL_MS = 5000` cache (call within window skips, call past 5.001s retries); reconcile rejection **swallowed** AND `completedAt` NOT cached so the next call retries; per-user isolation; reconcile-before-service ordering pinned on every endpoint via shared `order` array.
* **`getActivities`** — every filter forwarded, ISO `dateFrom`/`dateTo` parsed to `Date`, `Math.min(limit, 100)` cap incl. boundary `limit = 100`, `{activities, total}` envelope shape so future service-side fields don't leak.
* **`getRunningCount` / `getSummary`** — `{count}` / `{counts}` envelopes + reconcile-first ordering + error propagation.
* **`exportCsv`** — filter forwarding + `Content-Type: text/csv` + `Content-Disposition: attachment; filename=activity-log.csv` + body via `res.send`; service rejection skips BOTH header writes and `send`.
* **`getActivity`** — `NotFoundException` on null lookup (cross-user safety via composite-key `findByIdAndUserId`); `details ?? {}` default coercion; live-logs override behaviour (status==='in_progress' AND `workId` AND `work.generateStatus.recentLogs.length > 0` → override; otherwise preserve `activity.details.liveLogs`; null work / no `generateStatus` / empty `recentLogs` / missing `workId` all preserve original; no `liveLogs` key injected when activity had none and override path didn't fire).

## Mocked surfaces

`@ever-works/agent/{activity-log,database,entities}` are stubbed at the top of the spec so the transitive TypeORM / agent runtime trees aren't pulled in. Mirrors the convention in `activity-log.listener.spec.ts` and `notifications.controller.spec.ts`.

## Test plan

- [x] `pnpm --filter ever-works-api jest src/activity-log/activity-log.controller.spec.ts` — 33/33 green locally
- [ ] CI green on `tests/api-activity-log-controller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test coverage added for activity tracking features, including endpoint behavior, filtering, error handling, and data transformation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->