### PR TITLE
test(agent): cover ExecutablePipelineRunner directly (+49 tests)

### DIFF
--- a/COVERAGE-TRACKER.md
+++ b/COVERAGE-TRACKER.md
@@ -21,8 +21,72 @@
 
 ## Inventory snapshot (2026-05-07, refreshed 2026-05-09)
 
-- **Spec files (`*.spec.ts`)**: ~518 across `apps/` + `packages/` (was 517
+- **Spec files (`*.spec.ts`)**: ~519 across `apps/` + `packages/` (was 518
   earlier on 2026-05-10; +1 net spec file in the agent
+  `ExecutablePipelineRunner` direct-coverage sweep — adds
+  `packages/agent/src/pipeline/executable-pipeline.class.spec.ts`
+  (49 tests on the 333-LOC runtime wrapper that owns the
+  `PipelineState` mutation flow consumed by the step-pipeline
+  executor — every `running`/`completed`/`failed`/`skipped`
+  transition flows through this class, so a regression here
+  would silently corrupt the run-state observed by both the
+  orchestrator AND the activity-log emitter that reads
+  `runner.getState()`. Pins: `PipelineRuntimeEvents` literal
+  wire format (`pipeline:state-changed` + `pipeline:step-status-changed`
+  — wire-format break is deliberate); the **STATE_CHANGED is
+  declared but NEVER emitted** gotcha (only STEP_STATUS_CHANGED
+  fires today — pinned so a future "wire up state-change events"
+  feature is a deliberate change, not an accident); constructor
+  initialises every step in `pending` status with empty
+  `completedSteps`/`failedSteps` arrays; **duplicate step IDs
+  collapse via Map.set semantics** (the second definition wins —
+  pinned so a future "throw on duplicate id" refactor breaks
+  loudly); zero-step pipeline does not throw; **EventEmitter is
+  optional** (verified across all five status-mutating methods —
+  none throw without an emitter); `getStepDefinition` reads
+  through `pipeline.steps.find` NOT the internal Map (so post-
+  construction mutations to `pipeline.steps` are reflected here
+  but not in `getStepState` — useful invariant for caller code);
+  `startExecution` stamps `state.startedAt` from `Date.now()`
+  AND **preserves `completedSteps`/`failedSteps`** on a second
+  call (no idempotency reset — pinned); `completeExecution`
+  clears `isRunning` + stamps `completedAt` AND preserves
+  `startedAt` (audit trail); `cancelExecution` is the only
+  method that flips `isCancelled` to true; `updateStepStatus`
+  throws verbatim `'Step "<id>" not found in pipeline'` for
+  unknown ids; sets `startedAt` ONLY on `running` and
+  `completedAt` on `completed`/`failed`/`skipped` (not on
+  `pending`/`running`); updates `currentStep` to the running
+  step AND clears it on any other transition that matches the
+  CURRENT step (parallel-step safety: transitioning a different
+  step does NOT clear `currentStep` of an unrelated running
+  step); STEP_STATUS_CHANGED payload shape pinned (`stepId`,
+  `previousStatus` reflects pre-update state, `newStatus`,
+  `timestamp` from `Date.now()`); **`previousStatus` is
+  HARDCODED in `markStepComplete` (always `'running'`) and
+  `markStepFailed` (always `'running'`) and `markStepSkipped`
+  (always `'pending'`) regardless of actual prior state** —
+  pinned so a future "compute previousStatus from state"
+  refactor must update both source and tests deliberately;
+  `markStepComplete` attaches `result.metrics` only when
+  metrics are provided (omits `result` entirely when undefined,
+  does NOT set `{metrics: undefined}`); preserves chronological
+  append order across multiple completions (`['s2','s1','s3']`
+  if completed in that order — no internal sort); `markStepFailed`
+  attaches the `Error` instance verbatim under `stepState.error`
+  AND does NOT add the failed step to `completedSteps`; preserves
+  multiple-failures append order; `markStepSkipped` is the **only
+  asymmetric mutator**: it appends to `completedSteps` (skipped
+  is "done") AND does **NOT clear `currentStep`**, so a step can
+  be skipped while another step is running; full-lifecycle
+  integration test confirms a 3-step pipeline emits exactly 6
+  STEP_STATUS_CHANGED events in `s1:running → s1:completed →
+  s2:running → s2:completed → s3:running → s3:completed` order;
+  mixed lifecycle (completed + failed + skipped) and cancel-
+  mid-flight scenarios both exercised), closing the per-file
+  zero-coverage gap on the runtime-state-machine in
+  `packages/agent/src/pipeline/executable-pipeline.class.ts` —
+  see `Done` ledger; +1 net spec file in the prior agent
   `pipeline-result.validator` direct-coverage sweep — adds
   `packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts`
   (78 tests on the 122-LOC pure-function validator pinning the
@@ -341,7 +405,26 @@ deliberate change),`packages/agent/src/comparison-generator/comparison/prompt-ke
 
 > Most-recent first. The 2026-05-08 row for the agent `config` + `constants` + `onboarding` submodules sits above the existing header so it is rendered as plain text rather than a misaligned table cell — the table that follows is unchanged.
 
-**2026-05-10 — packages/agent pipeline-result.validator direct coverage (+78 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+**2026-05-10 — packages/agent ExecutablePipelineRunner direct coverage (+49 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [PR pending])**
+
+Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/executable-pipeline.class.ts` (333 LOC) — the runtime wrapper that owns the `PipelineState` mutation flow consumed by the step-pipeline executor (`step-pipeline-executor.service.ts:159` instantiates a fresh `ExecutablePipelineRunner` per pipeline run). Every `running`/`completed`/`failed`/`skipped` transition flows through this class via `startStep`/`markStepComplete`/`markStepFailed`/`markStepSkipped`, and every state read (`getState()`, `getCurrentStep()`, `getStepState()`) returns a snapshot built up here — so a regression in any of the five mutators would silently corrupt the run-state observed by both the orchestrator AND the activity-log emitter. The new file is `packages/agent/src/pipeline/executable-pipeline.class.spec.ts` and pins:
+
+- **`PipelineRuntimeEvents` barrel (2 tests)** — literal wire format `pipeline:state-changed` + `pipeline:step-status-changed` (changing these strings is a wire-format break and must be deliberate). PLUS the **STATE_CHANGED-declared-but-never-emitted gotcha**: today only `STEP_STATUS_CHANGED` fires; `STATE_CHANGED` is reserved/unused. Pinned so a future "wire up state-change events" feature is a deliberate change, not an accident.
+- **Constructor / initial state (5 tests)** — every step starts in `pending` status with empty `completedSteps`/`failedSteps` arrays and undefined `currentStep`/`startedAt`/`completedAt`; `getPipeline()` returns the original reference (no clone); zero-step pipeline does not throw; **duplicate step IDs collapse via Map.set semantics** (the second definition wins — pinned so a future "throw on duplicate id" refactor breaks loudly); EventEmitter is optional (constructor + every mutator works without one).
+- **Read accessors (4 tests)** — `getStepState` returns the stored state by id (undefined for unknown ids); `getStepDefinition` reads through `pipeline.steps.find` NOT the internal Map (so post-construction mutations to `pipeline.steps` are reflected here but NOT in `getStepState` — useful invariant for caller code); `getCurrentStep` is undefined initially, set to the running step id, and cleared on completion; `isRunning`/`isCancelled` reflect `state.isRunning`/`state.isCancelled` accurately across the lifecycle.
+- **`startExecution` (2 tests)** — stamps `state.startedAt` from `Date.now()` AND sets `isRunning=true`; **preserves `completedSteps`/`failedSteps`** on a second call (no idempotency reset — pinned so a future "reset on start" refactor must update this test deliberately).
+- **`completeExecution` (2 tests)** — clears `isRunning` + stamps `completedAt`; preserves `startedAt` for the audit trail.
+- **`cancelExecution` (1 test)** — only method that flips `isCancelled` to `true` (also clears `isRunning` and stamps `completedAt`).
+- **`updateStepStatus` (8 tests)** — throws verbatim `'Step "<id>" not found in pipeline'` for unknown ids; sets `startedAt` ONLY on `running` transition; sets `completedAt` on `completed`/`failed`/`skipped` (not on `pending`/`running`); updates `currentStep` to the new running step AND clears it on any other transition that matches the CURRENT step (**parallel-step safety**: transitioning a different step does NOT clear `currentStep` of an unrelated running step); STEP_STATUS_CHANGED payload shape pinned (`stepId`, `previousStatus` reflects pre-update state, `newStatus`, `timestamp` from `Date.now()`); `previousStatus` reflects the actual prior state (NOT the new status); does NOT emit when constructed without an EventEmitter.
+- **`startStep` convenience (1 test)** — pure delegation to `updateStepStatus(stepId, 'running')`.
+- **`markStepComplete` (7 tests)** — throws verbatim error for unknown step; sets `status=completed`, stamps `completedAt`, appends to `completedSteps`, clears `currentStep`; attaches `result.metrics` ONLY when metrics provided (omits `result` entirely when undefined, does NOT set `{metrics: undefined}`); preserves chronological append order across multiple completions (`['s2','s1','s3']` if completed in that order — no internal sort); **`previousStatus` is HARDCODED to `'running'`** in the emitted event regardless of actual prior state — pinned so a future "compute previousStatus from state" refactor must update both source and tests deliberately; does NOT throw without an EventEmitter.
+- **`markStepFailed` (6 tests)** — throws verbatim error for unknown step; sets `status=failed`, stamps `completedAt`, appends to `failedSteps`, clears `currentStep`; attaches the `Error` instance verbatim under `stepState.error` AND does NOT add the failed step to `completedSteps`; preserves multiple-failures append order; **`previousStatus` is HARDCODED to `'running'`**; does NOT throw without an EventEmitter.
+- **`markStepSkipped` (6 tests)** — throws verbatim error for unknown step; sets `status=skipped`, stamps `completedAt`, appends to `completedSteps` (skipped is "done"); omits `result` when reason undefined; **the only asymmetric mutator — does NOT clear `currentStep`**, so a step can be skipped while another step is running (a future refactor that "unifies" the three methods must be deliberate); **`previousStatus` is HARDCODED to `'pending'`** (distinct from complete/failed which both use `'running'`); does NOT throw without an EventEmitter.
+- **Full lifecycle integration (3 tests)** — a 3-step pipeline emits exactly 6 STEP_STATUS_CHANGED events in `s1:running → s1:completed → s2:running → s2:completed → s3:running → s3:completed` order; mixed lifecycle (completed + failed + skipped) preserves the right step lists; cancellation mid-flight preserves pre-cancel `completedSteps` AND stamps the cancellation timestamp.
+
+Total agent-package suite: 3981 → 4030 tests across 179 → 180 suites, all green. **Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/executable-pipeline.class.ts`** — the remaining pipeline gap is `pipeline/step-pipeline-executor.service.ts` (813 LOC), the richest integration-style target tracked separately.
+
+**2026-05-10 — packages/agent pipeline-result.validator direct coverage (+78 tests across 1 new spec, scheduled-task `platform-tests-and-docs` cycle, [#682](https://github.com/ever-works/ever-works/pull/682))**
 
 Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/validators/pipeline-result.validator.ts` (122 LOC) — the pure-function shape validator used by the in-process pipeline executors to reject malformed `PipelineResult` envelopes returned from third-party pipeline plugins (e.g. `standard-pipeline`, `agent-pipeline`, the CLI-wrapper plugins like `claude-code` / `codex` / `gemini` / `opencode`). A regression here would let an ill-formed plugin response propagate downstream and crash the orchestrator at a much later (and harder-to-diagnose) call site. The new file is `packages/agent/src/pipeline/validators/pipeline-result.validator.spec.ts` and pins:
 

--- a/packages/agent/src/pipeline/executable-pipeline.class.spec.ts
+++ b/packages/agent/src/pipeline/executable-pipeline.class.spec.ts
@@ -1,0 +1,524 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { ExecutablePipeline, PipelineStepDefinition } from '@ever-works/plugin';
+import {
+    ExecutablePipelineRunner,
+    PipelineRuntimeEvents,
+    type StateChangePayload,
+} from './executable-pipeline.class';
+
+function makeStep(
+    id: string,
+    overrides: Partial<PipelineStepDefinition> = {},
+): PipelineStepDefinition {
+    return {
+        id,
+        name: `Step ${id}`,
+        position: { type: 'after', stepId: '__start__' } as never,
+        ...overrides,
+    } as PipelineStepDefinition;
+}
+
+function makePipeline(stepIds: string[] = ['s1', 's2', 's3']): ExecutablePipeline {
+    return {
+        steps: stepIds.map((id) => makeStep(id)),
+    } as ExecutablePipeline;
+}
+
+describe('ExecutablePipelineRunner', () => {
+    let pipeline: ExecutablePipeline;
+    let runner: ExecutablePipelineRunner;
+    let emitter: EventEmitter2;
+    let emitSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        pipeline = makePipeline();
+        emitter = new EventEmitter2();
+        emitSpy = jest.spyOn(emitter, 'emit');
+        runner = new ExecutablePipelineRunner(pipeline, emitter);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('PipelineRuntimeEvents barrel', () => {
+        it('pins literal event names (wire format)', () => {
+            // The two literal strings are emitted on the EventEmitter2 bus and consumed
+            // by callers outside this package — changing these strings is a wire-format
+            // break and must be deliberate.
+            expect(PipelineRuntimeEvents.STATE_CHANGED).toBe('pipeline:state-changed');
+            expect(PipelineRuntimeEvents.STEP_STATUS_CHANGED).toBe('pipeline:step-status-changed');
+        });
+
+        it('STATE_CHANGED is exported but NEVER emitted by this class (declared-but-unused gotcha)', () => {
+            // Pinned so a future "wire up state-change events" feature is deliberate.
+            // Today: only STEP_STATUS_CHANGED fires; STATE_CHANGED is reserved.
+            const r = new ExecutablePipelineRunner(makePipeline(['only-step']), emitter);
+            r.startExecution();
+            r.startStep('only-step');
+            r.markStepComplete('only-step');
+            r.completeExecution();
+
+            const events = emitSpy.mock.calls.map((c) => c[0]);
+            expect(events).not.toContain(PipelineRuntimeEvents.STATE_CHANGED);
+            expect(events.every((e) => e === PipelineRuntimeEvents.STEP_STATUS_CHANGED)).toBe(true);
+        });
+    });
+
+    describe('constructor / initial state', () => {
+        it('initialises with all steps in pending status and empty step lists', () => {
+            const state = runner.getState();
+            expect(state.isRunning).toBe(false);
+            expect(state.isCancelled).toBe(false);
+            expect(state.completedSteps).toEqual([]);
+            expect(state.failedSteps).toEqual([]);
+            expect(state.currentStep).toBeUndefined();
+            expect(state.startedAt).toBeUndefined();
+            expect(state.completedAt).toBeUndefined();
+            expect(state.steps.size).toBe(3);
+            for (const stepId of ['s1', 's2', 's3']) {
+                const stepState = state.steps.get(stepId);
+                expect(stepState?.status).toBe('pending');
+                expect(stepState?.definition.id).toBe(stepId);
+            }
+        });
+
+        it('preserves the original pipeline reference (no clone)', () => {
+            expect(runner.getPipeline()).toBe(pipeline);
+        });
+
+        it('handles a pipeline with zero steps without throwing', () => {
+            const empty = new ExecutablePipelineRunner(makePipeline([]));
+            const state = empty.getState();
+            expect(state.steps.size).toBe(0);
+            expect(state.completedSteps).toEqual([]);
+            expect(state.failedSteps).toEqual([]);
+        });
+
+        it('handles a pipeline with duplicate step IDs by collapsing into the LAST definition (Map.set semantics)', () => {
+            // Pinned: the constructor uses Map.set keyed by step.id; if two definitions
+            // share an id the second one wins. This is documented behaviour rather
+            // than a bug — but worth pinning so a future "throw on duplicate id"
+            // refactor breaks loudly.
+            const dup = new ExecutablePipelineRunner({
+                steps: [makeStep('s1', { name: 'first' }), makeStep('s1', { name: 'second' })],
+            } as ExecutablePipeline);
+            expect(dup.getState().steps.size).toBe(1);
+            expect(dup.getState().steps.get('s1')?.definition.name).toBe('second');
+        });
+
+        it('does not throw when constructed without an EventEmitter (optional dep)', () => {
+            const noEmitter = new ExecutablePipelineRunner(pipeline);
+            expect(() => {
+                noEmitter.startExecution();
+                noEmitter.startStep('s1');
+                noEmitter.markStepComplete('s1');
+                noEmitter.completeExecution();
+            }).not.toThrow();
+        });
+    });
+
+    describe('getStepState / getStepDefinition / getCurrentStep', () => {
+        it('getStepState returns the stored state for a known step', () => {
+            const stepState = runner.getStepState('s1');
+            expect(stepState?.status).toBe('pending');
+        });
+
+        it('getStepState returns undefined for an unknown step id', () => {
+            expect(runner.getStepState('does-not-exist')).toBeUndefined();
+        });
+
+        it('getStepDefinition uses Array.find on pipeline.steps (NOT the internal Map)', () => {
+            // Pinned: the implementation goes through pipeline.steps with .find rather
+            // than reading the internal stepStates map. If pipeline.steps mutates after
+            // construction, getStepDefinition reflects the mutation but getStepState
+            // does not. Useful invariant for caller code.
+            expect(runner.getStepDefinition('s2')?.id).toBe('s2');
+            expect(runner.getStepDefinition('does-not-exist')).toBeUndefined();
+        });
+
+        it('getCurrentStep returns undefined initially and after pipeline completion', () => {
+            expect(runner.getCurrentStep()).toBeUndefined();
+            runner.startExecution();
+            runner.startStep('s1');
+            expect(runner.getCurrentStep()).toBe('s1');
+            runner.markStepComplete('s1');
+            expect(runner.getCurrentStep()).toBeUndefined();
+        });
+    });
+
+    describe('isRunning / isCancelled', () => {
+        it('reflect state.isRunning / state.isCancelled accurately across the lifecycle', () => {
+            expect(runner.isRunning()).toBe(false);
+            expect(runner.isCancelled()).toBe(false);
+
+            runner.startExecution();
+            expect(runner.isRunning()).toBe(true);
+            expect(runner.isCancelled()).toBe(false);
+
+            runner.cancelExecution();
+            expect(runner.isRunning()).toBe(false);
+            expect(runner.isCancelled()).toBe(true);
+        });
+
+        it('completeExecution does NOT set isCancelled', () => {
+            runner.startExecution();
+            runner.completeExecution();
+            expect(runner.isRunning()).toBe(false);
+            expect(runner.isCancelled()).toBe(false);
+        });
+    });
+
+    describe('startExecution', () => {
+        it('records executionStartTime on state.startedAt and sets isRunning=true', () => {
+            const before = Date.now();
+            runner.startExecution();
+            const after = Date.now();
+            const state = runner.getState();
+            expect(state.isRunning).toBe(true);
+            expect(state.startedAt).toBeGreaterThanOrEqual(before);
+            expect(state.startedAt).toBeLessThanOrEqual(after);
+        });
+
+        it('does NOT clear completedSteps / failedSteps if called twice (no-op idempotency NOT guaranteed)', () => {
+            // Pinned: startExecution is destructive on the top-level fields it touches
+            // but PRESERVES completedSteps / failedSteps via the spread. A future
+            // "reset on start" refactor must update this test deliberately.
+            runner.startExecution();
+            runner.startStep('s1');
+            runner.markStepComplete('s1');
+            const before = runner.getState().completedSteps.slice();
+
+            runner.startExecution();
+            const state = runner.getState();
+            expect(state.completedSteps).toEqual(before);
+            expect(state.isRunning).toBe(true);
+        });
+    });
+
+    describe('completeExecution', () => {
+        it('sets isRunning=false and stamps completedAt', () => {
+            runner.startExecution();
+            const beforeStop = Date.now();
+            runner.completeExecution();
+            const afterStop = Date.now();
+            const state = runner.getState();
+            expect(state.isRunning).toBe(false);
+            expect(state.completedAt).toBeGreaterThanOrEqual(beforeStop);
+            expect(state.completedAt).toBeLessThanOrEqual(afterStop);
+        });
+
+        it('preserves startedAt when completing (audit trail)', () => {
+            runner.startExecution();
+            const startedAt = runner.getState().startedAt;
+            runner.completeExecution();
+            expect(runner.getState().startedAt).toBe(startedAt);
+        });
+    });
+
+    describe('cancelExecution', () => {
+        it('sets isRunning=false, isCancelled=true, AND stamps completedAt', () => {
+            runner.startExecution();
+            runner.cancelExecution();
+            const state = runner.getState();
+            expect(state.isRunning).toBe(false);
+            expect(state.isCancelled).toBe(true);
+            expect(state.completedAt).toBeDefined();
+        });
+    });
+
+    describe('updateStepStatus', () => {
+        it('throws verbatim "Step \\"<id>\\" not found in pipeline" for unknown step', () => {
+            expect(() => runner.updateStepStatus('nope', 'running')).toThrow(
+                'Step "nope" not found in pipeline',
+            );
+        });
+
+        it('sets startedAt only on running status', () => {
+            runner.updateStepStatus('s1', 'running');
+            const state = runner.getStepState('s1')!;
+            expect(state.status).toBe('running');
+            expect(state.startedAt).toBeDefined();
+            expect(state.completedAt).toBeUndefined();
+        });
+
+        it('sets completedAt on completed/failed/skipped (NOT pending or running)', () => {
+            const ids = ['s1', 's2', 's3'] as const;
+            const statuses = ['completed', 'failed', 'skipped'] as const;
+            for (let i = 0; i < ids.length; i++) {
+                runner.updateStepStatus(ids[i], statuses[i]);
+                expect(runner.getStepState(ids[i])?.completedAt).toBeDefined();
+            }
+            // 'pending' is untouched (default already)
+            const r = new ExecutablePipelineRunner(makePipeline(['p1']), emitter);
+            r.updateStepStatus('p1', 'pending');
+            expect(r.getStepState('p1')?.completedAt).toBeUndefined();
+            expect(r.getStepState('p1')?.startedAt).toBeUndefined();
+        });
+
+        it('updates currentStep when status===running and clears it on any other transition that matches the current step', () => {
+            runner.updateStepStatus('s1', 'running');
+            expect(runner.getCurrentStep()).toBe('s1');
+            runner.updateStepStatus('s1', 'completed');
+            expect(runner.getCurrentStep()).toBeUndefined();
+        });
+
+        it('does NOT clear currentStep when transitioning a DIFFERENT step (parallel-step safety)', () => {
+            runner.updateStepStatus('s1', 'running');
+            runner.updateStepStatus('s2', 'completed');
+            expect(runner.getCurrentStep()).toBe('s1');
+        });
+
+        it('emits STEP_STATUS_CHANGED with the documented payload shape', () => {
+            const before = Date.now();
+            runner.updateStepStatus('s1', 'running');
+            const after = Date.now();
+            expect(emitSpy).toHaveBeenCalledWith(
+                PipelineRuntimeEvents.STEP_STATUS_CHANGED,
+                expect.objectContaining({
+                    stepId: 's1',
+                    previousStatus: 'pending',
+                    newStatus: 'running',
+                }),
+            );
+            const payload = emitSpy.mock.calls[0][1] as StateChangePayload;
+            expect(payload.timestamp).toBeGreaterThanOrEqual(before);
+            expect(payload.timestamp).toBeLessThanOrEqual(after);
+        });
+
+        it('previousStatus reflects the state BEFORE the update (not the new status)', () => {
+            runner.updateStepStatus('s1', 'running');
+            emitSpy.mockClear();
+            runner.updateStepStatus('s1', 'completed');
+            const payload = emitSpy.mock.calls[0][1] as StateChangePayload;
+            expect(payload.previousStatus).toBe('running');
+            expect(payload.newStatus).toBe('completed');
+        });
+
+        it('does NOT emit when constructed without an EventEmitter', () => {
+            const noEmitter = new ExecutablePipelineRunner(pipeline);
+            expect(() => noEmitter.updateStepStatus('s1', 'running')).not.toThrow();
+            // Spy on EventEmitter prototype emit to confirm it was not invoked.
+            const protoSpy = jest.spyOn(EventEmitter2.prototype, 'emit');
+            noEmitter.updateStepStatus('s1', 'completed');
+            expect(protoSpy).not.toHaveBeenCalled();
+            protoSpy.mockRestore();
+        });
+    });
+
+    describe('startStep convenience', () => {
+        it('delegates to updateStepStatus with status=running', () => {
+            const spy = jest.spyOn(runner, 'updateStepStatus');
+            runner.startStep('s1');
+            expect(spy).toHaveBeenCalledWith('s1', 'running');
+        });
+    });
+
+    describe('markStepComplete', () => {
+        it('throws verbatim error for unknown step', () => {
+            expect(() => runner.markStepComplete('nope')).toThrow(
+                'Step "nope" not found in pipeline',
+            );
+        });
+
+        it('sets status=completed, stamps completedAt, appends to completedSteps, clears currentStep', () => {
+            runner.startStep('s1');
+            const before = Date.now();
+            runner.markStepComplete('s1');
+            const after = Date.now();
+            const state = runner.getState();
+            const stepState = state.steps.get('s1')!;
+            expect(stepState.status).toBe('completed');
+            expect(stepState.completedAt).toBeGreaterThanOrEqual(before);
+            expect(stepState.completedAt).toBeLessThanOrEqual(after);
+            expect(state.completedSteps).toEqual(['s1']);
+            expect(state.currentStep).toBeUndefined();
+        });
+
+        it('attaches metrics under result.metrics (only when metrics provided)', () => {
+            runner.markStepComplete('s1', { tokensUsed: 100, latencyMs: 250 } as never);
+            expect(runner.getStepState('s1')?.result).toEqual({
+                metrics: { tokensUsed: 100, latencyMs: 250 },
+            });
+        });
+
+        it('omits result when metrics===undefined (does NOT set {metrics: undefined})', () => {
+            runner.markStepComplete('s1');
+            expect(runner.getStepState('s1')?.result).toBeUndefined();
+        });
+
+        it('appends in chronological order across multiple completions (preserves order)', () => {
+            runner.markStepComplete('s2');
+            runner.markStepComplete('s1');
+            runner.markStepComplete('s3');
+            expect(runner.getState().completedSteps).toEqual(['s2', 's1', 's3']);
+        });
+
+        it('emits STEP_STATUS_CHANGED with previousStatus="running" (HARDCODED, NOT read from state)', () => {
+            // Pinned: markStepComplete emits previousStatus:'running' as a literal,
+            // even if the step was actually pending. Same pattern in markStepFailed.
+            // A future "compute previousStatus from state" refactor must be deliberate.
+            runner.markStepComplete('s1');
+            const payload = emitSpy.mock.calls[0][1] as StateChangePayload;
+            expect(payload.previousStatus).toBe('running');
+            expect(payload.newStatus).toBe('completed');
+        });
+
+        it('does NOT throw without an EventEmitter', () => {
+            const noEmitter = new ExecutablePipelineRunner(pipeline);
+            expect(() => noEmitter.markStepComplete('s1')).not.toThrow();
+        });
+    });
+
+    describe('markStepFailed', () => {
+        it('throws verbatim error for unknown step', () => {
+            expect(() => runner.markStepFailed('nope', new Error('x'))).toThrow(
+                'Step "nope" not found in pipeline',
+            );
+        });
+
+        it('sets status=failed, stamps completedAt, appends to failedSteps, attaches the Error', () => {
+            const err = new Error('step blew up');
+            runner.startStep('s1');
+            runner.markStepFailed('s1', err);
+            const state = runner.getState();
+            const stepState = state.steps.get('s1')!;
+            expect(stepState.status).toBe('failed');
+            expect(stepState.completedAt).toBeDefined();
+            expect(stepState.error).toBe(err);
+            expect(state.failedSteps).toEqual(['s1']);
+            expect(state.currentStep).toBeUndefined();
+        });
+
+        it('does NOT add the failed step to completedSteps', () => {
+            runner.markStepFailed('s1', new Error('x'));
+            expect(runner.getState().completedSteps).not.toContain('s1');
+        });
+
+        it('emits STEP_STATUS_CHANGED with previousStatus="running" (HARDCODED)', () => {
+            runner.markStepFailed('s1', new Error('x'));
+            const payload = emitSpy.mock.calls[0][1] as StateChangePayload;
+            expect(payload.previousStatus).toBe('running');
+            expect(payload.newStatus).toBe('failed');
+        });
+
+        it('preserves multiple failures in append order', () => {
+            runner.markStepFailed('s1', new Error('a'));
+            runner.markStepFailed('s2', new Error('b'));
+            expect(runner.getState().failedSteps).toEqual(['s1', 's2']);
+        });
+
+        it('does NOT throw without an EventEmitter', () => {
+            const noEmitter = new ExecutablePipelineRunner(pipeline);
+            expect(() => noEmitter.markStepFailed('s1', new Error('x'))).not.toThrow();
+        });
+    });
+
+    describe('markStepSkipped', () => {
+        it('throws verbatim error for unknown step', () => {
+            expect(() => runner.markStepSkipped('nope')).toThrow(
+                'Step "nope" not found in pipeline',
+            );
+        });
+
+        it('sets status=skipped, stamps completedAt, appends to completedSteps (skipped is "done")', () => {
+            runner.markStepSkipped('s1', 'no items to process');
+            const state = runner.getState();
+            const stepState = state.steps.get('s1')!;
+            expect(stepState.status).toBe('skipped');
+            expect(stepState.completedAt).toBeDefined();
+            expect(stepState.result).toEqual({ skipReason: 'no items to process' });
+            expect(state.completedSteps).toEqual(['s1']);
+            expect(state.failedSteps).toEqual([]);
+        });
+
+        it('omits result when reason===undefined', () => {
+            runner.markStepSkipped('s1');
+            expect(runner.getStepState('s1')?.result).toBeUndefined();
+            expect(runner.getStepState('s1')?.status).toBe('skipped');
+        });
+
+        it('does NOT clear currentStep (asymmetric with markStepComplete / markStepFailed)', () => {
+            // Pinned: markStepSkipped notably does NOT touch currentStep, while
+            // markStepComplete and markStepFailed both clear it. This is a
+            // documented asymmetry — a step can be skipped while another is running.
+            // A future refactor that "unifies" the three methods must be deliberate.
+            runner.startStep('s1');
+            runner.markStepSkipped('s2');
+            expect(runner.getCurrentStep()).toBe('s1');
+        });
+
+        it('emits STEP_STATUS_CHANGED with previousStatus="pending" (HARDCODED, distinct from complete/failed)', () => {
+            runner.markStepSkipped('s1');
+            const payload = emitSpy.mock.calls[0][1] as StateChangePayload;
+            expect(payload.previousStatus).toBe('pending');
+            expect(payload.newStatus).toBe('skipped');
+        });
+
+        it('does NOT throw without an EventEmitter', () => {
+            const noEmitter = new ExecutablePipelineRunner(pipeline);
+            expect(() => noEmitter.markStepSkipped('s1', 'reason')).not.toThrow();
+        });
+    });
+
+    describe('full lifecycle integration', () => {
+        it('a 3-step pipeline emits exactly 6 STEP_STATUS_CHANGED events (running+completed per step) in order', () => {
+            runner.startExecution();
+            runner.startStep('s1');
+            runner.markStepComplete('s1');
+            runner.startStep('s2');
+            runner.markStepComplete('s2');
+            runner.startStep('s3');
+            runner.markStepComplete('s3');
+            runner.completeExecution();
+
+            const stepEvents = emitSpy.mock.calls.filter(
+                (c) => c[0] === PipelineRuntimeEvents.STEP_STATUS_CHANGED,
+            );
+            expect(stepEvents).toHaveLength(6);
+            const transitions = stepEvents.map((c) => `${c[1].stepId}:${c[1].newStatus}`);
+            expect(transitions).toEqual([
+                's1:running',
+                's1:completed',
+                's2:running',
+                's2:completed',
+                's3:running',
+                's3:completed',
+            ]);
+        });
+
+        it('mixed lifecycle: some completed, some failed, some skipped', () => {
+            runner.startExecution();
+            runner.startStep('s1');
+            runner.markStepComplete('s1');
+            runner.startStep('s2');
+            runner.markStepFailed('s2', new Error('whoops'));
+            runner.markStepSkipped('s3', 'previous step failed');
+            runner.completeExecution();
+
+            const state = runner.getState();
+            expect(state.completedSteps).toEqual(['s1', 's3']);
+            expect(state.failedSteps).toEqual(['s2']);
+            expect(state.steps.get('s1')?.status).toBe('completed');
+            expect(state.steps.get('s2')?.status).toBe('failed');
+            expect(state.steps.get('s3')?.status).toBe('skipped');
+            expect(state.isRunning).toBe(false);
+            expect(state.isCancelled).toBe(false);
+        });
+
+        it('cancellation mid-flight preserves pre-cancel completedSteps and stamps the cancellation timestamp', () => {
+            runner.startExecution();
+            runner.startStep('s1');
+            runner.markStepComplete('s1');
+            runner.startStep('s2');
+            runner.cancelExecution();
+
+            const state = runner.getState();
+            expect(state.completedSteps).toEqual(['s1']);
+            expect(state.steps.get('s2')?.status).toBe('running');
+            expect(state.isRunning).toBe(false);
+            expect(state.isCancelled).toBe(true);
+            expect(state.completedAt).toBeDefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Closes the per-file zero-coverage gap on `packages/agent/src/pipeline/executable-pipeline.class.ts` (333 LOC) — the runtime wrapper that owns the `PipelineState` mutation flow consumed by the step-pipeline executor.
- Every `running`/`completed`/`failed`/`skipped` transition flows through this class; a regression in any of the five mutators would silently corrupt the run-state observed by both the orchestrator AND the activity-log emitter.
- Total agent-package suite: 3981 → 4030 tests across 179 → 180 suites, all green.

## Coverage breakdown

- **`PipelineRuntimeEvents` barrel (2)** — wire-format pin (`pipeline:state-changed` + `pipeline:step-status-changed`); **STATE_CHANGED-declared-but-never-emitted gotcha** pinned (today only STEP_STATUS_CHANGED fires).
- **Constructor / initial state (5)** — all-pending startup; original pipeline reference preserved; zero-step pipeline OK; duplicate step IDs collapse via Map.set semantics (second wins); EventEmitter is optional.
- **Read accessors (4)** — `getStepState` undefined for unknown id; `getStepDefinition` uses `pipeline.steps.find` NOT internal Map; `getCurrentStep` across lifecycle; `isRunning`/`isCancelled` mirror state.
- **`startExecution` (2)** — stamps `state.startedAt` + `isRunning=true`; **preserves `completedSteps`/`failedSteps` on second call (no reset)**.
- **`completeExecution` (2)** — clears `isRunning` + stamps `completedAt`; preserves `startedAt` for audit trail.
- **`cancelExecution` (1)** — the only method that flips `isCancelled=true`.
- **`updateStepStatus` (8)** — verbatim error `'Step "<id>" not found in pipeline'`; per-status `startedAt`/`completedAt` rules; `currentStep` parallel-step safety; payload shape; `previousStatus` reflects pre-update state; no-throw without emitter.
- **`startStep` (1)** — pure delegation to `updateStepStatus(stepId, 'running')`.
- **`markStepComplete` (7)** — `result.metrics` ONLY when provided; chronological append order; **`previousStatus` HARDCODED `'running'`** (NOT read from state) — pinned so a future "compute previousStatus" refactor breaks loudly.
- **`markStepFailed` (6)** — Error attached verbatim under `stepState.error`; failed step does NOT land in `completedSteps`; **`previousStatus` HARDCODED `'running'`**.
- **`markStepSkipped` (6)** — appends to `completedSteps` (skipped is "done"); **the only asymmetric mutator — does NOT clear `currentStep`**; **`previousStatus` HARDCODED `'pending'`** (distinct from complete/failed).
- **Full lifecycle integration (3)** — 3-step pipeline emits exactly 6 STEP_STATUS_CHANGED events in expected order; mixed completed/failed/skipped; cancel-mid-flight preserves pre-cancel completedSteps and stamps cancellation timestamp.

## Test plan

- [x] `cd packages/agent && pnpm test` (179 → 180 suites; 3981 → 4030 tests, all green)
- [x] No production code changed — pure new spec file at `packages/agent/src/pipeline/executable-pipeline.class.spec.ts`.
- [x] `pnpm format:check` passes for both touched files.
- [x] `COVERAGE-TRACKER.md` updated (Inventory snapshot + new Done ledger entry; backfilled #682 link for the prior validator PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for pipeline execution operations, including runtime event handling, lifecycle management, and step status transitions.

* **Documentation**
  * Updated test coverage tracking metrics reflecting recent test additions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->