### PR TITLE
feat(github): OAuth button for read:packages + write:packages PAT

### DIFF
--- a/apps/api/src/plugins-capabilities/oauth/oauth.controller.ts
+++ b/apps/api/src/plugins-capabilities/oauth/oauth.controller.ts
@@ -117,4 +117,64 @@ export class OAuthController {
     async disconnectProvider(@Request() req, @Param('providerId') providerId: string) {
         await this.oauthService.disconnectProvider(req.user.userId, providerId);
     }
+
+    @Get(':providerId/read-packages/connect/url')
+    @ApiOperation({
+        summary: 'Get OAuth authorization URL for read:packages + write:packages',
+        description:
+            'Variant of `connect/url` that requests `read:packages` + `write:packages` scopes. The resulting token is stored on the plugin settings under `readPackagesPat` instead of replacing the main OAuth connection.',
+    })
+    @ApiParam({ name: 'providerId', description: 'OAuth provider ID' })
+    @ApiQuery({ name: 'callbackUrl', required: false })
+    @ApiQuery({ name: 'state', required: false })
+    @ApiQuery({ name: 'forceConsent', required: false })
+    @ApiResponse({ status: 200, description: 'OAuth authorization URL' })
+    async getReadPackagesConnectUrl(
+        @Request() req,
+        @Param('providerId') providerId: string,
+        @Query('callbackUrl') callbackUrl?: string,
+        @Query('state') state?: string,
+        @Query('forceConsent') forceConsent?: string,
+    ) {
+        try {
+            return await this.oauthService.getReadPackagesOAuthUrl({
+                userId: req.user.userId,
+                redirectUri: callbackUrl || '',
+                forceConsent: forceConsent === 'true',
+                providerId,
+                state,
+            });
+        } catch (error) {
+            throw new BadRequestException(
+                error instanceof Error ? error.message : 'Failed to get OAuth URL',
+            );
+        }
+    }
+
+    @Get(':providerId/read-packages/callback/plugins')
+    @ApiOperation({
+        summary: 'OAuth callback handler for the read-packages flow',
+        description:
+            "Receives the GitHub OAuth callback for the read-packages variant. Exchanges the code for a token and writes it to the user's plugin settings under `readPackagesPat` (used by the Kubernetes deploy provider as an imagePullSecret password for private GHCR images). Does NOT touch the main OAuth connection.",
+    })
+    @ApiParam({ name: 'providerId', description: 'OAuth provider ID' })
+    @ApiQuery({ name: 'code', required: true })
+    @ApiQuery({ name: 'state', required: false })
+    @ApiResponse({ status: 200, description: 'Read-packages PAT saved' })
+    async handleReadPackagesOAuthCallback(
+        @Request() req,
+        @Param('providerId') providerId: string,
+        @Query('code') code: string,
+        @Query('state') state?: string,
+    ) {
+        if (!code) {
+            throw new BadRequestException('Authorization code is required');
+        }
+        return this.oauthService.handleReadPackagesOAuthCallback(
+            req.user.userId,
+            providerId,
+            code,
+            state,
+        );
+    }
 }

--- a/apps/api/src/plugins-capabilities/oauth/oauth.service.ts
+++ b/apps/api/src/plugins-capabilities/oauth/oauth.service.ts
@@ -174,6 +174,79 @@ export class OAuthService {
         await this.oauthFacade.revokeToken(userId, providerId);
     }
 
+    /**
+     * Variant of {@link getOAuthUrl} that requests the GitHub `read:packages`
+     * and `write:packages` scopes regardless of the plugin's configured
+     * scopes. Used by the "Authorize with GitHub" button on the GitHub
+     * plugin's `readPackagesPat` field — the resulting token is stored in
+     * plugin settings instead of replacing the user's main OAuth connection.
+     *
+     * The exact same `oauthFacade.getAuthorizationUrl()` path is used; only
+     * the `scopes` slice of the config is overridden, so providers that
+     * ignore `scopes` (non-OAuth-with-scopes flows) keep behaving as before.
+     */
+    async getReadPackagesOAuthUrl({
+        userId,
+        providerId,
+        redirectUri,
+        state,
+        forceConsent,
+    }: {
+        userId: string;
+        providerId: string;
+        redirectUri: string;
+        state?: string;
+        forceConsent?: boolean;
+    }): Promise<{ url: string; state: string }> {
+        void userId;
+        const finalState = state || randomBytes(16).toString('hex');
+
+        const config = await this.getOAuthConfig(providerId, redirectUri);
+        const url = this.oauthFacade.getAuthorizationUrl(providerId, finalState, {
+            ...config,
+            scopes: ['read:packages', 'write:packages'],
+            forceConsent,
+        });
+
+        return { url, state: finalState };
+    }
+
+    /**
+     * Callback handler for the read-packages OAuth flow. Exchanges the code
+     * for a token (using the SAME GitHub OAuth app credentials as the main
+     * flow) and writes the resulting access token to the user's GitHub
+     * plugin settings under `readPackagesPat` — the same field a user can
+     * fill manually with a fine-grained PAT.
+     *
+     * Critically, this does NOT touch `authAccountRepository`. The main
+     * GitHub OAuth connection (used for git operations, repo OAuth scopes)
+     * is left untouched; the two tokens live independently.
+     */
+    async handleReadPackagesOAuthCallback(
+        userId: string,
+        providerId: string,
+        code: string,
+        state?: string,
+    ): Promise<{ providerId: string; connected: true }> {
+        void state;
+
+        const config = await this.getOAuthConfig(providerId);
+        const token = await this.oauthFacade.exchangeCodeForToken(providerId, code, config);
+
+        await this.pluginSettingsService.updateUserSettings(
+            providerId,
+            userId,
+            { readPackagesPat: token.accessToken },
+            { secretKeys: ['readPackagesPat'] },
+        );
+
+        this.logger.log(
+            `Stored read-packages OAuth token for user ${userId} on plugin ${providerId}`,
+        );
+
+        return { providerId, connected: true };
+    }
+
     private async getOAuthConfig(
         providerId: string,
         redirectUri?: string,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2952,7 +2952,9 @@
                 "clusterIngressClassDefault": "default",
                 "clusterIngressClassUnknown": "unknown controller",
                 "clusterIngressClassPreVerify": "Save & verify to detect this cluster's IngressClass list. Leave blank for the cluster default.",
-                "clusterIngressClassEmpty": "No ingress controller detected. Install ingress-nginx, Traefik, or another controller in your cluster, then re-save to refresh this list."
+                "clusterIngressClassEmpty": "No ingress controller detected. Install ingress-nginx, Traefik, or another controller in your cluster, then re-save to refresh this list.",
+                "githubPackagesOAuthConnect": "Authorize with GitHub (read:packages + write:packages)",
+                "githubPackagesOAuthFailed": "Failed to start GitHub authorization. Try again or paste a PAT manually."
             },
             "oauth": {
                 "title": "Account Connection",

--- a/apps/web/src/app/actions/dashboard/oauth.ts
+++ b/apps/web/src/app/actions/dashboard/oauth.ts
@@ -86,6 +86,55 @@ export async function connectGitProvider(
     return connectOAuthProvider(providerId, returnPath, forceConsent);
 }
 
+/**
+ * Start the GitHub read-packages OAuth flow. Mirrors `connectOAuthProvider`
+ * but hits the dedicated `/oauth/:providerId/read-packages/connect/url`
+ * endpoint, which forces `scope=read:packages write:packages` and routes
+ * the callback into plugin settings (`readPackagesPat`) instead of the
+ * user's main OAuth connection. Used by the GitHub plugin's
+ * "Connect via GitHub (read:packages + write:packages)" button.
+ */
+export async function connectReadPackagesOAuthProvider(
+    providerId: string,
+    returnPath?: string,
+    forceConsent?: boolean,
+) {
+    try {
+        if (!providerId) {
+            return { success: false, error: 'Provider ID is required' };
+        }
+
+        const state = generateHexToken(16);
+        await setOAuthStateCookie(state);
+
+        const params = new URLSearchParams();
+        if (returnPath) {
+            params.append('returnPath', returnPath);
+        }
+
+        const queryString = params.toString();
+        const callbackPath = routeWithParams(ROUTES.API_OAUTH_READ_PACKAGES_CALLBACK, {
+            providerId,
+        });
+        const callbackUrl = withAppUrl(callbackPath) + (queryString ? `?${queryString}` : '');
+
+        const response = await oauthAPI.getReadPackagesConnectUrl(
+            providerId,
+            callbackUrl,
+            state,
+            forceConsent,
+        );
+
+        return { success: true, url: response.url, state: response.state };
+    } catch (error) {
+        console.error('Failed to get read-packages OAuth connect URL:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to start OAuth flow',
+        };
+    }
+}
+
 export async function disconnectOAuthProvider(providerId: string) {
     try {
         if (!providerId) {

--- a/apps/web/src/app/api/oauth/[providerId]/read-packages/callback/plugins/route.ts
+++ b/apps/web/src/app/api/oauth/[providerId]/read-packages/callback/plugins/route.ts
@@ -1,0 +1,79 @@
+import { redirect } from '@/i18n/navigation';
+import { oauthAPI } from '@/lib/api';
+import { getOAuthStateCookie, removeOAuthStateCookie } from '@/lib/auth';
+import { ROUTES } from '@/lib/constants';
+import { getLocale } from 'next-intl/server';
+import { NextRequest } from 'next/server';
+import { appendQueryParams, getOAuthRouteErrorCode } from '../../../../callback-errors';
+
+/**
+ * Callback route for the GitHub read-packages OAuth flow. Mirrors the main
+ * plugins-callback route but calls `oauthAPI.readPackagesCallback()` which
+ * writes the resulting access token into the user's GitHub plugin settings
+ * under `readPackagesPat` — instead of replacing the main OAuth connection.
+ *
+ * On success/error the user is redirected back to the git-provider plugin
+ * settings page (or the explicit `returnPath` if one was provided when the
+ * flow was initiated) with the same `oauth_*` query-string contract the
+ * main callback uses, so the existing toast / inline messaging surfaces
+ * the result without extra UI plumbing.
+ */
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ providerId: string }> },
+) {
+    const { providerId } = await params;
+    const queryParams = request.nextUrl.searchParams;
+    const code = queryParams.get('code');
+    const state = queryParams.get('state');
+    const returnPath = queryParams.get('returnPath');
+    const defaultPath = ROUTES.DASHBOARD_SETTINGS_PLUGIN_CATEGORY('git-provider');
+    const targetPath = returnPath || defaultPath;
+
+    const locale = await getLocale();
+
+    if (!code) {
+        return redirect({
+            locale,
+            href: appendQueryParams(targetPath, {
+                oauth_error: 'oauth_missing_code',
+                oauth_provider: providerId,
+                oauth_intent: 'read_packages',
+            }),
+        });
+    }
+
+    const storedState = await getOAuthStateCookie();
+    if (state && state !== storedState) {
+        await removeOAuthStateCookie();
+        return redirect({
+            locale,
+            href: appendQueryParams(targetPath, {
+                oauth_error: 'oauth_invalid_state',
+                oauth_provider: providerId,
+                oauth_intent: 'read_packages',
+            }),
+        });
+    }
+
+    await removeOAuthStateCookie();
+
+    let href: string;
+    try {
+        await oauthAPI.readPackagesCallback(providerId, code, state || undefined);
+        href = appendQueryParams(targetPath, {
+            oauth_connected: 'true',
+            oauth_provider: providerId,
+            oauth_intent: 'read_packages',
+        });
+    } catch (error) {
+        console.error(`Failed to complete read-packages OAuth flow for ${providerId}:`, error);
+        href = appendQueryParams(targetPath, {
+            oauth_error: getOAuthRouteErrorCode(error, 'oauth_connect_failed'),
+            oauth_provider: providerId,
+            oauth_intent: 'read_packages',
+        });
+    }
+
+    return redirect({ locale, href });
+}

--- a/apps/web/src/components/plugins/form/GithubPackagesOAuthButton.tsx
+++ b/apps/web/src/components/plugins/form/GithubPackagesOAuthButton.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
+import { Github, ExternalLink, Loader2 } from 'lucide-react';
+import { connectReadPackagesOAuthProvider } from '@/app/actions/dashboard/oauth';
+
+interface GithubPackagesOAuthButtonProps {
+    /** The plugin ID — always `'github'` today, but threaded so the
+     *  component stays portable if another provider grows the same flow. */
+    pluginId: string;
+}
+
+/**
+ * Inline "Connect via GitHub" button rendered beside the
+ * `readPackagesPat` secret input on the GitHub plugin settings form.
+ *
+ * Click → call `connectReadPackagesOAuthProvider` server action → server
+ * builds the GitHub OAuth URL (with `scope=read:packages write:packages`
+ * forced) → we redirect the whole window to GitHub. After auth GitHub
+ * redirects back to `/api/oauth/github/read-packages/callback/plugins`,
+ * which exchanges the code and writes the resulting token into the
+ * user's `readPackagesPat` plugin setting. The page reloads with
+ * `oauth_connected=true&oauth_intent=read_packages` so existing toast
+ * machinery surfaces the result.
+ */
+export function GithubPackagesOAuthButton({ pluginId }: GithubPackagesOAuthButtonProps) {
+    const t = useTranslations('dashboard.plugins.settingsField');
+    const pathname = usePathname();
+    const [isPending, startTransition] = useTransition();
+    const [error, setError] = useState<string | null>(null);
+
+    const handleConnect = () => {
+        setError(null);
+        startTransition(async () => {
+            try {
+                // Strip the locale prefix so the callback redirects back to
+                // the same settings page the user is on. The server action
+                // re-adds the locale via `redirect()` from next-intl.
+                const returnPath = pathname?.replace(/^\/[a-z]{2}(?=\/|$)/, '') || undefined;
+                const result = await connectReadPackagesOAuthProvider(
+                    pluginId,
+                    returnPath,
+                    /* forceConsent */ true,
+                );
+                if (!result.success || !result.url) {
+                    setError(result.error ?? t('githubPackagesOAuthFailed'));
+                    return;
+                }
+                window.location.href = result.url;
+            } catch (err) {
+                setError(err instanceof Error ? err.message : t('githubPackagesOAuthFailed'));
+            }
+        });
+    };
+
+    return (
+        <div className="space-y-1.5">
+            <button
+                type="button"
+                onClick={handleConnect}
+                disabled={isPending}
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border dark:border-border-dark bg-surface-secondary dark:bg-surface-secondary-dark text-sm font-medium text-text dark:text-text-dark hover:border-primary/50 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+                {isPending ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                    <Github className="w-4 h-4" />
+                )}
+                {t('githubPackagesOAuthConnect')}
+                {!isPending && <ExternalLink className="w-3.5 h-3.5 opacity-60" />}
+            </button>
+            {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+    );
+}

--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { PluginModelSelect } from './PluginModelSelect';
 import { PluginSettingsObjectField } from './PluginSettingsObjectField';
 import { PluginSettingsArrayField } from './PluginSettingsArrayField';
+import { GithubPackagesOAuthButton } from './GithubPackagesOAuthButton';
 import { isType, getPrimaryType } from './utils';
 
 interface PluginSettingsFieldProps {
@@ -363,6 +364,10 @@ export function PluginSettingsField({
                 {label}
                 {required && <span className="text-danger ml-1">*</span>}
             </label>
+
+            {schema.widget === 'github-packages-oauth' && pluginId && (
+                <GithubPackagesOAuthButton pluginId={pluginId} />
+            )}
 
             {renderInput()}
 

--- a/apps/web/src/lib/api/plugins-capabilities/oauth.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/oauth.ts
@@ -56,6 +56,37 @@ export const oauthAPI = {
         );
     },
 
+    /**
+     * Get OAuth authorization URL for the GitHub read-packages flow. The
+     * resulting token is stored in plugin settings under `readPackagesPat`
+     * instead of replacing the main OAuth connection.
+     */
+    getReadPackagesConnectUrl: async (
+        providerId: string,
+        callbackUrl?: string,
+        state?: string,
+        forceConsent?: boolean,
+    ) => {
+        const params = new URLSearchParams();
+        if (callbackUrl) params.append('callbackUrl', callbackUrl);
+        if (state) params.append('state', state);
+        if (forceConsent) params.append('forceConsent', 'true');
+        const query = params.toString() ? `?${params.toString()}` : '';
+        return serverFetch<{
+            url: string;
+            state: string;
+        }>(`/oauth/${providerId}/read-packages/connect/url${query}`);
+    },
+
+    /** Callback for the read-packages OAuth flow (server-side, no UI). */
+    readPackagesCallback: async (providerId: string, code: string, state?: string) => {
+        const params = new URLSearchParams({ code });
+        if (state) params.append('state', state);
+        return serverFetch<{ providerId: string; connected: true }>(
+            `/oauth/${providerId}/read-packages/callback/plugins?${params.toString()}`,
+        );
+    },
+
     getUser: async (providerId: string) => {
         return serverFetch<{
             success: boolean;

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -117,6 +117,7 @@ export const ROUTES = {
     API_CHAT: '/api/chat',
     API_OAUTH_CALLBACK: '/api/oauth/:providerId/callback',
     API_OAUTH_PLUGINS_CALLBACK: '/api/oauth/:providerId/callback/plugins',
+    API_OAUTH_READ_PACKAGES_CALLBACK: '/api/oauth/:providerId/read-packages/callback/plugins',
 } as const;
 
 export const routeWithParams = (route: string, params: Record<string, string>) => {

--- a/packages/plugins/github/src/__tests__/github.plugin.spec.ts
+++ b/packages/plugins/github/src/__tests__/github.plugin.spec.ts
@@ -76,7 +76,7 @@ describe('GitHubPlugin', () => {
 			expect(props.readPackagesPat).toBeDefined();
 			expect(props.readPackagesPat['x-secret']).toBe(true);
 			expect(props.readPackagesPat['x-scope']).toBe('user');
-			expect(props.readPackagesPat['x-widget']).toBe('password');
+			expect(props.readPackagesPat['x-widget']).toBe('github-packages-oauth');
 		});
 	});
 

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -77,12 +77,12 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 			},
 			readPackagesPat: {
 				type: 'string',
-				title: 'Read packages PAT (optional)',
+				title: 'Read packages PAT',
 				description:
-					'Fine-grained GitHub PAT with `read:packages` scope. Used by the Kubernetes deploy provider to pull private GHCR images from your cluster. Leave blank if your generated website repo is public.',
+					'Used by the Kubernetes deploy provider to pull private GHCR images. Click "Connect" to authorize via GitHub (recommended — least-privilege token with `read:packages` + `write:packages` only) or paste a fine-grained PAT manually. Leave blank if your generated website repo is public.',
 				'x-secret': true,
 				'x-scope': 'user',
-				'x-widget': 'password'
+				'x-widget': 'github-packages-oauth'
 			}
 		}
 	};


### PR DESCRIPTION
## Summary

Adds an opt-in OAuth flow on the GitHub plugin so users can authorize the platform for `read:packages` + `write:packages` by clicking a button, instead of manually pasting a fine-grained PAT. Pairs with #689 (the PAT field). Both paths coexist — OAuth is the recommended UX; manual paste stays as the escape hatch.

## Why

Closing the last UX gap in the k8s deploy flow: pulling private GHCR images requires a `read:packages` token, and the standard GitHub OAuth (login + git operations) doesn't include that scope. Today users have to mint a fine-grained PAT and paste it. This PR adds a one-click alternative.

## How it works

1. Button next to the `readPackagesPat` field calls the new server action.
2. Server builds an OAuth URL via the existing OAuth facade, but forces `scopes: ['read:packages', 'write:packages']` through the config override path.
3. Browser redirects to GitHub. User grants scopes.
4. GitHub redirects to the new callback path `/api/oauth/github/read-packages/callback/plugins`.
5. Callback exchanges the code using the SAME GitHub OAuth app credentials, then writes the resulting token into `PluginSettings.readPackagesPat` via `pluginSettingsService.updateUserSettings` — same field a user would fill manually.
6. **Crucially**, the AuthAccount table is NOT touched. The user's main OAuth connection (git operations, repo scopes) is left alone. Two tokens live independently.

## File map

| Layer | File | Change |
|---|---|---|
| API | `apps/api/src/plugins-capabilities/oauth/oauth.service.ts` | `getReadPackagesOAuthUrl()` + `handleReadPackagesOAuthCallback()` |
| API | `apps/api/src/plugins-capabilities/oauth/oauth.controller.ts` | 2 new routes |
| Web | `apps/web/src/lib/api/plugins-capabilities/oauth.ts` | `getReadPackagesConnectUrl()` + `readPackagesCallback()` |
| Web | `apps/web/src/lib/constants.ts` | `API_OAUTH_READ_PACKAGES_CALLBACK` route |
| Web | `apps/web/src/app/actions/dashboard/oauth.ts` | `connectReadPackagesOAuthProvider()` server action |
| Web | `apps/web/src/app/api/oauth/[providerId]/read-packages/callback/plugins/route.ts` | Next.js callback handler |
| Web | `apps/web/src/components/plugins/form/GithubPackagesOAuthButton.tsx` | New inline button component |
| Web | `apps/web/src/components/plugins/form/PluginSettingsField.tsx` | Widget branch for `github-packages-oauth` |
| Web | `apps/web/messages/en.json` | 2 i18n strings |
| Plugin | `packages/plugins/github/src/github.plugin.ts` | `readPackagesPat` field gets `x-widget: github-packages-oauth` + clearer description |

## Test plan

- [ ] Visit `/en/settings/plugins/git-provider` → GitHub card → see the new "Authorize with GitHub (read:packages + write:packages)" button above the Read packages PAT input.
- [ ] Click → full-window redirect to GitHub → consent screen shows ONLY `read:packages` and `write:packages` scopes → approve.
- [ ] Land back on the git-provider settings page with `oauth_connected=true&oauth_intent=read_packages` in the URL.
- [ ] Confirm `readPackagesPat` is now populated (masked) in the form.
- [ ] Confirm the main GitHub OAuth connection (git operations) is untouched — the user can still push commits, etc.
- [ ] Confirm the PAT-paste path still works (overwrite the field with a real PAT, save, then re-authorize via OAuth — second authorize replaces it).
- [ ] Trigger a k8s deploy on a Work whose website repo is private; confirm the rendered `imagePullSecret` uses the token (the workflow logs the registry username + masked password length).

## Out of scope

- Unit tests for the two new service methods are mechanical against existing `oauth.service.spec.ts` patterns — happy to land them in a follow-up so this PR stays the right size to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated GitHub Packages authorization flow.
  * Users can connect GitHub Packages independently from their main GitHub account.
  * New "Connect via GitHub" button in plugin settings to start the Packages OAuth flow.
  * Settings now show a GitHub Packages-specific control and status.
  * OAuth connection for Packages stores a separate token without altering primary GitHub connection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/692)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->