### PR TITLE
chore(onboarding): EW-608 follow-up cleanups (Greptile P1+P2 from PR #705)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AuthUser } from '@/lib/auth';
-import React, { Suspense, useState, useCallback, useRef, useEffect } from 'react';
+import React, { Suspense, useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { ChevronLeft, ChevronRight, GripVertical } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -16,7 +16,9 @@ import { useKeyboardShortcuts } from '@/lib/hooks/use-keyboard-shortcuts';
 import { ConnectGithubModal } from '@/components/auth/connect-github-modal';
 import { BackgroundActivityProvider } from '@/lib/hooks/use-background-activity';
 import { EverWorksOnboardingWizard } from '@/components/onboarding/EverWorksOnboardingWizard';
+import { computeStepList } from '@/components/onboarding/useOnboardingFlow';
 import { dismissOnboarding } from '@/app/actions/onboarding/state';
+import { ONBOARDING_DEFAULT_STATE } from '@ever-works/contracts/api';
 import type { OnboardingCatalogResponse, OnboardingStateResponse } from '@ever-works/contracts/api';
 import type { UserPlugin } from '@/lib/api/plugins';
 import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
@@ -74,10 +76,18 @@ export function DashboardLayoutClient({
     const [mainStyle, setMainStyle] = useState<React.CSSProperties | undefined>(undefined);
     const [isMobile, setIsMobile] = useState<boolean>(false);
 
-    // The v2 wizard derives its own step list — we only need step + total
-    // counts for the header "x of N" badge. Approximating with the persisted
-    // `lastStep` is sufficient because the badge is informational only.
-    const onboardingTotalSteps = 9;
+    // The v2 wizard derives its own step list from the user's choices —
+    // config sub-steps are skipped when the user picks an Ever Works default
+    // for that bucket. Re-derive the same way here so the header "x of N"
+    // badge matches the actual flow length (7 with all defaults, up to 10
+    // with all BYOK + 'k8s' deploy). Hardcoding `9` drifted the badge any
+    // time the user picked Ever Works for at least one bucket. Greptile P2
+    // from PR #705.
+    const onboardingStepList = useMemo(
+        () => computeStepList(onboardingState.state ?? ONBOARDING_DEFAULT_STATE),
+        [onboardingState.state],
+    );
+    const onboardingTotalSteps = onboardingStepList.length;
     const onboardingCurrentStep = Math.min(
         (onboardingState.state?.lastStep ?? 0) + 1,
         onboardingTotalSteps,

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -4,6 +4,7 @@ import { Repository, LessThan, IsNull, Brackets, Raw, LessThanOrEqual, In } from
 import { Work } from '../../entities/work.entity';
 import { User } from '../../entities';
 import { buildCaseInsensitiveLikeClause, prepareCaseInsensitiveContainsPattern } from '../utils';
+import { config } from '../../config';
 
 /**
  * Cross-database case-insensitive LIKE using LOWER() function.
@@ -184,11 +185,18 @@ export class WorkRepository {
         userId: string,
         deployProvider = 'ever-works',
     ): Promise<number> {
-        const all = await this.repository.find({
+        // The Ever Works Deploy quota check (`EverWorksDeployQuotaService`)
+        // only cares whether the user is **at or over** the cap. Cap the
+        // fetched rows at `maxWorksPerUser + 1` so the in-process filter
+        // doesn't have to scan an unbounded set if the user has many
+        // archived/deleted Works under this provider. Greptile P1 from PR #705.
+        const maxRows = config.everWorks.deploy.getMaxWorksPerUser() + 1;
+        const candidates = await this.repository.find({
             where: { userId, deployProvider },
             select: { id: true, generateStatus: true } as never,
+            take: maxRows,
         });
-        return all.filter((w) => {
+        return candidates.filter((w) => {
             const status = (w.generateStatus as { status?: string } | null | undefined)?.status;
             return status !== 'DELETED' && status !== 'ARCHIVED';
         }).length;


### PR DESCRIPTION
## Summary
Two tiny follow-up cleanups deferred from the PR #705 review on EW-608.

### 1. Greptile P1 — bound \`countActiveByDeployProvider\` row scan
\`packages/agent/src/database/repositories/work.repository.ts\`. The Ever Works Deploy quota check used to \`repository.find()\` an unbounded set of rows for \`(userId, deployProvider)\` and filter in-process. The service only cares whether the user is at-or-over the cap, so cap the fetched row count at \`maxWorksPerUser + 1\`. Bounds memory/IO when a user has many archived/deleted Works under the same provider.

### 2. Greptile P2 — derive onboarding step count from the actual flow
\`apps/web/src/app/[locale]/(dashboard)/layout-client.tsx\`. \`onboardingTotalSteps\` was hardcoded to \`9\`, so the dashboard header's "x of N" badge drifted whenever the user picked an Ever Works default for any bucket (config sub-steps get dropped by \`computeStepList\`). Re-derive from the same \`computeStepList\` the wizard itself uses, so the badge always matches the real flow length (7–10 steps depending on choices).

## Test plan
- [x] \`pnpm exec jest --testPathPattern='ever-works-deploy-quota|work.repository'\` — 75 tests pass
- [x] \`pnpm exec vitest run\` in \`apps/web\` — 25 tests pass
- [x] \`tsc --noEmit\` on \`apps/web\` — clean

## Not in this PR (filed as separate Jira)
- The full EW-608 §1 wire-up — making \`storageProvider='ever-works-git'\` actually create the repo in \`ever-works-cloud\` via \`EverWorksGitProvider\` (currently the column is set but no caller invokes the provider). Needs its own ticket because the wire-up touches the git facade's token resolver + activity-log integration + owner override on the Work entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)