### PR TITLE
release(stage→main): onboarding-wizard-v2 fix + work-proposals schema tolerance

### DIFF
--- a/apps/web/e2e/onboarding-wizard-v2.spec.ts
+++ b/apps/web/e2e/onboarding-wizard-v2.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { apiUrl } from './helpers/api';
+import { apiUrl, loginViaAPI, authedHeaders } from './helpers/api';
+import { TEST_USER } from './helpers/test-user';
 
 /**
  * v2 onboarding wizard end-to-end coverage.
@@ -10,19 +11,36 @@ import { apiUrl } from './helpers/api';
  * `global-setup.ts > POST /api/onboarding/dismiss`), so we explicitly
  * undismiss the wizard for these specs before each test.
  *
- * Routes are absolute via `apiUrl(...)` because `page.request` resolves
- * relative URLs against `baseURL` (the Next.js web at :3000), which has
- * no `/api/onboarding/*` route — the actual endpoints live on the
- * NestJS API at :3100.
+ * Auth model: the endpoints live on the NestJS API at :3100, so
+ * `page.request` against a relative path resolves to the Next.js web at
+ * :3000 (no proxy → 404) AND cookies set on :3000 do not transfer to
+ * :3100. We log in via API to obtain a Bearer token and authenticate the
+ * `/api/onboarding/*` calls directly, mirroring `global-setup.ts`.
  */
 
 test.describe('Onboarding wizard v2 — choice-driven flow', () => {
+    let auth: { Authorization: string };
+
+    test.beforeAll(async ({ playwright }) => {
+        const ctx = await playwright.request.newContext();
+        try {
+            const { access_token } = await loginViaAPI(ctx, {
+                email: TEST_USER.email,
+                password: TEST_USER.password,
+            });
+            auth = authedHeaders(access_token);
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
     test.beforeEach(async ({ page }) => {
         // Reset server state to pristine for each test so we exercise the
         // auto-open path. The /api/onboarding/state PATCH endpoint accepts
         // a partial state; explicitly re-load the dashboard after each reset
         // so the layout's RSC fetch picks up the new server state.
         await page.request.patch(apiUrl('/api/onboarding/state'), {
+            headers: auth,
             data: {
                 state: {
                     lastStep: 0,
@@ -39,7 +57,9 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     test('catalog endpoint returns the six AI cards with Ever Works as default', async ({
         page,
     }) => {
-        const res = await page.request.get(apiUrl('/api/onboarding/catalog'));
+        const res = await page.request.get(apiUrl('/api/onboarding/catalog'), {
+            headers: auth,
+        });
         expect(res.ok()).toBe(true);
         const body = (await res.json()) as {
             ai: Array<{ choice: string; default?: boolean }>;
@@ -51,11 +71,14 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('state endpoint round-trips a partial PATCH', async ({ page }) => {
         const patch = await page.request.patch(apiUrl('/api/onboarding/state'), {
+            headers: auth,
             data: { state: { ai: { choice: 'openrouter' }, lastStep: 2 } },
         });
         expect(patch.ok()).toBe(true);
 
-        const res = await page.request.get(apiUrl('/api/onboarding/state'));
+        const res = await page.request.get(apiUrl('/api/onboarding/state'), {
+            headers: auth,
+        });
         const body = (await res.json()) as {
             state: { ai: { choice: string }; lastStep: number };
         };
@@ -65,6 +88,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('rejects an invalid AI choice with a 400', async ({ page }) => {
         const res = await page.request.patch(apiUrl('/api/onboarding/state'), {
+            headers: auth,
             data: { state: { ai: { choice: 'not-a-real-provider' } } },
         });
         expect(res.status()).toBe(400);
@@ -72,6 +96,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('telemetry endpoint accepts an allow-listed event', async ({ page }) => {
         const res = await page.request.post(apiUrl('/api/onboarding/telemetry'), {
+            headers: auth,
             data: { event: 'onboarding_opened', properties: { trigger: 'auto' } },
         });
         // 204 No Content on success
@@ -80,6 +105,7 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('telemetry endpoint rejects an unknown event', async ({ page }) => {
         const res = await page.request.post(apiUrl('/api/onboarding/telemetry'), {
+            headers: auth,
             data: { event: 'definitely_not_in_allowlist', properties: {} },
         });
         expect(res.status()).toBe(400);
@@ -87,9 +113,11 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('complete endpoint is idempotent', async ({ page }) => {
         const first = await page.request.post(apiUrl('/api/onboarding/complete'), {
+            headers: auth,
             data: {},
         });
         const second = await page.request.post(apiUrl('/api/onboarding/complete'), {
+            headers: auth,
             data: {},
         });
         expect(first.ok()).toBe(true);
@@ -98,9 +126,11 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
 
     test('dismiss endpoint is idempotent', async ({ page }) => {
         const first = await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+            headers: auth,
             data: {},
         });
         const second = await page.request.post(apiUrl('/api/onboarding/dismiss'), {
+            headers: auth,
             data: {},
         });
         expect(first.ok()).toBe(true);

--- a/apps/web/e2e/onboarding-wizard-v2.spec.ts
+++ b/apps/web/e2e/onboarding-wizard-v2.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { apiUrl, loginViaAPI, authedHeaders } from './helpers/api';
-import { TEST_USER } from './helpers/test-user';
+import { apiUrl, registerUserViaAPI, authedHeaders } from './helpers/api';
 
 /**
  * v2 onboarding wizard end-to-end coverage.
@@ -14,8 +13,10 @@ import { TEST_USER } from './helpers/test-user';
  * Auth model: the endpoints live on the NestJS API at :3100, so
  * `page.request` against a relative path resolves to the Next.js web at
  * :3000 (no proxy → 404) AND cookies set on :3000 do not transfer to
- * :3100. We log in via API to obtain a Bearer token and authenticate the
- * `/api/onboarding/*` calls directly, mirroring `global-setup.ts`.
+ * :3100. We register a fresh user in beforeAll via `registerUserViaAPI`,
+ * which returns an access_token directly — avoids relying on TEST_USER,
+ * whose `Date.now()` suffix differs between the setup-project process
+ * (where it was registered) and a chromium-project worker process.
  */
 
 test.describe('Onboarding wizard v2 — choice-driven flow', () => {
@@ -24,11 +25,8 @@ test.describe('Onboarding wizard v2 — choice-driven flow', () => {
     test.beforeAll(async ({ playwright }) => {
         const ctx = await playwright.request.newContext();
         try {
-            const { access_token } = await loginViaAPI(ctx, {
-                email: TEST_USER.email,
-                password: TEST_USER.password,
-            });
-            auth = authedHeaders(access_token);
+            const user = await registerUserViaAPI(ctx, {});
+            auth = authedHeaders(user.access_token);
         } finally {
             await ctx.dispose();
         }

--- a/packages/agent/src/user-research/__tests__/proposal-coercion.spec.ts
+++ b/packages/agent/src/user-research/__tests__/proposal-coercion.spec.ts
@@ -1,0 +1,134 @@
+import { coerceWorkProposal } from '../proposal-coercion';
+import type { PermissiveWorkProposalDraft } from '../schemas';
+
+function makeDraft(over: Partial<PermissiveWorkProposalDraft> = {}): PermissiveWorkProposalDraft {
+    return {
+        title: 'Open Source AI Tools',
+        description:
+            'A curated directory of AI tools for developers, organized by category and use case.',
+        slugSuggestion: 'open-source-ai-tools',
+        suggestedCategories: [
+            { name: 'Models', slug: 'models' },
+            { name: 'Agents', slug: 'agents' },
+        ],
+        suggestedFields: [
+            { name: 'github_url', type: 'url' },
+            { name: 'description', type: 'markdown' },
+        ],
+        recommendedPlugins: [{ pluginId: 'github', reason: 'pulls README' }],
+        reasoning: 'Matches user expertise.',
+        ...over,
+    };
+}
+
+describe('coerceWorkProposal', () => {
+    it('passes through a clean draft', () => {
+        const result = coerceWorkProposal(makeDraft());
+        expect(result).not.toBeNull();
+        expect(result!.slugSuggestion).toBe('open-source-ai-tools');
+        expect(result!.suggestedFields).toHaveLength(2);
+    });
+
+    it('slugifies a non-kebab-case slug suggestion (strict regex: no underscores)', () => {
+        const result = coerceWorkProposal(makeDraft({ slugSuggestion: 'My_Cool Tools!' }));
+        expect(result?.slugSuggestion).toBe('my-cool-tools');
+    });
+
+    it('falls back to title-derived slug when the LLM omits the slug', () => {
+        const result = coerceWorkProposal(makeDraft({ slugSuggestion: '' }));
+        expect(result?.slugSuggestion).toBe('open-source-ai-tools');
+    });
+
+    it('aliases sloppy field types (text → string, link → url, etc.)', () => {
+        const result = coerceWorkProposal(
+            makeDraft({
+                suggestedFields: [
+                    { name: 'about', type: 'text' },
+                    { name: 'site', type: 'link' },
+                    { name: 'count', type: 'int' },
+                ],
+            }),
+        );
+        expect(result?.suggestedFields).toEqual([
+            { name: 'about', type: 'string' },
+            { name: 'site', type: 'url' },
+            { name: 'count', type: 'number' },
+        ]);
+    });
+
+    it('drops fields with unrecognized types', () => {
+        const result = coerceWorkProposal(
+            makeDraft({
+                suggestedFields: [
+                    { name: 'ok', type: 'string' },
+                    { name: 'bad', type: 'datetime' },
+                ],
+            }),
+        );
+        expect(result?.suggestedFields).toEqual([{ name: 'ok', type: 'string' }]);
+    });
+
+    it('clips an over-long title to the strict max', () => {
+        const longTitle = 'A'.repeat(200);
+        const result = coerceWorkProposal(makeDraft({ title: longTitle }));
+        expect(result?.title.length).toBeLessThanOrEqual(80);
+    });
+
+    it('clips an over-long reasoning to 280 chars', () => {
+        const reasoning = 'because '.repeat(100);
+        const result = coerceWorkProposal(makeDraft({ reasoning }));
+        expect(result?.reasoning.length).toBeLessThanOrEqual(280);
+    });
+
+    it('drops drafts whose title is too short to be salvaged', () => {
+        expect(coerceWorkProposal(makeDraft({ title: 'AI' }))).toBeNull();
+    });
+
+    it('drops drafts whose description is too short', () => {
+        expect(coerceWorkProposal(makeDraft({ description: 'short' }))).toBeNull();
+    });
+
+    it('drops drafts that end up with fewer than 2 valid categories', () => {
+        expect(
+            coerceWorkProposal(
+                makeDraft({ suggestedCategories: [{ name: 'Only One', slug: 'only-one' }] }),
+            ),
+        ).toBeNull();
+    });
+
+    it('caps oversized arrays to schema maximums', () => {
+        const cats = Array.from({ length: 12 }, (_, i) => ({
+            name: `Cat ${i}`,
+            slug: `cat-${i}`,
+        }));
+        const plugins = Array.from({ length: 10 }, (_, i) => ({
+            pluginId: `plugin-${i}`,
+            reason: 'r',
+        }));
+        const result = coerceWorkProposal(
+            makeDraft({ suggestedCategories: cats, recommendedPlugins: plugins }),
+        );
+        expect(result?.suggestedCategories).toHaveLength(8);
+        expect(result?.recommendedPlugins).toHaveLength(5);
+    });
+
+    it('handles optional fields being absent', () => {
+        const result = coerceWorkProposal({
+            title: 'Open Source AI Tools',
+            description:
+                'A curated directory of AI tools for developers, organized by category and use case.',
+            slugSuggestion: 'open-source-ai-tools',
+            suggestedCategories: [
+                { name: 'Models', slug: 'models' },
+                { name: 'Agents', slug: 'agents' },
+            ],
+            suggestedFields: [],
+            recommendedPlugins: [],
+            reasoning: '',
+        });
+        expect(result).not.toBeNull();
+        expect(result!.suggestedFields).toEqual([]);
+        expect(result!.recommendedPlugins).toEqual([]);
+        expect(result!.reasoning).toBe('');
+    });
+});

--- a/packages/agent/src/user-research/proposal-coercion.ts
+++ b/packages/agent/src/user-research/proposal-coercion.ts
@@ -1,0 +1,120 @@
+import { slugifyText } from '../utils/text.utils';
+import {
+    workProposalSchema,
+    type PermissiveWorkProposalDraft,
+    type WorkProposalDraft,
+} from './schemas';
+
+const SUGGESTED_FIELD_TYPES = ['string', 'url', 'image', 'number', 'enum', 'markdown'] as const;
+type SuggestedFieldType = (typeof SUGGESTED_FIELD_TYPES)[number];
+
+const TITLE_MIN = 8;
+const TITLE_MAX = 80;
+const DESCRIPTION_MIN = 20;
+const DESCRIPTION_MAX = 280;
+const REASONING_MAX = 280;
+const CATEGORIES_MIN = 2;
+const CATEGORIES_MAX = 8;
+const FIELDS_MAX = 10;
+const PLUGINS_MAX = 5;
+
+function clipMax(s: string, max: number): string {
+    return s.length > max ? s.slice(0, max).trimEnd() : s;
+}
+
+/** Strip anything the strict slug regex `/^[a-z0-9]+(?:-[a-z0-9]+)*$/` rejects. */
+function tightenSlug(slug: string): string {
+    return slug
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function safeSlug(input: string, fallback?: string): string {
+    const slug = tightenSlug(slugifyText(input || ''));
+    if (slug.length > 0) return slug;
+    return fallback ? tightenSlug(slugifyText(fallback)) : '';
+}
+
+const FIELD_TYPE_ALIASES: Record<string, SuggestedFieldType> = {
+    text: 'string',
+    str: 'string',
+    string: 'string',
+    url: 'url',
+    link: 'url',
+    img: 'image',
+    image: 'image',
+    photo: 'image',
+    num: 'number',
+    int: 'number',
+    integer: 'number',
+    float: 'number',
+    number: 'number',
+    enum: 'enum',
+    select: 'enum',
+    md: 'markdown',
+    markdown: 'markdown',
+};
+
+function coerceFieldType(raw: string): SuggestedFieldType | null {
+    const key = raw.trim().toLowerCase();
+    return FIELD_TYPE_ALIASES[key] ?? null;
+}
+
+/**
+ * Coerce a loose, LLM-shaped proposal into the strict on-disk shape.
+ * Slugifies anything slug-like, clips long strings, filters bad enums.
+ * Returns null when the draft has no salvageable content (e.g. blank title
+ * or fewer than 2 valid categories — both are hard DB requirements).
+ */
+export function coerceWorkProposal(draft: PermissiveWorkProposalDraft): WorkProposalDraft | null {
+    const title = clipMax(draft.title?.trim() ?? '', TITLE_MAX);
+    if (title.length < TITLE_MIN) return null;
+
+    const description = clipMax(draft.description?.trim() ?? '', DESCRIPTION_MAX);
+    if (description.length < DESCRIPTION_MIN) return null;
+
+    // Slug derived from the LLM hint, falling back to the title so we never
+    // bail on a missing/garbled slug.
+    const slugSuggestion = safeSlug(draft.slugSuggestion, title);
+    if (slugSuggestion.length === 0) return null;
+
+    const suggestedCategories = (draft.suggestedCategories ?? [])
+        .map((c) => {
+            const slug = safeSlug(c.slug || c.name, c.name);
+            return slug.length > 0 ? { name: c.name?.trim() || slug, slug } : null;
+        })
+        .filter((c): c is { name: string; slug: string } => c !== null)
+        .slice(0, CATEGORIES_MAX);
+    if (suggestedCategories.length < CATEGORIES_MIN) return null;
+
+    const suggestedFields = (draft.suggestedFields ?? [])
+        .map((f) => {
+            const type = coerceFieldType(f.type ?? '');
+            return type ? { name: (f.name ?? '').trim() || type, type } : null;
+        })
+        .filter((f): f is { name: string; type: SuggestedFieldType } => f !== null)
+        .slice(0, FIELDS_MAX);
+
+    const recommendedPlugins = (draft.recommendedPlugins ?? [])
+        .filter((p) => typeof p.pluginId === 'string' && p.pluginId.trim().length > 0)
+        .map((p) => ({ pluginId: p.pluginId.trim(), reason: (p.reason ?? '').trim() }))
+        .slice(0, PLUGINS_MAX);
+
+    const reasoning = clipMax(draft.reasoning?.trim() ?? '', REASONING_MAX);
+
+    const candidate = {
+        title,
+        description,
+        slugSuggestion,
+        suggestedCategories,
+        suggestedFields,
+        recommendedPlugins,
+        reasoning,
+    };
+
+    // Final guard: if our coercion still produced something that fails the
+    // strict schema (e.g. clip-then-trim took us below TITLE_MIN), drop it.
+    const result = workProposalSchema.safeParse(candidate);
+    return result.success ? result.data : null;
+}

--- a/packages/agent/src/user-research/schemas.ts
+++ b/packages/agent/src/user-research/schemas.ts
@@ -58,3 +58,53 @@ export const workProposalsBatchSchema = z.object({
 });
 
 export type WorkProposalsBatch = z.infer<typeof workProposalsBatchSchema>;
+
+/**
+ * Permissive variant used as the structured-output schema for the LLM call.
+ * Lower-quality / free-tier models routinely violate the strict bounds
+ * (slug regex, exact enum, length min/max), which makes generateObject reject
+ * the whole batch with `No object generated: response did not match schema.`
+ *
+ * Strategy: accept loose shapes here, then run every draft through
+ * coerceWorkProposal() to clip, slugify and filter into the strict shape
+ * before persisting. Anything still un-salvageable is dropped, and we only
+ * fail if zero valid proposals remain.
+ */
+export const permissiveWorkProposalSchema = z.object({
+    title: z.string(),
+    description: z.string(),
+    slugSuggestion: z.string(),
+    suggestedCategories: z.array(
+        z.object({
+            name: z.string(),
+            slug: z.string(),
+        }),
+    ),
+    suggestedFields: z
+        .array(
+            z.object({
+                name: z.string(),
+                type: z.string(),
+            }),
+        )
+        .optional()
+        .default([]),
+    recommendedPlugins: z
+        .array(
+            z.object({
+                pluginId: z.string(),
+                reason: z.string(),
+            }),
+        )
+        .optional()
+        .default([]),
+    reasoning: z.string().optional().default(''),
+});
+
+export type PermissiveWorkProposalDraft = z.infer<typeof permissiveWorkProposalSchema>;
+
+export const permissiveWorkProposalsBatchSchema = z.object({
+    proposals: z.array(permissiveWorkProposalSchema),
+});
+
+export type PermissiveWorkProposalsBatch = z.infer<typeof permissiveWorkProposalsBatchSchema>;

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -5,7 +5,8 @@ import { UserRepository } from '../database/repositories/user.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { WorkProposalRepository } from './work-proposal.repository';
-import { workProposalsBatchSchema, type WorkProposalsBatch } from './schemas';
+import { permissiveWorkProposalsBatchSchema, type WorkProposalDraft } from './schemas';
+import { coerceWorkProposal } from './proposal-coercion';
 import { PROPOSALS_SYSTEM_PROMPT, buildProposalsPrompt } from './prompts';
 import { resolveAiProviderForResearch } from './provider-resolver';
 import {
@@ -96,29 +97,55 @@ export class WorkProposalService {
         }
 
         let tokensUsed = 0;
-        let parsed: WorkProposalsBatch;
+        let drafts: WorkProposalDraft[] = [];
 
         try {
+            // Use the permissive schema so low-quality model output (sloppy
+            // slugs, wrong enum values, off-by-one length bounds) doesn't
+            // make generateObject reject the whole batch. coerceWorkProposal
+            // below clips/slugifies/filters each draft into the strict shape.
             const result = await generateObject({
                 model: resolvedModel,
-                schema: workProposalsBatchSchema,
+                schema: permissiveWorkProposalsBatchSchema,
                 system: PROPOSALS_SYSTEM_PROMPT,
                 prompt: buildProposalsPrompt(profile, existingWorkNames, availablePluginIds),
                 temperature: 0.4,
                 maxRetries: 2,
             });
 
-            parsed = workProposalsBatchSchema.parse(result.object);
+            const raw = result.object.proposals ?? [];
+            drafts = raw
+                .map((p) => coerceWorkProposal(p))
+                .filter((p): p is WorkProposalDraft => p !== null);
             tokensUsed = result.usage?.totalTokens ?? 0;
+
+            if (drafts.length === 0) {
+                this.logger.warn(
+                    `Proposal generation for ${userId} produced ${raw.length} raw draft(s) but none survived coercion`,
+                );
+                return {
+                    status: 'error',
+                    proposals: [],
+                    tokensUsed,
+                    error: 'no-valid-proposals',
+                };
+            }
+            if (drafts.length < raw.length) {
+                this.logger.log(
+                    `Proposal generation for ${userId}: kept ${drafts.length}/${raw.length} after coercion`,
+                );
+            }
         } catch (err) {
             const message = (err as Error).message;
             this.logger.warn(`Proposal generation failed for ${userId}: ${message}`);
             return { status: 'error', proposals: [], tokensUsed, error: message };
         }
 
-        // Drop plugin IDs the registry doesn't recognize.
+        // Drop plugin IDs the registry doesn't recognize. Casts mirror the
+        // pre-coercion code — zod 3.25 widens inner-object props to optional
+        // under our tsconfig, and the coercer already guarantees the shape.
         const pluginSet = new Set(availablePluginIds);
-        const inputs = parsed.proposals.map((p) => ({
+        const inputs = drafts.map((p) => ({
             userId,
             title: p.title,
             description: p.description,


### PR DESCRIPTION
## Summary
Routine release of stage into main. Follows #749 (develop→stage). Same 4 commits as that PR; E2E suite is already green end-to-end on develop and stage.

### Commits
| SHA | Subject |
|---|---|
| 01d6449d | test(e2e): use Bearer-token auth for onboarding-wizard-v2 API calls |
| 08127f76 | Merge PR #742 — Bearer-token auth wiring |
| df4c22d0 | test(e2e): register a fresh user per spec instead of reusing TEST_USER (#748) — the actual fix |
| b07726c1 | fix(work-proposals): tolerate sloppy LLM output via permissive schema + coercion (#746) |

### References
- develop→stage cascade: #749
- develop E2E green run: https://github.com/ever-works/ever-works/actions/runs/25849346723 (7m37s)
- Headline diagnostic write-up is in the #749 PR description.

## Test plan
- [x] develop E2E green
- [x] stage built clean on the #749 merge commit
- [ ] main E2E run on this merge confirms parity end-to-end