### PR TITLE
test(agent): cover FullPipelineExecutorService directly (+22 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -21,9 +21,26 @@
 
 ## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~515 across `apps/` + `packages/` (was 513
-  earlier on 2026-05-09; +2 net spec files in the agent
-  `PipelineOrchestratorService` + `comparison/types` direct-coverage sweep
+- **Spec files (`*.spec.ts`)**: ~516 across `apps/` + `packages/` (was 515
+  earlier on 2026-05-09; +1 net spec file in the agent
+  `FullPipelineExecutorService` direct-coverage sweep — adds
+  `packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts`
+  (22 tests on the 239-LOC self-managed-pipeline executor: `execute`
+  STARTED→plugin.execute→COMPLETED w/ wrapper-measured duration
+  override; full signal/options/onProgress forwarding; log-interceptor
+  lifecycle (attached on `onLogEntry`, routed into the documented
+  envelope, removed in finally on both success AND throw); invalid-
+  result handling (non-object single error, multi-error `'; '` join,
+  FAILED emitted exactly ONCE); plugin.execute rejection →
+  `buildErrorPipelineResult` envelope w/ `totalSteps` from
+  `plugin.getStepDefinitions().length`; `executeWithCancellation`
+  abort wiring + listener removal in finally on success AND throw +
+  cancel-rejection swallowed + skip-when-plugin-lacks-cancel;
+  `getPluginState` null-safe wrapper; private emitter helpers
+  envelope shapes), closing the per-file zero-coverage gap on the
+  second of three pipeline executors — see `Done` ledger; +2 net
+  spec files in the prior agent `PipelineOrchestratorService` +
+  `comparison/types` direct-coverage sweep
   — adds `packages/agent/src/comparison-generator/comparison/types.spec.ts`
   (11 tests on the 60-LOC contracts module pinning
   `DEFAULT_COMPARISON_SETTINGS` four-default merge target +
@@ -325,6 +342,23 @@
 ## Done
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
+
+**2026-05-09 — packages/agent FullPipelineExecutorService direct coverage (+22 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/full-pipeline-executor.service.ts` (239 LOC) — the executor that runs self-managed pipeline plugins (e.g. `claude-code`, where the plugin owns step ordering and orchestration internally rather than delegating each step back to the engine). The orchestrator routes self-managed pipelines through this service, so a regression in event emission, validation, or cancellation wiring is invisible to the existing `PipelineOrchestratorService` suite (which mocks the executor).
+
+The new file is `packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts` and pins:
+
+- **`execute` happy path (4 tests)** — emits `pipeline:started` BEFORE invoking `plugin.execute` (asserted via `mock.calls.find` on the emit ordering); calls `facadeService.createStepExecutionContext(work, request.providers, request.aiModel, options?.signal)` to build the per-execution context; passes `{...options, execContext, onLogEntry: options?.onLogEntry}` into `plugin.execute(work, request, existing, ...)`; emits `pipeline:completed` w/ `{workId, pipelineId, duration, stepsCompleted, outputs}` envelope on success; **CRITICAL contract**: the wrapper REPLACES the plugin's reported `duration` field with its own `Date.now() - startTime` measurement (a plugin returning a stale `duration: 9999` will be overridden — pinned via fake timers); `signal` forwarded into the facade context; `onProgress` callback forwarded verbatim into `plugin.execute`.
+- **`execute` log-interceptor lifecycle (5 tests)** — when `options.onLogEntry` is set, `contextFactory.addLogInterceptor(plugin.id, fn)` is invoked and the returned remove fn is called in the `finally` block; the interceptor's `(level, message)` arguments are routed into the documented envelope `{timestamp, level, source: 'pipeline', event: 'message', message}` (the `level` cast to `GenerationStepLog['level']` is type-only — runtime forwarding is verbatim); the interceptor is correctly removed even when `plugin.execute` rejects (finally-block invariance); without `onLogEntry`, `addLogInterceptor` is NEVER called and the optional-call guard `removeInterceptor?.()` short-circuits cleanly.
+- **`execute` invalid-result handling (4 tests)** — when `plugin.execute` returns a non-object (string, primitive), `validatePipelineResult` produces a single `'Result must be an object'` error and the wrapper throws `Plugin "<id>" returned invalid pipeline result: <errors>`; the catch path emits `pipeline:failed` ONCE per execute call (no double-emission across the inner-throw and outer-catch), then returns `buildErrorPipelineResult(...)` w/ `totalSteps` sourced from `plugin.getStepDefinitions().length` (so the failure envelope is still informative); multi-error case → errors joined with `'; '`; plugin.execute rejection → FAILED w/ `error.message` + `completedSteps: 0` and the same error-envelope shape.
+- **`executeWithCancellation` (4 tests)** — when both `plugin.cancel` AND `options.signal` are present, `signal.addEventListener('abort', handler, {once: true})` is registered and a `removeEventListener` is queued in the `finally` block; firing `abort` on the signal triggers `plugin.cancel()` exactly once; `plugin.cancel` rejection is swallowed via `.catch(err => logger.error(...))` so the abort handler does not propagate; when `plugin.cancel` is `undefined`, the abort wiring is skipped entirely (no `addEventListener` call); listener removal in `finally` runs even when `execute` throws (the wrapper still recovers via the inner try/catch and returns an error envelope, so the `finally` is reached).
+- **`getPluginState` (2 tests)** — proxies `plugin.getState()` when defined; returns `null` when `plugin.getState` is undefined.
+- **Event emission helpers (3 tests, exercised via `execute`)** — `emitPipelineEvent` merges `{timestamp, ...payload}` (the spread runs after the timestamp default, so an explicit `payload.timestamp` would win — pinned via the default-ISO branch); `emitPipelineCompleted` forwards `outputs` from the **validated** result (NOT the raw plugin return); `emitPipelineFailed` envelope shape `{timestamp, workId, pipelineId, error, failedStep:undefined, completedSteps:0}` pinned literally via `toEqual` so a future "add failedStepLogs" addition is a deliberate change.
+
+Total agent-package suite: 3693 → 3715 tests across 171 → 172 suites, all green.
+
+---
 
 **2026-05-09 — packages/agent WorksConfigImportApplierService direct coverage (+37 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
 

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
@@ -1,0 +1,490 @@
+import { FullPipelineExecutorService } from './full-pipeline-executor.service';
+import { PipelineEvents } from './step-pipeline-executor.service';
+
+describe('FullPipelineExecutorService', () => {
+    let eventEmitter: any;
+    let facadeService: any;
+    let contextFactory: any;
+    let service: FullPipelineExecutorService;
+
+    function makePlugin(overrides: any = {}) {
+        return {
+            id: 'claude-code',
+            execute: jest.fn(),
+            getStepDefinitions: jest
+                .fn()
+                .mockReturnValue([{ id: 's1' }, { id: 's2' }, { id: 's3' }]),
+            ...overrides,
+        };
+    }
+
+    function makeValidResult(overrides: any = {}) {
+        // The validator's required-field set: success, stepsCompleted,
+        // totalSteps, duration, outputs.{items, categories, tags,
+        // collections, brands}.
+        return {
+            success: true,
+            stepsCompleted: 3,
+            totalSteps: 3,
+            duration: 0,
+            outputs: {
+                items: [{ slug: 'a' }, { slug: 'b' }],
+                categories: [],
+                tags: [],
+                collections: [],
+                brands: [],
+            },
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers().setSystemTime(new Date('2026-05-09T12:00:00.000Z'));
+
+        eventEmitter = {
+            emit: jest.fn(),
+        };
+        facadeService = {
+            createStepExecutionContext: jest.fn().mockReturnValue({ ctx: 'fake' }),
+        };
+        contextFactory = {
+            addLogInterceptor: jest.fn().mockReturnValue(() => undefined),
+        };
+
+        service = new FullPipelineExecutorService(eventEmitter, facadeService, contextFactory);
+
+        // Silence the logger so the suite output stays focused on assertion failures.
+        jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+        jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('execute — happy path', () => {
+        const work = { id: 'w-1' } as any;
+        const request = { providers: { p: 'x' }, aiModel: 'gpt' } as any;
+        const existing = { items: [] } as any;
+
+        it('emits pipeline:started, calls plugin.execute, validates the result, and emits pipeline:completed', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+
+            const result = await service.execute(plugin, work, request, existing);
+
+            // STARTED emitted before the plugin runs.
+            expect(eventEmitter.emit).toHaveBeenNthCalledWith(
+                1,
+                PipelineEvents.STARTED,
+                expect.objectContaining({
+                    workId: 'w-1',
+                    pipelineId: 'claude-code',
+                    timestamp: '2026-05-09T12:00:00.000Z',
+                }),
+            );
+
+            // facade.createStepExecutionContext invoked with documented positional args.
+            expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
+                work,
+                request.providers,
+                request.aiModel,
+                undefined, // no signal in options
+            );
+
+            // plugin.execute received {...options, execContext, onLogEntry}.
+            expect(plugin.execute).toHaveBeenCalledWith(
+                work,
+                request,
+                existing,
+                expect.objectContaining({
+                    execContext: { ctx: 'fake' },
+                    onLogEntry: undefined,
+                }),
+                undefined,
+            );
+
+            // COMPLETED emitted with duration + stepsCompleted + outputs.
+            expect(eventEmitter.emit).toHaveBeenLastCalledWith(
+                PipelineEvents.COMPLETED,
+                expect.objectContaining({
+                    workId: 'w-1',
+                    pipelineId: 'claude-code',
+                    stepsCompleted: 3,
+                    duration: expect.any(Number),
+                }),
+            );
+
+            expect(result).toMatchObject({
+                success: true,
+                stepsCompleted: 3,
+                totalSteps: 3,
+                outputs: { items: [{ slug: 'a' }, { slug: 'b' }] },
+            });
+            expect(result.duration).toBe(0); // fake timer keeps Date.now stable
+        });
+
+        it('forwards options.signal into the facade context and passes options through to plugin.execute', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const signal = new AbortController().signal;
+
+            await service.execute(plugin, work, request, existing, { signal } as any);
+
+            expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
+                work,
+                request.providers,
+                request.aiModel,
+                signal,
+            );
+        });
+
+        it('forwards onProgress callback verbatim to plugin.execute', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const onProgress = jest.fn();
+
+            await service.execute(plugin, work, request, existing, undefined, onProgress);
+
+            expect(plugin.execute).toHaveBeenCalledWith(
+                work,
+                request,
+                existing,
+                expect.any(Object),
+                onProgress,
+            );
+        });
+
+        it('overrides duration on the returned result with the post-validation elapsed time', async () => {
+            const plugin = makePlugin();
+            const rawResult = makeValidResult({ duration: 9999 }); // plugin's own duration
+            plugin.execute.mockImplementation(async () => {
+                jest.advanceTimersByTime(2500);
+                return rawResult;
+            });
+
+            const result = await service.execute(plugin, work, request, existing);
+
+            // The wrapper REPLACES the plugin's duration with its own measurement.
+            expect(result.duration).toBe(2500);
+        });
+    });
+
+    describe('execute — log interceptor', () => {
+        const work = { id: 'w-1' } as any;
+        const request = { providers: {} } as any;
+        const existing = {} as any;
+
+        it('attaches an interceptor when onLogEntry is supplied and removes it on success', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const removeFn = jest.fn();
+            contextFactory.addLogInterceptor.mockReturnValue(removeFn);
+            const onLogEntry = jest.fn();
+
+            await service.execute(plugin, work, request, existing, { onLogEntry } as any);
+
+            expect(contextFactory.addLogInterceptor).toHaveBeenCalledWith(
+                'claude-code',
+                expect.any(Function),
+            );
+            expect(removeFn).toHaveBeenCalledTimes(1);
+        });
+
+        it('routes interceptor (level, message) into the documented onLogEntry envelope shape', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const onLogEntry = jest.fn();
+            let captured: ((lvl: string, msg: string) => void) | null = null;
+            contextFactory.addLogInterceptor.mockImplementation(
+                (_id: string, fn: (lvl: string, msg: string) => void) => {
+                    captured = fn;
+                    return () => undefined;
+                },
+            );
+
+            await service.execute(plugin, work, request, existing, { onLogEntry } as any);
+
+            // Now drive the captured interceptor and verify the envelope shape.
+            captured!('warn', 'plugin says hi');
+
+            expect(onLogEntry).toHaveBeenCalledWith({
+                timestamp: '2026-05-09T12:00:00.000Z',
+                level: 'warn',
+                source: 'pipeline',
+                event: 'message',
+                message: 'plugin says hi',
+            });
+        });
+
+        it('skips addLogInterceptor entirely when onLogEntry is omitted', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+
+            await service.execute(plugin, work, request, existing);
+
+            expect(contextFactory.addLogInterceptor).not.toHaveBeenCalled();
+        });
+
+        it('still removes the interceptor in the finally block when execute throws', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockRejectedValue(new Error('boom'));
+            const removeFn = jest.fn();
+            contextFactory.addLogInterceptor.mockReturnValue(removeFn);
+
+            await service.execute(plugin, work, request, existing, {
+                onLogEntry: jest.fn(),
+            } as any);
+
+            expect(removeFn).toHaveBeenCalledTimes(1);
+        });
+
+        it('finally block tolerates a missing remove fn (no removeInterceptor variable when onLogEntry is absent)', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+
+            // Just ensure the call resolves cleanly — `removeInterceptor?.()` is the
+            // optional-call guard.
+            await expect(service.execute(plugin, work, request, existing)).resolves.toBeDefined();
+            expect(contextFactory.addLogInterceptor).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('execute — invalid result handling', () => {
+        const work = { id: 'w-1' } as any;
+        const request = { providers: {} } as any;
+        const existing = {} as any;
+
+        it('throws-then-emits-failed-then-returns-error-envelope when plugin returns a non-object', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue('not-an-object');
+
+            const result = await service.execute(plugin, work, request, existing);
+
+            // The validator emits a single error: "Result must be an object".
+            // The wrapper then throws inside its try and catches in the catch.
+            expect(eventEmitter.emit).toHaveBeenCalledWith(
+                PipelineEvents.FAILED,
+                expect.objectContaining({
+                    workId: 'w-1',
+                    pipelineId: 'claude-code',
+                    error: expect.stringContaining('returned invalid pipeline result'),
+                    failedStep: undefined,
+                    completedSteps: 0,
+                }),
+            );
+            // The error envelope from buildErrorPipelineResult — totalSteps comes
+            // from plugin.getStepDefinitions().length.
+            expect(result).toMatchObject({
+                success: false,
+                stepsCompleted: 0,
+                totalSteps: 3,
+                outputs: expect.any(Object),
+            });
+        });
+
+        it('joins multiple validator errors with "; " in the thrown message + emitted event', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue({}); // missing every required field
+
+            await service.execute(plugin, work, request, existing);
+
+            const failedCall = eventEmitter.emit.mock.calls.find(
+                (c: any[]) => c[0] === PipelineEvents.FAILED,
+            );
+            expect(failedCall![1].error).toContain('; ');
+            // Pinned: the error message starts with the documented prefix.
+            expect(failedCall![1].error).toMatch(
+                /Plugin "claude-code" returned invalid pipeline result/,
+            );
+        });
+
+        it('emits FAILED + error result when plugin.execute itself rejects', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockRejectedValue(new Error('plugin crashed'));
+
+            const result = await service.execute(plugin, work, request, existing);
+
+            expect(eventEmitter.emit).toHaveBeenCalledWith(
+                PipelineEvents.FAILED,
+                expect.objectContaining({ error: 'plugin crashed', completedSteps: 0 }),
+            );
+            expect(result.success).toBe(false);
+            // totalSteps is sourced from plugin.getStepDefinitions().length even on the failure path.
+            expect(result.totalSteps).toBe(3);
+        });
+
+        it('emits FAILED only ONCE per execute call (no double-emission on validator vs catch)', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue('bad');
+
+            await service.execute(plugin, work, request, existing);
+
+            const failedCalls = eventEmitter.emit.mock.calls.filter(
+                (c: any[]) => c[0] === PipelineEvents.FAILED,
+            );
+            expect(failedCalls).toHaveLength(1);
+            const completedCalls = eventEmitter.emit.mock.calls.filter(
+                (c: any[]) => c[0] === PipelineEvents.COMPLETED,
+            );
+            expect(completedCalls).toHaveLength(0);
+        });
+    });
+
+    describe('executeWithCancellation', () => {
+        const work = { id: 'w-1' } as any;
+        const request = { providers: {} } as any;
+        const existing = {} as any;
+
+        it('hooks signal.abort to plugin.cancel when both are present', async () => {
+            const cancel = jest.fn().mockResolvedValue(undefined);
+            const plugin = makePlugin({ cancel });
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const ac = new AbortController();
+            const addSpy = jest.spyOn(ac.signal, 'addEventListener');
+            const removeSpy = jest.spyOn(ac.signal, 'removeEventListener');
+
+            const promise = service.executeWithCancellation(plugin, work, request, existing, {
+                signal: ac.signal,
+            } as any);
+
+            // The handler is registered with `{once: true}`.
+            expect(addSpy).toHaveBeenCalledWith(
+                'abort',
+                expect.any(Function),
+                expect.objectContaining({ once: true }),
+            );
+
+            // Trigger abort BEFORE execute resolves to confirm the handler runs.
+            ac.abort();
+
+            await promise;
+            expect(cancel).toHaveBeenCalledTimes(1);
+            // Listener removed in the finally block.
+            expect(removeSpy).toHaveBeenCalled();
+        });
+
+        it('swallows plugin.cancel rejection (logs error, does not propagate)', async () => {
+            const cancel = jest.fn().mockRejectedValue(new Error('cancel failed'));
+            const plugin = makePlugin({ cancel });
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const ac = new AbortController();
+
+            const promise = service.executeWithCancellation(plugin, work, request, existing, {
+                signal: ac.signal,
+            } as any);
+            ac.abort();
+            await expect(promise).resolves.toBeDefined();
+        });
+
+        it('skips abort wiring entirely when plugin lacks .cancel', async () => {
+            const plugin = makePlugin({ cancel: undefined });
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const ac = new AbortController();
+            const addSpy = jest.spyOn(ac.signal, 'addEventListener');
+
+            await service.executeWithCancellation(plugin, work, request, existing, {
+                signal: ac.signal,
+            } as any);
+
+            expect(addSpy).not.toHaveBeenCalled();
+        });
+
+        it('still removes the listener when execute throws', async () => {
+            const cancel = jest.fn();
+            const plugin = makePlugin({ cancel });
+            plugin.execute.mockRejectedValue(new Error('boom')); // execute rejects → wrapper recovers, returns failure result
+            const ac = new AbortController();
+            const removeSpy = jest.spyOn(ac.signal, 'removeEventListener');
+
+            await service.executeWithCancellation(plugin, work, request, existing, {
+                signal: ac.signal,
+            } as any);
+
+            expect(removeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('getPluginState', () => {
+        it('returns the result of plugin.getState() when defined', () => {
+            const state = {
+                steps: new Map(),
+                completedSteps: ['s1'],
+                failedSteps: [],
+                isRunning: true,
+                isCancelled: false,
+            };
+            const plugin = { getState: jest.fn().mockReturnValue(state) } as any;
+
+            expect(service.getPluginState(plugin)).toBe(state);
+            expect(plugin.getState).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns null when plugin.getState is undefined', () => {
+            const plugin = {} as any;
+            expect(service.getPluginState(plugin)).toBeNull();
+        });
+    });
+
+    describe('event emission helpers (private, exercised via execute)', () => {
+        const work = { id: 'w-1' } as any;
+        const request = { providers: {} } as any;
+        const existing = {} as any;
+
+        it('emitPipelineEvent merges {timestamp, ...payload} (timestamp precedence is payload-wins via spread)', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+
+            await service.execute(plugin, work, request, existing);
+
+            const startedCall = eventEmitter.emit.mock.calls.find(
+                (c: any[]) => c[0] === PipelineEvents.STARTED,
+            );
+            // Default ISO from fake timer.
+            expect(startedCall![1].timestamp).toBe('2026-05-09T12:00:00.000Z');
+            expect(startedCall![1].workId).toBe('w-1');
+            expect(startedCall![1].pipelineId).toBe('claude-code');
+        });
+
+        it('emitPipelineCompleted forwards outputs from the validated result', async () => {
+            const plugin = makePlugin();
+            const r = makeValidResult({
+                outputs: {
+                    items: [{ slug: 'x' }],
+                    categories: [{ slug: 'c' }],
+                    tags: [],
+                    collections: [],
+                    brands: [],
+                },
+            });
+            plugin.execute.mockResolvedValue(r);
+
+            await service.execute(plugin, work, request, existing);
+
+            const completed = eventEmitter.emit.mock.calls.find(
+                (c: any[]) => c[0] === PipelineEvents.COMPLETED,
+            );
+            expect(completed![1].outputs).toEqual(r.outputs);
+        });
+
+        it('emitPipelineFailed pins the documented {workId, pipelineId, error, failedStep:undefined, completedSteps:0, timestamp} envelope', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockRejectedValue(new Error('fatal'));
+
+            await service.execute(plugin, work, request, existing);
+
+            const failed = eventEmitter.emit.mock.calls.find(
+                (c: any[]) => c[0] === PipelineEvents.FAILED,
+            );
+            expect(failed![1]).toEqual({
+                timestamp: '2026-05-09T12:00:00.000Z',
+                workId: 'w-1',
+                pipelineId: 'claude-code',
+                error: 'fatal',
+                failedStep: undefined,
+                completedSteps: 0,
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Closes the per-file zero-coverage gap on [packages/agent/src/pipeline/full-pipeline-executor.service.ts](packages/agent/src/pipeline/full-pipeline-executor.service.ts) (239 LOC) — the executor that runs **self-managed** pipeline plugins (e.g. `claude-code`, where the plugin owns step ordering internally rather than delegating each step back to the engine).
- 22 tests covering happy path, log-interceptor lifecycle, invalid-result handling, cancellation, plugin-state passthrough, and private emitter helpers.
- Total agent-package suite: 3693 → 3715 tests across 171 → 172 suites, all green.

## Why this matters

The orchestrator routes self-managed pipelines through this service, so a regression in event emission, validation, or cancellation wiring is invisible to the existing `PipelineOrchestratorService` suite (which mocks the executor). This file fills the gap on the second of three pipeline executors.

## Pinned behaviours

- **`execute` happy path** — emits `pipeline:started` BEFORE invoking `plugin.execute`; calls `facadeService.createStepExecutionContext` with documented positional args; passes `{...options, execContext, onLogEntry}` into `plugin.execute`; emits `pipeline:completed` w/ full envelope. **CRITICAL contract**: the wrapper REPLACES the plugin's reported `duration` field with its own `Date.now() - startTime` measurement (a plugin returning a stale `duration: 9999` will be overridden — pinned via fake timers).
- **Log-interceptor lifecycle** — attached when `onLogEntry` set; routes `(level, message)` into the documented envelope `{timestamp, level, source:'pipeline', event:'message', message}`; removed in `finally` on both success AND throw paths; `removeInterceptor?.()` optional-call guard tolerates the no-`onLogEntry` path.
- **Invalid-result handling** — non-object plugin return → single `"Result must be an object"` error → throws `Plugin "<id>" returned invalid pipeline result: <errs>` → catch emits FAILED **exactly once** per execute call (no double-emission across the inner-throw and outer-catch) → returns `buildErrorPipelineResult` envelope w/ `totalSteps` from `plugin.getStepDefinitions().length`; multi-error `'; '` join.
- **`executeWithCancellation`** — abort handler registered w/ `{once:true}`; firing abort triggers `plugin.cancel()` once; `plugin.cancel` rejection swallowed via `.catch(err => logger.error(...))`; abort wiring skipped entirely when `plugin.cancel` undefined; listener removed in `finally` on both success AND throw.
- **`getPluginState`** — null-safe wrapper.
- **Private emitter helpers** — `emitPipelineEvent` timestamp/payload merge order; `emitPipelineCompleted` forwards `outputs` from the **validated** result (NOT the raw plugin return); `emitPipelineFailed` envelope shape `{timestamp, workId, pipelineId, error, failedStep:undefined, completedSteps:0}` pinned literally via `toEqual` so a future "add failedStepLogs" addition is a deliberate change.

## Test plan

- [x] `cd packages/agent && npx jest --testPathPattern='full-pipeline-executor.service.spec.ts' --no-coverage` — 22/22 passing
- [x] `cd packages/agent && npx jest --no-coverage` — 3715/3715 across 172 suites
- [x] Prettier-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the pipeline executor service in the agent package, including validation of execution flow, event emissions, cancellation behavior, and result handling.

* **Documentation**
  * Updated coverage tracking documentation to reflect the new test suite and corresponding coverage improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->