### PR TITLE
feat(user-research): provider fallback chain across AI + search

### DIFF
--- a/.env.compose
+++ b/.env.compose
@@ -262,3 +262,7 @@ USER_RESEARCH_ENABLED=true
 USER_RESEARCH_SCHEDULED_RERUN_ENABLED=false
 USER_RESEARCH_SCHEDULED_RERUN_BATCH=20
 USER_RESEARCH_SCHEDULED_RERUN_STALE_DAYS=30
+
+# Max providers tried per call (per capability) before giving up. Caps fallback
+# so a flapping vendor can't burn through every configured key. Default 2.
+USER_RESEARCH_PROVIDER_FALLBACK_MAX=2

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -246,3 +246,7 @@ USER_RESEARCH_ENABLED=true
 USER_RESEARCH_SCHEDULED_RERUN_ENABLED=false
 USER_RESEARCH_SCHEDULED_RERUN_BATCH=20
 USER_RESEARCH_SCHEDULED_RERUN_STALE_DAYS=30
+
+# Max providers tried per call (per capability) before giving up. Caps fallback
+# so a flapping vendor can't burn through every configured key. Default 2.
+USER_RESEARCH_PROVIDER_FALLBACK_MAX=2

--- a/apps/api/src/work-proposals/dto/work-proposal.dto.spec.ts
+++ b/apps/api/src/work-proposals/dto/work-proposal.dto.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+
+// The DTO re-imports enums from @ever-works/agent/user-research, whose
+// transitive imports drag in the agent's entities (which reach back through
+// @src/* paths and break Jest resolution). Stub the surface area we use.
+jest.mock(
+    '@ever-works/agent/user-research',
+    () => ({
+        WorkProposalStatus: {
+            PENDING: 'pending',
+            DISMISSED: 'dismissed',
+            ACCEPTED: 'accepted',
+        },
+        WorkProposalSource: {
+            AUTO_SIGNUP: 'auto-signup',
+            USER_REFRESH: 'user-refresh',
+            DISCOVER: 'discover',
+            SCHEDULED: 'scheduled',
+        },
+    }),
+    { virtual: true },
+);
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ListWorkProposalsQueryDto } from './work-proposal.dto';
+
+describe('ListWorkProposalsQueryDto', () => {
+    async function transformAndValidate(input: Record<string, unknown>) {
+        const instance = plainToInstance(ListWorkProposalsQueryDto, input);
+        const errors = await validate(instance);
+        return { instance, errors };
+    }
+
+    it('accepts a single statuses value (string from Express)', async () => {
+        const { instance, errors } = await transformAndValidate({ statuses: 'pending' });
+        expect(errors).toHaveLength(0);
+        expect(instance.statuses).toEqual(['pending']);
+    });
+
+    it('accepts a repeated statuses query (array from Express)', async () => {
+        const { instance, errors } = await transformAndValidate({
+            statuses: ['pending', 'accepted'],
+        });
+        expect(errors).toHaveLength(0);
+        expect(instance.statuses).toEqual(['pending', 'accepted']);
+    });
+
+    it('omits statuses entirely (defaults applied in controller)', async () => {
+        const { instance, errors } = await transformAndValidate({});
+        expect(errors).toHaveLength(0);
+        expect(instance.statuses).toBeUndefined();
+    });
+
+    it('rejects an unknown status value', async () => {
+        const { errors } = await transformAndValidate({ statuses: 'bogus' });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].constraints).toMatchObject({ isEnum: expect.any(String) });
+    });
+});

--- a/apps/api/src/work-proposals/dto/work-proposal.dto.ts
+++ b/apps/api/src/work-proposals/dto/work-proposal.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsArray, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
 import { WorkProposalSource, WorkProposalStatus } from '@ever-works/agent/user-research';
 
@@ -10,6 +11,11 @@ export class ListWorkProposalsQueryDto {
         description: 'Filter by status (default: pending only)',
     })
     @IsOptional()
+    // Express parses `?statuses=pending` as a string and `?statuses=a&statuses=b`
+    // as an array. Normalize to array so @IsArray accepts both shapes.
+    @Transform(({ value }) =>
+        value === undefined || value === null ? value : Array.isArray(value) ? value : [value],
+    )
     @IsArray()
     @IsEnum(WorkProposalStatus, { each: true })
     statuses?: WorkProposalStatus[];

--- a/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
+++ b/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
@@ -1,0 +1,165 @@
+import {
+    capChain,
+    isTransientProviderError,
+    resolveProviderChain,
+    tryInOrder,
+} from '../provider-resolver';
+import type {
+    PluginRegistryService,
+    RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+
+type FakePlugin = {
+    id: string;
+    defaultForCapabilities?: string[];
+};
+
+function makeRegistered(p: FakePlugin): RegisteredPlugin {
+    return {
+        plugin: { id: p.id } as RegisteredPlugin['plugin'],
+        manifest: {
+            defaultForCapabilities: p.defaultForCapabilities,
+        } as unknown as RegisteredPlugin['manifest'],
+        state: 'loaded',
+    } as RegisteredPlugin;
+}
+
+function makeRegistry(plugins: FakePlugin[]): PluginRegistryService {
+    return {
+        getEnabledPluginsScoped: jest.fn().mockResolvedValue(plugins.map(makeRegistered)),
+    } as unknown as PluginRegistryService;
+}
+
+describe('resolveProviderChain', () => {
+    it('puts defaultForCapabilities plugins first', async () => {
+        const registry = makeRegistry([
+            { id: 'extra' },
+            { id: 'preferred', defaultForCapabilities: ['ai-provider'] },
+            { id: 'other' },
+        ]);
+
+        const chain = await resolveProviderChain(registry, 'ai-provider', 'user-1');
+
+        expect(chain.map((p) => p.plugin.id)).toEqual(['preferred', 'extra', 'other']);
+    });
+
+    it('returns empty list when no plugins are enabled', async () => {
+        const registry = makeRegistry([]);
+        await expect(resolveProviderChain(registry, 'ai-provider', 'u')).resolves.toEqual([]);
+    });
+
+    it('queries enabled plugins scoped to the user only (no workId)', async () => {
+        const registry = makeRegistry([{ id: 'p1' }]);
+        await resolveProviderChain(registry, 'search', 'u-7');
+        expect(registry.getEnabledPluginsScoped).toHaveBeenCalledWith('search', undefined, 'u-7');
+    });
+});
+
+describe('capChain', () => {
+    it('caps to max', () => {
+        expect(capChain([1, 2, 3, 4], 2)).toEqual([1, 2]);
+    });
+
+    it('returns at least 1 when max is positive but smaller than 1 is impossible', () => {
+        expect(capChain([1, 2, 3], 1)).toEqual([1]);
+    });
+
+    it('returns full chain when max <= 0', () => {
+        expect(capChain([1, 2, 3], 0)).toEqual([1, 2, 3]);
+        expect(capChain([1, 2, 3], -1)).toEqual([1, 2, 3]);
+    });
+});
+
+describe('tryInOrder', () => {
+    const plugins = [
+        makeRegistered({ id: 'a' }),
+        makeRegistered({ id: 'b' }),
+        makeRegistered({ id: 'c' }),
+    ];
+
+    it('returns the first success without trying later providers', async () => {
+        const attempt = jest.fn().mockResolvedValueOnce('ok');
+        const result = await tryInOrder(plugins, attempt, () => true);
+        expect(result).toBe('ok');
+        expect(attempt).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through transient errors to the next provider', async () => {
+        const attempt = jest
+            .fn<Promise<string>, [RegisteredPlugin]>()
+            .mockRejectedValueOnce(new Error('rate limit'))
+            .mockRejectedValueOnce(new Error('429 quota'))
+            .mockResolvedValueOnce('third-time');
+
+        const result = await tryInOrder(plugins, attempt, () => true);
+        expect(result).toBe('third-time');
+        expect(attempt).toHaveBeenCalledTimes(3);
+    });
+
+    it('rethrows the first non-retryable error immediately', async () => {
+        const attempt = jest
+            .fn<Promise<string>, [RegisteredPlugin]>()
+            .mockRejectedValueOnce(new Error('401 unauthorized'));
+
+        await expect(tryInOrder(plugins, attempt, () => false)).rejects.toThrow('401 unauthorized');
+        expect(attempt).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws if the chain is empty', async () => {
+        await expect(
+            tryInOrder(
+                [],
+                async () => 'x',
+                () => true,
+            ),
+        ).rejects.toThrow('No providers available');
+    });
+
+    it('rethrows the last transient error if every provider fails', async () => {
+        const attempt = jest
+            .fn<Promise<string>, [RegisteredPlugin]>()
+            .mockRejectedValue(new Error('rate limit'));
+
+        await expect(tryInOrder(plugins, attempt, () => true)).rejects.toThrow('rate limit');
+        expect(attempt).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe('isTransientProviderError', () => {
+    it('classifies rate-limit / 5xx / network shapes as transient', () => {
+        for (const msg of [
+            'rate limit exceeded',
+            'HTTP 429 Too Many Requests',
+            'quota exhausted',
+            'request timeout',
+            'ETIMEDOUT',
+            'ECONNRESET',
+            'socket hang up',
+            'overloaded',
+            'service unavailable',
+            'bad gateway',
+            'gateway timeout',
+            '502 Bad Gateway',
+            '503 Service Unavailable',
+            '504 Gateway Timeout',
+        ]) {
+            expect(isTransientProviderError(new Error(msg))).toBe(true);
+        }
+    });
+
+    it('classifies auth / config errors as NON-transient', () => {
+        for (const msg of [
+            '401 Unauthorized',
+            '403 Forbidden',
+            'invalid api key',
+            'invalid_api_key',
+        ]) {
+            expect(isTransientProviderError(new Error(msg))).toBe(false);
+        }
+    });
+
+    it('returns false for non-Error rejections', () => {
+        expect(isTransientProviderError('string error')).toBe(false);
+        expect(isTransientProviderError(undefined)).toBe(false);
+    });
+});

--- a/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
+++ b/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
@@ -1,13 +1,16 @@
 import {
     capChain,
+    isAuthOrConfigError,
     isTransientProviderError,
+    resolveAiProviderForResearch,
     resolveProviderChain,
-    tryInOrder,
+    resolveSearchProviderIds,
 } from '../provider-resolver';
 import type {
     PluginRegistryService,
     RegisteredPlugin,
 } from '../../plugins/services/plugin-registry.service';
+import type { AiFacadeService } from '../../facades/ai.facade';
 
 type FakePlugin = {
     id: string;
@@ -70,58 +73,46 @@ describe('capChain', () => {
     });
 });
 
-describe('tryInOrder', () => {
-    const plugins = [
-        makeRegistered({ id: 'a' }),
-        makeRegistered({ id: 'b' }),
-        makeRegistered({ id: 'c' }),
-    ];
+describe('resolveSearchProviderIds', () => {
+    it('returns capped, defaultForCapabilities-first plugin IDs', async () => {
+        const registry = makeRegistry([
+            { id: 'brave' },
+            { id: 'tavily', defaultForCapabilities: ['search'] },
+            { id: 'exa' },
+        ]);
 
-    it('returns the first success without trying later providers', async () => {
-        const attempt = jest.fn().mockResolvedValueOnce('ok');
-        const result = await tryInOrder(plugins, attempt, () => true);
-        expect(result).toBe('ok');
-        expect(attempt).toHaveBeenCalledTimes(1);
+        const prev = process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+        process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX = '2';
+        try {
+            await expect(resolveSearchProviderIds(registry, 'u-1')).resolves.toEqual([
+                'tavily',
+                'brave',
+            ]);
+        } finally {
+            if (prev === undefined) delete process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+            else process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX = prev;
+        }
+    });
+});
+
+describe('isAuthOrConfigError', () => {
+    it('matches 401/403/invalid api key shapes', () => {
+        for (const msg of [
+            '401 Unauthorized',
+            '403 Forbidden',
+            'request is forbidden',
+            'unauthorized request',
+            'invalid api key',
+            'invalid_api_key',
+        ]) {
+            expect(isAuthOrConfigError(new Error(msg))).toBe(true);
+        }
     });
 
-    it('falls through transient errors to the next provider', async () => {
-        const attempt = jest
-            .fn<Promise<string>, [RegisteredPlugin]>()
-            .mockRejectedValueOnce(new Error('rate limit'))
-            .mockRejectedValueOnce(new Error('429 quota'))
-            .mockResolvedValueOnce('third-time');
-
-        const result = await tryInOrder(plugins, attempt, () => true);
-        expect(result).toBe('third-time');
-        expect(attempt).toHaveBeenCalledTimes(3);
-    });
-
-    it('rethrows the first non-retryable error immediately', async () => {
-        const attempt = jest
-            .fn<Promise<string>, [RegisteredPlugin]>()
-            .mockRejectedValueOnce(new Error('401 unauthorized'));
-
-        await expect(tryInOrder(plugins, attempt, () => false)).rejects.toThrow('401 unauthorized');
-        expect(attempt).toHaveBeenCalledTimes(1);
-    });
-
-    it('throws if the chain is empty', async () => {
-        await expect(
-            tryInOrder(
-                [],
-                async () => 'x',
-                () => true,
-            ),
-        ).rejects.toThrow('No providers available');
-    });
-
-    it('rethrows the last transient error if every provider fails', async () => {
-        const attempt = jest
-            .fn<Promise<string>, [RegisteredPlugin]>()
-            .mockRejectedValue(new Error('rate limit'));
-
-        await expect(tryInOrder(plugins, attempt, () => true)).rejects.toThrow('rate limit');
-        expect(attempt).toHaveBeenCalledTimes(3);
+    it('returns false for transient and unknown shapes', () => {
+        expect(isAuthOrConfigError(new Error('rate limit'))).toBe(false);
+        expect(isAuthOrConfigError(new Error('500 Internal Server Error'))).toBe(false);
+        expect(isAuthOrConfigError(undefined)).toBe(false);
     });
 });
 
@@ -137,8 +128,10 @@ describe('isTransientProviderError', () => {
             'socket hang up',
             'overloaded',
             'service unavailable',
+            'internal server error',
             'bad gateway',
             'gateway timeout',
+            '500 Internal Server Error',
             '502 Bad Gateway',
             '503 Service Unavailable',
             '504 Gateway Timeout',
@@ -161,5 +154,84 @@ describe('isTransientProviderError', () => {
     it('returns false for non-Error rejections', () => {
         expect(isTransientProviderError('string error')).toBe(false);
         expect(isTransientProviderError(undefined)).toBe(false);
+    });
+});
+
+describe('resolveAiProviderForResearch', () => {
+    const registry = makeRegistry([{ id: 'openai' }, { id: 'anthropic' }]);
+
+    function makeAiFacade(getProviderConfig: jest.Mock): AiFacadeService {
+        return { getProviderConfig } as unknown as AiFacadeService;
+    }
+
+    it('returns the first usable provider config', async () => {
+        const getProviderConfig = jest.fn().mockResolvedValueOnce({
+            providerId: 'openai',
+            providerName: 'OpenAI',
+            baseUrl: 'https://api.openai.com/v1',
+            apiKey: 'sk-test',
+            defaultModel: 'gpt-4o',
+            routing: {},
+        });
+
+        const result = await resolveAiProviderForResearch(
+            makeAiFacade(getProviderConfig),
+            registry,
+            'u',
+        );
+
+        expect(result).toMatchObject({
+            providerId: 'openai',
+            providerName: 'OpenAI',
+            modelName: 'gpt-4o',
+        });
+        expect(getProviderConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips providers with no apiKey/baseUrl and tries the next one', async () => {
+        const getProviderConfig = jest
+            .fn()
+            .mockResolvedValueOnce({
+                providerId: 'openai',
+                baseUrl: '',
+                apiKey: '',
+                defaultModel: 'gpt-4o',
+                routing: {},
+            })
+            .mockResolvedValueOnce({
+                providerId: 'anthropic',
+                providerName: 'Anthropic',
+                baseUrl: 'https://api.anthropic.com',
+                apiKey: 'sk-ant',
+                defaultModel: 'claude-haiku',
+                routing: {},
+            });
+
+        const result = await resolveAiProviderForResearch(
+            makeAiFacade(getProviderConfig),
+            registry,
+            'u',
+        );
+
+        expect(result?.providerId).toBe('anthropic');
+        expect(getProviderConfig).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-throws auth errors instead of silently masking with the next provider', async () => {
+        const getProviderConfig = jest.fn().mockRejectedValue(new Error('401 Unauthorized'));
+
+        await expect(
+            resolveAiProviderForResearch(makeAiFacade(getProviderConfig), registry, 'u'),
+        ).rejects.toThrow('401 Unauthorized');
+        expect(getProviderConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when no provider has a usable config', async () => {
+        const registry = makeRegistry([]);
+        const getProviderConfig = jest.fn();
+        await expect(
+            resolveAiProviderForResearch(makeAiFacade(getProviderConfig), registry, 'u'),
+        ).resolves.toBeNull();
+        expect(getProviderConfig).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/user-research/provider-resolver.ts
+++ b/packages/agent/src/user-research/provider-resolver.ts
@@ -1,8 +1,21 @@
-import type { Logger } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { LanguageModel } from 'ai';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import type {
     PluginRegistryService,
     RegisteredPlugin,
 } from '../plugins/services/plugin-registry.service';
+import type { AiFacadeService } from '../facades/ai.facade';
+
+const DEFAULT_PROVIDER_FALLBACK_MAX = 2;
+
+function getProviderFallbackMax(): number {
+    const raw = process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+    if (!raw) return DEFAULT_PROVIDER_FALLBACK_MAX;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_PROVIDER_FALLBACK_MAX;
+}
 
 /**
  * Returns the user's enabled plugins for a capability, ordered with
@@ -27,28 +40,38 @@ export function capChain<T>(chain: T[], max: number): T[] {
     return chain.slice(0, Math.max(1, max));
 }
 
-export async function tryInOrder<T>(
-    chain: RegisteredPlugin[],
-    attempt: (plugin: RegisteredPlugin) => Promise<T>,
-    isRetryable: (err: unknown) => boolean,
-    logger?: Logger,
-): Promise<T> {
-    if (chain.length === 0) {
-        throw new Error('No providers available');
-    }
-    let lastErr: unknown;
-    for (const p of chain) {
-        try {
-            return await attempt(p);
-        } catch (err) {
-            if (!isRetryable(err)) throw err;
-            logger?.warn(
-                `provider ${p.plugin.id} failed (retryable): ${(err as Error)?.message ?? err}`,
-            );
-            lastErr = err;
-        }
-    }
-    throw lastErr ?? new Error('all providers failed');
+/**
+ * Returns ordered plugin IDs of the user's enabled search providers, capped
+ * by USER_RESEARCH_PROVIDER_FALLBACK_MAX. Convenience over
+ * resolveProviderChain + capChain + .map(p.plugin.id) at the call site.
+ */
+export async function resolveSearchProviderIds(
+    registry: PluginRegistryService,
+    userId: string,
+): Promise<string[]> {
+    const chain = capChain(
+        await resolveProviderChain(registry, PLUGIN_CAPABILITIES.SEARCH, userId),
+        getProviderFallbackMax(),
+    );
+    return chain.map((p) => p.plugin.id);
+}
+
+/**
+ * Auth / invalid-key shapes. Treated separately from transient errors so a
+ * bad key surfaces loudly instead of being masked by silently trying the
+ * next provider.
+ */
+export function isAuthOrConfigError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const msg = err.message.toLowerCase();
+    return (
+        msg.includes('401') ||
+        msg.includes('403') ||
+        msg.includes('unauthorized') ||
+        msg.includes('forbidden') ||
+        msg.includes('invalid api key') ||
+        msg.includes('invalid_api_key')
+    );
 }
 
 /**
@@ -59,17 +82,8 @@ export async function tryInOrder<T>(
  */
 export function isTransientProviderError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
+    if (isAuthOrConfigError(err)) return false;
     const msg = err.message.toLowerCase();
-    if (
-        msg.includes('401') ||
-        msg.includes('403') ||
-        msg.includes('unauthorized') ||
-        msg.includes('forbidden') ||
-        msg.includes('invalid api key') ||
-        msg.includes('invalid_api_key')
-    ) {
-        return false;
-    }
     return (
         msg.includes('rate limit') ||
         msg.includes('rate_limit') ||
@@ -83,10 +97,68 @@ export function isTransientProviderError(err: unknown): boolean {
         msg.includes('socket hang up') ||
         msg.includes('overloaded') ||
         msg.includes('service unavailable') ||
+        msg.includes('internal server error') ||
         msg.includes('bad gateway') ||
         msg.includes('gateway timeout') ||
+        msg.includes('500') ||
         msg.includes('502') ||
         msg.includes('503') ||
         msg.includes('504')
     );
+}
+
+export interface ResolvedAiProvider {
+    model: LanguageModel;
+    providerId: string;
+    providerName: string;
+    modelName: string;
+}
+
+/**
+ * Walks the user's enabled ai-provider plugins in priority order and returns
+ * the first one with a usable config (baseUrl + apiKey + model). Capped by
+ * USER_RESEARCH_PROVIDER_FALLBACK_MAX so one bad provider chain can't burn
+ * through every configured key. Auth-shape errors re-throw so misconfigured
+ * keys aren't silently masked by trying the next provider.
+ */
+export async function resolveAiProviderForResearch(
+    aiFacade: AiFacadeService,
+    registry: PluginRegistryService,
+    userId: string,
+    logger?: Logger,
+): Promise<ResolvedAiProvider | null> {
+    const chain = capChain(
+        await resolveProviderChain(registry, PLUGIN_CAPABILITIES.AI_PROVIDER, userId),
+        getProviderFallbackMax(),
+    );
+    if (chain.length === 0) return null;
+
+    for (const candidate of chain) {
+        try {
+            const cfg = await aiFacade.getProviderConfig({
+                userId,
+                providerOverride: candidate.plugin.id,
+            });
+            if (!cfg.baseUrl || !cfg.apiKey) continue;
+            const modelName =
+                cfg.routing.complexModel ?? cfg.routing.mediumModel ?? cfg.defaultModel;
+            if (!modelName) continue;
+
+            const provider = createOpenAICompatible({
+                name: cfg.providerId,
+                baseURL: cfg.baseUrl,
+                apiKey: cfg.apiKey,
+            });
+            return {
+                model: provider(modelName),
+                providerId: cfg.providerId,
+                providerName: cfg.providerName ?? cfg.providerId,
+                modelName,
+            };
+        } catch (err) {
+            if (isAuthOrConfigError(err)) throw err;
+            logger?.warn(`ai-provider ${candidate.plugin.id} unusable: ${(err as Error).message}`);
+        }
+    }
+    return null;
 }

--- a/packages/agent/src/user-research/provider-resolver.ts
+++ b/packages/agent/src/user-research/provider-resolver.ts
@@ -1,0 +1,92 @@
+import type { Logger } from '@nestjs/common';
+import type {
+    PluginRegistryService,
+    RegisteredPlugin,
+} from '../plugins/services/plugin-registry.service';
+
+/**
+ * Returns the user's enabled plugins for a capability, ordered with
+ * `defaultForCapabilities`-first (same convention as BaseFacadeService).
+ */
+export async function resolveProviderChain(
+    registry: PluginRegistryService,
+    capability: string,
+    userId: string,
+): Promise<RegisteredPlugin[]> {
+    const plugins = await registry.getEnabledPluginsScoped(capability, undefined, userId);
+    return plugins.sort((a, b) => {
+        const ad = a.manifest.defaultForCapabilities?.includes(capability) ? 0 : 1;
+        const bd = b.manifest.defaultForCapabilities?.includes(capability) ? 0 : 1;
+        return ad - bd;
+    });
+}
+
+/** Cap how many providers we try per call so a flapping vendor can't burn through every key. */
+export function capChain<T>(chain: T[], max: number): T[] {
+    if (max <= 0) return chain;
+    return chain.slice(0, Math.max(1, max));
+}
+
+export async function tryInOrder<T>(
+    chain: RegisteredPlugin[],
+    attempt: (plugin: RegisteredPlugin) => Promise<T>,
+    isRetryable: (err: unknown) => boolean,
+    logger?: Logger,
+): Promise<T> {
+    if (chain.length === 0) {
+        throw new Error('No providers available');
+    }
+    let lastErr: unknown;
+    for (const p of chain) {
+        try {
+            return await attempt(p);
+        } catch (err) {
+            if (!isRetryable(err)) throw err;
+            logger?.warn(
+                `provider ${p.plugin.id} failed (retryable): ${(err as Error)?.message ?? err}`,
+            );
+            lastErr = err;
+        }
+    }
+    throw lastErr ?? new Error('all providers failed');
+}
+
+/**
+ * Heuristic classifier for "the next provider might succeed" — covers the
+ * usual rate-limit / quota / 5xx / network shapes across LLM + search APIs.
+ * Auth/config errors are NOT retryable (don't burn the next provider on a
+ * bad key).
+ */
+export function isTransientProviderError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const msg = err.message.toLowerCase();
+    if (
+        msg.includes('401') ||
+        msg.includes('403') ||
+        msg.includes('unauthorized') ||
+        msg.includes('forbidden') ||
+        msg.includes('invalid api key') ||
+        msg.includes('invalid_api_key')
+    ) {
+        return false;
+    }
+    return (
+        msg.includes('rate limit') ||
+        msg.includes('rate_limit') ||
+        msg.includes('rate-limit') ||
+        msg.includes('429') ||
+        msg.includes('quota') ||
+        msg.includes('timeout') ||
+        msg.includes('etimedout') ||
+        msg.includes('econnrefused') ||
+        msg.includes('econnreset') ||
+        msg.includes('socket hang up') ||
+        msg.includes('overloaded') ||
+        msg.includes('service unavailable') ||
+        msg.includes('bad gateway') ||
+        msg.includes('gateway timeout') ||
+        msg.includes('502') ||
+        msg.includes('503') ||
+        msg.includes('504')
+    );
+}

--- a/packages/agent/src/user-research/tools/search-web.tool.ts
+++ b/packages/agent/src/user-research/tools/search-web.tool.ts
@@ -3,11 +3,18 @@ import { z } from 'zod';
 import { Logger } from '@nestjs/common';
 import type { SearchFacadeService } from '../../facades/search.facade';
 import type { UserResearchLimitsService } from '../limits';
+import { isTransientProviderError } from '../provider-resolver';
 
 interface CreateSearchWebToolOptions {
     searchFacade: SearchFacadeService;
     limits: UserResearchLimitsService;
     userId: string;
+    /**
+     * Ordered list of search plugin IDs to try. Empty / undefined means
+     * "let the facade pick its default". The tool walks the chain on
+     * transient errors so a flapping provider doesn't drop the whole run.
+     */
+    providerChain?: string[];
     logger?: Logger;
     onResult?: (results: { title: string; url: string }[]) => void;
 }
@@ -19,6 +26,8 @@ const inputSchema = z.object({
 
 export function createSearchWebTool(opts: CreateSearchWebToolOptions) {
     const log = opts.logger ?? new Logger('UserResearch:searchWeb');
+    const chain =
+        opts.providerChain && opts.providerChain.length > 0 ? opts.providerChain : [undefined];
 
     return tool({
         description:
@@ -32,27 +41,40 @@ export function createSearchWebTool(opts: CreateSearchWebToolOptions) {
                 return { results: [], error: 'rate_limited' as const };
             }
 
-            try {
-                const results = await opts.searchFacade.search(
-                    input.query,
-                    { maxResults: input.limit ?? 5 },
-                    { userId: opts.userId },
-                );
+            let lastErr: unknown;
+            for (const providerOverride of chain) {
+                try {
+                    const results = await opts.searchFacade.search(
+                        input.query,
+                        { maxResults: input.limit ?? 5 },
+                        { userId: opts.userId, providerOverride },
+                    );
 
-                await opts.limits.incrementSearches(opts.userId);
+                    await opts.limits.incrementSearches(opts.userId);
 
-                const compact = results.slice(0, input.limit ?? 5).map((r) => ({
-                    title: r.title,
-                    url: r.url,
-                    publishedDate: r.publishedDate,
-                }));
+                    const compact = results.slice(0, input.limit ?? 5).map((r) => ({
+                        title: r.title,
+                        url: r.url,
+                        publishedDate: r.publishedDate,
+                    }));
 
-                opts.onResult?.(compact);
-                return { results: compact };
-            } catch (err) {
-                log.warn(`searchWeb failed: ${(err as Error).message}`);
-                return { results: [], error: (err as Error).message };
+                    opts.onResult?.(compact);
+                    return { results: compact };
+                } catch (err) {
+                    lastErr = err;
+                    if (!isTransientProviderError(err)) {
+                        log.warn(`searchWeb failed (non-retryable): ${(err as Error).message}`);
+                        return { results: [], error: (err as Error).message };
+                    }
+                    log.warn(
+                        `searchWeb provider ${providerOverride ?? '<default>'} failed (retryable): ${(err as Error).message}`,
+                    );
+                }
             }
+            return {
+                results: [],
+                error: (lastErr as Error)?.message ?? 'all search providers failed',
+            };
         },
     });
 }

--- a/packages/agent/src/user-research/user-research.service.ts
+++ b/packages/agent/src/user-research/user-research.service.ts
@@ -3,17 +3,83 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { generateText, stepCountIs } from 'ai';
 import type { LanguageModel } from 'ai';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import { AiFacadeService } from '../facades/ai.facade';
 import { SearchFacadeService } from '../facades/search.facade';
 import { ContentExtractorFacadeService } from '../facades/content-extractor.facade';
 import { UserRepository } from '../database/repositories/user.repository';
 import { AuthAccountRepository } from '../database/repositories/auth-account.repository';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import type { InferredUserProfile } from '../entities';
 import { UserResearchCompletedEvent, UserResearchFailedEvent } from './events';
 import { USER_RESEARCH_AGENT_PROMPT, buildSeedPrompt, deriveVerticals } from './prompts';
 import { inferredProfileSchema, type InferredProfile } from './schemas';
 import { UserResearchLimitsService, UserResearchRateLimitedError } from './limits';
+import { capChain, resolveProviderChain } from './provider-resolver';
 import { createSearchWebTool, createFetchPageTool, createFinalizeTool } from './tools';
+
+const DEFAULT_PROVIDER_FALLBACK_MAX = 2;
+
+function getProviderFallbackMax(): number {
+    const raw = process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+    if (!raw) return DEFAULT_PROVIDER_FALLBACK_MAX;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_PROVIDER_FALLBACK_MAX;
+}
+
+export interface ResolvedAiProvider {
+    model: LanguageModel;
+    providerId: string;
+    providerName: string;
+    modelName: string;
+}
+
+/**
+ * Walks the user's enabled ai-provider plugins in priority order and returns
+ * the first one with a usable config (baseUrl + apiKey + model). Capped by
+ * USER_RESEARCH_PROVIDER_FALLBACK_MAX so one bad provider chain can't burn
+ * through every configured key.
+ */
+export async function resolveAiProviderForResearch(
+    aiFacade: AiFacadeService,
+    registry: PluginRegistryService,
+    userId: string,
+    logger?: Logger,
+): Promise<ResolvedAiProvider | null> {
+    const chain = capChain(
+        await resolveProviderChain(registry, PLUGIN_CAPABILITIES.AI_PROVIDER, userId),
+        getProviderFallbackMax(),
+    );
+    if (chain.length === 0) return null;
+
+    for (const candidate of chain) {
+        try {
+            const cfg = await aiFacade.getProviderConfig({
+                userId,
+                providerOverride: candidate.plugin.id,
+            });
+            if (!cfg.baseUrl || !cfg.apiKey) continue;
+            const modelName =
+                cfg.routing.complexModel ?? cfg.routing.mediumModel ?? cfg.defaultModel;
+            if (!modelName) continue;
+
+            const provider = createOpenAICompatible({
+                name: cfg.providerId,
+                baseURL: cfg.baseUrl,
+                apiKey: cfg.apiKey,
+            });
+            return {
+                model: provider(modelName),
+                providerId: cfg.providerId,
+                providerName: cfg.providerName ?? cfg.providerId,
+                modelName,
+            };
+        } catch (err) {
+            logger?.warn(`ai-provider ${candidate.plugin.id} unusable: ${(err as Error).message}`);
+        }
+    }
+    return null;
+}
 
 export interface UserResearchResult {
     status: 'completed' | 'rate-limited' | 'no-data' | 'error';
@@ -51,6 +117,7 @@ export class UserResearchService {
         private readonly aiFacade: AiFacadeService,
         private readonly searchFacade: SearchFacadeService,
         private readonly contentExtractor: ContentExtractorFacadeService,
+        private readonly registry: PluginRegistryService,
         private readonly limits: UserResearchLimitsService,
         @Optional() private readonly events?: EventEmitter2,
     ) {}
@@ -106,53 +173,22 @@ export class UserResearchService {
             );
         }
 
-        let model: LanguageModel;
-        let providerName: string;
-        try {
-            const providerConfig = await this.aiFacade.getProviderConfig({
-                userId,
-            });
-            if (!providerConfig.baseUrl || !providerConfig.apiKey) {
-                return {
-                    status: 'error',
-                    tokensUsed: 0,
-                    toolCallsCount: 0,
-                    durationMs: Date.now() - startedAt,
-                    error: 'ai-provider-not-configured',
-                };
-            }
-            const provider = createOpenAICompatible({
-                name: providerConfig.providerId,
-                baseURL: providerConfig.baseUrl,
-                apiKey: providerConfig.apiKey,
-            });
-            const modelName =
-                providerConfig.routing.complexModel ??
-                providerConfig.routing.mediumModel ??
-                providerConfig.defaultModel;
-            if (!modelName) {
-                return {
-                    status: 'error',
-                    tokensUsed: 0,
-                    toolCallsCount: 0,
-                    durationMs: Date.now() - startedAt,
-                    error: 'no-model-configured',
-                };
-            }
-            model = provider(modelName);
-            providerName = providerConfig.providerName ?? providerConfig.providerId;
-        } catch (err) {
-            this.logger.warn(
-                `Could not resolve AI provider for user research: ${(err as Error).message}`,
-            );
+        const resolved = await resolveAiProviderForResearch(
+            this.aiFacade,
+            this.registry,
+            userId,
+            this.logger,
+        );
+        if (!resolved) {
             return {
                 status: 'error',
                 tokensUsed: 0,
                 toolCallsCount: 0,
                 durationMs: Date.now() - startedAt,
-                error: 'ai-provider-error',
+                error: 'ai-provider-not-configured',
             };
         }
+        const { model, providerName } = resolved;
 
         let finalProfile: InferredProfile | null = null;
         let tokensUsed = 0;
@@ -164,6 +200,11 @@ export class UserResearchService {
             : timeoutSignal;
 
         const seedPrompt = buildSeedPrompt(user, socials);
+
+        const searchChain = capChain(
+            await resolveProviderChain(this.registry, PLUGIN_CAPABILITIES.SEARCH, userId),
+            getProviderFallbackMax(),
+        ).map((p) => p.plugin.id);
 
         try {
             this.logger.log(
@@ -179,6 +220,7 @@ export class UserResearchService {
                         searchFacade: this.searchFacade,
                         limits: this.limits,
                         userId,
+                        providerChain: searchChain,
                         logger: this.logger,
                     }),
                     fetchPage: createFetchPageTool({

--- a/packages/agent/src/user-research/user-research.service.ts
+++ b/packages/agent/src/user-research/user-research.service.ts
@@ -1,9 +1,6 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { generateText, stepCountIs } from 'ai';
-import type { LanguageModel } from 'ai';
-import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import { AiFacadeService } from '../facades/ai.facade';
 import { SearchFacadeService } from '../facades/search.facade';
 import { ContentExtractorFacadeService } from '../facades/content-extractor.facade';
@@ -15,71 +12,8 @@ import { UserResearchCompletedEvent, UserResearchFailedEvent } from './events';
 import { USER_RESEARCH_AGENT_PROMPT, buildSeedPrompt, deriveVerticals } from './prompts';
 import { inferredProfileSchema, type InferredProfile } from './schemas';
 import { UserResearchLimitsService, UserResearchRateLimitedError } from './limits';
-import { capChain, resolveProviderChain } from './provider-resolver';
+import { resolveAiProviderForResearch, resolveSearchProviderIds } from './provider-resolver';
 import { createSearchWebTool, createFetchPageTool, createFinalizeTool } from './tools';
-
-const DEFAULT_PROVIDER_FALLBACK_MAX = 2;
-
-function getProviderFallbackMax(): number {
-    const raw = process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
-    if (!raw) return DEFAULT_PROVIDER_FALLBACK_MAX;
-    const n = Number(raw);
-    return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_PROVIDER_FALLBACK_MAX;
-}
-
-export interface ResolvedAiProvider {
-    model: LanguageModel;
-    providerId: string;
-    providerName: string;
-    modelName: string;
-}
-
-/**
- * Walks the user's enabled ai-provider plugins in priority order and returns
- * the first one with a usable config (baseUrl + apiKey + model). Capped by
- * USER_RESEARCH_PROVIDER_FALLBACK_MAX so one bad provider chain can't burn
- * through every configured key.
- */
-export async function resolveAiProviderForResearch(
-    aiFacade: AiFacadeService,
-    registry: PluginRegistryService,
-    userId: string,
-    logger?: Logger,
-): Promise<ResolvedAiProvider | null> {
-    const chain = capChain(
-        await resolveProviderChain(registry, PLUGIN_CAPABILITIES.AI_PROVIDER, userId),
-        getProviderFallbackMax(),
-    );
-    if (chain.length === 0) return null;
-
-    for (const candidate of chain) {
-        try {
-            const cfg = await aiFacade.getProviderConfig({
-                userId,
-                providerOverride: candidate.plugin.id,
-            });
-            if (!cfg.baseUrl || !cfg.apiKey) continue;
-            const modelName =
-                cfg.routing.complexModel ?? cfg.routing.mediumModel ?? cfg.defaultModel;
-            if (!modelName) continue;
-
-            const provider = createOpenAICompatible({
-                name: cfg.providerId,
-                baseURL: cfg.baseUrl,
-                apiKey: cfg.apiKey,
-            });
-            return {
-                model: provider(modelName),
-                providerId: cfg.providerId,
-                providerName: cfg.providerName ?? cfg.providerId,
-                modelName,
-            };
-        } catch (err) {
-            logger?.warn(`ai-provider ${candidate.plugin.id} unusable: ${(err as Error).message}`);
-        }
-    }
-    return null;
-}
 
 export interface UserResearchResult {
     status: 'completed' | 'rate-limited' | 'no-data' | 'error';
@@ -173,22 +107,39 @@ export class UserResearchService {
             );
         }
 
-        const resolved = await resolveAiProviderForResearch(
-            this.aiFacade,
-            this.registry,
-            userId,
-            this.logger,
-        );
-        if (!resolved) {
+        let resolvedModel;
+        let providerName: string;
+        let searchChain: string[];
+        try {
+            const resolved = await resolveAiProviderForResearch(
+                this.aiFacade,
+                this.registry,
+                userId,
+                this.logger,
+            );
+            if (!resolved) {
+                return {
+                    status: 'error',
+                    tokensUsed: 0,
+                    toolCallsCount: 0,
+                    durationMs: Date.now() - startedAt,
+                    error: 'ai-provider-not-configured',
+                };
+            }
+            resolvedModel = resolved.model;
+            providerName = resolved.providerName;
+            searchChain = await resolveSearchProviderIds(this.registry, userId);
+        } catch (err) {
+            const message = (err as Error).message;
+            this.logger.warn(`Provider resolution failed for ${userId}: ${message}`);
             return {
                 status: 'error',
                 tokensUsed: 0,
                 toolCallsCount: 0,
                 durationMs: Date.now() - startedAt,
-                error: 'ai-provider-not-configured',
+                error: message,
             };
         }
-        const { model, providerName } = resolved;
 
         let finalProfile: InferredProfile | null = null;
         let tokensUsed = 0;
@@ -201,18 +152,13 @@ export class UserResearchService {
 
         const seedPrompt = buildSeedPrompt(user, socials);
 
-        const searchChain = capChain(
-            await resolveProviderChain(this.registry, PLUGIN_CAPABILITIES.SEARCH, userId),
-            getProviderFallbackMax(),
-        ).map((p) => p.plugin.id);
-
         try {
             this.logger.log(
                 `User research starting for ${userId} via "${providerName}" (timeout=${timeoutMs}ms, steps=${maxSteps})`,
             );
 
             const result = await generateText({
-                model,
+                model: resolvedModel,
                 system: USER_RESEARCH_AGENT_PROMPT,
                 prompt: seedPrompt,
                 tools: {

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { generateObject } from 'ai';
 import { AiFacadeService } from '../facades/ai.facade';
 import { UserRepository } from '../database/repositories/user.repository';
@@ -8,6 +7,7 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { WorkProposalRepository } from './work-proposal.repository';
 import { workProposalsBatchSchema, type WorkProposalsBatch } from './schemas';
 import { PROPOSALS_SYSTEM_PROMPT, buildProposalsPrompt } from './prompts';
+import { resolveAiProviderForResearch } from './user-research.service';
 import {
     WorkProposalStatus,
     type WorkProposal,
@@ -68,45 +68,28 @@ export class WorkProposalService {
             .map((p) => p.plugin.id)
             .filter(Boolean);
 
-        let providerName: string;
-        let modelName: string;
+        const resolved = await resolveAiProviderForResearch(
+            this.aiFacade,
+            this.registry,
+            userId,
+            this.logger,
+        );
+        if (!resolved) {
+            return {
+                status: 'error',
+                proposals: [],
+                tokensUsed: 0,
+                error: 'ai-provider-not-configured',
+            };
+        }
+        const { model, providerName, modelName } = resolved;
+
         let tokensUsed = 0;
         let parsed: WorkProposalsBatch;
 
         try {
-            const providerConfig = await this.aiFacade.getProviderConfig({
-                userId,
-            });
-            if (!providerConfig.baseUrl || !providerConfig.apiKey) {
-                return {
-                    status: 'error',
-                    proposals: [],
-                    tokensUsed: 0,
-                    error: 'ai-provider-not-configured',
-                };
-            }
-            const provider = createOpenAICompatible({
-                name: providerConfig.providerId,
-                baseURL: providerConfig.baseUrl,
-                apiKey: providerConfig.apiKey,
-            });
-            modelName =
-                providerConfig.routing.complexModel ??
-                providerConfig.routing.mediumModel ??
-                providerConfig.defaultModel ??
-                '';
-            if (!modelName) {
-                return {
-                    status: 'error',
-                    proposals: [],
-                    tokensUsed: 0,
-                    error: 'no-model-configured',
-                };
-            }
-            providerName = providerConfig.providerName ?? providerConfig.providerId;
-
             const result = await generateObject({
-                model: provider(modelName),
+                model,
                 schema: workProposalsBatchSchema,
                 system: PROPOSALS_SYSTEM_PROMPT,
                 prompt: buildProposalsPrompt(profile, existingWorkNames, availablePluginIds),

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -7,7 +7,7 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { WorkProposalRepository } from './work-proposal.repository';
 import { workProposalsBatchSchema, type WorkProposalsBatch } from './schemas';
 import { PROPOSALS_SYSTEM_PROMPT, buildProposalsPrompt } from './prompts';
-import { resolveAiProviderForResearch } from './user-research.service';
+import { resolveAiProviderForResearch } from './provider-resolver';
 import {
     WorkProposalStatus,
     type WorkProposal,
@@ -68,28 +68,39 @@ export class WorkProposalService {
             .map((p) => p.plugin.id)
             .filter(Boolean);
 
-        const resolved = await resolveAiProviderForResearch(
-            this.aiFacade,
-            this.registry,
-            userId,
-            this.logger,
-        );
-        if (!resolved) {
-            return {
-                status: 'error',
-                proposals: [],
-                tokensUsed: 0,
-                error: 'ai-provider-not-configured',
-            };
+        let resolvedModel;
+        let providerName: string;
+        let modelName: string;
+        try {
+            const resolved = await resolveAiProviderForResearch(
+                this.aiFacade,
+                this.registry,
+                userId,
+                this.logger,
+            );
+            if (!resolved) {
+                return {
+                    status: 'error',
+                    proposals: [],
+                    tokensUsed: 0,
+                    error: 'ai-provider-not-configured',
+                };
+            }
+            resolvedModel = resolved.model;
+            providerName = resolved.providerName;
+            modelName = resolved.modelName;
+        } catch (err) {
+            const message = (err as Error).message;
+            this.logger.warn(`Provider resolution failed for ${userId}: ${message}`);
+            return { status: 'error', proposals: [], tokensUsed: 0, error: message };
         }
-        const { model, providerName, modelName } = resolved;
 
         let tokensUsed = 0;
         let parsed: WorkProposalsBatch;
 
         try {
             const result = await generateObject({
-                model,
+                model: resolvedModel,
                 schema: workProposalsBatchSchema,
                 system: PROPOSALS_SYSTEM_PROMPT,
                 prompt: buildProposalsPrompt(profile, existingWorkNames, availablePluginIds),


### PR DESCRIPTION
Mirrors BaseFacadeService.resolvePlugin() ordering (defaultForCapabilities first) and walks the user's enabled plugin chain on transient errors so a single flapping vendor can't drop the whole research run. Capped via USER_RESEARCH_PROVIDER_FALLBACK_MAX (default 2) so a chain of bad keys can't burn through every configured provider.

- new provider-resolver helper (chain ordering, cap, transient classifier)
- resolveAiProviderForResearch() iterates ai-provider chain in UserResearchService and WorkProposalService until one returns a usable config (baseUrl + apiKey + model)
- searchWeb tool walks the user's search-plugin chain with providerOverride, falling through on rate-limit / 5xx / network shapes (auth/config errors are still non-retryable)
- fetchPage tool unchanged — ContentExtractorFacadeService already walks candidates internally
- env docs + 14 new unit tests for the resolver helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-chain support for AI and web-search with optional ordered provider lists.
  * New env var to cap fallback attempts (USER_RESEARCH_PROVIDER_FALLBACK_MAX, default 2).

* **Bug Fixes / Improvements**
  * Search tool retries alternate providers on transient failures.
  * Centralized provider resolution and clearer error classification for provider selection.
  * Query param handling: single or repeated status params normalized to an array.

* **Tests**
  * Added tests covering provider selection, fallback limits, and error classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/724)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->