### PR TITLE
test(e2e): fix onboarding-wizard-v2 + user-journey (relative URLs / v2 dismiss)

### DIFF
--- a/apps/web/e2e/onboarding-wizard-v2.spec.ts
+++ b/apps/web/e2e/onboarding-wizard-v2.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { apiUrl } from './helpers/api';
 
 /**
  * v2 onboarding wizard end-to-end coverage.
@@ -8,6 +9,11 @@ import { test, expect } from '@playwright/test';
  * storageState has `dismissedAt` already set in the API (see
  * `global-setup.ts > POST /api/onboarding/dismiss`), so we explicitly
  * undismiss the wizard for these specs before each test.
+ *
+ * Routes are absolute via `apiUrl(...)` because `page.request` resolves
+ * relative URLs against `baseURL` (the Next.js web at :3000), which has
+ * no `/api/onboarding/*` route — the actual endpoints live on the
+ * NestJS API at :3100.
  */
 
 test.describe('Onboarding wizard v2 — choice-driven flow', () => {
@@ -16,7 +22,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
         // auto-open path. The /api/onboarding/state PATCH endpoint accepts
         // a partial state; explicitly re-load the dashboard after each reset
         // so the layout's RSC fetch picks up the new server state.
-        await page.request.patch('/api/onboarding/state', {
+        await page.request.patch(apiUrl('/api/onboarding/state'), {
             data: {
                 state: {
                     lastStep: 0,
@@ -33,7 +39,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     test('catalog endpoint returns the six AI cards with Ever Works as default', async ({
         page,
     }) => {
-        const res = await page.request.get('/api/onboarding/catalog');
+        const res = await page.request.get(apiUrl('/api/onboarding/catalog'));
         expect(res.ok()).toBe(true);
         const body = (await res.json()) as {
             ai: Array<{ choice: string; default?: boolean }>;
@@ -44,12 +50,12 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     });
 
     test('state endpoint round-trips a partial PATCH', async ({ page }) => {
-        const patch = await page.request.patch('/api/onboarding/state', {
+        const patch = await page.request.patch(apiUrl('/api/onboarding/state'), {
             data: { state: { ai: { choice: 'openrouter' }, lastStep: 2 } },
         });
         expect(patch.ok()).toBe(true);
 
-        const res = await page.request.get('/api/onboarding/state');
+        const res = await page.request.get(apiUrl('/api/onboarding/state'));
         const body = (await res.json()) as {
             state: { ai: { choice: string }; lastStep: number };
         };
@@ -58,14 +64,14 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     });
 
     test('rejects an invalid AI choice with a 400', async ({ page }) => {
-        const res = await page.request.patch('/api/onboarding/state', {
+        const res = await page.request.patch(apiUrl('/api/onboarding/state'), {
             data: { state: { ai: { choice: 'not-a-real-provider' } } },
         });
         expect(res.status()).toBe(400);
     });
 
     test('telemetry endpoint accepts an allow-listed event', async ({ page }) => {
-        const res = await page.request.post('/api/onboarding/telemetry', {
+        const res = await page.request.post(apiUrl('/api/onboarding/telemetry'), {
             data: { event: 'onboarding_opened', properties: { trigger: 'auto' } },
         });
         // 204 No Content on success
@@ -73,22 +79,30 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     });
 
     test('telemetry endpoint rejects an unknown event', async ({ page }) => {
-        const res = await page.request.post('/api/onboarding/telemetry', {
+        const res = await page.request.post(apiUrl('/api/onboarding/telemetry'), {
             data: { event: 'definitely_not_in_allowlist', properties: {} },
         });
         expect(res.status()).toBe(400);
     });
 
     test('complete endpoint is idempotent', async ({ page }) => {
-        const first = await page.request.post('/api/onboarding/complete', { data: {} });
-        const second = await page.request.post('/api/onboarding/complete', { data: {} });
+        const first = await page.request.post(apiUrl('/api/onboarding/complete'), {
+            data: {},
+        });
+        const second = await page.request.post(apiUrl('/api/onboarding/complete'), {
+            data: {},
+        });
         expect(first.ok()).toBe(true);
         expect(second.ok()).toBe(true);
     });
 
     test('dismiss endpoint is idempotent', async ({ page }) => {
-        const first = await page.request.post('/api/onboarding/dismiss', { data: {} });
-        const second = await page.request.post('/api/onboarding/dismiss', { data: {} });
+        const first = await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+            data: {},
+        });
+        const second = await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+            data: {},
+        });
         expect(first.ok()).toBe(true);
         expect(second.ok()).toBe(true);
     });

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { apiUrl } from './helpers/api';
 
 /**
  * Full user journey E2E test.
@@ -40,6 +41,10 @@ test.describe('Complete user journey', () => {
 
         // ---- Step 2: Navigate to create work ----
         // Pre-dismiss the onboarding wizard so the modal doesn't intercept clicks.
+        // v1 wizard stores dismissal in localStorage; v2 wizard reads `dismissedAt`
+        // from the API (users.onboarding_dismissed_at). Address both — the v2 modal
+        // portal was blocking the manual-card click below for 100+ retries until the
+        // 240s test budget exhausted.
         await page.evaluate(() => {
             try {
                 window.localStorage.setItem(
@@ -54,6 +59,24 @@ test.describe('Complete user journey', () => {
                 /* ignore */
             }
         });
+        try {
+            const loginRes = await page.request.post(apiUrl('/api/auth/login'), {
+                data: { email: user.email, password: user.password },
+            });
+            if (loginRes.ok()) {
+                const { access_token } = (await loginRes.json()) as { access_token?: string };
+                if (access_token) {
+                    await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+                        headers: { Authorization: `Bearer ${access_token}` },
+                        data: {},
+                    });
+                }
+            }
+        } catch {
+            // Older API builds without the v2 endpoint — the localStorage seed
+            // above still covers v1 specs that don't depend on v2 dismissal.
+        }
+        await page.reload({ waitUntil: 'domcontentloaded' });
 
         // Dismiss the "Connect your GitHub account" modal if it appears.
         const dismissGithubModal = page.getByRole('button', {


### PR DESCRIPTION
## Summary
Fixes the 8 remaining E2E failures from run 25784488449 on develop. Two related issues, both the same class of bug as #712 — Playwright \`page.request\` calls with relative URLs resolve against \`baseURL=http://localhost:3000\` (Next.js), which has no \`/api/onboarding/*\` proxy.

### 1. \`onboarding-wizard-v2.spec.ts\` — all 7 tests failing
Every test used \`page.request.{get,patch,post}('/api/onboarding/...')\`. Those requests hit the Next.js web on :3000 instead of the NestJS API on :3100 and silently 404, so \`res.ok()\` was \`false\` → all 7 tests failed at \`expect(res.ok()).toBe(true)\`. Route all 7 through the existing \`apiUrl()\` helper so they target the NestJS API at :3100.

### 2. \`user-journey.spec.ts:81\` — timeout at the manual-card click
The "Configure / Manual" click retried 100+ times before the 240s test budget exhausted. Root cause: after UI registration the v2 onboarding wizard auto-opens (server-side \`onboarding_dismissed_at\` is NULL), and the modal portal intercepted the click. The localStorage seed at line 43-56 only dismisses **v1**; v2 reads from the server.

Mirror the \`global-setup.ts\` v2 dismiss flow: login via API for a bearer token, POST \`/api/onboarding/dismiss\`, reload the page so the layout's RSC fetch picks up the new state. Tolerates older API builds via try/catch — the v1 seed still works on older API builds.

## Test plan
- [x] Both files re-run through \`prettier --write\` (format:check passes)
- [ ] Next full E2E run on develop has zero \`onboarding-wizard-v2\` failures
- [ ] \`user-journey.spec.ts\` completes within its 240s budget

## References
- E2E run that surfaced these: https://github.com/ever-works/ever-works/actions/runs/25784488449
- Same bug class fixed by: #712 (\`global-setup.ts\` dismiss endpoint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test coverage for the onboarding wizard v2, including comprehensive validation of catalog, state management, and AI-choice flows.
  * Improved testing of onboarding dismissal workflows to support both legacy and current implementation approaches.
  * Strengthened test infrastructure with API-based request handling for improved reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/741)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->