### PR TITLE
test(agent): cover database helpers + enrichment-prompt utils (+64 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -21,10 +21,26 @@
 
 ## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~502 across `apps/` + `packages/` (was 492
-  earlier on 2026-05-09; +10 net spec files in the agent NestJS-module
-  wiring sweep — adds `*.module.spec.ts` for ALL 10 previously-uncovered
-  modules in `packages/agent/src/`: `work-operations`, `notifications`,
+- **Spec files (`*.spec.ts`)**: ~505 across `apps/` + `packages/` (was 502
+  earlier on 2026-05-09; +3 net spec files in the agent
+  database-helpers + enrichment-prompt utility sweep — adds
+  `packages/agent/src/database/utils/helper.spec.ts` (16 tests on
+  `getTlsOptions` + `parseDatabaseUrl`),
+  `packages/agent/src/database/database-config.factory.spec.ts`
+  (27 tests on the 7 documented `DatabaseConfigurations` entries +
+  `createDatabaseModuleWithEnv` env-write contract + cross-config
+  invariant), and `packages/agent/src/import/enrichment-prompt.utils.spec.ts`
+  (21 tests on `buildImportGenerationDto` covering name fallback,
+  hardcoded generation_method/website_repository_creation_method,
+  pluginConfig defaults, providers default-agent-pipeline merging, and
+  the prompt's expansion-factor matrix + four-step header ordering +
+  legal-safety + 30%-cap directives). Closes three previously-uncovered
+  tiny utility files in `packages/agent/src/` covering 279 LOC of
+  source. Total agent-package suite: 3185 → 3249 tests across 154 → 157
+  suites — see `Done` ledger; +10 net spec files in the prior agent
+  NestJS-module wiring sweep — adds `*.module.spec.ts` for ALL 10
+  previously-uncovered modules in `packages/agent/src/`: `work-operations`,
+  `notifications`,
   `activity-log`, `community-pr`, `template-catalog`,
   `comparison-generator`, `pipeline`, `import`,
   `generators/website-generator`, `generators/data-generator`. 50 tests
@@ -174,6 +190,18 @@
 ## Done
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
+
+**2026-05-09 — packages/agent database helpers + import enrichment-prompt utils (+64 tests across 3 new specs, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes three previously-uncovered tiny utility files in `packages/agent/src/`. Each one is a pure-function helper without per-file co-located coverage; together they account for 50 + 137 + 92 = 279 LOC of zero-coverage agent-package source. Three new spec files:
+
+- **`packages/agent/src/database/utils/helper.spec.ts`** (16 tests) — `getTlsOptions` four-branch matrix (`dbSslMode=false` → undefined w/o `console.error` even when a cert is provided; `true` + `undefined` cert → `'DATABASE_CA_CERT is not defined. TLS options cannot be configured.'` console.error + undefined return; `true` + empty-string cert → same console.error path (empty string is falsy); valid base64 → `{rejectUnauthorized:true, ca:<decoded>}` w/o console.error, including a multi-line PEM round-trip; `Buffer.from` rejection swallowed with `'Error decoding DATABASE_CA_CERT:' + error.message` console.error and undefined return — pinned via a `jest.spyOn(Buffer, 'from')` that throws). `parseDatabaseUrl` happy paths (full PostgreSQL URL → `{protocol, username, password, host, port, database, searchParams}` envelope; URL without explicit port → `port: undefined`; MySQL URL with empty password; multiple `&`-joined search params; trailing-slash path → `database: ''`; protocol trailing-colon strip), invalid-URL `null` (both invalid-string and empty-string), and the URL-encoded-credentials passthrough (`us%40er` / `p%40ss` preserved verbatim — caller is responsible for decoding, pinned so a future `decodeURIComponent` wrap is a deliberate change).
+- **`packages/agent/src/database/database-config.factory.spec.ts`** (27 tests) — `createDatabaseModuleWithEnv` (env-write happy path + last-write-wins overwrite + empty-map still returns `DatabaseModule` reference); `DatabaseConfigurations.cli` (`APP_TYPE=cli` + `DATABASE_TYPE=sqlite`); `DatabaseConfigurations.apiDevelopment` (`APP_TYPE=api` + sqlite + `DATABASE_IN_MEMORY=true` + `DATABASE_LOGGING=true`); `DatabaseConfigurations.apiProduction` (no-arg → 4 env vars, no `DATABASE_PATH`; explicit path → `DATABASE_PATH` set; empty-string path → not-set via the `&&`-spread truthy gate); `DatabaseConfigurations.test` (`NODE_ENV=test` + sqlite + logging-off, deliberately does NOT set `DATABASE_IN_MEMORY` so the agent default kicks in); `DatabaseConfigurations.postgres` (url branch sets `DATABASE_URL` and explicitly does NOT also set per-field env vars; logging-omitted → coerced to `'false'`; per-field defaults `localhost`/`5432`/`postgres`/`''`/`ever_works` when no options; per-field overrides land via `String()` on numbers; `port:0` → `'5432'` documenting the `||`-not-`??` semantics so a future `??` widening is a deliberate API change); `DatabaseConfigurations.mysql` (mirror set: url branch with no per-field bleed; logging-off default; per-field defaults `localhost`/`3306`/`root`/`''`/`ever_works`; per-field overrides; `port:0` → `'3306'`); a `cross-configuration contract` `it.each` table pinning that all six configurations return the same `DatabaseModule` reference. The spec mocks `'./database.module'` to a sentinel object so the suite does NOT pull TypeORM/`@nestjs/typeorm` into the JIT and does NOT exercise any module-init side-effect — the factory contract is purely (a) mutate `process.env` and (b) return the static `DatabaseModule` reference. Every spec snapshots/restores 12 tracked env vars in `beforeEach`/`afterEach` so the suite leaves no global state behind.
+- **`packages/agent/src/import/enrichment-prompt.utils.spec.ts`** (21 tests) — `buildImportGenerationDto` envelope (returns a `CreateItemsGeneratorDto` instance, NOT a plain object); name fallback chain (`work.name` truthy wins; `undefined` → `work.slug`; `null` → `work.slug` (`??` not `||` semantics); empty-string `''` → preserved as `''` since `??` does not coerce empty strings — pinned so a future `||` switch is deliberate); hardcoded `generation_method: GenerationMethod.CREATE_UPDATE` and `website_repository_creation_method: WebsiteRepositoryCreationMethod.CREATE_USING_TEMPLATE`; `update_with_pull_request` default-false + explicit-`true` + explicit-`false` (default-arg parameter destructuring contract); `model` verbatim passthrough (undefined or string); `pluginConfig` literal triple `{target_items: 500, max_pages_to_process: 1000, capture_screenshots: true}`; per-call freshness (no shared-mutable-state between two consecutive invocations — both `providers` and `pluginConfig` are fresh objects per call). Providers section: default `{pipeline: 'agent-pipeline'}` when no providers passed; explicit `pipeline` override preserved; passing other keys with no `pipeline` → default-pipeline merged via `??` while sibling keys flow through; full multi-key passthrough preserves `search`/`extract_content`/`ai`. Prompt section: source URL embedded in opening line; default `expansionFactor: 2.5` → `Math.round(100/2.5) = 40` → `'at most 40%'`; custom `expansionFactor: 4` → `25%`; non-integer `expansionFactor: 3` → `Math.round(100/3) = 33` → `'33%'`; all four documented step headers present in document order via `indexOf` ordering check (`## Step 1 — Process source links` → `## Step 2 — Discover more items` → `## Step 3 — Enrich descriptions` → `## Step 4 — Build original taxonomy`); legal-safety guidance present (`'Do NOT copy descriptions or metadata from the source'` + `'legally problematic'`); closing `'Do not stop early'` directive ends with `'exhausted.'`; original-taxonomy 30%-cap directive verbatim. Mocks none — the function is a pure builder; assertions are direct on the returned DTO.
+
+Total agent-package suite: 3185 → 3249 tests across 154 → 157 suites, all green (full run on the branch verified locally before push).
+
+---
 
 **2026-05-09 — packages/agent NestJS-module wiring sweep (+50 tests across 10 new specs, scheduled-task `platform-tests-and-docs` cycle, [#651](https://github.com/ever-works/ever-works/pull/651))**
 

--- a/packages/agent/src/database/database-config.factory.spec.ts
+++ b/packages/agent/src/database/database-config.factory.spec.ts
@@ -1,0 +1,263 @@
+// Mock the DatabaseModule import so this spec stays a pure factory test —
+// it does NOT pull TypeORM / @nestjs/typeorm into the JIT, and does NOT
+// run any module-init side-effect. The factory is contractually meant to
+// (a) mutate process.env and (b) return the SAME DatabaseModule reference,
+// regardless of the input. Mocking the module to a sentinel object lets us
+// assert (b) by reference equality.
+jest.mock('./database.module', () => ({
+    __esModule: true,
+    DatabaseModule: { __mock: 'DatabaseModule' },
+}));
+
+import { createDatabaseModuleWithEnv, DatabaseConfigurations } from './database-config.factory';
+import { DatabaseModule } from './database.module';
+
+describe('database-config.factory', () => {
+    // Snapshot every env var the factory writes so each test starts clean
+    // and the suite leaves no global state behind.
+    const TRACKED_KEYS = [
+        'APP_TYPE',
+        'NODE_ENV',
+        'DATABASE_TYPE',
+        'DATABASE_IN_MEMORY',
+        'DATABASE_LOGGING',
+        'DATABASE_PATH',
+        'DATABASE_URL',
+        'DATABASE_HOST',
+        'DATABASE_PORT',
+        'DATABASE_USERNAME',
+        'DATABASE_PASSWORD',
+        'DATABASE_NAME',
+    ] as const;
+    const ORIGINAL_ENV: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        for (const key of TRACKED_KEYS) {
+            ORIGINAL_ENV[key] = process.env[key];
+            delete process.env[key];
+        }
+    });
+
+    afterEach(() => {
+        for (const key of TRACKED_KEYS) {
+            const original = ORIGINAL_ENV[key];
+            if (original === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = original;
+            }
+        }
+    });
+
+    describe('createDatabaseModuleWithEnv', () => {
+        it('writes every entry into process.env and returns the DatabaseModule reference', () => {
+            const result = createDatabaseModuleWithEnv({
+                APP_TYPE: 'cli',
+                DATABASE_TYPE: 'sqlite',
+                DATABASE_LOGGING: 'true',
+            });
+            expect(process.env.APP_TYPE).toBe('cli');
+            expect(process.env.DATABASE_TYPE).toBe('sqlite');
+            expect(process.env.DATABASE_LOGGING).toBe('true');
+            expect(result).toBe(DatabaseModule);
+        });
+
+        it('overwrites pre-existing env values (last write wins)', () => {
+            process.env.APP_TYPE = 'cli';
+            createDatabaseModuleWithEnv({ APP_TYPE: 'api' });
+            expect(process.env.APP_TYPE).toBe('api');
+        });
+
+        it('returns the SAME DatabaseModule reference even when the env map is empty', () => {
+            expect(createDatabaseModuleWithEnv({})).toBe(DatabaseModule);
+        });
+    });
+
+    describe('DatabaseConfigurations.cli', () => {
+        it('sets APP_TYPE=cli + DATABASE_TYPE=sqlite and returns the DatabaseModule', () => {
+            const result = DatabaseConfigurations.cli();
+            expect(process.env.APP_TYPE).toBe('cli');
+            expect(process.env.DATABASE_TYPE).toBe('sqlite');
+            expect(result).toBe(DatabaseModule);
+        });
+    });
+
+    describe('DatabaseConfigurations.apiDevelopment', () => {
+        it('sets the API + in-memory + logging-on env shape', () => {
+            DatabaseConfigurations.apiDevelopment();
+            expect(process.env.APP_TYPE).toBe('api');
+            expect(process.env.DATABASE_TYPE).toBe('sqlite');
+            expect(process.env.DATABASE_IN_MEMORY).toBe('true');
+            expect(process.env.DATABASE_LOGGING).toBe('true');
+        });
+
+        it('returns the DatabaseModule reference', () => {
+            expect(DatabaseConfigurations.apiDevelopment()).toBe(DatabaseModule);
+        });
+    });
+
+    describe('DatabaseConfigurations.apiProduction', () => {
+        it('sets the API + persistent + logging-off env shape WITHOUT a DATABASE_PATH when no arg is passed', () => {
+            DatabaseConfigurations.apiProduction();
+            expect(process.env.APP_TYPE).toBe('api');
+            expect(process.env.DATABASE_TYPE).toBe('sqlite');
+            expect(process.env.DATABASE_IN_MEMORY).toBe('false');
+            expect(process.env.DATABASE_LOGGING).toBe('false');
+            expect(process.env.DATABASE_PATH).toBeUndefined();
+        });
+
+        it('sets DATABASE_PATH only when the arg is truthy', () => {
+            DatabaseConfigurations.apiProduction('/var/lib/ever-works/db.sqlite');
+            expect(process.env.DATABASE_PATH).toBe('/var/lib/ever-works/db.sqlite');
+        });
+
+        it('does NOT set DATABASE_PATH when the arg is the empty string (falsy)', () => {
+            DatabaseConfigurations.apiProduction('');
+            expect(process.env.DATABASE_PATH).toBeUndefined();
+        });
+    });
+
+    describe('DatabaseConfigurations.test', () => {
+        it('sets NODE_ENV=test + sqlite + logging-off', () => {
+            DatabaseConfigurations.test();
+            expect(process.env.NODE_ENV).toBe('test');
+            expect(process.env.DATABASE_TYPE).toBe('sqlite');
+            expect(process.env.DATABASE_LOGGING).toBe('false');
+        });
+
+        it('does NOT set DATABASE_IN_MEMORY (relies on agent default)', () => {
+            DatabaseConfigurations.test();
+            expect(process.env.DATABASE_IN_MEMORY).toBeUndefined();
+        });
+    });
+
+    describe('DatabaseConfigurations.postgres', () => {
+        it('uses DATABASE_URL when options.url is provided (skips host/port/etc.)', () => {
+            DatabaseConfigurations.postgres({
+                url: 'postgres://u:p@db.example.com:6432/app',
+                logging: true,
+            });
+            expect(process.env.APP_TYPE).toBe('api');
+            expect(process.env.DATABASE_TYPE).toBe('postgres');
+            expect(process.env.DATABASE_URL).toBe('postgres://u:p@db.example.com:6432/app');
+            expect(process.env.DATABASE_LOGGING).toBe('true');
+            // The url branch must NOT also set the per-field env vars.
+            expect(process.env.DATABASE_HOST).toBeUndefined();
+            expect(process.env.DATABASE_PORT).toBeUndefined();
+            expect(process.env.DATABASE_USERNAME).toBeUndefined();
+            expect(process.env.DATABASE_PASSWORD).toBeUndefined();
+            expect(process.env.DATABASE_NAME).toBeUndefined();
+        });
+
+        it('coerces logging to "false" when omitted from the url branch', () => {
+            DatabaseConfigurations.postgres({ url: 'postgres://localhost/db' });
+            expect(process.env.DATABASE_LOGGING).toBe('false');
+        });
+
+        it('uses the per-field defaults when no options object is passed', () => {
+            DatabaseConfigurations.postgres();
+            expect(process.env.APP_TYPE).toBe('api');
+            expect(process.env.DATABASE_TYPE).toBe('postgres');
+            expect(process.env.DATABASE_HOST).toBe('localhost');
+            expect(process.env.DATABASE_PORT).toBe('5432');
+            expect(process.env.DATABASE_USERNAME).toBe('postgres');
+            expect(process.env.DATABASE_PASSWORD).toBe('');
+            expect(process.env.DATABASE_NAME).toBe('ever_works');
+            expect(process.env.DATABASE_LOGGING).toBe('false');
+            expect(process.env.DATABASE_URL).toBeUndefined();
+        });
+
+        it('overrides every per-field default when options are provided', () => {
+            DatabaseConfigurations.postgres({
+                host: 'pg.internal',
+                port: 6543,
+                username: 'app',
+                password: 's3cret',
+                databaseName: 'ever_works_prod',
+                logging: true,
+            });
+            expect(process.env.DATABASE_HOST).toBe('pg.internal');
+            expect(process.env.DATABASE_PORT).toBe('6543');
+            expect(process.env.DATABASE_USERNAME).toBe('app');
+            expect(process.env.DATABASE_PASSWORD).toBe('s3cret');
+            expect(process.env.DATABASE_NAME).toBe('ever_works_prod');
+            expect(process.env.DATABASE_LOGGING).toBe('true');
+        });
+
+        it('preserves a literal `0` port via the `||` fallback (defaults to 5432 because 0 is falsy)', () => {
+            // This pins the current `||` semantics — port: 0 falls through to
+            // the default. A future refactor to `??` would let 0 through and
+            // is therefore a deliberate API change.
+            DatabaseConfigurations.postgres({ port: 0 });
+            expect(process.env.DATABASE_PORT).toBe('5432');
+        });
+    });
+
+    describe('DatabaseConfigurations.mysql', () => {
+        it('uses DATABASE_URL when options.url is provided (skips host/port/etc.)', () => {
+            DatabaseConfigurations.mysql({
+                url: 'mysql://root:secret@db.example.com:3306/app',
+                logging: true,
+            });
+            expect(process.env.APP_TYPE).toBe('api');
+            expect(process.env.DATABASE_TYPE).toBe('mysql');
+            expect(process.env.DATABASE_URL).toBe('mysql://root:secret@db.example.com:3306/app');
+            expect(process.env.DATABASE_LOGGING).toBe('true');
+            expect(process.env.DATABASE_HOST).toBeUndefined();
+            expect(process.env.DATABASE_PORT).toBeUndefined();
+        });
+
+        it('coerces logging to "false" when omitted from the url branch', () => {
+            DatabaseConfigurations.mysql({ url: 'mysql://localhost/db' });
+            expect(process.env.DATABASE_LOGGING).toBe('false');
+        });
+
+        it('uses the per-field defaults when no options object is passed', () => {
+            DatabaseConfigurations.mysql();
+            expect(process.env.APP_TYPE).toBe('api');
+            expect(process.env.DATABASE_TYPE).toBe('mysql');
+            expect(process.env.DATABASE_HOST).toBe('localhost');
+            expect(process.env.DATABASE_PORT).toBe('3306');
+            expect(process.env.DATABASE_USERNAME).toBe('root');
+            expect(process.env.DATABASE_PASSWORD).toBe('');
+            expect(process.env.DATABASE_NAME).toBe('ever_works');
+            expect(process.env.DATABASE_LOGGING).toBe('false');
+            expect(process.env.DATABASE_URL).toBeUndefined();
+        });
+
+        it('overrides every per-field default when options are provided', () => {
+            DatabaseConfigurations.mysql({
+                host: 'mysql.internal',
+                port: 33060,
+                username: 'app',
+                password: 's3cret',
+                databaseName: 'ever_works_prod',
+                logging: true,
+            });
+            expect(process.env.DATABASE_HOST).toBe('mysql.internal');
+            expect(process.env.DATABASE_PORT).toBe('33060');
+            expect(process.env.DATABASE_USERNAME).toBe('app');
+            expect(process.env.DATABASE_PASSWORD).toBe('s3cret');
+            expect(process.env.DATABASE_NAME).toBe('ever_works_prod');
+            expect(process.env.DATABASE_LOGGING).toBe('true');
+        });
+
+        it('preserves a literal `0` port via the `||` fallback (defaults to 3306 because 0 is falsy)', () => {
+            DatabaseConfigurations.mysql({ port: 0 });
+            expect(process.env.DATABASE_PORT).toBe('3306');
+        });
+    });
+
+    describe('cross-configuration contract', () => {
+        it.each([
+            ['cli', () => DatabaseConfigurations.cli()],
+            ['apiDevelopment', () => DatabaseConfigurations.apiDevelopment()],
+            ['apiProduction', () => DatabaseConfigurations.apiProduction()],
+            ['test', () => DatabaseConfigurations.test()],
+            ['postgres', () => DatabaseConfigurations.postgres()],
+            ['mysql', () => DatabaseConfigurations.mysql()],
+        ])('%s returns the same DatabaseModule reference', (_name, run) => {
+            expect(run()).toBe(DatabaseModule);
+        });
+    });
+});

--- a/packages/agent/src/database/utils/helper.spec.ts
+++ b/packages/agent/src/database/utils/helper.spec.ts
@@ -1,0 +1,168 @@
+import { getTlsOptions, parseDatabaseUrl } from './helper';
+
+describe('database/utils/helper', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('getTlsOptions', () => {
+        it('returns undefined when SSL mode is disabled', () => {
+            expect(getTlsOptions(false, undefined)).toBeUndefined();
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('returns undefined and short-circuits before reading the cert when SSL mode is disabled even with a cert provided', () => {
+            const result = getTlsOptions(false, 'aGVsbG8=');
+            expect(result).toBeUndefined();
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('logs an error and returns undefined when SSL mode is enabled but no CA cert is provided', () => {
+            expect(getTlsOptions(true, undefined)).toBeUndefined();
+            expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'DATABASE_CA_CERT is not defined. TLS options cannot be configured.',
+            );
+        });
+
+        it('logs the same error and returns undefined when caCertBase64 is the empty string (falsy)', () => {
+            expect(getTlsOptions(true, '')).toBeUndefined();
+            expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'DATABASE_CA_CERT is not defined. TLS options cannot be configured.',
+            );
+        });
+
+        it('decodes a valid base64 cert into the rejectUnauthorized + ca shape', () => {
+            // "hello" → base64 "aGVsbG8="
+            const result = getTlsOptions(true, 'aGVsbG8=');
+            expect(result).toEqual({
+                rejectUnauthorized: true,
+                ca: 'hello',
+            });
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('decodes a multi-line PEM cert preserving newlines', () => {
+            const pem =
+                '-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIQ\n-----END CERTIFICATE-----\n';
+            const encoded = Buffer.from(pem, 'ascii').toString('base64');
+            const result = getTlsOptions(true, encoded);
+            expect(result).toEqual({
+                rejectUnauthorized: true,
+                ca: pem,
+            });
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('catches Buffer-decode failures and logs an error returning undefined', () => {
+            const fromSpy = jest.spyOn(Buffer, 'from').mockImplementation(() => {
+                throw new Error('boom');
+            });
+            try {
+                expect(getTlsOptions(true, 'aGVsbG8=')).toBeUndefined();
+                expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+                expect(consoleErrorSpy).toHaveBeenCalledWith(
+                    'Error decoding DATABASE_CA_CERT:',
+                    'boom',
+                );
+            } finally {
+                fromSpy.mockRestore();
+            }
+        });
+    });
+
+    describe('parseDatabaseUrl', () => {
+        it('parses a fully-qualified PostgreSQL URL into all fields', () => {
+            const result = parseDatabaseUrl('postgres://user:pass@host:5432/mydb?ssl=true');
+            expect(result).toEqual({
+                protocol: 'postgres',
+                username: 'user',
+                password: 'pass',
+                host: 'host',
+                port: 5432,
+                database: 'mydb',
+                searchParams: { ssl: 'true' },
+            });
+        });
+
+        it('returns undefined port when the URL has no explicit port', () => {
+            const result = parseDatabaseUrl('postgres://user:pass@host/mydb');
+            expect(result).toEqual({
+                protocol: 'postgres',
+                username: 'user',
+                password: 'pass',
+                host: 'host',
+                port: undefined,
+                database: 'mydb',
+                searchParams: {},
+            });
+        });
+
+        it('parses a MySQL URL', () => {
+            const result = parseDatabaseUrl('mysql://root:@localhost:3306/ever_works');
+            expect(result).toEqual({
+                protocol: 'mysql',
+                username: 'root',
+                password: '',
+                host: 'localhost',
+                port: 3306,
+                database: 'ever_works',
+                searchParams: {},
+            });
+        });
+
+        it('captures multiple search params', () => {
+            const result = parseDatabaseUrl(
+                'postgres://u:p@host:5432/db?ssl=true&sslmode=require&pool=20',
+            );
+            expect(result).toEqual({
+                protocol: 'postgres',
+                username: 'u',
+                password: 'p',
+                host: 'host',
+                port: 5432,
+                database: 'db',
+                searchParams: {
+                    ssl: 'true',
+                    sslmode: 'require',
+                    pool: '20',
+                },
+            });
+        });
+
+        it('returns an empty database string when the path is just a slash', () => {
+            const result = parseDatabaseUrl('postgres://u:p@host:5432/');
+            expect(result?.database).toBe('');
+        });
+
+        it('strips the trailing colon from the protocol', () => {
+            const result = parseDatabaseUrl('postgres://u:p@host:5432/db');
+            expect(result?.protocol).toBe('postgres');
+        });
+
+        it('returns null for an invalid URL', () => {
+            expect(parseDatabaseUrl('not a url at all')).toBeNull();
+        });
+
+        it('returns null for the empty string', () => {
+            expect(parseDatabaseUrl('')).toBeNull();
+        });
+
+        it('handles URL-encoded credentials by passing them through verbatim from URL parser', () => {
+            // The URL parser keeps username/password URL-encoded as-is — the
+            // caller is responsible for decoding (this test pins that
+            // current behaviour so a future decodeURIComponent change is
+            // a deliberate one).
+            const result = parseDatabaseUrl('postgres://us%40er:p%40ss@host:5432/db');
+            expect(result?.username).toBe('us%40er');
+            expect(result?.password).toBe('p%40ss');
+        });
+    });
+});

--- a/packages/agent/src/import/enrichment-prompt.utils.spec.ts
+++ b/packages/agent/src/import/enrichment-prompt.utils.spec.ts
@@ -1,0 +1,269 @@
+import { buildImportGenerationDto } from './enrichment-prompt.utils';
+import {
+    CreateItemsGeneratorDto,
+    GenerationMethod,
+    WebsiteRepositoryCreationMethod,
+} from '@src/items-generator/dto';
+import type { Work } from '@src/entities/work.entity';
+
+const makeWork = (overrides: Partial<Work> = {}): Work => {
+    return {
+        id: 'work-1',
+        name: 'Awesome Tools',
+        slug: 'awesome-tools',
+        ...overrides,
+    } as Work;
+};
+
+describe('buildImportGenerationDto', () => {
+    it('returns a CreateItemsGeneratorDto instance', () => {
+        const dto = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://github.com/example/awesome',
+        });
+        expect(dto).toBeInstanceOf(CreateItemsGeneratorDto);
+    });
+
+    it('uses work.name when present and falls back to work.slug otherwise', () => {
+        const namedDto = buildImportGenerationDto({
+            work: makeWork({ name: 'Awesome Tools' }),
+            sourceUrl: 'https://x',
+        });
+        expect(namedDto.name).toBe('Awesome Tools');
+
+        const slugDto = buildImportGenerationDto({
+            work: makeWork({ name: undefined }),
+            sourceUrl: 'https://x',
+        });
+        expect(slugDto.name).toBe('awesome-tools');
+    });
+
+    it('treats null work.name like undefined and falls back to slug', () => {
+        // The source uses `work.name ?? work.slug` so a `null` should also
+        // fall through to the slug — pin this so a future refactor to `||`
+        // (which would also catch the empty string) is a deliberate change.
+        const dto = buildImportGenerationDto({
+            work: makeWork({ name: null as unknown as string }),
+            sourceUrl: 'https://x',
+        });
+        expect(dto.name).toBe('awesome-tools');
+    });
+
+    it('preserves an empty-string work.name (??-not-||) — does NOT fall back to slug', () => {
+        const dto = buildImportGenerationDto({
+            work: makeWork({ name: '' }),
+            sourceUrl: 'https://x',
+        });
+        expect(dto.name).toBe('');
+    });
+
+    it('hardcodes generation_method to CREATE_UPDATE and template-based website creation', () => {
+        const dto = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://x',
+        });
+        expect(dto.generation_method).toBe(GenerationMethod.CREATE_UPDATE);
+        expect(dto.website_repository_creation_method).toBe(
+            WebsiteRepositoryCreationMethod.CREATE_USING_TEMPLATE,
+        );
+    });
+
+    it('defaults update_with_pull_request to false and accepts an explicit override', () => {
+        expect(
+            buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            }).update_with_pull_request,
+        ).toBe(false);
+
+        expect(
+            buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                updateWithPullRequest: true,
+            }).update_with_pull_request,
+        ).toBe(true);
+
+        expect(
+            buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                updateWithPullRequest: false,
+            }).update_with_pull_request,
+        ).toBe(false);
+    });
+
+    it('forwards model verbatim (including undefined)', () => {
+        const undefinedDto = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://x',
+        });
+        expect(undefinedDto.model).toBeUndefined();
+
+        const explicitDto = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://x',
+            model: 'gpt-5.1',
+        });
+        expect(explicitDto.model).toBe('gpt-5.1');
+    });
+
+    it('hardcodes pluginConfig defaults (target_items=500, max_pages_to_process=1000, capture_screenshots=true)', () => {
+        const dto = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://x',
+        });
+        expect(dto.pluginConfig).toEqual({
+            target_items: 500,
+            max_pages_to_process: 1000,
+            capture_screenshots: true,
+        });
+    });
+
+    describe('providers', () => {
+        it('falls back to the default agent-pipeline when no providers are passed', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            });
+            expect(dto.providers).toEqual({ pipeline: 'agent-pipeline' });
+        });
+
+        it('preserves a caller-provided pipeline override', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                providers: { pipeline: 'standard-pipeline' },
+            });
+            expect(dto.providers?.pipeline).toBe('standard-pipeline');
+        });
+
+        it('uses the default pipeline when providers is passed but pipeline is undefined', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                providers: { search: 'tavily' } as never,
+            });
+            expect(dto.providers?.pipeline).toBe('agent-pipeline');
+            // Other passed provider keys are merged through verbatim.
+            expect((dto.providers as { search?: string }).search).toBe('tavily');
+        });
+
+        it('forwards every other provider key from the input verbatim', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                providers: {
+                    search: 'tavily',
+                    extract_content: 'firecrawl',
+                    ai: 'openai',
+                } as never,
+            });
+            expect(dto.providers).toEqual({
+                pipeline: 'agent-pipeline',
+                search: 'tavily',
+                extract_content: 'firecrawl',
+                ai: 'openai',
+            });
+        });
+    });
+
+    describe('prompt', () => {
+        it('embeds the source URL in the opening line', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://github.com/example/awesome-list',
+            });
+            expect(dto.prompt).toContain(
+                'Build a comprehensive work using this awesome list as your research starting point: https://github.com/example/awesome-list',
+            );
+        });
+
+        it('uses the default expansion factor of 2.5 → max source pct 40', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            });
+            expect(dto.prompt).toContain('Source items must represent at most 40% of the final');
+        });
+
+        it('rounds the maxSourcePct from a custom expansion factor (factor=4 → 25%)', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                expansionFactor: 4,
+            });
+            expect(dto.prompt).toContain('Source items must represent at most 25% of the final');
+        });
+
+        it('rounds the maxSourcePct from a non-integer expansion factor (factor=3 → 33%)', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+                expansionFactor: 3,
+            });
+            // Math.round(100/3) = 33
+            expect(dto.prompt).toContain('Source items must represent at most 33% of the final');
+        });
+
+        it('contains all four documented step headers in order', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            });
+            const prompt = dto.prompt as string;
+            const step1 = prompt.indexOf('## Step 1 — Process source links');
+            const step2 = prompt.indexOf('## Step 2 — Discover more items');
+            const step3 = prompt.indexOf('## Step 3 — Enrich descriptions');
+            const step4 = prompt.indexOf('## Step 4 — Build original taxonomy');
+            expect(step1).toBeGreaterThanOrEqual(0);
+            expect(step2).toBeGreaterThan(step1);
+            expect(step3).toBeGreaterThan(step2);
+            expect(step4).toBeGreaterThan(step3);
+        });
+
+        it('contains the legal-safety guidance about not copying descriptions', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            });
+            expect(dto.prompt).toContain('Do NOT copy descriptions or metadata from the source');
+            expect(dto.prompt).toContain('legally problematic');
+        });
+
+        it('contains the "do not stop early" directive at the end', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            });
+            expect(dto.prompt?.trimEnd().endsWith('exhausted.')).toBe(true);
+            expect(dto.prompt).toContain('Do not stop early');
+        });
+
+        it('contains the original-taxonomy 30% cap directive', () => {
+            const dto = buildImportGenerationDto({
+                work: makeWork(),
+                sourceUrl: 'https://x',
+            });
+            expect(dto.prompt).toContain(
+                "The source's categories/tags should be at most 30% of the final taxonomy.",
+            );
+        });
+    });
+
+    it('builds a fresh DTO instance per call (no shared mutable state across invocations)', () => {
+        const a = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://a',
+        });
+        const b = buildImportGenerationDto({
+            work: makeWork(),
+            sourceUrl: 'https://b',
+        });
+        expect(a).not.toBe(b);
+        expect(a.providers).not.toBe(b.providers);
+        expect(a.pluginConfig).not.toBe(b.pluginConfig);
+        expect(a.prompt).toContain('https://a');
+        expect(b.prompt).toContain('https://b');
+    });
+});


### PR DESCRIPTION
## Summary

Closes three previously-uncovered tiny utility files in `packages/agent/src/` covering 279 LOC of zero-coverage agent-package source.

- `packages/agent/src/database/utils/helper.spec.ts` (16 tests) — `getTlsOptions` four-branch matrix + `parseDatabaseUrl` happy/error paths (URL-encoded credentials passthrough pinned).
- `packages/agent/src/database/database-config.factory.spec.ts` (27 tests) — all 7 `DatabaseConfigurations` entries + `createDatabaseModuleWithEnv` + cross-config invariant. Mocks `./database.module` to a sentinel so the suite does not pull TypeORM into the JIT.
- `packages/agent/src/import/enrichment-prompt.utils.spec.ts` (21 tests) — `buildImportGenerationDto` envelope + name fallback + providers default-pipeline + prompt expansion-factor matrix + four-step header ordering.

## Coverage delta

- Total agent-package suite: 3185 → 3249 tests across 154 → 157 suites, all green.
- All 3 new specs run individually + the full suite was run end-to-end before push.
- Closes the per-file zero-coverage gap on these three tiny utility files.

## Notes

This continues the [#651](https://github.com/ever-works/ever-works/pull/651) hourly sweep — was originally bundled in that PR but auto-merge picked up the prior commit before this commit could be appended, so it is shipping as a follow-up.

## Test plan

- [x] `npx jest --testPathPattern='helper.spec'` (16 tests — green)
- [x] `npx jest --testPathPattern='database-config.factory.spec'` (27 tests — green)
- [x] `npx jest --testPathPattern='enrichment-prompt.utils.spec'` (21 tests — green)
- [x] `pnpm test` from `packages/agent` (3249 tests / 157 suites — green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)