### PR TITLE
fix(onboarding): address AI-bot review findings on PR #705 (3 P1/P2)

### DIFF
--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils/cn';
@@ -73,7 +74,14 @@ export function EverWorksOnboardingWizard({
         initial: initialState,
         catalog,
         patchState: async (patch) => {
-            await patchOnboardingState(patch);
+            const result = await patchOnboardingState(patch);
+            // If the server-action wrapper reports `success: false` (e.g. API
+            // 4xx/5xx, validation error), surface it so the user knows their
+            // progress wasn't saved. Silent failures previously let the user
+            // click through the whole wizard with nothing persisted.
+            if (!result.success) {
+                toast.error(result.error ?? 'Failed to save your onboarding progress');
+            }
         },
         trackEvent: (event, props) => {
             void trackOnboardingEvent(event, props);

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -95,6 +95,19 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
 }
 
 describe('WorkLifecycleService.createWork — provider defaults + quota', () => {
+    // `resolveProviderDefaults` reads `config.everWorks.deploy.isEnabled()`,
+    // which derives from `DEPLOY_EVER_WORKS_ENABLED`. Tests that exercise
+    // the `ever-works` deploy path need the flag on; tests that exercise
+    // the fallback path need it off.
+    const previousFlag = process.env.DEPLOY_EVER_WORKS_ENABLED;
+    afterEach(() => {
+        if (previousFlag === undefined) {
+            delete process.env.DEPLOY_EVER_WORKS_ENABLED;
+        } else {
+            process.env.DEPLOY_EVER_WORKS_ENABLED = previousFlag;
+        }
+    });
+
     it('falls back to user-github + vercel when the user has no onboarding state and the DTO is silent', async () => {
         const { service, deps } = makeService(null);
 
@@ -104,6 +117,7 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
         const persisted = deps.workRepo.create.mock.calls[0][0];
         expect(persisted.storageProvider).toBe('user-github');
         expect(persisted.deployProvider).toBe('vercel');
+        expect(persisted.gitProvider).toBe('github');
         expect(deps.quota.assertWithinQuota).not.toHaveBeenCalled();
     });
 
@@ -151,15 +165,19 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
     });
 
     it('invokes the Ever Works Deploy quota check when deploy === ever-works', async () => {
+        process.env.DEPLOY_EVER_WORKS_ENABLED = 'true';
         const { service, deps } = makeService(null);
 
         await service.createWork({ ...baseDto, deployProvider: 'ever-works' }, baseUser);
 
         expect(deps.quota.assertWithinQuota).toHaveBeenCalledWith(baseUser.id);
         expect(deps.workRepo.create).toHaveBeenCalledTimes(1);
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.deployProvider).toBe('ever-works');
     });
 
     it('bubbles up EverWorksDeployQuotaExceededError before any DB write', async () => {
+        process.env.DEPLOY_EVER_WORKS_ENABLED = 'true';
         const { service, deps } = makeService(null);
         deps.quota.assertWithinQuota.mockRejectedValueOnce(
             new EverWorksDeployQuotaExceededError(3, 3),
@@ -184,5 +202,92 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
         const persisted = deps.workRepo.create.mock.calls[0][0];
         expect(persisted.storageProvider).toBe('user-github');
         expect(persisted.deployProvider).toBe('vercel');
+        expect(persisted.gitProvider).toBe('github');
+    });
+
+    it('rewrites deploy=ever-works → vercel when DEPLOY_EVER_WORKS_ENABLED is off', async () => {
+        // Critical safeguard: there is no plugin registered with id
+        // `ever-works`. Persisting it on the Work would break the deploy
+        // facade later. The wizard's default state still says `ever-works`,
+        // so the rewrite has to live in the seed code.
+        delete process.env.DEPLOY_EVER_WORKS_ENABLED;
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'user-github' },
+            deploy: { choice: 'ever-works' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+
+        await service.createWork(baseDto, baseUser);
+
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.deployProvider).toBe('vercel');
+        expect(deps.quota.assertWithinQuota).not.toHaveBeenCalled();
+    });
+
+    it("derives gitProvider from the onboarding storage choice (ever-works-git → 'github')", async () => {
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'ever-works-git' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+
+        // Don't pass gitProvider in the DTO so the seed code has to derive it.
+        const dtoNoGit = { ...baseDto } as CreateWorkDto;
+        delete (dtoNoGit as { gitProvider?: string }).gitProvider;
+
+        await service.createWork(dtoNoGit, baseUser);
+
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.storageProvider).toBe('ever-works-git');
+        expect(persisted.gitProvider).toBe('github');
+    });
+
+    it("derives gitProvider from the onboarding storage choice (user-gitlab → 'gitlab')", async () => {
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'user-gitlab' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+
+        const dtoNoGit = { ...baseDto } as CreateWorkDto;
+        delete (dtoNoGit as { gitProvider?: string }).gitProvider;
+
+        await service.createWork(dtoNoGit, baseUser);
+
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.gitProvider).toBe('gitlab');
+    });
+
+    it('honours an explicit DTO gitProvider override even when storage choice would derive a different one', async () => {
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'user-gitlab' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+
+        await service.createWork({ ...baseDto, gitProvider: 'github' }, baseUser);
+
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.gitProvider).toBe('github');
     });
 });

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -30,7 +30,37 @@ import { WebsiteRepositoryCreationMethod } from '@src/items-generator/dto/create
 import { TemplateCatalogService } from '../template-catalog/template-catalog.service';
 import { WorkWebsiteRepositoryStateService } from './work-website-repository-state.service';
 import { EverWorksDeployQuotaService } from '@src/ever-works-providers';
+import { config } from '@src/config';
 import type { OnboardingWizardStateV2 } from '@ever-works/contracts/api';
+
+/**
+ * Map a wizard "storage" choice onto the existing `gitProvider` field.
+ *
+ * The Work entity still drives every repository operation off
+ * `work.gitProvider` (see git facade + repository-management). The onboarding
+ * wizard's storage step is a higher-level choice that needs to translate
+ * back into a concrete git-provider plugin id, otherwise picking
+ * `ever-works-git` would silently fall back to whatever `gitProvider` the
+ * DTO carried (default `github`).
+ */
+function gitProviderFromStorageChoice(storage: string): string | undefined {
+    switch (storage) {
+        case 'ever-works-git':
+            // Ever Works Git is a managed GitHub org, so the runtime git
+            // provider is still GitHub.
+            return 'github';
+        case 'user-github':
+            return 'github';
+        case 'user-gitlab':
+            return 'gitlab';
+        case 'user-git':
+            // Self-hosted Git is "planned" in the catalog. Until a concrete
+            // plugin lands, fall through to the caller's default.
+            return undefined;
+        default:
+            return undefined;
+    }
+}
 
 @Injectable()
 export class WorkLifecycleService {
@@ -52,19 +82,28 @@ export class WorkLifecycleService {
     ) {}
 
     /**
-     * Resolve storage / deploy provider for a new Work. Precedence:
+     * Resolve storage / deploy / git provider for a new Work. Precedence:
      *
      *   1. value the client passed in the DTO (explicit overrides win),
      *   2. the user's persisted onboarding choice (if any),
      *   3. the historical fallback (`user-github` / `vercel`).
      *
-     * Returning a separate object keeps the assignment logic small and
-     * unit-testable.
+     * Two additional safeguards:
+     *
+     *   - `deployProvider === 'ever-works'` is only persisted when the env
+     *     flag is on. There's no plugin registered with id `ever-works`, so
+     *     the deploy facade would throw at deploy time on environments where
+     *     the feature is off (which is the prod default until the tenant
+     *     cluster is wired up). Fall back to `vercel` in that case.
+     *   - The storage choice is translated back into a concrete `gitProvider`
+     *     value, since repository operations still read `work.gitProvider`.
+     *     Without this, picking `ever-works-git` in the wizard had no
+     *     runtime effect.
      */
     private async resolveProviderDefaults(
-        dto: Pick<CreateWorkDto, 'storageProvider' | 'deployProvider'>,
+        dto: Pick<CreateWorkDto, 'storageProvider' | 'deployProvider' | 'gitProvider'>,
         userId: string,
-    ): Promise<{ storageProvider: string; deployProvider: string }> {
+    ): Promise<{ storageProvider: string; deployProvider: string; gitProvider: string }> {
         let onboardingState: OnboardingWizardStateV2 | null | undefined;
         try {
             const user = await this.userRepository.findById(userId);
@@ -75,11 +114,21 @@ export class WorkLifecycleService {
             );
         }
 
-        return {
-            storageProvider:
-                dto.storageProvider ?? onboardingState?.storage?.choice ?? 'user-github',
-            deployProvider: dto.deployProvider ?? onboardingState?.deploy?.choice ?? 'vercel',
-        };
+        const storageProvider =
+            dto.storageProvider ?? onboardingState?.storage?.choice ?? 'user-github';
+
+        let deployProvider = dto.deployProvider ?? onboardingState?.deploy?.choice ?? 'vercel';
+        if (deployProvider === 'ever-works' && !config.everWorks.deploy.isEnabled()) {
+            this.logger.warn(
+                `deployProvider 'ever-works' selected by user ${userId} but DEPLOY_EVER_WORKS_ENABLED is off — falling back to 'vercel' to avoid persisting an unresolvable provider id`,
+            );
+            deployProvider = 'vercel';
+        }
+
+        const gitProvider =
+            dto.gitProvider ?? gitProviderFromStorageChoice(storageProvider) ?? 'github';
+
+        return { storageProvider, deployProvider, gitProvider };
     }
 
     private normalizeWebsiteTemplateSelection(value?: string | null): string | null {
@@ -148,23 +197,15 @@ export class WorkLifecycleService {
     }
 
     async createWork(createWorkDto: CreateWorkDto, user: User) {
-        const {
-            slug,
-            name,
-            description,
-            owner,
-            readmeConfig,
-            organization,
-            gitProvider,
-            websiteTemplateId,
-        } = createWorkDto;
+        const { slug, name, description, owner, readmeConfig, organization, websiteTemplateId } =
+            createWorkDto;
 
         const selectedWebsiteTemplateId = await this.resolveValidatedWebsiteTemplateSelection(
             websiteTemplateId,
             user.id,
         );
 
-        const { storageProvider, deployProvider } = await this.resolveProviderDefaults(
+        const { storageProvider, deployProvider, gitProvider } = await this.resolveProviderDefaults(
             createWorkDto,
             user.id,
         );


### PR DESCRIPTION
## Summary
Three real bugs surfaced by Greptile + Codex on PR #705 that I missed in the original cascade. Fixing on develop before continuing the cascade to stage/main.

### 1. Codex P1 — \`deployProvider = 'ever-works'\` resolves to no plugin
\`EverWorksK8sDeployProvider\` is a NestJS service, not a registered plugin. \`deployFacade.registry.get('ever-works')\` throws. The wizard's default state seeds \`deploy.choice = 'ever-works'\` regardless of the env flag, so new Works on environments where \`DEPLOY_EVER_WORKS_ENABLED\` is off (prod default) would silently persist an unresolvable provider id and break at deploy time.
**Fix:** \`resolveProviderDefaults\` rewrites \`ever-works\` → \`vercel\` when the env flag is off, with a logger warning.

### 2. Codex P2 — storage choice doesn't propagate to gitProvider
Repository ops still read \`work.gitProvider\`. Picking \`ever-works-git\` in the wizard left \`gitProvider\` whatever the DTO carried (default \`github\`) — the storage choice was effectively a no-op for non-GitHub picks.
**Fix:** New \`gitProviderFromStorageChoice()\` mapping (\`ever-works-git\` / \`user-github\` → \`github\`, \`user-gitlab\` → \`gitlab\`). Explicit DTO \`gitProvider\` still wins.

### 3. Greptile P2 — wizard silently drops patchState errors
\`patchOnboardingState\` returns \`{ success: false, error }\` on failure; the wizard awaited it but discarded the result. User would click through the whole wizard with nothing persisted and no toast.
**Fix:** Surface failures via \`toast.error()\`.

## Test plan
- [x] \`pnpm exec jest --testPathPattern='work-lifecycle'\` — 16 tests pass (6 existing + 10 with my 4 new ones)
- [x] \`tsc --noEmit\` on apps/web — clean
- [x] Agent build emits no errors on the touched files (pre-existing build failures in works.controller / item-import are EW-533 unrelated)

## Follow-ups not in this PR
- Greptile P1 migrations (develop dropped migrations + uses \`synchronize:true\`; theoretical until that decision flips)
- Greptile P1 \`countActiveByDeployProvider\` full-table scan (bounded by 3-works cap; trivial \`.take()\` cleanup)
- Greptile P2 hardcoded \`onboardingTotalSteps = 9\` (cosmetic badge drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding wizard now displays error notifications when saving progress fails.

* **Bug Fixes**
  * Improved git provider and deploy provider resolution during work creation, with proper fallback handling when features are unavailable.

* **Tests**
  * Enhanced test coverage for work lifecycle service to validate provider defaults and feature flag behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/714)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->