### PR TITLE
fix(e2e): point onboarding-dismiss POST at NestJS API (fixes 45-min e2e timeout)

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -54,8 +54,10 @@ setup('authenticate', async ({ page, baseURL }) => {
     // 3. Pre-dismiss the onboarding wizard so subsequent authenticated tests
     //    aren't blocked by the modal portal intercepting clicks. v2 stores
     //    the dismissed flag on the server (users.onboarding_dismissed_at) so
-    //    we POST /api/onboarding/dismiss here. The legacy localStorage key
-    //    is kept for the few specs still on v1.
+    //    we POST /api/onboarding/dismiss against the NestJS API directly
+    //    (port 3100). The baseURL is :3000 (Next.js) which doesn't proxy
+    //    /api routes, so a relative POST would silently 404. The legacy
+    //    localStorage key is kept for the few specs still on v1.
     const ONBOARDING_KEY = 'ever-works-onboarding';
     await page.evaluate((key) => {
         try {
@@ -67,10 +69,30 @@ setup('authenticate', async ({ page, baseURL }) => {
             // localStorage may not be available; tests can dismiss manually.
         }
     }, ONBOARDING_KEY);
-    await page.request.post('/api/onboarding/dismiss').catch(() => {
+
+    const apiBase = process.env.API_URL || 'http://localhost:3100';
+    try {
+        const loginRes = await fetch(`${apiBase}/api/auth/login`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                email: TEST_USER.email,
+                password: TEST_USER.password,
+            }),
+        });
+        if (loginRes.ok) {
+            const { access_token } = (await loginRes.json()) as { access_token?: string };
+            if (access_token) {
+                await fetch(`${apiBase}/api/onboarding/dismiss`, {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${access_token}` },
+                });
+            }
+        }
+    } catch {
         // Wizard-v2 endpoint may not exist on older API builds — the
         // localStorage shim above keeps the legacy tests green either way.
-    });
+    }
 
     // 4. Dismiss the "Connect your GitHub account" modal if it appears, and
     //    record the dismissal in localStorage (key is keyed by userId, so we


### PR DESCRIPTION
## Summary
- The wizard-v2 dismiss POST in \`apps/web/e2e/global-setup.ts\` used a relative URL. Playwright resolved it against \`baseURL = http://localhost:3000\` (Next.js), which has no \`/api/onboarding/*\` route — request silently 404'd.
- Result: \`users.onboarding_dismissed_at\` stayed NULL for the e2e test user, the wizard auto-opened on every authenticated dashboard render, and the modal portal blocked Playwright clicks. Prime suspect for the develop e2e regression from ~7 min (last green: 002dbdd) to 43+ min / cancelled.
- Switch to an explicit \`API_URL\` (default \`:3100\`) login + Bearer-token dismiss. Legacy localStorage shim retained for v1 specs.

## Test plan
- [x] Diff is read-only on global setup (no behaviour change for non-onboarding specs)
- [ ] Merge to develop → confirm next E2E run on develop returns to the ~7-min baseline
- [ ] Confirm PR #705 (develop → stage) e2e (22.x) goes green on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test infrastructure for onboarding wizard initialization during automated testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/712)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->