### PR TITLE
fix(work-proposals): tolerate sloppy LLM output via permissive schema + coercion

### DIFF
--- a/packages/agent/src/user-research/__tests__/proposal-coercion.spec.ts
+++ b/packages/agent/src/user-research/__tests__/proposal-coercion.spec.ts
@@ -1,0 +1,134 @@
+import { coerceWorkProposal } from '../proposal-coercion';
+import type { PermissiveWorkProposalDraft } from '../schemas';
+
+function makeDraft(over: Partial<PermissiveWorkProposalDraft> = {}): PermissiveWorkProposalDraft {
+    return {
+        title: 'Open Source AI Tools',
+        description:
+            'A curated directory of AI tools for developers, organized by category and use case.',
+        slugSuggestion: 'open-source-ai-tools',
+        suggestedCategories: [
+            { name: 'Models', slug: 'models' },
+            { name: 'Agents', slug: 'agents' },
+        ],
+        suggestedFields: [
+            { name: 'github_url', type: 'url' },
+            { name: 'description', type: 'markdown' },
+        ],
+        recommendedPlugins: [{ pluginId: 'github', reason: 'pulls README' }],
+        reasoning: 'Matches user expertise.',
+        ...over,
+    };
+}
+
+describe('coerceWorkProposal', () => {
+    it('passes through a clean draft', () => {
+        const result = coerceWorkProposal(makeDraft());
+        expect(result).not.toBeNull();
+        expect(result!.slugSuggestion).toBe('open-source-ai-tools');
+        expect(result!.suggestedFields).toHaveLength(2);
+    });
+
+    it('slugifies a non-kebab-case slug suggestion (strict regex: no underscores)', () => {
+        const result = coerceWorkProposal(makeDraft({ slugSuggestion: 'My_Cool Tools!' }));
+        expect(result?.slugSuggestion).toBe('my-cool-tools');
+    });
+
+    it('falls back to title-derived slug when the LLM omits the slug', () => {
+        const result = coerceWorkProposal(makeDraft({ slugSuggestion: '' }));
+        expect(result?.slugSuggestion).toBe('open-source-ai-tools');
+    });
+
+    it('aliases sloppy field types (text → string, link → url, etc.)', () => {
+        const result = coerceWorkProposal(
+            makeDraft({
+                suggestedFields: [
+                    { name: 'about', type: 'text' },
+                    { name: 'site', type: 'link' },
+                    { name: 'count', type: 'int' },
+                ],
+            }),
+        );
+        expect(result?.suggestedFields).toEqual([
+            { name: 'about', type: 'string' },
+            { name: 'site', type: 'url' },
+            { name: 'count', type: 'number' },
+        ]);
+    });
+
+    it('drops fields with unrecognized types', () => {
+        const result = coerceWorkProposal(
+            makeDraft({
+                suggestedFields: [
+                    { name: 'ok', type: 'string' },
+                    { name: 'bad', type: 'datetime' },
+                ],
+            }),
+        );
+        expect(result?.suggestedFields).toEqual([{ name: 'ok', type: 'string' }]);
+    });
+
+    it('clips an over-long title to the strict max', () => {
+        const longTitle = 'A'.repeat(200);
+        const result = coerceWorkProposal(makeDraft({ title: longTitle }));
+        expect(result?.title.length).toBeLessThanOrEqual(80);
+    });
+
+    it('clips an over-long reasoning to 280 chars', () => {
+        const reasoning = 'because '.repeat(100);
+        const result = coerceWorkProposal(makeDraft({ reasoning }));
+        expect(result?.reasoning.length).toBeLessThanOrEqual(280);
+    });
+
+    it('drops drafts whose title is too short to be salvaged', () => {
+        expect(coerceWorkProposal(makeDraft({ title: 'AI' }))).toBeNull();
+    });
+
+    it('drops drafts whose description is too short', () => {
+        expect(coerceWorkProposal(makeDraft({ description: 'short' }))).toBeNull();
+    });
+
+    it('drops drafts that end up with fewer than 2 valid categories', () => {
+        expect(
+            coerceWorkProposal(
+                makeDraft({ suggestedCategories: [{ name: 'Only One', slug: 'only-one' }] }),
+            ),
+        ).toBeNull();
+    });
+
+    it('caps oversized arrays to schema maximums', () => {
+        const cats = Array.from({ length: 12 }, (_, i) => ({
+            name: `Cat ${i}`,
+            slug: `cat-${i}`,
+        }));
+        const plugins = Array.from({ length: 10 }, (_, i) => ({
+            pluginId: `plugin-${i}`,
+            reason: 'r',
+        }));
+        const result = coerceWorkProposal(
+            makeDraft({ suggestedCategories: cats, recommendedPlugins: plugins }),
+        );
+        expect(result?.suggestedCategories).toHaveLength(8);
+        expect(result?.recommendedPlugins).toHaveLength(5);
+    });
+
+    it('handles optional fields being absent', () => {
+        const result = coerceWorkProposal({
+            title: 'Open Source AI Tools',
+            description:
+                'A curated directory of AI tools for developers, organized by category and use case.',
+            slugSuggestion: 'open-source-ai-tools',
+            suggestedCategories: [
+                { name: 'Models', slug: 'models' },
+                { name: 'Agents', slug: 'agents' },
+            ],
+            suggestedFields: [],
+            recommendedPlugins: [],
+            reasoning: '',
+        });
+        expect(result).not.toBeNull();
+        expect(result!.suggestedFields).toEqual([]);
+        expect(result!.recommendedPlugins).toEqual([]);
+        expect(result!.reasoning).toBe('');
+    });
+});

--- a/packages/agent/src/user-research/proposal-coercion.ts
+++ b/packages/agent/src/user-research/proposal-coercion.ts
@@ -1,0 +1,120 @@
+import { slugifyText } from '../utils/text.utils';
+import {
+    workProposalSchema,
+    type PermissiveWorkProposalDraft,
+    type WorkProposalDraft,
+} from './schemas';
+
+const SUGGESTED_FIELD_TYPES = ['string', 'url', 'image', 'number', 'enum', 'markdown'] as const;
+type SuggestedFieldType = (typeof SUGGESTED_FIELD_TYPES)[number];
+
+const TITLE_MIN = 8;
+const TITLE_MAX = 80;
+const DESCRIPTION_MIN = 20;
+const DESCRIPTION_MAX = 280;
+const REASONING_MAX = 280;
+const CATEGORIES_MIN = 2;
+const CATEGORIES_MAX = 8;
+const FIELDS_MAX = 10;
+const PLUGINS_MAX = 5;
+
+function clipMax(s: string, max: number): string {
+    return s.length > max ? s.slice(0, max).trimEnd() : s;
+}
+
+/** Strip anything the strict slug regex `/^[a-z0-9]+(?:-[a-z0-9]+)*$/` rejects. */
+function tightenSlug(slug: string): string {
+    return slug
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function safeSlug(input: string, fallback?: string): string {
+    const slug = tightenSlug(slugifyText(input || ''));
+    if (slug.length > 0) return slug;
+    return fallback ? tightenSlug(slugifyText(fallback)) : '';
+}
+
+const FIELD_TYPE_ALIASES: Record<string, SuggestedFieldType> = {
+    text: 'string',
+    str: 'string',
+    string: 'string',
+    url: 'url',
+    link: 'url',
+    img: 'image',
+    image: 'image',
+    photo: 'image',
+    num: 'number',
+    int: 'number',
+    integer: 'number',
+    float: 'number',
+    number: 'number',
+    enum: 'enum',
+    select: 'enum',
+    md: 'markdown',
+    markdown: 'markdown',
+};
+
+function coerceFieldType(raw: string): SuggestedFieldType | null {
+    const key = raw.trim().toLowerCase();
+    return FIELD_TYPE_ALIASES[key] ?? null;
+}
+
+/**
+ * Coerce a loose, LLM-shaped proposal into the strict on-disk shape.
+ * Slugifies anything slug-like, clips long strings, filters bad enums.
+ * Returns null when the draft has no salvageable content (e.g. blank title
+ * or fewer than 2 valid categories — both are hard DB requirements).
+ */
+export function coerceWorkProposal(draft: PermissiveWorkProposalDraft): WorkProposalDraft | null {
+    const title = clipMax(draft.title?.trim() ?? '', TITLE_MAX);
+    if (title.length < TITLE_MIN) return null;
+
+    const description = clipMax(draft.description?.trim() ?? '', DESCRIPTION_MAX);
+    if (description.length < DESCRIPTION_MIN) return null;
+
+    // Slug derived from the LLM hint, falling back to the title so we never
+    // bail on a missing/garbled slug.
+    const slugSuggestion = safeSlug(draft.slugSuggestion, title);
+    if (slugSuggestion.length === 0) return null;
+
+    const suggestedCategories = (draft.suggestedCategories ?? [])
+        .map((c) => {
+            const slug = safeSlug(c.slug || c.name, c.name);
+            return slug.length > 0 ? { name: c.name?.trim() || slug, slug } : null;
+        })
+        .filter((c): c is { name: string; slug: string } => c !== null)
+        .slice(0, CATEGORIES_MAX);
+    if (suggestedCategories.length < CATEGORIES_MIN) return null;
+
+    const suggestedFields = (draft.suggestedFields ?? [])
+        .map((f) => {
+            const type = coerceFieldType(f.type ?? '');
+            return type ? { name: (f.name ?? '').trim() || type, type } : null;
+        })
+        .filter((f): f is { name: string; type: SuggestedFieldType } => f !== null)
+        .slice(0, FIELDS_MAX);
+
+    const recommendedPlugins = (draft.recommendedPlugins ?? [])
+        .filter((p) => typeof p.pluginId === 'string' && p.pluginId.trim().length > 0)
+        .map((p) => ({ pluginId: p.pluginId.trim(), reason: (p.reason ?? '').trim() }))
+        .slice(0, PLUGINS_MAX);
+
+    const reasoning = clipMax(draft.reasoning?.trim() ?? '', REASONING_MAX);
+
+    const candidate = {
+        title,
+        description,
+        slugSuggestion,
+        suggestedCategories,
+        suggestedFields,
+        recommendedPlugins,
+        reasoning,
+    };
+
+    // Final guard: if our coercion still produced something that fails the
+    // strict schema (e.g. clip-then-trim took us below TITLE_MIN), drop it.
+    const result = workProposalSchema.safeParse(candidate);
+    return result.success ? result.data : null;
+}

--- a/packages/agent/src/user-research/schemas.ts
+++ b/packages/agent/src/user-research/schemas.ts
@@ -58,3 +58,53 @@ export const workProposalsBatchSchema = z.object({
 });
 
 export type WorkProposalsBatch = z.infer<typeof workProposalsBatchSchema>;
+
+/**
+ * Permissive variant used as the structured-output schema for the LLM call.
+ * Lower-quality / free-tier models routinely violate the strict bounds
+ * (slug regex, exact enum, length min/max), which makes generateObject reject
+ * the whole batch with `No object generated: response did not match schema.`
+ *
+ * Strategy: accept loose shapes here, then run every draft through
+ * coerceWorkProposal() to clip, slugify and filter into the strict shape
+ * before persisting. Anything still un-salvageable is dropped, and we only
+ * fail if zero valid proposals remain.
+ */
+export const permissiveWorkProposalSchema = z.object({
+    title: z.string(),
+    description: z.string(),
+    slugSuggestion: z.string(),
+    suggestedCategories: z.array(
+        z.object({
+            name: z.string(),
+            slug: z.string(),
+        }),
+    ),
+    suggestedFields: z
+        .array(
+            z.object({
+                name: z.string(),
+                type: z.string(),
+            }),
+        )
+        .optional()
+        .default([]),
+    recommendedPlugins: z
+        .array(
+            z.object({
+                pluginId: z.string(),
+                reason: z.string(),
+            }),
+        )
+        .optional()
+        .default([]),
+    reasoning: z.string().optional().default(''),
+});
+
+export type PermissiveWorkProposalDraft = z.infer<typeof permissiveWorkProposalSchema>;
+
+export const permissiveWorkProposalsBatchSchema = z.object({
+    proposals: z.array(permissiveWorkProposalSchema),
+});
+
+export type PermissiveWorkProposalsBatch = z.infer<typeof permissiveWorkProposalsBatchSchema>;

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -5,7 +5,8 @@ import { UserRepository } from '../database/repositories/user.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { WorkProposalRepository } from './work-proposal.repository';
-import { workProposalsBatchSchema, type WorkProposalsBatch } from './schemas';
+import { permissiveWorkProposalsBatchSchema, type WorkProposalDraft } from './schemas';
+import { coerceWorkProposal } from './proposal-coercion';
 import { PROPOSALS_SYSTEM_PROMPT, buildProposalsPrompt } from './prompts';
 import { resolveAiProviderForResearch } from './provider-resolver';
 import {
@@ -96,29 +97,55 @@ export class WorkProposalService {
         }
 
         let tokensUsed = 0;
-        let parsed: WorkProposalsBatch;
+        let drafts: WorkProposalDraft[] = [];
 
         try {
+            // Use the permissive schema so low-quality model output (sloppy
+            // slugs, wrong enum values, off-by-one length bounds) doesn't
+            // make generateObject reject the whole batch. coerceWorkProposal
+            // below clips/slugifies/filters each draft into the strict shape.
             const result = await generateObject({
                 model: resolvedModel,
-                schema: workProposalsBatchSchema,
+                schema: permissiveWorkProposalsBatchSchema,
                 system: PROPOSALS_SYSTEM_PROMPT,
                 prompt: buildProposalsPrompt(profile, existingWorkNames, availablePluginIds),
                 temperature: 0.4,
                 maxRetries: 2,
             });
 
-            parsed = workProposalsBatchSchema.parse(result.object);
+            const raw = result.object.proposals ?? [];
+            drafts = raw
+                .map((p) => coerceWorkProposal(p))
+                .filter((p): p is WorkProposalDraft => p !== null);
             tokensUsed = result.usage?.totalTokens ?? 0;
+
+            if (drafts.length === 0) {
+                this.logger.warn(
+                    `Proposal generation for ${userId} produced ${raw.length} raw draft(s) but none survived coercion`,
+                );
+                return {
+                    status: 'error',
+                    proposals: [],
+                    tokensUsed,
+                    error: 'no-valid-proposals',
+                };
+            }
+            if (drafts.length < raw.length) {
+                this.logger.log(
+                    `Proposal generation for ${userId}: kept ${drafts.length}/${raw.length} after coercion`,
+                );
+            }
         } catch (err) {
             const message = (err as Error).message;
             this.logger.warn(`Proposal generation failed for ${userId}: ${message}`);
             return { status: 'error', proposals: [], tokensUsed, error: message };
         }
 
-        // Drop plugin IDs the registry doesn't recognize.
+        // Drop plugin IDs the registry doesn't recognize. Casts mirror the
+        // pre-coercion code — zod 3.25 widens inner-object props to optional
+        // under our tsconfig, and the coercer already guarantees the shape.
         const pluginSet = new Set(availablePluginIds);
-        const inputs = parsed.proposals.map((p) => ({
+        const inputs = drafts.map((p) => ({
             userId,
             title: p.title,
             description: p.description,


### PR DESCRIPTION
## Summary

`WorkProposalService.generate()` was failing with `WARN [WorkProposalService] Proposal generation failed: No object generated: response did not match schema.` whenever the LLM's output didn't match every constraint of `workProposalsBatchSchema` — common on free-tier / weak models that emit `'text'` instead of `'string'`, slugs with underscores, off-by-one length bounds, etc. One bad item in the batch = entire batch rejected = zero proposals saved.

Switch the LLM call to a **permissive** schema and coerce each draft into the strict on-disk shape locally. Only fail if zero drafts survive coercion.

## Changes

- `packages/agent/src/user-research/schemas.ts` — add `permissiveWorkProposalsBatchSchema` (any-string slugs, any-string field types, optional fields/plugins/reasoning, no length min/max).
- `packages/agent/src/user-research/proposal-coercion.ts` — new `coerceWorkProposal(draft)` that:
  - clips title/description/reasoning to strict bounds
  - slugifies + tightens slugs against `/^[a-z0-9]+(?:-[a-z0-9]+)*$/`
  - aliases sloppy field types (`text`→`string`, `link`→`url`, `int`→`number`, `md`→`markdown`, etc.)
  - drops fields with unrecognized types, plugins with empty IDs
  - caps arrays at the strict maxima
  - re-validates against the strict `workProposalSchema` and returns `null` if anything is still un-salvageable.
- `packages/agent/src/user-research/work-proposal.service.ts` — generate against the permissive schema, coerce, drop unsalvageables. New `error: 'no-valid-proposals'` only when *zero* drafts survive; partial-loss runs log `kept N/M after coercion`.
- 12 new unit tests covering happy path, slugification, alias mapping, clipping, optional fields, and unsalvageable inputs.

## Test plan

- [ ] Repro the failure locally: trigger refresh on a free-tier OpenRouter model that previously returned `No object generated`. Should now persist proposals.
- [ ] Force the LLM to emit `'text'` field types (e.g. via a stricter prompt) — observe `kept N/M after coercion` log line, valid proposals saved.
- [ ] Confirm strict-schema invariants still hold: dismiss a saved proposal, reopen the form, all categories slugified, all field types valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced work proposal generation with improved validation and normalization of AI-generated content.
  * Automatic field type mapping and slugification for consistency.
  * Content length enforcement and array size limits for compliance.

* **Tests**
  * Added comprehensive test suite for proposal validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/746)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->