### PR TITLE
release(stage→main): EW-614 EverWorks Git wire-up + supporting fixes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,12 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubicloud-standard-8
-    timeout-minutes: 45
+    # 150 min covers the current 1-worker × 333-spec suite even with retries
+    # and slow specs. The prior 45-min ceiling was too tight: a single full
+    # run on develop hit the wall partway through. Keep the headroom while
+    # we work through suite-level test debt; revisit downward only once the
+    # suite consistently finishes well under it.
+    timeout-minutes: 150
 
     strategy:
       fail-fast: false

--- a/apps/api/src/activity-log/activity-log.listener.spec.ts
+++ b/apps/api/src/activity-log/activity-log.listener.spec.ts
@@ -119,7 +119,7 @@ describe('ActivityLogListener', () => {
     });
 
     describe('onWorkCreated', () => {
-        it('logs a WORK_CREATED activity with the correct fields', async () => {
+        it('logs a WORK_CREATED activity with the correct fields (no platform actor → no metadata)', async () => {
             const work: any = { id: 'w1', userId: 'u1', name: 'My Work' };
             await listener.onWorkCreated({ work } as WorkCreatedEvent);
 
@@ -130,6 +130,34 @@ describe('ActivityLogListener', () => {
                 action: 'work.created',
                 status: ActivityStatus.COMPLETED,
                 summary: 'Created work: My Work',
+                metadata: undefined,
+            });
+        });
+
+        it("EW-614: includes actor+repository metadata when the platform created the repo on the user's behalf", async () => {
+            const work: any = { id: 'w1', userId: 'u1', name: 'My Work' };
+            const platformActor = {
+                actorKind: 'platform' as const,
+                actor: 'ever-works-cloud',
+                repoFullName: 'ever-works-cloud/evereq-my-work',
+                htmlUrl: 'https://github.com/ever-works-cloud/evereq-my-work',
+            };
+            await listener.onWorkCreated({ work, platformActor } as WorkCreatedEvent);
+
+            expect(activityLogService.log).toHaveBeenCalledWith({
+                userId: 'u1',
+                workId: 'w1',
+                actionType: ActivityActionType.WORK_CREATED,
+                action: 'work.created',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Created work: My Work',
+                metadata: {
+                    actor: { kind: 'platform', id: 'ever-works-cloud' },
+                    repository: {
+                        fullName: 'ever-works-cloud/evereq-my-work',
+                        htmlUrl: 'https://github.com/ever-works-cloud/evereq-my-work',
+                    },
+                },
             });
         });
 

--- a/apps/api/src/activity-log/activity-log.listener.ts
+++ b/apps/api/src/activity-log/activity-log.listener.ts
@@ -30,6 +30,24 @@ export class ActivityLogListener {
     @OnEvent(WorkCreatedEvent.EVENT_NAME)
     async onWorkCreated(event: WorkCreatedEvent) {
         try {
+            // When the platform provisions the underlying repo on the user's
+            // behalf (EW-614 — "Ever Works Git" storage), the event carries a
+            // `platformActor` payload. We record it under `metadata.actor` so
+            // the activity-log UI can show "Ever Works (on your behalf)"
+            // instead of attributing the action to the user alone.
+            const metadata = event.platformActor
+                ? {
+                      actor: {
+                          kind: event.platformActor.actorKind,
+                          id: event.platformActor.actor,
+                      },
+                      repository: {
+                          fullName: event.platformActor.repoFullName,
+                          htmlUrl: event.platformActor.htmlUrl,
+                      },
+                  }
+                : undefined;
+
             await this.activityLogService.log({
                 userId: event.work.userId,
                 workId: event.work.id,
@@ -37,6 +55,7 @@ export class ActivityLogListener {
                 action: 'work.created',
                 status: ActivityStatus.COMPLETED,
                 summary: `Created work: ${event.work.name}`,
+                metadata,
             });
         } catch (error) {
             this.logger.error('Failed to log work created activity:', error);

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -98,8 +98,34 @@ export function DashboardLayoutClient({
     const shouldAutoOpenOnboarding =
         onboardingTotalWorks === 0 && !isOnboardingDismissed && !isOnboardingCompleted;
     const isOnboardingOpen = onboardingOpenManually || shouldAutoOpenOnboarding;
+    // Track header-badge dismissal separately from wizard dismissal — both share
+    // `dismissedAt` on the server, but dismissing the badge X must not require
+    // marking onboarding as completed, and dismissing the wizard must leave the
+    // badge visible. v1 kept the same split as `headerDismissed` in localStorage;
+    // keep the client-only convention to avoid an API/DB migration.
+    const headerDismissedKey = `ever-works-onboarding-header-dismissed:${user.id}`;
+    const [headerDismissed, setHeaderDismissed] = useState(false);
+    // Gate the badge on hydration so users who previously dismissed don't see
+    // a one-frame flash of the badge before the useEffect reads localStorage.
+    // Trade-off: all users see ~one frame without the badge instead — that's a
+    // strictly better failure mode for an informational element.
+    const [headerHydrated, setHeaderHydrated] = useState(false);
+    useEffect(() => {
+        try {
+            if (typeof window !== 'undefined') {
+                setHeaderDismissed(window.localStorage.getItem(headerDismissedKey) === '1');
+            }
+        } catch {
+            // localStorage unavailable (private mode, quota) — leave default.
+        }
+        setHeaderHydrated(true);
+    }, [headerDismissedKey]);
     const showOnboardingBadge =
-        onboardingTotalWorks === 0 && isOnboardingDismissed && !isOnboardingCompleted;
+        headerHydrated &&
+        onboardingTotalWorks === 0 &&
+        isOnboardingDismissed &&
+        !isOnboardingCompleted &&
+        !headerDismissed;
 
     const setChatOpen = useCallback((value: boolean, resetOnOpen = true) => {
         setChatOpenRaw(value);
@@ -235,12 +261,21 @@ export function DashboardLayoutClient({
         void dismissOnboarding();
     }, []);
     const dismissOnboardingBadge = useCallback(() => {
+        setHeaderDismissed(true);
+        try {
+            if (typeof window !== 'undefined') {
+                window.localStorage.setItem(headerDismissedKey, '1');
+            }
+        } catch {
+            // localStorage unavailable; state update alone hides the badge for
+            // this session, which is still better than the prior no-op.
+        }
         setOnboardingState((prev) => ({
             ...prev,
             dismissedAt: prev.dismissedAt ?? new Date().toISOString(),
         }));
         void dismissOnboarding();
-    }, []);
+    }, [headerDismissedKey]);
 
     // Ensure chat is in resizable (non-expanded) mode. Used when user interacts
     // with the sidebar so we collapse the expanded view back to the resizable width.

--- a/docs/specs/features/onboarding-wizard-v2/ew-614-storage-wireup.md
+++ b/docs/specs/features/onboarding-wizard-v2/ew-614-storage-wireup.md
@@ -1,0 +1,205 @@
+# EW-614 — Wire EverWorksGitProvider into createWork
+
+> **Status**: implemented (2026-05-13). This document is the in-tree
+> companion to the Jira ticket [EW-614]. It describes what the wire-up
+> changes, where, and how to verify.
+
+EW-608 shipped the choice-driven onboarding wizard plus an env-gated
+`EverWorksGitProvider` service. The provider was built and unit-tested but
+**never called** — `work.storageProvider = 'ever-works-git'` was persisted
+but the runtime repo create still fell through to the user's GitHub OAuth
+via the existing git facade. EW-614 closes that gap end-to-end.
+
+After this change, picking **Ever Works Git** in the wizard produces a
+real private repository under
+[github.com/ever-works-cloud](https://github.com/ever-works-cloud), pushed
+to with the platform PAT (see `EVER_WORKS_CUSTOMERS_GITHUB_PAT`), never
+the user's personal credentials.
+
+---
+
+## 1. Scope at a glance
+
+| Piece                     | Where                                                                                                                  | What changes                                                                                                                                                                                                                                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Pre-create**         | `packages/agent/src/services/work-lifecycle.service.ts::createWork`                                                    | If `storageProvider==='ever-works-git'` AND `everWorksGit.isEnabled()`, pre-generate the Work UUID and call `EverWorksGitProvider.createRepository(...)` BEFORE the DB insert. Override `workData.owner`/`organization`/`sourceRepository.relatedRepositories.work` from the provider response. |
+| **B. Token resolver**     | `packages/agent/src/facades/git.facade.ts::resolvePluginAndToken`                                                      | New short-circuit at the top of the resolver: when `options.workId` belongs to an `ever-works-git` Work AND the env flag is on, return the platform PAT before any user-OAuth lookup. Transparently routes ALL git-facade methods (create, push, pull, status, getRepository, ...).             |
+| **C. Activity-log actor** | `packages/agent/src/events/work-created.event.ts` + `apps/api/src/activity-log/activity-log.listener.ts`               | `WorkCreatedEvent` gains an optional `platformActor` payload. The activity-log listener forwards it under `metadata.actor` / `metadata.repository` so audit rows distinguish "platform acted on user's behalf" from a regular user-initiated create.                                            |
+| **D. Tests**              | `work-lifecycle.create-defaults.spec.ts`, `git.facade.spec.ts`, `activity-log.listener.spec.ts`, `work.module.spec.ts` | 11 new unit tests covering the platform-PAT happy path, flag-off fallback, non-ever-works-git fallback, missing-workId fallback, transient DB blip fallback, direct-token-wins precedence, and provider-error → HTTP-exception mapping.                                                         |
+| **E. Update guard**       | `packages/agent/src/dto/update-work.dto.ts` (no change needed)                                                         | `UpdateWorkDto` already omits `storageProvider`, and the global `ValidationPipe` is `whitelist: true`. Clients cannot mutate the field after create.                                                                                                                                            |
+
+> "Piece D — schema-level `actorKind` column on `activity_log`" was
+> filed as out-of-scope on the original EW-614 ticket (waiting for ≥2
+> non-user actor kinds before paying for the schema migration). The
+> metadata-JSONB path is sufficient today.
+
+---
+
+## 2. Why pre-create the repo BEFORE the DB insert
+
+Two reasons:
+
+1. **No orphan DB rows.** If GitHub rejects the create (rate-limit, org PAT
+   revoked, network blip), the Work never enters our DB, so a retry by the
+   user gets a clean slate.
+2. **`relatedRepositories.work` captures the actual repo name.** The
+   provider's collision-suffix path (`-{shortId}`) means the resolved repo
+   name can differ from the user's `slug`. Pre-creating lets us persist
+   the full coordinates in `sourceRepository` on the first DB write,
+   without a follow-up UPDATE.
+
+The Work UUID is pre-generated with `node:crypto.randomUUID()` and passed
+to the provider so its collision-suffix derivation
+(`work.id.replace(/-/g, '').slice(0, 7)`) is deterministic; the same UUID
+is then handed to TypeORM as the row's `id`.
+
+### Failure cleanup
+
+The DB insert can still fail AFTER the GitHub repo was created (slug
+collision on `(userId, owner, slug)`, transient DB blip). When that
+happens today the `ever-works-cloud` repo is left orphaned. We didn't add
+a compensating delete because:
+
+- The slug-collision branch in `workRepository.create` was already a
+  user-visible error before EW-614; one orphaned repo every few thousand
+  creates is acceptable.
+- A best-effort `EverWorksGitProvider.deleteRepository` doesn't exist
+  yet; adding it just for this rollback widens the surface unnecessarily.
+- A cleanup cron over `ever-works-cloud` repos with no matching Work row
+  is a better long-term fix.
+
+Tracked as a follow-up cleanup task on the EW-614 close-out comment.
+
+---
+
+## 3. Why the git-facade hook lives in `resolvePluginAndToken`
+
+Every git-facade method (`createRepository`, `push`, `pull`, `status`,
+`getRepository`, `hasRepositoryAccess`, ...) funnels through
+`resolvePluginAndToken(options)`. Adding the platform-PAT short-circuit at
+the top of that one method gives us:
+
+- **Single edit point** — no need to teach each facade method about
+  storage-provider semantics.
+- **No new API surface** — the existing `GitFacadeOptions.workId` already
+  flows through. Callers that don't pass `workId` (one-off lookups against
+  arbitrary repos) get unchanged behaviour.
+- **Test coverage via existing methods** — we exercise `createRepository`
+  in the new tests; the same short-circuit fires for `push`/`pull`/etc.
+
+The resolver returns `null` (falls through to existing OAuth/PAT logic)
+when ANY of these is true:
+
+- `options.workId` is unset
+- `STORAGE_EVER_WORKS_GIT_ENABLED` is off
+- The Work doesn't exist or has a different `storageProvider`
+- `EVER_WORKS_CUSTOMERS_GITHUB_PAT` is empty (misconfig safety)
+- `workRepository.findById` throws (transient DB blip)
+
+The last point — fall through on DB error — matches "what the user sees
+when the feature is off" and avoids crashing every git call when the
+Work-table read blips.
+
+---
+
+## 4. Activity-log payload
+
+When the platform creates the repo, the `WorkCreatedEvent` is emitted
+with a `platformActor` payload:
+
+```ts
+new WorkCreatedEvent(work, {
+	actorKind: 'platform',
+	actor: 'ever-works-cloud',
+	repoFullName: 'ever-works-cloud/evereq-my-work',
+	htmlUrl: 'https://github.com/ever-works-cloud/evereq-my-work'
+});
+```
+
+The listener records it under `metadata`:
+
+```json
+{
+	"actor": { "kind": "platform", "id": "ever-works-cloud" },
+	"repository": {
+		"fullName": "ever-works-cloud/evereq-my-work",
+		"htmlUrl": "https://github.com/ever-works-cloud/evereq-my-work"
+	}
+}
+```
+
+A regular user-initiated create (any non-Ever-Works-Git storage) still
+fires `WorkCreatedEvent` — we now emit it unconditionally, fixing a
+gap where the event was wired but never raised — and the activity row's
+`metadata` is `undefined`. Down-stream consumers (`activity-log.listener`,
+`work-created.listener` for user-research learning) handle both shapes.
+
+---
+
+## 5. Error mapping
+
+`EverWorksGitProvider` throws typed errors. `WorkLifecycleService` maps
+them to HTTP-shaped NestJS exceptions so controllers don't have to:
+
+| Provider error                   | HTTP exception                      | When it fires                                                                                                                                 |
+| -------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EverWorksGitDisabledError`      | `BadRequestException` (400)         | Feature flag was on at `resolveProviderDefaults` time but off by the time the provider executed — should be impossible, but mapped for safety |
+| `EverWorksGitMisconfiguredError` | `ServiceUnavailableException` (503) | PAT empty or org empty mid-flight (env was misconfigured between API startup and now)                                                         |
+| `EverWorksGitRequestError`       | `ServiceUnavailableException` (503) | GitHub returned a non-2xx (rate-limit, 5xx, both `{user}-{slug}` AND `{user}-{slug}-{shortId}` already taken in the org)                      |
+
+The Work is NOT persisted in any of these cases (the provider call comes
+before `workRepository.create`).
+
+---
+
+## 6. Configuration touchpoints (unchanged from EW-608)
+
+All env values are inherited from the EW-608 wiring (PR #721) — nothing
+new in `.env.example`, the k8s manifests, or the deploy workflows.
+
+```env
+STORAGE_EVER_WORKS_GIT_ENABLED=true            # gate
+EVER_WORKS_CUSTOMERS_GITHUB_ORG=ever-works-cloud
+EVER_WORKS_CUSTOMERS_GITHUB_PAT=github_pat_…    # secret (GH Actions)
+EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY=private
+```
+
+See `docs/specs/features/onboarding-wizard-v2/deployment.md` §1 for the
+rotation runbook.
+
+---
+
+## 7. Smoke-test recipe (post-cascade)
+
+On any env (dev/stage/prod) with the flag enabled:
+
+1. Register a fresh user via `POST /api/auth/register`.
+2. Drive the wizard with default storage (Ever Works Git) OR call
+   `POST /api/works { slug, name, description, storageProvider: 'ever-works-git' }`
+   directly.
+3. Verify the response: `work.owner === 'ever-works-cloud'`,
+   `work.organization === true`, `work.sourceRepository.relatedRepositories.work`
+   set.
+4. `GET https://github.com/orgs/ever-works-cloud/repositories` →
+   the new private repo appears with name `{user-slug}-{work-slug}`.
+5. `GET /api/activity-log?workId={id}` → the WORK_CREATED row's
+   `metadata` matches §4.
+6. Trigger any downstream git op (e.g. generate items, push README) —
+   confirm the operation lands in `ever-works-cloud` and NOT the user's
+   personal GitHub.
+7. Clean up: delete the repo via the API (uses the platform PAT
+   transparently) + delete the test user.
+
+---
+
+## 8. Out-of-scope
+
+- Switching `storageProvider` after Work creation. UI doesn't expose it
+  and `UpdateWorkDto` doesn't accept it. Future ticket if needed.
+- The "Ever Works Deploy" equivalent — blocked on `k8s-works` cluster +
+  SSL termination, which is owner-provisioned separately.
+- Moving the platform PAT to a GitHub App installation token (cleaner
+  long-term, eliminates manual PAT rotation). Separate ticket.
+- Schema-level `actor_kind` column on `activity_log`. Metadata-JSONB is
+  enough until we have ≥2 non-user actor kinds.
+- Orphan-repo cleanup cron (see §2 "Failure cleanup").

--- a/docs/specs/features/onboarding-wizard-v2/tasks.md
+++ b/docs/specs/features/onboarding-wizard-v2/tasks.md
@@ -148,15 +148,26 @@ them forward (apps/web Vitest runner, Playwright wizard spec, brand SVGs,
 `WorksService.create` wire-up). Items still requiring ops action are
 documented in [`./deployment.md`](./deployment.md):
 
-- [ ] **T60**. Create the `ever-works-cloud` GitHub PAT (manual web-UI
+- [x] **T60**. Create the `ever-works-cloud` GitHub PAT (manual web-UI
       step — GitHub disallows API creation; see deployment.md §1.3); store
       in k8s + GH-Actions secrets; flip `STORAGE_EVER_WORKS_GIT_ENABLED=true`.
-- [ ] **T61**. Push the `do-sfo2-k8s-ever` kubeconfig into the API
+      _Shipped 2026-05-12 via PR #721._
+- [ ] **T61**. Push the `k8s-works` kubeconfig into the API
       deployment secret as `EVER_WORKS_DEPLOY_KUBECONFIG`; flip
-      `DEPLOY_EVER_WORKS_ENABLED=true` (see deployment.md §2).
-- [ ] **T62**. Admin override for the 3-Work cap (lifts the limit for a
+      `DEPLOY_EVER_WORKS_ENABLED=true` (see deployment.md §2). _Blocked
+      on `k8s-works` cluster + SSL termination being owner-provisioned._
+- [x] **T62**. Wire `EverWorksGitProvider` into `WorkLifecycleService.createWork`
+      so picking "Ever Works Git" actually publishes to `ever-works-cloud`
+      via the platform PAT (not the user's OAuth). _Shipped 2026-05-13 via
+      EW-614 — see [`./ew-614-storage-wireup.md`](./ew-614-storage-wireup.md)._
+- [ ] **T63**. Admin override for the 3-Work cap (lifts the limit for a
       specific user — useful for internal Ever Works staff demoing the flow).
-- [ ] **T63**. Cost reporting / per-user usage panel for Ever Works Deploy.
-- [ ] **T64**. Migrate `EverWorksGitProvider` to the GitHub App
+- [ ] **T64**. Cost reporting / per-user usage panel for Ever Works Deploy.
+- [ ] **T65**. Migrate `EverWorksGitProvider` to the GitHub App
       installation-token path so we don't rely on a long-lived PAT (the App
-      is already installed for user GitHub flows).
+      is already installed for user GitHub flows). Tracked as a follow-up
+      on EW-614.
+- [ ] **T66**. Orphan-repo cleanup cron over `ever-works-cloud` repos
+      with no matching Work row (handles the rare slug-collision rollback
+      case where the GitHub repo was created but the DB insert failed —
+      see EW-614 wire-up doc §2).

--- a/packages/agent/src/events/work-created.event.ts
+++ b/packages/agent/src/events/work-created.event.ts
@@ -1,10 +1,33 @@
 import { Work } from '@src/entities';
 import { BaseEvent } from './base';
 
+/**
+ * Optional metadata describing a non-user actor that caused the Work to be
+ * created. Today this is set only when the platform creates the underlying
+ * GitHub repository on the user's behalf via `EverWorksGitProvider` (the
+ * "Ever Works Git" storage choice — see EW-614). Downstream listeners
+ * (activity log) record this so the audit trail distinguishes
+ * "platform created this repo for the user" from "user created this repo
+ * with their own OAuth token".
+ */
+export interface WorkCreatedPlatformActor {
+    /** Stable kind tag: `'platform'` today. Extend if more actor kinds appear. */
+    readonly actorKind: 'platform';
+    /** Logical actor identifier — e.g. `'ever-works-cloud'` (the GitHub org). */
+    readonly actor: string;
+    /** `{owner}/{repo}` of the repo that was provisioned. */
+    readonly repoFullName: string;
+    /** Repo HTML URL — useful for activity-log UI links. */
+    readonly htmlUrl: string;
+}
+
 export class WorkCreatedEvent extends BaseEvent {
     static EVENT_NAME = 'work.created';
 
-    constructor(public readonly work: Work) {
+    constructor(
+        public readonly work: Work,
+        public readonly platformActor?: WorkCreatedPlatformActor,
+    ) {
         super();
     }
 }

--- a/packages/agent/src/facades/__tests__/git.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.spec.ts
@@ -928,6 +928,207 @@ describe('GitFacadeService', () => {
         });
     });
 
+    // ─────────────────────────────────────────────────────────────────────
+    // EW-614 — resolvePluginAndToken: platform-PAT routing for
+    // Works whose `storageProvider === 'ever-works-git'`.
+    //
+    // The hook short-circuits BEFORE any user-credential lookup so:
+    //   - createRepository, push, pull, status, getRepository, etc.
+    //     all transparently target the platform org with the platform PAT
+    //   - the user's personal GitHub OAuth is never touched for these Works
+    //
+    // Tested via `createRepository` because it goes through
+    // `resolvePluginAndToken` and lets us assert the token passed downstream.
+    // ─────────────────────────────────────────────────────────────────────
+    describe('EW-614 — resolvePluginAndToken: ever-works-git platform-PAT routing', () => {
+        const PLATFORM_PAT = 'github_pat_test_platform_value';
+        const previousFlag = process.env.STORAGE_EVER_WORKS_GIT_ENABLED;
+        const previousPat = process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT;
+
+        afterEach(() => {
+            if (previousFlag === undefined) delete process.env.STORAGE_EVER_WORKS_GIT_ENABLED;
+            else process.env.STORAGE_EVER_WORKS_GIT_ENABLED = previousFlag;
+            if (previousPat === undefined) delete process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT;
+            else process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = previousPat;
+        });
+
+        function setupGithubPlugin() {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+            return gitPlugin;
+        }
+
+        it('routes the platform PAT when work.storageProvider==="ever-works-git" AND flag on', async () => {
+            process.env.STORAGE_EVER_WORKS_GIT_ENABLED = 'true';
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = PLATFORM_PAT;
+
+            const gitPlugin = setupGithubPlugin();
+            workRepository.findById.mockResolvedValue({
+                id: 'work-1',
+                storageProvider: 'ever-works-git',
+            } as never);
+
+            await service.createRepository(
+                { name: 'ever-works-cloud-repo', isPrivate: true },
+                { providerId: 'github', userId: 'user-1', workId: 'work-1' },
+            );
+
+            // Platform PAT was passed to the plugin, NOT a user OAuth token.
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'ever-works-cloud-repo', isPrivate: true },
+                PLATFORM_PAT,
+            );
+            // User-OAuth lookup path was NOT touched.
+            expect(authAccountRepository.findConnectedProviderAccount).not.toHaveBeenCalled();
+        });
+
+        it('falls through to user OAuth/PAT when the flag is OFF (even with matching storageProvider)', async () => {
+            delete process.env.STORAGE_EVER_WORKS_GIT_ENABLED;
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = PLATFORM_PAT;
+
+            const gitPlugin = setupGithubPlugin();
+            authAccountRepository.findConnectedProviderAccount.mockResolvedValue(
+                createMockProviderAccount({ accessToken: 'user-oauth-token' }),
+            );
+
+            await service.createRepository(
+                { name: 'repo', isPrivate: false },
+                { providerId: 'github', userId: 'user-1', workId: 'work-1' },
+            );
+
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'repo', isPrivate: false },
+                'user-oauth-token',
+            );
+        });
+
+        it('falls through to user OAuth/PAT when storageProvider is NOT "ever-works-git"', async () => {
+            process.env.STORAGE_EVER_WORKS_GIT_ENABLED = 'true';
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = PLATFORM_PAT;
+
+            const gitPlugin = setupGithubPlugin();
+            workRepository.findById.mockResolvedValue({
+                id: 'work-1',
+                storageProvider: 'user-github',
+            } as never);
+            authAccountRepository.findConnectedProviderAccount.mockResolvedValue(
+                createMockProviderAccount({ accessToken: 'user-oauth-token' }),
+            );
+
+            await service.createRepository(
+                { name: 'repo', isPrivate: false },
+                { providerId: 'github', userId: 'user-1', workId: 'work-1' },
+            );
+
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'repo', isPrivate: false },
+                'user-oauth-token',
+            );
+        });
+
+        it('falls through when no workId is provided (one-off facade calls)', async () => {
+            process.env.STORAGE_EVER_WORKS_GIT_ENABLED = 'true';
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = PLATFORM_PAT;
+
+            const gitPlugin = setupGithubPlugin();
+            authAccountRepository.findConnectedProviderAccount.mockResolvedValue(
+                createMockProviderAccount({ accessToken: 'user-oauth-token' }),
+            );
+
+            await service.createRepository(
+                { name: 'repo', isPrivate: false },
+                { providerId: 'github', userId: 'user-1' },
+            );
+
+            expect(workRepository.findById).not.toHaveBeenCalled();
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'repo', isPrivate: false },
+                'user-oauth-token',
+            );
+        });
+
+        it('falls through when PAT env var is empty (misconfig safety)', async () => {
+            process.env.STORAGE_EVER_WORKS_GIT_ENABLED = 'true';
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = '';
+
+            const gitPlugin = setupGithubPlugin();
+            workRepository.findById.mockResolvedValue({
+                id: 'work-1',
+                storageProvider: 'ever-works-git',
+            } as never);
+            authAccountRepository.findConnectedProviderAccount.mockResolvedValue(
+                createMockProviderAccount({ accessToken: 'user-oauth-token' }),
+            );
+
+            await service.createRepository(
+                { name: 'repo', isPrivate: false },
+                { providerId: 'github', userId: 'user-1', workId: 'work-1' },
+            );
+
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'repo', isPrivate: false },
+                'user-oauth-token',
+            );
+        });
+
+        it('falls through when workRepository.findById throws (transient DB blip)', async () => {
+            process.env.STORAGE_EVER_WORKS_GIT_ENABLED = 'true';
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = PLATFORM_PAT;
+
+            const gitPlugin = setupGithubPlugin();
+            // The new EW-614 helper swallows the error and returns null. Use
+            // `mockRejectedValueOnce` so the existing `getInstallationTokenForWork`
+            // path (which also calls findById downstream) doesn't get nuked
+            // by the same mock — its own missing-work path returns null.
+            workRepository.findById.mockRejectedValueOnce(new Error('db blip'));
+            workRepository.findById.mockResolvedValue(null);
+            authAccountRepository.findConnectedProviderAccount.mockResolvedValue(
+                createMockProviderAccount({ accessToken: 'user-oauth-token' }),
+            );
+
+            await service.createRepository(
+                { name: 'repo', isPrivate: false },
+                { providerId: 'github', userId: 'user-1', workId: 'work-1' },
+            );
+
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'repo', isPrivate: false },
+                'user-oauth-token',
+            );
+        });
+
+        it('preserves direct-token-wins precedence (options.token > platform PAT)', async () => {
+            process.env.STORAGE_EVER_WORKS_GIT_ENABLED = 'true';
+            process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT = PLATFORM_PAT;
+
+            const gitPlugin = setupGithubPlugin();
+            workRepository.findById.mockResolvedValue({
+                id: 'work-1',
+                storageProvider: 'ever-works-git',
+            } as never);
+
+            await service.createRepository(
+                { name: 'repo', isPrivate: false },
+                {
+                    providerId: 'github',
+                    userId: 'user-1',
+                    workId: 'work-1',
+                    token: 'explicit-token-wins',
+                },
+            );
+
+            expect(gitPlugin.createRepository).toHaveBeenCalledWith(
+                { name: 'repo', isPrivate: false },
+                'explicit-token-wins',
+            );
+            expect(workRepository.findById).not.toHaveBeenCalled();
+        });
+    });
+
     describe('deleteRepository', () => {
         it('should call plugin.deleteRepository', async () => {
             const gitPlugin = createMockGitPlugin('github', 'GitHub');

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -823,6 +823,17 @@ export class GitFacadeService implements IGitFacade {
             return { plugin, token: options.token };
         }
 
+        // EW-614 — when the Work was created via "Ever Works Git" storage,
+        // the underlying repo lives in the platform org (`ever-works-cloud`)
+        // and the user's personal OAuth token cannot reach it. Short-circuit
+        // to the platform PAT BEFORE any user-credential lookup. Works
+        // transparently for every git-facade method that takes `workId`
+        // (createRepository, push, pull, status, getRepository, ...).
+        const platformToken = await this.tryResolveEverWorksGitPlatformToken(options);
+        if (platformToken) {
+            return { plugin, token: platformToken };
+        }
+
         if (!options.userId) {
             throw new GitFacadeError(
                 'No token provided and no userId for credential lookup',
@@ -869,6 +880,39 @@ export class GitFacadeService implements IGitFacade {
         } catch {
             return null;
         }
+    }
+
+    /**
+     * EW-614 — return the platform PAT when the Work's `storageProvider`
+     * is `'ever-works-git'` AND the global env flag is on. Returns `null`
+     * when:
+     *   - no `workId` is provided (one-off facade calls without a Work),
+     *   - the Work doesn't exist or has a different storageProvider,
+     *   - the feature flag is off, or
+     *   - the PAT env var is empty.
+     *
+     * Short-lived `repo lookup` failures (DB transient errors) are swallowed
+     * — falling through to the existing user-OAuth resolution path is the
+     * safer default than crashing every git call when the Work-table read
+     * blips. The resulting behaviour matches what callers see when the flag
+     * is off: regular OAuth/PAT lookup.
+     */
+    private async tryResolveEverWorksGitPlatformToken(
+        options: GitFacadeOptions,
+    ): Promise<string | null> {
+        if (!options.workId) return null;
+        if (!config.everWorks.git.isEnabled()) return null;
+
+        let work;
+        try {
+            work = await this.workRepository.findById(options.workId);
+        } catch {
+            return null;
+        }
+        if (!work || work.storageProvider !== 'ever-works-git') return null;
+
+        const pat = config.everWorks.git.getPat();
+        return pat || null;
     }
 
     private async resolvePlugin(

--- a/packages/agent/src/items-generator/item-import-executor.service.spec.ts
+++ b/packages/agent/src/items-generator/item-import-executor.service.spec.ts
@@ -213,6 +213,41 @@ describe('ItemImportExecutorService', () => {
         expect(result.created).toBe(0);
     });
 
+    it("rewrites slug to existing item's when matched only by source_url ('update' strategy)", async () => {
+        const work = makeWork();
+        const git = makeGitFacade();
+        const repo = makeDataRepo({
+            getItems: jest
+                .fn()
+                .mockResolvedValue([
+                    { slug: 'existing-tool', source_url: 'https://shared.test/x' },
+                ]),
+        });
+        dataRepoCreateMock.mockResolvedValue(repo);
+        const service = new ItemImportExecutorService(git as any, itemImportService);
+
+        // Incoming row's slug ('incoming-tool') differs from the existing
+        // item's slug ('existing-tool'), but their source_url matches.
+        // writeItem must target 'existing-tool' — otherwise the update
+        // hits a non-existent directory because updates skip createItemDir.
+        await service.executeImport(work as any, { id: 'u-1' } as any, {
+            rows: [
+                row(0, {
+                    name: 'Incoming Tool',
+                    slug: 'incoming-tool',
+                    source_url: 'https://shared.test/x',
+                }),
+            ],
+            duplicate_strategy: 'update',
+        });
+
+        expect(repo.createItemDir).not.toHaveBeenCalled();
+        expect(repo.writeItem).toHaveBeenCalledTimes(1);
+        const writeArg = (repo.writeItem as jest.Mock).mock.calls[0][0];
+        expect(writeArg.slug).toBe('existing-tool');
+        expect(writeArg.source_url).toBe('https://shared.test/x');
+    });
+
     it('collects per-row errors without aborting the batch and still commits the successes', async () => {
         const work = makeWork();
         const git = makeGitFacade();

--- a/packages/agent/src/items-generator/item-import-executor.service.ts
+++ b/packages/agent/src/items-generator/item-import-executor.service.ts
@@ -83,9 +83,18 @@ export class ItemImportExecutorService {
         );
         const existingSlugs = new Set<string>();
         const existingUrls = new Set<string>();
+        // Map source_url → existing item's slug. When `duplicate_strategy=update`
+        // matches a row by URL only and the incoming row's slug differs from
+        // the existing item's directory, the update must target the existing
+        // slug — otherwise `writeItem` (which skips `createItemDir` on update)
+        // tries to write into a directory that doesn't exist.
+        const urlToExistingSlug = new Map<string, string>();
         for (const item of existingItems) {
             if (item.slug) existingSlugs.add(item.slug);
-            if (item.source_url) existingUrls.add(item.source_url);
+            if (item.source_url) {
+                existingUrls.add(item.source_url);
+                if (item.slug) urlToExistingSlug.set(item.source_url, item.slug);
+            }
         }
 
         const defaultBranch = await this.gitFacade.getMainBranch(provider, dest);
@@ -156,13 +165,22 @@ export class ItemImportExecutorService {
                     skippedCount += 1;
                     continue;
                 }
-                plan.push({ kind: 'update', rowIndex: row.rowIndex, itemData });
+                const matchedBySlug = slug.length > 0 && existingSlugs.has(slug);
+                const sourceUrl =
+                    typeof itemData.source_url === 'string' ? itemData.source_url : undefined;
+                // If the row matched only by source_url and the incoming slug
+                // differs from the existing item's directory, rewrite the slug
+                // so `writeItem` targets the correct existing directory.
+                const existingSlug = sourceUrl ? urlToExistingSlug.get(sourceUrl) : undefined;
+                const updateData: MutableItemData =
+                    !matchedBySlug && existingSlug && existingSlug !== slug
+                        ? { ...itemData, slug: existingSlug }
+                        : itemData;
+                plan.push({ kind: 'update', rowIndex: row.rowIndex, itemData: updateData });
                 // Even on update, mark the URL as taken so a subsequent row
                 // with the same source_url is also routed to update / skip
                 // instead of trying to create a fresh item directory.
-                if (typeof itemData.source_url === 'string') {
-                    existingUrls.add(itemData.source_url);
-                }
+                if (sourceUrl) existingUrls.add(sourceUrl);
                 continue;
             }
 

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -49,6 +49,8 @@ interface MockDeps {
     workRepo: { create: jest.Mock; updateGenerateStatus: jest.Mock };
     userRepo: { findById: jest.Mock };
     quota: { assertWithinQuota: jest.Mock };
+    everWorksGit: { isEnabled: jest.Mock; createRepository: jest.Mock };
+    eventEmitter: { emit: jest.Mock };
 }
 
 function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
@@ -57,9 +59,9 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
 } {
     const workRepo = {
         create: jest.fn(async (data: Record<string, unknown>) => ({
-            id: 'w-1',
+            id: (data.id as string) ?? 'w-1',
             ...data,
-            getRepoOwner: () => 'evereq',
+            getRepoOwner: () => (data.owner as string) ?? 'evereq',
         })),
         updateGenerateStatus: jest.fn().mockResolvedValue(undefined),
     };
@@ -73,6 +75,14 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
         getDefaultTemplateIdForUser: jest.fn().mockResolvedValue(null),
     };
     const quota = { assertWithinQuota: jest.fn().mockResolvedValue(undefined) };
+
+    // EW-614 — `EverWorksGitProvider` is called from `createWork` when
+    // `storageProvider === 'ever-works-git'` AND `isEnabled()` returns true.
+    // Default the mock to disabled; individual tests flip it on as needed.
+    const everWorksGit = {
+        isEnabled: jest.fn().mockReturnValue(false),
+        createRepository: jest.fn(),
+    };
 
     const eventEmitter = { emit: jest.fn() };
 
@@ -88,10 +98,11 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
         templateCatalog as never,
         {} as never,
         quota as never,
+        everWorksGit as never,
         eventEmitter as never,
     );
 
-    return { service, deps: { workRepo, userRepo, quota } };
+    return { service, deps: { workRepo, userRepo, quota, everWorksGit, eventEmitter } };
 }
 
 describe('WorkLifecycleService.createWork — provider defaults + quota', () => {
@@ -289,5 +300,176 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
 
         const persisted = deps.workRepo.create.mock.calls[0][0];
         expect(persisted.gitProvider).toBe('github');
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // EW-614 — EverWorksGitProvider wire-up
+    //
+    // When `storageProvider==='ever-works-git'` AND `everWorksGit.isEnabled()`
+    // is true, `createWork` MUST:
+    //   1. Pre-generate a UUID and pass it to `everWorksGit.createRepository`
+    //      so the provider can derive a deterministic collision-suffix.
+    //   2. Persist the Work with `owner = <platform org>` and
+    //      `organization = true` so `getRepoOwner()` returns the platform org.
+    //   3. Persist `sourceRepository.relatedRepositories.work` from the
+    //      provider's response (captures the actual repo name in collision
+    //      cases).
+    //   4. Emit `WorkCreatedEvent` with a `platformActor` payload so the
+    //      activity-log listener records "Ever Works on user's behalf".
+    //   5. Map provider errors onto HTTP-shaped exceptions:
+    //      - `EverWorksGitDisabledError`     → `BadRequestException`
+    //      - `EverWorksGitMisconfiguredError`→ `ServiceUnavailableException`
+    //      - `EverWorksGitRequestError`      → `ServiceUnavailableException`
+    // ─────────────────────────────────────────────────────────────────────
+    const everWorksRepoRef = {
+        owner: 'ever-works-cloud',
+        repo: 'evereq-my-work',
+        fullName: 'ever-works-cloud/evereq-my-work',
+        htmlUrl: 'https://github.com/ever-works-cloud/evereq-my-work',
+        cloneUrl: 'https://github.com/ever-works-cloud/evereq-my-work.git',
+        privateRepo: true,
+    };
+
+    it('EW-614: ever-works-git + flag on → calls provider, persists platform org, emits platformActor', async () => {
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'ever-works-git' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+        deps.everWorksGit.isEnabled.mockReturnValue(true);
+        deps.everWorksGit.createRepository.mockResolvedValue(everWorksRepoRef);
+        const dtoNoGit = { ...baseDto } as CreateWorkDto;
+        delete (dtoNoGit as { gitProvider?: string }).gitProvider;
+
+        await service.createWork(dtoNoGit, { ...baseUser, username: 'evereq' } as never);
+
+        expect(deps.everWorksGit.createRepository).toHaveBeenCalledTimes(1);
+        const provArg = deps.everWorksGit.createRepository.mock.calls[0][0];
+        expect(provArg.work.userId).toBe(baseUser.id);
+        expect(provArg.work.userSlug).toBe('evereq');
+        expect(provArg.work.slug).toBe('my-work');
+        // Pre-generated UUID is what gets persisted as work.id.
+        expect(typeof provArg.work.id).toBe('string');
+        expect(provArg.work.id.length).toBeGreaterThan(0);
+
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.id).toBe(provArg.work.id);
+        expect(persisted.owner).toBe('ever-works-cloud');
+        expect(persisted.organization).toBe(true);
+        expect(persisted.storageProvider).toBe('ever-works-git');
+        expect(persisted.gitProvider).toBe('github');
+        expect(persisted.sourceRepository).toEqual(
+            expect.objectContaining({
+                owner: 'ever-works-cloud',
+                repo: 'evereq-my-work',
+                relatedRepositories: {
+                    work: { owner: 'ever-works-cloud', repo: 'evereq-my-work' },
+                },
+            }),
+        );
+
+        // WorkCreatedEvent emitted with platformActor payload.
+        expect(deps.eventEmitter.emit).toHaveBeenCalledWith(
+            'work.created',
+            expect.objectContaining({
+                platformActor: {
+                    actorKind: 'platform',
+                    actor: 'ever-works-cloud',
+                    repoFullName: 'ever-works-cloud/evereq-my-work',
+                    htmlUrl: 'https://github.com/ever-works-cloud/evereq-my-work',
+                },
+            }),
+        );
+    });
+
+    it('EW-614: ever-works-git + flag OFF → provider NOT called, falls through to existing path', async () => {
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'ever-works-git' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+        deps.everWorksGit.isEnabled.mockReturnValue(false);
+
+        await service.createWork(baseDto, baseUser);
+
+        expect(deps.everWorksGit.createRepository).not.toHaveBeenCalled();
+        const persisted = deps.workRepo.create.mock.calls[0][0];
+        expect(persisted.storageProvider).toBe('ever-works-git');
+        expect(persisted.owner).toBe(baseDto.owner); // not overridden
+        // Event still emitted, but without platformActor payload.
+        const emitted = deps.eventEmitter.emit.mock.calls[0]?.[1];
+        expect(emitted?.platformActor).toBeUndefined();
+    });
+
+    it('EW-614: provider EverWorksGitDisabledError → BadRequestException, no Work persisted', async () => {
+        const { EverWorksGitDisabledError } = await import('../../ever-works-providers/types');
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'ever-works-git' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+        deps.everWorksGit.isEnabled.mockReturnValue(true);
+        deps.everWorksGit.createRepository.mockRejectedValue(new EverWorksGitDisabledError());
+
+        await expect(service.createWork(baseDto, baseUser)).rejects.toMatchObject({
+            status: 400,
+        });
+        expect(deps.workRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('EW-614: provider EverWorksGitRequestError → ServiceUnavailableException, no Work persisted', async () => {
+        const { EverWorksGitRequestError } = await import('../../ever-works-providers/types');
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'ever-works-git' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+        deps.everWorksGit.isEnabled.mockReturnValue(true);
+        deps.everWorksGit.createRepository.mockRejectedValue(
+            new EverWorksGitRequestError(502, 'upstream down'),
+        );
+
+        await expect(service.createWork(baseDto, baseUser)).rejects.toMatchObject({
+            status: 503,
+        });
+        expect(deps.workRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('EW-614: non-ever-works-git storage → provider never called even if flag on', async () => {
+        const state: OnboardingWizardStateV2 = {
+            version: 2,
+            lastStep: 0,
+            ai: { choice: 'ever-works' },
+            storage: { choice: 'user-github' },
+            deploy: { choice: 'vercel' },
+            skippedSteps: [],
+            pluginsReviewed: false,
+        };
+        const { service, deps } = makeService(state);
+        deps.everWorksGit.isEnabled.mockReturnValue(true);
+
+        await service.createWork(baseDto, baseUser);
+
+        expect(deps.everWorksGit.createRepository).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -93,6 +93,13 @@ describe('WorkLifecycleService', () => {
         const everWorksDeployQuota = {
             assertWithinQuota: jest.fn().mockResolvedValue(undefined),
         } as never;
+        // EW-614: WorkLifecycleService also depends on EverWorksGitProvider.
+        // These tests don't exercise the EverWorks Git path; default the
+        // mock to disabled so the createWork code-path skips it.
+        const everWorksGit = {
+            isEnabled: jest.fn().mockReturnValue(false),
+            createRepository: jest.fn(),
+        } as never;
         eventEmitter = {
             emit: jest.fn(),
         };
@@ -109,6 +116,7 @@ describe('WorkLifecycleService', () => {
             templateCatalogService,
             websiteRepositoryState,
             everWorksDeployQuota,
+            everWorksGit,
             eventEmitter as never,
         );
     });

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -4,11 +4,17 @@ import {
     Injectable,
     Logger,
     NotFoundException,
+    ServiceUnavailableException,
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { randomUUID } from 'node:crypto';
 import { WorkRepository } from '@src/database/repositories/work.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
-import { WorksConfigSyncRequestedEvent } from '@src/events';
+import {
+    WorkCreatedEvent,
+    WorksConfigSyncRequestedEvent,
+    type WorkCreatedPlatformActor,
+} from '@src/events';
 import { DataGeneratorService } from '@src/generators/data-generator/data-generator.service';
 import { MarkdownGeneratorService } from '@src/generators/markdown-generator/markdown-generator.service';
 import { WebsiteGeneratorService } from '@src/generators/website-generator/website-generator.service';
@@ -29,7 +35,14 @@ import {
 import { WebsiteRepositoryCreationMethod } from '@src/items-generator/dto/create-items-generator.dto';
 import { TemplateCatalogService } from '../template-catalog/template-catalog.service';
 import { WorkWebsiteRepositoryStateService } from './work-website-repository-state.service';
-import { EverWorksDeployQuotaService } from '@src/ever-works-providers';
+import {
+    EverWorksDeployQuotaService,
+    EverWorksGitDisabledError,
+    EverWorksGitMisconfiguredError,
+    EverWorksGitProvider,
+    EverWorksGitRequestError,
+    type EverWorksGitRepoRef,
+} from '@src/ever-works-providers';
 import { config } from '@src/config';
 import type { OnboardingWizardStateV2 } from '@ever-works/contracts/api';
 
@@ -78,6 +91,7 @@ export class WorkLifecycleService {
         private readonly templateCatalogService: TemplateCatalogService,
         private readonly websiteRepositoryState: WorkWebsiteRepositoryStateService,
         private readonly everWorksDeployQuota: EverWorksDeployQuotaService,
+        private readonly everWorksGit: EverWorksGitProvider,
         private readonly eventEmitter: EventEmitter2,
     ) {}
 
@@ -217,7 +231,13 @@ export class WorkLifecycleService {
             await this.everWorksDeployQuota.assertWithinQuota(user.id);
         }
 
-        const workData: Partial<CreateWorkDto & { userId: string }> = {
+        // The shape we hand to `workRepository.create()` is a subset of
+        // `Partial<Work>` (TypeORM accepts the full entity shape on save).
+        // We layer the create-time DTO fields + an optional `id` (when the
+        // platform pre-generates a UUID for the EW-614 path) + the
+        // `sourceRepository` JSONB that records the resolved repo
+        // coordinates.
+        const workData: Partial<Work> = {
             slug,
             name,
             description,
@@ -231,6 +251,51 @@ export class WorkLifecycleService {
             organization,
         };
 
+        // EW-614 — when the user picks "Ever Works Git" AND the feature flag
+        // is on, the platform provisions the GitHub repo in the
+        // `ever-works-cloud` org BEFORE the Work is persisted. The repo
+        // identifier is then woven into the workData so:
+        //   - `work.owner` becomes the platform org (drives `getRepoOwner()`)
+        //   - `work.organization` is true (the owner is an org, not a user)
+        //   - `sourceRepository.relatedRepositories.work` records the
+        //     resolved repo coordinates (handles the collision-suffix path
+        //     the provider transparently does on `422 name already exists`)
+        //
+        // We pre-generate the Work UUID so `EverWorksGitProvider.buildRepoName`
+        // can derive a deterministic collision suffix from it. The same UUID
+        // is persisted on the DB row in a single TypeORM `save()`.
+        let everWorksRepo: EverWorksGitRepoRef | undefined;
+        if (storageProvider === 'ever-works-git' && this.everWorksGit.isEnabled()) {
+            const workId = randomUUID();
+            try {
+                everWorksRepo = await this.everWorksGit.createRepository({
+                    work: {
+                        id: workId,
+                        slug,
+                        userId: user.id,
+                        userSlug: user.username,
+                        description,
+                    },
+                });
+            } catch (error) {
+                this.rethrowEverWorksGitError(error);
+            }
+
+            workData.id = workId;
+            workData.owner = everWorksRepo!.owner;
+            workData.organization = true;
+            workData.sourceRepository = {
+                url: everWorksRepo!.htmlUrl,
+                owner: everWorksRepo!.owner,
+                repo: everWorksRepo!.repo,
+                type: 'data_repo',
+                importedAt: new Date(),
+                relatedRepositories: {
+                    work: { owner: everWorksRepo!.owner, repo: everWorksRepo!.repo },
+                },
+            };
+        }
+
         try {
             const dir = await this.workRepository.create(workData, user);
             dir.owner = dir.getRepoOwner();
@@ -242,6 +307,25 @@ export class WorkLifecycleService {
                 });
             }
 
+            // Emit `WorkCreatedEvent` so downstream listeners (activity log,
+            // work-proposal learning ingest) record the create. When the
+            // platform provisioned the repo, carry that fact as a
+            // `platformActor` payload so the audit row distinguishes
+            // "platform created this on the user's behalf" from a regular
+            // user-initiated repo create. EW-614.
+            const platformActor: WorkCreatedPlatformActor | undefined = everWorksRepo
+                ? {
+                      actorKind: 'platform',
+                      actor: everWorksRepo.owner,
+                      repoFullName: everWorksRepo.fullName,
+                      htmlUrl: everWorksRepo.htmlUrl,
+                  }
+                : undefined;
+            this.eventEmitter.emit(
+                WorkCreatedEvent.EVENT_NAME,
+                new WorkCreatedEvent(dir, platformActor),
+            );
+
             return {
                 status: 'success',
                 work: dir,
@@ -249,6 +333,38 @@ export class WorkLifecycleService {
         } catch (error) {
             rethrowAsNormalized(error, this.logger, 'creating work');
         }
+    }
+
+    /**
+     * Map EverWorks Git provider errors onto HTTP-shaped exceptions. The
+     * deploy facade lives behind the same boundary so this keeps the
+     * controller-level mapping consistent across both platform-default
+     * providers.
+     */
+    private rethrowEverWorksGitError(error: unknown): never {
+        if (error instanceof EverWorksGitDisabledError) {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'Ever Works Git storage is currently disabled.',
+                code: error.code,
+            });
+        }
+        if (error instanceof EverWorksGitMisconfiguredError) {
+            throw new ServiceUnavailableException({
+                status: 'error',
+                message:
+                    'Ever Works Git storage is misconfigured. Please contact support — your work was not created.',
+                code: error.code,
+            });
+        }
+        if (error instanceof EverWorksGitRequestError) {
+            throw new ServiceUnavailableException({
+                status: 'error',
+                message: `Ever Works Git storage is temporarily unavailable: ${error.message}`,
+                code: error.code,
+            });
+        }
+        throw error;
     }
 
     async updateWork(id: string, updateDto: UpdateWorkDto, user: User) {

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -104,6 +104,7 @@ jest.mock('../plugins/services/settings-schema-validator.service', () => ({
 jest.mock('@src/ever-works-providers', () => ({
     EVER_WORKS_DEPLOY_QUOTA_COUNTER: Symbol('EVER_WORKS_DEPLOY_QUOTA_COUNTER'),
     EverWorksDeployQuotaService: class EverWorksDeployQuotaService {},
+    EverWorksGitProvider: class EverWorksGitProvider {},
 }));
 jest.mock('@src/database/repositories/work.repository', () => ({
     WorkRepository: class WorkRepository {},
@@ -113,6 +114,7 @@ import { WorkModule } from './work.module';
 import {
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
     EverWorksDeployQuotaService,
+    EverWorksGitProvider,
 } from '@src/ever-works-providers';
 import { WorkDetailService } from './work-detail.service';
 import { WorkOwnershipService } from './work-ownership.service';
@@ -212,6 +214,7 @@ describe('WorkModule', () => {
             PluginOperationsService,
             SettingsSchemaValidatorService,
             EverWorksDeployQuotaService,
+            EverWorksGitProvider,
         ];
 
         it.each(expectedProviders)('declares %p as a provider', (provider) => {
@@ -219,8 +222,9 @@ describe('WorkModule', () => {
         });
 
         it('keeps the providers list at the documented shape (class providers + the EverWorks quota counter factory)', () => {
-            // 28 class providers + 1 factory provider object for the
-            // EVER_WORKS_DEPLOY_QUOTA_COUNTER token = 29 entries total.
+            // 29 class providers + 1 factory provider object for the
+            // EVER_WORKS_DEPLOY_QUOTA_COUNTER token = 30 entries total.
+            // (EW-614 added EverWorksGitProvider.)
             expect(meta('providers')).toHaveLength(expectedProviders.length + 1);
         });
 
@@ -266,8 +270,11 @@ describe('WorkModule', () => {
                     provider === WorksConfigSyncListener ||
                     provider === SettingsSchemaValidatorService ||
                     provider === PluginOperationsService ||
-                    provider === EverWorksDeployQuotaService
+                    provider === EverWorksDeployQuotaService ||
+                    provider === EverWorksGitProvider
                 ) {
+                    // EW-614: EverWorksGitProvider is consumed inside the
+                    // module (by WorkLifecycleService.createWork); not exported.
                     expect(exports).not.toContain(provider);
                 } else {
                     expect(exports).toContain(provider);

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -41,6 +41,7 @@ import { NotificationsModule } from '@src/notifications';
 import {
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
     EverWorksDeployQuotaService,
+    EverWorksGitProvider,
     type EverWorksDeployQuotaCounter,
 } from '@src/ever-works-providers';
 import { WorkRepository } from '@src/database/repositories/work.repository';
@@ -95,6 +96,11 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         PluginOperationsService,
         SettingsSchemaValidatorService,
         EverWorksDeployQuotaService,
+        // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
+        // the platform GitHub org (`ever-works-cloud`) using a server-held
+        // PAT, so users picking "Ever Works Git" don't need to bring their
+        // own GitHub. Consumed by `WorkLifecycleService.createWork`.
+        EverWorksGitProvider,
         {
             // The Ever Works Deploy quota service is repo-agnostic — it
             // takes a small `EverWorksDeployQuotaCounter` it can consult.


### PR DESCRIPTION
Cascade of #732 from stage to main.

Includes:
- #731: feat(onboarding): wire EverWorksGitProvider into createWork (EW-614)
- #720: fix: Codex P2 follow-ups on #715 (header badge + duplicate-by-URL slug)
- #726: ci(e2e): bump job timeout-minutes from 45 to 150

🤖 Generated with [Claude Code](https://claude.com/claude-code)