### PR TITLE
fix(e2e): surface non-2xx onboarding dismiss responses (follow-up to #712)

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -70,7 +70,7 @@ setup('authenticate', async ({ page, baseURL }) => {
         }
     }, ONBOARDING_KEY);
 
-    const apiBase = process.env.API_URL || 'http://localhost:3100';
+    let apiBase = process.env.API_URL || 'http://localhost:3100';
     try {
         const loginRes = await fetch(`${apiBase}/api/auth/login`, {
             method: 'POST',
@@ -83,10 +83,20 @@ setup('authenticate', async ({ page, baseURL }) => {
         if (loginRes.ok) {
             const { access_token } = (await loginRes.json()) as { access_token?: string };
             if (access_token) {
-                await fetch(`${apiBase}/api/onboarding/dismiss`, {
+                const dismissRes = await fetch(`${apiBase}/api/onboarding/dismiss`, {
                     method: 'POST',
                     headers: { Authorization: `Bearer ${access_token}` },
                 });
+                // If the endpoint exists but rejects the call, surface it.
+                // 404 is tolerated (older API builds without v2 wizard route),
+                // but anything else means onboarding_dismissed_at stays NULL
+                // and the modal will block subsequent Playwright clicks — the
+                // exact regression this setup is meant to prevent.
+                if (!dismissRes.ok && dismissRes.status !== 404) {
+                    console.warn(
+                        `[e2e global-setup] onboarding dismiss returned ${dismissRes.status} ${dismissRes.statusText} — wizard may still block clicks`,
+                    );
+                }
             }
         }
     } catch {


### PR DESCRIPTION
## Summary
Follow-up to merged PR #712 — applies the two review nits Greptile raised on the original branch.

**P1 — silent dismiss failure (the same class of bug #712 was meant to close):**
`apps/web/e2e/global-setup.ts` called `POST /api/onboarding/dismiss` but never inspected the response. The login step was correctly gated on `loginRes.ok`; the dismiss step was not. If the NestJS endpoint had returned a non-2xx (rejected token, 500, etc.), `users.onboarding_dismissed_at` would stay NULL and the wizard modal would continue to block Playwright clicks — exactly the regression #712 closed. Now we capture `dismissRes` and emit a clear `console.warn` on any status other than 2xx or 404 (404 is still tolerated for older API builds that don't have the v2 wizard route).

**P2 — `let` over `const` for env-derived `apiBase`:** team convention is `let` for variables sourced from environment variables, since the value is conceptually mutable per environment.

## Test plan
- [x] Diff is contained to `apps/web/e2e/global-setup.ts` — no behaviour change for happy-path (2xx) or older builds (404)
- [ ] Merge to develop and confirm e2e (22.x) still hits the ~7-min baseline
- [ ] Confirm the warning fires only when the NestJS dismiss endpoint truly fails

## References
- Original PR: #712
- Greptile review comments: P1 line 90 (dismiss-status check), P2 line 73 (let over const)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup with enhanced handling of onboarding dismissal interactions and better error tolerance for API compatibility across different builds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/713)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->