### PR TITLE
test(agent): cover markdown-generator helper classes (+30 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -21,68 +21,91 @@
 
 ## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~487 across `apps/` + `packages/` (was 486
-  earlier on 2026-05-09; +1 net spec file in the agent
-  `BranchSyncService` direct-coverage sweep — adds
-  `packages/agent/src/generators/website-generator/branch-sync.service.spec.ts`
-  (24 tests covering `syncBranch` clone-rename-replaceRemote-push-cleanup
-  pipeline + temp-dir cleanup on failure paths, `syncAllBranches`
-  branch-mapping expansion + skip-mapped-target rule + sequential
-  `MAX_CONCURRENT_SYNCS=1` semantics + per-batch 1000ms inter-batch
-  delay + `Promise.allSettled` rejection-to-error-result coercion +
-  optional `cleanupExtraBranches` purge w/ swallowed delete failures
-    - warn-and-return-early on `listBranches` failure, `syncFromTemplate`
-      beta-branch-mapping construction + outer try/catch null fallback +
-      resolveForWork-rethrow pin), closing the per-file zero-coverage gap
-      inside `packages/agent/src/generators/website-generator/` for the
-      branch-sync surface — see `Done` ledger; +2 net spec files in the
-      earlier agent `BaseFacadeService`/`FacadesModule` direct-coverage
-      sweep — adds
-      `packages/agent/src/facades/__tests__/base.facade.spec.ts` (66 tests
-      on the abstract base via a `TestFacadeService extends BaseFacadeService`
-      re-exposer) and `packages/agent/src/facades/__tests__/facades.module.spec.ts`
-      (9 tests pinning the module providers/exports + barrel runtime symbols),
-      closing the per-file zero-coverage gap inside `packages/agent/src/facades/`
-      — see `Done` ledger; +0 net spec files in the WorkGenerationService
-      orchestrators follow-up sweep — extends the existing
-      `services/__tests__/work-generation.service.spec.ts` from 126 → 172
-      tests, closing the previously-pending 7 multi-step pipeline orchestrators
-      (`processGeneration` / `executeGenerationPipeline` / `finalizeGeneration` /
-      `runInProcessGeneration` / `prepareProviders` /
-      `ensureProvidersEnabledForWork` / `dispatchGenerationTask`) — see `Done`
-      ledger; **the WorkGenerationService private-orchestrator zero-coverage
-      gap is now empty.** The earlier 2026-05-09 sweep covered 7 simpler
-      helpers: `resolveGenerationFinalStatus` / `resolveGenerationErrorMessage` /
-      `buildScheduleRunOutcome` / `isNonFatalWebsiteGenerationError` /
-      `markGenerationStarted` / `finalizeCancelledGeneration` /
-      `handleErrorNotification`; +1 packages/agent service spec landed 2026-05-09
-      in the small-service coverage sweep #6 — `WorkGenerationService` (focused
-      first sweep covering wrapper / simpler methods) — see `Done` ledger; +1 packages/agent service spec
-      landed earlier 2026-05-09
-      in the small-service coverage sweep #5 — `ItemHealthService` — see
-      `Done` ledger;
-      +1 packages/agent service spec landed earlier 2026-05-09
-      in the small-service coverage sweep #4 — `WorkTaxonomyService` — see
-      `Done` ledger;
-      +1 packages/agent service spec landed earlier 2026-05-09
-      in the small-service coverage sweep #3 — `WorkMemberService` — see
-      `Done` ledger;
-      +3 packages/agent service specs landed earlier 2026-05-09
-      in the small-service coverage sweep #2 — `ItemSourceValidationSchedulerService` +
-      `WorkDetailService` + `RepositoryManagementService` — see `Done` ledger;
-      +2 packages/agent service specs landed earlier 2026-05-09
-      in the small-service coverage sweep — `WorkAdvancedPromptsService` +
-      `WorkWebsiteRepositoryStateService` — see `Done` ledger;
-      +1 prior packages/agent service spec landed 2026-05-09
-      in the WorkOwnershipService sweep — see `Done` ledger; +4 packages/agent
-      repository specs landed earlier 2026-05-09
-      in sweep #3: activity-log + notification + work-member + work — closing the
-      agent-package repository zero-coverage gap entirely; +4 in the previous
-      sweep #2: work-custom-domain + user + conversation + template; +8 in
-      the prior sweep — subscription-plan + work-advanced-prompts +
-      user-template-preference + user-subscription + usage-ledger +
-      webhook-subscription + refresh-token + onboarding-request. See `Done`
-      for the running ledger).
+- **Spec files (`*.spec.ts`)**: ~489 across `apps/` + `packages/` (was 487
+  earlier on 2026-05-09; +2 net spec files in the agent
+  markdown-generator helper-class sweep — adds
+  `packages/agent/src/generators/markdown-generator/readme-builder.spec.ts`
+  (17 tests on the fluent `ReadmeBuilder` builder — `addHeader`/`addSubHeader`/`addParagraph`/`addNewLine` chaining,
+  `enableToC()` opt-in rendering w/ `## 📑 Table of Contents`
+    - en-US-formatted counts + duplicate-slug `-1`/`-2` disambiguation
+      via github-slugger + `0` rendered as `(0)` not omitted, `addItem`
+      format `- [name](url) - description` + optional `([Read more](/details/<slug>.md))` + backtick-wrapped tag
+      list joined w/ spaces, end-to-end document shape) and
+      `packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts`
+      (13 tests on the on-disk repository helper — `cleanup` recursive
+      `rm`, `resetFiles` allowlist (`.git`, `.gitignore`, `.github`,
+      `.vscode`, `.env`, `.nvmrc`, plus every dotfile starting with
+      `.git`) + sequential await-per-iteration removal order +
+      `readdir`-failure short-circuit, `ensureWorksExist` recursive
+      mkdir of `details/`, `writeReadme`/`writeDetails`/`writeLicense`
+      utf-8 writes, `removeDetails` rm with `force:true` only — NOT
+      recursive, the public readonly `dir` field, and the `dir` →
+      `dir/details` derivation contract — `node:fs/promises` is mocked at
+      module scope so the suite never touches the real filesystem),
+      closing the markdown-generator helper-class zero-coverage gap (the
+      remaining file in the subdir is `markdown-generator.service.ts`,
+      508 LOC, deferred to a dedicated follow-up) — see `Done` ledger;
+      +1 net spec file in the prior agent
+      `BranchSyncService` direct-coverage sweep — adds
+      `packages/agent/src/generators/website-generator/branch-sync.service.spec.ts`
+      (24 tests covering `syncBranch` clone-rename-replaceRemote-push-cleanup
+      pipeline + temp-dir cleanup on failure paths, `syncAllBranches`
+      branch-mapping expansion + skip-mapped-target rule + sequential
+      `MAX_CONCURRENT_SYNCS=1` semantics + per-batch 1000ms inter-batch
+      delay + `Promise.allSettled` rejection-to-error-result coercion +
+      optional `cleanupExtraBranches` purge w/ swallowed delete failures
+        - warn-and-return-early on `listBranches` failure, `syncFromTemplate`
+          beta-branch-mapping construction + outer try/catch null fallback +
+          resolveForWork-rethrow pin), closing the per-file zero-coverage gap
+          inside `packages/agent/src/generators/website-generator/` for the
+          branch-sync surface — see `Done` ledger; +2 net spec files in the
+          earlier agent `BaseFacadeService`/`FacadesModule` direct-coverage
+          sweep — adds
+          `packages/agent/src/facades/__tests__/base.facade.spec.ts` (66 tests
+          on the abstract base via a `TestFacadeService extends BaseFacadeService`
+          re-exposer) and `packages/agent/src/facades/__tests__/facades.module.spec.ts`
+          (9 tests pinning the module providers/exports + barrel runtime symbols),
+          closing the per-file zero-coverage gap inside `packages/agent/src/facades/`
+          — see `Done` ledger; +0 net spec files in the WorkGenerationService
+          orchestrators follow-up sweep — extends the existing
+          `services/__tests__/work-generation.service.spec.ts` from 126 → 172
+          tests, closing the previously-pending 7 multi-step pipeline orchestrators
+          (`processGeneration` / `executeGenerationPipeline` / `finalizeGeneration` /
+          `runInProcessGeneration` / `prepareProviders` /
+          `ensureProvidersEnabledForWork` / `dispatchGenerationTask`) — see `Done`
+          ledger; **the WorkGenerationService private-orchestrator zero-coverage
+          gap is now empty.** The earlier 2026-05-09 sweep covered 7 simpler
+          helpers: `resolveGenerationFinalStatus` / `resolveGenerationErrorMessage` /
+          `buildScheduleRunOutcome` / `isNonFatalWebsiteGenerationError` /
+          `markGenerationStarted` / `finalizeCancelledGeneration` /
+          `handleErrorNotification`; +1 packages/agent service spec landed 2026-05-09
+          in the small-service coverage sweep #6 — `WorkGenerationService` (focused
+          first sweep covering wrapper / simpler methods) — see `Done` ledger; +1 packages/agent service spec
+          landed earlier 2026-05-09
+          in the small-service coverage sweep #5 — `ItemHealthService` — see
+          `Done` ledger;
+          +1 packages/agent service spec landed earlier 2026-05-09
+          in the small-service coverage sweep #4 — `WorkTaxonomyService` — see
+          `Done` ledger;
+          +1 packages/agent service spec landed earlier 2026-05-09
+          in the small-service coverage sweep #3 — `WorkMemberService` — see
+          `Done` ledger;
+          +3 packages/agent service specs landed earlier 2026-05-09
+          in the small-service coverage sweep #2 — `ItemSourceValidationSchedulerService` +
+          `WorkDetailService` + `RepositoryManagementService` — see `Done` ledger;
+          +2 packages/agent service specs landed earlier 2026-05-09
+          in the small-service coverage sweep — `WorkAdvancedPromptsService` +
+          `WorkWebsiteRepositoryStateService` — see `Done` ledger;
+          +1 prior packages/agent service spec landed 2026-05-09
+          in the WorkOwnershipService sweep — see `Done` ledger; +4 packages/agent
+          repository specs landed earlier 2026-05-09
+          in sweep #3: activity-log + notification + work-member + work — closing the
+          agent-package repository zero-coverage gap entirely; +4 in the previous
+          sweep #2: work-custom-domain + user + conversation + template; +8 in
+          the prior sweep — subscription-plan + work-advanced-prompts +
+          user-template-preference + user-subscription + usage-ledger +
+          webhook-subscription + refresh-token + onboarding-request. See `Done`
+          for the running ledger).
 - **Playwright e2e suites**: 31 in `apps/web/e2e/`
 - **API source spec count**: **101** specs inside `apps/api/src/` (was 95
   earlier on 2026-05-09; +6 small-utility DTO specs landed in the
@@ -106,6 +129,17 @@
 ## Done
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
+
+**2026-05-09 — packages/agent markdown-generator helper-class coverage (+30 tests across 2 new specs, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes the markdown-generator helper-class zero-coverage gap. The two helpers in `packages/agent/src/generators/markdown-generator/` that previously had no co-located spec — `readme-builder.ts` (87 LOC) and `markdown-repository.ts` (66 LOC) — are now both pinned. The 508-LOC `markdown-generator.service.ts` orchestrator is deferred to a dedicated follow-up.
+
+- **`packages/agent/src/generators/markdown-generator/readme-builder.spec.ts`** (17 tests) — `build()` envelope shape (header + body + footer separator, multi-line header/footer preserved verbatim); `addHeader` H1 + double-newline; `addSubHeader` H2 + ToC entry registration + chainability; `addParagraph` + `addNewLine` newline composition; `enableToC()` opt-in (default-omitted vs explicit-rendered with `## 📑 Table of Contents` header), en-US-formatted counts (`1234 → "1,234"`, `0 → "0"` not omitted, `undefined → omitted entirely`), github-slugger duplicate-slug `-1`/`-2`/... disambiguation (which forced a per-test `jest.isolateModules()` reload because the source module instantiates the slugger at top-level and never resets it — the spec pins this current behavior so a future module-level `slugger.reset()` call would be a deliberate change); `addItem` line format `- [name](url) - description` with optional `([Read more](/details/<slug>.md))` suffix, backtick-wrapped tag list joined w/ spaces, BOTH-suffixes ordering (details link THEN tags), missing-tags-or-empty-array no-suffix path; end-to-end document shape (header → ToC → sub-header → items → footer). `github-slugger` is mocked at module scope (it ships ESM-only and Jest's CJS pipeline cannot import it; the mock is a deterministic `lowercase + non-alphanum→'-' + start/end-trim + count++` slugger with the same dedup contract).
+- **`packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts`** (13 tests) — `cleanup` calls `fs.rm(dir, {recursive:true, force:true})` once; `resetFiles` removes every non-allowlisted entry (`README.md`, ad-hoc files, even the `details/` directory itself) then re-creates it via `ensureWorksExist`, with the standard allowlist preserved (`.git`, `.gitignore`, `.github`, `.vscode`, `.env`, `.nvmrc`) PLUS every dotfile starting with `.git` (covers `.gitattributes`, `.gitkeep`, etc. via the `startsWith('.git')` branch), sequential await-per-iteration removal order pinned via shared `order` array, empty-`readdir` still calls `mkdir(details/, recursive:true)`, `readdir`-failure short-circuits without calling `mkdir` or `rm`; `ensureWorksExist` calls `mkdir(detailsPath, {recursive:true})`; `writeReadme`/`writeDetails`/`writeLicense` write `dir/README.md`/`dir/details/<slug>.md`/`dir/LICENSE.md` respectively with `'utf-8'` encoding; `removeDetails` calls `fs.rm` with `{force:true}` ONLY (NOT `recursive:true` — the spec explicitly pins that detail-removal is a file-only operation, not a directory delete); `dir` is exposed as a public readonly property and the `dir → dir/details` derivation is pinned via a custom-dir test. `node:fs/promises` is mocked at module scope so the suite never touches the real filesystem.
+
+Total agent-package suite: 3024 → 3054 tests across 139 → 141 suites, all green.
+
+---
 
 **2026-05-09 — packages/agent BranchSyncService direct coverage (+24 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [#644](https://github.com/ever-works/ever-works/pull/644))**
 

--- a/packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts
+++ b/packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts
@@ -1,0 +1,181 @@
+import { MarkdownRepository } from './markdown-repository';
+import * as path from 'node:path';
+
+jest.mock('node:fs/promises', () => ({
+    rm: jest.fn().mockResolvedValue(undefined),
+    readdir: jest.fn().mockResolvedValue([]),
+    mkdir: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+}));
+
+const fsMock = jest.requireMock('node:fs/promises') as {
+    rm: jest.Mock;
+    readdir: jest.Mock;
+    mkdir: jest.Mock;
+    writeFile: jest.Mock;
+};
+
+describe('MarkdownRepository', () => {
+    const dir = path.join('/tmp', 'work');
+    const detailsDir = path.join(dir, 'details');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        fsMock.rm.mockResolvedValue(undefined);
+        fsMock.readdir.mockResolvedValue([]);
+        fsMock.mkdir.mockResolvedValue(undefined);
+        fsMock.writeFile.mockResolvedValue(undefined);
+    });
+
+    describe('cleanup', () => {
+        it('rms the entire dir recursive+force', async () => {
+            await new MarkdownRepository(dir).cleanup();
+            expect(fsMock.rm).toHaveBeenCalledTimes(1);
+            expect(fsMock.rm).toHaveBeenCalledWith(dir, { recursive: true, force: true });
+        });
+    });
+
+    describe('resetFiles', () => {
+        it('removes every non-allowlisted entry then ensures details/ exists', async () => {
+            fsMock.readdir.mockResolvedValueOnce([
+                'README.md',
+                'old-cache',
+                'details',
+                'random.txt',
+            ] as any);
+
+            await new MarkdownRepository(dir).resetFiles();
+
+            const removed = fsMock.rm.mock.calls.map((c) => c[0]);
+            expect(removed).toEqual([
+                path.join(dir, 'README.md'),
+                path.join(dir, 'old-cache'),
+                path.join(dir, 'details'),
+                path.join(dir, 'random.txt'),
+            ]);
+            for (const call of fsMock.rm.mock.calls) {
+                expect(call[1]).toEqual({ recursive: true, force: true });
+            }
+            expect(fsMock.mkdir).toHaveBeenCalledWith(detailsDir, { recursive: true });
+        });
+
+        it('preserves the standard allowlist + every dotfile starting with ".git"', async () => {
+            fsMock.readdir.mockResolvedValueOnce([
+                '.git',
+                '.gitignore',
+                '.github',
+                '.vscode',
+                '.env',
+                '.nvmrc',
+                '.gitattributes', // covered by `.git*` startsWith branch
+                '.gitkeep', // covered by `.git*` startsWith branch
+                'something.md',
+            ] as any);
+
+            await new MarkdownRepository(dir).resetFiles();
+
+            // Only `something.md` should be removed.
+            expect(fsMock.rm).toHaveBeenCalledTimes(1);
+            expect(fsMock.rm).toHaveBeenCalledWith(path.join(dir, 'something.md'), {
+                recursive: true,
+                force: true,
+            });
+            // Still calls mkdir at the end via ensureWorksExist().
+            expect(fsMock.mkdir).toHaveBeenCalledWith(detailsDir, { recursive: true });
+        });
+
+        it('still ensures details/ exists when readdir returns an empty list', async () => {
+            fsMock.readdir.mockResolvedValueOnce([] as any);
+
+            await new MarkdownRepository(dir).resetFiles();
+
+            expect(fsMock.rm).not.toHaveBeenCalled();
+            expect(fsMock.mkdir).toHaveBeenCalledWith(detailsDir, { recursive: true });
+        });
+
+        it('propagates readdir failure (no mkdir, no rm)', async () => {
+            fsMock.readdir.mockRejectedValueOnce(new Error('ENOENT'));
+
+            await expect(new MarkdownRepository(dir).resetFiles()).rejects.toThrow('ENOENT');
+            expect(fsMock.rm).not.toHaveBeenCalled();
+            expect(fsMock.mkdir).not.toHaveBeenCalled();
+        });
+
+        it('removes entries sequentially in directory-listing order (await per iteration)', async () => {
+            fsMock.readdir.mockResolvedValueOnce(['a', 'b', 'c'] as any);
+            const order: string[] = [];
+            fsMock.rm.mockImplementation(async (target: string) => {
+                order.push(target);
+            });
+
+            await new MarkdownRepository(dir).resetFiles();
+
+            expect(order).toEqual([path.join(dir, 'a'), path.join(dir, 'b'), path.join(dir, 'c')]);
+        });
+    });
+
+    describe('ensureWorksExist', () => {
+        it('mkdirs the details/ subdir recursively', async () => {
+            await new MarkdownRepository(dir).ensureWorksExist();
+            expect(fsMock.mkdir).toHaveBeenCalledWith(detailsDir, { recursive: true });
+        });
+    });
+
+    describe('writeReadme', () => {
+        it('writes README.md at the root with utf-8', async () => {
+            await new MarkdownRepository(dir).writeReadme('# Hello');
+            expect(fsMock.writeFile).toHaveBeenCalledWith(
+                path.join(dir, 'README.md'),
+                '# Hello',
+                'utf-8',
+            );
+        });
+    });
+
+    describe('writeDetails / removeDetails', () => {
+        it('writes details/<slug>.md with utf-8', async () => {
+            await new MarkdownRepository(dir).writeDetails('cool-thing', '# Cool');
+            expect(fsMock.writeFile).toHaveBeenCalledWith(
+                path.join(detailsDir, 'cool-thing.md'),
+                '# Cool',
+                'utf-8',
+            );
+        });
+
+        it('rms the per-slug detail file with force only (NOT recursive)', async () => {
+            await new MarkdownRepository(dir).removeDetails('gone');
+            expect(fsMock.rm).toHaveBeenCalledWith(path.join(detailsDir, 'gone.md'), {
+                force: true,
+            });
+            // Note: explicitly NOT recursive — files only.
+        });
+    });
+
+    describe('writeLicense', () => {
+        it('writes LICENSE.md at the root with utf-8', async () => {
+            await new MarkdownRepository(dir).writeLicense('MIT');
+            expect(fsMock.writeFile).toHaveBeenCalledWith(
+                path.join(dir, 'LICENSE.md'),
+                'MIT',
+                'utf-8',
+            );
+        });
+    });
+
+    describe('contracts', () => {
+        it('exposes the input dir as a public readonly property', () => {
+            const repo = new MarkdownRepository(dir);
+            expect(repo.dir).toBe(dir);
+        });
+
+        it('builds the details/ path from the constructor dir argument', async () => {
+            const customDir = path.join('/srv', 'data');
+            await new MarkdownRepository(customDir).writeDetails('s', 'x');
+            expect(fsMock.writeFile).toHaveBeenCalledWith(
+                path.join(customDir, 'details', 's.md'),
+                'x',
+                'utf-8',
+            );
+        });
+    });
+});

--- a/packages/agent/src/generators/markdown-generator/readme-builder.spec.ts
+++ b/packages/agent/src/generators/markdown-generator/readme-builder.spec.ts
@@ -1,0 +1,229 @@
+// `github-slugger` is shipped as ESM-only, which Jest's CommonJS pipeline
+// cannot parse. Replace it with a tiny deterministic stand-in that mirrors
+// the slugify-with-dedup behaviour the builder relies on (lowercase, runs
+// of non-alphanumeric → `-`, append `-1`/`-2`/... for repeats per instance).
+jest.mock('github-slugger', () => {
+    return class MockGithubSlugger {
+        private seen = new Map<string, number>();
+        slug(input: string): string {
+            const base = input
+                .toLowerCase()
+                .replace(/&/g, '')
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+            const count = this.seen.get(base) ?? 0;
+            this.seen.set(base, count + 1);
+            return count === 0 ? base : `${base}-${count}`;
+        }
+    };
+});
+
+import type { ItemData } from '@ever-works/plugin';
+
+// `readme-builder` instantiates the slugger at module load and never resets
+// it. Across tests, identical headers would otherwise drift to `tools-1`,
+// `tools-2`, etc. Reload the module per test so each scenario starts with a
+// pristine slugger.
+let ReadmeBuilder: typeof import('./readme-builder').ReadmeBuilder;
+beforeEach(() => {
+    jest.isolateModules(() => {
+        ReadmeBuilder = require('./readme-builder').ReadmeBuilder;
+    });
+});
+
+function makeItem(overrides: Partial<ItemData> = {}): ItemData {
+    return {
+        slug: 'foo',
+        name: 'Foo',
+        description: 'A foo',
+        source_url: 'https://foo.test',
+        ...overrides,
+    } as ItemData;
+}
+
+describe('ReadmeBuilder', () => {
+    describe('build envelope', () => {
+        it('emits header + body + footer with empty body', () => {
+            const out = new ReadmeBuilder('HDR', 'FTR').build();
+            expect(out).toBe('HDR\n\nFTR');
+        });
+
+        it('preserves multiline header/footer verbatim', () => {
+            const out = new ReadmeBuilder('# Hello\nLine 2', '> bye').build();
+            expect(out.startsWith('# Hello\nLine 2\n')).toBe(true);
+            expect(out.endsWith('> bye')).toBe(true);
+        });
+    });
+
+    describe('section helpers', () => {
+        it('addHeader emits H1 with two trailing newlines', () => {
+            const out = new ReadmeBuilder('', '').addHeader('Title').build();
+            expect(out).toContain('# Title\n\n');
+        });
+
+        it('addSubHeader emits H2, registers a ToC entry, and is chainable', () => {
+            const builder = new ReadmeBuilder('', '');
+            const ret = builder.addSubHeader('Tools', 12);
+            expect(ret).toBe(builder);
+            const out = builder.enableToC().build();
+            expect(out).toContain('## Tools\n\n');
+            expect(out).toContain('## 📑 Table of Contents');
+            expect(out).toContain('- [Tools (12)](#tools)');
+        });
+
+        it('addParagraph + addNewLine compose with double + single newlines', () => {
+            const out = new ReadmeBuilder('', '')
+                .addParagraph('Para A')
+                .addNewLine()
+                .addParagraph('Para B')
+                .build();
+            // Body ends with the trailing `\n` from build() too.
+            expect(out).toContain('Para A\n\n\nPara B\n\n');
+        });
+
+        it('every section helper is chainable (returns the builder)', () => {
+            const b = new ReadmeBuilder('', '');
+            expect(b.addHeader('h')).toBe(b);
+            expect(b.addParagraph('p')).toBe(b);
+            expect(b.addNewLine()).toBe(b);
+            expect(b.enableToC()).toBe(b);
+        });
+    });
+
+    describe('Table of Contents', () => {
+        it('is omitted when enableToC() is not called', () => {
+            const out = new ReadmeBuilder('H', 'F')
+                .addSubHeader('Tools', 5)
+                .addSubHeader('Libraries', 10)
+                .build();
+            expect(out).not.toContain('Table of Contents');
+            expect(out).toContain('## Tools');
+            expect(out).toContain('## Libraries');
+        });
+
+        it('is rendered with anchor slugs and en-US-formatted counts', () => {
+            const out = new ReadmeBuilder('', '')
+                .enableToC()
+                .addSubHeader('Tools & Utilities', 1234)
+                .addSubHeader('Libraries')
+                .build();
+
+            expect(out).toContain('## 📑 Table of Contents\n\n');
+            // The slugger lowercases, drops `&`, and collapses non-alphanum
+            // runs into single `-` (the exact slug shape comes from
+            // github-slugger; here we assert against a stable substring that
+            // both the real library and our mock agree on).
+            expect(out).toMatch(/- \[Tools & Utilities \(1,234\)\]\(#tools-+utilities\)/);
+            // Count omitted when undefined.
+            expect(out).toContain('- [Libraries](#libraries)');
+            // The body subheaders still render.
+            expect(out).toContain('## Tools & Utilities\n\n');
+            expect(out).toContain('## Libraries\n\n');
+        });
+
+        it('disambiguates duplicate slugs across the document', () => {
+            const out = new ReadmeBuilder('', '')
+                .enableToC()
+                .addSubHeader('Tools')
+                .addSubHeader('Tools')
+                .build();
+            // github-slugger appends -1, -2, ... for repeats.
+            expect(out).toContain('- [Tools](#tools)');
+            expect(out).toContain('- [Tools](#tools-1)');
+        });
+
+        it('renders 0 as "0" not as omitted', () => {
+            const out = new ReadmeBuilder('', '').enableToC().addSubHeader('Empty', 0).build();
+            expect(out).toContain('- [Empty (0)](#empty)');
+        });
+    });
+
+    describe('addItem', () => {
+        it('emits the standard item line without details and with no tags', () => {
+            const out = new ReadmeBuilder('', '').addItem(makeItem()).build();
+            expect(out).toContain('- [Foo](https://foo.test) - A foo\n');
+            expect(out).not.toContain('Read more');
+            expect(out).not.toContain('`');
+        });
+
+        it('appends the details link when hasDetails=true', () => {
+            const out = new ReadmeBuilder('', '')
+                .addItem(makeItem({ slug: 'cool-thing' }), { hasDetails: true })
+                .build();
+            expect(out).toContain(
+                '- [Foo](https://foo.test) - A foo ([Read more](/details/cool-thing.md))',
+            );
+        });
+
+        it('joins tags with spaces and wraps each in backticks', () => {
+            const out = new ReadmeBuilder('', '')
+                .addItem(
+                    makeItem({
+                        tags: [
+                            { name: 'rust', slug: 'rust' },
+                            { name: 'cli', slug: 'cli' },
+                        ] as any,
+                    }),
+                )
+                .build();
+            expect(out).toContain('- [Foo](https://foo.test) - A foo `rust` `cli`');
+        });
+
+        it('emits BOTH the details link AND the tags when both are present', () => {
+            const out = new ReadmeBuilder('', '')
+                .addItem(
+                    makeItem({
+                        slug: 's',
+                        tags: [{ name: 'a', slug: 'a' }] as any,
+                    }),
+                    { hasDetails: true },
+                )
+                .build();
+            expect(out).toContain(
+                '- [Foo](https://foo.test) - A foo ([Read more](/details/s.md)) `a`',
+            );
+        });
+
+        it('skips the tags suffix when tags is missing or empty array', () => {
+            const out1 = new ReadmeBuilder('', '').addItem(makeItem({ tags: [] as any })).build();
+            const out2 = new ReadmeBuilder('', '').addItem(makeItem({ tags: undefined })).build();
+            expect(out1).not.toContain('`');
+            expect(out2).not.toContain('`');
+        });
+
+        it('addItem is chainable for multi-item runs', () => {
+            const b = new ReadmeBuilder('', '');
+            expect(b.addItem(makeItem())).toBe(b);
+            const out = b.addItem(makeItem({ slug: 'b', name: 'Bar' })).build();
+            expect(out).toMatch(/- \[Foo\].*\n- \[Bar\]/);
+        });
+    });
+
+    describe('end-to-end shape', () => {
+        it('produces a sensible README from header → ToC → sections → items → footer', () => {
+            const out = new ReadmeBuilder('# Awesome List', '## License\n\nMIT')
+                .addHeader('Awesome List')
+                .enableToC()
+                .addSubHeader('Tools', 2)
+                .addItem(makeItem({ slug: 'a', name: 'A', description: 'An A' }))
+                .addItem(
+                    makeItem({
+                        slug: 'b',
+                        name: 'B',
+                        description: 'A B',
+                        tags: [{ name: 't', slug: 't' }] as any,
+                    }),
+                    { hasDetails: true },
+                )
+                .build();
+
+            expect(out.startsWith('# Awesome List\n')).toBe(true);
+            expect(out).toContain('## 📑 Table of Contents');
+            expect(out).toContain('- [Tools (2)](#tools)');
+            expect(out).toContain('## Tools');
+            expect(out).toContain('- [A](https://foo.test) - An A');
+            expect(out).toContain('- [B](https://foo.test) - A B ([Read more](/details/b.md)) `t`');
+            expect(out.endsWith('## License\n\nMIT')).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Closes the markdown-generator helper-class zero-coverage gap. The two helpers in `packages/agent/src/generators/markdown-generator/` that previously had no co-located spec — `readme-builder.ts` (87 LOC) and `markdown-repository.ts` (66 LOC) — are now both pinned.
- The 508-LOC `markdown-generator.service.ts` orchestrator is deferred to a dedicated follow-up.
- Total agent-package suite: 3024 → 3054 tests across 139 → 141 suites, all green.

### `readme-builder.spec.ts` — 17 tests

- `build()` envelope: header + body + footer separator; multi-line header/footer preserved verbatim.
- `addHeader`/`addSubHeader`/`addParagraph`/`addNewLine` chainability + double-newline trailing rules.
- `enableToC()` opt-in: default-omitted vs explicit `## 📑 Table of Contents` header; en-US-formatted counts (`1234 → "1,234"`, `0 → "(0)"` not omitted, `undefined → count omitted entirely`); github-slugger duplicate-slug `-1`/`-2`/... disambiguation pinned via per-test `jest.isolateModules()` reload (the source instantiates the slugger at top-level and never calls `.reset()`, so without per-test reload identical headers would drift across tests; current behavior pinned so a future module-level `slugger.reset()` call would be a deliberate change).
- `addItem` line format with optional `([Read more](/details/<slug>.md))` suffix + backtick-wrapped tag list; BOTH-suffix ordering (details THEN tags); missing-or-empty tags no-suffix path.
- End-to-end document shape from header → ToC → items → footer.

`github-slugger` is shipped ESM-only and Jest's CJS pipeline cannot import it; mocked at module scope with a deterministic `lowercase + non-alphanum→'-' + trim + count++` slugger that matches the real dedup contract.

### `markdown-repository.spec.ts` — 13 tests

- `cleanup()` rms the entire dir recursive+force.
- `resetFiles()` preserves the standard allowlist (`.git`, `.gitignore`, `.github`, `.vscode`, `.env`, `.nvmrc`) PLUS every dotfile starting with `.git` (covers `.gitattributes`, `.gitkeep`, etc. via the `startsWith` branch); sequential await-per-iteration removal order pinned; empty-`readdir` still mkdirs `details/`; `readdir`-failure short-circuits without `mkdir` or `rm`.
- `ensureWorksExist` mkdirs `details/` recursively.
- `writeReadme`/`writeDetails`/`writeLicense` utf-8 writes with the correct paths.
- `removeDetails` uses `{force:true}` ONLY (NOT `recursive:true`), pinned explicitly because the helper is intentionally file-only.
- Public readonly `dir` field; the `dir → dir/details` derivation contract is pinned via a custom-dir test.

`node:fs/promises` is mocked at module scope so the suite never touches the real filesystem.

## Test plan

- [x] `cd packages/agent && npx jest --testPathPattern='(readme-builder|markdown-repository).spec.ts' --no-coverage` — 30/30 passing locally
- [x] `cd packages/agent && npx jest --no-coverage` — 3054/3054 passing across 141 suites
- [x] Prettier-clean (`pnpm format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Introduced comprehensive test specification files covering critical system components.

* **Documentation**
  * Updated coverage tracking documentation with expanded inventory snapshot, detailed spec file breakdown, and new closure ledger entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/646)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->