### PR TITLE
feat(EW-357): AI-generated SVG icons for app categories

### DIFF
--- a/apps/web/src/components/works/detail/items/CategoriesTab.tsx
+++ b/apps/web/src/components/works/detail/items/CategoriesTab.tsx
@@ -1,17 +1,54 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Category, ItemData } from '@/lib/api/types-only';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils/cn';
 import { useTranslations } from 'next-intl';
-import { Plus, Pencil, Trash2, Search, FolderTree } from 'lucide-react';
+import { FolderTree, Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import { useRouter } from '@/i18n/navigation';
 import { getCategoryNames } from '@/lib/utils/items';
 import { CategoryModal } from './CategoryModal';
 import { createCategory, updateCategory, deleteCategory } from '@/app/actions/dashboard/taxonomy';
 import { toast } from 'sonner';
+
+/**
+ * Render the category's icon. Resolution order:
+ *   1. `icon_svg` — server-sanitized inline SVG. Rendered with
+ *      dangerouslySetInnerHTML so `stroke="currentColor"` themes
+ *      through the wrapping span's text color. Backend strips
+ *      scripts/event handlers/foreignObject before persistence
+ *      (see svg-sanitizer.ts in @ever-works/agent).
+ *   2. `icon_url` — legacy external image URL.
+ *   3. Default `<FolderTree>` Lucide glyph.
+ */
+function CategoryIcon({ category }: { category: Category }) {
+    if (category.icon_svg) {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex w-6 h-6 items-center justify-center text-text-secondary dark:text-text-secondary-dark shrink-0 [&>svg]:w-full [&>svg]:h-full"
+                dangerouslySetInnerHTML={{ __html: category.icon_svg }}
+            />
+        );
+    }
+    if (category.icon_url) {
+        return (
+            <img
+                src={category.icon_url}
+                alt=""
+                className="w-6 h-6 rounded"
+            />
+        );
+    }
+    return (
+        <FolderTree
+            strokeWidth={1.3}
+            className="w-4 h-4 text-text-muted dark:text-text-muted-dark shrink-0"
+        />
+    );
+}
 
 interface CategoriesTabProps {
     workId: string;
@@ -212,18 +249,7 @@ export function CategoriesTab({ workId, initialCategories, items, canEdit }: Cat
                                     >
                                         <td className="px-4 py-3">
                                             <div className="flex items-center gap-3">
-                                                {category.icon_url ? (
-                                                    <img
-                                                        src={category.icon_url}
-                                                        alt=""
-                                                        className="w-6 h-6 rounded"
-                                                    />
-                                                ) : (
-                                                    <FolderTree
-                                                        strokeWidth={1.3}
-                                                        className="w-4 h-4 text-text-muted dark:text-text-muted-dark shrink-0"
-                                                    />
-                                                )}
+                                                <CategoryIcon category={category} />
                                                 <span className="font-medium text-sm text-text dark:text-text-dark">
                                                     {category.name}
                                                 </span>

--- a/apps/web/src/components/works/detail/items/CategoriesTab.tsx
+++ b/apps/web/src/components/works/detail/items/CategoriesTab.tsx
@@ -34,13 +34,7 @@ function CategoryIcon({ category }: { category: Category }) {
         );
     }
     if (category.icon_url) {
-        return (
-            <img
-                src={category.icon_url}
-                alt=""
-                className="w-6 h-6 rounded"
-            />
-        );
+        return <img src={category.icon_url} alt="" className="w-6 h-6 rounded" />;
     }
     return (
         <FolderTree

--- a/packages/agent/jest.config.js
+++ b/packages/agent/jest.config.js
@@ -30,6 +30,9 @@ module.exports = {
         '^@ever-works/plugin/(.*)$': '<rootDir>/../../plugin/src/$1/index.ts',
         '^@ever-works/contracts$': '<rootDir>/../../contracts/src/index.ts',
         '^@ever-works/contracts/(.*)$': '<rootDir>/../../contracts/src/$1/index.ts',
+        // p-map is ESM-only and ts-jest can't load it. Substitute a
+        // Promise.all-based stub for all specs (see test/jest-mocks/p-map.ts).
+        '^p-map$': '<rootDir>/../test/jest-mocks/p-map.ts',
         // Handle .js extension in ESM-style imports (resolve to .ts)
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },

--- a/packages/agent/src/dto/taxonomy.dto.ts
+++ b/packages/agent/src/dto/taxonomy.dto.ts
@@ -4,6 +4,13 @@ import { sanitizeName, sanitizeDescription } from '../utils/sanitize.util';
 
 // Category DTOs
 
+/**
+ * Hard cap on inline SVG payload size. Sanitized icons should be well
+ * under 3KB; the limit gives headroom for legitimate paths while
+ * rejecting obvious abuse (megabyte rasterized blobs encoded as data URIs).
+ */
+const MAX_ICON_SVG_LENGTH = 8000;
+
 export class CreateCategoryDto {
     @IsString()
     @MaxLength(100)
@@ -20,6 +27,11 @@ export class CreateCategoryDto {
     @IsOptional()
     @MaxLength(500)
     icon_url?: string;
+
+    @IsString()
+    @IsOptional()
+    @MaxLength(MAX_ICON_SVG_LENGTH)
+    icon_svg?: string;
 
     @IsNumber()
     @IsOptional()
@@ -44,6 +56,11 @@ export class UpdateCategoryDto {
     @IsOptional()
     @MaxLength(500)
     icon_url?: string;
+
+    @IsString()
+    @IsOptional()
+    @MaxLength(MAX_ICON_SVG_LENGTH)
+    icon_svg?: string;
 
     @IsNumber()
     @IsOptional()
@@ -70,6 +87,11 @@ export class CreateCollectionDto {
     @MaxLength(500)
     icon_url?: string;
 
+    @IsString()
+    @IsOptional()
+    @MaxLength(MAX_ICON_SVG_LENGTH)
+    icon_svg?: string;
+
     @IsNumber()
     @IsOptional()
     @Min(0)
@@ -93,6 +115,11 @@ export class UpdateCollectionDto {
     @IsOptional()
     @MaxLength(500)
     icon_url?: string;
+
+    @IsString()
+    @IsOptional()
+    @MaxLength(MAX_ICON_SVG_LENGTH)
+    icon_svg?: string;
 
     @IsNumber()
     @IsOptional()

--- a/packages/agent/src/dto/taxonomy.dto.ts
+++ b/packages/agent/src/dto/taxonomy.dto.ts
@@ -5,11 +5,13 @@ import { sanitizeName, sanitizeDescription } from '../utils/sanitize.util';
 // Category DTOs
 
 /**
- * Hard cap on inline SVG payload size. Sanitized icons should be well
- * under 3KB; the limit gives headroom for legitimate paths while
- * rejecting obvious abuse (megabyte rasterized blobs encoded as data URIs).
+ * Hard cap on inline SVG payload size — matches `MAX_SVG_LENGTH` in
+ * `services/category-icon/svg-sanitizer.ts`. Keep these aligned so the
+ * DTO rejects oversized payloads at the API boundary with a clear 400
+ * instead of silently falling through to the sanitizer's `too-large`
+ * branch (which surfaces as a generic fallback icon downstream).
  */
-const MAX_ICON_SVG_LENGTH = 8000;
+const MAX_ICON_SVG_LENGTH = 4000;
 
 export class CreateCategoryDto {
     @IsString()

--- a/packages/agent/src/generators/data-generator/data-generator.module.spec.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.module.spec.ts
@@ -53,7 +53,7 @@ describe('DataGeneratorModule', () => {
         expect(exports).toHaveLength(1);
     });
 
-    it('imports the documented 4 modules by name', () => {
+    it('imports the documented 5 modules by name', () => {
         const imports = meta('imports') as Array<{ name?: string }>;
         const names = imports.map((m) => m?.name);
         expect(names).toEqual(
@@ -62,9 +62,10 @@ describe('DataGeneratorModule', () => {
                 'PipelineModule',
                 'DatabaseModule',
                 'WorkOperationsModule',
+                'CategoryIconModule',
             ]),
         );
-        expect(imports).toHaveLength(4);
+        expect(imports).toHaveLength(5);
     });
 });
 

--- a/packages/agent/src/generators/data-generator/data-generator.module.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.module.ts
@@ -6,9 +6,16 @@ import { DatabaseModule } from '@src/database';
 import { WorkOperationsModule } from '@src/work-operations';
 import { WorksConfigService } from '@src/works-config/services/works-config.service';
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
+import { CategoryIconModule } from '../../services/category-icon/category-icon.module';
 
 @Module({
-    imports: [FacadesModule, PipelineModule, DatabaseModule, WorkOperationsModule],
+    imports: [
+        FacadesModule,
+        PipelineModule,
+        DatabaseModule,
+        WorkOperationsModule,
+        CategoryIconModule,
+    ],
     providers: [DataGeneratorService, WorksConfigService, WorksConfigWriterService],
     exports: [DataGeneratorService],
 })

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -30,7 +30,9 @@ import type {
     PipelineResult,
     PipelineProgress,
     ReferenceEntry,
+    FacadeOptions,
 } from '@ever-works/plugin';
+import { CategoryIconService } from '../../services/category-icon';
 import { mergeReferences } from '@ever-works/plugin';
 import type { WorkHistoryChangeEntry } from '@ever-works/contracts/api';
 import type { GenerationLogCollector } from './generation-log-collector';
@@ -98,6 +100,7 @@ export class DataGeneratorService {
         private readonly pipelineOrchestrator: PipelineOrchestratorService,
         private readonly workOperations: WorkOperationsService,
         private readonly worksConfigWriter: WorksConfigWriterService,
+        private readonly categoryIconService: CategoryIconService,
     ) {}
 
     private getWorkOwner(work: Work): User {
@@ -363,10 +366,33 @@ export class DataGeneratorService {
                 await data.resetFiles();
             }
 
+            const mergedCategories = this.merge(
+                existingCategories,
+                [...newCategories],
+            ) as Category[];
+            const mergedCollections = this.merge(
+                existingCollections,
+                [...newCollections],
+            ) as Collection[];
+
+            // Auto-generate SVG icons for any category/collection that
+            // doesn't already have one. Opt-out via pluginConfig flag.
+            const facadeOptions: FacadeOptions = { userId: user.id, workId: work.id };
+            const enrichedCategories = await this.maybeEnrichCategoryIcons(
+                mergedCategories,
+                createItemsGeneratorDto,
+                facadeOptions,
+            );
+            const enrichedCollections = await this.maybeEnrichCollectionIcons(
+                mergedCollections,
+                createItemsGeneratorDto,
+                facadeOptions,
+            );
+
             const promises = [
-                data.writeCategories(this.merge(existingCategories, [...newCategories])),
+                data.writeCategories(enrichedCategories),
                 data.writeTags(this.merge(existingTags, [...newTags])),
-                data.writeCollections(this.merge(existingCollections, [...newCollections])),
+                data.writeCollections(enrichedCollections),
             ];
 
             const generatedReferences = this.extractPipelineReferences(pipelineResult);
@@ -1396,6 +1422,59 @@ export class DataGeneratorService {
             map.set(item.id, item);
         }
         return Array.from(map.values());
+    }
+
+    /**
+     * Resolve and attach `icon_svg` for each category lacking one.
+     * Returns the input list unchanged when icon generation is disabled
+     * via pluginConfig.generate_category_icons === false. Failures
+     * inside the icon service never abort the generation pipeline —
+     * worst case, categories ship without icons and the UI fallback
+     * renders.
+     */
+    private async maybeEnrichCategoryIcons(
+        categories: Category[],
+        dto: CreateItemsGeneratorDto,
+        facadeOptions: FacadeOptions,
+    ): Promise<Category[]> {
+        if (!this.shouldGenerateCategoryIcons(dto)) {
+            return categories;
+        }
+
+        try {
+            return await this.categoryIconService.enrichCategories(categories, {
+                facadeOptions,
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Category icon enrichment skipped due to error: ${message}`);
+            return categories;
+        }
+    }
+
+    private async maybeEnrichCollectionIcons(
+        collections: Collection[],
+        dto: CreateItemsGeneratorDto,
+        facadeOptions: FacadeOptions,
+    ): Promise<Collection[]> {
+        if (!this.shouldGenerateCategoryIcons(dto)) {
+            return collections;
+        }
+
+        try {
+            return await this.categoryIconService.enrichCollections(collections, {
+                facadeOptions,
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Collection icon enrichment skipped due to error: ${message}`);
+            return collections;
+        }
+    }
+
+    private shouldGenerateCategoryIcons(dto: CreateItemsGeneratorDto): boolean {
+        const pluginConfig = dto.pluginConfig as Record<string, unknown> | undefined;
+        return pluginConfig?.generate_category_icons !== false;
     }
 
     private getDefaultReadme(work: Work) {

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -366,14 +366,12 @@ export class DataGeneratorService {
                 await data.resetFiles();
             }
 
-            const mergedCategories = this.merge(
-                existingCategories,
-                [...newCategories],
-            ) as Category[];
-            const mergedCollections = this.merge(
-                existingCollections,
-                [...newCollections],
-            ) as Collection[];
+            const mergedCategories = this.merge(existingCategories, [
+                ...newCategories,
+            ]) as Category[];
+            const mergedCollections = this.merge(existingCollections, [
+                ...newCollections,
+            ]) as Collection[];
 
             // Auto-generate SVG icons for any category/collection that
             // doesn't already have one. Opt-out via pluginConfig flag.

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -412,7 +412,7 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
     });
 
     it('EW-614: provider EverWorksGitDisabledError → BadRequestException, no Work persisted', async () => {
-        const { EverWorksGitDisabledError } = await import('../../ever-works-providers/types');
+        const { EverWorksGitDisabledError } = await import('../../ever-works-providers/types.js');
         const state: OnboardingWizardStateV2 = {
             version: 2,
             lastStep: 0,
@@ -433,7 +433,7 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
     });
 
     it('EW-614: provider EverWorksGitRequestError → ServiceUnavailableException, no Work persisted', async () => {
-        const { EverWorksGitRequestError } = await import('../../ever-works-providers/types');
+        const { EverWorksGitRequestError } = await import('../../ever-works-providers/types.js');
         const state: OnboardingWizardStateV2 = {
             version: 2,
             lastStep: 0,

--- a/packages/agent/src/services/__tests__/work-taxonomy.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-taxonomy.service.spec.ts
@@ -382,11 +382,7 @@ describe('WorkTaxonomyService', () => {
                 '<svg viewBox="0 0 24 24"><circle fill="url(https://tracker.example/pixel)" cx="12" cy="12" r="6"/></svg>';
 
             await expect(
-                service.createCategory(
-                    'w-1',
-                    { name: 'Beacon', icon_svg: beacon } as any,
-                    'u-1',
-                ),
+                service.createCategory('w-1', { name: 'Beacon', icon_svg: beacon } as any, 'u-1'),
             ).rejects.toBeInstanceOf(BadRequestException);
             expect(dataGenerator.saveCategories).not.toHaveBeenCalled();
         });
@@ -582,12 +578,7 @@ describe('WorkTaxonomyService', () => {
             const malicious =
                 '<svg viewBox="0 0 24 24" onload="alert(1)"><script>steal()</script><path d="M0 0"/></svg>';
 
-            await service.updateCategory(
-                'w-1',
-                'a',
-                { icon_svg: malicious } as any,
-                'u-1',
-            );
+            await service.updateCategory('w-1', 'a', { icon_svg: malicious } as any, 'u-1');
 
             const [, , saved] = dataGenerator.saveCategories.mock.calls[0];
             expect(saved[0].icon_svg).not.toMatch(/\bonload=/i);
@@ -602,12 +593,7 @@ describe('WorkTaxonomyService', () => {
                 collections: [],
             });
 
-            await service.updateCategory(
-                'w-1',
-                'a',
-                { icon_svg: '' } as any,
-                'u-1',
-            );
+            await service.updateCategory('w-1', 'a', { icon_svg: '' } as any, 'u-1');
 
             const [, , saved] = dataGenerator.saveCategories.mock.calls[0];
             expect(saved[0].icon_svg).toBe('');

--- a/packages/agent/src/services/__tests__/work-taxonomy.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-taxonomy.service.spec.ts
@@ -344,6 +344,52 @@ describe('WorkTaxonomyService', () => {
             ).rejects.toBeInstanceOf(ForbiddenException);
             expect(dataGenerator.saveCategories).not.toHaveBeenCalled();
         });
+
+        // ============================================================================
+        // icon_svg sanitization (stored-XSS guard — frontend renders inline)
+        // ============================================================================
+        it('sanitizes inline icon_svg before persisting (strips <script>)', async () => {
+            const malicious =
+                '<svg viewBox="0 0 24 24"><script>alert(1)</script><circle cx="12" cy="12" r="6"/></svg>';
+
+            await service.createCategory(
+                'w-1',
+                { name: 'New Cat', icon_svg: malicious } as any,
+                'u-1',
+            );
+
+            const saved: Category[] = dataGenerator.saveCategories.mock.calls[0][2];
+            const persisted = saved[saved.length - 1];
+            expect(persisted.icon_svg).toBeDefined();
+            expect(persisted.icon_svg).not.toContain('<script');
+            expect(persisted.icon_svg).not.toContain('alert');
+            expect(persisted.icon_svg).toContain('<circle');
+        });
+
+        it('rejects icon_svg with no <svg> root with BadRequestException; nothing persisted', async () => {
+            await expect(
+                service.createCategory(
+                    'w-1',
+                    { name: 'Bad', icon_svg: '<div>not-an-svg</div>' } as any,
+                    'u-1',
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(dataGenerator.saveCategories).not.toHaveBeenCalled();
+        });
+
+        it('rejects icon_svg with external paint-server URL (IP-leak vector)', async () => {
+            const beacon =
+                '<svg viewBox="0 0 24 24"><circle fill="url(https://tracker.example/pixel)" cx="12" cy="12" r="6"/></svg>';
+
+            await expect(
+                service.createCategory(
+                    'w-1',
+                    { name: 'Beacon', icon_svg: beacon } as any,
+                    'u-1',
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(dataGenerator.saveCategories).not.toHaveBeenCalled();
+        });
     });
 
     // ============================================================================
@@ -522,6 +568,67 @@ describe('WorkTaxonomyService', () => {
                 service.updateCategory('w-1', 'a', { name: 'X' } as any, 'u-1'),
             ).rejects.toBeInstanceOf(ForbiddenException);
             expect(dataGenerator.getCategoriesTags).not.toHaveBeenCalled();
+        });
+
+        // ============================================================================
+        // icon_svg sanitization on update (stored-XSS guard)
+        // ============================================================================
+        it('sanitizes incoming icon_svg before persisting on update', async () => {
+            dataGenerator.getCategoriesTags.mockResolvedValue({
+                categories: [buildCategory({ id: 'a' })],
+                tags: [],
+                collections: [],
+            });
+            const malicious =
+                '<svg viewBox="0 0 24 24" onload="alert(1)"><script>steal()</script><path d="M0 0"/></svg>';
+
+            await service.updateCategory(
+                'w-1',
+                'a',
+                { icon_svg: malicious } as any,
+                'u-1',
+            );
+
+            const [, , saved] = dataGenerator.saveCategories.mock.calls[0];
+            expect(saved[0].icon_svg).not.toMatch(/\bonload=/i);
+            expect(saved[0].icon_svg).not.toContain('<script');
+            expect(saved[0].icon_svg).not.toContain('steal');
+        });
+
+        it('treats empty-string icon_svg as clear (sets to empty), not BadRequest', async () => {
+            dataGenerator.getCategoriesTags.mockResolvedValue({
+                categories: [buildCategory({ id: 'a', icon_svg: '<svg/>' })],
+                tags: [],
+                collections: [],
+            });
+
+            await service.updateCategory(
+                'w-1',
+                'a',
+                { icon_svg: '' } as any,
+                'u-1',
+            );
+
+            const [, , saved] = dataGenerator.saveCategories.mock.calls[0];
+            expect(saved[0].icon_svg).toBe('');
+        });
+
+        it('rejects update with malformed icon_svg; nothing persisted', async () => {
+            dataGenerator.getCategoriesTags.mockResolvedValue({
+                categories: [buildCategory({ id: 'a' })],
+                tags: [],
+                collections: [],
+            });
+
+            await expect(
+                service.updateCategory(
+                    'w-1',
+                    'a',
+                    { icon_svg: '<svg viewBox="0 0 24 24"><circle/>' } as any,
+                    'u-1',
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(dataGenerator.saveCategories).not.toHaveBeenCalled();
         });
     });
 
@@ -873,6 +980,29 @@ describe('WorkTaxonomyService', () => {
                     priority: undefined,
                 },
             });
+        });
+
+        it('sanitizes icon_svg on create and rejects malformed payloads', async () => {
+            const malicious =
+                '<svg viewBox="0 0 24 24"><foreignObject><div onclick="x()"></div></foreignObject><rect width="24" height="24"/></svg>';
+
+            await service.createCollection(
+                'w-1',
+                { name: 'Safe Picks', icon_svg: malicious } as any,
+                'u-1',
+            );
+
+            const [, , saved] = dataGenerator.saveCollections.mock.calls[0];
+            expect(saved[0].icon_svg).not.toContain('foreignObject');
+            expect(saved[0].icon_svg).not.toContain('onclick');
+
+            await expect(
+                service.createCollection(
+                    'w-1',
+                    { name: 'Bad Picks', icon_svg: '<div/>' } as any,
+                    'u-1',
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
         });
     });
 

--- a/packages/agent/src/services/category-icon/__tests__/category-icon.service.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/category-icon.service.spec.ts
@@ -1,0 +1,235 @@
+// p-map is ESM-only and Jest can't load it under ts-jest. Replace with a
+// trivial Promise.all-equivalent — concurrency limits don't matter for tests.
+jest.mock('p-map', () => ({
+    __esModule: true,
+    default: async <T, R>(
+        input: Iterable<T>,
+        mapper: (value: T, index: number) => Promise<R> | R,
+    ): Promise<R[]> => Promise.all([...input].map((value, index) => mapper(value, index))),
+}));
+
+import type { Cache } from 'cache-manager';
+import type { Category, ChatCompletionResponse, FacadeOptions } from '@ever-works/plugin';
+
+import type { AiFacadeService } from '../../../facades/ai.facade';
+import { CategoryIconService } from '../category-icon.service';
+
+const FACADE_OPTIONS: FacadeOptions = { userId: 'user-1', workId: 'work-1' };
+
+const CLEAN_AI_SVG =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="6"/></svg>';
+
+function buildAiResponse(content: string): ChatCompletionResponse {
+    return {
+        id: 'r-1',
+        model: 'mock-model',
+        choices: [
+            {
+                index: 0,
+                message: { role: 'assistant', content },
+                finishReason: 'stop',
+            },
+        ],
+        created: Date.now(),
+    } as unknown as ChatCompletionResponse;
+}
+
+function makeAiFacadeMock(content: string | (() => Promise<ChatCompletionResponse>)): AiFacadeService {
+    const createChatCompletion = jest.fn().mockImplementation(async () => {
+        if (typeof content === 'function') {
+            return content();
+        }
+        return buildAiResponse(content);
+    });
+    return { createChatCompletion } as unknown as AiFacadeService;
+}
+
+function makeCacheMock(initial: Record<string, string> = {}): Cache & { _store: Map<string, string> } {
+    const store = new Map<string, string>(Object.entries(initial));
+    return {
+        _store: store,
+        get: jest.fn(async (key: string) => store.get(key)),
+        set: jest.fn(async (key: string, value: unknown) => {
+            store.set(key, String(value));
+        }),
+        del: jest.fn(async (key: string) => {
+            store.delete(key);
+        }),
+    } as unknown as Cache & { _store: Map<string, string> };
+}
+
+describe('CategoryIconService', () => {
+    describe('ensureIcon', () => {
+        it('returns from cache without calling AI when a cached entry exists', async () => {
+            const cached = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
+            const cache = makeCacheMock({ 'category-icon:v1:productivity': cached });
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: 'Productivity',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('cache');
+            expect(result.svg).toBe(cached);
+            expect(aiFacade.createChatCompletion).not.toHaveBeenCalled();
+        });
+
+        it('returns curated SVG without calling AI when name matches a known concept', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: 'Time-Tracking',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('curated');
+            expect(result.svg).toContain('<svg');
+            expect(aiFacade.createChatCompletion).not.toHaveBeenCalled();
+            // and writes to cache for next time
+            expect(cache._store.has('category-icon:v1:time-tracking')).toBe(true);
+        });
+
+        it('falls through to AI when no curated match exists', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: 'Quantum Spectroscopy Hardware',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('ai');
+            expect(aiFacade.createChatCompletion).toHaveBeenCalledTimes(1);
+            expect(cache._store.has('category-icon:v1:quantum spectroscopy hardware')).toBe(true);
+        });
+
+        it('falls back to the static glyph when AI fails and no curated match exists', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(async () => {
+                throw new Error('provider down');
+            });
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: 'Astrophysics Telescopes',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('fallback');
+            expect(result.svg).toContain('<svg');
+        });
+
+        it('falls back to the static glyph when AI returns markup that fails sanitization', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock('<svg viewBox="0 0 24 24"><script>alert(1)</script>');
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: 'Astrophysics Telescopes',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('fallback');
+            expect(result.svg).not.toContain('script');
+        });
+
+        it('skips the AI tier when disableAi is true', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: 'Quantum Spectroscopy Hardware',
+                facadeOptions: FACADE_OPTIONS,
+                disableAi: true,
+            });
+
+            expect(result.source).toBe('fallback');
+            expect(aiFacade.createChatCompletion).not.toHaveBeenCalled();
+        });
+
+        it('returns the fallback when name normalizes to an empty string', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const result = await service.ensureIcon({
+                name: '   ',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('fallback');
+            expect(aiFacade.createChatCompletion).not.toHaveBeenCalled();
+        });
+
+        it('still works without an injected cache (degrades gracefully)', async () => {
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade);
+
+            const result = await service.ensureIcon({
+                name: 'Productivity',
+                facadeOptions: FACADE_OPTIONS,
+            });
+
+            expect(result.source).toBe('curated');
+        });
+    });
+
+    describe('enrichCategories', () => {
+        it('skips entries that already have a non-empty icon_svg', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const input: Category[] = [
+                { id: 'a', name: 'Productivity', icon_svg: '<svg>existing</svg>' },
+                { id: 'b', name: 'Time-Tracking' },
+            ];
+
+            const out = await service.enrichCategories(input, { facadeOptions: FACADE_OPTIONS });
+
+            expect(out).toHaveLength(2);
+            expect(out[0].icon_svg).toBe('<svg>existing</svg>');
+            expect(out[1].icon_svg).toContain('<svg');
+        });
+
+        it('returns the input unchanged when given an empty list', async () => {
+            const cache = makeCacheMock();
+            const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const out = await service.enrichCategories([], { facadeOptions: FACADE_OPTIONS });
+            expect(out).toEqual([]);
+        });
+
+        it('continues the batch when a single category resolution throws', async () => {
+            const cache = makeCacheMock();
+            // First call fails, subsequent calls succeed.
+            let calls = 0;
+            const aiFacade = makeAiFacadeMock(async () => {
+                calls += 1;
+                if (calls === 1) throw new Error('rate limited');
+                return buildAiResponse(CLEAN_AI_SVG);
+            });
+            const service = new CategoryIconService(aiFacade, cache);
+
+            const input: Category[] = [
+                { id: 'a', name: 'Quantum Spectroscopy Hardware' },
+                { id: 'b', name: 'Productivity' }, // hits curated, no AI call
+                { id: 'c', name: 'Astrophysics Telescopes' },
+            ];
+
+            const out = await service.enrichCategories(input, { facadeOptions: FACADE_OPTIONS });
+            expect(out).toHaveLength(3);
+            // First entry's AI call failed → fallback applied (not undefined)
+            expect(out[0].icon_svg).toBeDefined();
+            expect(out[1].icon_svg).toContain('<svg');
+            expect(out[2].icon_svg).toBeDefined();
+        });
+    });
+});

--- a/packages/agent/src/services/category-icon/__tests__/category-icon.service.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/category-icon.service.spec.ts
@@ -34,7 +34,9 @@ function buildAiResponse(content: string): ChatCompletionResponse {
     } as unknown as ChatCompletionResponse;
 }
 
-function makeAiFacadeMock(content: string | (() => Promise<ChatCompletionResponse>)): AiFacadeService {
+function makeAiFacadeMock(
+    content: string | (() => Promise<ChatCompletionResponse>),
+): AiFacadeService {
     const createChatCompletion = jest.fn().mockImplementation(async () => {
         if (typeof content === 'function') {
             return content();
@@ -44,7 +46,9 @@ function makeAiFacadeMock(content: string | (() => Promise<ChatCompletionRespons
     return { createChatCompletion } as unknown as AiFacadeService;
 }
 
-function makeCacheMock(initial: Record<string, string> = {}): Cache & { _store: Map<string, string> } {
+function makeCacheMock(
+    initial: Record<string, string> = {},
+): Cache & { _store: Map<string, string> } {
     const store = new Map<string, string>(Object.entries(initial));
     return {
         _store: store,
@@ -61,7 +65,8 @@ function makeCacheMock(initial: Record<string, string> = {}): Cache & { _store: 
 describe('CategoryIconService', () => {
     describe('ensureIcon', () => {
         it('returns from cache without calling AI when a cached entry exists', async () => {
-            const cached = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
+            const cached =
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
             const cache = makeCacheMock({ 'category-icon:v1:productivity': cached });
             const aiFacade = makeAiFacadeMock(CLEAN_AI_SVG);
             const service = new CategoryIconService(aiFacade, cache);

--- a/packages/agent/src/services/category-icon/__tests__/category-icon.service.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/category-icon.service.spec.ts
@@ -1,12 +1,8 @@
-// p-map is ESM-only and Jest can't load it under ts-jest. Replace with a
-// trivial Promise.all-equivalent — concurrency limits don't matter for tests.
-jest.mock('p-map', () => ({
-    __esModule: true,
-    default: async <T, R>(
-        input: Iterable<T>,
-        mapper: (value: T, index: number) => Promise<R> | R,
-    ): Promise<R[]> => Promise.all([...input].map((value, index) => mapper(value, index))),
-}));
+// Note: `p-map` is ESM-only and unloadable under ts-jest. The
+// substitution lives globally in jest.config.js's moduleNameMapper
+// (-> packages/agent/test/jest-mocks/p-map.ts) so every spec that
+// transitively touches it gets the stub automatically — no per-spec
+// jest.mock needed.
 
 import type { Cache } from 'cache-manager';
 import type { Category, ChatCompletionResponse, FacadeOptions } from '@ever-works/plugin';

--- a/packages/agent/src/services/category-icon/__tests__/curated-mapping.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/curated-mapping.spec.ts
@@ -1,0 +1,100 @@
+import {
+    CATEGORY_ICON_LIBRARY,
+    getFallbackIcon,
+    lookupCuratedIcon,
+} from '../curated-mapping';
+
+describe('lookupCuratedIcon', () => {
+    describe('null inputs', () => {
+        it.each<[string, string | null | undefined]>([
+            ['empty string', ''],
+            ['whitespace only', '   '],
+            ['undefined', undefined],
+            ['null', null],
+        ])('returns null for %s', (_, input) => {
+            expect(lookupCuratedIcon(input as string)).toBeNull();
+        });
+    });
+
+    describe('exact slug match', () => {
+        it('matches a library key directly', () => {
+            const icon = lookupCuratedIcon('rocket');
+            expect(icon).not.toBeNull();
+            expect(icon?.name).toBe('rocket');
+        });
+
+        it('normalizes spaces and underscores to hyphens', () => {
+            expect(lookupCuratedIcon('map pin')?.name).toBe('map-pin');
+            expect(lookupCuratedIcon('map_pin')?.name).toBe('map-pin');
+            expect(lookupCuratedIcon('Map-Pin')?.name).toBe('map-pin');
+        });
+    });
+
+    describe('keyword pattern match', () => {
+        it.each<[string, string]>([
+            ['Open-Source', 'code'],
+            ['open source projects', 'code'],
+            ['FOSS Tools', 'code'],
+            ['Time-Tracking', 'clock'],
+            ['Productivity', 'briefcase'],
+            ['Free apps', 'gift'],
+            ['AI Chatbots', 'brain'],
+            ['Machine Learning', 'brain'],
+            ['Cloud Storage', 'cloud'],
+            ['SaaS', 'cloud'],
+            ['SQL Databases', 'database'],
+            ['Security Tools', 'shield'],
+            ['Auth & Identity', 'shield'],
+            ['Email Clients', 'mail'],
+            ['Project Management', 'kanban'],
+            ['Customer Support', 'headphones'],
+            ['No-code Automation', 'workflow'],
+            ['Container Orchestration', 'package'],
+            ['DevOps', 'rocket'],
+        ])('maps "%s" to %s', (name, expectedIconName) => {
+            const icon = lookupCuratedIcon(name);
+            expect(icon).not.toBeNull();
+            expect(icon?.name).toBe(expectedIconName);
+        });
+
+        it('returns null for category names with no rule match', () => {
+            expect(lookupCuratedIcon('Quantum Spectroscopy Hardware')).toBeNull();
+            expect(lookupCuratedIcon('Astrophysics Telescopes')).toBeNull();
+            expect(lookupCuratedIcon('Glassblowing Furnaces')).toBeNull();
+        });
+
+        it('prefers more-specific rules ordered first (time-tracking vs time)', () => {
+            const tt = lookupCuratedIcon('Time-Tracking');
+            const tt2 = lookupCuratedIcon('Time tracking apps');
+            expect(tt?.name).toBe('clock');
+            expect(tt2?.name).toBe('clock');
+        });
+    });
+});
+
+describe('getFallbackIcon', () => {
+    it('returns the tag glyph from the library', () => {
+        const icon = getFallbackIcon();
+        expect(icon).toBeDefined();
+        expect(icon.name).toBe('tag');
+        expect(icon.svg).toContain('<svg');
+        expect(icon.svg).toContain('</svg>');
+    });
+});
+
+describe('CATEGORY_ICON_LIBRARY', () => {
+    it('every entry has a name and a non-empty SVG', () => {
+        for (const [key, icon] of Object.entries(CATEGORY_ICON_LIBRARY)) {
+            expect(icon.name).toBe(key);
+            expect(icon.svg.length).toBeGreaterThan(50);
+            expect(icon.svg.startsWith('<svg')).toBe(true);
+            expect(icon.svg.endsWith('</svg>')).toBe(true);
+        }
+    });
+
+    it('every entry uses currentColor for stroke (themable)', () => {
+        for (const icon of Object.values(CATEGORY_ICON_LIBRARY)) {
+            expect(icon.svg).toContain('stroke="currentColor"');
+        }
+    });
+});

--- a/packages/agent/src/services/category-icon/__tests__/curated-mapping.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/curated-mapping.spec.ts
@@ -1,8 +1,4 @@
-import {
-    CATEGORY_ICON_LIBRARY,
-    getFallbackIcon,
-    lookupCuratedIcon,
-} from '../curated-mapping';
+import { CATEGORY_ICON_LIBRARY, getFallbackIcon, lookupCuratedIcon } from '../curated-mapping';
 
 describe('lookupCuratedIcon', () => {
     describe('null inputs', () => {

--- a/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
@@ -105,6 +105,30 @@ describe('sanitizeSvg', () => {
             }
         });
 
+        it('detects a dangerous URL on every call (regression: stateful /g regex bypass)', () => {
+            // Greptile P1: when DANGEROUS_URL_VALUE_RE was declared with the `g`
+            // flag, RegExp.prototype.test() retained `lastIndex` across calls.
+            // After a successful match at offset N, the next call starts
+            // searching from N — and any payload whose `javascript:` appears
+            // before that offset returned `false`, silently bypassing the check.
+            // This test calls sanitizeSvg with two different payloads in
+            // succession and asserts both are rejected.
+            const padded = `<svg viewBox="0 0 24 24"><circle fill="url(javascript:alert(1))" cx="12" cy="12" r="6" data-pad="${'x'.repeat(60)}"/></svg>`;
+            const compact =
+                '<svg viewBox="0 0 24 24"><circle fill="url(javascript:alert(2))" cx="12" cy="12" r="6"/></svg>';
+
+            const first = sanitizeSvg(padded);
+            const second = sanitizeSvg(compact);
+            const third = sanitizeSvg(compact);
+
+            for (const result of [first, second, third]) {
+                expect(result.ok).toBe(false);
+                if (result.ok === false) {
+                    expect(result.reason).toBe('dangerous-content');
+                }
+            }
+        });
+
         it.each<[string, string]>([
             [
                 'http://… in fill',

--- a/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
@@ -105,6 +105,37 @@ describe('sanitizeSvg', () => {
             }
         });
 
+        it.each<[string, string]>([
+            [
+                'http://… in fill',
+                '<svg viewBox="0 0 24 24"><circle fill="url(http://tracker.example/pixel.svg#g)" cx="12" cy="12" r="6"/></svg>',
+            ],
+            [
+                'https://… in fill',
+                '<svg viewBox="0 0 24 24"><rect fill="url(https://tracker.example/pixel)" width="24" height="24"/></svg>',
+            ],
+            [
+                'protocol-relative // in stroke',
+                '<svg viewBox="0 0 24 24"><circle stroke="url(//tracker.example/pixel)" cx="12" cy="12" r="6"/></svg>',
+            ],
+        ])('rejects external paint-server reference (%s) — IP-leak vector', (_, input) => {
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(false);
+            if (result.ok === false) {
+                expect(result.reason).toBe('dangerous-content');
+            }
+        });
+
+        it('allows local fragment paint refs like url(#myGradient)', () => {
+            const input =
+                '<svg viewBox="0 0 24 24"><defs><linearGradient id="g"><stop offset="0"/></linearGradient></defs><circle fill="url(#g)" cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).toContain('url(#g)');
+            }
+        });
+
         it('strips comments, DOCTYPE, processing instructions, and CDATA', () => {
             const input =
                 '<?xml version="1.0"?><!DOCTYPE svg><svg viewBox="0 0 24 24"><!-- payload --><![CDATA[stuff]]><circle cx="12" cy="12" r="6"/></svg>';

--- a/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
@@ -1,0 +1,188 @@
+import { MAX_SVG_LENGTH, sanitizeSvg } from '../svg-sanitizer';
+
+describe('sanitizeSvg', () => {
+    describe('rejection', () => {
+        it.each<[string, unknown]>([
+            ['null input', null],
+            ['undefined input', undefined],
+            ['empty string', ''],
+            ['whitespace only', '   \n  '],
+            ['non-string input', 123],
+        ])('rejects %s', (_, input) => {
+            const result = sanitizeSvg(input as string);
+            expect(result.ok).toBe(false);
+            if (result.ok === false) {
+                expect(result.reason).toBe('empty');
+            }
+        });
+
+        it('rejects markup with no <svg> root', () => {
+            const result = sanitizeSvg('<div>not an svg</div>');
+            expect(result.ok).toBe(false);
+            if (result.ok === false) {
+                expect(result.reason).toBe('no-svg-tag');
+            }
+        });
+
+        it('rejects an unclosed <svg>', () => {
+            const result = sanitizeSvg('<svg viewBox="0 0 24 24"><circle/>');
+            expect(result.ok).toBe(false);
+            if (result.ok === false) {
+                expect(result.reason).toBe('unclosed-svg');
+            }
+        });
+
+        it('rejects payloads exceeding MAX_SVG_LENGTH', () => {
+            const filler = '<path d="M0 0L1 1"/>'.repeat(500);
+            const oversize = `<svg viewBox="0 0 24 24">${filler}</svg>`;
+            expect(oversize.length).toBeGreaterThan(MAX_SVG_LENGTH);
+
+            const result = sanitizeSvg(oversize);
+            expect(result.ok).toBe(false);
+            if (result.ok === false) {
+                expect(result.reason).toBe('too-large');
+            }
+        });
+    });
+
+    describe('scrubbing', () => {
+        it('strips <script> blocks', () => {
+            const input = '<svg viewBox="0 0 24 24"><script>alert(1)</script><circle cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).not.toContain('script');
+                expect(result.svg).not.toContain('alert');
+                expect(result.svg).toContain('<circle');
+            }
+        });
+
+        it('strips <foreignObject> blocks', () => {
+            const input =
+                '<svg viewBox="0 0 24 24"><foreignObject><div onclick="x()"></div></foreignObject><circle cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).not.toContain('foreignObject');
+                expect(result.svg).not.toContain('onclick');
+                expect(result.svg).toContain('<circle');
+            }
+        });
+
+        it('strips event handler attributes (on*)', () => {
+            const input = '<svg viewBox="0 0 24 24"><circle onload="evil()" onclick="evil()" cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).not.toMatch(/\bonload=/i);
+                expect(result.svg).not.toMatch(/\bonclick=/i);
+                expect(result.svg).not.toContain('evil');
+            }
+        });
+
+        it('strips xlink:href and href attributes', () => {
+            const input =
+                '<svg viewBox="0 0 24 24"><a href="https://evil.example.com"><circle xlink:href="#bad" cx="12" cy="12" r="6"/></a></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).not.toMatch(/\bhref=/i);
+                expect(result.svg).not.toMatch(/\bxlink:href=/i);
+            }
+        });
+
+        it('rejects payloads containing javascript:/data:/vbscript: URL schemes that survive scrubbing', () => {
+            // The href stripper removes most vectors; this construct hides one
+            // inside fill="url(...)".
+            const input =
+                '<svg viewBox="0 0 24 24"><circle fill="url(javascript:alert(1))" cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(false);
+            if (result.ok === false) {
+                expect(result.reason).toBe('dangerous-content');
+            }
+        });
+
+        it('strips comments, DOCTYPE, processing instructions, and CDATA', () => {
+            const input =
+                '<?xml version="1.0"?><!DOCTYPE svg><svg viewBox="0 0 24 24"><!-- payload --><![CDATA[stuff]]><circle cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).not.toContain('<!--');
+                expect(result.svg).not.toContain('DOCTYPE');
+                expect(result.svg).not.toContain('CDATA');
+                expect(result.svg).not.toContain('<?xml');
+            }
+        });
+    });
+
+    describe('normalization', () => {
+        it('forces viewBox to "0 0 24 24"', () => {
+            const input = '<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).toContain('viewBox="0 0 24 24"');
+                expect(result.svg).not.toContain('0 0 100 100');
+            }
+        });
+
+        it('adds viewBox when missing', () => {
+            const input = '<svg><circle cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).toContain('viewBox="0 0 24 24"');
+            }
+        });
+
+        it('strips width and height attributes from the root', () => {
+            const input =
+                '<svg width="48" height="48" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).not.toMatch(/\bwidth=/);
+                expect(result.svg).not.toMatch(/\bheight=/);
+            }
+        });
+
+        it('ensures xmlns is present', () => {
+            const input = '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+            }
+        });
+
+        it('discards content outside the <svg>...</svg> root', () => {
+            const input = 'Sure, here is your icon:\n<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>\nLet me know if you need adjustments.';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg.startsWith('<svg')).toBe(true);
+                expect(result.svg.endsWith('</svg>')).toBe(true);
+                expect(result.svg).not.toContain('Sure');
+                expect(result.svg).not.toContain('Let me know');
+            }
+        });
+    });
+
+    describe('happy path', () => {
+        it('passes a clean curated icon through unchanged in spirit', () => {
+            const input =
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>';
+            const result = sanitizeSvg(input);
+            expect(result.ok).toBe(true);
+            if (result.ok === true) {
+                expect(result.svg).toContain('<circle');
+                expect(result.svg).toContain('viewBox="0 0 24 24"');
+                expect(result.svg).toContain('stroke="currentColor"');
+                expect(result.bytes).toBeGreaterThan(0);
+                expect(result.bytes).toBeLessThanOrEqual(MAX_SVG_LENGTH);
+            }
+        });
+    });
+});

--- a/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
+++ b/packages/agent/src/services/category-icon/__tests__/svg-sanitizer.spec.ts
@@ -47,7 +47,8 @@ describe('sanitizeSvg', () => {
 
     describe('scrubbing', () => {
         it('strips <script> blocks', () => {
-            const input = '<svg viewBox="0 0 24 24"><script>alert(1)</script><circle cx="12" cy="12" r="6"/></svg>';
+            const input =
+                '<svg viewBox="0 0 24 24"><script>alert(1)</script><circle cx="12" cy="12" r="6"/></svg>';
             const result = sanitizeSvg(input);
             expect(result.ok).toBe(true);
             if (result.ok === true) {
@@ -70,7 +71,8 @@ describe('sanitizeSvg', () => {
         });
 
         it('strips event handler attributes (on*)', () => {
-            const input = '<svg viewBox="0 0 24 24"><circle onload="evil()" onclick="evil()" cx="12" cy="12" r="6"/></svg>';
+            const input =
+                '<svg viewBox="0 0 24 24"><circle onload="evil()" onclick="evil()" cx="12" cy="12" r="6"/></svg>';
             const result = sanitizeSvg(input);
             expect(result.ok).toBe(true);
             if (result.ok === true) {
@@ -158,7 +160,8 @@ describe('sanitizeSvg', () => {
         });
 
         it('discards content outside the <svg>...</svg> root', () => {
-            const input = 'Sure, here is your icon:\n<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>\nLet me know if you need adjustments.';
+            const input =
+                'Sure, here is your icon:\n<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>\nLet me know if you need adjustments.';
             const result = sanitizeSvg(input);
             expect(result.ok).toBe(true);
             if (result.ok === true) {

--- a/packages/agent/src/services/category-icon/ai-generator.ts
+++ b/packages/agent/src/services/category-icon/ai-generator.ts
@@ -62,16 +62,11 @@ export interface CategoryIconGenerateSuccess {
 
 export interface CategoryIconGenerateFailure {
     readonly ok: false;
-    readonly reason:
-        | 'no-content'
-        | 'sanitize-failed'
-        | 'facade-error';
+    readonly reason: 'no-content' | 'sanitize-failed' | 'facade-error';
     readonly detail?: string;
 }
 
-export type CategoryIconGenerateResult =
-    | CategoryIconGenerateSuccess
-    | CategoryIconGenerateFailure;
+export type CategoryIconGenerateResult = CategoryIconGenerateSuccess | CategoryIconGenerateFailure;
 
 /**
  * Ask the configured AI provider for an SVG icon describing a category.
@@ -121,9 +116,7 @@ export async function generateCategoryIconSvg(
     const sanitized = sanitizeSvg(stripped);
     if (sanitized.ok === false) {
         const reason = sanitized.reason;
-        logger?.warn(
-            `Category icon for "${name}" failed sanitization (${reason}); model=${model}`,
-        );
+        logger?.warn(`Category icon for "${name}" failed sanitization (${reason}); model=${model}`);
         return {
             ok: false,
             reason: 'sanitize-failed',

--- a/packages/agent/src/services/category-icon/ai-generator.ts
+++ b/packages/agent/src/services/category-icon/ai-generator.ts
@@ -1,0 +1,155 @@
+import type { Logger } from '@nestjs/common';
+import type { FacadeOptions, IAiFacade } from '@ever-works/plugin';
+
+import { sanitizeSvg, type SanitizeResult } from './svg-sanitizer';
+
+/**
+ * Locked-down system prompt used to coax an LLM into emitting a single
+ * minimal SVG suitable for category icons. The output constraints are
+ * verified by the SVG sanitizer regardless of how well the model
+ * complies, so this prompt is best-effort, not a safety boundary.
+ */
+const ICON_SYSTEM_PROMPT = `You generate tiny, minimal SVG icons for app category badges.
+
+Rules — you MUST follow ALL of them:
+1. Output ONE <svg> element and NOTHING else. No prose, no markdown,
+   no explanation, no <?xml?> declaration, no <!DOCTYPE>.
+2. Root attributes MUST be exactly:
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 24 24"
+   fill="none"
+   stroke="currentColor"
+   stroke-width="2"
+   stroke-linecap="round"
+   stroke-linejoin="round"
+3. Use ONLY these elements: <path>, <circle>, <rect>, <line>,
+   <polyline>, <polygon>, <ellipse>. Nothing else.
+4. NO <script>, NO <foreignObject>, NO <iframe>, NO <embed>, NO <object>,
+   NO <use> with external href, NO <image>, NO <text>, NO <animate>,
+   NO comments, NO event handler attributes (on*), NO inline style="".
+5. Use stroke="currentColor" so the consumer can theme the icon.
+   Do NOT pick a fill or stroke color other than currentColor or "none".
+6. Keep the geometry simple — under 6 child elements is ideal.
+   Total payload should fit comfortably under 1KB.
+7. The icon should be visually distinct and readable at 16×16 pixels.
+
+Category to draw: "{category_name}"
+{category_description_block}
+Output the SVG and nothing else.`;
+
+const CATEGORY_DESCRIPTION_TEMPLATE = (description: string): string =>
+    `Description (use this to inform what the icon depicts): "${description}"\n`;
+
+const MARKDOWN_FENCE_RE = /^```(?:svg|xml|html)?\s*\n?|\n?```\s*$/g;
+
+const PROVIDER_TASK_ID = 'category-icon-generation';
+
+export interface CategoryIconGenerateOptions {
+    /** Category name (free-form, e.g. "Time Tracking", "Open-Source"). */
+    readonly name: string;
+    /** Optional description used as additional prompt context. */
+    readonly description?: string;
+    /** Facade context — required by AiFacade for plugin/key resolution. */
+    readonly facadeOptions: FacadeOptions;
+    /** Optional logger for diagnostic output. */
+    readonly logger?: Pick<Logger, 'log' | 'warn' | 'debug' | 'error'>;
+}
+
+export interface CategoryIconGenerateSuccess {
+    readonly ok: true;
+    readonly svg: string;
+    readonly bytes: number;
+    readonly model: string;
+}
+
+export interface CategoryIconGenerateFailure {
+    readonly ok: false;
+    readonly reason:
+        | 'no-content'
+        | 'sanitize-failed'
+        | 'facade-error';
+    readonly detail?: string;
+}
+
+export type CategoryIconGenerateResult =
+    | CategoryIconGenerateSuccess
+    | CategoryIconGenerateFailure;
+
+/**
+ * Ask the configured AI provider for an SVG icon describing a category.
+ * The output is run through the SVG sanitizer before being returned;
+ * dangerous or malformed responses become a `sanitize-failed` failure
+ * the caller can fall back from gracefully.
+ */
+export async function generateCategoryIconSvg(
+    aiFacade: IAiFacade,
+    options: CategoryIconGenerateOptions,
+): Promise<CategoryIconGenerateResult> {
+    const { name, description, facadeOptions, logger } = options;
+
+    const prompt = ICON_SYSTEM_PROMPT.replace('{category_name}', name).replace(
+        '{category_description_block}',
+        description ? CATEGORY_DESCRIPTION_TEMPLATE(description) : '',
+    );
+
+    let raw: string;
+    let model: string;
+
+    try {
+        const response = await aiFacade.createChatCompletion(
+            {
+                messages: [{ role: 'user', content: prompt }],
+                // Low temperature: we want consistency, not creativity.
+                temperature: 0.2,
+                routing: {
+                    // Cheapest tier — this is a tiny, well-bounded task.
+                    complexity: 'simple',
+                    taskId: PROVIDER_TASK_ID,
+                },
+            },
+            facadeOptions,
+        );
+
+        const content = response.choices[0]?.message?.content;
+        if (!content || typeof content !== 'string') {
+            return { ok: false, reason: 'no-content' };
+        }
+
+        raw = content;
+        model = response.model;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger?.warn(`Category icon generation failed for "${name}": ${message}`);
+        return { ok: false, reason: 'facade-error', detail: message };
+    }
+
+    const stripped = stripMarkdownFences(raw).trim();
+
+    const sanitized: SanitizeResult = sanitizeSvg(stripped);
+    if (!sanitized.ok) {
+        logger?.warn(
+            `Category icon for "${name}" failed sanitization (${sanitized.reason}); model=${model}`,
+        );
+        return {
+            ok: false,
+            reason: 'sanitize-failed',
+            detail: sanitized.reason,
+        };
+    }
+
+    return {
+        ok: true,
+        svg: sanitized.svg,
+        bytes: sanitized.bytes,
+        model,
+    };
+}
+
+/**
+ * Many models wrap code output in ```svg / ``` fences despite being
+ * asked not to. Strip those before sanitization rather than rejecting
+ * an otherwise-valid icon.
+ */
+function stripMarkdownFences(input: string): string {
+    return input.replace(MARKDOWN_FENCE_RE, '').trim();
+}

--- a/packages/agent/src/services/category-icon/ai-generator.ts
+++ b/packages/agent/src/services/category-icon/ai-generator.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@nestjs/common';
 import type { FacadeOptions, IAiFacade } from '@ever-works/plugin';
 
-import { sanitizeSvg, type SanitizeResult } from './svg-sanitizer';
+import { sanitizeSvg } from './svg-sanitizer';
 
 /**
  * Locked-down system prompt used to coax an LLM into emitting a single
@@ -41,8 +41,6 @@ const CATEGORY_DESCRIPTION_TEMPLATE = (description: string): string =>
     `Description (use this to inform what the icon depicts): "${description}"\n`;
 
 const MARKDOWN_FENCE_RE = /^```(?:svg|xml|html)?\s*\n?|\n?```\s*$/g;
-
-const PROVIDER_TASK_ID = 'category-icon-generation';
 
 export interface CategoryIconGenerateOptions {
     /** Category name (free-form, e.g. "Time Tracking", "Open-Source"). */
@@ -101,11 +99,6 @@ export async function generateCategoryIconSvg(
                 messages: [{ role: 'user', content: prompt }],
                 // Low temperature: we want consistency, not creativity.
                 temperature: 0.2,
-                routing: {
-                    // Cheapest tier — this is a tiny, well-bounded task.
-                    complexity: 'simple',
-                    taskId: PROVIDER_TASK_ID,
-                },
             },
             facadeOptions,
         );
@@ -125,15 +118,16 @@ export async function generateCategoryIconSvg(
 
     const stripped = stripMarkdownFences(raw).trim();
 
-    const sanitized: SanitizeResult = sanitizeSvg(stripped);
-    if (!sanitized.ok) {
+    const sanitized = sanitizeSvg(stripped);
+    if (sanitized.ok === false) {
+        const reason = sanitized.reason;
         logger?.warn(
-            `Category icon for "${name}" failed sanitization (${sanitized.reason}); model=${model}`,
+            `Category icon for "${name}" failed sanitization (${reason}); model=${model}`,
         );
         return {
             ok: false,
             reason: 'sanitize-failed',
-            detail: sanitized.reason,
+            detail: reason,
         };
     }
 

--- a/packages/agent/src/services/category-icon/category-icon.module.ts
+++ b/packages/agent/src/services/category-icon/category-icon.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+
+import { FacadesModule } from '../../facades/facades.module';
+import { CategoryIconService } from './category-icon.service';
+
+/**
+ * Category icon resolution subsystem (EW-357).
+ *
+ * Exports {@link CategoryIconService} so the data-generator and any
+ * future consumer (e.g. a Trigger.dev backfill task) can resolve and
+ * persist `icon_svg` for AI-classified categories.
+ *
+ * The service depends on:
+ *   - {@link AiFacadeService} — provided by FacadesModule.
+ *   - The global `CACHE_MANAGER` — registered at the API root via
+ *     `CacheFactory.TypeORM({ isGlobal: true })`. The injection is
+ *     marked `@Optional()` in the service so contexts without a cache
+ *     (unit tests, the CLI) still work.
+ */
+@Module({
+    imports: [FacadesModule],
+    providers: [CategoryIconService],
+    exports: [CategoryIconService],
+})
+export class CategoryIconModule {}

--- a/packages/agent/src/services/category-icon/category-icon.service.ts
+++ b/packages/agent/src/services/category-icon/category-icon.service.ts
@@ -1,0 +1,209 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+import type { FacadeOptions } from '@ever-works/plugin';
+
+import { AiFacadeService } from '../../facades/ai.facade';
+import {
+    generateCategoryIconSvg,
+    type CategoryIconGenerateResult,
+} from './ai-generator';
+import {
+    getFallbackIcon,
+    lookupCuratedIcon,
+} from './curated-mapping';
+import { sanitizeSvg } from './svg-sanitizer';
+
+/** Cache key version. Bump to invalidate the entire icon cache (e.g.
+ *  if the prompt template or palette changes meaningfully). */
+const CACHE_KEY_VERSION = 'v1';
+
+/** Effectively-permanent TTL for cached icons (90 days). Icons are
+ *  stable artifacts; this is a soft refresh interval, not a hard
+ *  expiry. Browsers / consumers never see the cache, only the YAML. */
+const CACHE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+const CACHE_KEY_PREFIX = `category-icon:${CACHE_KEY_VERSION}`;
+
+export type CategoryIconSource = 'cache' | 'curated' | 'ai' | 'fallback';
+
+export interface CategoryIconResult {
+    /** Sanitized SVG markup ready to persist into Category.icon_svg. */
+    readonly svg: string;
+    /** Where the SVG came from — useful for telemetry / logging. */
+    readonly source: CategoryIconSource;
+    /** Byte length of the SVG (UTF-8). */
+    readonly bytes: number;
+    /** Model name when source === 'ai'; undefined otherwise. */
+    readonly model?: string;
+}
+
+export interface EnsureCategoryIconOptions {
+    /** Category name (free-form). */
+    readonly name: string;
+    /** Optional description used as additional AI prompt context. */
+    readonly description?: string;
+    /** AI facade context — required for AI generation. */
+    readonly facadeOptions: FacadeOptions;
+    /**
+     * Skip the AI tier entirely. When true, returns curated → fallback
+     * only. Useful when the host work has AI icon generation disabled.
+     */
+    readonly disableAi?: boolean;
+}
+
+/**
+ * Resolves an SVG icon for a category, consulting tiered sources in
+ * order: cache → curated lookup → AI generation → static fallback.
+ *
+ * The cache is keyed by normalized category name (not by workId), so a
+ * once-generated icon for "Productivity" is reused across every work
+ * the platform serves. Cache misses for AI-tier hits are written back
+ * before returning.
+ */
+@Injectable()
+export class CategoryIconService {
+    private readonly logger = new Logger(CategoryIconService.name);
+
+    constructor(
+        private readonly aiFacade: AiFacadeService,
+        @Optional()
+        @Inject(CACHE_MANAGER)
+        private readonly cache?: Cache,
+    ) {}
+
+    /**
+     * Resolve the icon for a category. Always returns a usable SVG —
+     * the fallback tier guarantees a non-null result even when AI and
+     * curated lookups both miss.
+     */
+    async ensureIcon(options: EnsureCategoryIconOptions): Promise<CategoryIconResult> {
+        const normalizedName = normalizeName(options.name);
+        if (!normalizedName) {
+            return this.fallback();
+        }
+
+        // 1. Cache hit — return immediately.
+        const cacheKey = buildCacheKey(normalizedName);
+        const cached = await this.readCache(cacheKey);
+        if (cached) {
+            return {
+                svg: cached,
+                source: 'cache',
+                bytes: Buffer.byteLength(cached, 'utf8'),
+            };
+        }
+
+        // 2. Curated lookup — fast, free, visually consistent.
+        const curated = lookupCuratedIcon(options.name);
+        if (curated) {
+            const sanitized = sanitizeSvg(curated.svg);
+            if (sanitized.ok) {
+                await this.writeCache(cacheKey, sanitized.svg);
+                return {
+                    svg: sanitized.svg,
+                    source: 'curated',
+                    bytes: sanitized.bytes,
+                };
+            }
+            // Curated icons are sanitizer-clean by construction; this
+            // would indicate a regression in the library.
+            this.logger.warn(
+                `Curated icon for "${options.name}" failed sanitization: ${sanitized.reason}`,
+            );
+        }
+
+        // 3. AI generation — only when allowed.
+        if (!options.disableAi) {
+            const generated = await this.tryGenerate(options);
+            if (generated) {
+                await this.writeCache(cacheKey, generated.svg);
+                return generated;
+            }
+        }
+
+        // 4. Hard fallback — guaranteed non-null icon.
+        return this.fallback();
+    }
+
+    private async tryGenerate(
+        options: EnsureCategoryIconOptions,
+    ): Promise<CategoryIconResult | null> {
+        const result: CategoryIconGenerateResult = await generateCategoryIconSvg(this.aiFacade, {
+            name: options.name,
+            description: options.description,
+            facadeOptions: options.facadeOptions,
+            logger: this.logger,
+        });
+
+        if (!result.ok) {
+            this.logger.debug(
+                `AI icon generation for "${options.name}" did not produce a usable SVG: ${result.reason}`,
+            );
+            return null;
+        }
+
+        return {
+            svg: result.svg,
+            source: 'ai',
+            bytes: result.bytes,
+            model: result.model,
+        };
+    }
+
+    private fallback(): CategoryIconResult {
+        const icon = getFallbackIcon();
+        // Defensive sanitize so the fallback obeys the same hygiene rules.
+        const sanitized = sanitizeSvg(icon.svg);
+        if (sanitized.ok) {
+            return {
+                svg: sanitized.svg,
+                source: 'fallback',
+                bytes: sanitized.bytes,
+            };
+        }
+        // Should never happen — the curated library ships with valid SVGs.
+        return {
+            svg: icon.svg,
+            source: 'fallback',
+            bytes: Buffer.byteLength(icon.svg, 'utf8'),
+        };
+    }
+
+    private async readCache(key: string): Promise<string | null> {
+        if (!this.cache) {
+            return null;
+        }
+        try {
+            const value = await this.cache.get<string>(key);
+            return typeof value === 'string' && value.length > 0 ? value : null;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.debug(`Cache read miss for ${key}: ${message}`);
+            return null;
+        }
+    }
+
+    private async writeCache(key: string, svg: string): Promise<void> {
+        if (!this.cache) {
+            return;
+        }
+        try {
+            await this.cache.set(key, svg, CACHE_TTL_MS);
+        } catch (error) {
+            // A cache failure is never fatal — the caller already has
+            // the SVG it needs and the next request will retry the
+            // resolution. Log and move on.
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Failed to cache icon for ${key}: ${message}`);
+        }
+    }
+}
+
+function normalizeName(name: string): string {
+    return (name ?? '').toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+function buildCacheKey(normalizedName: string): string {
+    return `${CACHE_KEY_PREFIX}:${normalizedName}`;
+}

--- a/packages/agent/src/services/category-icon/category-icon.service.ts
+++ b/packages/agent/src/services/category-icon/category-icon.service.ts
@@ -6,10 +6,7 @@ import type { Category, Collection, FacadeOptions } from '@ever-works/plugin';
 
 import { AiFacadeService } from '../../facades/ai.facade';
 import { generateCategoryIconSvg } from './ai-generator';
-import {
-    getFallbackIcon,
-    lookupCuratedIcon,
-} from './curated-mapping';
+import { getFallbackIcon, lookupCuratedIcon } from './curated-mapping';
 import { sanitizeSvg } from './svg-sanitizer';
 
 /**
@@ -152,11 +149,9 @@ export class CategoryIconService {
             return [];
         }
 
-        return pMap(
-            categories,
-            async (category) => this.enrichOne(category, options),
-            { concurrency: ENRICHMENT_CONCURRENCY },
-        );
+        return pMap(categories, async (category) => this.enrichOne(category, options), {
+            concurrency: ENRICHMENT_CONCURRENCY,
+        });
     }
 
     /**
@@ -171,11 +166,9 @@ export class CategoryIconService {
             return [];
         }
 
-        return pMap(
-            collections,
-            async (collection) => this.enrichOne(collection, options),
-            { concurrency: ENRICHMENT_CONCURRENCY },
-        );
+        return pMap(collections, async (collection) => this.enrichOne(collection, options), {
+            concurrency: ENRICHMENT_CONCURRENCY,
+        });
     }
 
     private async enrichOne<T extends IconBearing & { name: string; description?: string }>(

--- a/packages/agent/src/services/category-icon/category-icon.service.ts
+++ b/packages/agent/src/services/category-icon/category-icon.service.ts
@@ -1,7 +1,8 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
-import type { FacadeOptions } from '@ever-works/plugin';
+import pMap from 'p-map';
+import type { Category, Collection, FacadeOptions } from '@ever-works/plugin';
 
 import { AiFacadeService } from '../../facades/ai.facade';
 import {
@@ -13,6 +14,16 @@ import {
     lookupCuratedIcon,
 } from './curated-mapping';
 import { sanitizeSvg } from './svg-sanitizer';
+
+/**
+ * How many categories to resolve in parallel during bulk enrichment.
+ * AI calls are the bottleneck — keep concurrency modest so a single
+ * generation pass doesn't fan out into rate-limit territory.
+ */
+const ENRICHMENT_CONCURRENCY = 4;
+
+/** What the entity already has — used to decide whether to skip. */
+type IconBearing = { readonly icon_svg?: string };
 
 /** Cache key version. Bump to invalidate the entire icon cache (e.g.
  *  if the prompt template or palette changes meaningfully). */
@@ -124,6 +135,72 @@ export class CategoryIconService {
 
         // 4. Hard fallback — guaranteed non-null icon.
         return this.fallback();
+    }
+
+    /**
+     * Bulk enrichment for an array of categories. Items that already
+     * have a non-empty `icon_svg` are returned untouched. Resolution
+     * runs at controlled concurrency so a 50-category pass doesn't
+     * blow through provider rate limits.
+     *
+     * Failures for individual categories never abort the batch — the
+     * affected entry retains whatever icon_svg it came in with (or
+     * none, which the UI handles via the fallback render path).
+     */
+    async enrichCategories<T extends Category>(
+        categories: readonly T[],
+        options: Omit<EnsureCategoryIconOptions, 'name' | 'description'>,
+    ): Promise<T[]> {
+        if (!categories || categories.length === 0) {
+            return [];
+        }
+
+        return pMap(
+            categories,
+            async (category) => this.enrichOne(category, options),
+            { concurrency: ENRICHMENT_CONCURRENCY },
+        );
+    }
+
+    /**
+     * Same as {@link enrichCategories} but for collections (which share
+     * the icon_svg field shape).
+     */
+    async enrichCollections<T extends Collection>(
+        collections: readonly T[],
+        options: Omit<EnsureCategoryIconOptions, 'name' | 'description'>,
+    ): Promise<T[]> {
+        if (!collections || collections.length === 0) {
+            return [];
+        }
+
+        return pMap(
+            collections,
+            async (collection) => this.enrichOne(collection, options),
+            { concurrency: ENRICHMENT_CONCURRENCY },
+        );
+    }
+
+    private async enrichOne<T extends IconBearing & { name: string; description?: string }>(
+        entity: T,
+        options: Omit<EnsureCategoryIconOptions, 'name' | 'description'>,
+    ): Promise<T> {
+        if (entity.icon_svg && entity.icon_svg.trim().length > 0) {
+            return entity;
+        }
+
+        try {
+            const resolved = await this.ensureIcon({
+                ...options,
+                name: entity.name,
+                description: entity.description,
+            });
+            return { ...entity, icon_svg: resolved.svg };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Failed to enrich icon for "${entity.name}": ${message}`);
+            return entity;
+        }
     }
 
     private async tryGenerate(

--- a/packages/agent/src/services/category-icon/category-icon.service.ts
+++ b/packages/agent/src/services/category-icon/category-icon.service.ts
@@ -5,10 +5,7 @@ import pMap from 'p-map';
 import type { Category, Collection, FacadeOptions } from '@ever-works/plugin';
 
 import { AiFacadeService } from '../../facades/ai.facade';
-import {
-    generateCategoryIconSvg,
-    type CategoryIconGenerateResult,
-} from './ai-generator';
+import { generateCategoryIconSvg } from './ai-generator';
 import {
     getFallbackIcon,
     lookupCuratedIcon,
@@ -109,7 +106,7 @@ export class CategoryIconService {
         const curated = lookupCuratedIcon(options.name);
         if (curated) {
             const sanitized = sanitizeSvg(curated.svg);
-            if (sanitized.ok) {
+            if (sanitized.ok === true) {
                 await this.writeCache(cacheKey, sanitized.svg);
                 return {
                     svg: sanitized.svg,
@@ -206,14 +203,14 @@ export class CategoryIconService {
     private async tryGenerate(
         options: EnsureCategoryIconOptions,
     ): Promise<CategoryIconResult | null> {
-        const result: CategoryIconGenerateResult = await generateCategoryIconSvg(this.aiFacade, {
+        const result = await generateCategoryIconSvg(this.aiFacade, {
             name: options.name,
             description: options.description,
             facadeOptions: options.facadeOptions,
             logger: this.logger,
         });
 
-        if (!result.ok) {
+        if (result.ok === false) {
             this.logger.debug(
                 `AI icon generation for "${options.name}" did not produce a usable SVG: ${result.reason}`,
             );

--- a/packages/agent/src/services/category-icon/curated-mapping.ts
+++ b/packages/agent/src/services/category-icon/curated-mapping.ts
@@ -1,0 +1,373 @@
+/**
+ * Curated category-name → SVG icon mapping (Tier 1 of icon resolution).
+ *
+ * Why: AI-generated SVGs are visually inconsistent and cost ~$0.01-0.05 per
+ * call. ~80% of categories Ever Works classifiers produce match well-known
+ * concepts (Productivity, Open-Source, Time-Tracking, …) for which a small
+ * library of hand-picked Lucide icons gives instant, free, visually
+ * consistent results. Tier 2 (AI generation) only fires for the long tail.
+ *
+ * The icons themselves are minimal Lucide-style SVG markup (24×24 viewBox,
+ * 2px stroke, currentColor) embedded as strings to keep the agent package
+ * dependency-free of React/Lucide. Source: lucide.dev (ISC license).
+ */
+
+export interface CuratedIcon {
+    /** Lucide icon name — useful for debugging / future swaps. */
+    readonly name: string;
+    /** Inline SVG markup. 24×24 viewBox, currentColor stroke, no width/height. */
+    readonly svg: string;
+}
+
+const SVG_OPEN =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">';
+const SVG_CLOSE = '</svg>';
+
+const wrap = (paths: string): string => `${SVG_OPEN}${paths}${SVG_CLOSE}`;
+
+/**
+ * Library of curated icons keyed by short slug. Add new entries here and
+ * reference them from KEYWORD_RULES below.
+ */
+export const CATEGORY_ICON_LIBRARY: Readonly<Record<string, CuratedIcon>> = Object.freeze({
+    code: {
+        name: 'code',
+        svg: wrap('<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>'),
+    },
+    'code-2': {
+        name: 'code-2',
+        svg: wrap(
+            '<path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/>',
+        ),
+    },
+    briefcase: {
+        name: 'briefcase',
+        svg: wrap(
+            '<rect width="20" height="14" x="2" y="7" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>',
+        ),
+    },
+    clock: {
+        name: 'clock',
+        svg: wrap('<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>'),
+    },
+    gift: {
+        name: 'gift',
+        svg: wrap(
+            '<rect x="3" y="8" width="18" height="4" rx="1"/><path d="M12 8v13"/><path d="M19 12v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7"/><path d="M7.5 8a2.5 2.5 0 0 1 0-5A4.8 8 0 0 1 12 8a4.8 8 0 0 1 4.5-5 2.5 2.5 0 0 1 0 5"/>',
+        ),
+    },
+    brain: {
+        name: 'brain',
+        svg: wrap(
+            '<path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/>',
+        ),
+    },
+    cloud: {
+        name: 'cloud',
+        svg: wrap('<path d="M17.5 19a4.5 4.5 0 1 0-1.42-8.78 7 7 0 1 0-13.04 3.78"/>'),
+    },
+    database: {
+        name: 'database',
+        svg: wrap(
+            '<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0 0 18 0V5"/><path d="M3 12a9 3 0 0 0 18 0"/>',
+        ),
+    },
+    search: {
+        name: 'search',
+        svg: wrap('<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>'),
+    },
+    shield: {
+        name: 'shield',
+        svg: wrap(
+            '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/>',
+        ),
+    },
+    'chart-bar': {
+        name: 'chart-bar',
+        svg: wrap(
+            '<path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16h2"/><path d="M11 12h2"/><path d="M15 8h2"/>',
+        ),
+    },
+    'message-circle': {
+        name: 'message-circle',
+        svg: wrap('<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/>'),
+    },
+    mail: {
+        name: 'mail',
+        svg: wrap(
+            '<rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>',
+        ),
+    },
+    calendar: {
+        name: 'calendar',
+        svg: wrap(
+            '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>',
+        ),
+    },
+    music: {
+        name: 'music',
+        svg: wrap(
+            '<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>',
+        ),
+    },
+    video: {
+        name: 'video',
+        svg: wrap(
+            '<path d="m22 8-6 4 6 4V8Z"/><rect width="14" height="12" x="2" y="6" rx="2" ry="2"/>',
+        ),
+    },
+    camera: {
+        name: 'camera',
+        svg: wrap(
+            '<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/>',
+        ),
+    },
+    palette: {
+        name: 'palette',
+        svg: wrap(
+            '<circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>',
+        ),
+    },
+    terminal: {
+        name: 'terminal',
+        svg: wrap('<polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/>'),
+    },
+    'file-text': {
+        name: 'file-text',
+        svg: wrap(
+            '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/>',
+        ),
+    },
+    'check-square': {
+        name: 'check-square',
+        svg: wrap(
+            '<polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>',
+        ),
+    },
+    'book-open': {
+        name: 'book-open',
+        svg: wrap(
+            '<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>',
+        ),
+    },
+    newspaper: {
+        name: 'newspaper',
+        svg: wrap(
+            '<path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2Zm0 0a2 2 0 0 1-2-2v-9c0-1.1.9-2 2-2h2"/><path d="M18 14h-8"/><path d="M15 18h-5"/><path d="M10 6h8v4h-8z"/>',
+        ),
+    },
+    users: {
+        name: 'users',
+        svg: wrap(
+            '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+        ),
+    },
+    gamepad: {
+        name: 'gamepad',
+        svg: wrap(
+            '<line x1="6" x2="10" y1="11" y2="11"/><line x1="8" x2="8" y1="9" y2="13"/><line x1="15" x2="15.01" y1="12" y2="12"/><line x1="18" x2="18.01" y1="10" y2="10"/><path d="M17.32 5H6.68a4 4 0 0 0-3.978 3.59c-.006.052-.01.101-.017.152C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258a3.998 3.998 0 0 0-3.995-3.742Z"/>',
+        ),
+    },
+    'dollar-sign': {
+        name: 'dollar-sign',
+        svg: wrap(
+            '<line x1="12" x2="12" y1="2" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>',
+        ),
+    },
+    'shopping-cart': {
+        name: 'shopping-cart',
+        svg: wrap(
+            '<circle cx="8" cy="21" r="1"/><circle cx="19" cy="21" r="1"/><path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"/>',
+        ),
+    },
+    plane: {
+        name: 'plane',
+        svg: wrap(
+            '<path d="M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z"/>',
+        ),
+    },
+    heart: {
+        name: 'heart',
+        svg: wrap(
+            '<path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"/>',
+        ),
+    },
+    'cloud-sun': {
+        name: 'cloud-sun',
+        svg: wrap(
+            '<path d="M12 2v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="M20 12h2"/><path d="m19.07 4.93-1.41 1.41"/><path d="M15.947 12.65a4 4 0 0 0-5.925-4.128"/><path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z"/>',
+        ),
+    },
+    'map-pin': {
+        name: 'map-pin',
+        svg: wrap(
+            '<path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/>',
+        ),
+    },
+    activity: {
+        name: 'activity',
+        svg: wrap('<path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.5.5 0 0 1-.96 0L9.68 3.18a.5.5 0 0 0-.96 0l-2.35 8.36A2 2 0 0 1 4.44 13H2"/>'),
+    },
+    flask: {
+        name: 'flask',
+        svg: wrap(
+            '<path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2"/><path d="M6.453 15h11.094"/><path d="M8.5 2h7"/>',
+        ),
+    },
+    rocket: {
+        name: 'rocket',
+        svg: wrap(
+            '<path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>',
+        ),
+    },
+    package: {
+        name: 'package',
+        svg: wrap(
+            '<path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="m7.5 4.27 9 5.15"/>',
+        ),
+    },
+    plug: {
+        name: 'plug',
+        svg: wrap(
+            '<path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/>',
+        ),
+    },
+    workflow: {
+        name: 'workflow',
+        svg: wrap(
+            '<rect width="8" height="8" x="3" y="3" rx="2"/><path d="M7 11v4a2 2 0 0 0 2 2h4"/><rect width="8" height="8" x="13" y="13" rx="2"/>',
+        ),
+    },
+    globe: {
+        name: 'globe',
+        svg: wrap(
+            '<circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/>',
+        ),
+    },
+    archive: {
+        name: 'archive',
+        svg: wrap(
+            '<rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/>',
+        ),
+    },
+    headphones: {
+        name: 'headphones',
+        svg: wrap(
+            '<path d="M3 14h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H4a1 1 0 0 1-1-1zm18 0h-3a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h2a1 1 0 0 0 1-1z"/><path d="M21 14a9 9 0 0 0-18 0"/>',
+        ),
+    },
+    'user-check': {
+        name: 'user-check',
+        svg: wrap(
+            '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><polyline points="16 11 18 13 22 9"/>',
+        ),
+    },
+    kanban: {
+        name: 'kanban',
+        svg: wrap(
+            '<path d="M6 5v11"/><path d="M12 5v6"/><path d="M18 5v14"/>',
+        ),
+    },
+    tag: {
+        name: 'tag',
+        svg: wrap(
+            '<path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r=".5" fill="currentColor"/>',
+        ),
+    },
+});
+
+export type CuratedIconKey = keyof typeof CATEGORY_ICON_LIBRARY;
+
+interface KeywordRule {
+    readonly patterns: readonly RegExp[];
+    readonly iconKey: CuratedIconKey;
+}
+
+/**
+ * Ordered match rules: first hit wins. More-specific patterns should
+ * appear before more-general ones (e.g. `time-tracking` before `time`).
+ */
+const KEYWORD_RULES: readonly KeywordRule[] = [
+    { patterns: [/\btime[-\s]?tracking\b/i, /\btimesheet/i], iconKey: 'clock' },
+    { patterns: [/\bopen[-\s]?source\b/i, /\bfoss\b/i, /\boss\b/i], iconKey: 'code' },
+    { patterns: [/\bcommercial\b/i, /\benterprise\b/i, /\bbusiness\b/i, /\bb2b\b/i], iconKey: 'briefcase' },
+    { patterns: [/\bproductivity\b/i], iconKey: 'briefcase' },
+    { patterns: [/\bfree(ware)?\b/i, /\bgift\b/i, /\bfreemium\b/i], iconKey: 'gift' },
+    { patterns: [/\b(?:ai|gpt|llm|machine[-\s]?learning|neural)\b/i], iconKey: 'brain' },
+    { patterns: [/\b(?:cloud|saas|paas|iaas)\b/i], iconKey: 'cloud' },
+    { patterns: [/\bdatabase\b/i, /\bdb\b/i, /\bdata[-\s]?store\b/i, /\bsql\b/i, /\bnosql\b/i], iconKey: 'database' },
+    { patterns: [/\bsearch\b/i, /\bdiscover/i], iconKey: 'search' },
+    { patterns: [/\b(?:security|auth|encryption|privacy|firewall|antivirus)\b/i], iconKey: 'shield' },
+    { patterns: [/\b(?:analytic|metric|dashboard|insight|report)/i], iconKey: 'chart-bar' },
+    { patterns: [/\b(?:chat|messaging|messenger|im)\b/i], iconKey: 'message-circle' },
+    { patterns: [/\b(?:email|mail|inbox|smtp)\b/i], iconKey: 'mail' },
+    { patterns: [/\b(?:calendar|schedul|booking|appointment)/i], iconKey: 'calendar' },
+    { patterns: [/\b(?:music|audio|podcast|sound)\b/i], iconKey: 'music' },
+    { patterns: [/\b(?:video|stream|broadcast)/i], iconKey: 'video' },
+    { patterns: [/\b(?:photo|camera|image)\b/i], iconKey: 'camera' },
+    { patterns: [/\b(?:design|graphics|illustrat|sketch|figma)/i], iconKey: 'palette' },
+    { patterns: [/\b(?:cli|terminal|shell|console)\b/i, /\b(?:ide|editor)\b/i], iconKey: 'terminal' },
+    { patterns: [/\b(?:dev|developer)[-\s]?tools?\b/i, /\bcoding\b/i, /\bprogramming\b/i], iconKey: 'code-2' },
+    { patterns: [/\b(?:notes?|journal|document|wiki|knowledge)\b/i], iconKey: 'file-text' },
+    { patterns: [/\b(?:todo|tasks?|gtd|reminder)\b/i], iconKey: 'check-square' },
+    { patterns: [/\b(?:education|learn|course|training|tutorial|book|read)/i], iconKey: 'book-open' },
+    { patterns: [/\b(?:news|newsletter|rss)\b/i], iconKey: 'newspaper' },
+    { patterns: [/\b(?:social|community|forum|network)/i], iconKey: 'users' },
+    { patterns: [/\bgam(?:ing|es?)\b/i], iconKey: 'gamepad' },
+    { patterns: [/\b(?:finance|banking|crypto|payment|invest|fintech|accounting)/i], iconKey: 'dollar-sign' },
+    { patterns: [/\b(?:shopping|ecommerce|retail|marketplace|store)\b/i], iconKey: 'shopping-cart' },
+    { patterns: [/\b(?:travel|flight|hotel|tourism|booking)\b/i], iconKey: 'plane' },
+    { patterns: [/\b(?:health|fitness|medical|wellness|workout)\b/i], iconKey: 'heart' },
+    { patterns: [/\b(?:weather|climate|forecast)\b/i], iconKey: 'cloud-sun' },
+    { patterns: [/\b(?:maps?|navigation|geo|location)/i], iconKey: 'map-pin' },
+    { patterns: [/\b(?:monitor|observ|logging|tracing|alerting)/i], iconKey: 'activity' },
+    { patterns: [/\b(?:test|qa|quality[-\s]?assurance|automated[-\s]?testing)\b/i], iconKey: 'flask' },
+    { patterns: [/\b(?:deployment|devops|ci[-\s]?cd|hosting)\b/i], iconKey: 'rocket' },
+    { patterns: [/\b(?:container|docker|kubernetes|k8s|orchestrat)/i], iconKey: 'package' },
+    { patterns: [/\b(?:api|microservice|webhook|integration|service)\b/i], iconKey: 'plug' },
+    { patterns: [/\b(?:collaboration|teamwork)\b/i, /\bteams?\b/i], iconKey: 'users' },
+    { patterns: [/\b(?:project[-\s]?management|pm|agile|scrum|kanban)\b/i], iconKey: 'kanban' },
+    { patterns: [/\b(?:crm|customer[-\s]?support|helpdesk|ticketing)\b/i], iconKey: 'headphones' },
+    { patterns: [/\b(?:hr|hrm|human[-\s]?resources|recruit|hiring|payroll)\b/i], iconKey: 'user-check' },
+    { patterns: [/\b(?:automation|workflow|rpa|no[-\s]?code|low[-\s]?code|zapier)\b/i], iconKey: 'workflow' },
+    { patterns: [/\b(?:vpn|networking|proxy|browser|web)\b/i], iconKey: 'globe' },
+    { patterns: [/\b(?:backup|archive|storage)\b/i], iconKey: 'archive' },
+];
+
+const FALLBACK_ICON_KEY: CuratedIconKey = 'tag';
+
+/**
+ * Resolve a category name to a curated icon. Returns null when the name
+ * doesn't match any known concept — the caller should fall back to AI
+ * generation (Tier 2) or {@link getFallbackIcon}.
+ */
+export function lookupCuratedIcon(categoryName: string): CuratedIcon | null {
+    if (!categoryName) {
+        return null;
+    }
+
+    const normalized = categoryName.toLowerCase().trim();
+    if (!normalized) {
+        return null;
+    }
+
+    // Exact slug match against the library (e.g. "code-2", "rocket").
+    const slugified = normalized.replace(/[\s_]+/g, '-').replace(/[^a-z0-9-]/g, '');
+    if (slugified && slugified in CATEGORY_ICON_LIBRARY) {
+        return CATEGORY_ICON_LIBRARY[slugified];
+    }
+
+    // Pattern-based keyword match — first rule whose pattern hits wins.
+    for (const rule of KEYWORD_RULES) {
+        if (rule.patterns.some((re) => re.test(normalized))) {
+            return CATEGORY_ICON_LIBRARY[rule.iconKey];
+        }
+    }
+
+    return null;
+}
+
+/** Default "?" / generic-tag icon used when no other source produces SVG. */
+export function getFallbackIcon(): CuratedIcon {
+    return CATEGORY_ICON_LIBRARY[FALLBACK_ICON_KEY];
+}

--- a/packages/agent/src/services/category-icon/curated-mapping.ts
+++ b/packages/agent/src/services/category-icon/curated-mapping.ts
@@ -36,9 +36,7 @@ export const CATEGORY_ICON_LIBRARY: Readonly<Record<string, CuratedIcon>> = Obje
     },
     'code-2': {
         name: 'code-2',
-        svg: wrap(
-            '<path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/>',
-        ),
+        svg: wrap('<path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/>'),
     },
     briefcase: {
         name: 'briefcase',
@@ -206,7 +204,9 @@ export const CATEGORY_ICON_LIBRARY: Readonly<Record<string, CuratedIcon>> = Obje
     },
     activity: {
         name: 'activity',
-        svg: wrap('<path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.5.5 0 0 1-.96 0L9.68 3.18a.5.5 0 0 0-.96 0l-2.35 8.36A2 2 0 0 1 4.44 13H2"/>'),
+        svg: wrap(
+            '<path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.5.5 0 0 1-.96 0L9.68 3.18a.5.5 0 0 0-.96 0l-2.35 8.36A2 2 0 0 1 4.44 13H2"/>',
+        ),
     },
     flask: {
         name: 'flask',
@@ -264,9 +264,7 @@ export const CATEGORY_ICON_LIBRARY: Readonly<Record<string, CuratedIcon>> = Obje
     },
     kanban: {
         name: 'kanban',
-        svg: wrap(
-            '<path d="M6 5v11"/><path d="M12 5v6"/><path d="M18 5v14"/>',
-        ),
+        svg: wrap('<path d="M6 5v11"/><path d="M12 5v6"/><path d="M18 5v14"/>'),
     },
     tag: {
         name: 'tag',
@@ -290,14 +288,23 @@ interface KeywordRule {
 const KEYWORD_RULES: readonly KeywordRule[] = [
     { patterns: [/\btime[-\s]?tracking\b/i, /\btimesheet/i], iconKey: 'clock' },
     { patterns: [/\bopen[-\s]?source\b/i, /\bfoss\b/i, /\boss\b/i], iconKey: 'code' },
-    { patterns: [/\bcommercial\b/i, /\benterprise\b/i, /\bbusiness\b/i, /\bb2b\b/i], iconKey: 'briefcase' },
+    {
+        patterns: [/\bcommercial\b/i, /\benterprise\b/i, /\bbusiness\b/i, /\bb2b\b/i],
+        iconKey: 'briefcase',
+    },
     { patterns: [/\bproductivity\b/i], iconKey: 'briefcase' },
     { patterns: [/\bfree(ware)?\b/i, /\bgift\b/i, /\bfreemium\b/i], iconKey: 'gift' },
     { patterns: [/\b(?:ai|gpt|llm|machine[-\s]?learning|neural)\b/i], iconKey: 'brain' },
     { patterns: [/\b(?:cloud|saas|paas|iaas)\b/i], iconKey: 'cloud' },
-    { patterns: [/\bdatabase\b/i, /\bdb\b/i, /\bdata[-\s]?store\b/i, /\bsql\b/i, /\bnosql\b/i], iconKey: 'database' },
+    {
+        patterns: [/\bdatabase\b/i, /\bdb\b/i, /\bdata[-\s]?store\b/i, /\bsql\b/i, /\bnosql\b/i],
+        iconKey: 'database',
+    },
     { patterns: [/\bsearch\b/i, /\bdiscover/i], iconKey: 'search' },
-    { patterns: [/\b(?:security|auth|encryption|privacy|firewall|antivirus)\b/i], iconKey: 'shield' },
+    {
+        patterns: [/\b(?:security|auth|encryption|privacy|firewall|antivirus)\b/i],
+        iconKey: 'shield',
+    },
     { patterns: [/\b(?:analytic|metric|dashboard|insight|report)/i], iconKey: 'chart-bar' },
     { patterns: [/\b(?:chat|messaging|messenger|im)\b/i], iconKey: 'message-circle' },
     { patterns: [/\b(?:email|mail|inbox|smtp)\b/i], iconKey: 'mail' },
@@ -306,30 +313,54 @@ const KEYWORD_RULES: readonly KeywordRule[] = [
     { patterns: [/\b(?:video|stream|broadcast)/i], iconKey: 'video' },
     { patterns: [/\b(?:photo|camera|image)\b/i], iconKey: 'camera' },
     { patterns: [/\b(?:design|graphics|illustrat|sketch|figma)/i], iconKey: 'palette' },
-    { patterns: [/\b(?:cli|terminal|shell|console)\b/i, /\b(?:ide|editor)\b/i], iconKey: 'terminal' },
-    { patterns: [/\b(?:dev|developer)[-\s]?tools?\b/i, /\bcoding\b/i, /\bprogramming\b/i], iconKey: 'code-2' },
+    {
+        patterns: [/\b(?:cli|terminal|shell|console)\b/i, /\b(?:ide|editor)\b/i],
+        iconKey: 'terminal',
+    },
+    {
+        patterns: [/\b(?:dev|developer)[-\s]?tools?\b/i, /\bcoding\b/i, /\bprogramming\b/i],
+        iconKey: 'code-2',
+    },
     { patterns: [/\b(?:notes?|journal|document|wiki|knowledge)\b/i], iconKey: 'file-text' },
     { patterns: [/\b(?:todo|tasks?|gtd|reminder)\b/i], iconKey: 'check-square' },
-    { patterns: [/\b(?:education|learn|course|training|tutorial|book|read)/i], iconKey: 'book-open' },
+    {
+        patterns: [/\b(?:education|learn|course|training|tutorial|book|read)/i],
+        iconKey: 'book-open',
+    },
     { patterns: [/\b(?:news|newsletter|rss)\b/i], iconKey: 'newspaper' },
     { patterns: [/\b(?:social|community|forum|network)/i], iconKey: 'users' },
     { patterns: [/\bgam(?:ing|es?)\b/i], iconKey: 'gamepad' },
-    { patterns: [/\b(?:finance|banking|crypto|payment|invest|fintech|accounting)/i], iconKey: 'dollar-sign' },
-    { patterns: [/\b(?:shopping|ecommerce|retail|marketplace|store)\b/i], iconKey: 'shopping-cart' },
+    {
+        patterns: [/\b(?:finance|banking|crypto|payment|invest|fintech|accounting)/i],
+        iconKey: 'dollar-sign',
+    },
+    {
+        patterns: [/\b(?:shopping|ecommerce|retail|marketplace|store)\b/i],
+        iconKey: 'shopping-cart',
+    },
     { patterns: [/\b(?:travel|flight|hotel|tourism|booking)\b/i], iconKey: 'plane' },
     { patterns: [/\b(?:health|fitness|medical|wellness|workout)\b/i], iconKey: 'heart' },
     { patterns: [/\b(?:weather|climate|forecast)\b/i], iconKey: 'cloud-sun' },
     { patterns: [/\b(?:maps?|navigation|geo|location)/i], iconKey: 'map-pin' },
     { patterns: [/\b(?:monitor|observ|logging|tracing|alerting)/i], iconKey: 'activity' },
-    { patterns: [/\b(?:test|qa|quality[-\s]?assurance|automated[-\s]?testing)\b/i], iconKey: 'flask' },
+    {
+        patterns: [/\b(?:test|qa|quality[-\s]?assurance|automated[-\s]?testing)\b/i],
+        iconKey: 'flask',
+    },
     { patterns: [/\b(?:deployment|devops|ci[-\s]?cd|hosting)\b/i], iconKey: 'rocket' },
     { patterns: [/\b(?:container|docker|kubernetes|k8s|orchestrat)/i], iconKey: 'package' },
     { patterns: [/\b(?:api|microservice|webhook|integration|service)\b/i], iconKey: 'plug' },
     { patterns: [/\b(?:collaboration|teamwork)\b/i, /\bteams?\b/i], iconKey: 'users' },
     { patterns: [/\b(?:project[-\s]?management|pm|agile|scrum|kanban)\b/i], iconKey: 'kanban' },
     { patterns: [/\b(?:crm|customer[-\s]?support|helpdesk|ticketing)\b/i], iconKey: 'headphones' },
-    { patterns: [/\b(?:hr|hrm|human[-\s]?resources|recruit|hiring|payroll)\b/i], iconKey: 'user-check' },
-    { patterns: [/\b(?:automation|workflow|rpa|no[-\s]?code|low[-\s]?code|zapier)\b/i], iconKey: 'workflow' },
+    {
+        patterns: [/\b(?:hr|hrm|human[-\s]?resources|recruit|hiring|payroll)\b/i],
+        iconKey: 'user-check',
+    },
+    {
+        patterns: [/\b(?:automation|workflow|rpa|no[-\s]?code|low[-\s]?code|zapier)\b/i],
+        iconKey: 'workflow',
+    },
     { patterns: [/\b(?:vpn|networking|proxy|browser|web)\b/i], iconKey: 'globe' },
     { patterns: [/\b(?:backup|archive|storage)\b/i], iconKey: 'archive' },
 ];

--- a/packages/agent/src/services/category-icon/index.ts
+++ b/packages/agent/src/services/category-icon/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public surface of the category-icon subsystem (EW-357).
+ *
+ * Resolution order for any given category name:
+ *   1. {@link lookupCuratedIcon} — fast in-process map (Tier 1).
+ *   2. AI generation via {@link CategoryIconGeneratorService} (Tier 2).
+ *   3. {@link getFallbackIcon} — generic tag glyph (last resort).
+ *
+ * All persisted SVG content passes through {@link sanitizeSvg} regardless
+ * of source.
+ */
+
+export {
+    CATEGORY_ICON_LIBRARY,
+    getFallbackIcon,
+    lookupCuratedIcon,
+    type CuratedIcon,
+    type CuratedIconKey,
+} from './curated-mapping';
+
+export {
+    MAX_SVG_LENGTH,
+    sanitizeSvg,
+    type SanitizeFailure,
+    type SanitizeFailureReason,
+    type SanitizeResult,
+    type SanitizeSuccess,
+} from './svg-sanitizer';

--- a/packages/agent/src/services/category-icon/index.ts
+++ b/packages/agent/src/services/category-icon/index.ts
@@ -2,9 +2,10 @@
  * Public surface of the category-icon subsystem (EW-357).
  *
  * Resolution order for any given category name:
- *   1. {@link lookupCuratedIcon} — fast in-process map (Tier 1).
- *   2. AI generation via {@link CategoryIconGeneratorService} (Tier 2).
- *   3. {@link getFallbackIcon} — generic tag glyph (last resort).
+ *   1. Cache lookup ({@link CategoryIconService}).
+ *   2. {@link lookupCuratedIcon} — fast in-process map (Tier 1).
+ *   3. AI generation via {@link generateCategoryIconSvg} (Tier 2).
+ *   4. {@link getFallbackIcon} — generic tag glyph (last resort).
  *
  * All persisted SVG content passes through {@link sanitizeSvg} regardless
  * of source.
@@ -26,3 +27,18 @@ export {
     type SanitizeResult,
     type SanitizeSuccess,
 } from './svg-sanitizer';
+
+export {
+    generateCategoryIconSvg,
+    type CategoryIconGenerateFailure,
+    type CategoryIconGenerateOptions,
+    type CategoryIconGenerateResult,
+    type CategoryIconGenerateSuccess,
+} from './ai-generator';
+
+export {
+    CategoryIconService,
+    type CategoryIconResult,
+    type CategoryIconSource,
+    type EnsureCategoryIconOptions,
+} from './category-icon.service';

--- a/packages/agent/src/services/category-icon/index.ts
+++ b/packages/agent/src/services/category-icon/index.ts
@@ -42,3 +42,5 @@ export {
     type CategoryIconSource,
     type EnsureCategoryIconOptions,
 } from './category-icon.service';
+
+export { CategoryIconModule } from './category-icon.module';

--- a/packages/agent/src/services/category-icon/svg-sanitizer.ts
+++ b/packages/agent/src/services/category-icon/svg-sanitizer.ts
@@ -5,25 +5,34 @@
  *   1. Curated library (trusted, hardcoded Lucide markup).
  *   2. AI generator (untrusted-ish — model output, even with a locked
  *      prompt, can include comments, forbidden tags, or unbalanced markup).
- *   3. User paste via the category modal (fully untrusted).
+ *   3. User paste via the category modal / taxonomy API (fully untrusted).
  *
- * Output is rendered by the frontend as
- *   <img src="data:image/svg+xml;utf8,<svg…>">
- * Browsers sandbox SVGs loaded via <img> (no script execution, no external
- * resource loading), so the primary risks reduce to malformed markup that
- * breaks layout or oversized payloads. This sanitizer enforces:
+ * Output is rendered by the frontend INLINE via `dangerouslySetInnerHTML`
+ * (see `apps/web/src/components/works/detail/items/CategoriesTab.tsx`),
+ * so the SVG executes in the host document's origin. There is no `<img>`
+ * sandbox, no CSP isolation — anything that survives this pass runs with
+ * full DOM access. Treat this sanitizer as the only line of defence and
+ * fail closed on anything ambiguous. The passes enforced:
  *
- *   - Comments / DOCTYPE / processing instructions stripped.
+ *   - Comments / DOCTYPE / processing instructions / CDATA stripped so
+ *     payloads cannot hide inside them.
  *   - Forbidden elements removed: <script>, <foreignObject>, <iframe>,
- *     <embed>, <object>, <use> referencing external URLs.
- *   - Forbidden attributes removed: on*, xlink:href to external URLs,
- *     javascript: / data: URLs.
+ *     <embed>, <object>, <animate*>, <set>, <handler>, <listener>.
+ *   - Forbidden attributes removed: on* event handlers, xlink:href/href
+ *     (the most common SVG XSS vector), inline style (can carry
+ *     url(javascript:…)).
+ *   - URL schemes rejected anywhere in the body: javascript:, data:,
+ *     vbscript:, file:.
+ *   - External paint-server references rejected: any `url(<scheme>://…)`
+ *     in fill/stroke/filter/etc. would otherwise leak the viewer's IP to
+ *     an arbitrary host as a tracking pixel.
  *   - viewBox normalized to "0 0 24 24"; width/height attrs stripped.
- *   - Total length capped at MAX_SVG_LENGTH bytes.
+ *   - Total length capped at MAX_SVG_LENGTH bytes (matches the DTO cap).
  *
  * The sanitizer is intentionally regex-based to keep the agent package
  * free of jsdom / DOMPurify (heavy server-side deps). For the trust
- * profile above, conservative regex passes are sufficient.
+ * profile above, conservative regex passes that reject anything they
+ * can't fully parse are sufficient.
  */
 
 export const MAX_SVG_LENGTH = 4000;
@@ -51,6 +60,12 @@ const STYLE_ATTR_RE = /\s+style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 const WIDTH_HEIGHT_ATTR_RE = /\s+(?:width|height)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 
 const DANGEROUS_URL_VALUE_RE = /\b(?:javascript|data|vbscript|file)\s*:/gi;
+
+// External paint-server references: `url(http://…)`, `url(https://…)`,
+// `url(//host/…)`. Local fragment refs like `url(#id)` are fine and stay.
+// Without this guard, an attribute like `fill="url(https://tracker/pixel)"`
+// turns the inline SVG into an IP-logging beacon for any viewer.
+const EXTERNAL_URL_REF_RE = /url\s*\(\s*['"]?\s*(?:[a-z][a-z0-9+.-]*:)?\/\//i;
 
 const SVG_OPEN_TAG_RE = /<svg\b([^>]*)>/i;
 
@@ -114,6 +129,13 @@ export function sanitizeSvg(input: string | null | undefined): SanitizeResult {
     // After scrubbing, double-check no dangerous URL scheme leaked
     // through (e.g. inside fill="url(javascript:…)" — paranoid belt).
     if (DANGEROUS_URL_VALUE_RE.test(working)) {
+        return { ok: false, reason: 'dangerous-content' };
+    }
+
+    // Reject external paint-server references — `url(https://…)` etc.
+    // would fetch from an arbitrary host when the SVG renders inline and
+    // leak the viewer's IP. Local `url(#id)` fragment refs are fine.
+    if (EXTERNAL_URL_REF_RE.test(working)) {
         return { ok: false, reason: 'dangerous-content' };
     }
 

--- a/packages/agent/src/services/category-icon/svg-sanitizer.ts
+++ b/packages/agent/src/services/category-icon/svg-sanitizer.ts
@@ -44,8 +44,7 @@ const FORBIDDEN_ELEMENT_RE =
 
 const EVENT_HANDLER_ATTR_RE = /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 
-const DANGEROUS_HREF_RE =
-    /\s+(?:xlink:href|href)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+const DANGEROUS_HREF_RE = /\s+(?:xlink:href|href)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 
 const STYLE_ATTR_RE = /\s+style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 

--- a/packages/agent/src/services/category-icon/svg-sanitizer.ts
+++ b/packages/agent/src/services/category-icon/svg-sanitizer.ts
@@ -59,7 +59,13 @@ const STYLE_ATTR_RE = /\s+style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 
 const WIDTH_HEIGHT_ATTR_RE = /\s+(?:width|height)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 
-const DANGEROUS_URL_VALUE_RE = /\b(?:javascript|data|vbscript|file)\s*:/gi;
+// IMPORTANT: no `g` flag. JavaScript regexes are stateful when `g` is set —
+// `RegExp.prototype.test()` advances `lastIndex` between calls, so a match
+// at byte offset 50 in call 1 leaves lastIndex at ~62, and a payload whose
+// `javascript:` lives before offset 62 in call 2 silently slips through
+// (test() returns false, lastIndex resets to 0, alternating bypass).
+// `.test()` is an existence check; iteration semantics buy nothing here.
+const DANGEROUS_URL_VALUE_RE = /\b(?:javascript|data|vbscript|file)\s*:/i;
 
 // External paint-server references: `url(http://…)`, `url(https://…)`,
 // `url(//host/…)`. Local fragment refs like `url(#id)` are fine and stay.

--- a/packages/agent/src/services/category-icon/svg-sanitizer.ts
+++ b/packages/agent/src/services/category-icon/svg-sanitizer.ts
@@ -1,0 +1,192 @@
+/**
+ * Server-side SVG sanitizer for category icons.
+ *
+ * Inputs come from one of three sources:
+ *   1. Curated library (trusted, hardcoded Lucide markup).
+ *   2. AI generator (untrusted-ish — model output, even with a locked
+ *      prompt, can include comments, forbidden tags, or unbalanced markup).
+ *   3. User paste via the category modal (fully untrusted).
+ *
+ * Output is rendered by the frontend as
+ *   <img src="data:image/svg+xml;utf8,<svg…>">
+ * Browsers sandbox SVGs loaded via <img> (no script execution, no external
+ * resource loading), so the primary risks reduce to malformed markup that
+ * breaks layout or oversized payloads. This sanitizer enforces:
+ *
+ *   - Comments / DOCTYPE / processing instructions stripped.
+ *   - Forbidden elements removed: <script>, <foreignObject>, <iframe>,
+ *     <embed>, <object>, <use> referencing external URLs.
+ *   - Forbidden attributes removed: on*, xlink:href to external URLs,
+ *     javascript: / data: URLs.
+ *   - viewBox normalized to "0 0 24 24"; width/height attrs stripped.
+ *   - Total length capped at MAX_SVG_LENGTH bytes.
+ *
+ * The sanitizer is intentionally regex-based to keep the agent package
+ * free of jsdom / DOMPurify (heavy server-side deps). For the trust
+ * profile above, conservative regex passes are sufficient.
+ */
+
+export const MAX_SVG_LENGTH = 4000;
+
+const COMMENT_RE = /<!--[\s\S]*?-->/g;
+const DOCTYPE_RE = /<!DOCTYPE[\s\S]*?>/gi;
+const PI_RE = /<\?[\s\S]*?\?>/g;
+const CDATA_RE = /<!\[CDATA\[[\s\S]*?\]\]>/g;
+
+// Match paired or self-closing forbidden elements. The non-capturing
+// group has two arms: self-close (`<script/>`) or full pair
+// (`<script ...>body</script>`). Without the explicit `>` after the
+// attribute capture, a non-greedy body match would terminate at the
+// opening `>` and leave the body intact — which is exactly what we
+// were trying to remove.
+const FORBIDDEN_ELEMENT_RE =
+    /<\s*(script|foreignObject|iframe|embed|object|animate|animateTransform|set|handler|listener)\b[^>]*(?:\/>|>[\s\S]*?<\/\s*\1\s*>)/gi;
+
+const EVENT_HANDLER_ATTR_RE = /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+
+const DANGEROUS_HREF_RE =
+    /\s+(?:xlink:href|href)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+
+const STYLE_ATTR_RE = /\s+style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+
+const WIDTH_HEIGHT_ATTR_RE = /\s+(?:width|height)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+
+const DANGEROUS_URL_VALUE_RE = /\b(?:javascript|data|vbscript|file)\s*:/gi;
+
+const SVG_OPEN_TAG_RE = /<svg\b([^>]*)>/i;
+
+const NORMALIZED_VIEWBOX = '0 0 24 24';
+
+export type SanitizeFailureReason =
+    | 'empty'
+    | 'too-large'
+    | 'no-svg-tag'
+    | 'unclosed-svg'
+    | 'dangerous-content';
+
+export interface SanitizeFailure {
+    readonly ok: false;
+    readonly reason: SanitizeFailureReason;
+}
+
+export interface SanitizeSuccess {
+    readonly ok: true;
+    readonly svg: string;
+    readonly bytes: number;
+}
+
+export type SanitizeResult = SanitizeSuccess | SanitizeFailure;
+
+/**
+ * Run the sanitizer over an SVG string. Always returns; never throws.
+ * On failure, callers should fall back to the curated default icon.
+ */
+export function sanitizeSvg(input: string | null | undefined): SanitizeResult {
+    if (!input || typeof input !== 'string') {
+        return { ok: false, reason: 'empty' };
+    }
+
+    let working = input.trim();
+    if (!working) {
+        return { ok: false, reason: 'empty' };
+    }
+
+    // Drop comments / DOCTYPE / PIs / CDATA before any structural checks
+    // so attackers can't hide payloads inside them.
+    working = working
+        .replace(COMMENT_RE, '')
+        .replace(DOCTYPE_RE, '')
+        .replace(PI_RE, '')
+        .replace(CDATA_RE, '');
+
+    // Strip forbidden elements wholesale (both paired and self-closing).
+    working = working.replace(FORBIDDEN_ELEMENT_RE, '');
+
+    // Strip event handler attributes anywhere they appear.
+    working = working.replace(EVENT_HANDLER_ATTR_RE, '');
+
+    // Strip xlink:href / href attributes — inline icons should not need
+    // them, and they're the most common SVG XSS vector.
+    working = working.replace(DANGEROUS_HREF_RE, '');
+
+    // Strip inline style attributes — they can pull in url(javascript:…).
+    working = working.replace(STYLE_ATTR_RE, '');
+
+    // After scrubbing, double-check no dangerous URL scheme leaked
+    // through (e.g. inside fill="url(javascript:…)" — paranoid belt).
+    if (DANGEROUS_URL_VALUE_RE.test(working)) {
+        return { ok: false, reason: 'dangerous-content' };
+    }
+
+    // Must be a single <svg>…</svg> root.
+    const openMatch = working.match(SVG_OPEN_TAG_RE);
+    if (!openMatch) {
+        return { ok: false, reason: 'no-svg-tag' };
+    }
+
+    const closeIndex = working.toLowerCase().lastIndexOf('</svg>');
+    if (closeIndex === -1) {
+        return { ok: false, reason: 'unclosed-svg' };
+    }
+
+    // Discard any prose / leading whitespace the model might have
+    // emitted before the opening <svg>, and anything trailing after
+    // </svg>.
+    const startIndex = working.toLowerCase().indexOf('<svg');
+    working = working.slice(startIndex, closeIndex + '</svg>'.length);
+
+    // Re-run the open-tag match against the trimmed string so the
+    // captured attributes reflect the actual root element.
+    const trimmedOpen = working.match(SVG_OPEN_TAG_RE);
+    if (!trimmedOpen) {
+        return { ok: false, reason: 'no-svg-tag' };
+    }
+
+    const normalizedAttrs = normalizeRootAttrs(trimmedOpen[1] ?? '');
+    working = working.replace(SVG_OPEN_TAG_RE, `<svg${normalizedAttrs}>`);
+
+    // Collapse runs of whitespace — keeps payloads small for YAML.
+    working = working.replace(/\s+/g, ' ').replace(/>\s+</g, '><').trim();
+
+    const bytes = Buffer.byteLength(working, 'utf8');
+    if (bytes > MAX_SVG_LENGTH) {
+        return { ok: false, reason: 'too-large' };
+    }
+
+    return { ok: true, svg: working, bytes };
+}
+
+/**
+ * Strip width/height (we render at the consumer's chosen size), drop
+ * any href attrs that survived the body pass, and ensure viewBox and
+ * xmlns are present. Returns the new attribute string with a leading
+ * space (or empty).
+ */
+function normalizeRootAttrs(rawAttrs: string): string {
+    let attrs = rawAttrs;
+
+    // Strip width/height; consumer renders at desired size.
+    attrs = attrs.replace(WIDTH_HEIGHT_ATTR_RE, '');
+
+    // Strip event handlers and href once more in case they were on <svg>.
+    attrs = attrs.replace(EVENT_HANDLER_ATTR_RE, '');
+    attrs = attrs.replace(DANGEROUS_HREF_RE, '');
+    attrs = attrs.replace(STYLE_ATTR_RE, '');
+
+    // Ensure viewBox is present and normalized.
+    if (/\bviewBox\s*=\s*/i.test(attrs)) {
+        attrs = attrs.replace(
+            /\bviewBox\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/i,
+            `viewBox="${NORMALIZED_VIEWBOX}"`,
+        );
+    } else {
+        attrs = `${attrs} viewBox="${NORMALIZED_VIEWBOX}"`;
+    }
+
+    // Ensure xmlns is present so the browser treats the file as SVG.
+    if (!/\bxmlns\s*=\s*/i.test(attrs)) {
+        attrs = ` xmlns="http://www.w3.org/2000/svg"${attrs}`;
+    }
+
+    return attrs.replace(/\s+/g, ' ').trimEnd();
+}

--- a/packages/agent/src/services/work-taxonomy.service.ts
+++ b/packages/agent/src/services/work-taxonomy.service.ts
@@ -96,6 +96,7 @@ export class WorkTaxonomyService {
             name: dto.name.trim(),
             description: dto.description?.trim(),
             icon_url: dto.icon_url?.trim(),
+            icon_svg: dto.icon_svg?.trim(),
             priority: dto.priority,
         };
 
@@ -159,6 +160,7 @@ export class WorkTaxonomyService {
             ...(dto.name && { name: dto.name.trim() }),
             ...(dto.description !== undefined && { description: dto.description?.trim() }),
             ...(dto.icon_url !== undefined && { icon_url: dto.icon_url?.trim() }),
+            ...(dto.icon_svg !== undefined && { icon_svg: dto.icon_svg?.trim() }),
             ...(dto.priority !== undefined && { priority: dto.priority }),
         };
 
@@ -180,7 +182,9 @@ export class WorkTaxonomyService {
                     fieldsChanged: Object.keys(dto).filter(
                         (key) =>
                             (dto as Record<string, unknown>)[key] !== undefined &&
-                            ['name', 'description', 'icon_url', 'priority'].includes(key),
+                            ['name', 'description', 'icon_url', 'icon_svg', 'priority'].includes(
+                                key,
+                            ),
                     ),
                 },
             ],
@@ -442,6 +446,7 @@ export class WorkTaxonomyService {
             name: dto.name.trim(),
             description: dto.description?.trim(),
             icon_url: dto.icon_url?.trim(),
+            icon_svg: dto.icon_svg?.trim(),
             priority: dto.priority,
         };
 
@@ -505,6 +510,7 @@ export class WorkTaxonomyService {
             ...(dto.name && { name: dto.name.trim() }),
             ...(dto.description !== undefined && { description: dto.description?.trim() }),
             ...(dto.icon_url !== undefined && { icon_url: dto.icon_url?.trim() }),
+            ...(dto.icon_svg !== undefined && { icon_svg: dto.icon_svg?.trim() }),
             ...(dto.priority !== undefined && { priority: dto.priority }),
         };
 
@@ -526,7 +532,9 @@ export class WorkTaxonomyService {
                     fieldsChanged: Object.keys(dto).filter(
                         (key) =>
                             (dto as Record<string, unknown>)[key] !== undefined &&
-                            ['name', 'description', 'icon_url', 'priority'].includes(key),
+                            ['name', 'description', 'icon_url', 'icon_svg', 'priority'].includes(
+                                key,
+                            ),
                     ),
                 },
             ],

--- a/packages/agent/src/services/work-taxonomy.service.ts
+++ b/packages/agent/src/services/work-taxonomy.service.ts
@@ -17,6 +17,7 @@ import { WorkGenerationHistoryRepository } from '@src/database/repositories/work
 import { GenerateStatusType } from '@src/entities/types';
 import { WorkHistoryActivityType, type WorkHistoryChangeEntry } from '@ever-works/contracts/api';
 import { buildWorkChangelog } from '@src/utils/work-changelog.utils';
+import { sanitizeSvg } from './category-icon/svg-sanitizer';
 
 /**
  * Service for managing work taxonomy (categories and tags).
@@ -37,6 +38,25 @@ export class WorkTaxonomyService {
             throw new NotFoundException(`User not found: ${userId}`);
         }
         return user;
+    }
+
+    /**
+     * Run user-supplied icon_svg through the same sanitizer the generator
+     * pipeline uses. The frontend renders this via dangerouslySetInnerHTML
+     * (see CategoriesTab), so unsanitized input is a stored-XSS sink for
+     * any user with write access. Return shape:
+     *   - `undefined`  → field was not supplied; caller must skip the spread.
+     *   - `''`         → caller explicitly cleared the icon.
+     *   - `'<svg…/>'`  → sanitized SVG safe for inline injection.
+     */
+    private sanitizeIconSvgInput(input: string | undefined): string | undefined {
+        if (input === undefined) return undefined;
+        const trimmed = input.trim();
+        if (!trimmed) return '';
+        const result = sanitizeSvg(trimmed);
+        if (result.ok === true) return result.svg;
+        if (result.reason === 'empty') return '';
+        throw new BadRequestException(`Invalid icon_svg: ${result.reason}`);
     }
 
     private async recordTaxonomyHistory(params: {
@@ -96,7 +116,7 @@ export class WorkTaxonomyService {
             name: dto.name.trim(),
             description: dto.description?.trim(),
             icon_url: dto.icon_url?.trim(),
-            icon_svg: dto.icon_svg?.trim(),
+            icon_svg: this.sanitizeIconSvgInput(dto.icon_svg),
             priority: dto.priority,
         };
 
@@ -160,7 +180,9 @@ export class WorkTaxonomyService {
             ...(dto.name && { name: dto.name.trim() }),
             ...(dto.description !== undefined && { description: dto.description?.trim() }),
             ...(dto.icon_url !== undefined && { icon_url: dto.icon_url?.trim() }),
-            ...(dto.icon_svg !== undefined && { icon_svg: dto.icon_svg?.trim() }),
+            ...(dto.icon_svg !== undefined && {
+                icon_svg: this.sanitizeIconSvgInput(dto.icon_svg),
+            }),
             ...(dto.priority !== undefined && { priority: dto.priority }),
         };
 
@@ -446,7 +468,7 @@ export class WorkTaxonomyService {
             name: dto.name.trim(),
             description: dto.description?.trim(),
             icon_url: dto.icon_url?.trim(),
-            icon_svg: dto.icon_svg?.trim(),
+            icon_svg: this.sanitizeIconSvgInput(dto.icon_svg),
             priority: dto.priority,
         };
 
@@ -510,7 +532,9 @@ export class WorkTaxonomyService {
             ...(dto.name && { name: dto.name.trim() }),
             ...(dto.description !== undefined && { description: dto.description?.trim() }),
             ...(dto.icon_url !== undefined && { icon_url: dto.icon_url?.trim() }),
-            ...(dto.icon_svg !== undefined && { icon_svg: dto.icon_svg?.trim() }),
+            ...(dto.icon_svg !== undefined && {
+                icon_svg: this.sanitizeIconSvgInput(dto.icon_svg),
+            }),
             ...(dto.priority !== undefined && { priority: dto.priority }),
         };
 

--- a/packages/agent/test/jest-mocks/p-map.ts
+++ b/packages/agent/test/jest-mocks/p-map.ts
@@ -1,0 +1,19 @@
+/**
+ * Jest replacement for the ESM-only `p-map` package.
+ *
+ * `p-map` ships as ESM and ts-jest can't load it under the agent's
+ * CommonJS test runner. The runtime behaviour we care about for tests
+ * is "iterate the inputs through the mapper and return their results"
+ * — concurrency limits don't affect correctness in unit tests, so a
+ * straight Promise.all is sufficient.
+ *
+ * Wired in via `moduleNameMapper` in jest.config.js so every spec
+ * automatically picks up this stub regardless of its import chain.
+ */
+export default async function pMap<T, R>(
+    input: Iterable<T>,
+    mapper: (value: T, index: number) => Promise<R> | R,
+): Promise<R[]> {
+    const items = Array.from(input);
+    return Promise.all(items.map((value, index) => mapper(value, index)));
+}

--- a/packages/contracts/src/item/item.types.ts
+++ b/packages/contracts/src/item/item.types.ts
@@ -14,6 +14,12 @@ export interface Category {
 	readonly name: string;
 	readonly description?: string;
 	readonly icon_url?: string;
+	/**
+	 * Inline SVG markup for the category icon. Populated by the
+	 * AI category-icon generator (curated lookup → AI fallback).
+	 * Sanitized server-side before persistence.
+	 */
+	readonly icon_svg?: string;
 	/** Lower numbers = higher priority (e.g., 1 = first, 2 = second, etc.) */
 	readonly priority?: number;
 }
@@ -34,6 +40,11 @@ export interface Collection {
 	readonly name: string;
 	readonly description?: string;
 	readonly icon_url?: string;
+	/**
+	 * Inline SVG markup for the collection icon. Same generator path
+	 * as `Category.icon_svg`; sanitized server-side.
+	 */
+	readonly icon_svg?: string;
 	/** Lower numbers = higher priority (e.g., 1 = first, 2 = second, etc.) */
 	readonly priority?: number;
 }


### PR DESCRIPTION
## Summary

Implements [EW-357](https://evertech.atlassian.net/browse/EW-357) — AI-generated SVG icons for Ever Works categories. After the AI classifier produces categories, the data generator now resolves an SVG icon for each one (cache → curated Lucide map → AI generation → static fallback), sanitizes it, and persists it as `Category.icon_svg` in the work's YAML repo. Frontend renders the SVG inline so `stroke="currentColor"` themes through the page palette.

- **Tier 1 (curated, free):** 43 hand-picked Lucide-style SVGs + 45 keyword rules. Covers the bulk of common categories (Open-Source → Code, Productivity → Briefcase, Time-Tracking → Clock, AI → Brain, etc.).
- **Tier 2 (AI):** `aiFacade.createChatCompletion` with a locked-down system prompt (24×24 viewBox, currentColor stroke, allowed-element whitelist, no scripts/foreignObjects/event handlers). Only used when the curated map misses.
- **Sanitization:** server-side regex scrub (strips `<script>`, `<foreignObject>`, `<iframe>`, `<embed>`, `<object>`, `<animate*>`, `on*` attrs, `href`/`xlink:href`, `javascript:`/`data:`/`vbscript:` URLs), viewBox normalization, 4KB hard cap. All persisted SVGs pass through it regardless of source.
- **Cache:** global `CACHE_MANAGER` (TypeORM-backed), keyed by normalized category name (cross-work shared), 90-day TTL.
- **Opt-out:** `pluginConfig.generate_category_icons === false` on the generation request — same shape as the existing `generate_categories` / `generate_tags` toggles.

## Architecture choice

Three integration points were possible; this PR takes **Option B: agent-layer post-pipeline enrichment**. Pipeline produces categories without icons, then `DataGeneratorService` enriches them via `CategoryIconService.enrichCategories` before `data.writeCategories`. No plugin SDK changes; cleanest scope for v1.

## Files

| Area | Files |
|---|---|
| Schema | `packages/contracts/src/item/item.types.ts`, `packages/agent/src/dto/taxonomy.dto.ts`, `packages/agent/src/services/work-taxonomy.service.ts` |
| Service stack | `packages/agent/src/services/category-icon/{curated-mapping,svg-sanitizer,ai-generator,category-icon.service,category-icon.module,index}.ts` |
| Wiring | `packages/agent/src/generators/data-generator/{data-generator.service,data-generator.module}.ts` |
| Frontend | `apps/web/src/components/works/detail/items/CategoriesTab.tsx` |
| Tests | `packages/agent/src/services/category-icon/__tests__/*.spec.ts` (61 tests) |
| Test infra | `packages/agent/test/jest-mocks/p-map.ts`, `packages/agent/jest.config.js`, `packages/agent/src/generators/data-generator/data-generator.module.spec.ts` |

## Test plan

- [x] `pnpm test` from `packages/agent` — 4350/4350 tests across 199 suites
- [x] `npx tsc --noEmit` from `apps/web` — clean
- [x] `tsc -p tsconfig.types.json` from `packages/agent` — 0 issues in source files
- [ ] Verify icon resolution end-to-end on a real generation run (depends on staging)
- [ ] Inspect a generated YAML to confirm `icon_svg` round-trips cleanly through `yaml.stringify`

## Deferred to follow-up PR

- Trigger.dev backfill task (`packages/tasks/`) for existing categories that pre-date this PR — the in-pipeline enrichment only covers new generations.
- `askText` method on `AiFacade` so the icon generator can route at "simple" complexity (today it uses the default model).

## Notes for reviewers

- The frontend uses `dangerouslySetInnerHTML` to render `icon_svg` so `stroke="currentColor"` themes correctly. The XSS surface is bounded by `svg-sanitizer.ts` — review that file carefully if you have safety concerns.
- The cache key is `category-icon:v1:<normalized name>`. Bump the `v1` constant in `category-icon.service.ts` if a future change to the prompt or palette warrants invalidating all cached icons.
- All 4350 agent tests pass, but two pre-existing test files (`work-lifecycle.create-defaults.spec.ts` line 415/436) had unrelated `--moduleResolution` errors when building types via `tsc -p tsconfig.types.json`. These exist on develop too; not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-357]: https://evertech.atlassian.net/browse/EW-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Categories and collections support inline SVG icons; UI renders inline SVG when available and falls back to generated or default icons.
  * Automatic icon generation/enrichment is available during data initialization.

* **Bug Fixes / Reliability**
  * Server-side SVG sanitization and defensive fallbacks prevent unsafe or malformed SVGs from being stored or rendered.

* **Tests**
  * Extensive tests added for sanitization, curated mappings, generation, enrichment, and taxonomy write flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/735)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->