### PR TITLE
test(agent): cover WorkModule wiring (+35 tests)

### DIFF
--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -1,0 +1,270 @@
+// The transitive dependencies of `WorkModule` pull in heavy runtime trees
+// (TypeORM entities, BullMQ, plugin services that import ESM-only `p-map`).
+// We replace each module with an empty class shell at module-scope so the
+// `Reflect.getMetadata` calls return the real `WorkModule`'s metadata
+// without forcing those trees to load under Jest's CJS transformer.
+jest.mock('@src/database/database.module', () => ({
+    DatabaseModule: class DatabaseModule {},
+}));
+jest.mock('../generators/data-generator/data-generator.module', () => ({
+    DataGeneratorModule: class DataGeneratorModule {},
+}));
+jest.mock('../items-generator/items-generator.module', () => ({
+    ItemsGeneratorModule: class ItemsGeneratorModule {},
+}));
+jest.mock('../facades/facades.module', () => ({
+    FacadesModule: class FacadesModule {},
+}));
+jest.mock('../generators/markdown-generator/markdown-generator.module', () => ({
+    MarkdownGeneratorModule: class MarkdownGeneratorModule {},
+}));
+jest.mock('../generators/website-generator/website-generator.module', () => ({
+    WebsiteGeneratorModule: class WebsiteGeneratorModule {},
+}));
+jest.mock('../import/import.module', () => ({
+    ImportModule: class ImportModule {},
+}));
+jest.mock('../community-pr/community-pr.module', () => ({
+    CommunityPrModule: class CommunityPrModule {},
+}));
+jest.mock('../comparison-generator/comparison-generator.module', () => ({
+    ComparisonGeneratorModule: class ComparisonGeneratorModule {},
+}));
+jest.mock('../template-catalog/template-catalog.module', () => ({
+    TemplateCatalogModule: class TemplateCatalogModule {},
+}));
+jest.mock('@src/subscriptions', () => ({
+    SubscriptionsModule: class SubscriptionsModule {},
+}));
+jest.mock('@src/notifications', () => ({
+    NotificationsModule: class NotificationsModule {},
+}));
+
+// Provider classes — replace with empty shells so the metadata still records
+// the right class identities without dragging in the full implementations.
+jest.mock('./work-detail.service', () => ({ WorkDetailService: class {} }));
+jest.mock('./work-ownership.service', () => ({ WorkOwnershipService: class {} }));
+jest.mock('./work-query.service', () => ({ WorkQueryService: class {} }));
+jest.mock('./work-lifecycle.service', () => ({ WorkLifecycleService: class {} }));
+jest.mock('./work-generation.service', () => ({ WorkGenerationService: class {} }));
+jest.mock('./work-schedule.service', () => ({ WorkScheduleService: class {} }));
+jest.mock('./work-schedule-dispatcher.service', () => ({
+    WorkScheduleDispatcherService: class {},
+}));
+jest.mock('./work-member.service', () => ({ WorkMemberService: class {} }));
+jest.mock('./work-import.service', () => ({ WorkImportService: class {} }));
+jest.mock('./work-advanced-prompts.service', () => ({
+    WorkAdvancedPromptsService: class {},
+}));
+jest.mock('./work-taxonomy.service', () => ({ WorkTaxonomyService: class {} }));
+jest.mock('./generator-form-schema.service', () => ({
+    GeneratorFormSchemaService: class {},
+}));
+jest.mock('./work-website-repository-state.service', () => ({
+    WorkWebsiteRepositoryStateService: class {},
+}));
+jest.mock('./item-health.service', () => ({ ItemHealthService: class {} }));
+jest.mock('./item-source-validation-scheduler.service', () => ({
+    ItemSourceValidationSchedulerService: class {},
+}));
+jest.mock('./repository-management.service', () => ({
+    RepositoryManagementService: class {},
+}));
+jest.mock('@src/works-config/services/works-config-import-applier.service', () => ({
+    WorksConfigImportApplierService: class {},
+}));
+jest.mock('@src/works-config/services/works-config-import-planner.service', () => ({
+    WorksConfigImportPlannerService: class {},
+}));
+jest.mock('@src/works-config/services/works-config-projection.service', () => ({
+    WorksConfigProjectionService: class {},
+}));
+jest.mock('@src/works-config/services/works-config-repository-sync.service', () => ({
+    WorksConfigRepositorySyncService: class {},
+}));
+jest.mock('@src/works-config/services/works-config-restore.service', () => ({
+    WorksConfigRestoreService: class {},
+}));
+jest.mock('@src/works-config/services/works-config.service', () => ({
+    WorksConfigService: class {},
+}));
+jest.mock('@src/works-config/services/works-config-sync.listener', () => ({
+    WorksConfigSyncListener: class {},
+}));
+jest.mock('@src/works-config/services/works-config-writer.service', () => ({
+    WorksConfigWriterService: class {},
+}));
+jest.mock('../plugins/services/plugin-operations.service', () => ({
+    PluginOperationsService: class {},
+}));
+jest.mock('../plugins/services/settings-schema-validator.service', () => ({
+    SettingsSchemaValidatorService: class {},
+}));
+
+import { WorkModule } from './work.module';
+import { WorkDetailService } from './work-detail.service';
+import { WorkOwnershipService } from './work-ownership.service';
+import { WorkQueryService } from './work-query.service';
+import { WorkLifecycleService } from './work-lifecycle.service';
+import { WorkGenerationService } from './work-generation.service';
+import { WorkScheduleService } from './work-schedule.service';
+import { WorkScheduleDispatcherService } from './work-schedule-dispatcher.service';
+import { WorkMemberService } from './work-member.service';
+import { WorkImportService } from './work-import.service';
+import { WorkAdvancedPromptsService } from './work-advanced-prompts.service';
+import { WorkTaxonomyService } from './work-taxonomy.service';
+import { GeneratorFormSchemaService } from './generator-form-schema.service';
+import { WorkWebsiteRepositoryStateService } from './work-website-repository-state.service';
+import { ItemHealthService } from './item-health.service';
+import { ItemSourceValidationSchedulerService } from './item-source-validation-scheduler.service';
+import { RepositoryManagementService } from './repository-management.service';
+import { WorksConfigImportApplierService } from '@src/works-config/services/works-config-import-applier.service';
+import { WorksConfigImportPlannerService } from '@src/works-config/services/works-config-import-planner.service';
+import { WorksConfigProjectionService } from '@src/works-config/services/works-config-projection.service';
+import { WorksConfigRepositorySyncService } from '@src/works-config/services/works-config-repository-sync.service';
+import { WorksConfigRestoreService } from '@src/works-config/services/works-config-restore.service';
+import { WorksConfigService } from '@src/works-config/services/works-config.service';
+import { WorksConfigSyncListener } from '@src/works-config/services/works-config-sync.listener';
+import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
+import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
+import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
+import { CommunityPrModule } from '../community-pr/community-pr.module';
+import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
+import { TemplateCatalogModule } from '../template-catalog/template-catalog.module';
+
+const meta = (key: string): unknown[] => Reflect.getMetadata(key, WorkModule) ?? [];
+
+describe('WorkModule', () => {
+    describe('imports', () => {
+        it('imports the documented 12-module set (DatabaseModule + 6 generator/feature modules + Subscriptions/Notifications/CommunityPr/ComparisonGenerator/TemplateCatalog)', () => {
+            const imports = meta('imports') as Array<{ name?: string }>;
+            const names = imports.map((m) => m?.name).filter(Boolean) as string[];
+
+            expect(names).toEqual(
+                expect.arrayContaining([
+                    'DatabaseModule',
+                    'DataGeneratorModule',
+                    'ItemsGeneratorModule',
+                    'FacadesModule',
+                    'MarkdownGeneratorModule',
+                    'WebsiteGeneratorModule',
+                    'ImportModule',
+                    'SubscriptionsModule',
+                    'NotificationsModule',
+                    'CommunityPrModule',
+                    'ComparisonGeneratorModule',
+                    'TemplateCatalogModule',
+                ]),
+            );
+            // Pin the count too — silent additions break this regression guard.
+            expect(imports).toHaveLength(12);
+        });
+
+        it('does NOT import PluginsModule directly (it is registered globally via forRoot at the app root, per JSDoc)', () => {
+            // Pinned: the JSDoc explicitly documents that `PluginsModule` is
+            // global. A future `imports: [..., PluginsModule]` addition would
+            // double-register and is wrong.
+            const imports = meta('imports') as Array<{ name?: string }>;
+            expect(imports.map((m) => m?.name)).not.toContain('PluginsModule');
+        });
+    });
+
+    describe('providers', () => {
+        const expectedProviders = [
+            WorkOwnershipService,
+            WorkWebsiteRepositoryStateService,
+            WorkQueryService,
+            WorkLifecycleService,
+            WorkGenerationService,
+            WorkDetailService,
+            WorkScheduleService,
+            WorkScheduleDispatcherService,
+            WorkMemberService,
+            WorkImportService,
+            WorkAdvancedPromptsService,
+            WorkTaxonomyService,
+            ItemHealthService,
+            ItemSourceValidationSchedulerService,
+            RepositoryManagementService,
+            GeneratorFormSchemaService,
+            WorksConfigImportPlannerService,
+            WorksConfigImportApplierService,
+            WorksConfigRestoreService,
+            WorksConfigService,
+            WorksConfigWriterService,
+            WorksConfigProjectionService,
+            WorksConfigRepositorySyncService,
+            WorksConfigSyncListener,
+            PluginOperationsService,
+            SettingsSchemaValidatorService,
+        ];
+
+        it.each(expectedProviders)('declares %p as a provider', (provider) => {
+            expect(meta('providers')).toContain(provider);
+        });
+
+        it('keeps the providers list at the documented 26-provider shape', () => {
+            expect(meta('providers')).toHaveLength(expectedProviders.length);
+        });
+
+        it('declares WorksConfigSyncListener as a provider (the @OnEvent listener pattern requires registration here so Nest scans its decorators)', () => {
+            // Pin: even though the listener has no public service consumers,
+            // it MUST appear in `providers` for the @OnEvent dispatcher to
+            // discover it. A future "remove unused listener" cleanup would
+            // break the works-config sync feature silently — flag it here.
+            expect(meta('providers')).toContain(WorksConfigSyncListener);
+        });
+    });
+
+    describe('exports', () => {
+        it('exports every service that is also a provider EXCEPT the listener and the schema-validator (intentional internal-only)', () => {
+            const exports = meta('exports');
+            const providers = meta('providers');
+
+            // Pinned: WorksConfigSyncListener is NOT exported (Nest doesn't
+            // export listeners, they're internal) and SettingsSchemaValidatorService
+            // is NOT exported (consumers go through PluginOperationsService).
+            // PluginOperationsService IS a provider but NOT exported either —
+            // current behaviour pinned (downstream services that need it would
+            // import the plugins module directly).
+            for (const provider of providers) {
+                if (
+                    provider === WorksConfigSyncListener ||
+                    provider === SettingsSchemaValidatorService ||
+                    provider === PluginOperationsService
+                ) {
+                    expect(exports).not.toContain(provider);
+                } else {
+                    expect(exports).toContain(provider);
+                }
+            }
+        });
+
+        it('re-exports CommunityPrModule, ComparisonGeneratorModule, TemplateCatalogModule (downstream feature consumers rely on transitive availability)', () => {
+            const exports = meta('exports');
+            expect(exports).toContain(CommunityPrModule);
+            expect(exports).toContain(ComparisonGeneratorModule);
+            expect(exports).toContain(TemplateCatalogModule);
+        });
+
+        it('keeps the exports list at the documented 26-entry shape (23 services + 3 re-exported modules)', () => {
+            expect(meta('exports')).toHaveLength(26);
+        });
+
+        it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {
+            // Pin the boundary: DatabaseModule re-export would silently
+            // give every WorkModule consumer access to the entire entity
+            // tree. The current intent is that consumers explicitly import
+            // it when needed.
+            const exports = meta('exports') as Array<{ name?: string }>;
+            expect(exports.map((m) => m?.name)).not.toContain('DatabaseModule');
+        });
+    });
+
+    describe('class identity', () => {
+        it('WorkModule is a class function (Nest discovers @Module via the class itself)', () => {
+            expect(typeof WorkModule).toBe('function');
+            expect(WorkModule.name).toBe('WorkModule');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- `packages/agent/src/services/work.module.ts` had no direct module-wiring spec. `WorkModule` is the central composition root for ~26 services (plus 3 transitively re-exported feature modules) — a single typo in providers/exports would silently break a downstream consumer.
- Adds a co-located spec under `packages/agent/src/services/work.module.spec.ts` following the existing `*.module.spec.ts` pattern (every transitive module/service mocked at module scope to keep the heavy ESM-only / TypeORM trees out of the Jest CJS path).

## What's pinned
- **`imports`**: documented 12-module set pinned by name + length regression guard. PluginsModule deliberately NOT imported (the JSDoc documents that it is registered globally via `forRoot` at the app root); a future `imports: [..., PluginsModule]` would double-register.
- **`providers`**: every documented service identity + the 26-provider count.
- `WorksConfigSyncListener` registration pinned (without it the `@OnEvent` dispatcher cannot discover the works-config sync handler — a "remove unused listener" cleanup would silently break the sync feature).
- **`exports`**: every provider IS exported EXCEPT `WorksConfigSyncListener`, `SettingsSchemaValidatorService`, and `PluginOperationsService` (intentional internal-only — pinned so a future "expose everything" refactor breaks deliberately). The 3 feature modules (`CommunityPrModule` / `ComparisonGeneratorModule` / `TemplateCatalogModule`) are re-exported.
- **Boundary check**: `exports` does NOT re-export `DatabaseModule` — callers must import it explicitly when they need entities/repositories. A re-export would silently grant every WorkModule consumer access to the entire entity tree.
- Class identity: `WorkModule` is a function with `.name === 'WorkModule'` so Nest's `@Module` discovery finds it.

## Test plan
- [x] `cd packages/agent && npx jest --testPathPattern='services/work.module.spec'` — 35/35 passing locally
- [x] `npx prettier --check packages/agent/src/services/work.module.spec.ts` clean
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)