### PR TITLE
feat(deploy): plumb GitHub read:packages PAT for private GHCR pulls from k8s

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -38,6 +38,10 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         token?: string;
         settings?: Record<string, unknown>;
         deployProvider?: string;
+        /** Settings returned by deployFacade.getOtherPluginSettings('github', ...).
+         *  Defaults to an empty object (no PAT saved). Tests for the GHCR PAT
+         *  flow override this with `{ readPackagesPat: '...' }`. */
+        githubPluginSettings?: Record<string, unknown>;
     }) => {
         const work = {
             id: 'work-1',
@@ -59,6 +63,9 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
                 work,
                 settings: overrides.settings ?? {},
             }),
+            getOtherPluginSettings: jest
+                .fn()
+                .mockResolvedValue(overrides.githubPluginSettings ?? {}),
         };
 
         const gitFacade = {
@@ -243,6 +250,109 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         // Vars never carry the kubeconfig.
         const allVarValues = variables.map((v: any) => v.value).join('\n');
         expect(allVarValues).not.toContain('leaked-12345');
+    });
+
+    describe('Kubernetes GHCR pull token (bug D)', () => {
+        it('pushes GITHUB_READ_PACKAGES_TOKEN when deployProvider=k8s and the user has saved a PAT', async () => {
+            const { service, githubPlugin, deployFacade } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                githubPluginSettings: { readPackagesPat: 'ghp_fine_grained_pat_value' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            // The facade was asked for the GitHub plugin's settings, not just
+            // the deploy plugin's — that's the cross-plugin read this flow
+            // requires.
+            expect(deployFacade.getOtherPluginSettings).toHaveBeenCalledWith('github', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            const { secrets } = captureCalls(githubPlugin);
+            const pat = secrets.find((s: any) => s.key === 'GITHUB_READ_PACKAGES_TOKEN');
+            expect(pat?.value).toBe('ghp_fine_grained_pat_value');
+        });
+
+        it('does NOT push GITHUB_READ_PACKAGES_TOKEN when no PAT is saved', async () => {
+            const { service, githubPlugin, deployFacade } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                githubPluginSettings: {},
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(deployFacade.getOtherPluginSettings).toHaveBeenCalledTimes(1);
+            const { secrets } = captureCalls(githubPlugin);
+            expect(
+                secrets.find((s: any) => s.key === 'GITHUB_READ_PACKAGES_TOKEN'),
+            ).toBeUndefined();
+        });
+
+        it('skips the cross-plugin read entirely for non-k8s providers', async () => {
+            const { service, githubPlugin, deployFacade } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                githubPluginSettings: { readPackagesPat: 'should-not-be-pushed' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            // Vercel doesn't need a packages PAT — the cross-plugin read is
+            // a no-op for non-k8s flows so we don't even ask.
+            expect(deployFacade.getOtherPluginSettings).not.toHaveBeenCalled();
+            const { secrets } = captureCalls(githubPlugin);
+            expect(
+                secrets.find((s: any) => s.key === 'GITHUB_READ_PACKAGES_TOKEN'),
+            ).toBeUndefined();
+        });
+
+        it('does not block the deploy when the GitHub plugin settings lookup throws', async () => {
+            const { service, githubPlugin, deployFacade } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+            });
+            deployFacade.getOtherPluginSettings.mockRejectedValueOnce(new Error('boom'));
+
+            await expect(service.deploy('work-1', 'user-1', {})).resolves.toBe(true);
+
+            // Deploy still ran — the standard k8s secrets were pushed.
+            const { secrets } = captureCalls(githubPlugin);
+            expect(secrets.find((s: any) => s.key === 'K8S_TOKEN')).toBeDefined();
+        });
+
+        it('trims whitespace and treats blank/whitespace-only PATs as missing', async () => {
+            const { service, githubPlugin } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                githubPluginSettings: { readPackagesPat: '   \n\t ' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            expect(
+                secrets.find((s: any) => s.key === 'GITHUB_READ_PACKAGES_TOKEN'),
+            ).toBeUndefined();
+        });
     });
 
     it('emits DeploymentDispatchedEvent after a successful dispatch', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -89,6 +89,7 @@ export class DeployService {
         });
 
         await this.setRequiredSecrets(ctx, token, work, plugin, settings);
+        await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
 
@@ -280,6 +281,51 @@ export class DeployService {
                     }`,
                 );
             }
+        }
+    }
+
+    /**
+     * For k8s deploys, push the GitHub `read:packages` PAT (if the user
+     * has saved one on their GitHub plugin settings) as a separate GitHub
+     * Actions secret. The `deploy_k8s.yaml` workflow prefers this over
+     * the workflow's built-in `GITHUB_TOKEN` for the imagePullSecret
+     * because `GITHUB_TOKEN` does not have `packages:read` for GHCR
+     * images owned by a different repo than the workflow itself.
+     *
+     * For non-k8s providers, or when the user hasn't saved a PAT, this
+     * is a no-op. The Vercel path doesn't read this secret.
+     */
+    private async setKubernetesGhcrPullSecret(ctx: RepoContext, work: Work, userId: string) {
+        if (work.deployProvider !== 'k8s') {
+            return;
+        }
+        try {
+            const githubSettings = await this.deployFacade.getOtherPluginSettings('github', {
+                userId,
+                workId: work.id,
+            });
+            const pat =
+                typeof githubSettings?.readPackagesPat === 'string'
+                    ? githubSettings.readPackagesPat.trim()
+                    : '';
+            if (!pat) {
+                // Workflow falls back to GITHUB_TOKEN; that works when the
+                // image and the workflow are in the same repo (the default
+                // case for the generated website's own GHCR image).
+                return;
+            }
+            await this.setSecret(ctx, 'GITHUB_READ_PACKAGES_TOKEN', pat);
+            this.logger.log(
+                `Pushed GITHUB_READ_PACKAGES_TOKEN to ${ctx.owner}/${ctx.repo} for k8s GHCR pull`,
+            );
+        } catch (error) {
+            // Don't block the deploy on this — the workflow has a safe
+            // fallback. Just log so operators can debug if pulls fail.
+            this.logger.warn(
+                `Failed to push GITHUB_READ_PACKAGES_TOKEN for ${ctx.owner}/${ctx.repo}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
         }
     }
 

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -348,6 +348,26 @@ export class DeployFacadeService implements IDeployFacade {
         return { ...result, settings };
     }
 
+    /**
+     * Resolve another plugin's user-scoped settings for the same deploy
+     * request. The k8s deploy needs to read the GitHub plugin's
+     * `readPackagesPat` to mint an imagePullSecret for private GHCR — but
+     * the k8s plugin itself has no cross-plugin access. The deploy
+     * orchestrator is the right layer to do this stitching, so this method
+     * exposes the (already-injected) settings service in a controlled,
+     * secret-including form.
+     */
+    async getOtherPluginSettings(
+        pluginId: string,
+        options: DeployFacadeOptions,
+    ): Promise<Record<string, unknown>> {
+        return this.settingsService.getSettings(pluginId, {
+            userId: options.userId,
+            workId: options.workId,
+            includeSecrets: true,
+        });
+    }
+
     // Domain management methods
     // DB is the primary source of truth; provider APIs are used for sync and verification.
 

--- a/packages/plugins/github/src/__tests__/github.plugin.spec.ts
+++ b/packages/plugins/github/src/__tests__/github.plugin.spec.ts
@@ -70,6 +70,14 @@ describe('GitHubPlugin', () => {
 			expect(props.apiBaseUrl.default).toBe('https://api.github.com');
 			expect(props.apiBaseUrl['x-hidden']).toBe(true);
 		});
+
+		it('exposes readPackagesPat as a user-scoped secret for GHCR private pulls from k8s', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.readPackagesPat).toBeDefined();
+			expect(props.readPackagesPat['x-secret']).toBe(true);
+			expect(props.readPackagesPat['x-scope']).toBe('user');
+			expect(props.readPackagesPat['x-widget']).toBe('password');
+		});
 	});
 
 	describe('IGitProviderPlugin pure helpers', () => {

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -74,6 +74,15 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 				format: 'uri',
 				'x-hidden': true,
 				'x-scope': 'global'
+			},
+			readPackagesPat: {
+				type: 'string',
+				title: 'Read packages PAT (optional)',
+				description:
+					'Fine-grained GitHub PAT with `read:packages` scope. Used by the Kubernetes deploy provider to pull private GHCR images from your cluster. Leave blank if your generated website repo is public.',
+				'x-secret': true,
+				'x-scope': 'user',
+				'x-widget': 'password'
 			}
 		}
 	};

--- a/packages/plugins/github/src/types.ts
+++ b/packages/plugins/github/src/types.ts
@@ -2,6 +2,11 @@ export interface GitHubSettings {
 	readonly clientId?: string;
 	readonly clientSecret?: string;
 	readonly apiBaseUrl?: string;
+	/** Fine-grained GitHub PAT with `read:packages` scope.
+	 * Used by the Kubernetes deploy provider to mint an imagePullSecret
+	 * for private GHCR images. Optional — only required when the
+	 * generated website repo (and therefore its GHCR image) is private. */
+	readonly readPackagesPat?: string;
 }
 
 export interface GitHubWorkflow {


### PR DESCRIPTION
## Summary

Cross-plugin platform-side plumbing so the Kubernetes deploy provider can pull **private** GHCR images. Pairs with [ever-works/directory-web-template](https://github.com/ever-works/directory-web-template) PR (link in comments once that's open).

This is the follow-up to #688 (the UI surface). #688 made the k8s plugin's settings UX usable; this PR closes the actual deployment data flow for private images.

## The bug

When deploying a Work whose website repo is private:

1. Build step pushes a private image to `ghcr.io/<owner>/<work-slug>`.
2. Deploy workflow tries to create a `docker-registry` secret using `secrets.GITHUB_TOKEN` for the password.
3. The workflow's `GITHUB_TOKEN` only has `packages:read` on **its own** repo. It cannot read packages owned by a different account.
4. The Deployment ends up in `ImagePullBackOff`.

## What's in this PR

- **GitHub plugin (`packages/plugins/github/src/github.plugin.ts`):** new optional `readPackagesPat` field — user-scoped, secret, password widget. User pastes a fine-grained GitHub PAT with `read:packages` once.
- **`GitHubSettings` type (`packages/plugins/github/src/types.ts`):** extended.
- **`DeployFacadeService.getOtherPluginSettings(pluginId, options)`** (`packages/agent/src/facades/deploy.facade.ts`): new method, exposes the already-injected `PluginSettingsService` in a controlled, user-scoped, secret-included form. Lets the deploy orchestrator read another plugin's settings without leaking the service surface.
- **`DeployService.setKubernetesGhcrPullSecret`** (`apps/api/src/plugins-capabilities/deploy/deploy.service.ts`): new step in the deploy pipeline. Only runs for `work.deployProvider === 'k8s'`. Looks up the user's GitHub plugin settings, extracts `readPackagesPat`, and pushes it as a `GITHUB_READ_PACKAGES_TOKEN` GitHub Actions secret on the website repo. Lookup errors are non-fatal (workflow has a fallback).

The matching workflow change in `directory-web-template` teaches `deploy_k8s.yaml` to prefer the new secret over `GITHUB_TOKEN` for the imagePullSecret password (priority order documented inline).

## Tests

`apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts` — 5 new test cases:
- pushes `GITHUB_READ_PACKAGES_TOKEN` when deployProvider=k8s and the user has saved a PAT,
- does NOT push it when no PAT is saved,
- skips the cross-plugin read entirely for non-k8s providers,
- does not block the deploy if the GitHub plugin settings lookup throws,
- treats blank/whitespace-only PATs as missing.

`packages/plugins/github/src/__tests__/github.plugin.spec.ts` — 1 new test verifying the schema flags.

All 14 `deploy.service.spec.ts` cases pass. All 21 `github.plugin.spec.ts` cases pass. `tsc` clean on touched files.

## Test plan

- [ ] Visit `/en/settings/plugins/git-provider`, paste a fine-grained PAT with `read:packages` into the new field, save.
- [ ] Set a Work's `deployProvider` to `k8s` (UI or `.works/works.yml`).
- [ ] Hit **Deploy** on that Work.
- [ ] Verify the website repo's GitHub Actions secrets now include `GITHUB_READ_PACKAGES_TOKEN` (alongside `K8S_TOKEN`, `K8S_NAMESPACE`, etc).
- [ ] Confirm the `deploy_k8s.yaml` run creates an imagePullSecret with the PAT, and the Deployment reaches `Available` (no `ImagePullBackOff`).
- [ ] Confirm a deploy with no PAT saved still works for public-website repos (no token pushed, `GITHUB_TOKEN` fallback handles same-repo GHCR).
- [ ] Confirm Vercel deploys are unchanged (no cross-plugin read attempted).

## Out of scope

- Existing develop `K8s Plugin E2E` failures (pre-existing `force: Forbidden` on kind-based SSA tests) — same as flagged in #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub plugin gains an optional personal access token setting for pulling private container images.
  * Kubernetes deployments will automatically add that token as a repository secret so private registry pulls work.

* **Tests**
  * Added coverage for secret injection behavior, whitespace/blank handling, cross-plugin settings lookup, and non-Kubernetes cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/689)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->