### PR TITLE
fix(k8s-plugin): use server-side apply (fixes K8s Plugin E2E HTTP 422)

### DIFF
--- a/packages/plugins/k8s/src/__tests__/k8s-api.service.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s-api.service.spec.ts
@@ -26,6 +26,7 @@ function makeFactory(overrides: Partial<KubernetesClientFactory> = {}): {
 		createNamespace: ReturnType<typeof vi.fn>;
 		readNamespace: ReturnType<typeof vi.fn>;
 	};
+	objectApi: { patch: ReturnType<typeof vi.fn> };
 	createKubeConfig: ReturnType<typeof vi.fn>;
 } {
 	const versionApi = { getCode: vi.fn(async () => ({ gitVersion: 'v1.30.4', platform: 'linux/amd64' })) };
@@ -78,6 +79,7 @@ function makeFactory(overrides: Partial<KubernetesClientFactory> = {}): {
 		createNamespace: vi.fn(async () => undefined),
 		readNamespace: vi.fn(async () => undefined)
 	};
+	const objectApi = { patch: vi.fn(async () => undefined) };
 	const createKubeConfig = vi.fn(() => ({
 		loadFromString: vi.fn(),
 		setCurrentContext: vi.fn(),
@@ -90,10 +92,11 @@ function makeFactory(overrides: Partial<KubernetesClientFactory> = {}): {
 		networkingV1Api: () => networkingApi as never,
 		appsV1Api: () => appsApi as never,
 		coreV1Api: () => coreApi as never,
+		objectApi: () => objectApi as never,
 		...overrides
 	};
 
-	return { factory, versionApi, networkingApi, appsApi, coreApi, createKubeConfig };
+	return { factory, versionApi, networkingApi, appsApi, coreApi, objectApi, createKubeConfig };
 }
 
 describe('KubernetesApiService.validateConnection', () => {
@@ -232,27 +235,30 @@ describe('KubernetesApiService.listManagedDeployments', () => {
 });
 
 describe('KubernetesApiService SSA apply helpers', () => {
-	it('applyDeployment uses the field manager and force=true', async () => {
-		const { factory, appsApi } = makeFactory();
+	const SERVER_SIDE_APPLY = 'application/apply-patch+yaml';
+
+	it('applyDeployment uses Server-Side Apply with field manager and force=true', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
-		await svc.applyDeployment(VALID, {
+		const manifest = {
 			apiVersion: 'apps/v1',
 			kind: 'Deployment',
 			metadata: { name: 'site-a', namespace: 'ever-works' },
 			spec: {}
-		});
-		expect(appsApi.patchNamespacedDeployment).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: 'site-a',
-				namespace: 'ever-works',
-				fieldManager: FIELD_MANAGER,
-				force: true
-			})
+		};
+		await svc.applyDeployment(VALID, manifest);
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
 		);
 	});
 
-	it('applyService passes manifest body through to CoreV1', async () => {
-		const { factory, coreApi } = makeFactory();
+	it('applyService routes Server-Side Apply through the object API', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
 		const manifest = {
 			apiVersion: 'v1',
@@ -260,13 +266,18 @@ describe('KubernetesApiService SSA apply helpers', () => {
 			metadata: { name: 'site-a', namespace: 'ns' }
 		};
 		await svc.applyService(VALID, manifest);
-		expect(coreApi.patchNamespacedService).toHaveBeenCalledWith(
-			expect.objectContaining({ body: manifest, fieldManager: FIELD_MANAGER })
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
 		);
 	});
 
-	it('applyIngress passes manifest body through to NetworkingV1', async () => {
-		const { factory, networkingApi } = makeFactory();
+	it('applyIngress routes Server-Side Apply through the object API', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
 		const manifest = {
 			apiVersion: 'networking.k8s.io/v1',
@@ -274,13 +285,18 @@ describe('KubernetesApiService SSA apply helpers', () => {
 			metadata: { name: 'site-a', namespace: 'ns' }
 		};
 		await svc.applyIngress(VALID, manifest);
-		expect(networkingApi.patchNamespacedIngress).toHaveBeenCalledWith(
-			expect.objectContaining({ body: manifest, fieldManager: FIELD_MANAGER })
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
 		);
 	});
 
-	it('applyImagePullSecret patches the namespaced Secret', async () => {
-		const { factory, coreApi } = makeFactory();
+	it('applyImagePullSecret routes Server-Side Apply through the object API', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
 		const manifest = {
 			apiVersion: 'v1',
@@ -288,7 +304,14 @@ describe('KubernetesApiService SSA apply helpers', () => {
 			metadata: { name: 'pull', namespace: 'ns' }
 		};
 		await svc.applyImagePullSecret(VALID, manifest);
-		expect(coreApi.patchNamespacedSecret).toHaveBeenCalled();
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
+		);
 	});
 });
 

--- a/packages/plugins/k8s/src/k8s-api.service.ts
+++ b/packages/plugins/k8s/src/k8s-api.service.ts
@@ -97,6 +97,24 @@ interface CoreV1ApiLike {
 }
 
 /**
+ * Subset of @kubernetes/client-node KubernetesObjectApi we depend on. Used
+ * for Server-Side Apply so we can specify Content-Type
+ * `application/apply-patch+yaml` and pass `force=true` — the typed
+ * patchNamespaced* methods on AppsV1Api/CoreV1Api/NetworkingV1Api default to
+ * Strategic Merge Patch, which rejects `force` with a 422.
+ */
+interface KubernetesObjectApiLike {
+	patch(
+		spec: Record<string, unknown>,
+		pretty?: string,
+		dryRun?: string,
+		fieldManager?: string,
+		force?: boolean,
+		patchStrategy?: string
+	): Promise<unknown>;
+}
+
+/**
  * Hook so tests can inject mock clients without dynamic-importing the real
  * `@kubernetes/client-node` package.
  */
@@ -106,7 +124,11 @@ export interface KubernetesClientFactory {
 	networkingV1Api(client: KubernetesApiClientLike): NetworkingV1ApiLike;
 	appsV1Api(client: KubernetesApiClientLike): AppsV1ApiLike;
 	coreV1Api(client: KubernetesApiClientLike): CoreV1ApiLike;
+	objectApi(client: KubernetesApiClientLike): KubernetesObjectApiLike;
 }
+
+/** Content-Type for Kubernetes Server-Side Apply patches. */
+const SERVER_SIDE_APPLY: string = 'application/apply-patch+yaml';
 
 /**
  * Default factory using the real `@kubernetes/client-node`.
@@ -156,6 +178,13 @@ export const defaultClientFactory: KubernetesClientFactory = {
 	coreV1Api(client) {
 		const k8s = k8sClientLoader();
 		return client.makeApiClient(k8s.CoreV1Api as never);
+	},
+	objectApi(client) {
+		const k8s = k8sClientLoader();
+		// KubernetesObjectApi.makeApiClient consumes the KubeConfig directly
+		// rather than going through makeApiClient(...), so it can pick up the
+		// default namespace from the current context.
+		return k8s.KubernetesObjectApi.makeApiClient(client as never) as unknown as KubernetesObjectApiLike;
 	}
 };
 
@@ -283,15 +312,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const apps = this.factory.appsV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await apps.patchNamespacedDeployment({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	async applyService(
@@ -300,15 +322,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const core = this.factory.coreV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await core.patchNamespacedService({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	/**
@@ -358,15 +373,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const net = this.factory.networkingV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await net.patchNamespacedIngress({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	async applyImagePullSecret(
@@ -375,15 +383,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const core = this.factory.coreV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await core.patchNamespacedSecret({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	async readIngress(


### PR DESCRIPTION
## Summary
Fixes the K8s Plugin E2E suite that has been failing on all 4 matrix entries (kind v1.28/v1.30 × ingress=true/false) since at least 2026-05-12 15:09 — most visibly on the recent #718 stage→main release.

**Root cause:**
\`applyDeployment\`, \`applyService\`, \`applyIngress\`, and \`applyImagePullSecret\` were calling the typed \`patchNamespaced*\` methods on \`AppsV1Api\` / \`CoreV1Api\` / \`NetworkingV1Api\` with \`force: true\`. Those typed methods default to Strategic Merge Patch (\`Content-Type: application/strategic-merge-patch+json\`). The Kubernetes API only accepts \`force\` on Server-Side Apply (\`application/apply-patch+yaml\`) and rejects everything else with:

\`\`\`
HTTP 422 — PatchOptions.meta.k8s.io "" is invalid:
  force: Forbidden: may not be specified for non-apply patch
\`\`\`

**Fix:**
Switch the four apply* helpers to \`KubernetesObjectApi.patch()\` with explicit \`patchStrategy: 'application/apply-patch+yaml'\` (\`PatchStrategy.ServerSideApply\`). This sets the correct Content-Type, so \`fieldManager\` + \`force: true\` are now valid per K8s API rules. The intent (server-side apply with FIELD_MANAGER, force conflicts) is unchanged — only the wire-level Content-Type was wrong.

The factory gains an \`objectApi(client)\` hook so unit tests can mock it the same way they mock the typed APIs. Unit-test assertions updated to the new shape.

## Test plan
- [x] Unit tests in \`packages/plugins/k8s/src/__tests__/k8s-api.service.spec.ts\` updated to assert \`objectApi.patch\` is called with the SSA Content-Type
- [ ] K8s Plugin E2E (kind v1.28/v1.30, ingress=true/false) passes on this branch
- [ ] No regression in the existing apply* call sites in \`k8s.plugin.ts\`

## References
- Failing run: https://github.com/ever-works/ever-works/actions/runs/25751916234
- K8s docs on Server-Side Apply: https://kubernetes.io/docs/reference/using-api/server-side-apply/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Kubernetes Server-Side Apply implementation to use a unified object patching approach for Deployments, Services, Ingresses, and image pull Secrets, replacing resource-specific patch methods with a consistent generic API endpoint.

* **Tests**
  * Enhanced test coverage to validate Server-Side Apply behavior through the new unified patching mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/719)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->