### PR TITLE
test(e2e): bump default test timeout 30s -> 90s

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     retries: process.env.CI ? 2 : 0,
     workers: process.env.CI ? 1 : undefined,
     reporter: process.env.CI ? 'github' : 'html',
+    // First-hit dashboard routes hit Next.js dev-mode compilation (~10–15s
+    // each), and several spec files chain multiple such hits. 30s (Playwright
+    // default) leaves no headroom and produces "T" (timeout) bursts across
+    // the profile/settings sweep in CI. 90s removes the cold-compile cliff
+    // while keeping genuine hangs surfaced reasonably fast.
+    timeout: 90_000,
 
     use: {
         baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',


### PR DESCRIPTION
## Summary
Bumps Playwright's per-test timeout default from 30s (built-in) to 90s. The current 30s default is too tight for the authenticated dashboard sweep — first-hit Next.js dev-mode compilation takes ~10–15s per cold route, and several specs chain multiple cold hits. That's what's been producing the burst of \`T\` (timeout) markers in CI at indices ~120–150 (profile / settings / security-settings / settings-extra / settings).

No tests removed, no coverage limited — only the per-test budget moved.

Specs that already override their own timeout (\`auth.spec.ts\`, \`user-journey.spec.ts\`, \`dashboard-comprehensive.spec.ts\`, \`works-detail.spec.ts\`, \`settings-extra.spec.ts\`) sit above 90s already, so this is purely additive headroom.

## Test plan
- [ ] Next E2E run on develop hits significantly fewer T markers in the profile/settings sweep
- [ ] No new failures attributable to longer-running test slots