### PR TITLE
test(e2e): register fresh user per spec (real fix for onboarding-wizard-v2 401)

### DIFF
--- a/apps/web/e2e/onboarding-wizard-v2.spec.ts
+++ b/apps/web/e2e/onboarding-wizard-v2.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { apiUrl, loginViaAPI, authedHeaders } from './helpers/api';
-import { TEST_USER } from './helpers/test-user';
+import { apiUrl, registerUserViaAPI, authedHeaders } from './helpers/api';
 
 /**
  * v2 onboarding wizard end-to-end coverage.
@@ -14,8 +13,10 @@ import { TEST_USER } from './helpers/test-user';
  * Auth model: the endpoints live on the NestJS API at :3100, so
  * `page.request` against a relative path resolves to the Next.js web at
  * :3000 (no proxy → 404) AND cookies set on :3000 do not transfer to
- * :3100. We log in via API to obtain a Bearer token and authenticate the
- * `/api/onboarding/*` calls directly, mirroring `global-setup.ts`.
+ * :3100. We register a fresh user in beforeAll via `registerUserViaAPI`,
+ * which returns an access_token directly — avoids relying on TEST_USER,
+ * whose `Date.now()` suffix differs between the setup-project process
+ * (where it was registered) and a chromium-project worker process.
  */
 
 test.describe('Onboarding wizard v2 — choice-driven flow', () => {
@@ -24,11 +25,8 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     test.beforeAll(async ({ playwright }) => {
         const ctx = await playwright.request.newContext();
         try {
-            const { access_token } = await loginViaAPI(ctx, {
-                email: TEST_USER.email,
-                password: TEST_USER.password,
-            });
-            auth = authedHeaders(access_token);
+            const user = await registerUserViaAPI(ctx, {});
+            auth = authedHeaders(user.access_token);
         } finally {
             await ctx.dispose();
         }


### PR DESCRIPTION
## Summary
Real fix for the 7 onboarding-wizard-v2 tests that have been failing in CI through #741, #742 and the Better Auth UUID fix #743. Earlier diagnoses were wrong on two points — corrected here.

### Real root cause
\`apps/web/e2e/helpers/test-user.ts\` computes \`const suffix = Date.now().toString(36)\` at **module-load time**. Playwright loads that module separately in the **setup-project process** (where global-setup registers the user) and in any **chromium worker process** that imports it. The two processes get different \`suffix\` values, so the email \`TEST_USER\` resolves to in beforeAll is \`e2e-BBBB@test.local\` while global-setup registered \`e2e-AAAA@test.local\`. NestJS returns 401, and Playwright reports the 6 subsequent tests as failed-on-beforeAll-error.

### What's NOT the root cause (so I don't repeat my own bad diagnoses)
- **Auth realms**: NestJS already accepts both \`Authorization: Bearer <better-auth-token>\` **and** Better Auth session cookies via \`auth.api.getSession({ headers })\` (see \`AuthSessionGuard\` → \`AuthProviderService.authenticate\`). Goal (2) is already shipped.
- **\`ensureCredentialAccount\`**: insert-only (line 22-24 returns existing row unchanged on conflict). Not the dangerous self-heal I previously flagged. Untouched.
- **The Better Auth UUID fix**: already on develop (\`a7d7c349\`). Working as intended — register correctly seats both the \`users\` row and the \`account\` (credential) row.

### Fix
Replace the \`TEST_USER\`-based login flow in \`beforeAll\` with \`registerUserViaAPI\` (from \`helpers/api.ts\`), which generates a unique user inside the spec's own process AND returns \`access_token\` in a single API call. No cross-process suffix race, no reliance on global-setup's user being addressable from a different worker.

### Files changed
- \`apps/web/e2e/onboarding-wizard-v2.spec.ts\` — 7 → 7 (no count change), 16 lines diff: swap \`loginViaAPI(TEST_USER)\` for \`registerUserViaAPI(ctx, {})\`, drop \`TEST_USER\` import, update header comment.

No NestJS, helper, or app-code changes.

## Test plan
- [ ] Next full E2E run on develop has 0 onboarding-wizard-v2 failures
- [ ] No other specs regress (this change touches only one file)

## References
- Failing run: https://github.com/ever-works/ever-works/actions/runs/25842840230
- Auth audit (this PR's investigation): in-thread Sonnet research

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated onboarding wizard end-to-end test authentication setup to use fresh user registration instead of pre-existing credentials, improving test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/748)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->