### PR TITLE
test(agent): cover pipeline-result.validator directly (+78 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -65,126 +65,85 @@
   reuses the validator and projects the errors[] into a single Error
   message via `errors.join('; ')`, with the documented two-format
   string `Invalid pipeline result${pluginId ? \` from plugin '<id>'\`
-  : ''}: <joined errors>` pinned for both no-plugin-id AND with-plugin-id
-  cases, the empty-string-pluginId-treated-as-falsy case (no `from
-  plugin '...'` segment), the whitespace-only-pluginId-treated-as-truthy
-  case (no implicit `.trim()`, included verbatim — pinned so a future
-  trim refactor breaks loudly), success-on-failed-run (`success: false`
-  with an `error` field is a perfectly valid PipelineResult SHAPE — the
-  wrapper only throws when the shape is wrong, not when the run itself
-  failed), and the per-call fresh-Error-instance contract); +1 net spec
-  file in the prior agent `PipelineFacadeService` direct-coverage sweep
-  — adds `packages/agent/src/pipeline/pipeline-facade.service.spec.ts`
-  (30 tests on the 300-LOC facade-binding service that creates the
-  `StepExecutionContext` consumed by both pipeline executors:
-  guard-rails (throws on missing `work.user` / empty `user.id`);
-  logger prefix `[work.slug]` applied to every log/debug/warn/error/
-  verbose call w/ `verbose?.()` optional-chain tolerating undefined;
-  bound AI facade w/ `aiModelOverride` defaulting into
-  `options.routing.modelOverride` and `options.model` via `??`-
-  precedence (caller-supplied override wins); bound search /
-  screenshot / content-extractor facades each forwarding their
-  `providerOverrides.<key>` into the underlying call; bound prompt
-  facade carrying NO providerOverride field (workId+userId only);
-  bound data-source facade w/ caller workId/userId OVERWRITTEN by
-  binding (spread runs first), `getEnabledSources` `||`-fallback on
-  falsy userId; optional data-source dep undefined when not provided;
-  binding context shape — non-AI facades do NOT carry
-  `aiModelOverride`), closing the per-file zero-coverage gap on the
-  third pipeline service in `packages/agent/src/pipeline/` after the
-  orchestrator + full executor — see `Done` ledger; +1 net spec file
-  in the prior agent `FullPipelineExecutorService` direct-coverage
-  sweep — adds
-  `packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts`
-  (22 tests on the 239-LOC self-managed-pipeline executor: `execute`
-  STARTED→plugin.execute→COMPLETED w/ wrapper-measured duration
-  override; full signal/options/onProgress forwarding; log-interceptor
-  lifecycle (attached on `onLogEntry`, routed into the documented
-  envelope, removed in finally on both success AND throw); invalid-
-  result handling (non-object single error, multi-error `'; '` join,
-  FAILED emitted exactly ONCE); plugin.execute rejection →
-  `buildErrorPipelineResult` envelope w/ `totalSteps` from
-  `plugin.getStepDefinitions().length`; `executeWithCancellation`
-  abort wiring + listener removal in finally on success AND throw +
-  cancel-rejection swallowed + skip-when-plugin-lacks-cancel;
-  `getPluginState` null-safe wrapper; private emitter helpers
-  envelope shapes), closing the per-file zero-coverage gap on the
-  second of three pipeline executors — see `Done` ledger; +2 net
-  spec files in the prior agent `PipelineOrchestratorService` +
-  `comparison/types` direct-coverage sweep
-  — adds `packages/agent/src/comparison-generator/comparison/types.spec.ts`
-  (11 tests on the 60-LOC contracts module pinning
-  `DEFAULT_COMPARISON_SETTINGS` four-default merge target +
-  `ComparisonProgressStage` literal union + minimal-and-maximal type
-  literals for every documented `Comparison*` envelope) and
-  `packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts`
-  (33 tests on the 262-LOC routing service: `execute` step-vs-full
-  routing via `isStepOrchestratablePipeline`; `executeWithMode` forced
-  step / forced full / full→step fallback w/ warn when no self-managed
-  plugin exists; `getRecommendedMode` four-branch projection;
-  `hasFullPipelinePlugin` boolean; `getAvailablePipelinePlugins`
-  registry filter chain (`PIPELINE` capability + state===loaded +
-  `isPipelinePlugin` shape filter); `resumeFromCheckpoint` proxy
-  forwarding incl. null-passthrough; `clearCheckpoint` proxy;
-  `resumeOrExecute` resume-then-fallback w/ self-managed plugins
-  skipping resume entirely; `resolvePipelinePlugin` private 3-level
-  priority chain (explicit id w/ `registry.get` + state + scope check
-  → `defaultForCapabilities` pass → first-loaded-and-enabled fallback
-  → throws when none available), incl. null-pipelineId vs
-  string-pipelineId branch, wrong-capabilities skip via
-  `isPipelinePlugin`, `work.user` undefined → undefined userId
-  forwarding to `isPluginEnabledForScope`. Total agent-package suite:
-  3474 → 3507 tests across 165 → 166 suites — see `Done` ledger;
-  +3 net spec files in the prior security + utility coverage sweep
-  #7 — adds
-  `packages/agent/src/utils/__tests__/work-changelog.utils.spec.ts`
-  (23 tests on `buildWorkChangelog` covering the empty-input null
-  contract, count partitioning, entries reference passthrough,
-  summary-override semantics including the empty-string preservation
-  vs `??`-fallback gotcha, default-summary builder pluralisation +
-  fixed `, ` join order + zero-count omission, entityType label
-  resolution across all 5 documented literals (`item`/`comparison`/
-  `category`/`tag`/`collection`) with `entries[0]`-only derivation
-  pinned, `?? 'item'` fallback for malformed entries, and the exact
-  5-field envelope shape with no extra keys),
-  `packages/agent/src/utils/__tests__/github-app.utils.spec.ts`
-  (30 tests on the security-critical 105-LOC GitHub-App utility —
-  RS256 JWT generation w/ public-key round-trip verification +
-  `iat = now-60` / `exp = now+9*60` / `iss = appId` payload pinning +
-  base64url segment shape + appId verbatim-passthrough; `Bearer`
-  header construction; `requestGitHubAppInstallationAccessToken*`
-  fetch URL/method/headers shape + `expires_at ?? null` coercion +
-  non-OK error message format + missing/empty-token rejection;
-  `verifyGitHubWebhookSignature` constant-time compare with the
-  explicit length-guard pinned ahead of `timingSafeEqual` to avoid
-  the RangeError it throws on mismatched-length inputs, plus
-  scheme-prefix strict-equality check, secret-dependence check,
-  body-dependence check, and empty-body happy-path), and
-  `packages/agent/src/pipeline/__tests__/pipeline-result.validator.spec.ts`
-  (53 tests on `validatePipelineResult` + `validatePipelineResultOrThrow` —
-  the type-checker every pipeline plugin output passes through —
-  covering the non-object short-circuit, happy-path reference
-  passthrough, all top-level scalar typeof checks, the
-  `outputs`-null guard that prevents child-error cascading, all 5
-  output-array fields independently rejected when missing/non-array,
-  `state` (optional) three-way branch (missing → pass /
-  explicitly-null → error + skip children / non-object → error),
-  `error` accepting string OR `Error` instance, `failedStep`
-  typeof-string only, declaration-order error accumulation, and
-  the throwing variant's `pluginId` interpolation including the
-  empty-string-as-no-plugin behaviour pinning the
-  `pluginId ? ...` falsy branch). Earlier on 2026-05-09 was 507;
-  +3 net spec files in the agent tiny-utility
-  coverage sweep — adds
-  `packages/agent/src/activity-log/activity-log-analytics-dispatcher.spec.ts`
-  (7 tests on the string DI-token literal + `ActivityLogAnalyticsDispatcher`
-  interface + barrel re-export — pins the string-vs-Symbol-token shape so
-  a future swap to `Symbol(...)` (which would silently break every
-  cross-module `@Inject(ACTIVITY_LOG_ANALYTICS_DISPATCHER)` binding) is a
-  deliberate change),
-  `packages/agent/src/comparison-generator/comparison/prompt-keys.spec.ts`
-  (8 tests on the three documented Langfuse-facing prompt keys
-  `comparison.structure` / `comparison.markdown` / `comparison.extended-analysis`
+  : ''}: <joined errors>`pinned for both no-plugin-id AND with-plugin-id
+cases, the empty-string-pluginId-treated-as-falsy case (no`from
+  plugin '...'`segment), the whitespace-only-pluginId-treated-as-truthy
+case (no implicit`.trim()`, included verbatim — pinned so a future
+trim refactor breaks loudly), success-on-failed-run (`success: false`with an`error`field is a perfectly valid PipelineResult SHAPE — the
+wrapper only throws when the shape is wrong, not when the run itself
+failed), and the per-call fresh-Error-instance contract); +1 net spec
+file in the prior agent`PipelineFacadeService`direct-coverage sweep
+— adds`packages/agent/src/pipeline/pipeline-facade.service.spec.ts`(30 tests on the 300-LOC facade-binding service that creates the`StepExecutionContext`consumed by both pipeline executors:
+guard-rails (throws on missing`work.user`/ empty`user.id`);
+logger prefix `[work.slug]`applied to every log/debug/warn/error/
+verbose call w/`verbose?.()`optional-chain tolerating undefined;
+bound AI facade w/`aiModelOverride`defaulting into`options.routing.modelOverride`and`options.model`via`??`-
+precedence (caller-supplied override wins); bound search /
+screenshot / content-extractor facades each forwarding their
+`providerOverrides.<key>`into the underlying call; bound prompt
+facade carrying NO providerOverride field (workId+userId only);
+bound data-source facade w/ caller workId/userId OVERWRITTEN by
+binding (spread runs first),`getEnabledSources` `||`-fallback on
+falsy userId; optional data-source dep undefined when not provided;
+binding context shape — non-AI facades do NOT carry
+`aiModelOverride`), closing the per-file zero-coverage gap on the
+third pipeline service in `packages/agent/src/pipeline/`after the
+orchestrator + full executor — see`Done`ledger; +1 net spec file
+in the prior agent`FullPipelineExecutorService`direct-coverage
+sweep — adds`packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts`(22 tests on the 239-LOC self-managed-pipeline executor:`execute`STARTED→plugin.execute→COMPLETED w/ wrapper-measured duration
+override; full signal/options/onProgress forwarding; log-interceptor
+lifecycle (attached on`onLogEntry`, routed into the documented
+envelope, removed in finally on both success AND throw); invalid-
+result handling (non-object single error, multi-error `'; '`join,
+FAILED emitted exactly ONCE); plugin.execute rejection →`buildErrorPipelineResult`envelope w/`totalSteps`from`plugin.getStepDefinitions().length`; `executeWithCancellation`abort wiring + listener removal in finally on success AND throw +
+cancel-rejection swallowed + skip-when-plugin-lacks-cancel;`getPluginState`null-safe wrapper; private emitter helpers
+envelope shapes), closing the per-file zero-coverage gap on the
+second of three pipeline executors — see`Done`ledger; +2 net
+spec files in the prior agent`PipelineOrchestratorService`+`comparison/types`direct-coverage sweep
+— adds`packages/agent/src/comparison-generator/comparison/types.spec.ts`(11 tests on the 60-LOC contracts module pinning`DEFAULT_COMPARISON_SETTINGS`four-default merge target +`ComparisonProgressStage`literal union + minimal-and-maximal type
+literals for every documented`Comparison*`envelope) and`packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts`(33 tests on the 262-LOC routing service:`execute`step-vs-full
+routing via`isStepOrchestratablePipeline`; `executeWithMode`forced
+step / forced full / full→step fallback w/ warn when no self-managed
+plugin exists;`getRecommendedMode`four-branch projection;`hasFullPipelinePlugin`boolean;`getAvailablePipelinePlugins`
+registry filter chain (`PIPELINE`capability + state===loaded +`isPipelinePlugin`shape filter);`resumeFromCheckpoint`proxy
+forwarding incl. null-passthrough;`clearCheckpoint`proxy;`resumeOrExecute`resume-then-fallback w/ self-managed plugins
+skipping resume entirely;`resolvePipelinePlugin`private 3-level
+priority chain (explicit id w/`registry.get`+ state + scope check
+→`defaultForCapabilities`pass → first-loaded-and-enabled fallback
+→ throws when none available), incl. null-pipelineId vs
+string-pipelineId branch, wrong-capabilities skip via`isPipelinePlugin`, `work.user`undefined → undefined userId
+forwarding to`isPluginEnabledForScope`. Total agent-package suite:
+3474 → 3507 tests across 165 → 166 suites — see `Done`ledger;
++3 net spec files in the prior security + utility coverage sweep
+#7 — adds`packages/agent/src/utils/**tests**/work-changelog.utils.spec.ts`(23 tests on`buildWorkChangelog`covering the empty-input null
+contract, count partitioning, entries reference passthrough,
+summary-override semantics including the empty-string preservation
+vs`??`-fallback gotcha, default-summary builder pluralisation +
+fixed `, ` join order + zero-count omission, entityType label
+resolution across all 5 documented literals (`item`/`comparison`/
+`category`/`tag`/`collection`) with `entries[0]`-only derivation
+pinned, `?? 'item'`fallback for malformed entries, and the exact
+5-field envelope shape with no extra keys),`packages/agent/src/utils/**tests**/github-app.utils.spec.ts`(30 tests on the security-critical 105-LOC GitHub-App utility —
+RS256 JWT generation w/ public-key round-trip verification +`iat = now-60`/`exp = now+9*60`/`iss = appId`payload pinning +
+base64url segment shape + appId verbatim-passthrough;`Bearer`header construction;`requestGitHubAppInstallationAccessToken\*`fetch URL/method/headers shape +`expires_at ?? null`coercion +
+non-OK error message format + missing/empty-token rejection;`verifyGitHubWebhookSignature`constant-time compare with the
+explicit length-guard pinned ahead of`timingSafeEqual`to avoid
+the RangeError it throws on mismatched-length inputs, plus
+scheme-prefix strict-equality check, secret-dependence check,
+body-dependence check, and empty-body happy-path), and`packages/agent/src/pipeline/**tests**/pipeline-result.validator.spec.ts`(53 tests on`validatePipelineResult`+`validatePipelineResultOrThrow`—
+the type-checker every pipeline plugin output passes through —
+covering the non-object short-circuit, happy-path reference
+passthrough, all top-level scalar typeof checks, the`outputs`-null guard that prevents child-error cascading, all 5
+output-array fields independently rejected when missing/non-array,
+`state`(optional) three-way branch (missing → pass /
+explicitly-null → error + skip children / non-object → error),`error`accepting string OR`Error`instance,`failedStep`typeof-string only, declaration-order error accumulation, and
+the throwing variant's`pluginId`interpolation including the
+empty-string-as-no-plugin behaviour pinning the`pluginId ? ...`falsy branch). Earlier on 2026-05-09 was 507;
++3 net spec files in the agent tiny-utility
+coverage sweep — adds`packages/agent/src/activity-log/activity-log-analytics-dispatcher.spec.ts`(7 tests on the string DI-token literal +`ActivityLogAnalyticsDispatcher`interface + barrel re-export — pins the string-vs-Symbol-token shape so
+a future swap to`Symbol(...)`(which would silently break every
+cross-module`@Inject(ACTIVITY_LOG_ANALYTICS_DISPATCHER)`binding) is a
+deliberate change),`packages/agent/src/comparison-generator/comparison/prompt-keys.spec.ts`(8 tests on the three documented Langfuse-facing prompt keys`comparison.structure`/`comparison.markdown`/`comparison.extended-analysis`
     - dotted-namespace regex + uniqueness + `as const` JSON-roundtrip
     - barrel `COMPARISON_PROMPT_KEYS`-rename pin — pinned so the
       agent-package keys stay aligned with the Langfuse UI), and

--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -21,10 +21,60 @@
 
 ## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~517 across `apps/` + `packages/` (was 516
+- **Spec files (`*.spec.ts`)**: ~518 across `apps/` + `packages/` (was 517
   earlier on 2026-05-10; +1 net spec file in the agent
-  `PipelineFacadeService` direct-coverage sweep — adds
-  `packages/agent/src/pipeline/pipeline-facade.service.spec.ts`
+  `pipeline-result.validator` direct-coverage sweep — adds
+  `packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts`
+  (78 tests on the 122-LOC pure-function validator pinning the
+  `validatePipelineResult(unknown) → {valid, errors[], result?}` envelope
+  used by the in-process pipeline executors to reject malformed
+  PipelineResult shapes returned from third-party plugins: the
+  early-return short-circuit on non-object inputs (null/undefined/
+  number/string/boolean) yielding the single-message
+  `['Result must be an object']` envelope vs. the per-field accumulator
+  branch that runs for arrays-as-objects (typeof [] === 'object', so
+  arrays fall through to per-field checks instead of short-circuiting —
+  pinned because a future `Array.isArray` short-circuit refactor would
+  silently change behaviour); the eight per-field check ORDER pinned
+  (success → outputs → stepsCompleted → totalSteps → state → duration →
+  error → failedStep) so a reorder of the validator breaks loudly; the
+  outputs object's five required arrays (items/categories/tags/
+  collections/brands) AND the documented short-circuit where the nested
+  array checks DO NOT run when outputs itself is missing/null/non-object
+  (single-envelope-error policy, no error-spam); the state object's
+  partial-optional shape — `state===undefined` skips ALL nested checks,
+  `state===null/non-object` produces a SINGLE envelope error and skips
+  the four nested checks, but `state===object` runs all four nested
+  checks (isRunning bool / isCancelled bool / completedSteps array /
+  failedSteps array); the documented gotcha that `duration` is labelled
+  "Optional fields validation" in the source comment block but is
+  ACTUALLY required (no `r.duration !== undefined` gate before the
+  typeof check) — pinned by an explicit "duration is NOT optional"
+  describe block that fails if a future "make duration truly optional"
+  refactor lands without updating callers; the truly-optional `error`
+  field accepting `undefined`, `string`, AND `instanceof Error` (incl.
+  TypeError as Error subclass) but rejecting null/number/plain-object;
+  the truly-optional `failedStep` field accepting `undefined` and
+  `string` but rejecting null/number; the "no range check" semantics for
+  `duration` (negative numbers pass — pinned because a future `>= 0`
+  guard would change behaviour); NaN-passes-typeof-number gotcha pinned
+  for `stepsCompleted` (a future switch to `Number.isFinite` should be
+  deliberate); result envelope shape (`result.result === input` on
+  success, `result.result === undefined` on failure, no clone); plus
+  the `validatePipelineResultOrThrow(unknown, pluginId?)` thin wrapper —
+  reuses the validator and projects the errors[] into a single Error
+  message via `errors.join('; ')`, with the documented two-format
+  string `Invalid pipeline result${pluginId ? \` from plugin '<id>'\`
+  : ''}: <joined errors>` pinned for both no-plugin-id AND with-plugin-id
+  cases, the empty-string-pluginId-treated-as-falsy case (no `from
+  plugin '...'` segment), the whitespace-only-pluginId-treated-as-truthy
+  case (no implicit `.trim()`, included verbatim — pinned so a future
+  trim refactor breaks loudly), success-on-failed-run (`success: false`
+  with an `error` field is a perfectly valid PipelineResult SHAPE — the
+  wrapper only throws when the shape is wrong, not when the run itself
+  failed), and the per-call fresh-Error-instance contract); +1 net spec
+  file in the prior agent `PipelineFacadeService` direct-coverage sweep
+  — adds `packages/agent/src/pipeline/pipeline-facade.service.spec.ts`
   (30 tests on the 300-LOC facade-binding service that creates the
   `StepExecutionContext` consumed by both pipeline executors:
   guard-rails (throws on missing `work.user` / empty `user.id`);
@@ -363,6 +413,24 @@
 ## Done
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
+
+**2026-05-10 — packages/agent pipeline-result.validator direct coverage (+78 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/validators/pipeline-result.validator.ts` (122 LOC) — the pure-function shape validator used by the in-process pipeline executors to reject malformed `PipelineResult` envelopes returned from third-party pipeline plugins (e.g. `standard-pipeline`, `agent-pipeline`, the CLI-wrapper plugins like `claude-code` / `codex` / `gemini` / `opencode`). A regression here would let an ill-formed plugin response propagate downstream and crash the orchestrator at a much later (and harder-to-diagnose) call site. The new file is `packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts` and pins:
+
+- **Non-object short-circuit (5+1 tests)** — `null`, `undefined`, `number`, `string`, `boolean` all return the single-error envelope `{valid:false, errors:['Result must be an object'], result:undefined}`. Plus the **arrays-fall-through gotcha**: `typeof [] === 'object' && [] !== null`, so `validatePipelineResult([])` does NOT short-circuit on the early return — it falls through to the per-field accumulator and produces a list of field errors instead of the single envelope error. Pinned so a future `Array.isArray` short-circuit refactor breaks loudly.
+- **Happy path (4 tests)** — fully-populated valid result, in-flight result (`state.isRunning=true`), cancelled result (`state.isCancelled=true`), and failed-but-shape-valid result (`success: false`).
+- **`success` field (5 tests, parametrized)** — `undefined`, `null`, `number`, `string`, `object` all rejected with verbatim `'Missing or invalid "success" field (expected boolean)'`.
+- **`outputs` field (16 tests)** — `outputs===missing/null/non-object` produces a SINGLE envelope error and the nested array checks DO NOT run (no error spam — pinned because the implementation has explicit short-circuit logic). The five required nested arrays (`items`, `categories`, `tags`, `collections`, `brands`) each rejected when missing OR when set to a non-array (object instead of array). When `outputs={}`, ALL FIVE nested errors are reported. Forward-compatibility: extra unknown keys on `outputs` are accepted (does not over-validate).
+- **`stepsCompleted` / `totalSteps` fields (7 tests)** — both rejected when `undefined`/`null`/string. PLUS the **NaN-passes-typeof-number gotcha** pinned for `stepsCompleted` (since `typeof NaN === 'number'` the typeof check passes — a future switch to `Number.isFinite` should be deliberate).
+- **`state` field (12 tests)** — three-mode optionality: `state===undefined` skips ALL nested checks (zero state errors); `state===null/non-object/string` produces a SINGLE envelope error and skips the four nested checks; `state===object` runs all four nested checks (`isRunning` bool / `isCancelled` bool / `completedSteps` array / `failedSteps` array). When `state={}`, ALL FOUR nested errors are reported.
+- **`duration` field (6 tests)** — pinned the documented gotcha that `duration` is labelled "Optional fields validation" in the source comment block but is ACTUALLY required (no `r.duration !== undefined` gate before the typeof check). Rejected when missing / `undefined` / `null` / string. Accepts `0` AND **negative numbers** (no range check — pinned because a future `>= 0` guard would change behaviour).
+- **`error` field (7 tests, truly optional)** — accepts `undefined`, string, `instanceof Error`, AND `instanceof TypeError` (Error subclass — `instanceof Error` matches). Rejects number, plain object, AND `null` (null is not undefined, not a string, and not `instanceof Error`).
+- **`failedStep` field (4 tests, truly optional)** — accepts `undefined` and string; rejects number and `null`.
+- **Result envelope shape (3 tests)** — `result.result === input` (same reference, no clone) on success; `result.result === undefined` on failure; the eight per-field check ORDER pinned (success → outputs → stepsCompleted → totalSteps → state → duration → error → failedStep) so a reorder of the validator breaks loudly.
+- **`validatePipelineResultOrThrow` thin wrapper (8 tests)** — returns the validated result unchanged on success (same reference); throws Error with verbatim `Invalid pipeline result: <errors-joined-with-"; ">` when no plugin id; throws Error with `Invalid pipeline result from plugin '<id>': <joined>` when plugin id provided. Pinned: empty-string pluginId treated as falsy (no `from plugin '...'` segment); whitespace-only pluginId treated as truthy and included verbatim with NO implicit `.trim()` (a future trim refactor breaks loudly); success-on-failed-run is valid (a `success: false` with an `error` field is a perfectly valid PipelineResult SHAPE — the wrapper only throws when the SHAPE is wrong, not when the run itself failed); per-call fresh Error instance (not a singleton).
+
+Total agent-package suite: 3903 → 3981 tests across 178 → 179 suites, all green. **Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/validators/`** (the only file in that directory) — the remaining pipeline gap is now `pipeline/executable-pipeline.class.ts` (333 LOC) and `pipeline/step-pipeline-executor.service.ts` (813 LOC), both of which are richer integration-style targets and tracked separately.
 
 **2026-05-09 — packages/agent WorkPluginRepository direct coverage (+38 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
 

--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -100,7 +100,7 @@ cancel-rejection swallowed + skip-when-plugin-lacks-cancel;`getPluginState`null-
 envelope shapes), closing the per-file zero-coverage gap on the
 second of three pipeline executors — see`Done`ledger; +2 net
 spec files in the prior agent`PipelineOrchestratorService`+`comparison/types`direct-coverage sweep
-— adds`packages/agent/src/comparison-generator/comparison/types.spec.ts`(11 tests on the 60-LOC contracts module pinning`DEFAULT_COMPARISON_SETTINGS`four-default merge target +`ComparisonProgressStage`literal union + minimal-and-maximal type
+— adds`packages/agent/src/comparison-generator/comparison/types.spec.ts`(11 tests on the 60-LOC contracts module pinning`DEFAULT*COMPARISON_SETTINGS`four-default merge target +`ComparisonProgressStage`literal union + minimal-and-maximal type
 literals for every documented`Comparison*`envelope) and`packages/agent/src/pipeline/pipeline-orchestrator.service.spec.ts`(33 tests on the 262-LOC routing service:`execute`step-vs-full
 routing via`isStepOrchestratablePipeline`; `executeWithMode`forced
 step / forced full / full→step fallback w/ warn when no self-managed
@@ -143,85 +143,73 @@ empty-string-as-no-plugin behaviour pinning the`pluginId ? ...`falsy branch). Ea
 coverage sweep — adds`packages/agent/src/activity-log/activity-log-analytics-dispatcher.spec.ts`(7 tests on the string DI-token literal +`ActivityLogAnalyticsDispatcher`interface + barrel re-export — pins the string-vs-Symbol-token shape so
 a future swap to`Symbol(...)`(which would silently break every
 cross-module`@Inject(ACTIVITY_LOG_ANALYTICS_DISPATCHER)`binding) is a
-deliberate change),`packages/agent/src/comparison-generator/comparison/prompt-keys.spec.ts`(8 tests on the three documented Langfuse-facing prompt keys`comparison.structure`/`comparison.markdown`/`comparison.extended-analysis`
-    - dotted-namespace regex + uniqueness + `as const` JSON-roundtrip
-    - barrel `COMPARISON_PROMPT_KEYS`-rename pin — pinned so the
+deliberate change),`packages/agent/src/comparison-generator/comparison/prompt-keys.spec.ts`(8 tests on the three documented Langfuse-facing prompt keys`comparison.structure`/`comparison.markdown`/`comparison.extended-analysis`    - dotted-namespace regex + uniqueness +`as const`JSON-roundtrip
+    - barrel`COMPARISON_PROMPT_KEYS`-rename pin — pinned so the
       agent-package keys stay aligned with the Langfuse UI), and
-      `packages/agent/src/plugins/utils/__tests__/plugin-model-settings.utils.spec.ts`
-      (22 tests on `buildProviderModelSummaries` covering all 5 documented
+      `packages/agent/src/plugins/utils/**tests**/plugin-model-settings.utils.spec.ts`      (22 tests on`buildProviderModelSummaries`covering all 5 documented
       rules: schema-without-model-fields short-circuit (undef schema / no
-      properties / no `x-widget:'model-select'` / all-empty-resolved →
+      properties / no`x-widget:'model-select'`/ all-empty-resolved →
       undefined), happy-path summary shape (key/label/value/source/isWorkOverride),
-      `isWorkOverride === source==='work'` matrix across all 5 SettingSource
-      literals, `title || key` fallback (incl. empty-string `title` falsy gotcha),
+     `isWorkOverride === source==='work'`matrix across all 5 SettingSource
+      literals,`title || key`fallback (incl. empty-string`title`falsy gotcha),
       value normalisation (whitespace trim, post-trim empty skip, non-string
       number/null/undefined skip, missing-from-map skip, undefined-resolved-arg,
-      `setting.source` undefined coercion), dedup by trimmed value (collapses
+     `setting.source`undefined coercion), dedup by trimmed value (collapses
       same-model-twice, case-sensitive distinction, leading/trailing whitespace
-      does NOT bypass dedup), `MODEL_FIELD_ORDER` sort
-      (`defaultModel` → `simpleModel` → `mediumModel` → `complexModel` → `model`
-      with reverse-registered properties as the proof, unrecognised keys pushed
-      to end, both-unrecognised → stable insertion order via `return 0`), and
+      does NOT bypass dedup),`MODEL_FIELD_ORDER` sort
+      (`defaultModel`→`simpleModel`→`mediumModel`→`complexModel`→`model`      with reverse-registered properties as the proof, unrecognised keys pushed
+      to end, both-unrecognised → stable insertion order via`return 0`), and
       non-model-field filtering ignoring `x-widget:'password'`/no-widget
-      siblings). Closes three previously-uncovered files in `packages/agent/src/`
-      — see `Done` ledger; +1 net spec file in the prior agent `database.config`
-      direct-coverage sweep — adds
-      `packages/agent/src/database/database.config.spec.ts` (28 tests on
-      the 201-LOC config registrar covering: `ENTITIES` list shape
+      siblings). Closes three previously-uncovered files in `packages/agent/src/`      — see`Done`ledger; +1 net spec file in the prior agent`database.config`       direct-coverage sweep — adds
+      `packages/agent/src/database/database.config.spec.ts`(28 tests on
+      the 201-LOC config registrar covering:`ENTITIES`list shape
       invariants (>20 entities, all functions, no duplicates); SQLite
-      branch matrix (test env → `:memory:`; CLI app type →
+      branch matrix (test env →`:memory:`; CLI app type →
       `~/.ever-works/ever-works.db`; API+development w/ in-memory=false →
       `tmpdir/ever-works-api.db`; API+development w/ in-memory=true →
-      `:memory:`; falsy `getEnvironment` → development fallback; falsy
-      `getAppType` → API fallback; sqlite/sqlite3 alias coercion to
-      better-sqlite3; `:`-prefix path skips mkdir; mkdir-on-missing-dir
-      vs no-mkdir-on-existing); SSL mode (sslMode=true → `getTlsOptions`
-      call; sslMode=false → `ssl` field omitted; autoMigrate→synchronize;
+      `:memory:`; falsy `getEnvironment`→ development fallback; falsy
+     `getAppType`→ API fallback; sqlite/sqlite3 alias coercion to
+      better-sqlite3;`:`-prefix path skips mkdir; mkdir-on-missing-dir
+      vs no-mkdir-on-existing); SSL mode (sslMode=true → `getTlsOptions`      call; sslMode=false →`ssl`field omitted; autoMigrate→synchronize;
       loggingEnabled passthrough); DATABASE_URL branch (parser invoked,
       url+database both forwarded; null parser → undefined database;
       honoured even for mysql); Postgres host defaults (localhost / 5432 /
       postgres / "" / ever_works) + every override; parseInt port coercion;
-      MySQL/MariaDB alias normalisation to `mysql` driver + 3306 / root /
+      MySQL/MariaDB alias normalisation to`mysql`driver + 3306 / root /
       ever_works defaults + overrides; unknown-type fallback to
-      `better-sqlite3 :memory:`; `getDatabaseConfig` wrapper proxy. Mocks
+     `better-sqlite3 :memory:`; `getDatabaseConfig`wrapper proxy. Mocks
       the entity barrels at module scope to empty class shells so the
       TypeORM CJS init never loads — sidesteps the known
-      `path-scurry` initialization bug under Jest), closing the per-file
-      zero-coverage gap on the only `database/*.ts` file outside the
-      repository sub-tree that lacked direct unit coverage — see `Done`
-      ledger; +1 net spec file in the prior agent `sanitize.util`
-      direct-coverage sweep — adds
-      `packages/agent/src/utils/__tests__/sanitize.util.spec.ts` (54 tests
-      on the security-critical 213-LOC sanitization utility — `sanitizeText`
-      default-options matrix + every override toggle independently pinned +
-      the `maxLength:0` falsy-zero gotcha + documented operation order
+     `path-scurry`initialization bug under Jest), closing the per-file
+      zero-coverage gap on the only`database/*.ts`file outside the
+      repository sub-tree that lacked direct unit coverage — see`Done`      ledger; +1 net spec file in the prior agent`sanitize.util`       direct-coverage sweep — adds
+      `packages/agent/src/utils/**tests**/sanitize.util.spec.ts`(54 tests
+      on the security-critical 213-LOC sanitization utility —`sanitizeText`      default-options matrix + every override toggle independently pinned +
+      the`maxLength:0`falsy-zero gotcha + documented operation order
       control-strip → newline-replace → collapse → trim → maxLength;
-      `sanitizeDescription` 500-char cap; `sanitizeName` 100-char cap;
-      `sanitizePrompt` 5000-char cap w/ newlines AND multi-space runs
-      preserved; `sanitizeObject` recursive walk w/ non-mutation guarantee
-        - array-element recursion + null-guard; `sanitizeStringTransform`
-          and `sanitizeDescriptionTransform` class-transformer adapters;
-          `sanitizeStringArray` falsy/non-array → `[]` + per-entry sanitise +
+     `sanitizeDescription`500-char cap;`sanitizeName`100-char cap;
+     `sanitizePrompt`5000-char cap w/ newlines AND multi-space runs
+      preserved;`sanitizeObject`recursive walk w/ non-mutation guarantee
+        - array-element recursion + null-guard;`sanitizeStringTransform`          and`sanitizeDescriptionTransform`class-transformer adapters;
+         `sanitizeStringArray`falsy/non-array →`[]`+ per-entry sanitise +
           post-filter empty-string drop), closing the security-critical
           zero-coverage gap on the most-imported utility in the agent package
-          — see `Done` ledger; +3 net spec files in the prior agent
+          — see`Done`ledger; +3 net spec files in the prior agent
           database-helpers + enrichment-prompt utility sweep — adds
-          `packages/agent/src/database/utils/helper.spec.ts` (16 tests on
-          `getTlsOptions` + `parseDatabaseUrl`),
-          `packages/agent/src/database/database-config.factory.spec.ts`
-          (27 tests on the 7 documented `DatabaseConfigurations` entries +
-          `createDatabaseModuleWithEnv` env-write contract + cross-config
-          invariant), and `packages/agent/src/import/enrichment-prompt.utils.spec.ts`
-          (21 tests on `buildImportGenerationDto` covering name fallback,
+         `packages/agent/src/database/utils/helper.spec.ts`(16 tests on
+         `getTlsOptions`+`parseDatabaseUrl`),
+          `packages/agent/src/database/database-config.factory.spec.ts`          (27 tests on the 7 documented`DatabaseConfigurations`entries +
+         `createDatabaseModuleWithEnv`env-write contract + cross-config
+          invariant), and`packages/agent/src/import/enrichment-prompt.utils.spec.ts`          (21 tests on`buildImportGenerationDto`covering name fallback,
           hardcoded generation_method/website_repository_creation_method,
           pluginConfig defaults, providers default-agent-pipeline merging, and
           the prompt's expansion-factor matrix + four-step header ordering +
           legal-safety + 30%-cap directives). Closes three previously-uncovered
-          tiny utility files in `packages/agent/src/` covering 279 LOC of
+          tiny utility files in`packages/agent/src/`covering 279 LOC of
           source. Total agent-package suite: 3185 → 3249 tests across 154 → 157
-          suites — see `Done` ledger; +10 net spec files in the prior agent
-          NestJS-module wiring sweep — adds `*.module.spec.ts` for ALL 10
-          previously-uncovered modules in `packages/agent/src/`: `work-operations`,
+          suites — see`Done`ledger; +10 net spec files in the prior agent
+          NestJS-module wiring sweep — adds`\_.module.spec.ts`for ALL 10
+          previously-uncovered modules in`packages/agent/src/`: `work-operations`,
           `notifications`,
           `activity-log`, `community-pr`, `template-catalog`,
           `comparison-generator`, `pipeline`, `import`,
@@ -231,124 +219,104 @@ deliberate change),`packages/agent/src/comparison-generator/comparison/prompt-ke
           invariants so a silent extra-import is a deliberate change), plus
           barrel re-exports where present. Each spec mocks transitive
           ESM-only / TypeORM-pulling dependencies (`DatabaseModule`,
-          `FacadesModule`, `data-generator.service` w/ `p-map`, etc.) at module
-          scope — same pattern as the existing `markdown-generator.module.spec.ts`
-          / `account-transfer.module.spec.ts` / `subscriptions.module.spec.ts`.
+          `FacadesModule`, `data-generator.service`w/`p-map`, etc.) at module
+          scope — same pattern as the existing `markdown-generator.module.spec.ts`          /`account-transfer.module.spec.ts`/`subscriptions.module.spec.ts`.
           This closes the agent-package NestJS-module zero-coverage gap entirely
-          (every `*.module.ts` under `packages/agent/src/` now has a co-located
-          spec). Highlights: `WorkOperationsModule`'s deliberate
-          `DatabaseModule` re-export pinned; `CommunityPrModule`'s
-          `DistributedTaskLockService` provided locally but NOT exported pinned;
-          `DataGeneratorModule`'s `WorksConfigService`/`WorksConfigWriterService`
-          helpers provided but NOT exported pinned; `PipelineModule`'s
-          intentional non-import of `PluginsModule` (which is `forRoot`-global)
-          pinned; — see `Done` ledger; +2 net spec files
-          in the prior agent `MarkdownGeneratorService` direct-coverage sweep — adds
-          `packages/agent/src/generators/markdown-generator/markdown-generator.service.spec.ts`
-          (49 tests on the 508-LOC orchestrator) and
-          `packages/agent/src/generators/markdown-generator/markdown-generator.module.spec.ts`
-          (5 tests pinning the module providers/exports + barrel runtime symbols),
+          (every `\*.module.ts`under`packages/agent/src/`now has a co-located
+          spec). Highlights:`WorkOperationsModule`'s deliberate
+          `DatabaseModule`re-export pinned;`CommunityPrModule`'s
+          `DistributedTaskLockService`provided locally but NOT exported pinned;
+         `DataGeneratorModule`'s `WorksConfigService`/`WorksConfigWriterService`          helpers provided but NOT exported pinned;`PipelineModule`'s
+          intentional non-import of `PluginsModule`(which is`forRoot`-global)
+          pinned; — see `Done`ledger; +2 net spec files
+          in the prior agent`MarkdownGeneratorService`direct-coverage sweep — adds
+         `packages/agent/src/generators/markdown-generator/markdown-generator.service.spec.ts`           (49 tests on the 508-LOC orchestrator) and
+          `packages/agent/src/generators/markdown-generator/markdown-generator.module.spec.ts`           (5 tests pinning the module providers/exports + barrel runtime symbols),
           closing the per-file zero-coverage gap inside
-          `packages/agent/src/generators/markdown-generator/` for the orchestrator
-          surface — see `Done` ledger; +1 net spec file in the prior agent
-          `WebsiteUpdateService` direct-coverage sweep — adds
-          `packages/agent/src/generators/website-generator/website-update.service.spec.ts`
-          (26 tests covering `updateRepository` duplicate-then-template
+          `packages/agent/src/generators/markdown-generator/`for the orchestrator
+          surface — see`Done`ledger; +1 net spec file in the prior agent
+         `WebsiteUpdateService`direct-coverage sweep — adds
+         `packages/agent/src/generators/website-generator/website-update.service.spec.ts`          (26 tests covering`updateRepository`duplicate-then-template
           fallback chain w/ wrapped "All update methods failed" rethrow,
-          `options.branch` override + `getLatestCommit` null-coercion +
-          falsy-`branchSync` coercion; `ensureTemplateDefaultBranch`
-          best-effort warn-and-continue across listing-fail / branch-missing
-          / non-Error rejection / `updateRepository`-fail; thin
-          `syncAllBranchesFromTemplate` delegate; `checkForUpdate`
-          four-branch projection w/ beta-branch path; private `updateFork`
-          pinned via reflection; `copyRepositoryFiles` `.git`-skip +
+         `options.branch`override +`getLatestCommit` null-coercion +
+          falsy-`branchSync`coercion;`ensureTemplateDefaultBranch`          best-effort warn-and-continue across listing-fail / branch-missing
+          / non-Error rejection /`updateRepository`-fail; thin
+          `syncAllBranchesFromTemplate`delegate;`checkForUpdate`          four-branch projection w/ beta-branch path; private`updateFork`          pinned via reflection;`copyRepositoryFiles` `.git`-skip +
           recursive subdir mirror w/ rm-rejection swallowed), closing the
           per-file zero-coverage gap inside
-          `packages/agent/src/generators/website-generator/` for the update
-          surface — see `Done` ledger; +2 net spec files in the prior agent
+          `packages/agent/src/generators/website-generator/`for the update
+          surface — see`Done`ledger; +2 net spec files in the prior agent
           markdown-generator helper-class sweep — adds
-          `packages/agent/src/generators/markdown-generator/readme-builder.spec.ts`
-          (17 tests on the fluent `ReadmeBuilder` builder — `addHeader`/`addSubHeader`/`addParagraph`/`addNewLine` chaining,
-          `enableToC()` opt-in rendering w/ `## 📑 Table of Contents`
-            - en-US-formatted counts + duplicate-slug `-1`/`-2` disambiguation
-              via github-slugger + `0` rendered as `(0)` not omitted, `addItem`
-              format `- [name](url) - description` + optional `([Read more](/details/<slug>.md))` + backtick-wrapped tag
+         `packages/agent/src/generators/markdown-generator/readme-builder.spec.ts`          (17 tests on the fluent`ReadmeBuilder`builder —`addHeader`/`addSubHeader`/`addParagraph`/`addNewLine`chaining,
+         `enableToC()`opt-in rendering w/`## 📑 Table of Contents`            - en-US-formatted counts + duplicate-slug`-1`/`-2`disambiguation
+              via github-slugger +`0`rendered as`(0)`not omitted,`addItem`              format`- [name](url) - description`+ optional`([Read more](/details/<slug>.md))`+ backtick-wrapped tag
               list joined w/ spaces, end-to-end document shape) and
-              `packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts`
-              (13 tests on the on-disk repository helper — `cleanup` recursive
-              `rm`, `resetFiles` allowlist (`.git`, `.gitignore`, `.github`,
+             `packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts`              (13 tests on the on-disk repository helper —`cleanup`recursive
+             `rm`, `resetFiles` allowlist (`.git`, `.gitignore`, `.github`,
               `.vscode`, `.env`, `.nvmrc`, plus every dotfile starting with
               `.git`) + sequential await-per-iteration removal order +
-              `readdir`-failure short-circuit, `ensureWorksExist` recursive
-              mkdir of `details/`, `writeReadme`/`writeDetails`/`writeLicense`
-              utf-8 writes, `removeDetails` rm with `force:true` only — NOT
-              recursive, the public readonly `dir` field, and the `dir` →
-              `dir/details` derivation contract — `node:fs/promises` is mocked at
+              `readdir`-failure short-circuit, `ensureWorksExist`recursive
+              mkdir of`details/`, `writeReadme`/`writeDetails`/`writeLicense`              utf-8 writes,`removeDetails`rm with`force:true`only — NOT
+              recursive, the public readonly`dir`field, and the`dir`→
+             `dir/details`derivation contract —`node:fs/promises`is mocked at
               module scope so the suite never touches the real filesystem),
               closing the markdown-generator helper-class zero-coverage gap (the
-              remaining file in the subdir is `markdown-generator.service.ts`,
-              508 LOC, deferred to a dedicated follow-up) — see `Done` ledger;
+              remaining file in the subdir is`markdown-generator.service.ts`,
+              508 LOC, deferred to a dedicated follow-up) — see `Done`ledger;
               +1 net spec file in the prior agent
-              `BranchSyncService` direct-coverage sweep — adds
-              `packages/agent/src/generators/website-generator/branch-sync.service.spec.ts`
-              (24 tests covering `syncBranch` clone-rename-replaceRemote-push-cleanup
-              pipeline + temp-dir cleanup on failure paths, `syncAllBranches`
-              branch-mapping expansion + skip-mapped-target rule + sequential
-              `MAX_CONCURRENT_SYNCS=1` semantics + per-batch 1000ms inter-batch
-              delay + `Promise.allSettled` rejection-to-error-result coercion +
-              optional `cleanupExtraBranches` purge w/ swallowed delete failures
-                - warn-and-return-early on `listBranches` failure, `syncFromTemplate`
-                  beta-branch-mapping construction + outer try/catch null fallback +
+             `BranchSyncService`direct-coverage sweep — adds
+             `packages/agent/src/generators/website-generator/branch-sync.service.spec.ts`              (24 tests covering`syncBranch`clone-rename-replaceRemote-push-cleanup
+              pipeline + temp-dir cleanup on failure paths,`syncAllBranches`               branch-mapping expansion + skip-mapped-target rule + sequential
+              `MAX_CONCURRENT_SYNCS=1`semantics + per-batch 1000ms inter-batch
+              delay +`Promise.allSettled`rejection-to-error-result coercion +
+              optional`cleanupExtraBranches`purge w/ swallowed delete failures
+                - warn-and-return-early on`listBranches`failure,`syncFromTemplate`                  beta-branch-mapping construction + outer try/catch null fallback +
                   resolveForWork-rethrow pin), closing the per-file zero-coverage gap
-                  inside `packages/agent/src/generators/website-generator/` for the
-                  branch-sync surface — see `Done` ledger; +2 net spec files in the
-                  earlier agent `BaseFacadeService`/`FacadesModule` direct-coverage
+                  inside`packages/agent/src/generators/website-generator/`for the
+                  branch-sync surface — see`Done`ledger; +2 net spec files in the
+                  earlier agent`BaseFacadeService`/`FacadesModule`direct-coverage
                   sweep — adds
-                  `packages/agent/src/facades/__tests__/base.facade.spec.ts` (66 tests
-                  on the abstract base via a `TestFacadeService extends BaseFacadeService`
-                  re-exposer) and `packages/agent/src/facades/__tests__/facades.module.spec.ts`
-                  (9 tests pinning the module providers/exports + barrel runtime symbols),
-                  closing the per-file zero-coverage gap inside `packages/agent/src/facades/`
-                  — see `Done` ledger; +0 net spec files in the WorkGenerationService
+                 `packages/agent/src/facades/**tests**/base.facade.spec.ts`(66 tests
+                  on the abstract base via a`TestFacadeService extends BaseFacadeService`                  re-exposer) and`packages/agent/src/facades/**tests**/facades.module.spec.ts`                  (9 tests pinning the module providers/exports + barrel runtime symbols),
+                  closing the per-file zero-coverage gap inside`packages/agent/src/facades/`                  — see`Done`ledger; +0 net spec files in the WorkGenerationService
                   orchestrators follow-up sweep — extends the existing
-                  `services/__tests__/work-generation.service.spec.ts` from 126 → 172
+                 `services/**tests**/work-generation.service.spec.ts` from 126 → 172
                   tests, closing the previously-pending 7 multi-step pipeline orchestrators
-                  (`processGeneration` / `executeGenerationPipeline` / `finalizeGeneration` /
-                  `runInProcessGeneration` / `prepareProviders` /
-                  `ensureProvidersEnabledForWork` / `dispatchGenerationTask`) — see `Done`
-                  ledger; **the WorkGenerationService private-orchestrator zero-coverage
+                  (`processGeneration`/`executeGenerationPipeline`/`finalizeGeneration`/
+                 `runInProcessGeneration`/`prepareProviders`/
+                 `ensureProvidersEnabledForWork`/`dispatchGenerationTask`) — see `Done`                  ledger; **the WorkGenerationService private-orchestrator zero-coverage
                   gap is now empty.** The earlier 2026-05-09 sweep covered 7 simpler
-                  helpers: `resolveGenerationFinalStatus` / `resolveGenerationErrorMessage` /
-                  `buildScheduleRunOutcome` / `isNonFatalWebsiteGenerationError` /
-                  `markGenerationStarted` / `finalizeCancelledGeneration` /
-                  `handleErrorNotification`; +1 packages/agent service spec landed 2026-05-09
-                  in the small-service coverage sweep #6 — `WorkGenerationService` (focused
-                  first sweep covering wrapper / simpler methods) — see `Done` ledger; +1 packages/agent service spec
+                  helpers:`resolveGenerationFinalStatus`/`resolveGenerationErrorMessage`/
+                 `buildScheduleRunOutcome`/`isNonFatalWebsiteGenerationError`/
+                 `markGenerationStarted`/`finalizeCancelledGeneration`/
+                 `handleErrorNotification`; +1 packages/agent service spec landed 2026-05-09
+                  in the small-service coverage sweep #6 — `WorkGenerationService`(focused
+                  first sweep covering wrapper / simpler methods) — see`Done`ledger; +1 packages/agent service spec
                   landed earlier 2026-05-09
-                  in the small-service coverage sweep #5 — `ItemHealthService` — see
-                  `Done` ledger;
+                  in the small-service coverage sweep #5 —`ItemHealthService`— see
+                 `Done`ledger;
                   +1 packages/agent service spec landed earlier 2026-05-09
-                  in the small-service coverage sweep #4 — `WorkTaxonomyService` — see
-                  `Done` ledger;
+                  in the small-service coverage sweep #4 —`WorkTaxonomyService`— see
+                 `Done`ledger;
                   +1 packages/agent service spec landed earlier 2026-05-09
-                  in the small-service coverage sweep #3 — `WorkMemberService` — see
-                  `Done` ledger;
+                  in the small-service coverage sweep #3 —`WorkMemberService`— see
+                 `Done`ledger;
                   +3 packages/agent service specs landed earlier 2026-05-09
-                  in the small-service coverage sweep #2 — `ItemSourceValidationSchedulerService` +
-                  `WorkDetailService` + `RepositoryManagementService` — see `Done` ledger;
+                  in the small-service coverage sweep #2 —`ItemSourceValidationSchedulerService`+
+                 `WorkDetailService`+`RepositoryManagementService`— see`Done`ledger;
                   +2 packages/agent service specs landed earlier 2026-05-09
-                  in the small-service coverage sweep — `WorkAdvancedPromptsService` +
-                  `WorkWebsiteRepositoryStateService` — see `Done` ledger;
+                  in the small-service coverage sweep —`WorkAdvancedPromptsService`+
+                 `WorkWebsiteRepositoryStateService`— see`Done`ledger;
                   +1 prior packages/agent service spec landed 2026-05-09
-                  in the WorkOwnershipService sweep — see `Done` ledger; +4 packages/agent
+                  in the WorkOwnershipService sweep — see`Done`ledger; +4 packages/agent
                   repository specs landed earlier 2026-05-09
                   in sweep #3: activity-log + notification + work-member + work — closing the
                   agent-package repository zero-coverage gap entirely; +4 in the previous
                   sweep #2: work-custom-domain + user + conversation + template; +8 in
                   the prior sweep — subscription-plan + work-advanced-prompts +
                   user-template-preference + user-subscription + usage-ledger +
-                  webhook-subscription + refresh-token + onboarding-request. See `Done`
-                  for the running ledger).
+                  webhook-subscription + refresh-token + onboarding-request. See`Done`
+  for the running ledger).
 - **Playwright e2e suites**: 31 in `apps/web/e2e/`
 - **API source spec count**: **101** specs inside `apps/api/src/` (was 95
   earlier on 2026-05-09; +6 small-utility DTO specs landed in the

--- a/packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts
+++ b/packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts
@@ -1,0 +1,576 @@
+import { validatePipelineResult, validatePipelineResultOrThrow } from './pipeline-result.validator';
+
+function buildValidResult(overrides: Record<string, unknown> = {}) {
+    return {
+        success: true,
+        outputs: {
+            items: [],
+            categories: [],
+            tags: [],
+            collections: [],
+            brands: [],
+        },
+        stepsCompleted: 3,
+        totalSteps: 5,
+        state: {
+            isRunning: false,
+            isCancelled: false,
+            completedSteps: [],
+            failedSteps: [],
+        },
+        duration: 1234,
+        ...overrides,
+    };
+}
+
+describe('validatePipelineResult', () => {
+    describe('non-object inputs', () => {
+        it.each([
+            ['null', null],
+            ['undefined', undefined],
+            ['number', 42],
+            ['string', 'hello'],
+            ['boolean', true],
+        ])('rejects %s with single "Result must be an object" error', (_label, value) => {
+            const result = validatePipelineResult(value);
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual(['Result must be an object']);
+            expect(result.result).toBeUndefined();
+        });
+
+        it('does NOT short-circuit on arrays — they are typeof "object" so they fall through to the per-field checks (and produce a list of field errors instead of a single envelope error)', () => {
+            // typeof [] === 'object' && [] !== null, so the early return does not fire.
+            // Arrays then fail per-field checks one-by-one. This pins the documented
+            // (slightly surprising) behaviour so a future refactor that adds an
+            // explicit `Array.isArray` short-circuit breaks loudly.
+            const result = validatePipelineResult([]);
+            expect(result.valid).toBe(false);
+            expect(result.errors).not.toEqual(['Result must be an object']);
+            expect(result.errors.length).toBeGreaterThan(1);
+        });
+    });
+
+    describe('happy path', () => {
+        it('accepts a fully-populated valid result with no errors', () => {
+            const input = buildValidResult();
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+            expect(result.result).toBe(input);
+        });
+
+        it('accepts an "in-flight" result (state.isRunning=true)', () => {
+            const input = buildValidResult({
+                state: {
+                    isRunning: true,
+                    isCancelled: false,
+                    completedSteps: ['s1'],
+                    failedSteps: [],
+                },
+            });
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+
+        it('accepts a cancelled result (state.isCancelled=true)', () => {
+            const input = buildValidResult({
+                state: { isRunning: false, isCancelled: true, completedSteps: [], failedSteps: [] },
+            });
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+
+        it('accepts a failed result with success=false', () => {
+            const input = buildValidResult({ success: false });
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+    });
+
+    describe('"success" field', () => {
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+            ['number', 1],
+            ['string', 'true'],
+            ['object', {}],
+        ])('rejects success=%s with documented error', (_label, value) => {
+            const input = buildValidResult();
+            (input as Record<string, unknown>).success = value;
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(false);
+            expect(result.errors).toContain(
+                'Missing or invalid "success" field (expected boolean)',
+            );
+        });
+    });
+
+    describe('"outputs" field', () => {
+        it('rejects missing outputs with single envelope error and no nested array errors', () => {
+            const input: Record<string, unknown> = buildValidResult();
+            delete input.outputs;
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(false);
+            expect(result.errors).toContain('Missing or invalid "outputs" field (expected object)');
+            // The nested checks short-circuit when outputs is not a non-null object,
+            // so we should NOT see five additional "outputs.items/categories/..." errors.
+            expect(result.errors).not.toContain(
+                'Missing or invalid "outputs.items" field (expected array)',
+            );
+            expect(result.errors).not.toContain(
+                'Missing or invalid "outputs.categories" field (expected array)',
+            );
+        });
+
+        it('rejects null outputs with single envelope error', () => {
+            const result = validatePipelineResult(buildValidResult({ outputs: null }));
+            expect(result.valid).toBe(false);
+            expect(result.errors).toContain('Missing or invalid "outputs" field (expected object)');
+            expect(result.errors).not.toContain(
+                'Missing or invalid "outputs.items" field (expected array)',
+            );
+        });
+
+        it('rejects non-object outputs (string)', () => {
+            const result = validatePipelineResult(buildValidResult({ outputs: 'not-an-object' }));
+            expect(result.valid).toBe(false);
+            expect(result.errors).toContain('Missing or invalid "outputs" field (expected object)');
+        });
+
+        it.each([
+            ['items', 'Missing or invalid "outputs.items" field (expected array)'],
+            ['categories', 'Missing or invalid "outputs.categories" field (expected array)'],
+            ['tags', 'Missing or invalid "outputs.tags" field (expected array)'],
+            ['collections', 'Missing or invalid "outputs.collections" field (expected array)'],
+            ['brands', 'Missing or invalid "outputs.brands" field (expected array)'],
+        ])('rejects missing outputs.%s', (field, expectedError) => {
+            const input = buildValidResult();
+            delete (input.outputs as Record<string, unknown>)[field];
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(false);
+            expect(result.errors).toContain(expectedError);
+        });
+
+        it.each([['items'], ['categories'], ['tags'], ['collections'], ['brands']])(
+            'rejects non-array outputs.%s (object instead of array)',
+            (field) => {
+                const input = buildValidResult();
+                (input.outputs as Record<string, unknown>)[field] = { not: 'an-array' };
+                const result = validatePipelineResult(input);
+                expect(result.valid).toBe(false);
+                expect(result.errors).toContain(
+                    `Missing or invalid "outputs.${field}" field (expected array)`,
+                );
+            },
+        );
+
+        it('reports ALL five missing array fields when outputs is an empty object', () => {
+            const result = validatePipelineResult(buildValidResult({ outputs: {} }));
+            expect(result.valid).toBe(false);
+            expect(result.errors).toContain(
+                'Missing or invalid "outputs.items" field (expected array)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "outputs.categories" field (expected array)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "outputs.tags" field (expected array)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "outputs.collections" field (expected array)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "outputs.brands" field (expected array)',
+            );
+        });
+
+        it('accepts outputs with extra unknown keys (forward-compatible — does not over-validate)', () => {
+            const input = buildValidResult();
+            (input.outputs as Record<string, unknown>).futureField = ['anything'];
+            const result = validatePipelineResult(input);
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('"stepsCompleted" / "totalSteps" fields', () => {
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+            ['string', '3'],
+            ['NaN does NOT trigger', NaN], // typeof NaN === 'number', so NaN passes the check
+        ])('stepsCompleted=%s', (label, value) => {
+            const input = buildValidResult();
+            (input as Record<string, unknown>).stepsCompleted = value;
+            const result = validatePipelineResult(input);
+            if (label === 'NaN does NOT trigger') {
+                // typeof NaN === 'number' — pinned because a switch to Number.isFinite
+                // would change behaviour and we want that change to be deliberate.
+                expect(result.errors).not.toContain(
+                    'Missing or invalid "stepsCompleted" field (expected number)',
+                );
+            } else {
+                expect(result.errors).toContain(
+                    'Missing or invalid "stepsCompleted" field (expected number)',
+                );
+            }
+        });
+
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+            ['string', '5'],
+        ])('rejects totalSteps=%s', (_label, value) => {
+            const input = buildValidResult();
+            (input as Record<string, unknown>).totalSteps = value;
+            const result = validatePipelineResult(input);
+            expect(result.errors).toContain(
+                'Missing or invalid "totalSteps" field (expected number)',
+            );
+        });
+    });
+
+    describe('"state" field', () => {
+        it('accepts state===undefined (entirely absent state object)', () => {
+            const input = buildValidResult();
+            delete (input as Record<string, unknown>).state;
+            const result = validatePipelineResult(input);
+            // Per the source: `if (r.state !== undefined && (typeof r.state !== 'object' || r.state === null))` —
+            // so undefined skips both branches and produces no state-related errors.
+            expect(result.errors.filter((e) => e.includes('"state'))).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects state===null with single envelope error (and no nested boolean/array errors)', () => {
+            const result = validatePipelineResult(buildValidResult({ state: null }));
+            expect(result.errors).toContain('Invalid "state" field (expected object)');
+            // Source: the else-if branch only runs when state is a non-null object,
+            // so null skips the per-field checks.
+            expect(result.errors).not.toContain(
+                'Missing or invalid "state.isRunning" field (expected boolean)',
+            );
+        });
+
+        it('rejects state===number with single envelope error', () => {
+            const result = validatePipelineResult(buildValidResult({ state: 42 }));
+            expect(result.errors).toContain('Invalid "state" field (expected object)');
+        });
+
+        it('rejects state===string with single envelope error', () => {
+            const result = validatePipelineResult(buildValidResult({ state: 'running' }));
+            expect(result.errors).toContain('Invalid "state" field (expected object)');
+        });
+
+        it.each([
+            ['isRunning', 'Missing or invalid "state.isRunning" field (expected boolean)'],
+            ['isCancelled', 'Missing or invalid "state.isCancelled" field (expected boolean)'],
+        ])('rejects missing state.%s', (field, expectedError) => {
+            const input = buildValidResult();
+            delete (input.state as Record<string, unknown>)[field];
+            const result = validatePipelineResult(input);
+            expect(result.errors).toContain(expectedError);
+        });
+
+        it.each([
+            ['completedSteps', 'Missing or invalid "state.completedSteps" field (expected array)'],
+            ['failedSteps', 'Missing or invalid "state.failedSteps" field (expected array)'],
+        ])('rejects missing state.%s', (field, expectedError) => {
+            const input = buildValidResult();
+            delete (input.state as Record<string, unknown>)[field];
+            const result = validatePipelineResult(input);
+            expect(result.errors).toContain(expectedError);
+        });
+
+        it.each([
+            ['isRunning', 'true', 'Missing or invalid "state.isRunning" field (expected boolean)'],
+            ['isCancelled', 1, 'Missing or invalid "state.isCancelled" field (expected boolean)'],
+        ])('rejects non-boolean state.%s', (field, value, expectedError) => {
+            const input = buildValidResult();
+            (input.state as Record<string, unknown>)[field] = value;
+            const result = validatePipelineResult(input);
+            expect(result.errors).toContain(expectedError);
+        });
+
+        it.each([
+            ['completedSteps', 'Missing or invalid "state.completedSteps" field (expected array)'],
+            ['failedSteps', 'Missing or invalid "state.failedSteps" field (expected array)'],
+        ])('rejects non-array state.%s (string)', (field, expectedError) => {
+            const input = buildValidResult();
+            (input.state as Record<string, unknown>)[field] = 'step1,step2';
+            const result = validatePipelineResult(input);
+            expect(result.errors).toContain(expectedError);
+        });
+
+        it('reports ALL four missing state fields when state is an empty object', () => {
+            const result = validatePipelineResult(buildValidResult({ state: {} }));
+            expect(result.errors).toContain(
+                'Missing or invalid "state.isRunning" field (expected boolean)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "state.isCancelled" field (expected boolean)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "state.completedSteps" field (expected array)',
+            );
+            expect(result.errors).toContain(
+                'Missing or invalid "state.failedSteps" field (expected array)',
+            );
+        });
+    });
+
+    describe('"duration" field (NOT optional in implementation)', () => {
+        // NOTE: the source-level comment says "Optional fields validation" above this
+        // block, but the actual code does NOT gate on `r.duration !== undefined` —
+        // it unconditionally requires `typeof r.duration === 'number'`. That makes
+        // duration effectively REQUIRED. Pinned here so a future "make duration
+        // truly optional" refactor breaks loudly.
+        it('rejects missing duration', () => {
+            const input = buildValidResult();
+            delete (input as Record<string, unknown>).duration;
+            const result = validatePipelineResult(input);
+            expect(result.errors).toContain(
+                'Missing or invalid "duration" field (expected number)',
+            );
+            expect(result.valid).toBe(false);
+        });
+
+        it('rejects duration===undefined explicitly', () => {
+            const result = validatePipelineResult(buildValidResult({ duration: undefined }));
+            expect(result.errors).toContain(
+                'Missing or invalid "duration" field (expected number)',
+            );
+        });
+
+        it('rejects duration===null', () => {
+            const result = validatePipelineResult(buildValidResult({ duration: null }));
+            expect(result.errors).toContain(
+                'Missing or invalid "duration" field (expected number)',
+            );
+        });
+
+        it('rejects duration as a string', () => {
+            const result = validatePipelineResult(buildValidResult({ duration: '1234' }));
+            expect(result.errors).toContain(
+                'Missing or invalid "duration" field (expected number)',
+            );
+        });
+
+        it('accepts duration=0', () => {
+            const result = validatePipelineResult(buildValidResult({ duration: 0 }));
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts negative duration (no range check)', () => {
+            // Pinned: there is no `>= 0` guard, so a negative duration passes.
+            // Useful to know if a regression accidentally introduces such a guard.
+            const result = validatePipelineResult(buildValidResult({ duration: -1 }));
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('"error" field (truly optional)', () => {
+        it('accepts error===undefined', () => {
+            const result = validatePipelineResult(buildValidResult({ error: undefined }));
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts error as a string', () => {
+            const result = validatePipelineResult(
+                buildValidResult({ error: 'something went wrong' }),
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts error as an Error instance', () => {
+            const result = validatePipelineResult(buildValidResult({ error: new Error('boom') }));
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts error as a TypeError (Error subclass — instanceof Error check)', () => {
+            const result = validatePipelineResult(
+                buildValidResult({ error: new TypeError('bad type') }),
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects error as a number', () => {
+            const result = validatePipelineResult(buildValidResult({ error: 42 }));
+            expect(result.errors).toContain('Invalid "error" field (expected string or Error)');
+        });
+
+        it('rejects error as a plain object', () => {
+            const result = validatePipelineResult(buildValidResult({ error: { message: 'oops' } }));
+            expect(result.errors).toContain('Invalid "error" field (expected string or Error)');
+        });
+
+        it('rejects error===null (null is NOT undefined and is not a string and is not instanceof Error)', () => {
+            const result = validatePipelineResult(buildValidResult({ error: null }));
+            expect(result.errors).toContain('Invalid "error" field (expected string or Error)');
+        });
+    });
+
+    describe('"failedStep" field (truly optional)', () => {
+        it('accepts failedStep===undefined', () => {
+            const result = validatePipelineResult(buildValidResult({ failedStep: undefined }));
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts failedStep as a string', () => {
+            const result = validatePipelineResult(
+                buildValidResult({ failedStep: 'fetch-content' }),
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects failedStep as a number', () => {
+            const result = validatePipelineResult(buildValidResult({ failedStep: 3 }));
+            expect(result.errors).toContain('Invalid "failedStep" field (expected string)');
+        });
+
+        it('rejects failedStep===null', () => {
+            const result = validatePipelineResult(buildValidResult({ failedStep: null }));
+            expect(result.errors).toContain('Invalid "failedStep" field (expected string)');
+        });
+    });
+
+    describe('result envelope shape', () => {
+        it('result.result is the same reference as the input on success (no clone)', () => {
+            const input = buildValidResult();
+            const out = validatePipelineResult(input);
+            expect(out.result).toBe(input);
+        });
+
+        it('result.result is undefined when validation fails', () => {
+            const out = validatePipelineResult(buildValidResult({ success: 'not-a-bool' }));
+            expect(out.valid).toBe(false);
+            expect(out.result).toBeUndefined();
+        });
+
+        it('errors array order is stable: success, outputs, stepsCompleted, totalSteps, state, duration, error, failedStep', () => {
+            // Build a result where every field is invalid.
+            const input = {
+                success: 'no',
+                outputs: 'bad',
+                stepsCompleted: 'a',
+                totalSteps: 'b',
+                state: 123,
+                duration: 'd',
+                error: 5,
+                failedStep: 9,
+            };
+            const out = validatePipelineResult(input);
+            expect(out.valid).toBe(false);
+            const errMessages = out.errors;
+            // Find indices to assert the documented order (matches the order of checks
+            // in the source). A reorder of the validator must update this test.
+            const successIdx = errMessages.findIndex((e) =>
+                e.startsWith('Missing or invalid "success"'),
+            );
+            const outputsIdx = errMessages.findIndex((e) =>
+                e.startsWith('Missing or invalid "outputs"'),
+            );
+            const stepsIdx = errMessages.findIndex((e) =>
+                e.startsWith('Missing or invalid "stepsCompleted"'),
+            );
+            const totalIdx = errMessages.findIndex((e) =>
+                e.startsWith('Missing or invalid "totalSteps"'),
+            );
+            const stateIdx = errMessages.findIndex((e) => e.startsWith('Invalid "state"'));
+            const durIdx = errMessages.findIndex((e) =>
+                e.startsWith('Missing or invalid "duration"'),
+            );
+            const errIdx = errMessages.findIndex((e) => e.startsWith('Invalid "error"'));
+            const failedStepIdx = errMessages.findIndex((e) =>
+                e.startsWith('Invalid "failedStep"'),
+            );
+
+            expect(successIdx).toBeGreaterThanOrEqual(0);
+            expect(outputsIdx).toBeGreaterThan(successIdx);
+            expect(stepsIdx).toBeGreaterThan(outputsIdx);
+            expect(totalIdx).toBeGreaterThan(stepsIdx);
+            expect(stateIdx).toBeGreaterThan(totalIdx);
+            expect(durIdx).toBeGreaterThan(stateIdx);
+            expect(errIdx).toBeGreaterThan(durIdx);
+            expect(failedStepIdx).toBeGreaterThan(errIdx);
+        });
+    });
+});
+
+describe('validatePipelineResultOrThrow', () => {
+    it('returns the validated result on success (same reference)', () => {
+        const input = buildValidResult();
+        const out = validatePipelineResultOrThrow(input);
+        expect(out).toBe(input);
+    });
+
+    it('returns the validated result on success even when an Error envelope is present', () => {
+        // success=false alone is a perfectly valid PipelineResult shape (a failed run);
+        // OrThrow only throws when the SHAPE is wrong, not when the run itself failed.
+        const input = buildValidResult({ success: false, error: new Error('step failed') });
+        const out = validatePipelineResultOrThrow(input);
+        expect(out).toBe(input);
+    });
+
+    it('throws Error with no plugin id when omitted', () => {
+        expect(() => validatePipelineResultOrThrow(null)).toThrow(
+            /^Invalid pipeline result: Result must be an object$/,
+        );
+    });
+
+    it('throws Error with plugin id segment when provided', () => {
+        expect(() => validatePipelineResultOrThrow(null, 'standard-pipeline')).toThrow(
+            /^Invalid pipeline result from plugin 'standard-pipeline': Result must be an object$/,
+        );
+    });
+
+    it('joins multiple errors with "; " separator (matches source `errors.join("; ")`)', () => {
+        // Build a result with TWO independent issues: missing success + missing duration.
+        const input = buildValidResult();
+        delete (input as Record<string, unknown>).success;
+        delete (input as Record<string, unknown>).duration;
+        try {
+            validatePipelineResultOrThrow(input, 'p1');
+            throw new Error('should have thrown');
+        } catch (err) {
+            const msg = (err as Error).message;
+            expect(msg).toContain("from plugin 'p1':");
+            expect(msg).toContain('Missing or invalid "success" field (expected boolean)');
+            expect(msg).toContain('Missing or invalid "duration" field (expected number)');
+            // Pin the documented separator.
+            expect(msg).toMatch(/expected boolean\); /);
+        }
+    });
+
+    it('handles empty-string plugin id as "no plugin" (truthy check `pluginId ? ... : ""`)', () => {
+        // Empty string is falsy, so the prefix segment is omitted.
+        expect(() => validatePipelineResultOrThrow(null, '')).toThrow(
+            /^Invalid pipeline result: Result must be an object$/,
+        );
+    });
+
+    it('treats whitespace-only plugin id as truthy and includes it verbatim (no trim)', () => {
+        // Pinned: the implementation does NOT `.trim()` pluginId — it just checks truthiness.
+        // A future "trim to no-op" refactor that changes behaviour will fail this test.
+        expect(() => validatePipelineResultOrThrow(null, '   ')).toThrow(/from plugin '   ':/);
+    });
+
+    it('rethrows a fresh Error per call (not a singleton)', () => {
+        let e1: Error | undefined;
+        let e2: Error | undefined;
+        try {
+            validatePipelineResultOrThrow(null);
+        } catch (err) {
+            e1 = err as Error;
+        }
+        try {
+            validatePipelineResultOrThrow(null);
+        } catch (err) {
+            e2 = err as Error;
+        }
+        expect(e1).toBeInstanceOf(Error);
+        expect(e2).toBeInstanceOf(Error);
+        expect(e1).not.toBe(e2);
+    });
+});


### PR DESCRIPTION
## Summary

- Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/validators/pipeline-result.validator.ts` (122 LOC) — the pure-function shape validator used by the in-process pipeline executors to reject malformed `PipelineResult` envelopes returned from third-party pipeline plugins (standard-pipeline, agent-pipeline, claude-code, codex, gemini, opencode, ...).
- A regression here would let an ill-formed plugin response propagate downstream and crash the orchestrator at a much later (and harder-to-diagnose) call site.
- Total agent-package suite: 3903 → 3981 tests across 178 → 179 suites, all green. **Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/validators/`** (the only file in that directory).

## Coverage breakdown

- **Non-object short-circuit (5+1 tests)** — null/undefined/number/string/boolean all return single-error envelope; arrays-fall-through gotcha pinned (`typeof [] === 'object'` so arrays do NOT short-circuit on the early return — they fall through to the per-field accumulator).
- **Happy path (4)** — valid / in-flight / cancelled / failed-but-valid-shape.
- **`success` field (5, parametrized)** — all non-boolean types rejected.
- **`outputs` field (16)** — missing/null/non-object short-circuit pinned (single envelope error, nested array checks DO NOT run); five required nested arrays (items/categories/tags/collections/brands) each rejected when missing OR non-array; ALL FIVE errors reported on `outputs={}`; extra unknown keys accepted (forward-compatible).
- **`stepsCompleted` / `totalSteps` (7)** — undefined/null/string rejected; NaN-passes-typeof-number gotcha pinned for `stepsCompleted` (a future `Number.isFinite` switch should be deliberate).
- **`state` field (12)** — three-mode optionality: `undefined` skips ALL nested checks, `null/non-object` produces SINGLE envelope error, object runs all four nested checks; ALL FOUR errors reported on `state={}`.
- **`duration` field (6)** — pinned the documented gotcha that duration is labelled "Optional fields validation" in source comments but is ACTUALLY required (no `r.duration !== undefined` gate); negative numbers accepted (no range check — pinned so a future `>= 0` guard would break the test deliberately).
- **`error` field (7, truly optional)** — accepts undefined/string/Error/TypeError (Error subclass via `instanceof`); rejects number/object/null.
- **`failedStep` field (4, truly optional)** — accepts undefined/string; rejects number/null.
- **Result envelope shape (3)** — `result.result === input` (same reference, no clone) on success; `result.result === undefined` on failure; the eight-field check ORDER pinned (success → outputs → stepsCompleted → totalSteps → state → duration → error → failedStep).
- **`validatePipelineResultOrThrow` thin wrapper (8)** — returns same reference on success; throws verbatim `Invalid pipeline result: <joined>` with no plugin id, `Invalid pipeline result from plugin '<id>': <joined>` with plugin id; empty-string id treated as falsy; whitespace-only id treated as truthy and included verbatim (no implicit `.trim()`); success-on-failed-run is valid (a `success: false` with an `error` field is a perfectly valid PipelineResult SHAPE — wrapper only throws when SHAPE is wrong); per-call fresh Error instance.

## Test plan

- [x] `cd packages/agent && pnpm test` (178 → 179 suites; 3903 → 3981 tests, all green)
- [x] No production code changed — pure new spec file at `packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts`.
- [x] `COVERAGE-TRACKER.md` updated (Inventory snapshot + new Done ledger entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for pipeline-result validation: rejects non-object inputs (arrays handled distinctly), enforces presence/type rules for success/state/outputs/duration, validates numeric/optional-field semantics, preserves/clears result envelopes, ensures stable error ordering, and verifies error-message formatting and throw-vs-return behaviors.

* **Documentation**
  * Updated coverage tracker and added a "Done" ledger entry dated 2026-05-10 reflecting the new spec and updated totals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/682)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->