### PR TITLE
fix(oauth): web client read-packages callback URL must match API path

### DIFF
--- a/apps/web/src/lib/api/plugins-capabilities/oauth.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/oauth.ts
@@ -83,7 +83,7 @@ export const oauthAPI = {
         const params = new URLSearchParams({ code });
         if (state) params.append('state', state);
         return serverFetch<{ providerId: string; connected: true }>(
-            `/oauth/${providerId}/read-packages/callback/plugins?${params.toString()}`,
+            `/oauth/${providerId}/callback/plugins/read-packages?${params.toString()}`,
         );
     },
 


### PR DESCRIPTION
Second half of #695 (already merged). The web client's oauthAPI.readPackagesCallback still hit the OLD URL after the API route was nested; users approving on GitHub then got 'Connection failed' because the Next.js callback handler 404'd against the API. Confirmed in prod logs.

```
ever-works-web pod log:
Failed to complete read-packages OAuth flow for github: Error [ApiResponseError]: 
Cannot GET /api/oauth/github/read-packages/callback/plugins?code=e8247c6bda112c653065&state=aeab96df678f239b
```

One-line fix to point the web-side serverFetch at the new path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the OAuth callback endpoint path for the read-packages flow to use the correct route structure, improving compatibility with the authentication process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/699)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->