### PR TITLE
test(agent): cover DatabaseModule decorator metadata (+15 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -343,6 +343,19 @@
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
 
+**2026-05-09 — packages/agent DatabaseModule decorator-metadata coverage (+15 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes the per-file zero-coverage gap on `packages/agent/src/database/database.module.ts` (96 LOC) — the central NestJS module that all `packages/agent` and `apps/api` feature modules import to resolve TypeORM-backed repositories. `database-config.factory.spec.ts` and `database.config.spec.ts` already cover the connection-options factory and entities list; this new spec restricts itself to the static `@Module()` decorator metadata so the wire surface (imports / providers / exports lists) is pinned regardless of the runtime DataSource. The new file is `packages/agent/src/database/database.module.spec.ts` and pins:
+
+- **`@Module() providers` (4 tests)** — every documented repository class is present in the providers list (23 of them, kept in a typed `REPOSITORY_PROVIDERS` constant in the spec so adding/removing a repository is an explicit, type-checked update); EXACTLY 23 providers (regression guard against silent additions); every provider is a class constructor (function with prototype) — pinned so a future `useClass`/`useFactory` swap is deliberate; `DataSource`/`EntityManager` are NOT directly provided (consumers depend on the typed wrappers).
+- **`@Module() exports` (4 tests)** — `TypeOrmModule` is exported (so consumers can `@InjectRepository(...)` even though the binding lives in this module's scope); every documented repository is exported; exactly 24 symbols (TypeOrmModule + 23 repositories); the providers-superset-of-exports invariant pinned (every provider is also exported — no "private helper" repositories silently held back).
+- **`@Module() imports` (5 tests)** — exactly 2 TypeOrmModule entries (the `forRootAsync` connection + the `forFeature(ENTITIES)` per-entity binding); exactly 1 `ConfigModule.forFeature(databaseConfig)` entry (pinned because `config.get('database')` depends on the forFeature scoping); exactly 3 imports total (regression guard); the `forRootAsync` DynamicModule wraps a single ConfigModule import so the inner factory can resolve `ConfigService` (a future "drop the imports forwarding" tweak would break the inner factory loudly); the `forFeature` DynamicModule binds providers + exports (pinned so a future "stop calling forFeature" tweak that orphans every `@InjectRepository(...)` consumer is a deliberate diff).
+- **Class identity (2 tests)** — `DatabaseModule` is a class function (so DI-resolution by class identity works); the documented class name `'DatabaseModule'` is preserved (so a string-based registry would still find it).
+
+Total agent-package suite: +15 tests across 1 new suite, all green.
+
+---
+
 **2026-05-09 — packages/agent FullPipelineExecutorService direct coverage (+22 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [#674](https://github.com/ever-works/ever-works/pull/674))**
 
 Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/full-pipeline-executor.service.ts` (239 LOC) — the executor that runs self-managed pipeline plugins (e.g. `claude-code`, where the plugin owns step ordering and orchestration internally rather than delegating each step back to the engine). The orchestrator routes self-managed pipelines through this service, so a regression in event emission, validation, or cancellation wiring is invisible to the existing `PipelineOrchestratorService` suite (which mocks the executor).

--- a/packages/agent/src/database/database.module.spec.ts
+++ b/packages/agent/src/database/database.module.spec.ts
@@ -1,0 +1,254 @@
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DatabaseModule } from './database.module';
+import { ApiKeyRepository } from './repositories/api-key.repository';
+import { WorkRepository } from './repositories/work.repository';
+import { WorkAdvancedPromptsRepository } from './repositories/work-advanced-prompts.repository';
+import { WorkCustomDomainRepository } from './repositories/work-custom-domain.repository';
+import { WorkMemberRepository } from './repositories/work-member.repository';
+import { RefreshTokenRepository } from './repositories/refresh-token.repository';
+import { AuthAccountRepository } from './repositories/auth-account.repository';
+import { UserRepository } from './repositories/user.repository';
+import { WorkGenerationHistoryRepository } from './repositories/work-generation-history.repository';
+import { SubscriptionPlanRepository } from './repositories/subscription-plan.repository';
+import { UserSubscriptionRepository } from './repositories/user-subscription.repository';
+import { WorkScheduleRepository } from './repositories/work-schedule.repository';
+import { UsageLedgerRepository } from './repositories/usage-ledger.repository';
+import { NotificationRepository } from './repositories/notification.repository';
+import { ActivityLogRepository } from './repositories/activity-log.repository';
+import { ConversationRepository } from './repositories/conversation.repository';
+import { GitHubAppInstallationRepository } from './repositories/github-app-installation.repository';
+import { GitHubAppInstallationRepoRepository } from './repositories/github-app-installation-repository.repository';
+import { GitHubAppUserLinkRepository } from './repositories/github-app-user-link.repository';
+import { OnboardingRequestRepository } from './repositories/onboarding-request.repository';
+import { TemplateRepository } from './repositories/template.repository';
+import { UserTemplatePreferenceRepository } from './repositories/user-template-preference.repository';
+import { WebhookSubscriptionRepository } from './repositories/webhook-subscription.repository';
+
+/**
+ * `DatabaseModule` is a wire-format-stable contract: every NestJS feature
+ * module across `packages/agent` and `apps/api` imports it and resolves
+ * exactly the documented set of TypeORM-backed repositories. Adding a
+ * provider without exporting it would silently break consumers; removing
+ * one would orphan downstream services. Pinning the
+ * `@Module()` Reflect-metadata snapshot here makes either change a
+ * deliberate, noisy diff.
+ *
+ * The module is also responsible for two TypeORM imports:
+ *   - `ConfigModule.forFeature(databaseConfig)` so `'database'` namespace
+ *     config is injectable, and
+ *   - `TypeOrmModule.forRootAsync(...)` plus `TypeOrmModule.forFeature(ENTITIES)`
+ *     so the connection + per-entity repositories are bound.
+ *
+ * The async useFactory simply pulls `'database'` from `ConfigService` and
+ * forwards it as the TypeORM connection options — covered separately in
+ * `database-config.factory.spec.ts` / `database.config.spec.ts`. This
+ * suite restricts itself to the static `@Module()` decorator metadata
+ * (`imports` shape, providers list, exports list) so the surface is
+ * pinned regardless of the runtime DataSource.
+ */
+describe('DatabaseModule decorator metadata', () => {
+    function getMeta(key: 'imports' | 'providers' | 'exports'): unknown[] {
+        return (Reflect.getMetadata(key, DatabaseModule) ?? []) as unknown[];
+    }
+
+    /**
+     * The 23 documented repository providers (kept here so adding a new
+     * repository is an explicit, type-checked update — silently appending
+     * a provider to `database.module.ts` without bumping this list will
+     * break the regression-guard test). Order does not matter at runtime
+     * but the list is sorted alphabetically by class name to make diffs
+     * easy to read.
+     */
+    const REPOSITORY_PROVIDERS = [
+        ActivityLogRepository,
+        ApiKeyRepository,
+        AuthAccountRepository,
+        ConversationRepository,
+        GitHubAppInstallationRepoRepository,
+        GitHubAppInstallationRepository,
+        GitHubAppUserLinkRepository,
+        NotificationRepository,
+        OnboardingRequestRepository,
+        RefreshTokenRepository,
+        SubscriptionPlanRepository,
+        TemplateRepository,
+        UsageLedgerRepository,
+        UserRepository,
+        UserSubscriptionRepository,
+        UserTemplatePreferenceRepository,
+        WebhookSubscriptionRepository,
+        WorkAdvancedPromptsRepository,
+        WorkCustomDomainRepository,
+        WorkGenerationHistoryRepository,
+        WorkMemberRepository,
+        WorkRepository,
+        WorkScheduleRepository,
+    ] as const;
+
+    describe('@Module() providers', () => {
+        it('declares every documented repository provider', () => {
+            const providers = getMeta('providers');
+            for (const repo of REPOSITORY_PROVIDERS) {
+                expect(providers).toContain(repo);
+            }
+        });
+
+        it('declares EXACTLY 23 providers (regression guard against silent additions)', () => {
+            const providers = getMeta('providers');
+            expect(providers.length).toBe(REPOSITORY_PROVIDERS.length);
+            expect(providers.length).toBe(23);
+        });
+
+        it('every provider is a class constructor (function with prototype) — pinned so a future `useClass`/`useFactory` swap is deliberate', () => {
+            const providers = getMeta('providers');
+            for (const provider of providers) {
+                expect(typeof provider).toBe('function');
+                expect((provider as { prototype?: unknown }).prototype).toBeDefined();
+            }
+        });
+
+        it('does NOT include the DataSource / EntityManager directly — only repository wrappers', () => {
+            // The intent is for consumers to depend on the typed repository
+            // wrappers (which encapsulate query-builder usage), NOT the raw
+            // DataSource. Pinned so a future "leak the DataSource" tweak
+            // is a deliberate downgrade.
+            const providers = getMeta('providers');
+            const providerNames = providers.map((p) => (p as { name?: string })?.name ?? String(p));
+            expect(providerNames).not.toContain('DataSource');
+            expect(providerNames).not.toContain('EntityManager');
+        });
+    });
+
+    describe('@Module() exports', () => {
+        it('exports `TypeOrmModule` so consumers can resolve `getRepositoryToken(...)` directly when needed', () => {
+            // Re-exporting `TypeOrmModule` from `forFeature(ENTITIES)` is
+            // what lets downstream feature modules (e.g. `WorkModule`)
+            // `@InjectRepository(Work)` even though the binding lives in
+            // this module's scope.
+            const exports = getMeta('exports');
+            expect(exports).toContain(TypeOrmModule);
+        });
+
+        it('exports every documented repository (so consumers can `@Inject` the wrapper)', () => {
+            const exports = getMeta('exports');
+            for (const repo of REPOSITORY_PROVIDERS) {
+                expect(exports).toContain(repo);
+            }
+        });
+
+        it('exports EXACTLY 24 symbols — TypeOrmModule + 23 repositories (regression guard)', () => {
+            // Pinned so a future "stop exporting WorkRepository" tweak (which
+            // would orphan every consumer) breaks loudly.
+            const exports = getMeta('exports');
+            expect(exports.length).toBe(REPOSITORY_PROVIDERS.length + 1);
+            expect(exports.length).toBe(24);
+        });
+
+        it('exports list is exactly the providers list + TypeOrmModule (no provider held back from consumers)', () => {
+            // This pins a property of the design: every repository is
+            // exported. If we ever want to add a "private helper" repository
+            // that's NOT exported, it has to be a deliberate change to this
+            // assertion.
+            const providers = getMeta('providers');
+            const exports = getMeta('exports');
+            const exportSet = new Set(exports);
+            for (const provider of providers) {
+                expect(exportSet.has(provider)).toBe(true);
+            }
+        });
+    });
+
+    describe('@Module() imports', () => {
+        it('includes TWO TypeOrmModule entries — one `forRootAsync` (DB connection) and one `forFeature` (per-entity repositories)', () => {
+            // Both `forRootAsync` and `forFeature` return DynamicModule
+            // descriptors with `module: TypeOrmModule`. We can only count
+            // them by iterating `imports`. Pinned so a future "merge into a
+            // single forFeatureAsync" refactor is a deliberate diff.
+            const imports = getMeta('imports');
+            const typeormImports = imports.filter((m) => {
+                const desc = m as { module?: unknown };
+                return desc?.module === TypeOrmModule;
+            });
+            expect(typeormImports.length).toBe(2);
+        });
+
+        it('includes a `ConfigModule.forFeature(databaseConfig)` entry exposing the `database` namespace', () => {
+            const imports = getMeta('imports');
+            const configImports = imports.filter((m) => {
+                const desc = m as { module?: unknown };
+                return desc?.module === ConfigModule;
+            });
+            // `forFeature(databaseConfig)` returns a DynamicModule with
+            // `module: ConfigModule`. Pinned so a future "drop the
+            // forFeature scoping in favour of forRoot only" tweak breaks
+            // loudly (the `config.get('database')` binding depends on this
+            // forFeature call).
+            expect(configImports.length).toBe(1);
+        });
+
+        it('declares EXACTLY 3 imports (1 ConfigModule.forFeature + 2 TypeOrmModule entries) — regression guard', () => {
+            const imports = getMeta('imports');
+            expect(imports.length).toBe(3);
+        });
+
+        it('the async TypeOrm DynamicModule wraps a single ConfigModule import so the inner factory can resolve ConfigService', () => {
+            // `TypeOrmModule.forRootAsync({ imports: [ConfigModule], useFactory, inject })`
+            // returns a DynamicModule shaped like
+            // `{ module: TypeOrmModule, imports: [ConfigModule] }` at the
+            // outer level — the actual `useFactory` is buried inside an
+            // inner DynamicModule that NestJS' TypeOrmModule constructs
+            // internally. We pin the OUTER shape (1 wrapped import) so a
+            // future "drop the imports forwarding" tweak is a deliberate
+            // diff (without it, the inner factory cannot resolve
+            // ConfigService).
+            const imports = getMeta('imports');
+            const typeormImports = imports.filter((m) => {
+                const desc = m as { module?: unknown };
+                return desc?.module === TypeOrmModule;
+            }) as Array<{ module: unknown; imports?: unknown[] }>;
+
+            // Of the two TypeOrmModule entries, exactly one is the async
+            // (forRootAsync) one — it carries a non-empty `imports` array
+            // (the ConfigModule forwarding). The other is `forFeature`
+            // which has providers/exports but no `imports` key.
+            const asyncEntries = typeormImports.filter((m) => Array.isArray(m.imports));
+            expect(asyncEntries.length).toBe(1);
+            expect(asyncEntries[0].imports!.length).toBe(1);
+        });
+
+        it('the per-entity `forFeature` DynamicModule binds providers + exports (the per-entity repositories)', () => {
+            // Pinned so a future "stop calling forFeature" tweak (which
+            // would orphan every `@InjectRepository(...)` consumer) is a
+            // deliberate diff.
+            const imports = getMeta('imports');
+            const typeormImports = imports.filter((m) => {
+                const desc = m as { module?: unknown };
+                return desc?.module === TypeOrmModule;
+            }) as Array<{ module: unknown; providers?: unknown[]; exports?: unknown[] }>;
+
+            const forFeatureEntries = typeormImports.filter(
+                (m) => Array.isArray(m.providers) && Array.isArray(m.exports),
+            );
+            expect(forFeatureEntries.length).toBe(1);
+            // `forFeature(ENTITIES)` provides one repository token per
+            // entity. The exact entity count is owned by `database.config`
+            // (covered in `database.config.spec.ts`); we only pin that the
+            // forFeature call binds at least 1 entity (defence against a
+            // future "empty forFeature call" no-op).
+            expect(forFeatureEntries[0].providers!.length).toBeGreaterThan(0);
+            expect(forFeatureEntries[0].exports!.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('class identity', () => {
+        it('DatabaseModule is a class function (so DI-resolution by class identity works)', () => {
+            expect(typeof DatabaseModule).toBe('function');
+            expect(DatabaseModule.prototype).toBeDefined();
+        });
+
+        it('exports the class under the documented name (so a string-based registry would still find it)', () => {
+            expect(DatabaseModule.name).toBe('DatabaseModule');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Closes the per-file zero-coverage gap on `packages/agent/src/database/database.module.ts` (96 LOC) — the central NestJS module that all `packages/agent` and `apps/api` feature modules import to resolve TypeORM-backed repositories.

The new spec restricts itself to the static \`@Module()\` decorator metadata (connection-options factory + entities list are already covered by \`database-config.factory.spec.ts\` / \`database.config.spec.ts\`):

- **Providers (4 tests)** — every documented repository class (23 of them, kept in a typed \`REPOSITORY_PROVIDERS\` constant in the spec so adding/removing one is an explicit, type-checked update); EXACTLY 23 (regression guard); every provider is a class constructor; DataSource/EntityManager NOT directly provided.
- **Exports (4 tests)** — TypeOrmModule + 23 repositories = 24 symbols; providers-superset-of-exports invariant pinned (no "private helper" repositories held back).
- **Imports (5 tests)** — exactly 2 TypeOrmModule entries (\`forRootAsync\` + \`forFeature\`) + 1 ConfigModule.forFeature; \`forRootAsync\` DynamicModule wraps a single ConfigModule import so the inner factory can resolve ConfigService; \`forFeature\` DynamicModule binds providers + exports.
- **Class identity (2 tests)** — class function + documented name.

Total agent-package suite: +15 tests across 1 new suite, all green locally.

## Test plan

- [x] \`pnpm --filter @ever-works/agent test database.module\` — 15/15 green locally
- [ ] CI \`lint-and-test (22.x)\` job
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new Jest test suite that validates the static Nest module configuration, exported providers/exports/imports consistency, and class identities to guard against regressions.

* **Documentation**
  * Updated coverage tracker with a "Done" ledger entry (2026-05-09) recording the new tests (+15) and run status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/676)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->