### PR TITLE
ci(e2e): bump job timeout-minutes 45 -> 150

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,12 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubicloud-standard-8
-    timeout-minutes: 45
+    # 150 min covers the current 1-worker × 333-spec suite even with retries
+    # and slow specs. The prior 45-min ceiling was too tight: a single full
+    # run on develop hit the wall partway through. Keep the headroom while
+    # we work through suite-level test debt; revisit downward only once the
+    # suite consistently finishes well under it.
+    timeout-minutes: 150
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Bumps the E2E job timeout from 45 to 150 minutes. A full run on develop with 1 worker × 333 specs + retries doesn't fit in 45 min — the previous ceiling killed the run partway through, even when individual specs were passing.

No tests removed or skipped, no coverage limited — only the wall-clock ceiling moved. We'll revisit this downward once the suite consistently finishes well under the new ceiling.

## Test plan
- [ ] Next push to develop runs the full E2E suite within 150 min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to allow extended test execution time, ensuring more comprehensive test coverage and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/726)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->