### PR TITLE
release(stage→main): wire Ever Works Git env (#721)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -165,6 +165,19 @@ spec:
             - name: RESEND_EMAIL_FROM
               value: "$RESEND_EMAIL_FROM"
 
+            # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+            # Gates EverWorksGitProvider which pushes per-Work repos to the
+            # platform-owned GitHub org. PAT is org-scoped to ever-works-cloud
+            # only. See docs/specs/features/onboarding-wizard-v2/deployment.md §1.
+            - name: STORAGE_EVER_WORKS_GIT_ENABLED
+              value: "$STORAGE_EVER_WORKS_GIT_ENABLED"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_ORG
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_ORG"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_PAT
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
           resources:
             requests:
               memory: "512Mi"

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -170,6 +170,19 @@ spec:
             - name: RESEND_EMAIL_FROM
               value: "$RESEND_EMAIL_FROM"
 
+            # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+            # Gates EverWorksGitProvider which pushes per-Work repos to the
+            # platform-owned GitHub org. PAT is org-scoped to ever-works-cloud
+            # only. See docs/specs/features/onboarding-wizard-v2/deployment.md §1.
+            - name: STORAGE_EVER_WORKS_GIT_ENABLED
+              value: "$STORAGE_EVER_WORKS_GIT_ENABLED"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_ORG
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_ORG"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_PAT
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
           resources:
             requests:
               memory: "512Mi"

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -165,6 +165,19 @@ spec:
             - name: RESEND_EMAIL_FROM
               value: "$RESEND_EMAIL_FROM"
 
+            # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+            # Gates EverWorksGitProvider which pushes per-Work repos to the
+            # platform-owned GitHub org. PAT is org-scoped to ever-works-cloud
+            # only. See docs/specs/features/onboarding-wizard-v2/deployment.md §1.
+            - name: STORAGE_EVER_WORKS_GIT_ENABLED
+              value: "$STORAGE_EVER_WORKS_GIT_ENABLED"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_ORG
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_ORG"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_PAT
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
+            - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
+              value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
           resources:
             requests:
               memory: "512Mi"

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -119,6 +119,15 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+          # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
+          # config (flag, org, visibility) is inlined here; only the PAT
+          # comes from secrets. See deployment.md §1.
+          STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
+          EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
+          EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
+          EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -119,6 +119,15 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+          # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
+          # config (flag, org, visibility) is inlined here; only the PAT
+          # comes from secrets. See deployment.md §1.
+          STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
+          EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
+          EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
+          EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -119,6 +119,15 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+          # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
+          # config (flag, org, visibility) is inlined here; only the PAT
+          # comes from secrets. See deployment.md §1.
+          STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
+          EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
+          EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
+          EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/docs/specs/features/onboarding-wizard-v2/deployment.md
+++ b/docs/specs/features/onboarding-wizard-v2/deployment.md
@@ -70,43 +70,70 @@ accidentally touch the `ever-works` source org.
 
 ### 1.4 Store the PAT
 
-Three deployment surfaces need the value:
+**The deploy pipeline does NOT use a k8s `Secret` resource.** The
+`ever-works-api` deployment on `do-sfo2-k8s-gauzy` has its env values
+inlined directly into the Deployment spec, which is rendered at
+release time by `envsubst < .deploy/k8s/k8s-manifest.<env>.yaml` inside
+the `Deploy to DO <env>` GitHub Actions workflow. The substitution
+source is **GitHub Actions repo secrets** plus inlined non-secret
+values in the workflow `env:` block.
 
-| Surface                                                                  | Where                                                                    | Key                               |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------ | --------------------------------- |
-| DigitalOcean k8s `default` namespace, `do-sfo2-k8s-gauzy`                | Secret `ever-works-secrets` (used by the `ever-works-api-*` deployments) | `EVER_WORKS_CUSTOMERS_GITHUB_PAT` |
-| GitHub Actions repo secrets (for CI deploys that template the manifests) | `https://github.com/ever-works/ever-works/settings/secrets/actions`      | `EVER_WORKS_CUSTOMERS_GITHUB_PAT` |
-| Local `.env` for ad-hoc dev                                              | `C:/Coding/Workspace/.config/ever-works.env` (gitignored)                | same                              |
+Two surfaces need the PAT value:
 
-```powershell
-# DO k8s secret update (Windows shell)
-$env:KUBECONFIG = "C:\Coding\Workspace\.config\k8s-gauzy-kubeconfig.yaml"
-kubectl --context do-sfo2-k8s-gauzy -n default `
-  patch secret ever-works-secrets `
-  -p "{\"stringData\":{\"EVER_WORKS_CUSTOMERS_GITHUB_PAT\":\"github_pat_xxx\"}}"
-```
+| Surface                         | Where                                                                                                                                                 | Key                               |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| **GitHub Actions repo secrets** | `https://github.com/ever-works/ever-works/settings/secrets/actions` (consumed by all three `deploy-do-{dev,stage,prod}.yml` workflows via `envsubst`) | `EVER_WORKS_CUSTOMERS_GITHUB_PAT` |
+| **Local `.env` for ad-hoc dev** | `C:/Coding/Workspace/.config/ever-works.env` (gitignored, loaded manually before `pnpm dev:api`)                                                      | same                              |
 
 ```bash
-# GitHub Actions repo secret
+# GitHub Actions repo secret (only step that ships the PAT to prod/stage/dev pods)
 gh secret set EVER_WORKS_CUSTOMERS_GITHUB_PAT \
   -R ever-works/ever-works \
   -b 'github_pat_xxx'
 ```
 
-### 1.5 Flip the flags
+The non-secret companions (`STORAGE_EVER_WORKS_GIT_ENABLED`,
+`EVER_WORKS_CUSTOMERS_GITHUB_ORG`, `EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY`)
+are checked in as plain values in each `deploy-do-<env>.yml` workflow's
+`env:` block — they're config, not secrets, so no need to roundtrip
+them through `secrets.*`.
 
-Also set in the same secret / GH Actions secrets / `.env`:
+### 1.5 Roll out the change
 
-```env
-STORAGE_EVER_WORKS_GIT_ENABLED=true
-EVER_WORKS_CUSTOMERS_GITHUB_ORG=ever-works-cloud
-EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY=private
+The wiring lives in the repo. Each `deploy-do-<env>.yml` workflow already
+contains:
+
+```yaml
+env:
+    STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
+    EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
+    EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
+    EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 ```
 
-Then `kubectl rollout restart deploy/ever-works-api -n default` (and
-`-stage` / `-dev` per env). The catalog endpoint flips the **Ever Works
-Git** card from Planned to live within seconds — the wizard refreshes on
-next dashboard load.
+and each `.deploy/k8s/k8s-manifest.<env>.yaml` references those via
+`$VAR` placeholders that `envsubst` fills.
+
+To roll out: merge to the target branch. The post-build `Deploy to DO <env>`
+workflow runs, `envsubst`s the new env values into the Deployment spec,
+applies the manifest, and the trailing `kubectl rollout restart deployment/ever-works-api`
+picks up the new env. The catalog endpoint flips the **Ever Works Git**
+card from Planned → live within seconds — the wizard refreshes on next
+dashboard load.
+
+To verify after the deploy workflow finishes:
+
+```bash
+KUBECONFIG=C:/Coding/Workspace/.config/k8s-gauzy-kubeconfig.yaml \
+  kubectl --context do-sfo2-k8s-gauzy -n default \
+  get deploy ever-works-api \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STORAGE_EVER_WORKS_GIT_ENABLED")].value}'
+# should print: true
+```
+
+To roll back without a code revert: clear the GH Actions secret or set
+the workflow's `STORAGE_EVER_WORKS_GIT_ENABLED` to `'false'` and rerun
+the deploy workflow.
 
 ---
 


### PR DESCRIPTION
## Summary
Cascade of #721 from stage to main. Activates Ever Works Git storage on production.

## Commits since previous main merge
- dcb9d596 — feat(deploy): wire EVER_WORKS_CUSTOMERS_GITHUB_* through k8s deploys (EW-608) (#721)

## Test plan
- [ ] Prod deploy succeeds (\`Deploy to DO Prod\` workflow auto-fires after docker build)
- [ ] Prod \`GET https://api.ever.works/api/onboarding/catalog\` returns the \`ever-works-git\` card with \`available: true\`
- [ ] Verify env on cluster: \`kubectl get deploy ever-works-api -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STORAGE_EVER_WORKS_GIT_ENABLED")].value}'\` returns \`true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)