### PR TITLE
feat(work): default deployProvider to 'ever-works' (EW-617 G6)

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -438,13 +438,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             await service.deploy('work-1', 'user-1', {});
 
             const { variables } = captureCalls(githubPlugin);
-            const deployProviderVar = variables.find(
-                (v: any) => v.key === 'DEPLOY_PROVIDER',
-            );
+            const deployProviderVar = variables.find((v: any) => v.key === 'DEPLOY_PROVIDER');
             expect(deployProviderVar?.value).toBe('ever-works');
         });
 
-        it("uses work.deployProvider when explicitly set (no override)", async () => {
+        it('uses work.deployProvider when explicitly set (no override)', async () => {
             const { service, githubPlugin } = buildService({
                 deployProvider: 'vercel',
                 plugin: {
@@ -456,9 +454,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             await service.deploy('work-1', 'user-1', {});
 
             const { variables } = captureCalls(githubPlugin);
-            const deployProviderVar = variables.find(
-                (v: any) => v.key === 'DEPLOY_PROVIDER',
-            );
+            const deployProviderVar = variables.find((v: any) => v.key === 'DEPLOY_PROVIDER');
             expect(deployProviderVar?.value).toBe('vercel');
         });
     });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -424,4 +424,42 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
 
         errorSpy.mockRestore();
     });
+
+    describe('default deployProvider fallback (EW-617 G6)', () => {
+        // When work.deployProvider is null/empty (e.g. older row pre-migration
+        // or anonymous quick-create that hasn't picked a provider yet), the
+        // service must fall back to 'ever-works', not the legacy 'vercel'.
+        it("sets DEPLOY_PROVIDER='ever-works' when work.deployProvider is falsy", async () => {
+            const { service, githubPlugin } = buildService({
+                deployProvider: '',
+                plugin: { id: 'ever-works' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { variables } = captureCalls(githubPlugin);
+            const deployProviderVar = variables.find(
+                (v: any) => v.key === 'DEPLOY_PROVIDER',
+            );
+            expect(deployProviderVar?.value).toBe('ever-works');
+        });
+
+        it("uses work.deployProvider when explicitly set (no override)", async () => {
+            const { service, githubPlugin } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml', 'deploy_prod.yaml'],
+                },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { variables } = captureCalls(githubPlugin);
+            const deployProviderVar = variables.find(
+                (v: any) => v.key === 'DEPLOY_PROVIDER',
+            );
+            expect(deployProviderVar?.value).toBe('vercel');
+        });
+    });
 });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -241,7 +241,7 @@ export class DeployService {
         plugin?: IDeploymentPlugin,
         settings?: Record<string, unknown>,
     ) {
-        const provider = work.deployProvider || 'vercel';
+        const provider = work.deployProvider || 'ever-works';
         try {
             await this.setVariable(ctx, 'DEPLOY_PROVIDER', provider);
         } catch (error) {

--- a/docs/specs/features/plugins-capabilities/spec.md
+++ b/docs/specs/features/plugins-capabilities/spec.md
@@ -146,7 +146,7 @@ true`.
   secrets on every dispatch (`TENANT_ID = work.id`, `DATA_REPOSITORY =
 work.getDataRepo()`, `<PROVIDER>_TOKEN = deployToken`, `DEPLOY_TOKEN =
 deployToken`) and one repository variable (`DEPLOY_PROVIDER =
-work.deployProvider || 'vercel'`). `DEPLOY_PROVIDER` is set as a
+work.deployProvider || 'ever-works'`). `DEPLOY_PROVIDER` is set as a
   variable, not a secret, because GitHub Actions templates need it
   available in `if:` conditions.
 - **FR-11** The deploy service MUST set two optional secrets when their

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -64,7 +64,7 @@ export class Work {
     @Column({ default: 'user-github' })
     storageProvider: string; // 'ever-works-git' | 'user-github' | 'user-gitlab' | 'user-git'
 
-    @Column({ default: 'vercel', nullable: true })
+    @Column({ default: 'ever-works', nullable: true })
     deployProvider?: string; // 'ever-works' | 'vercel' | 'k8s' | 'netlify' | ...
 
     @Column({ nullable: true })


### PR DESCRIPTION
## Summary

Flips the default `deployProvider` from `'vercel'` to `'ever-works'` so first-time users with no infra connected land on the Ever Works pipeline by default. Closes the third leg of the internal inconsistency where the wizard default and `countActiveByDeployProvider` query default were already `'ever-works'` but the column default and deploy service fallback were still `'vercel'`.

- `packages/agent/src/entities/work.entity.ts` — column default `'vercel'` → `'ever-works'`
- `apps/api/.../deploy.service.ts` — fallback when `work.deployProvider` is falsy now writes `DEPLOY_PROVIDER='ever-works'`
- Spec wording in `docs/specs/features/plugins-capabilities/spec.md` updated to match
- Two new regression tests pin the new fallback and the explicit-override path

Existing rows are untouched — the column-level default only affects new INSERTs that omit `deployProvider`. The flag-aware safeguard in `WorkLifecycleService.resolveProviderDefaults` is unchanged, so envs with `DEPLOY_EVER_WORKS_ENABLED` off still rewrite to `'vercel'` as before.

Sub-task: EW-623. Parent epic: EW-617.

## Test plan

- [ ] CI green: `apps/api` jest suite (new tests in `deploy.service.spec.ts`)
- [ ] CI green: `packages/agent` jest suite (existing `work-lifecycle.create-defaults.spec.ts` should keep passing — the safeguard rewrites to vercel in flag-off envs)
- [ ] No migration changes needed (new INSERTs only; ops can run `ALTER TABLE work ALTER COLUMN deploy_provider SET DEFAULT 'ever-works'` separately in postgres if they want the DB-level default to match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default deployment provider changed from Vercel to Ever-Works when no provider is set.
  * Default storage provider changed from Vercel to Ever-Works and is now nullable/optional.

* **Tests**
  * Added test coverage for deployment provider fallback behavior.

* **Documentation**
  * Updated deploy service specification to reflect the new default provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/752)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->