### PR TITLE
fix(test): drop dynamic ../index import from base.facade.spec to fix tsc TS2835

### DIFF
--- a/packages/agent/src/facades/__tests__/base.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/base.facade.spec.ts
@@ -773,13 +773,14 @@ describe('BaseFacadeService', () => {
         });
     });
 
-    describe('FacadesModule re-exports (sanity)', () => {
-        it('exposes BaseFacadeService + the three error classes via the package barrel', async () => {
-            const mod: typeof import('../index') = await import('../index');
-            expect(typeof mod.BaseFacadeService).toBe('function');
-            expect(typeof mod.FacadeError).toBe('function');
-            expect(typeof mod.NoProviderError).toBe('function');
-            expect(typeof mod.ProviderNotFoundError).toBe('function');
-        });
-    });
+    // NOTE: a barrel re-export sanity check for `BaseFacadeService` +
+    // `FacadeError` / `NoProviderError` / `ProviderNotFoundError` lives in
+    // `facades.module.spec.ts` (in the "barrel re-exports" block — see
+    // `re-exports the shared FacadeError + base classes (...)`). It is not
+    // duplicated here because a dynamic `await import('../index')` trips
+    // TS2835 under the agent package's `module: "NodeNext"` tsconfig (the
+    // build runs `tsc -p tsconfig.types.json` over `src/**/*.ts` so spec
+    // files participate in the type-check), while a static `import * as`
+    // would create a confusingly-shaped module-scope side-effect inside a
+    // file that is otherwise self-contained.
 });


### PR DESCRIPTION
## Summary

CI on `develop` is red ([run 25604189030](https://github.com/ever-works/ever-works/actions/runs/25604189030)) after #642 because the agent package builds with `tsc -p tsconfig.types.json` over `src/**/*.ts`, and a dynamic `await import('../index')` in the new `base.facade.spec.ts` trips TS2835:

> Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean '../index.js'?

The static `import * as facadesBarrel from '../index'` in the sibling `facades.module.spec.ts` is fine — that file already pins the same `BaseFacadeService` / `FacadeError` / `NoProviderError` / `ProviderNotFoundError` re-exports under its "barrel re-exports" block. So the simplest fix is to drop the duplicate dynamic-import test from base.facade.spec and leave a comment pointing at the canonical assertion.

74/75 tests preserved (the dropped test was a duplicate, not unique coverage).

## Test plan

- [x] `npx tsc -p tsconfig.types.json --noEmit` clean from `packages/agent`
- [x] `pnpm --filter @ever-works/agent test --testPathPattern='facades/__tests__/(base|facades)'` → 74/74 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed redundant barrel re-export sanity-check test and added clarifying documentation explaining the rationale for this decision.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/643)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->