### PR TITLE
fix(auth): generate Better Auth UUIDs in JS (unblocks register flow)

### DIFF
--- a/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
@@ -313,10 +313,26 @@ describe('createAuthRuntimeInstance', () => {
     });
 
     describe('advanced.database', () => {
-        it('sets `generateId` to `"uuid"` so Better Auth issues UUIDs not nanoids', () => {
+        it('sets `generateId` to a function that delegates to node:crypto.randomUUID', () => {
+            // Why a function and not the `'uuid'` sentinel: better-auth's
+            // sentinel path strips the `id` from the INSERT payload on
+            // Postgres (assuming a column-level DEFAULT), but our TypeORM
+            // `AuthAccount` entity uses `@PrimaryColumn` with no default,
+            // so the INSERT failed with `null value in column "id"`. A
+            // function generator is invoked on every create and the value
+            // is preserved through to the INSERT.
+            randomUUIDMock
+                .mockReturnValueOnce('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01')
+                .mockReturnValueOnce('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02');
             createAuthRuntimeInstance(makeDataSource('postgres', { master: {} }) as any);
 
-            expect(getCapturedOptions().advanced.database.generateId).toBe('uuid');
+            const generateId = getCapturedOptions().advanced.database.generateId;
+            expect(typeof generateId).toBe('function');
+
+            // Each invocation produces a fresh UUID by calling
+            // `node:crypto.randomUUID` (mocked above).
+            expect(generateId()).toBe('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01');
+            expect(generateId()).toBe('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee02');
         });
     });
 

--- a/apps/api/src/auth/providers/auth-runtime.instance.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.ts
@@ -65,7 +65,25 @@ export function createAuthRuntimeInstance(dataSource: DataSource) {
         trustedOrigins: getTrustedOrigins(),
         advanced: {
             database: {
-                generateId: 'uuid',
+                // Generate the row id in JS as a UUID string.
+                //
+                // The previous value `'uuid'` is a sentinel that tells
+                // `@better-auth/core/db/adapter/get-id-field.mjs` "the DB
+                // adapter supports UUIDs natively, let it generate." On
+                // Postgres (`supportsUUIDs=true`) better-auth then strips
+                // `id` from the INSERT payload entirely, expecting a
+                // `DEFAULT gen_random_uuid()` on the column. Our TypeORM
+                // `AuthAccount` entity uses `@PrimaryColumn({ type: 'varchar' })`
+                // with no default, so every `linkAccount` (the call path
+                // every register hits) failed with `null value in column "id"
+                // of relation "account" violates not-null constraint`.
+                //
+                // Passing a function bypasses the sentinel branch: better-auth
+                // calls this generator on every create and injects the value
+                // into the INSERT. Works on Postgres, sqlite, mysql alike,
+                // and matches the UUID format already used by the User
+                // entity's `@PrimaryGeneratedColumn('uuid')`.
+                generateId: () => randomUUID(),
             },
         },
         user: {


### PR DESCRIPTION
## Summary
Register flow has been 500'ing for every new user across dev/stage/prod with:

\`\`\`
error: null value in column \"id\" of relation \"account\" violates not-null constraint
  at Object.linkAccount (better-auth/dist/db/internal-adapter.mjs:471)
\`\`\`

### Root cause
\`apps/api/src/auth/providers/auth-runtime.instance.ts\` sets \`advanced.database.generateId: 'uuid'\`. That string is a **sentinel** — better-auth's \`@better-auth/core/db/adapter/get-id-field.mjs\` reads it as "the DB supports UUIDs natively, let it generate" and strips the \`id\` from the INSERT payload, expecting a column-level \`DEFAULT gen_random_uuid()\`.

Our TypeORM \`AuthAccount\` entity (\`packages/agent/src/entities/auth-account.entity.ts\`) declares \`id\` as \`@PrimaryColumn({ type: 'varchar' })\` — no default. Every \`linkAccount\` (which every register call hits, including email/password) inserts NULL → PostgreSQL rejects → 500.

### Fix
Switch \`generateId\` to a function. Better-auth invokes it on every create and the value flows through to the INSERT regardless of \`supportsUUIDs\`. Output is the same UUID format already used by \`User.id\` (\`@PrimaryGeneratedColumn('uuid')\`), so we keep one shape across the schema.

### Test plan
- [x] \`pnpm exec jest --testPathPattern='auth-runtime'\` — 47 tests pass; the \`advanced.database.generateId\` test now asserts the function shape + delegates to \`node:crypto.randomUUID\`.
- [ ] Cascade develop → stage → main; verify \`POST /api/auth/register\` returns 2xx with an \`access_token\`.

### Unblocks
- EW-614 prod smoke test (\`docs/specs/features/onboarding-wizard-v2/ew-614-storage-wireup.md\` §7) — was blocked on register failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UUID generation in authentication to ensure unique identifiers are properly created for each user session.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/743)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->