### PR TITLE
fix(onboarding): drop duplicated /api/ prefix from web client paths

### DIFF
--- a/apps/web/src/lib/api/onboarding.ts
+++ b/apps/web/src/lib/api/onboarding.ts
@@ -9,12 +9,12 @@ import type {
 /** Server-side client for the v2 onboarding wizard's REST surface. */
 export const onboardingAPI = {
     getState() {
-        return serverFetch<OnboardingStateResponse>('/api/onboarding/state');
+        return serverFetch<OnboardingStateResponse>('/onboarding/state');
     },
 
     patchState(body: OnboardingStatePatchRequest) {
         return serverMutation<OnboardingStateResponse>({
-            endpoint: '/api/onboarding/state',
+            endpoint: '/onboarding/state',
             data: body,
             method: 'PATCH',
             wrapInData: false,
@@ -23,7 +23,7 @@ export const onboardingAPI = {
 
     markCompleted() {
         return serverMutation<OnboardingStateResponse>({
-            endpoint: '/api/onboarding/complete',
+            endpoint: '/onboarding/complete',
             data: {},
             method: 'POST',
             wrapInData: false,
@@ -32,7 +32,7 @@ export const onboardingAPI = {
 
     markDismissed() {
         return serverMutation<OnboardingStateResponse>({
-            endpoint: '/api/onboarding/dismiss',
+            endpoint: '/onboarding/dismiss',
             data: {},
             method: 'POST',
             wrapInData: false,
@@ -40,12 +40,12 @@ export const onboardingAPI = {
     },
 
     getCatalog() {
-        return serverFetch<OnboardingCatalogResponse>('/api/onboarding/catalog');
+        return serverFetch<OnboardingCatalogResponse>('/onboarding/catalog');
     },
 
     track(event: string, properties?: Record<string, unknown>) {
         return serverMutation<void>({
-            endpoint: '/api/onboarding/telemetry',
+            endpoint: '/onboarding/telemetry',
             data: { event, properties },
             method: 'POST',
             wrapInData: false,


### PR DESCRIPTION
## Summary

- `apps/web/src/lib/constants.ts` normalises `API_URL` to always end in `/api`, so `serverFetch`/`serverMutation` callers must NOT include `/api/` in their endpoint paths.
- `apps/web/src/lib/api/onboarding.ts` was prefixing every path with `/api/`, producing requests like `…/api/api/onboarding/state`. NestJS rejected them with `Cannot PATCH /api/api/onboarding/state` (and same for GET state, POST complete/dismiss/telemetry, GET catalog).
- Aligned all six paths with the convention used by every other client in `apps/web/src/lib/api/*` (work-proposals, account, plugins, etc.).

## Test plan

- [ ] `pnpm dev` (or already-running dev stack) — open the dashboard with a fresh user; the onboarding wizard now successfully PATCHes `/api/onboarding/state` instead of returning 500.
- [ ] Dismiss the onboarding card → `POST /api/onboarding/dismiss` returns 2xx.
- [ ] Complete the wizard → `POST /api/onboarding/complete` returns 2xx.
- [ ] No `Cannot (GET|PATCH|POST) /api/api/...` lines in the API logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal routing for the onboarding service to enhance backend efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/725)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->