### PR TITLE
test(e2e): Bearer auth for onboarding-wizard-v2 (fixes 7 still-failing tests)

### DIFF
--- a/apps/web/e2e/onboarding-wizard-v2.spec.ts
+++ b/apps/web/e2e/onboarding-wizard-v2.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { apiUrl } from './helpers/api';
+import { apiUrl, loginViaAPI, authedHeaders } from './helpers/api';
+import { TEST_USER } from './helpers/test-user';
 
 /**
  * v2 onboarding wizard end-to-end coverage.
@@ -10,19 +11,36 @@ import { apiUrl } from './helpers/api';
  * `global-setup.ts > POST /api/onboarding/dismiss`), so we explicitly
  * undismiss the wizard for these specs before each test.
  *
- * Routes are absolute via `apiUrl(...)` because `page.request` resolves
- * relative URLs against `baseURL` (the Next.js web at :3000), which has
- * no `/api/onboarding/*` route — the actual endpoints live on the
- * NestJS API at :3100.
+ * Auth model: the endpoints live on the NestJS API at :3100, so
+ * `page.request` against a relative path resolves to the Next.js web at
+ * :3000 (no proxy → 404) AND cookies set on :3000 do not transfer to
+ * :3100. We log in via API to obtain a Bearer token and authenticate the
+ * `/api/onboarding/*` calls directly, mirroring `global-setup.ts`.
  */
 
 test.describe('Onboarding wizard v2 — choice-driven flow', () => {
+    let auth: { Authorization: string };
+
+    test.beforeAll(async ({ playwright }) => {
+        const ctx = await playwright.request.newContext();
+        try {
+            const { access_token } = await loginViaAPI(ctx, {
+                email: TEST_USER.email,
+                password: TEST_USER.password,
+            });
+            auth = authedHeaders(access_token);
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
     test.beforeEach(async ({ page }) => {
         // Reset server state to pristine for each test so we exercise the
         // auto-open path. The /api/onboarding/state PATCH endpoint accepts
         // a partial state; explicitly re-load the dashboard after each reset
         // so the layout's RSC fetch picks up the new server state.
         await page.request.patch(apiUrl('/api/onboarding/state'), {
+            headers: auth,
             data: {
                 state: {
                     lastStep: 0,
@@ -39,7 +57,9 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     test('catalog endpoint returns the six AI cards with Ever Works as default', async ({
         page,
     }) => {
-        const res = await page.request.get(apiUrl('/api/onboarding/catalog'));
+        const res = await page.request.get(apiUrl('/api/onboarding/catalog'), {
+            headers: auth,
+        });
         expect(res.ok()).toBe(true);
         const body = (await res.json()) as {
             ai: Array<{ choice: string; default?: boolean }>;
@@ -51,11 +71,14 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('state endpoint round-trips a partial PATCH', async ({ page }) => {
         const patch = await page.request.patch(apiUrl('/api/onboarding/state'), {
+            headers: auth,
             data: { state: { ai: { choice: 'openrouter' }, lastStep: 2 } },
         });
         expect(patch.ok()).toBe(true);
 
-        const res = await page.request.get(apiUrl('/api/onboarding/state'));
+        const res = await page.request.get(apiUrl('/api/onboarding/state'), {
+            headers: auth,
+        });
         const body = (await res.json()) as {
             state: { ai: { choice: string }; lastStep: number };
         };
@@ -65,6 +88,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('rejects an invalid AI choice with a 400', async ({ page }) => {
         const res = await page.request.patch(apiUrl('/api/onboarding/state'), {
+            headers: auth,
             data: { state: { ai: { choice: 'not-a-real-provider' } } },
         });
         expect(res.status()).toBe(400);
@@ -72,6 +96,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('telemetry endpoint accepts an allow-listed event', async ({ page }) => {
         const res = await page.request.post(apiUrl('/api/onboarding/telemetry'), {
+            headers: auth,
             data: { event: 'onboarding_opened', properties: { trigger: 'auto' } },
         });
         // 204 No Content on success
@@ -80,6 +105,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('telemetry endpoint rejects an unknown event', async ({ page }) => {
         const res = await page.request.post(apiUrl('/api/onboarding/telemetry'), {
+            headers: auth,
             data: { event: 'definitely_not_in_allowlist', properties: {} },
         });
         expect(res.status()).toBe(400);
@@ -87,9 +113,11 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('complete endpoint is idempotent', async ({ page }) => {
         const first = await page.request.post(apiUrl('/api/onboarding/complete'), {
+            headers: auth,
             data: {},
         });
         const second = await page.request.post(apiUrl('/api/onboarding/complete'), {
+            headers: auth,
             data: {},
         });
         expect(first.ok()).toBe(true);
@@ -98,9 +126,11 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('dismiss endpoint is idempotent', async ({ page }) => {
         const first = await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+            headers: auth,
             data: {},
         });
         const second = await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+            headers: auth,
             data: {},
         });
         expect(first.ok()).toBe(true);


### PR DESCRIPTION
## Summary
Follow-up to #741. Those 7 onboarding-wizard-v2 tests are **still failing** on develop after #741 merged. New diagnosis below.

### Root cause (deeper than #741 thought)

PR #741 routed the calls through \`apiUrl()\` so they now hit the NestJS API at \`localhost:3100\` instead of the Next.js web at \`:3000\`. That part was correct — \`apps/web/next.config.ts\` has **no rewrites** for \`/api/onboarding/*\`, and there are **no Next.js route handlers** under \`apps/web/src/app/**/api/onboarding/**\`. So the original relative-URL tests were always 404'ing.

But **cookies set on :3000 don't transfer to :3100** (different origin per port). The page.request fixture inherits cookies from storageState — all scoped to \`localhost:3000\`. So even with the correct URL, the NestJS auth guard rejects every call. \`res.ok()\` stays false → \`expect(res.ok()).toBe(true)\` fails.

### Fix

Login via API once per worker (\`beforeAll\`) using TEST_USER credentials, then pass \`Authorization: Bearer <access_token>\` on every \`page.request.*\` call. This is the same Bearer-token flow \`global-setup.ts\` already uses for its onboarding-dismiss POST after login. No tests removed, no scope reduced — only auth wiring corrected.

## Test plan
- [x] Spec re-formatted via \`prettier --write\` (format:check passes)
- [ ] Next E2E run on develop shows zero onboarding-wizard-v2 failures
- [ ] Other specs unaffected (this change is isolated to one spec file)

## References
- Failing run on develop: https://github.com/ever-works/ever-works/actions/runs/25821480123
- Previous attempt: #741 (relative→absolute URLs — necessary but not sufficient)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test infrastructure for onboarding workflows with improved API authentication setup and request handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/742)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->