### PR TITLE
release(stage→main): EW-608 follow-up cleanups

### DIFF
--- a/.env.compose
+++ b/.env.compose
@@ -262,3 +262,7 @@ USER_RESEARCH_ENABLED=true
 USER_RESEARCH_SCHEDULED_RERUN_ENABLED=false
 USER_RESEARCH_SCHEDULED_RERUN_BATCH=20
 USER_RESEARCH_SCHEDULED_RERUN_STALE_DAYS=30
+
+# Max providers tried per call (per capability) before giving up. Caps fallback
+# so a flapping vendor can't burn through every configured key. Default 2.
+USER_RESEARCH_PROVIDER_FALLBACK_MAX=2

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -246,3 +246,7 @@ USER_RESEARCH_ENABLED=true
 USER_RESEARCH_SCHEDULED_RERUN_ENABLED=false
 USER_RESEARCH_SCHEDULED_RERUN_BATCH=20
 USER_RESEARCH_SCHEDULED_RERUN_STALE_DAYS=30
+
+# Max providers tried per call (per capability) before giving up. Caps fallback
+# so a flapping vendor can't burn through every configured key. Default 2.
+USER_RESEARCH_PROVIDER_FALLBACK_MAX=2

--- a/apps/api/src/work-proposals/dto/work-proposal.dto.spec.ts
+++ b/apps/api/src/work-proposals/dto/work-proposal.dto.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+
+// The DTO re-imports enums from @ever-works/agent/user-research, whose
+// transitive imports drag in the agent's entities (which reach back through
+// @src/* paths and break Jest resolution). Stub the surface area we use.
+jest.mock(
+    '@ever-works/agent/user-research',
+    () => ({
+        WorkProposalStatus: {
+            PENDING: 'pending',
+            DISMISSED: 'dismissed',
+            ACCEPTED: 'accepted',
+        },
+        WorkProposalSource: {
+            AUTO_SIGNUP: 'auto-signup',
+            USER_REFRESH: 'user-refresh',
+            DISCOVER: 'discover',
+            SCHEDULED: 'scheduled',
+        },
+    }),
+    { virtual: true },
+);
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ListWorkProposalsQueryDto } from './work-proposal.dto';
+
+describe('ListWorkProposalsQueryDto', () => {
+    async function transformAndValidate(input: Record<string, unknown>) {
+        const instance = plainToInstance(ListWorkProposalsQueryDto, input);
+        const errors = await validate(instance);
+        return { instance, errors };
+    }
+
+    it('accepts a single statuses value (string from Express)', async () => {
+        const { instance, errors } = await transformAndValidate({ statuses: 'pending' });
+        expect(errors).toHaveLength(0);
+        expect(instance.statuses).toEqual(['pending']);
+    });
+
+    it('accepts a repeated statuses query (array from Express)', async () => {
+        const { instance, errors } = await transformAndValidate({
+            statuses: ['pending', 'accepted'],
+        });
+        expect(errors).toHaveLength(0);
+        expect(instance.statuses).toEqual(['pending', 'accepted']);
+    });
+
+    it('omits statuses entirely (defaults applied in controller)', async () => {
+        const { instance, errors } = await transformAndValidate({});
+        expect(errors).toHaveLength(0);
+        expect(instance.statuses).toBeUndefined();
+    });
+
+    it('rejects an unknown status value', async () => {
+        const { errors } = await transformAndValidate({ statuses: 'bogus' });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].constraints).toMatchObject({ isEnum: expect.any(String) });
+    });
+});

--- a/apps/api/src/work-proposals/dto/work-proposal.dto.ts
+++ b/apps/api/src/work-proposals/dto/work-proposal.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsArray, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
 import { WorkProposalSource, WorkProposalStatus } from '@ever-works/agent/user-research';
 
@@ -10,6 +11,11 @@ export class ListWorkProposalsQueryDto {
         description: 'Filter by status (default: pending only)',
     })
     @IsOptional()
+    // Express parses `?statuses=pending` as a string and `?statuses=a&statuses=b`
+    // as an array. Normalize to array so @IsArray accepts both shapes.
+    @Transform(({ value }) =>
+        value === undefined || value === null ? value : Array.isArray(value) ? value : [value],
+    )
     @IsArray()
     @IsEnum(WorkProposalStatus, { each: true })
     statuses?: WorkProposalStatus[];

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AuthUser } from '@/lib/auth';
-import React, { Suspense, useState, useCallback, useRef, useEffect } from 'react';
+import React, { Suspense, useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { ChevronLeft, ChevronRight, GripVertical } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -16,7 +16,9 @@ import { useKeyboardShortcuts } from '@/lib/hooks/use-keyboard-shortcuts';
 import { ConnectGithubModal } from '@/components/auth/connect-github-modal';
 import { BackgroundActivityProvider } from '@/lib/hooks/use-background-activity';
 import { EverWorksOnboardingWizard } from '@/components/onboarding/EverWorksOnboardingWizard';
+import { computeStepList } from '@/components/onboarding/useOnboardingFlow';
 import { dismissOnboarding } from '@/app/actions/onboarding/state';
+import { ONBOARDING_DEFAULT_STATE } from '@ever-works/contracts/api';
 import type { OnboardingCatalogResponse, OnboardingStateResponse } from '@ever-works/contracts/api';
 import type { UserPlugin } from '@/lib/api/plugins';
 import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
@@ -74,10 +76,18 @@ export function DashboardLayoutClient({
     const [mainStyle, setMainStyle] = useState<React.CSSProperties | undefined>(undefined);
     const [isMobile, setIsMobile] = useState<boolean>(false);
 
-    // The v2 wizard derives its own step list — we only need step + total
-    // counts for the header "x of N" badge. Approximating with the persisted
-    // `lastStep` is sufficient because the badge is informational only.
-    const onboardingTotalSteps = 9;
+    // The v2 wizard derives its own step list from the user's choices —
+    // config sub-steps are skipped when the user picks an Ever Works default
+    // for that bucket. Re-derive the same way here so the header "x of N"
+    // badge matches the actual flow length (7 with all defaults, up to 10
+    // with all BYOK + 'k8s' deploy). Hardcoding `9` drifted the badge any
+    // time the user picked Ever Works for at least one bucket. Greptile P2
+    // from PR #705.
+    const onboardingStepList = useMemo(
+        () => computeStepList(onboardingState.state ?? ONBOARDING_DEFAULT_STATE),
+        [onboardingState.state],
+    );
+    const onboardingTotalSteps = onboardingStepList.length;
     const onboardingCurrentStep = Math.min(
         (onboardingState.state?.lastStep ?? 0) + 1,
         onboardingTotalSteps,

--- a/apps/web/src/lib/api/onboarding.ts
+++ b/apps/web/src/lib/api/onboarding.ts
@@ -9,12 +9,12 @@ import type {
 /** Server-side client for the v2 onboarding wizard's REST surface. */
 export const onboardingAPI = {
     getState() {
-        return serverFetch<OnboardingStateResponse>('/api/onboarding/state');
+        return serverFetch<OnboardingStateResponse>('/onboarding/state');
     },
 
     patchState(body: OnboardingStatePatchRequest) {
         return serverMutation<OnboardingStateResponse>({
-            endpoint: '/api/onboarding/state',
+            endpoint: '/onboarding/state',
             data: body,
             method: 'PATCH',
             wrapInData: false,
@@ -23,7 +23,7 @@ export const onboardingAPI = {
 
     markCompleted() {
         return serverMutation<OnboardingStateResponse>({
-            endpoint: '/api/onboarding/complete',
+            endpoint: '/onboarding/complete',
             data: {},
             method: 'POST',
             wrapInData: false,
@@ -32,7 +32,7 @@ export const onboardingAPI = {
 
     markDismissed() {
         return serverMutation<OnboardingStateResponse>({
-            endpoint: '/api/onboarding/dismiss',
+            endpoint: '/onboarding/dismiss',
             data: {},
             method: 'POST',
             wrapInData: false,
@@ -40,12 +40,12 @@ export const onboardingAPI = {
     },
 
     getCatalog() {
-        return serverFetch<OnboardingCatalogResponse>('/api/onboarding/catalog');
+        return serverFetch<OnboardingCatalogResponse>('/onboarding/catalog');
     },
 
     track(event: string, properties?: Record<string, unknown>) {
         return serverMutation<void>({
-            endpoint: '/api/onboarding/telemetry',
+            endpoint: '/onboarding/telemetry',
             data: { event, properties },
             method: 'POST',
             wrapInData: false,

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -4,6 +4,7 @@ import { Repository, LessThan, IsNull, Brackets, Raw, LessThanOrEqual, In } from
 import { Work } from '../../entities/work.entity';
 import { User } from '../../entities';
 import { buildCaseInsensitiveLikeClause, prepareCaseInsensitiveContainsPattern } from '../utils';
+import { config } from '../../config';
 
 /**
  * Cross-database case-insensitive LIKE using LOWER() function.
@@ -184,11 +185,18 @@ export class WorkRepository {
         userId: string,
         deployProvider = 'ever-works',
     ): Promise<number> {
-        const all = await this.repository.find({
+        // The Ever Works Deploy quota check (`EverWorksDeployQuotaService`)
+        // only cares whether the user is **at or over** the cap. Cap the
+        // fetched rows at `maxWorksPerUser + 1` so the in-process filter
+        // doesn't have to scan an unbounded set if the user has many
+        // archived/deleted Works under this provider. Greptile P1 from PR #705.
+        const maxRows = config.everWorks.deploy.getMaxWorksPerUser() + 1;
+        const candidates = await this.repository.find({
             where: { userId, deployProvider },
             select: { id: true, generateStatus: true } as never,
+            take: maxRows,
         });
-        return all.filter((w) => {
+        return candidates.filter((w) => {
             const status = (w.generateStatus as { status?: string } | null | undefined)?.status;
             return status !== 'DELETED' && status !== 'ARCHIVED';
         }).length;

--- a/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
+++ b/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
@@ -1,0 +1,237 @@
+import {
+    capChain,
+    isAuthOrConfigError,
+    isTransientProviderError,
+    resolveAiProviderForResearch,
+    resolveProviderChain,
+    resolveSearchProviderIds,
+} from '../provider-resolver';
+import type {
+    PluginRegistryService,
+    RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import type { AiFacadeService } from '../../facades/ai.facade';
+
+type FakePlugin = {
+    id: string;
+    defaultForCapabilities?: string[];
+};
+
+function makeRegistered(p: FakePlugin): RegisteredPlugin {
+    return {
+        plugin: { id: p.id } as RegisteredPlugin['plugin'],
+        manifest: {
+            defaultForCapabilities: p.defaultForCapabilities,
+        } as unknown as RegisteredPlugin['manifest'],
+        state: 'loaded',
+    } as RegisteredPlugin;
+}
+
+function makeRegistry(plugins: FakePlugin[]): PluginRegistryService {
+    return {
+        getEnabledPluginsScoped: jest.fn().mockResolvedValue(plugins.map(makeRegistered)),
+    } as unknown as PluginRegistryService;
+}
+
+describe('resolveProviderChain', () => {
+    it('puts defaultForCapabilities plugins first', async () => {
+        const registry = makeRegistry([
+            { id: 'extra' },
+            { id: 'preferred', defaultForCapabilities: ['ai-provider'] },
+            { id: 'other' },
+        ]);
+
+        const chain = await resolveProviderChain(registry, 'ai-provider', 'user-1');
+
+        expect(chain.map((p) => p.plugin.id)).toEqual(['preferred', 'extra', 'other']);
+    });
+
+    it('returns empty list when no plugins are enabled', async () => {
+        const registry = makeRegistry([]);
+        await expect(resolveProviderChain(registry, 'ai-provider', 'u')).resolves.toEqual([]);
+    });
+
+    it('queries enabled plugins scoped to the user only (no workId)', async () => {
+        const registry = makeRegistry([{ id: 'p1' }]);
+        await resolveProviderChain(registry, 'search', 'u-7');
+        expect(registry.getEnabledPluginsScoped).toHaveBeenCalledWith('search', undefined, 'u-7');
+    });
+});
+
+describe('capChain', () => {
+    it('caps to max', () => {
+        expect(capChain([1, 2, 3, 4], 2)).toEqual([1, 2]);
+    });
+
+    it('returns at least 1 when max is positive but smaller than 1 is impossible', () => {
+        expect(capChain([1, 2, 3], 1)).toEqual([1]);
+    });
+
+    it('returns full chain when max <= 0', () => {
+        expect(capChain([1, 2, 3], 0)).toEqual([1, 2, 3]);
+        expect(capChain([1, 2, 3], -1)).toEqual([1, 2, 3]);
+    });
+});
+
+describe('resolveSearchProviderIds', () => {
+    it('returns capped, defaultForCapabilities-first plugin IDs', async () => {
+        const registry = makeRegistry([
+            { id: 'brave' },
+            { id: 'tavily', defaultForCapabilities: ['search'] },
+            { id: 'exa' },
+        ]);
+
+        const prev = process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+        process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX = '2';
+        try {
+            await expect(resolveSearchProviderIds(registry, 'u-1')).resolves.toEqual([
+                'tavily',
+                'brave',
+            ]);
+        } finally {
+            if (prev === undefined) delete process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+            else process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX = prev;
+        }
+    });
+});
+
+describe('isAuthOrConfigError', () => {
+    it('matches 401/403/invalid api key shapes', () => {
+        for (const msg of [
+            '401 Unauthorized',
+            '403 Forbidden',
+            'request is forbidden',
+            'unauthorized request',
+            'invalid api key',
+            'invalid_api_key',
+        ]) {
+            expect(isAuthOrConfigError(new Error(msg))).toBe(true);
+        }
+    });
+
+    it('returns false for transient and unknown shapes', () => {
+        expect(isAuthOrConfigError(new Error('rate limit'))).toBe(false);
+        expect(isAuthOrConfigError(new Error('500 Internal Server Error'))).toBe(false);
+        expect(isAuthOrConfigError(undefined)).toBe(false);
+    });
+});
+
+describe('isTransientProviderError', () => {
+    it('classifies rate-limit / 5xx / network shapes as transient', () => {
+        for (const msg of [
+            'rate limit exceeded',
+            'HTTP 429 Too Many Requests',
+            'quota exhausted',
+            'request timeout',
+            'ETIMEDOUT',
+            'ECONNRESET',
+            'socket hang up',
+            'overloaded',
+            'service unavailable',
+            'internal server error',
+            'bad gateway',
+            'gateway timeout',
+            '500 Internal Server Error',
+            '502 Bad Gateway',
+            '503 Service Unavailable',
+            '504 Gateway Timeout',
+        ]) {
+            expect(isTransientProviderError(new Error(msg))).toBe(true);
+        }
+    });
+
+    it('classifies auth / config errors as NON-transient', () => {
+        for (const msg of [
+            '401 Unauthorized',
+            '403 Forbidden',
+            'invalid api key',
+            'invalid_api_key',
+        ]) {
+            expect(isTransientProviderError(new Error(msg))).toBe(false);
+        }
+    });
+
+    it('returns false for non-Error rejections', () => {
+        expect(isTransientProviderError('string error')).toBe(false);
+        expect(isTransientProviderError(undefined)).toBe(false);
+    });
+});
+
+describe('resolveAiProviderForResearch', () => {
+    const registry = makeRegistry([{ id: 'openai' }, { id: 'anthropic' }]);
+
+    function makeAiFacade(getProviderConfig: jest.Mock): AiFacadeService {
+        return { getProviderConfig } as unknown as AiFacadeService;
+    }
+
+    it('returns the first usable provider config', async () => {
+        const getProviderConfig = jest.fn().mockResolvedValueOnce({
+            providerId: 'openai',
+            providerName: 'OpenAI',
+            baseUrl: 'https://api.openai.com/v1',
+            apiKey: 'sk-test',
+            defaultModel: 'gpt-4o',
+            routing: {},
+        });
+
+        const result = await resolveAiProviderForResearch(
+            makeAiFacade(getProviderConfig),
+            registry,
+            'u',
+        );
+
+        expect(result).toMatchObject({
+            providerId: 'openai',
+            providerName: 'OpenAI',
+            modelName: 'gpt-4o',
+        });
+        expect(getProviderConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips providers with no apiKey/baseUrl and tries the next one', async () => {
+        const getProviderConfig = jest
+            .fn()
+            .mockResolvedValueOnce({
+                providerId: 'openai',
+                baseUrl: '',
+                apiKey: '',
+                defaultModel: 'gpt-4o',
+                routing: {},
+            })
+            .mockResolvedValueOnce({
+                providerId: 'anthropic',
+                providerName: 'Anthropic',
+                baseUrl: 'https://api.anthropic.com',
+                apiKey: 'sk-ant',
+                defaultModel: 'claude-haiku',
+                routing: {},
+            });
+
+        const result = await resolveAiProviderForResearch(
+            makeAiFacade(getProviderConfig),
+            registry,
+            'u',
+        );
+
+        expect(result?.providerId).toBe('anthropic');
+        expect(getProviderConfig).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-throws auth errors instead of silently masking with the next provider', async () => {
+        const getProviderConfig = jest.fn().mockRejectedValue(new Error('401 Unauthorized'));
+
+        await expect(
+            resolveAiProviderForResearch(makeAiFacade(getProviderConfig), registry, 'u'),
+        ).rejects.toThrow('401 Unauthorized');
+        expect(getProviderConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when no provider has a usable config', async () => {
+        const registry = makeRegistry([]);
+        const getProviderConfig = jest.fn();
+        await expect(
+            resolveAiProviderForResearch(makeAiFacade(getProviderConfig), registry, 'u'),
+        ).resolves.toBeNull();
+        expect(getProviderConfig).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/user-research/provider-resolver.ts
+++ b/packages/agent/src/user-research/provider-resolver.ts
@@ -1,0 +1,164 @@
+import { Logger } from '@nestjs/common';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { LanguageModel } from 'ai';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import type {
+    PluginRegistryService,
+    RegisteredPlugin,
+} from '../plugins/services/plugin-registry.service';
+import type { AiFacadeService } from '../facades/ai.facade';
+
+const DEFAULT_PROVIDER_FALLBACK_MAX = 2;
+
+function getProviderFallbackMax(): number {
+    const raw = process.env.USER_RESEARCH_PROVIDER_FALLBACK_MAX;
+    if (!raw) return DEFAULT_PROVIDER_FALLBACK_MAX;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_PROVIDER_FALLBACK_MAX;
+}
+
+/**
+ * Returns the user's enabled plugins for a capability, ordered with
+ * `defaultForCapabilities`-first (same convention as BaseFacadeService).
+ */
+export async function resolveProviderChain(
+    registry: PluginRegistryService,
+    capability: string,
+    userId: string,
+): Promise<RegisteredPlugin[]> {
+    const plugins = await registry.getEnabledPluginsScoped(capability, undefined, userId);
+    return plugins.sort((a, b) => {
+        const ad = a.manifest.defaultForCapabilities?.includes(capability) ? 0 : 1;
+        const bd = b.manifest.defaultForCapabilities?.includes(capability) ? 0 : 1;
+        return ad - bd;
+    });
+}
+
+/** Cap how many providers we try per call so a flapping vendor can't burn through every key. */
+export function capChain<T>(chain: T[], max: number): T[] {
+    if (max <= 0) return chain;
+    return chain.slice(0, Math.max(1, max));
+}
+
+/**
+ * Returns ordered plugin IDs of the user's enabled search providers, capped
+ * by USER_RESEARCH_PROVIDER_FALLBACK_MAX. Convenience over
+ * resolveProviderChain + capChain + .map(p.plugin.id) at the call site.
+ */
+export async function resolveSearchProviderIds(
+    registry: PluginRegistryService,
+    userId: string,
+): Promise<string[]> {
+    const chain = capChain(
+        await resolveProviderChain(registry, PLUGIN_CAPABILITIES.SEARCH, userId),
+        getProviderFallbackMax(),
+    );
+    return chain.map((p) => p.plugin.id);
+}
+
+/**
+ * Auth / invalid-key shapes. Treated separately from transient errors so a
+ * bad key surfaces loudly instead of being masked by silently trying the
+ * next provider.
+ */
+export function isAuthOrConfigError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const msg = err.message.toLowerCase();
+    return (
+        msg.includes('401') ||
+        msg.includes('403') ||
+        msg.includes('unauthorized') ||
+        msg.includes('forbidden') ||
+        msg.includes('invalid api key') ||
+        msg.includes('invalid_api_key')
+    );
+}
+
+/**
+ * Heuristic classifier for "the next provider might succeed" — covers the
+ * usual rate-limit / quota / 5xx / network shapes across LLM + search APIs.
+ * Auth/config errors are NOT retryable (don't burn the next provider on a
+ * bad key).
+ */
+export function isTransientProviderError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    if (isAuthOrConfigError(err)) return false;
+    const msg = err.message.toLowerCase();
+    return (
+        msg.includes('rate limit') ||
+        msg.includes('rate_limit') ||
+        msg.includes('rate-limit') ||
+        msg.includes('429') ||
+        msg.includes('quota') ||
+        msg.includes('timeout') ||
+        msg.includes('etimedout') ||
+        msg.includes('econnrefused') ||
+        msg.includes('econnreset') ||
+        msg.includes('socket hang up') ||
+        msg.includes('overloaded') ||
+        msg.includes('service unavailable') ||
+        msg.includes('internal server error') ||
+        msg.includes('bad gateway') ||
+        msg.includes('gateway timeout') ||
+        msg.includes('500') ||
+        msg.includes('502') ||
+        msg.includes('503') ||
+        msg.includes('504')
+    );
+}
+
+export interface ResolvedAiProvider {
+    model: LanguageModel;
+    providerId: string;
+    providerName: string;
+    modelName: string;
+}
+
+/**
+ * Walks the user's enabled ai-provider plugins in priority order and returns
+ * the first one with a usable config (baseUrl + apiKey + model). Capped by
+ * USER_RESEARCH_PROVIDER_FALLBACK_MAX so one bad provider chain can't burn
+ * through every configured key. Auth-shape errors re-throw so misconfigured
+ * keys aren't silently masked by trying the next provider.
+ */
+export async function resolveAiProviderForResearch(
+    aiFacade: AiFacadeService,
+    registry: PluginRegistryService,
+    userId: string,
+    logger?: Logger,
+): Promise<ResolvedAiProvider | null> {
+    const chain = capChain(
+        await resolveProviderChain(registry, PLUGIN_CAPABILITIES.AI_PROVIDER, userId),
+        getProviderFallbackMax(),
+    );
+    if (chain.length === 0) return null;
+
+    for (const candidate of chain) {
+        try {
+            const cfg = await aiFacade.getProviderConfig({
+                userId,
+                providerOverride: candidate.plugin.id,
+            });
+            if (!cfg.baseUrl || !cfg.apiKey) continue;
+            const modelName =
+                cfg.routing.complexModel ?? cfg.routing.mediumModel ?? cfg.defaultModel;
+            if (!modelName) continue;
+
+            const provider = createOpenAICompatible({
+                name: cfg.providerId,
+                baseURL: cfg.baseUrl,
+                apiKey: cfg.apiKey,
+            });
+            return {
+                model: provider(modelName),
+                providerId: cfg.providerId,
+                providerName: cfg.providerName ?? cfg.providerId,
+                modelName,
+            };
+        } catch (err) {
+            if (isAuthOrConfigError(err)) throw err;
+            logger?.warn(`ai-provider ${candidate.plugin.id} unusable: ${(err as Error).message}`);
+        }
+    }
+    return null;
+}

--- a/packages/agent/src/user-research/tools/search-web.tool.ts
+++ b/packages/agent/src/user-research/tools/search-web.tool.ts
@@ -3,11 +3,18 @@ import { z } from 'zod';
 import { Logger } from '@nestjs/common';
 import type { SearchFacadeService } from '../../facades/search.facade';
 import type { UserResearchLimitsService } from '../limits';
+import { isTransientProviderError } from '../provider-resolver';
 
 interface CreateSearchWebToolOptions {
     searchFacade: SearchFacadeService;
     limits: UserResearchLimitsService;
     userId: string;
+    /**
+     * Ordered list of search plugin IDs to try. Empty / undefined means
+     * "let the facade pick its default". The tool walks the chain on
+     * transient errors so a flapping provider doesn't drop the whole run.
+     */
+    providerChain?: string[];
     logger?: Logger;
     onResult?: (results: { title: string; url: string }[]) => void;
 }
@@ -19,6 +26,8 @@ const inputSchema = z.object({
 
 export function createSearchWebTool(opts: CreateSearchWebToolOptions) {
     const log = opts.logger ?? new Logger('UserResearch:searchWeb');
+    const chain =
+        opts.providerChain && opts.providerChain.length > 0 ? opts.providerChain : [undefined];
 
     return tool({
         description:
@@ -32,27 +41,40 @@ export function createSearchWebTool(opts: CreateSearchWebToolOptions) {
                 return { results: [], error: 'rate_limited' as const };
             }
 
-            try {
-                const results = await opts.searchFacade.search(
-                    input.query,
-                    { maxResults: input.limit ?? 5 },
-                    { userId: opts.userId },
-                );
+            let lastErr: unknown;
+            for (const providerOverride of chain) {
+                try {
+                    const results = await opts.searchFacade.search(
+                        input.query,
+                        { maxResults: input.limit ?? 5 },
+                        { userId: opts.userId, providerOverride },
+                    );
 
-                await opts.limits.incrementSearches(opts.userId);
+                    await opts.limits.incrementSearches(opts.userId);
 
-                const compact = results.slice(0, input.limit ?? 5).map((r) => ({
-                    title: r.title,
-                    url: r.url,
-                    publishedDate: r.publishedDate,
-                }));
+                    const compact = results.slice(0, input.limit ?? 5).map((r) => ({
+                        title: r.title,
+                        url: r.url,
+                        publishedDate: r.publishedDate,
+                    }));
 
-                opts.onResult?.(compact);
-                return { results: compact };
-            } catch (err) {
-                log.warn(`searchWeb failed: ${(err as Error).message}`);
-                return { results: [], error: (err as Error).message };
+                    opts.onResult?.(compact);
+                    return { results: compact };
+                } catch (err) {
+                    lastErr = err;
+                    if (!isTransientProviderError(err)) {
+                        log.warn(`searchWeb failed (non-retryable): ${(err as Error).message}`);
+                        return { results: [], error: (err as Error).message };
+                    }
+                    log.warn(
+                        `searchWeb provider ${providerOverride ?? '<default>'} failed (retryable): ${(err as Error).message}`,
+                    );
+                }
             }
+            return {
+                results: [],
+                error: (lastErr as Error)?.message ?? 'all search providers failed',
+            };
         },
     });
 }

--- a/packages/agent/src/user-research/user-research.service.ts
+++ b/packages/agent/src/user-research/user-research.service.ts
@@ -1,18 +1,18 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { generateText, stepCountIs } from 'ai';
-import type { LanguageModel } from 'ai';
 import { AiFacadeService } from '../facades/ai.facade';
 import { SearchFacadeService } from '../facades/search.facade';
 import { ContentExtractorFacadeService } from '../facades/content-extractor.facade';
 import { UserRepository } from '../database/repositories/user.repository';
 import { AuthAccountRepository } from '../database/repositories/auth-account.repository';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import type { InferredUserProfile } from '../entities';
 import { UserResearchCompletedEvent, UserResearchFailedEvent } from './events';
 import { USER_RESEARCH_AGENT_PROMPT, buildSeedPrompt, deriveVerticals } from './prompts';
 import { inferredProfileSchema, type InferredProfile } from './schemas';
 import { UserResearchLimitsService, UserResearchRateLimitedError } from './limits';
+import { resolveAiProviderForResearch, resolveSearchProviderIds } from './provider-resolver';
 import { createSearchWebTool, createFetchPageTool, createFinalizeTool } from './tools';
 
 export interface UserResearchResult {
@@ -51,6 +51,7 @@ export class UserResearchService {
         private readonly aiFacade: AiFacadeService,
         private readonly searchFacade: SearchFacadeService,
         private readonly contentExtractor: ContentExtractorFacadeService,
+        private readonly registry: PluginRegistryService,
         private readonly limits: UserResearchLimitsService,
         @Optional() private readonly events?: EventEmitter2,
     ) {}
@@ -106,13 +107,17 @@ export class UserResearchService {
             );
         }
 
-        let model: LanguageModel;
+        let resolvedModel;
         let providerName: string;
+        let searchChain: string[];
         try {
-            const providerConfig = await this.aiFacade.getProviderConfig({
+            const resolved = await resolveAiProviderForResearch(
+                this.aiFacade,
+                this.registry,
                 userId,
-            });
-            if (!providerConfig.baseUrl || !providerConfig.apiKey) {
+                this.logger,
+            );
+            if (!resolved) {
                 return {
                     status: 'error',
                     tokensUsed: 0,
@@ -121,36 +126,18 @@ export class UserResearchService {
                     error: 'ai-provider-not-configured',
                 };
             }
-            const provider = createOpenAICompatible({
-                name: providerConfig.providerId,
-                baseURL: providerConfig.baseUrl,
-                apiKey: providerConfig.apiKey,
-            });
-            const modelName =
-                providerConfig.routing.complexModel ??
-                providerConfig.routing.mediumModel ??
-                providerConfig.defaultModel;
-            if (!modelName) {
-                return {
-                    status: 'error',
-                    tokensUsed: 0,
-                    toolCallsCount: 0,
-                    durationMs: Date.now() - startedAt,
-                    error: 'no-model-configured',
-                };
-            }
-            model = provider(modelName);
-            providerName = providerConfig.providerName ?? providerConfig.providerId;
+            resolvedModel = resolved.model;
+            providerName = resolved.providerName;
+            searchChain = await resolveSearchProviderIds(this.registry, userId);
         } catch (err) {
-            this.logger.warn(
-                `Could not resolve AI provider for user research: ${(err as Error).message}`,
-            );
+            const message = (err as Error).message;
+            this.logger.warn(`Provider resolution failed for ${userId}: ${message}`);
             return {
                 status: 'error',
                 tokensUsed: 0,
                 toolCallsCount: 0,
                 durationMs: Date.now() - startedAt,
-                error: 'ai-provider-error',
+                error: message,
             };
         }
 
@@ -171,7 +158,7 @@ export class UserResearchService {
             );
 
             const result = await generateText({
-                model,
+                model: resolvedModel,
                 system: USER_RESEARCH_AGENT_PROMPT,
                 prompt: seedPrompt,
                 tools: {
@@ -179,6 +166,7 @@ export class UserResearchService {
                         searchFacade: this.searchFacade,
                         limits: this.limits,
                         userId,
+                        providerChain: searchChain,
                         logger: this.logger,
                     }),
                     fetchPage: createFetchPageTool({

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { generateObject } from 'ai';
 import { AiFacadeService } from '../facades/ai.facade';
 import { UserRepository } from '../database/repositories/user.repository';
@@ -8,6 +7,7 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { WorkProposalRepository } from './work-proposal.repository';
 import { workProposalsBatchSchema, type WorkProposalsBatch } from './schemas';
 import { PROPOSALS_SYSTEM_PROMPT, buildProposalsPrompt } from './prompts';
+import { resolveAiProviderForResearch } from './provider-resolver';
 import {
     WorkProposalStatus,
     type WorkProposal,
@@ -68,16 +68,17 @@ export class WorkProposalService {
             .map((p) => p.plugin.id)
             .filter(Boolean);
 
+        let resolvedModel;
         let providerName: string;
         let modelName: string;
-        let tokensUsed = 0;
-        let parsed: WorkProposalsBatch;
-
         try {
-            const providerConfig = await this.aiFacade.getProviderConfig({
+            const resolved = await resolveAiProviderForResearch(
+                this.aiFacade,
+                this.registry,
                 userId,
-            });
-            if (!providerConfig.baseUrl || !providerConfig.apiKey) {
+                this.logger,
+            );
+            if (!resolved) {
                 return {
                     status: 'error',
                     proposals: [],
@@ -85,28 +86,21 @@ export class WorkProposalService {
                     error: 'ai-provider-not-configured',
                 };
             }
-            const provider = createOpenAICompatible({
-                name: providerConfig.providerId,
-                baseURL: providerConfig.baseUrl,
-                apiKey: providerConfig.apiKey,
-            });
-            modelName =
-                providerConfig.routing.complexModel ??
-                providerConfig.routing.mediumModel ??
-                providerConfig.defaultModel ??
-                '';
-            if (!modelName) {
-                return {
-                    status: 'error',
-                    proposals: [],
-                    tokensUsed: 0,
-                    error: 'no-model-configured',
-                };
-            }
-            providerName = providerConfig.providerName ?? providerConfig.providerId;
+            resolvedModel = resolved.model;
+            providerName = resolved.providerName;
+            modelName = resolved.modelName;
+        } catch (err) {
+            const message = (err as Error).message;
+            this.logger.warn(`Provider resolution failed for ${userId}: ${message}`);
+            return { status: 'error', proposals: [], tokensUsed: 0, error: message };
+        }
 
+        let tokensUsed = 0;
+        let parsed: WorkProposalsBatch;
+
+        try {
             const result = await generateObject({
-                model: provider(modelName),
+                model: resolvedModel,
                 schema: workProposalsBatchSchema,
                 system: PROPOSALS_SYSTEM_PROMPT,
                 prompt: buildProposalsPrompt(profile, existingWorkNames, availablePluginIds),

--- a/packages/plugins/k8s/src/__tests__/k8s-api.service.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s-api.service.spec.ts
@@ -26,6 +26,7 @@ function makeFactory(overrides: Partial<KubernetesClientFactory> = {}): {
 		createNamespace: ReturnType<typeof vi.fn>;
 		readNamespace: ReturnType<typeof vi.fn>;
 	};
+	objectApi: { patch: ReturnType<typeof vi.fn> };
 	createKubeConfig: ReturnType<typeof vi.fn>;
 } {
 	const versionApi = { getCode: vi.fn(async () => ({ gitVersion: 'v1.30.4', platform: 'linux/amd64' })) };
@@ -78,6 +79,7 @@ function makeFactory(overrides: Partial<KubernetesClientFactory> = {}): {
 		createNamespace: vi.fn(async () => undefined),
 		readNamespace: vi.fn(async () => undefined)
 	};
+	const objectApi = { patch: vi.fn(async () => undefined) };
 	const createKubeConfig = vi.fn(() => ({
 		loadFromString: vi.fn(),
 		setCurrentContext: vi.fn(),
@@ -90,10 +92,11 @@ function makeFactory(overrides: Partial<KubernetesClientFactory> = {}): {
 		networkingV1Api: () => networkingApi as never,
 		appsV1Api: () => appsApi as never,
 		coreV1Api: () => coreApi as never,
+		objectApi: () => objectApi as never,
 		...overrides
 	};
 
-	return { factory, versionApi, networkingApi, appsApi, coreApi, createKubeConfig };
+	return { factory, versionApi, networkingApi, appsApi, coreApi, objectApi, createKubeConfig };
 }
 
 describe('KubernetesApiService.validateConnection', () => {
@@ -232,27 +235,30 @@ describe('KubernetesApiService.listManagedDeployments', () => {
 });
 
 describe('KubernetesApiService SSA apply helpers', () => {
-	it('applyDeployment uses the field manager and force=true', async () => {
-		const { factory, appsApi } = makeFactory();
+	const SERVER_SIDE_APPLY = 'application/apply-patch+yaml';
+
+	it('applyDeployment uses Server-Side Apply with field manager and force=true', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
-		await svc.applyDeployment(VALID, {
+		const manifest = {
 			apiVersion: 'apps/v1',
 			kind: 'Deployment',
 			metadata: { name: 'site-a', namespace: 'ever-works' },
 			spec: {}
-		});
-		expect(appsApi.patchNamespacedDeployment).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: 'site-a',
-				namespace: 'ever-works',
-				fieldManager: FIELD_MANAGER,
-				force: true
-			})
+		};
+		await svc.applyDeployment(VALID, manifest);
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
 		);
 	});
 
-	it('applyService passes manifest body through to CoreV1', async () => {
-		const { factory, coreApi } = makeFactory();
+	it('applyService routes Server-Side Apply through the object API', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
 		const manifest = {
 			apiVersion: 'v1',
@@ -260,13 +266,18 @@ describe('KubernetesApiService SSA apply helpers', () => {
 			metadata: { name: 'site-a', namespace: 'ns' }
 		};
 		await svc.applyService(VALID, manifest);
-		expect(coreApi.patchNamespacedService).toHaveBeenCalledWith(
-			expect.objectContaining({ body: manifest, fieldManager: FIELD_MANAGER })
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
 		);
 	});
 
-	it('applyIngress passes manifest body through to NetworkingV1', async () => {
-		const { factory, networkingApi } = makeFactory();
+	it('applyIngress routes Server-Side Apply through the object API', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
 		const manifest = {
 			apiVersion: 'networking.k8s.io/v1',
@@ -274,13 +285,18 @@ describe('KubernetesApiService SSA apply helpers', () => {
 			metadata: { name: 'site-a', namespace: 'ns' }
 		};
 		await svc.applyIngress(VALID, manifest);
-		expect(networkingApi.patchNamespacedIngress).toHaveBeenCalledWith(
-			expect.objectContaining({ body: manifest, fieldManager: FIELD_MANAGER })
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
 		);
 	});
 
-	it('applyImagePullSecret patches the namespaced Secret', async () => {
-		const { factory, coreApi } = makeFactory();
+	it('applyImagePullSecret routes Server-Side Apply through the object API', async () => {
+		const { factory, objectApi } = makeFactory();
 		const svc = new KubernetesApiService(factory);
 		const manifest = {
 			apiVersion: 'v1',
@@ -288,7 +304,14 @@ describe('KubernetesApiService SSA apply helpers', () => {
 			metadata: { name: 'pull', namespace: 'ns' }
 		};
 		await svc.applyImagePullSecret(VALID, manifest);
-		expect(coreApi.patchNamespacedSecret).toHaveBeenCalled();
+		expect(objectApi.patch).toHaveBeenCalledWith(
+			manifest,
+			undefined,
+			undefined,
+			FIELD_MANAGER,
+			true,
+			SERVER_SIDE_APPLY
+		);
 	});
 });
 

--- a/packages/plugins/k8s/src/k8s-api.service.ts
+++ b/packages/plugins/k8s/src/k8s-api.service.ts
@@ -97,6 +97,24 @@ interface CoreV1ApiLike {
 }
 
 /**
+ * Subset of @kubernetes/client-node KubernetesObjectApi we depend on. Used
+ * for Server-Side Apply so we can specify Content-Type
+ * `application/apply-patch+yaml` and pass `force=true` — the typed
+ * patchNamespaced* methods on AppsV1Api/CoreV1Api/NetworkingV1Api default to
+ * Strategic Merge Patch, which rejects `force` with a 422.
+ */
+interface KubernetesObjectApiLike {
+	patch(
+		spec: Record<string, unknown>,
+		pretty?: string,
+		dryRun?: string,
+		fieldManager?: string,
+		force?: boolean,
+		patchStrategy?: string
+	): Promise<unknown>;
+}
+
+/**
  * Hook so tests can inject mock clients without dynamic-importing the real
  * `@kubernetes/client-node` package.
  */
@@ -106,7 +124,11 @@ export interface KubernetesClientFactory {
 	networkingV1Api(client: KubernetesApiClientLike): NetworkingV1ApiLike;
 	appsV1Api(client: KubernetesApiClientLike): AppsV1ApiLike;
 	coreV1Api(client: KubernetesApiClientLike): CoreV1ApiLike;
+	objectApi(client: KubernetesApiClientLike): KubernetesObjectApiLike;
 }
+
+/** Content-Type for Kubernetes Server-Side Apply patches. */
+const SERVER_SIDE_APPLY: string = 'application/apply-patch+yaml';
 
 /**
  * Default factory using the real `@kubernetes/client-node`.
@@ -156,6 +178,13 @@ export const defaultClientFactory: KubernetesClientFactory = {
 	coreV1Api(client) {
 		const k8s = k8sClientLoader();
 		return client.makeApiClient(k8s.CoreV1Api as never);
+	},
+	objectApi(client) {
+		const k8s = k8sClientLoader();
+		// KubernetesObjectApi.makeApiClient consumes the KubeConfig directly
+		// rather than going through makeApiClient(...), so it can pick up the
+		// default namespace from the current context.
+		return k8s.KubernetesObjectApi.makeApiClient(client as never) as unknown as KubernetesObjectApiLike;
 	}
 };
 
@@ -283,15 +312,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const apps = this.factory.appsV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await apps.patchNamespacedDeployment({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	async applyService(
@@ -300,15 +322,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const core = this.factory.coreV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await core.patchNamespacedService({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	/**
@@ -358,15 +373,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const net = this.factory.networkingV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await net.patchNamespacedIngress({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	async applyImagePullSecret(
@@ -375,15 +383,8 @@ export class KubernetesApiService {
 		contextOverride?: string
 	): Promise<void> {
 		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
-		const core = this.factory.coreV1Api(client);
-		const meta = (manifest.metadata as { name?: string; namespace?: string }) ?? {};
-		await core.patchNamespacedSecret({
-			name: meta.name ?? '',
-			namespace: meta.namespace ?? '',
-			body: manifest,
-			fieldManager: FIELD_MANAGER,
-			force: true
-		});
+		const objects = this.factory.objectApi(client);
+		await objects.patch(manifest, undefined, undefined, FIELD_MANAGER, true, SERVER_SIDE_APPLY);
 	}
 
 	async readIngress(


### PR DESCRIPTION
## Summary
Cascade of #728 from stage to main. Includes:
- #727: EW-608 follow-up cleanups (Greptile P1+P2 from PR #705)
- #719: fix(k8s-plugin) server-side apply
- #725: fix(onboarding) drop duplicated /api/ prefix from web client paths
- #724: feat(user-research) provider fallback chain across AI + search

🤖 Generated with [Claude Code](https://claude.com/claude-code)