### PR TITLE
test(gemini): make taxonomy-watcher serialization test order-agnostic

### DIFF
--- a/packages/plugins/gemini/src/__tests__/taxonomy-watcher.spec.ts
+++ b/packages/plugins/gemini/src/__tests__/taxonomy-watcher.spec.ts
@@ -115,14 +115,23 @@ describe('taxonomy-watcher', () => {
 			const categories = JSON.parse(await rf(join(workspacePath, '_meta', 'categories.json'), 'utf-8'));
 			const tags = JSON.parse(await rf(join(workspacePath, '_meta', 'tags.json'), 'utf-8'));
 
-			expect(categories).toEqual([
-				{ id: 'category-one', name: 'Category One' },
-				{ id: 'category-two', name: 'Category Two' }
-			]);
-			expect(tags).toEqual([
-				{ id: 'alpha', name: 'Alpha' },
-				{ id: 'beta', name: 'Beta' }
-			]);
+			// File-system event ordering is non-deterministic for concurrent writes —
+			// assert set membership (the serialization invariant the test cares about)
+			// rather than insertion order.
+			expect(categories).toHaveLength(2);
+			expect(categories).toEqual(
+				expect.arrayContaining([
+					{ id: 'category-one', name: 'Category One' },
+					{ id: 'category-two', name: 'Category Two' }
+				])
+			);
+			expect(tags).toHaveLength(2);
+			expect(tags).toEqual(
+				expect.arrayContaining([
+					{ id: 'alpha', name: 'Alpha' },
+					{ id: 'beta', name: 'Beta' }
+				])
+			);
 		} finally {
 			watcher.stop();
 		}


### PR DESCRIPTION
## Summary
- Pre-existing flake on the gemini-plugin's `taxonomy-watcher.spec.ts` ("should serialize taxonomy sync for rapid successive writes") because the test issues two concurrent `writeFile` calls via `Promise.all` and then asserts a specific order on the resulting `_meta/{categories,tags}.json` arrays. `fs.watch` event ordering is not deterministic for concurrent writes, so the second write occasionally surfaces first on CI.
- This was blocking PR [#658](https://github.com/ever-works/ever-works/pull/658) (and would block any subsequent PR that re-runs the gemini-plugin test suite).
- Fix: switch to set-membership assertions (`toHaveLength` + `arrayContaining`). Serialization (no entries lost / no duplicates), not insertion order, is the invariant this particular test cares about — the dedicated single-write tests above it still cover the deterministic happy path.

## Test plan
- [x] `pnpm --filter @ever-works/gemini-plugin test src/__tests__/taxonomy-watcher.spec.ts` — passes locally on Linux CI shape (Windows local fails on a different `fs.watch`-timing issue unrelated to this change; the only test that ever flaked on CI is the one being fixed)
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resilience for taxonomy synchronization to handle non-deterministic filesystem event ordering during concurrent operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/660)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->