### PR TITLE
fix(onboarding): SWC TDZ on OnboardingStatePatchInnerDto class order

### DIFF
--- a/apps/api/src/onboarding/dto/onboarding-state.dto.ts
+++ b/apps/api/src/onboarding/dto/onboarding-state.dto.ts
@@ -54,16 +54,12 @@ class DeployChoicePatchDto {
     choice!: OnboardingDeployChoice;
 }
 
-export class OnboardingStatePatchBodyDto {
-    @ApiPropertyOptional({
-        description: 'Partial state update. Server deep-merges with persisted version-2 shape.',
-    })
-    @IsOptional()
-    @ValidateNested()
-    @Type(() => OnboardingStatePatchInnerDto)
-    state?: OnboardingStatePatchInnerDto;
-}
-
+// `OnboardingStatePatchInnerDto` MUST be declared BEFORE
+// `OnboardingStatePatchBodyDto`: the latter references it inside a
+// `@Type(() => OnboardingStatePatchInnerDto)` decorator. Even though the
+// arrow function defers the lookup, SWC's class decorator evaluation
+// order trips a TDZ ReferenceError when the decorated outer class is
+// instantiated by Nest at startup. ts-jest tolerates it; SWC doesn't.
 export class OnboardingStatePatchInnerDto {
     @ApiPropertyOptional({ minimum: 0 })
     @IsOptional()
@@ -99,6 +95,16 @@ export class OnboardingStatePatchInnerDto {
     @IsOptional()
     @IsBoolean()
     pluginsReviewed?: boolean;
+}
+
+export class OnboardingStatePatchBodyDto {
+    @ApiPropertyOptional({
+        description: 'Partial state update. Server deep-merges with persisted version-2 shape.',
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => OnboardingStatePatchInnerDto)
+    state?: OnboardingStatePatchInnerDto;
 }
 
 export class OnboardingStateResponseDto {


### PR DESCRIPTION
## Summary
- Reorder `OnboardingStatePatchInnerDto` to be declared BEFORE `OnboardingStatePatchBodyDto` in `apps/api/src/onboarding/dto/onboarding-state.dto.ts`.
- The outer DTO has `@Type(() => OnboardingStatePatchInnerDto)` on its `state?` field. Under `@nestjs/swc`, class decorators evaluate at class-definition time, so referencing a class declared later triggers a TDZ `ReferenceError` when Nest instantiates the controller at startup.
- `ts-jest` tolerates the forward reference; SWC + the Playwright e2e job do not — boot fails before any request is served.

## Why this is the fix
- The TDZ is the root cause of the `ReferenceError: Cannot access 'OnboardingStatePatchInnerDto' before initialization` that broke `e2e (22.x)` on PR #705 (develop → stage).
- No behaviour change. Pure declaration-order fix + a comment documenting the SWC gotcha so we don't regress.

## Test plan
- [x] `pnpm --filter ever-works-api build` clean
- [ ] Merge to develop, confirm CI green
- [ ] Confirm PR #705 (develop → stage) e2e (22.x) goes green on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an internal error in the onboarding API that prevented proper request handling. Code reorganization ensures the API functions correctly without affecting user-facing behavior or interface changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/708)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->