### PR TITLE
test(agent): cover sanitize.util directly (+54 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -21,152 +21,167 @@
 
 ## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~505 across `apps/` + `packages/` (was 502
-  earlier on 2026-05-09; +3 net spec files in the agent
-  database-helpers + enrichment-prompt utility sweep — adds
-  `packages/agent/src/database/utils/helper.spec.ts` (16 tests on
-  `getTlsOptions` + `parseDatabaseUrl`),
-  `packages/agent/src/database/database-config.factory.spec.ts`
-  (27 tests on the 7 documented `DatabaseConfigurations` entries +
-  `createDatabaseModuleWithEnv` env-write contract + cross-config
-  invariant), and `packages/agent/src/import/enrichment-prompt.utils.spec.ts`
-  (21 tests on `buildImportGenerationDto` covering name fallback,
-  hardcoded generation_method/website_repository_creation_method,
-  pluginConfig defaults, providers default-agent-pipeline merging, and
-  the prompt's expansion-factor matrix + four-step header ordering +
-  legal-safety + 30%-cap directives). Closes three previously-uncovered
-  tiny utility files in `packages/agent/src/` covering 279 LOC of
-  source. Total agent-package suite: 3185 → 3249 tests across 154 → 157
-  suites — see `Done` ledger; +10 net spec files in the prior agent
-  NestJS-module wiring sweep — adds `*.module.spec.ts` for ALL 10
-  previously-uncovered modules in `packages/agent/src/`: `work-operations`,
-  `notifications`,
-  `activity-log`, `community-pr`, `template-catalog`,
-  `comparison-generator`, `pipeline`, `import`,
-  `generators/website-generator`, `generators/data-generator`. 50 tests
-  across the 10 specs pinning the standard `Reflect.getMetadata`-based
-  provider/exports/imports shape (with documented per-module length
-  invariants so a silent extra-import is a deliberate change), plus
-  barrel re-exports where present. Each spec mocks transitive
-  ESM-only / TypeORM-pulling dependencies (`DatabaseModule`,
-  `FacadesModule`, `data-generator.service` w/ `p-map`, etc.) at module
-  scope — same pattern as the existing `markdown-generator.module.spec.ts`
-  / `account-transfer.module.spec.ts` / `subscriptions.module.spec.ts`.
-  This closes the agent-package NestJS-module zero-coverage gap entirely
-  (every `*.module.ts` under `packages/agent/src/` now has a co-located
-  spec). Highlights: `WorkOperationsModule`'s deliberate
-  `DatabaseModule` re-export pinned; `CommunityPrModule`'s
-  `DistributedTaskLockService` provided locally but NOT exported pinned;
-  `DataGeneratorModule`'s `WorksConfigService`/`WorksConfigWriterService`
-  helpers provided but NOT exported pinned; `PipelineModule`'s
-  intentional non-import of `PluginsModule` (which is `forRoot`-global)
-  pinned; — see `Done` ledger; +2 net spec files
-  in the prior agent `MarkdownGeneratorService` direct-coverage sweep — adds
-  `packages/agent/src/generators/markdown-generator/markdown-generator.service.spec.ts`
-  (49 tests on the 508-LOC orchestrator) and
-  `packages/agent/src/generators/markdown-generator/markdown-generator.module.spec.ts`
-  (5 tests pinning the module providers/exports + barrel runtime symbols),
-  closing the per-file zero-coverage gap inside
-  `packages/agent/src/generators/markdown-generator/` for the orchestrator
-  surface — see `Done` ledger; +1 net spec file in the prior agent
-  `WebsiteUpdateService` direct-coverage sweep — adds
-  `packages/agent/src/generators/website-generator/website-update.service.spec.ts`
-  (26 tests covering `updateRepository` duplicate-then-template
-  fallback chain w/ wrapped "All update methods failed" rethrow,
-  `options.branch` override + `getLatestCommit` null-coercion +
-  falsy-`branchSync` coercion; `ensureTemplateDefaultBranch`
-  best-effort warn-and-continue across listing-fail / branch-missing
-  / non-Error rejection / `updateRepository`-fail; thin
-  `syncAllBranchesFromTemplate` delegate; `checkForUpdate`
-  four-branch projection w/ beta-branch path; private `updateFork`
-  pinned via reflection; `copyRepositoryFiles` `.git`-skip +
-  recursive subdir mirror w/ rm-rejection swallowed), closing the
-  per-file zero-coverage gap inside
-  `packages/agent/src/generators/website-generator/` for the update
-  surface — see `Done` ledger; +2 net spec files in the prior agent
-  markdown-generator helper-class sweep — adds
-  `packages/agent/src/generators/markdown-generator/readme-builder.spec.ts`
-  (17 tests on the fluent `ReadmeBuilder` builder — `addHeader`/`addSubHeader`/`addParagraph`/`addNewLine` chaining,
-  `enableToC()` opt-in rendering w/ `## 📑 Table of Contents`
-    - en-US-formatted counts + duplicate-slug `-1`/`-2` disambiguation
-      via github-slugger + `0` rendered as `(0)` not omitted, `addItem`
-      format `- [name](url) - description` + optional `([Read more](/details/<slug>.md))` + backtick-wrapped tag
-      list joined w/ spaces, end-to-end document shape) and
-      `packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts`
-      (13 tests on the on-disk repository helper — `cleanup` recursive
-      `rm`, `resetFiles` allowlist (`.git`, `.gitignore`, `.github`,
-      `.vscode`, `.env`, `.nvmrc`, plus every dotfile starting with
-      `.git`) + sequential await-per-iteration removal order +
-      `readdir`-failure short-circuit, `ensureWorksExist` recursive
-      mkdir of `details/`, `writeReadme`/`writeDetails`/`writeLicense`
-      utf-8 writes, `removeDetails` rm with `force:true` only — NOT
-      recursive, the public readonly `dir` field, and the `dir` →
-      `dir/details` derivation contract — `node:fs/promises` is mocked at
-      module scope so the suite never touches the real filesystem),
-      closing the markdown-generator helper-class zero-coverage gap (the
-      remaining file in the subdir is `markdown-generator.service.ts`,
-      508 LOC, deferred to a dedicated follow-up) — see `Done` ledger;
-      +1 net spec file in the prior agent
-      `BranchSyncService` direct-coverage sweep — adds
-      `packages/agent/src/generators/website-generator/branch-sync.service.spec.ts`
-      (24 tests covering `syncBranch` clone-rename-replaceRemote-push-cleanup
-      pipeline + temp-dir cleanup on failure paths, `syncAllBranches`
-      branch-mapping expansion + skip-mapped-target rule + sequential
-      `MAX_CONCURRENT_SYNCS=1` semantics + per-batch 1000ms inter-batch
-      delay + `Promise.allSettled` rejection-to-error-result coercion +
-      optional `cleanupExtraBranches` purge w/ swallowed delete failures
-        - warn-and-return-early on `listBranches` failure, `syncFromTemplate`
-          beta-branch-mapping construction + outer try/catch null fallback +
-          resolveForWork-rethrow pin), closing the per-file zero-coverage gap
-          inside `packages/agent/src/generators/website-generator/` for the
-          branch-sync surface — see `Done` ledger; +2 net spec files in the
-          earlier agent `BaseFacadeService`/`FacadesModule` direct-coverage
-          sweep — adds
-          `packages/agent/src/facades/__tests__/base.facade.spec.ts` (66 tests
-          on the abstract base via a `TestFacadeService extends BaseFacadeService`
-          re-exposer) and `packages/agent/src/facades/__tests__/facades.module.spec.ts`
-          (9 tests pinning the module providers/exports + barrel runtime symbols),
-          closing the per-file zero-coverage gap inside `packages/agent/src/facades/`
-          — see `Done` ledger; +0 net spec files in the WorkGenerationService
-          orchestrators follow-up sweep — extends the existing
-          `services/__tests__/work-generation.service.spec.ts` from 126 → 172
-          tests, closing the previously-pending 7 multi-step pipeline orchestrators
-          (`processGeneration` / `executeGenerationPipeline` / `finalizeGeneration` /
-          `runInProcessGeneration` / `prepareProviders` /
-          `ensureProvidersEnabledForWork` / `dispatchGenerationTask`) — see `Done`
-          ledger; **the WorkGenerationService private-orchestrator zero-coverage
-          gap is now empty.** The earlier 2026-05-09 sweep covered 7 simpler
-          helpers: `resolveGenerationFinalStatus` / `resolveGenerationErrorMessage` /
-          `buildScheduleRunOutcome` / `isNonFatalWebsiteGenerationError` /
-          `markGenerationStarted` / `finalizeCancelledGeneration` /
-          `handleErrorNotification`; +1 packages/agent service spec landed 2026-05-09
-          in the small-service coverage sweep #6 — `WorkGenerationService` (focused
-          first sweep covering wrapper / simpler methods) — see `Done` ledger; +1 packages/agent service spec
-          landed earlier 2026-05-09
-          in the small-service coverage sweep #5 — `ItemHealthService` — see
-          `Done` ledger;
-          +1 packages/agent service spec landed earlier 2026-05-09
-          in the small-service coverage sweep #4 — `WorkTaxonomyService` — see
-          `Done` ledger;
-          +1 packages/agent service spec landed earlier 2026-05-09
-          in the small-service coverage sweep #3 — `WorkMemberService` — see
-          `Done` ledger;
-          +3 packages/agent service specs landed earlier 2026-05-09
-          in the small-service coverage sweep #2 — `ItemSourceValidationSchedulerService` +
-          `WorkDetailService` + `RepositoryManagementService` — see `Done` ledger;
-          +2 packages/agent service specs landed earlier 2026-05-09
-          in the small-service coverage sweep — `WorkAdvancedPromptsService` +
-          `WorkWebsiteRepositoryStateService` — see `Done` ledger;
-          +1 prior packages/agent service spec landed 2026-05-09
-          in the WorkOwnershipService sweep — see `Done` ledger; +4 packages/agent
-          repository specs landed earlier 2026-05-09
-          in sweep #3: activity-log + notification + work-member + work — closing the
-          agent-package repository zero-coverage gap entirely; +4 in the previous
-          sweep #2: work-custom-domain + user + conversation + template; +8 in
-          the prior sweep — subscription-plan + work-advanced-prompts +
-          user-template-preference + user-subscription + usage-ledger +
-          webhook-subscription + refresh-token + onboarding-request. See `Done`
-          for the running ledger).
+- **Spec files (`*.spec.ts`)**: ~506 across `apps/` + `packages/` (was 505
+  earlier on 2026-05-09; +1 net spec file in the agent `sanitize.util`
+  direct-coverage sweep — adds
+  `packages/agent/src/utils/__tests__/sanitize.util.spec.ts` (54 tests
+  on the security-critical 213-LOC sanitization utility — `sanitizeText`
+  default-options matrix + every override toggle independently pinned +
+  the `maxLength:0` falsy-zero gotcha + documented operation order
+  control-strip → newline-replace → collapse → trim → maxLength;
+  `sanitizeDescription` 500-char cap; `sanitizeName` 100-char cap;
+  `sanitizePrompt` 5000-char cap w/ newlines AND multi-space runs
+  preserved; `sanitizeObject` recursive walk w/ non-mutation guarantee
+    - array-element recursion + null-guard; `sanitizeStringTransform`
+      and `sanitizeDescriptionTransform` class-transformer adapters;
+      `sanitizeStringArray` falsy/non-array → `[]` + per-entry sanitise +
+      post-filter empty-string drop), closing the security-critical
+      zero-coverage gap on the most-imported utility in the agent package
+      — see `Done` ledger; +3 net spec files in the prior agent
+      database-helpers + enrichment-prompt utility sweep — adds
+      `packages/agent/src/database/utils/helper.spec.ts` (16 tests on
+      `getTlsOptions` + `parseDatabaseUrl`),
+      `packages/agent/src/database/database-config.factory.spec.ts`
+      (27 tests on the 7 documented `DatabaseConfigurations` entries +
+      `createDatabaseModuleWithEnv` env-write contract + cross-config
+      invariant), and `packages/agent/src/import/enrichment-prompt.utils.spec.ts`
+      (21 tests on `buildImportGenerationDto` covering name fallback,
+      hardcoded generation_method/website_repository_creation_method,
+      pluginConfig defaults, providers default-agent-pipeline merging, and
+      the prompt's expansion-factor matrix + four-step header ordering +
+      legal-safety + 30%-cap directives). Closes three previously-uncovered
+      tiny utility files in `packages/agent/src/` covering 279 LOC of
+      source. Total agent-package suite: 3185 → 3249 tests across 154 → 157
+      suites — see `Done` ledger; +10 net spec files in the prior agent
+      NestJS-module wiring sweep — adds `*.module.spec.ts` for ALL 10
+      previously-uncovered modules in `packages/agent/src/`: `work-operations`,
+      `notifications`,
+      `activity-log`, `community-pr`, `template-catalog`,
+      `comparison-generator`, `pipeline`, `import`,
+      `generators/website-generator`, `generators/data-generator`. 50 tests
+      across the 10 specs pinning the standard `Reflect.getMetadata`-based
+      provider/exports/imports shape (with documented per-module length
+      invariants so a silent extra-import is a deliberate change), plus
+      barrel re-exports where present. Each spec mocks transitive
+      ESM-only / TypeORM-pulling dependencies (`DatabaseModule`,
+      `FacadesModule`, `data-generator.service` w/ `p-map`, etc.) at module
+      scope — same pattern as the existing `markdown-generator.module.spec.ts`
+      / `account-transfer.module.spec.ts` / `subscriptions.module.spec.ts`.
+      This closes the agent-package NestJS-module zero-coverage gap entirely
+      (every `*.module.ts` under `packages/agent/src/` now has a co-located
+      spec). Highlights: `WorkOperationsModule`'s deliberate
+      `DatabaseModule` re-export pinned; `CommunityPrModule`'s
+      `DistributedTaskLockService` provided locally but NOT exported pinned;
+      `DataGeneratorModule`'s `WorksConfigService`/`WorksConfigWriterService`
+      helpers provided but NOT exported pinned; `PipelineModule`'s
+      intentional non-import of `PluginsModule` (which is `forRoot`-global)
+      pinned; — see `Done` ledger; +2 net spec files
+      in the prior agent `MarkdownGeneratorService` direct-coverage sweep — adds
+      `packages/agent/src/generators/markdown-generator/markdown-generator.service.spec.ts`
+      (49 tests on the 508-LOC orchestrator) and
+      `packages/agent/src/generators/markdown-generator/markdown-generator.module.spec.ts`
+      (5 tests pinning the module providers/exports + barrel runtime symbols),
+      closing the per-file zero-coverage gap inside
+      `packages/agent/src/generators/markdown-generator/` for the orchestrator
+      surface — see `Done` ledger; +1 net spec file in the prior agent
+      `WebsiteUpdateService` direct-coverage sweep — adds
+      `packages/agent/src/generators/website-generator/website-update.service.spec.ts`
+      (26 tests covering `updateRepository` duplicate-then-template
+      fallback chain w/ wrapped "All update methods failed" rethrow,
+      `options.branch` override + `getLatestCommit` null-coercion +
+      falsy-`branchSync` coercion; `ensureTemplateDefaultBranch`
+      best-effort warn-and-continue across listing-fail / branch-missing
+      / non-Error rejection / `updateRepository`-fail; thin
+      `syncAllBranchesFromTemplate` delegate; `checkForUpdate`
+      four-branch projection w/ beta-branch path; private `updateFork`
+      pinned via reflection; `copyRepositoryFiles` `.git`-skip +
+      recursive subdir mirror w/ rm-rejection swallowed), closing the
+      per-file zero-coverage gap inside
+      `packages/agent/src/generators/website-generator/` for the update
+      surface — see `Done` ledger; +2 net spec files in the prior agent
+      markdown-generator helper-class sweep — adds
+      `packages/agent/src/generators/markdown-generator/readme-builder.spec.ts`
+      (17 tests on the fluent `ReadmeBuilder` builder — `addHeader`/`addSubHeader`/`addParagraph`/`addNewLine` chaining,
+      `enableToC()` opt-in rendering w/ `## 📑 Table of Contents`
+        - en-US-formatted counts + duplicate-slug `-1`/`-2` disambiguation
+          via github-slugger + `0` rendered as `(0)` not omitted, `addItem`
+          format `- [name](url) - description` + optional `([Read more](/details/<slug>.md))` + backtick-wrapped tag
+          list joined w/ spaces, end-to-end document shape) and
+          `packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts`
+          (13 tests on the on-disk repository helper — `cleanup` recursive
+          `rm`, `resetFiles` allowlist (`.git`, `.gitignore`, `.github`,
+          `.vscode`, `.env`, `.nvmrc`, plus every dotfile starting with
+          `.git`) + sequential await-per-iteration removal order +
+          `readdir`-failure short-circuit, `ensureWorksExist` recursive
+          mkdir of `details/`, `writeReadme`/`writeDetails`/`writeLicense`
+          utf-8 writes, `removeDetails` rm with `force:true` only — NOT
+          recursive, the public readonly `dir` field, and the `dir` →
+          `dir/details` derivation contract — `node:fs/promises` is mocked at
+          module scope so the suite never touches the real filesystem),
+          closing the markdown-generator helper-class zero-coverage gap (the
+          remaining file in the subdir is `markdown-generator.service.ts`,
+          508 LOC, deferred to a dedicated follow-up) — see `Done` ledger;
+          +1 net spec file in the prior agent
+          `BranchSyncService` direct-coverage sweep — adds
+          `packages/agent/src/generators/website-generator/branch-sync.service.spec.ts`
+          (24 tests covering `syncBranch` clone-rename-replaceRemote-push-cleanup
+          pipeline + temp-dir cleanup on failure paths, `syncAllBranches`
+          branch-mapping expansion + skip-mapped-target rule + sequential
+          `MAX_CONCURRENT_SYNCS=1` semantics + per-batch 1000ms inter-batch
+          delay + `Promise.allSettled` rejection-to-error-result coercion +
+          optional `cleanupExtraBranches` purge w/ swallowed delete failures
+            - warn-and-return-early on `listBranches` failure, `syncFromTemplate`
+              beta-branch-mapping construction + outer try/catch null fallback +
+              resolveForWork-rethrow pin), closing the per-file zero-coverage gap
+              inside `packages/agent/src/generators/website-generator/` for the
+              branch-sync surface — see `Done` ledger; +2 net spec files in the
+              earlier agent `BaseFacadeService`/`FacadesModule` direct-coverage
+              sweep — adds
+              `packages/agent/src/facades/__tests__/base.facade.spec.ts` (66 tests
+              on the abstract base via a `TestFacadeService extends BaseFacadeService`
+              re-exposer) and `packages/agent/src/facades/__tests__/facades.module.spec.ts`
+              (9 tests pinning the module providers/exports + barrel runtime symbols),
+              closing the per-file zero-coverage gap inside `packages/agent/src/facades/`
+              — see `Done` ledger; +0 net spec files in the WorkGenerationService
+              orchestrators follow-up sweep — extends the existing
+              `services/__tests__/work-generation.service.spec.ts` from 126 → 172
+              tests, closing the previously-pending 7 multi-step pipeline orchestrators
+              (`processGeneration` / `executeGenerationPipeline` / `finalizeGeneration` /
+              `runInProcessGeneration` / `prepareProviders` /
+              `ensureProvidersEnabledForWork` / `dispatchGenerationTask`) — see `Done`
+              ledger; **the WorkGenerationService private-orchestrator zero-coverage
+              gap is now empty.** The earlier 2026-05-09 sweep covered 7 simpler
+              helpers: `resolveGenerationFinalStatus` / `resolveGenerationErrorMessage` /
+              `buildScheduleRunOutcome` / `isNonFatalWebsiteGenerationError` /
+              `markGenerationStarted` / `finalizeCancelledGeneration` /
+              `handleErrorNotification`; +1 packages/agent service spec landed 2026-05-09
+              in the small-service coverage sweep #6 — `WorkGenerationService` (focused
+              first sweep covering wrapper / simpler methods) — see `Done` ledger; +1 packages/agent service spec
+              landed earlier 2026-05-09
+              in the small-service coverage sweep #5 — `ItemHealthService` — see
+              `Done` ledger;
+              +1 packages/agent service spec landed earlier 2026-05-09
+              in the small-service coverage sweep #4 — `WorkTaxonomyService` — see
+              `Done` ledger;
+              +1 packages/agent service spec landed earlier 2026-05-09
+              in the small-service coverage sweep #3 — `WorkMemberService` — see
+              `Done` ledger;
+              +3 packages/agent service specs landed earlier 2026-05-09
+              in the small-service coverage sweep #2 — `ItemSourceValidationSchedulerService` +
+              `WorkDetailService` + `RepositoryManagementService` — see `Done` ledger;
+              +2 packages/agent service specs landed earlier 2026-05-09
+              in the small-service coverage sweep — `WorkAdvancedPromptsService` +
+              `WorkWebsiteRepositoryStateService` — see `Done` ledger;
+              +1 prior packages/agent service spec landed 2026-05-09
+              in the WorkOwnershipService sweep — see `Done` ledger; +4 packages/agent
+              repository specs landed earlier 2026-05-09
+              in sweep #3: activity-log + notification + work-member + work — closing the
+              agent-package repository zero-coverage gap entirely; +4 in the previous
+              sweep #2: work-custom-domain + user + conversation + template; +8 in
+              the prior sweep — subscription-plan + work-advanced-prompts +
+              user-template-preference + user-subscription + usage-ledger +
+              webhook-subscription + refresh-token + onboarding-request. See `Done`
+              for the running ledger).
 - **Playwright e2e suites**: 31 in `apps/web/e2e/`
 - **API source spec count**: **101** specs inside `apps/api/src/` (was 95
   earlier on 2026-05-09; +6 small-utility DTO specs landed in the
@@ -190,6 +205,23 @@
 ## Done
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
+
+**2026-05-09 — packages/agent sanitize.util direct coverage (+54 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes the per-file zero-coverage gap on the security-critical `packages/agent/src/utils/sanitize.util.ts` (213 LOC) — the most heavily-imported utility in the agent package. The sanitiser is consumed by every DTO `@Transform` decorator (truncating user-supplied `name`/`description`/`prompt` BEFORE class-validator's `@MaxLength` runs, which is the documented contract that pins the silent-truncate behaviour throughout the agent-package DTO suite). The new file is `packages/agent/src/utils/__tests__/sanitize.util.spec.ts` and pins:
+
+- **`sanitizeText` (16 tests)** — three falsy-input branches (`undefined`/`null`/`''`) all → `''` empty-string short-circuit; default-options matrix (control-strip preserves `\n`/`\r`/`\t` because they're handled separately by `removeNewlines`/`collapseSpaces`; control-byte regex strips `0x00-0x08` + `0x0B` + `0x0C` + `0x0E-0x1F` + `0x7F`; newline → space; multi-space → single; trim); every option toggle independently turned off and verified (`removeNewlines:false` preserves `\n`, `collapseSpaces:false` preserves runs, `trim:false` preserves padding, `removeControlChars:false` preserves `\x00`); partial-options-merge with `DEFAULT_OPTIONS` (a custom `maxLength:100` does NOT unset the default trim/collapse/etc.); `maxLength` truncate-then-trim (mid-word cut, trailing-space cut → re-trimmed); `if (opts.maxLength && ...)` falsy-zero gotcha (`maxLength:0` skips truncation entirely, NOT zero-length output); documented operation order pinned via a single end-to-end test (control-strip → newline-replace → collapse → trim → maxLength).
+- **`sanitizeDescription` (4 tests)** — default 500-char cap; custom maxLength override; full strip+collapse pass via the underlying `sanitizeText`; falsy-input → `''`.
+- **`sanitizeName` (3 tests)** — default 100-char cap; custom maxLength override; same strip+collapse shape as description.
+- **`sanitizePrompt` (6 tests)** — default 5000-char cap; CRITICAL contract pin: newlines AND multi-space runs are PRESERVED (because prompts can be multi-line and indentation-sensitive); only trim + control-strip + maxLength apply; control bytes (incl. `0x07` BEL) still stripped.
+- **`sanitizeObject` (9 tests)** — `null`/`undefined` short-circuit return; top-level string-field sanitisation; non-mutation guarantee (input object is NOT modified, returned reference is distinct); recursive walk into nested objects; array-element walk (string elements sanitised, object elements recursed, primitives forwarded verbatim); options forwarded into the recursive call; `value && typeof value === 'object'` null-guard prevents infinite-recurse-on-null crash.
+- **`sanitizeStringTransform` (2 tests)** — class-transformer adapter for generic strings; non-string input forwarded verbatim (the cast to `string` is type-level only, NOT a runtime coercion).
+- **`sanitizeDescriptionTransform` (3 tests)** — class-transformer adapter for description fields; default 500-char cap; non-string forwarded verbatim.
+- **`sanitizeStringArray` (4 tests)** — `undefined`/`null`/non-array/empty-array → `[]` short-circuit; per-entry trim via `sanitizeText` then post-filter drop of empty strings (so a whitespace-only input collapses out); internal-whitespace collapse; survivor-order preservation.
+
+Total agent-package suite: 3249 → 3303 tests across 157 → 158 suites, all green.
+
+---
 
 **2026-05-09 — packages/agent database helpers + import enrichment-prompt utils (+64 tests across 3 new specs, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
 

--- a/packages/agent/src/utils/__tests__/sanitize.util.spec.ts
+++ b/packages/agent/src/utils/__tests__/sanitize.util.spec.ts
@@ -1,0 +1,314 @@
+import {
+    sanitizeText,
+    sanitizeDescription,
+    sanitizeName,
+    sanitizePrompt,
+    sanitizeObject,
+    sanitizeStringTransform,
+    sanitizeDescriptionTransform,
+    sanitizeStringArray,
+    type SanitizeTextOptions,
+} from '../sanitize.util';
+
+describe('sanitizeText', () => {
+    describe('falsy inputs', () => {
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+            ['empty string', ''],
+        ] as Array<[string, string | null | undefined]>)(
+            'returns empty string for %s',
+            (_label, input) => {
+                expect(sanitizeText(input)).toBe('');
+            },
+        );
+    });
+
+    describe('default options', () => {
+        it('removes control chars (except \\n, \\r, \\t)', () => {
+            // 0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, 0x7F should all be stripped.
+            const input = `a\x00b\x08c\x0Bd\x0Ce\x1Ff\x7Fg`;
+            expect(sanitizeText(input)).toBe('abcdefg');
+        });
+
+        it('preserves \\n, \\r, \\t when removeControlChars runs but treats them via separate rules', () => {
+            // \n and \r should be replaced with space by the removeNewlines pass
+            // (default true). \t is collapsed by collapseSpaces.
+            expect(sanitizeText('a\nb\rc\td')).toBe('a b c d');
+        });
+
+        it('replaces newlines with single space then collapses', () => {
+            expect(sanitizeText('a\n\n\nb')).toBe('a b');
+            expect(sanitizeText('a\r\nb')).toBe('a b');
+        });
+
+        it('collapses multiple spaces into one', () => {
+            expect(sanitizeText('a    b   c')).toBe('a b c');
+        });
+
+        it('trims leading and trailing whitespace', () => {
+            expect(sanitizeText('   hello   ')).toBe('hello');
+        });
+
+        it('combines all default passes correctly', () => {
+            expect(sanitizeText('  Hello\n\n  World  \x00!  ')).toBe('Hello World !');
+        });
+    });
+
+    describe('option overrides', () => {
+        it('honours removeNewlines:false (preserves newlines)', () => {
+            const result = sanitizeText('a\nb', { removeNewlines: false, collapseSpaces: false });
+            expect(result).toBe('a\nb');
+        });
+
+        it('honours collapseSpaces:false (preserves runs)', () => {
+            const result = sanitizeText('a    b', {
+                collapseSpaces: false,
+                removeNewlines: false,
+            });
+            expect(result).toBe('a    b');
+        });
+
+        it('honours trim:false (preserves padding)', () => {
+            const result = sanitizeText('  hi  ', {
+                trim: false,
+                collapseSpaces: false,
+                removeNewlines: false,
+            });
+            expect(result).toBe('  hi  ');
+        });
+
+        it('honours removeControlChars:false (preserves control bytes)', () => {
+            const result = sanitizeText('a\x00b', {
+                removeControlChars: false,
+                collapseSpaces: false,
+                removeNewlines: false,
+                trim: false,
+            });
+            expect(result).toBe('a\x00b');
+        });
+
+        it('partial options merge with DEFAULT_OPTIONS (does not unset other defaults)', () => {
+            // maxLength only — other defaults still apply.
+            const result = sanitizeText('  hello   world  ', { maxLength: 100 });
+            expect(result).toBe('hello world');
+        });
+    });
+
+    describe('maxLength truncation', () => {
+        it('truncates at maxLength and trims again', () => {
+            // Truncation cuts mid-word and the trailing whitespace from the
+            // cut is trimmed away by the post-truncate `.trim()`.
+            expect(sanitizeText('hello world how are you', { maxLength: 10 })).toBe('hello worl');
+        });
+
+        it('post-truncate trim drops trailing space left by the cut', () => {
+            // The substring "hello " ends with a space which gets trimmed.
+            expect(sanitizeText('hello world', { maxLength: 6 })).toBe('hello');
+        });
+
+        it('does not truncate when length <= maxLength', () => {
+            expect(sanitizeText('short', { maxLength: 100 })).toBe('short');
+        });
+
+        it('treats maxLength=0 as falsy → no truncation', () => {
+            // The source uses `if (opts.maxLength && ...)` so 0 is falsy.
+            expect(sanitizeText('hello world', { maxLength: 0 })).toBe('hello world');
+        });
+
+        it('treats undefined maxLength → no truncation', () => {
+            expect(sanitizeText('hello world')).toBe('hello world');
+        });
+    });
+
+    describe('order of operations', () => {
+        it('runs removeControlChars BEFORE removeNewlines BEFORE collapseSpaces BEFORE trim BEFORE maxLength', () => {
+            // Input has control char + newline + multiple spaces + leading/trailing whitespace,
+            // and is longer than maxLength.
+            const input = '   \x00 Hello\n  World  \x00 longerstuff   ';
+            const result = sanitizeText(input, { maxLength: 11 });
+            // After control-strip + newline-replace + collapse + trim:
+            // 'Hello World longerstuff'
+            // Truncate at 11 → 'Hello World' → trim trailing → 'Hello World'
+            expect(result).toBe('Hello World');
+        });
+    });
+});
+
+describe('sanitizeDescription', () => {
+    it('uses default 500-char cap', () => {
+        const long = 'a'.repeat(600);
+        expect(sanitizeDescription(long)).toHaveLength(500);
+    });
+
+    it('honours custom maxLength', () => {
+        expect(sanitizeDescription('a'.repeat(50), 20)).toHaveLength(20);
+    });
+
+    it('strips newlines, control bytes, and collapses spaces', () => {
+        expect(sanitizeDescription('  hi\n\nthere\x00 ')).toBe('hi there');
+    });
+
+    it('returns "" for falsy input', () => {
+        expect(sanitizeDescription(undefined)).toBe('');
+        expect(sanitizeDescription(null)).toBe('');
+    });
+});
+
+describe('sanitizeName', () => {
+    it('uses default 100-char cap', () => {
+        const long = 'a'.repeat(150);
+        expect(sanitizeName(long)).toHaveLength(100);
+    });
+
+    it('honours custom maxLength', () => {
+        expect(sanitizeName('a'.repeat(50), 20)).toHaveLength(20);
+    });
+
+    it('strips newlines + collapses spaces (same shape as description)', () => {
+        expect(sanitizeName('  Foo\nBar  ')).toBe('Foo Bar');
+    });
+});
+
+describe('sanitizePrompt', () => {
+    it('uses default 5000-char cap', () => {
+        const long = 'a'.repeat(6000);
+        expect(sanitizePrompt(long)).toHaveLength(5000);
+    });
+
+    it('PRESERVES newlines (prompts can be multi-line)', () => {
+        expect(sanitizePrompt('Line 1\nLine 2\nLine 3')).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    it('PRESERVES multi-space runs (no collapseSpaces)', () => {
+        expect(sanitizePrompt('a    b   c')).toBe('a    b   c');
+    });
+
+    it('still trims leading/trailing whitespace', () => {
+        expect(sanitizePrompt('   hi   ')).toBe('hi');
+    });
+
+    it('still strips control chars (except \\n, \\r, \\t)', () => {
+        expect(sanitizePrompt('a\x00b\x07c')).toBe('abc');
+    });
+
+    it('honours custom maxLength', () => {
+        expect(sanitizePrompt('a'.repeat(100), 30)).toHaveLength(30);
+    });
+});
+
+describe('sanitizeObject', () => {
+    it('returns the input verbatim when not an object', () => {
+        // The signature accepts `T extends Record<string, unknown>` but the
+        // runtime guard is defensive and returns falsy values as-is.
+        expect(sanitizeObject(null as any)).toBeNull();
+        expect(sanitizeObject(undefined as any)).toBeUndefined();
+    });
+
+    it('sanitizes top-level string fields', () => {
+        const result = sanitizeObject({ name: '  Foo  ', count: 7 });
+        expect(result).toEqual({ name: 'Foo', count: 7 });
+    });
+
+    it('does not mutate the input object', () => {
+        const input = { name: '  Foo  ' };
+        const result = sanitizeObject(input);
+        expect(input.name).toBe('  Foo  ');
+        expect(result).not.toBe(input); // Distinct reference.
+        expect(result.name).toBe('Foo');
+    });
+
+    it('recurses into nested object values', () => {
+        const result = sanitizeObject({ a: 1, nested: { b: '  bar  ', c: { d: '  deep  ' } } });
+        expect(result).toEqual({ a: 1, nested: { b: 'bar', c: { d: 'deep' } } });
+    });
+
+    it('walks string elements inside arrays', () => {
+        const result = sanitizeObject({ tags: ['  a  ', '  b  '] });
+        expect(result).toEqual({ tags: ['a', 'b'] });
+    });
+
+    it('recurses into object elements inside arrays', () => {
+        const result = sanitizeObject({ items: [{ name: '  one  ' }, { name: '  two  ' }] });
+        expect(result).toEqual({ items: [{ name: 'one' }, { name: 'two' }] });
+    });
+
+    it('preserves non-string non-object array elements verbatim', () => {
+        const input = { mixed: [1, true, null as any, '  trim me  '] };
+        const result = sanitizeObject(input);
+        expect(result).toEqual({ mixed: [1, true, null, 'trim me'] });
+    });
+
+    it('forwards options into the recursive call', () => {
+        const opts: SanitizeTextOptions = {
+            maxLength: 5,
+            trim: true,
+            removeControlChars: true,
+            removeNewlines: true,
+            collapseSpaces: true,
+        };
+        const result = sanitizeObject({ a: 'hello world', nested: { b: 'hello world' } }, opts);
+        expect(result).toEqual({ a: 'hello', nested: { b: 'hello' } });
+    });
+
+    it('skips null nested values without crashing', () => {
+        // The `value && typeof value === 'object'` guard short-circuits null.
+        const result = sanitizeObject({ a: null as any, b: '  hi  ' });
+        expect(result).toEqual({ a: null, b: 'hi' });
+    });
+});
+
+describe('sanitizeStringTransform', () => {
+    it('sanitizes when input is a string', () => {
+        expect(sanitizeStringTransform('  Hello\n  ')).toBe('Hello');
+    });
+
+    it('forwards non-string input verbatim (cast to string at type level)', () => {
+        expect(sanitizeStringTransform(42 as unknown)).toBe(42);
+        expect(sanitizeStringTransform(null as unknown)).toBeNull();
+        expect(sanitizeStringTransform(undefined as unknown)).toBeUndefined();
+    });
+});
+
+describe('sanitizeDescriptionTransform', () => {
+    it('sanitizes when input is a string (using description rules)', () => {
+        expect(sanitizeDescriptionTransform('  Multi\n\nLine\x00 ')).toBe('Multi Line');
+    });
+
+    it('caps at 500 chars by default', () => {
+        const long = 'a'.repeat(600);
+        expect(sanitizeDescriptionTransform(long)).toHaveLength(500);
+    });
+
+    it('forwards non-string input verbatim', () => {
+        expect(sanitizeDescriptionTransform(42 as unknown)).toBe(42);
+        expect(sanitizeDescriptionTransform(null as unknown)).toBeNull();
+    });
+});
+
+describe('sanitizeStringArray', () => {
+    it.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['non-array', 'not-an-array' as unknown as string[]],
+        ['empty array', []],
+    ] as Array<[string, string[] | null | undefined]>)('returns [] for %s', (_label, input) => {
+        expect(sanitizeStringArray(input)).toEqual([]);
+    });
+
+    it('trims each entry then drops empty strings', () => {
+        const result = sanitizeStringArray(['  a  ', '   ', 'b', '', '\x00 c\x00']);
+        expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('collapses internal whitespace in each entry', () => {
+        expect(sanitizeStringArray(['hello   world', 'foo\nbar'])).toEqual([
+            'hello world',
+            'foo bar',
+        ]);
+    });
+
+    it('preserves order of surviving entries', () => {
+        expect(sanitizeStringArray(['z', '   ', 'a', '   ', 'm'])).toEqual(['z', 'a', 'm']);
+    });
+});


### PR DESCRIPTION
## Summary

- Closes the per-file zero-coverage gap on the security-critical [packages/agent/src/utils/sanitize.util.ts](packages/agent/src/utils/sanitize.util.ts) (213 LOC) — the most heavily-imported utility in the agent package.
- 54 tests across all 7 exported functions (`sanitizeText`, `sanitizeDescription`, `sanitizeName`, `sanitizePrompt`, `sanitizeObject`, `sanitizeStringTransform`, `sanitizeDescriptionTransform`, `sanitizeStringArray`).
- Total agent-package suite: 3249 → 3303 tests across 157 → 158 suites, all green.

## Why this matters

The sanitiser is consumed by every DTO `@Transform` decorator throughout the agent-package — truncating user-supplied `name`/`description`/`prompt` BEFORE `class-validator`'s `@MaxLength` runs. That silent-truncate contract is pinned throughout the existing DTO suite (e.g. `agent/src/dto/dto.spec.ts`'s 250-char-name → 200 truncation pin). This spec puts the contract directly under the source.

## Pinned behaviours

- **`sanitizeText`** — three falsy-input branches (`undefined`/`null`/`''`) → `''`; control-byte regex strips `0x00-0x08` + `0x0B` + `0x0C` + `0x0E-0x1F` + `0x7F` while preserving `\n`/`\r`/`\t`; every default option independently togglable; `maxLength:0` is FALSY and skips truncation entirely (NOT zero-length output); operation order pinned end-to-end as control-strip → newline-replace → collapse → trim → maxLength.
- **`sanitizeDescription` / `sanitizeName`** — default 500-char / 100-char caps with full strip+collapse pass.
- **`sanitizePrompt`** — CRITICAL: newlines AND multi-space runs are PRESERVED (prompts are multi-line and indentation-sensitive); only trim + control-strip + maxLength apply; default 5000-char cap.
- **`sanitizeObject`** — non-mutation guarantee (returned reference is distinct from input), recursive walk into nested objects + array elements (strings sanitised, objects recursed, primitives forwarded verbatim), options forwarded into the recursive call, null-guard prevents infinite-recurse-on-null.
- **`sanitizeStringTransform` / `sanitizeDescriptionTransform`** — class-transformer adapters; non-string input forwarded verbatim (the `as string` cast is type-level only, NOT a runtime coercion).
- **`sanitizeStringArray`** — falsy/non-array/empty → `[]` short-circuit; per-entry sanitise then post-filter drop of empty strings (whitespace-only inputs collapse out); survivor-order preservation.

## Test plan

- [x] `cd packages/agent && npx jest --testPathPattern='sanitize.util.spec.ts' --no-coverage` — 54/54 passing locally
- [x] `cd packages/agent && npx jest --no-coverage` — 3303/3303 passing across 158 suites
- [x] Prettier-clean (`pnpm format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for sanitization utilities, validating control character removal, whitespace normalization, text truncation, recursive object handling, and array processing behavior.

* **Documentation**
  * Updated test coverage tracking documentation to reflect new test suite additions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/654)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->