### PR TITLE
feat: EW-611 + EW-612 + EW-610 — domain remove + deployProvider sync + deploy progress panel

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2173,6 +2173,10 @@
                 }
             },
             "deploy": {
+                "progress": {
+                    "loadingStatus": "Loading deploy status...",
+                    "openWebsite": "Open website"
+                },
                 "noProviderAlert": {
                     "title": "No Deployment Provider",
                     "description": "Select a deployment provider to deploy your Work's website.",

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/deploy/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/deploy/page.tsx
@@ -8,6 +8,7 @@ import { DeployTokenAlert } from '@/components/works/detail/deploy/DeployTokenAl
 import { DeployProviderSelector } from '@/components/works/detail/deploy/DeployProviderSelector';
 import { SharedWorkNoTokenAlert } from '@/components/works/detail/deploy/SharedWorkNoTokenAlert';
 import { DomainManagement } from '@/components/works/detail/deploy/DomainManagement';
+import { DeployProgressPanel } from '@/components/works/detail/deploy/DeployProgressPanel';
 import { canDeploy } from '@/lib/permissions';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -119,6 +120,7 @@ export default async function DeployPage({ params }: DeployPageParams) {
                 providerName={providerName}
                 websiteTemplates={websiteTemplates}
             />
+            <DeployProgressPanel workId={work.id} isDeploying={isDeploying(work)} />
             {work.website && <DomainManagement work={work} />}
         </div>
     );

--- a/apps/web/src/app/api/works/[id]/deploy/status/route.ts
+++ b/apps/web/src/app/api/works/[id]/deploy/status/route.ts
@@ -1,0 +1,42 @@
+import { workAPI } from '@/lib/api/work';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Live deploy status for the Work's Deploy page (EW-610).
+ *
+ * Returns a minimal status payload polled every 3s by
+ * `DeployProgressPanel`. Reuses the existing `GET /works/:id` API and
+ * extracts the deploy-relevant fields, so no new platform endpoint is
+ * needed and existing auth / multi-tenant rules apply unchanged.
+ *
+ * Shape:
+ *   {
+ *     deploymentState: 'INITIALIZING' | 'QUEUED' | 'BUILDING' | 'READY' | 'ERROR' | 'CANCELED' | null,
+ *     deploymentStartedAt: ISO string | null,
+ *     website: string | null,
+ *     deployProvider: 'k8s' | 'vercel' | null,
+ *   }
+ */
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
+    try {
+        const response = await workAPI.get(id);
+        const work = response?.work;
+        if (!work) {
+            return NextResponse.json({ error: 'work_not_found' }, { status: 404 });
+        }
+        return NextResponse.json({
+            deploymentState: work.deploymentState ?? null,
+            deploymentStartedAt: work.deploymentStartedAt ?? null,
+            website: work.website ?? null,
+            deployProvider: work.deployProvider ?? null,
+        });
+    } catch (error) {
+        return NextResponse.json(
+            {
+                error: error instanceof Error ? error.message : 'failed_to_load_deploy_status',
+            },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web/src/components/works/detail/deploy/DeployProgressPanel.tsx
+++ b/apps/web/src/components/works/detail/deploy/DeployProgressPanel.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { CheckCircle2, AlertCircle, Loader2, ExternalLink, Clock } from 'lucide-react';
+
+interface DeployStatus {
+    deploymentState:
+        | 'INITIALIZING'
+        | 'QUEUED'
+        | 'BUILDING'
+        | 'READY'
+        | 'ERROR'
+        | 'CANCELED'
+        | string
+        | null;
+    deploymentStartedAt: string | null;
+    website: string | null;
+    deployProvider: string | null;
+}
+
+interface DeployProgressPanelProps {
+    workId: string;
+    /** Initial isDeploying signal from the server-rendered parent. Used to
+     *  decide whether to mount the panel at all and start polling. */
+    isDeploying: boolean;
+}
+
+const TERMINAL_STATES = new Set(['READY', 'ERROR', 'CANCELED', 'TIMEOUT']);
+
+/**
+ * Live deploy progress panel (EW-610 — MVP).
+ *
+ * Polls `/api/works/:id/deploy/status` every 3s while a deploy is in
+ * flight (`isDeploying` from the parent OR the polled state is non-terminal).
+ * Surfaces:
+ *   - the current platform-side `deploymentState` with a colored badge
+ *   - elapsed time since `deploymentStartedAt`
+ *   - a link to the deployed website once `READY`
+ *   - a link to the GitHub Actions runs page on `ERROR` so the user can
+ *     drill into the workflow logs without needing to know which repo
+ *
+ * Out of scope for this MVP (tracked separately):
+ *   - per-step GitHub Actions workflow run timeline (needs new Octokit
+ *     calls + a new platform endpoint to surface them).
+ *   - "retry imagePullSecret" button when the pod is `ImagePullBackOff`.
+ *   - tailing `kubectl logs` of the deployed pod.
+ */
+// Inline state labels keep this MVP self-contained — these strings are
+// the canonical deployment-state enum names plus a short user-facing
+// description. They live here (not in i18n catalogs) so adding a new
+// state on the platform side doesn't require touching 20 locale files.
+const STATE_LABELS: Record<string, { title: string; message: string }> = {
+    INITIALIZING: {
+        title: 'Initializing deploy',
+        message: 'Setting up your deploy environment.',
+    },
+    QUEUED: {
+        title: 'Queued',
+        message: 'Waiting for the deploy workflow runner to pick up the job.',
+    },
+    BUILDING: {
+        title: 'Building',
+        message: 'Building your container image and pushing to the registry.',
+    },
+    READY: { title: 'Deployed successfully', message: 'Your website is live.' },
+    ERROR: {
+        title: 'Deploy failed',
+        message:
+            'The deploy workflow finished with an error. Check the GitHub Actions logs on the website repository for details.',
+    },
+    CANCELED: { title: 'Deploy canceled', message: 'The deploy was canceled.' },
+    TIMEOUT: {
+        title: 'Deploy timed out',
+        message: 'The deploy took too long to finish. The cluster may still be rolling out.',
+    },
+    UNKNOWN: { title: 'Status unknown', message: 'No recent deploy activity yet.' },
+};
+
+export function DeployProgressPanel({ workId, isDeploying }: DeployProgressPanelProps) {
+    const t = useTranslations('dashboard.workDetail.deploy.progress');
+    const [status, setStatus] = useState<DeployStatus | null>(null);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const [elapsedSeconds, setElapsedSeconds] = useState<number | null>(null);
+
+    // Decide whether to keep polling: start when `isDeploying` is true,
+    // continue until we observe a terminal state from the server. This
+    // catches the case where the parent's `isDeploying` resets to false
+    // before the platform reports READY/ERROR.
+    const shouldPoll =
+        isDeploying || (status?.deploymentState && !TERMINAL_STATES.has(status.deploymentState));
+
+    useEffect(() => {
+        if (!shouldPoll) {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+            return;
+        }
+
+        const poll = async () => {
+            try {
+                const res = await fetch(`/api/works/${workId}/deploy/status`);
+                if (res.ok) {
+                    setStatus(await res.json());
+                }
+            } catch {
+                // Silently ignore polling errors — the panel falls back to
+                // its last-known good state. The next tick will recover.
+            }
+        };
+
+        poll();
+        intervalRef.current = setInterval(poll, 3000);
+
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        };
+    }, [shouldPoll, workId]);
+
+    // Elapsed time ticker — independent of the poll cadence so the
+    // counter visibly moves every second.
+    useEffect(() => {
+        if (!status?.deploymentStartedAt) {
+            setElapsedSeconds(null);
+            return;
+        }
+        const startedAt = new Date(status.deploymentStartedAt).getTime();
+        const tick = () => {
+            setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
+        };
+        tick();
+        const interval = setInterval(tick, 1000);
+        return () => clearInterval(interval);
+    }, [status?.deploymentStartedAt]);
+
+    if (!isDeploying && !status) return null;
+    if (!status) {
+        return (
+            <div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">
+                <div className="flex items-center gap-3">
+                    <Loader2 className="w-5 h-5 animate-spin text-primary" />
+                    <span className="text-sm text-text dark:text-text-dark">
+                        {t('loadingStatus')}
+                    </span>
+                </div>
+            </div>
+        );
+    }
+
+    const stateKey = (status.deploymentState ?? 'UNKNOWN').toUpperCase();
+    const isReady = stateKey === 'READY';
+    const isError = stateKey === 'ERROR' || stateKey === 'TIMEOUT';
+    const isCanceled = stateKey === 'CANCELED';
+    const isInFlight = !isReady && !isError && !isCanceled && stateKey !== 'UNKNOWN';
+
+    return (
+        <div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">
+            <div className="flex items-start gap-4">
+                <div
+                    className={cn(
+                        'shrink-0 w-10 h-10 rounded-full flex items-center justify-center',
+                        isReady && 'bg-success/10 dark:bg-success-dark/10',
+                        isError && 'bg-error/10 dark:bg-error-dark/10',
+                        isInFlight && 'bg-primary/10 dark:bg-primary-dark/10',
+                        (isCanceled || stateKey === 'UNKNOWN') &&
+                            'bg-surface-secondary dark:bg-surface-secondary-dark',
+                    )}
+                >
+                    {isReady && <CheckCircle2 className="w-5 h-5 text-success" />}
+                    {isError && <AlertCircle className="w-5 h-5 text-error" />}
+                    {isInFlight && <Loader2 className="w-5 h-5 animate-spin text-primary" />}
+                    {(isCanceled || stateKey === 'UNKNOWN') && (
+                        <Clock className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
+                    )}
+                </div>
+
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                            {(STATE_LABELS[stateKey] || STATE_LABELS.UNKNOWN).title}
+                        </h3>
+                        <span
+                            className={cn(
+                                'text-xs px-2 py-0.5 rounded-full font-medium',
+                                isReady && 'bg-success/10 text-success',
+                                isError && 'bg-error/10 text-error',
+                                isInFlight && 'bg-primary/10 text-primary',
+                                (isCanceled || stateKey === 'UNKNOWN') &&
+                                    'bg-surface-secondary text-text-muted',
+                            )}
+                        >
+                            {stateKey}
+                        </span>
+                        {elapsedSeconds !== null && isInFlight && (
+                            <span className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {formatElapsed(elapsedSeconds)}
+                            </span>
+                        )}
+                    </div>
+
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1">
+                        {(STATE_LABELS[stateKey] || STATE_LABELS.UNKNOWN).message}
+                    </p>
+
+                    {isReady && status.website && (
+                        <a
+                            href={status.website}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 mt-3 text-sm text-primary hover:text-primary/80 font-medium"
+                        >
+                            {t('openWebsite')}
+                            <ExternalLink className="w-3.5 h-3.5" />
+                        </a>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function formatElapsed(seconds: number) {
+    if (seconds < 60) return `${seconds}s`;
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}m ${secs}s`;
+}

--- a/apps/web/src/components/works/detail/deploy/DomainManagement.tsx
+++ b/apps/web/src/components/works/detail/deploy/DomainManagement.tsx
@@ -127,7 +127,17 @@ function DomainManagementContent({ work }: DomainManagementProps) {
         toast.success(t('copied'));
     };
 
-    const isVercelAutoAssigned = (name: string) => name.endsWith('.vercel.app');
+    // A `*.vercel.app` hostname is auto-managed by Vercel when the Work
+    // deploys there — it can't be removed from the dashboard while the user
+    // is still deploying to Vercel (Vercel re-creates it).
+    //
+    // BUT once the user has switched `deployProvider` away from Vercel, that
+    // hostname is just a stale DB row pointing at a project the new provider
+    // doesn't know about. The user needs to be able to clean it up.
+    // (See EW-611.) The "no remove" gate therefore only applies while the
+    // Work's current provider is still `vercel`.
+    const isVercelAutoAssigned = (name: string) =>
+        name.endsWith('.vercel.app') && work.deployProvider === 'vercel';
 
     return (
         <div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -36,6 +36,7 @@ describe('WorkLifecycleService', () => {
     let deployFacade: any;
     let templateCatalogService: any;
     let websiteRepositoryState: any;
+    let eventEmitter: any;
     let service: WorkLifecycleService;
 
     afterAll(() => {
@@ -86,6 +87,10 @@ describe('WorkLifecycleService', () => {
             isInitialized: jest.fn().mockResolvedValue(false),
         };
 
+        eventEmitter = {
+            emit: jest.fn(),
+        };
+
         service = new WorkLifecycleService(
             workRepository,
             dataGenerator,
@@ -96,6 +101,7 @@ describe('WorkLifecycleService', () => {
             deployFacade,
             templateCatalogService,
             websiteRepositoryState,
+            eventEmitter as never,
         );
     });
 

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -5,7 +5,9 @@ import {
     Logger,
     NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { WorkRepository } from '@src/database/repositories/work.repository';
+import { WorksConfigSyncRequestedEvent } from '@src/events';
 import { DataGeneratorService } from '@src/generators/data-generator/data-generator.service';
 import { MarkdownGeneratorService } from '@src/generators/markdown-generator/markdown-generator.service';
 import { WebsiteGeneratorService } from '@src/generators/website-generator/website-generator.service';
@@ -41,6 +43,7 @@ export class WorkLifecycleService {
         private readonly deployFacade: DeployFacadeService,
         private readonly templateCatalogService: TemplateCatalogService,
         private readonly websiteRepositoryState: WorkWebsiteRepositoryStateService,
+        private readonly eventEmitter: EventEmitter2,
     ) {}
 
     private normalizeWebsiteTemplateSelection(value?: string | null): string | null {
@@ -256,6 +259,26 @@ export class WorkLifecycleService {
             }
 
             updatedWork.owner = updatedWork.getRepoOwner();
+
+            // EW-612: when `deployProvider` changes via the dashboard,
+            // commit the new value to `.works/works.yml` in the data repo
+            // so the next deploy doesn't hit the data-repo-wins precedence
+            // and silently flip the provider back. We do this by emitting
+            // the existing `WorksConfigSyncRequestedEvent`; the existing
+            // `WorksConfigSyncListener` + `WorksConfigRepositorySyncService`
+            // handle the YAML read-modify-write and the git commit/push.
+            //
+            // Only emit when the value actually changed — saving the same
+            // provider should be a no-op for the data repo.
+            if (
+                updateDto.deployProvider !== undefined &&
+                updateDto.deployProvider !== work.deployProvider
+            ) {
+                this.eventEmitter.emit(
+                    WorksConfigSyncRequestedEvent.EVENT_NAME,
+                    new WorksConfigSyncRequestedEvent(id, user.id, 'provider_changed'),
+                );
+            }
 
             return {
                 status: 'success',


### PR DESCRIPTION
Resolves [EW-611](https://evertech.atlassian.net/browse/EW-611), [EW-612](https://evertech.atlassian.net/browse/EW-612), and ships the MVP slice of [EW-610](https://evertech.atlassian.net/browse/EW-610).

## EW-611 — Stale Vercel domains permanently hidden Remove button

`DomainManagement.tsx` gated the Remove button on `!isVercelAutoAssigned(name)`, with `isVercelAutoAssigned` matching `*.vercel.app`. Intent: don't let users remove Vercel's auto-managed hostname while still deploying there. Bug: after switching to k8s, those rows are stale + un-removable.

**Fix:** the check now also requires `work.deployProvider === 'vercel'`. Once the user is off Vercel, those rows are removable.

## EW-612 — `deployProvider` UI change doesn't reach `.works/works.yml`

The sync pipeline (`WorksConfigSyncRequestedEvent` → listener → `WorksConfigRepositorySyncService`) was already wired up for schedule changes + plugin ops, but NOT for `PATCH /api/works/:id` when `deployProvider` changes. Result: data repo retained old value, next deploy's data-repo-wins precedence flipped dashboard back, `deploy_provider_conflict` activity log entry.

**Fix:** in `WorkLifecycleService.updateWork`, after the repository update succeeds, emit `WorksConfigSyncRequestedEvent(workId, userId, 'provider_changed')` iff `updateDto.deployProvider` is defined AND different from the current `work.deployProvider`. Constructor takes `EventEmitter2` (already wired globally).

## EW-610 — Live deploy status panel (MVP slice)

After Deploy is clicked, the dashboard goes silent until the deployment-verifier marks the Work as READY/ERROR. New panel polls every 3s and surfaces:
- Status badge (colored by state),
- Elapsed time counter,
- 'Open website' link once READY.

**Out of scope** for the MVP (filed as follow-up): GitHub Actions per-step timeline (needs new Octokit calls + new platform endpoint), retry-imagePullSecret button, kubectl logs streaming.

## Tests

`work-lifecycle.service.spec.ts` — all 6 existing tests still pass after the constructor signature change. `apps/web` tsc clean.

## Test plan after deploy

- [ ] On a Vercel-deployed Work: confirm `*.vercel.app` row STILL has no Remove button.
- [ ] Switch to k8s → confirm `*.vercel.app` row now shows Remove → click → row removed.
- [ ] Switch `deployProvider` → check the data repo's `.works/works.yml` for an auto-commit setting the new value.
- [ ] Click Deploy → confirm progress panel appears, polls every 3s, shows live state + elapsed time, then 'Open website' link when READY.

[EW-611]: https://evertech.atlassian.net/browse/EW-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-612]: https://evertech.atlassian.net/browse/EW-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-610]: https://evertech.atlassian.net/browse/EW-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deploy progress panel with live status polling, elapsed-time display, and quick "Open website" link when ready.
  * Added an API endpoint for fetching deploy status.

* **Bug Fixes**
  * Domain management now treats provider-assigned hostnames only when that provider is active, restoring correct verification/removal controls.

* **Improvements**
  * Changing the deployment provider via the dashboard now triggers automatic configuration synchronization.

* **Tests**
  * Test setup updated to mock lifecycle event emission.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/700)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->