### PR TITLE
fix: Codex P2 follow-ups on #715 (header badge + duplicate-by-URL slug)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -103,9 +103,7 @@ export function DashboardLayoutClient({
     useEffect(() => {
         try {
             if (typeof window !== 'undefined') {
-                setHeaderDismissed(
-                    window.localStorage.getItem(headerDismissedKey) === '1',
-                );
+                setHeaderDismissed(window.localStorage.getItem(headerDismissedKey) === '1');
             }
         } catch {
             // localStorage unavailable (private mode, quota) — leave default.

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -88,8 +88,26 @@ export function DashboardLayoutClient({
     const shouldAutoOpenOnboarding =
         onboardingTotalWorks === 0 && !isOnboardingDismissed && !isOnboardingCompleted;
     const isOnboardingOpen = onboardingOpenManually || shouldAutoOpenOnboarding;
+    // Track header-badge dismissal separately from wizard dismissal — both share
+    // `dismissedAt` on the server, but dismissing the badge X must not require
+    // marking onboarding as completed, and dismissing the wizard must leave the
+    // badge visible. v1 kept the same split as `headerDismissed` in localStorage;
+    // keep the client-only convention to avoid an API/DB migration.
+    const headerDismissedKey = `ever-works-onboarding-header-dismissed:${user.id}`;
+    const [headerDismissed, setHeaderDismissed] = useState(false);
+    useEffect(() => {
+        try {
+            if (typeof window === 'undefined') return;
+            setHeaderDismissed(window.localStorage.getItem(headerDismissedKey) === '1');
+        } catch {
+            // localStorage unavailable (private mode, quota) — leave default.
+        }
+    }, [headerDismissedKey]);
     const showOnboardingBadge =
-        onboardingTotalWorks === 0 && isOnboardingDismissed && !isOnboardingCompleted;
+        onboardingTotalWorks === 0 &&
+        isOnboardingDismissed &&
+        !isOnboardingCompleted &&
+        !headerDismissed;
 
     const setChatOpen = useCallback((value: boolean, resetOnOpen = true) => {
         setChatOpenRaw(value);
@@ -225,12 +243,21 @@ export function DashboardLayoutClient({
         void dismissOnboarding();
     }, []);
     const dismissOnboardingBadge = useCallback(() => {
+        setHeaderDismissed(true);
+        try {
+            if (typeof window !== 'undefined') {
+                window.localStorage.setItem(headerDismissedKey, '1');
+            }
+        } catch {
+            // localStorage unavailable; state update alone hides the badge for
+            // this session, which is still better than the prior no-op.
+        }
         setOnboardingState((prev) => ({
             ...prev,
             dismissedAt: prev.dismissedAt ?? new Date().toISOString(),
         }));
         void dismissOnboarding();
-    }, []);
+    }, [headerDismissedKey]);
 
     // Ensure chat is in resizable (non-expanded) mode. Used when user interacts
     // with the sidebar so we collapse the expanded view back to the resizable width.

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -95,15 +95,25 @@ export function DashboardLayoutClient({
     // keep the client-only convention to avoid an API/DB migration.
     const headerDismissedKey = `ever-works-onboarding-header-dismissed:${user.id}`;
     const [headerDismissed, setHeaderDismissed] = useState(false);
+    // Gate the badge on hydration so users who previously dismissed don't see
+    // a one-frame flash of the badge before the useEffect reads localStorage.
+    // Trade-off: all users see ~one frame without the badge instead — that's a
+    // strictly better failure mode for an informational element.
+    const [headerHydrated, setHeaderHydrated] = useState(false);
     useEffect(() => {
         try {
-            if (typeof window === 'undefined') return;
-            setHeaderDismissed(window.localStorage.getItem(headerDismissedKey) === '1');
+            if (typeof window !== 'undefined') {
+                setHeaderDismissed(
+                    window.localStorage.getItem(headerDismissedKey) === '1',
+                );
+            }
         } catch {
             // localStorage unavailable (private mode, quota) — leave default.
         }
+        setHeaderHydrated(true);
     }, [headerDismissedKey]);
     const showOnboardingBadge =
+        headerHydrated &&
         onboardingTotalWorks === 0 &&
         isOnboardingDismissed &&
         !isOnboardingCompleted &&

--- a/packages/agent/src/items-generator/item-import-executor.service.spec.ts
+++ b/packages/agent/src/items-generator/item-import-executor.service.spec.ts
@@ -213,6 +213,41 @@ describe('ItemImportExecutorService', () => {
         expect(result.created).toBe(0);
     });
 
+    it("rewrites slug to existing item's when matched only by source_url ('update' strategy)", async () => {
+        const work = makeWork();
+        const git = makeGitFacade();
+        const repo = makeDataRepo({
+            getItems: jest
+                .fn()
+                .mockResolvedValue([
+                    { slug: 'existing-tool', source_url: 'https://shared.test/x' },
+                ]),
+        });
+        dataRepoCreateMock.mockResolvedValue(repo);
+        const service = new ItemImportExecutorService(git as any, itemImportService);
+
+        // Incoming row's slug ('incoming-tool') differs from the existing
+        // item's slug ('existing-tool'), but their source_url matches.
+        // writeItem must target 'existing-tool' — otherwise the update
+        // hits a non-existent directory because updates skip createItemDir.
+        await service.executeImport(work as any, { id: 'u-1' } as any, {
+            rows: [
+                row(0, {
+                    name: 'Incoming Tool',
+                    slug: 'incoming-tool',
+                    source_url: 'https://shared.test/x',
+                }),
+            ],
+            duplicate_strategy: 'update',
+        });
+
+        expect(repo.createItemDir).not.toHaveBeenCalled();
+        expect(repo.writeItem).toHaveBeenCalledTimes(1);
+        const writeArg = (repo.writeItem as jest.Mock).mock.calls[0][0];
+        expect(writeArg.slug).toBe('existing-tool');
+        expect(writeArg.source_url).toBe('https://shared.test/x');
+    });
+
     it('collects per-row errors without aborting the batch and still commits the successes', async () => {
         const work = makeWork();
         const git = makeGitFacade();

--- a/packages/agent/src/items-generator/item-import-executor.service.ts
+++ b/packages/agent/src/items-generator/item-import-executor.service.ts
@@ -83,9 +83,18 @@ export class ItemImportExecutorService {
         );
         const existingSlugs = new Set<string>();
         const existingUrls = new Set<string>();
+        // Map source_url → existing item's slug. When `duplicate_strategy=update`
+        // matches a row by URL only and the incoming row's slug differs from
+        // the existing item's directory, the update must target the existing
+        // slug — otherwise `writeItem` (which skips `createItemDir` on update)
+        // tries to write into a directory that doesn't exist.
+        const urlToExistingSlug = new Map<string, string>();
         for (const item of existingItems) {
             if (item.slug) existingSlugs.add(item.slug);
-            if (item.source_url) existingUrls.add(item.source_url);
+            if (item.source_url) {
+                existingUrls.add(item.source_url);
+                if (item.slug) urlToExistingSlug.set(item.source_url, item.slug);
+            }
         }
 
         const defaultBranch = await this.gitFacade.getMainBranch(provider, dest);
@@ -156,13 +165,22 @@ export class ItemImportExecutorService {
                     skippedCount += 1;
                     continue;
                 }
-                plan.push({ kind: 'update', rowIndex: row.rowIndex, itemData });
+                const matchedBySlug = slug.length > 0 && existingSlugs.has(slug);
+                const sourceUrl =
+                    typeof itemData.source_url === 'string' ? itemData.source_url : undefined;
+                // If the row matched only by source_url and the incoming slug
+                // differs from the existing item's directory, rewrite the slug
+                // so `writeItem` targets the correct existing directory.
+                const existingSlug = sourceUrl ? urlToExistingSlug.get(sourceUrl) : undefined;
+                const updateData: MutableItemData =
+                    !matchedBySlug && existingSlug && existingSlug !== slug
+                        ? { ...itemData, slug: existingSlug }
+                        : itemData;
+                plan.push({ kind: 'update', rowIndex: row.rowIndex, itemData: updateData });
                 // Even on update, mark the URL as taken so a subsequent row
                 // with the same source_url is also routed to update / skip
                 // instead of trying to create a fresh item directory.
-                if (typeof itemData.source_url === 'string') {
-                    existingUrls.add(itemData.source_url);
-                }
+                if (sourceUrl) existingUrls.add(sourceUrl);
                 continue;
             }
 


### PR DESCRIPTION
## Summary
Addresses both P2 findings Codex flagged on the merged develop→stage release PR #715. Two unrelated issues, bundled because each is small and both came from the same review.

### 1. Header badge dismissal regression (EW-608 wizard) — \`apps/web/src/app/[locale]/(dashboard)/layout-client.tsx\`

\`dismissOnboardingBadge\` only re-set \`dismissedAt\`, but:
\`\`\`ts
const showOnboardingBadge =
    onboardingTotalWorks === 0 && isOnboardingDismissed && !isOnboardingCompleted;
const isOnboardingDismissed = Boolean(onboardingState.dismissedAt);
\`\`\`
So clicking the X on the header badge:
- writes the same dismissed timestamp again
- \`isOnboardingDismissed\` stays \`true\` (because the user had dismissed the wizard before)
- \`showOnboardingBadge\` stays \`true\` → badge never hides → X is a no-op

This regresses the v1 behavior where \`headerDismissed\` was a separate localStorage flag. Restored the split client-side, keyed by \`user.id\`:
- new \`headerDismissed\` boolean state, hydrated from \`localStorage.getItem('ever-works-onboarding-header-dismissed:<userId>')\` in a \`useEffect\`
- \`dismissOnboardingBadge\` now also flips that flag + writes the key
- \`showOnboardingBadge\` includes \`&& !headerDismissed\`

No API/DB migration needed; matches the original v1 client-only model.

### 2. \`duplicate_strategy=update\` writes to wrong slug — \`packages/agent/src/items-generator/item-import-executor.service.ts\`

When an incoming row matched an existing item only by \`source_url\` (slug differed), the code pushed the entry as \`{ kind: 'update', itemData }\` using the **incoming** row's slug. Downstream:
\`\`\`ts
if (entry.kind === 'update') {
    await data.writeItem(entry.itemData);  // skips createItemDir
    ...
}
\`\`\`
\`writeItem\` writes to \`<dataDir>/<incoming-slug>/<incoming-slug>.yml\`, but that directory doesn't exist (created only by \`createItemDir\`, which the update path skips). So \`duplicate_strategy=update\` silently per-row-errors out instead of updating the existing item.

Fix:
- build \`urlToExistingSlug: Map<string, string>\` alongside \`existingUrls\` from the items snapshot
- when the duplicate match is URL-only and the existing item's slug differs, rewrite \`itemData.slug\` to the existing slug before queueing the update entry
- added a regression test in \`item-import-executor.service.spec.ts\` covering the exact scenario (existing \`existing-tool\` + incoming \`incoming-tool\` sharing \`source_url\`)

## Test plan
- [x] Existing \`item-import-executor.service.spec.ts\` suite still passes (\`overwrites duplicates when strategy is 'update'\` — same slug case unchanged)
- [x] New test asserts \`writeItem\` is called with the existing item's slug, not the incoming row's, when only URL matches
- [ ] Header badge X actually hides the badge in the dashboard (manual smoke test)

## References
- Codex review thread on #715
- EW-608 (onboarding wizard v2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding header badge dismissal now persists locally to remain hidden after closing and avoids pre-hydration flashes.

* **Bug Fixes**
  * Improved duplicate-detection in item imports: when an imported item's source URL matches an existing item, the existing item is updated (incoming source URL retained, slug aligned to the matched item).

* **Tests**
  * Added a test verifying update behavior when source URL matches an existing item.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/720)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->