### PR TITLE
fix(test): EW-614 dynamic import → static (Docker build TS2835 hotfix)

### DIFF
--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -12,7 +12,11 @@ jest.mock('@src/generators/website-generator/website-update.service', () => ({
 }));
 
 import { WorkLifecycleService } from '../work-lifecycle.service';
-import { EverWorksDeployQuotaExceededError } from '../../ever-works-providers';
+import {
+    EverWorksDeployQuotaExceededError,
+    EverWorksGitDisabledError,
+    EverWorksGitRequestError,
+} from '../../ever-works-providers';
 import { CreateWorkDto } from '@src/dto/create-work.dto';
 import type { User } from '@src/entities/user.entity';
 import type { OnboardingWizardStateV2 } from '@ever-works/contracts/api';
@@ -412,7 +416,6 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
     });
 
     it('EW-614: provider EverWorksGitDisabledError → BadRequestException, no Work persisted', async () => {
-        const { EverWorksGitDisabledError } = await import('../../ever-works-providers/types');
         const state: OnboardingWizardStateV2 = {
             version: 2,
             lastStep: 0,
@@ -433,7 +436,6 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
     });
 
     it('EW-614: provider EverWorksGitRequestError → ServiceUnavailableException, no Work persisted', async () => {
-        const { EverWorksGitRequestError } = await import('../../ever-works-providers/types');
         const state: OnboardingWizardStateV2 = {
             version: 2,
             lastStep: 0,


### PR DESCRIPTION
## Summary
Hotfix for the prod docker build break introduced by PR #731 (EW-614).

Two \`await import('../../ever-works-providers/types')\` calls in my new test cases tripped TS2835 in the build container (\`moduleResolution: node16\` requires \`.js\` extension on relative imports). Run [25785578619](https://github.com/ever-works/ever-works/actions/runs/25785578619) failed; the post-merge deploy never fired, so prod is still on the pre-EW-614 image.

Convert both to static imports at the top of the file. No functional change.

## Test plan
- [x] \`jest --testPathPattern='work-lifecycle.create-defaults'\` — 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored error type imports in test suite to improve maintainability and code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/736)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->