### PR TITLE
release: develop → stage (EW-120 Activity Feed dual-mode + recent develop)

### DIFF
--- a/apps/api/src/activity-log/activity-log.controller.spec.ts
+++ b/apps/api/src/activity-log/activity-log.controller.spec.ts
@@ -9,6 +9,10 @@ jest.mock('@ever-works/agent/entities', () => ({
         WORK_CREATED: 'WORK_CREATED',
         GENERATION: 'GENERATION',
         DEPLOYMENT: 'DEPLOYMENT',
+        WEBSITE_USER_REGISTERED: 'website_user_registered',
+        WEBSITE_ITEM_SUBMITTED: 'website_item_submitted',
+        WEBSITE_REPORT_FILED: 'website_report_filed',
+        WEBSITE_REPORT_RESOLVED: 'website_report_resolved',
     },
     ActivityStatus: {
         IN_PROGRESS: 'in_progress',
@@ -67,6 +71,7 @@ describe('ActivityLogController', () => {
             summarizeStatuses: jest.fn(),
             exportCsv: jest.fn(),
             findByIdAndUserId: jest.fn(),
+            ingestFromWebsite: jest.fn(),
         } as any;
         workRepository = {
             findById: jest.fn(),
@@ -618,6 +623,94 @@ describe('ActivityLogController', () => {
             await expect(controller.getActivity(auth, 'someone-elses')).rejects.toBeInstanceOf(
                 NotFoundException,
             );
+        });
+    });
+
+    describe('ingestWebsiteEvent (EW-120)', () => {
+        const dto = {
+            workId: '11111111-1111-1111-1111-111111111111',
+            eventId: '22222222-2222-2222-2222-222222222222',
+            actionType: 'website_user_registered' as never,
+            occurredAt: '2026-05-13T10:00:00.000Z',
+            summary: 'User signed up',
+        };
+
+        beforeEach(() => {
+            // Default to push-mode Work for the happy path tests.
+            workRepository.findById.mockResolvedValue({
+                id: dto.workId,
+                activitySyncMode: 'push',
+            } as never);
+        });
+
+        it('delegates to ActivityLogService.ingestFromWebsite and returns the new id', async () => {
+            (activityLogService as any).ingestFromWebsite.mockResolvedValueOnce({ id: 'al-new' });
+            const result = await controller.ingestWebsiteEvent(dto as never);
+
+            expect((activityLogService as any).ingestFromWebsite).toHaveBeenCalledWith({
+                workId: dto.workId,
+                eventId: dto.eventId,
+                actionType: dto.actionType,
+                occurredAt: new Date(dto.occurredAt),
+                summary: dto.summary,
+                metadata: undefined,
+            });
+            expect(result).toEqual({ id: 'al-new' });
+        });
+
+        it('returns 404 when the Work does not exist', async () => {
+            workRepository.findById.mockResolvedValueOnce(null);
+            await expect(controller.ingestWebsiteEvent(dto as never)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect((activityLogService as any).ingestFromWebsite).not.toHaveBeenCalled();
+        });
+
+        it.each(['pull', 'disabled'] as const)(
+            'returns 409 (mode-mismatch) when Work is in %s mode',
+            async (mode) => {
+                workRepository.findById.mockResolvedValueOnce({
+                    id: dto.workId,
+                    activitySyncMode: mode,
+                } as never);
+
+                let captured: any;
+                try {
+                    await controller.ingestWebsiteEvent(dto as never);
+                } catch (err) {
+                    captured = err;
+                }
+                expect(captured).toBeDefined();
+                // ConflictException carries the typed body { error, mode, message }.
+                const response = (captured as { getResponse: () => unknown }).getResponse() as {
+                    error: string;
+                    mode: string;
+                };
+                expect(response.error).toBe('mode-mismatch');
+                expect(response.mode).toBe(mode);
+                expect((activityLogService as any).ingestFromWebsite).not.toHaveBeenCalled();
+            },
+        );
+
+        it('rethrows "work … not found" as a 404 NotFoundException', async () => {
+            (activityLogService as any).ingestFromWebsite.mockRejectedValueOnce(
+                new Error('Work missing not found'),
+            );
+
+            await expect(controller.ingestWebsiteEvent(dto as never)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('forwards optional metadata to the service unchanged', async () => {
+            (activityLogService as any).ingestFromWebsite.mockResolvedValueOnce({ id: 'al-meta' });
+            await controller.ingestWebsiteEvent({
+                ...dto,
+                metadata: { itemId: 'i-1', actor: 'bob' },
+            } as never);
+
+            const call = (activityLogService as any).ingestFromWebsite.mock.calls[0]![0];
+            expect(call.metadata).toEqual({ itemId: 'i-1', actor: 'bob' });
         });
     });
 });

--- a/apps/api/src/activity-log/activity-log.controller.ts
+++ b/apps/api/src/activity-log/activity-log.controller.ts
@@ -1,12 +1,17 @@
 import {
+    Body,
+    ConflictException,
     Controller,
     Get,
+    HttpCode,
+    NotFoundException,
     Param,
+    Post,
     Query,
     Res,
     DefaultValuePipe,
     ParseIntPipe,
-    NotFoundException,
+    UseGuards,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -16,11 +21,15 @@ import {
     ApiQuery,
     ApiParam,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { CurrentUser } from '../auth/decorators/user.decorator';
+import { Public } from '../auth/decorators/public.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import { ActivityLogService } from '@ever-works/agent/activity-log';
 import { WorkRepository } from '@ever-works/agent/database';
 import type { ActivityActionType, ActivityStatus } from '@ever-works/agent/entities';
+import { IngestEventDto } from './dto/ingest-event.dto';
+import { PlatformSecretGuard } from './guards/platform-secret.guard';
 
 type CsvResponse = {
     setHeader(name: string, value: string): void;
@@ -179,6 +188,63 @@ export class ActivityLogController {
         res.setHeader('Content-Type', 'text/csv');
         res.setHeader('Content-Disposition', 'attachment; filename=activity-log.csv');
         res.send(csv);
+    }
+
+    @Post('ingest')
+    @Public()
+    @UseGuards(PlatformSecretGuard)
+    // The shared `PLATFORM_API_SECRET_TOKEN` is pushed to every deployed
+    // site, so its blast radius if leaked is wide. Cap per-IP throughput to
+    // 60/min on top of the bearer check, mitigating spam even if a token
+    // is compromised before rotation lands.
+    @Throttle({ default: { limit: 60, ttl: 60_000 } })
+    @HttpCode(202)
+    @ApiOperation({
+        summary: 'Ingest a website-sourced activity event (EW-120)',
+        description:
+            'Called by the deployed directory site when a user registers, submits an item, or files/resolves a report. Authenticated via the `PLATFORM_API_SECRET_TOKEN` bearer token; idempotent by `(workId, eventId)`; rate-limited at 60 req/min per IP. Returns 409 when the target Work is configured for a non-push transport (pull / disabled).',
+    })
+    @ApiResponse({ status: 202, description: 'Event accepted' })
+    @ApiResponse({ status: 401, description: 'Missing or invalid bearer token' })
+    @ApiResponse({ status: 404, description: 'Work not found' })
+    @ApiResponse({
+        status: 409,
+        description: 'Work activitySyncMode is not "push" — ingest rejected (mode-mismatch).',
+    })
+    async ingestWebsiteEvent(@Body() dto: IngestEventDto) {
+        // Mode-aware gate (EW-120 dual-mode). Reading the Work once here is
+        // cheaper than letting it slip through and surfacing the wrong
+        // events under the directory owner's feed. The 409 body carries the
+        // current mode so the template can recover (or stop retrying) on
+        // its own.
+        const work = await this.workRepository.findById(dto.workId);
+        if (!work) {
+            throw new NotFoundException(`Work ${dto.workId} not found`);
+        }
+        if (work.activitySyncMode !== 'push') {
+            throw new ConflictException({
+                error: 'mode-mismatch',
+                mode: work.activitySyncMode,
+                message: `Work activitySyncMode is "${work.activitySyncMode}"; ingest only accepts push-mode events.`,
+            });
+        }
+
+        try {
+            const activity = await this.activityLogService.ingestFromWebsite({
+                workId: dto.workId,
+                eventId: dto.eventId,
+                actionType: dto.actionType,
+                occurredAt: new Date(dto.occurredAt),
+                summary: dto.summary,
+                metadata: dto.metadata,
+            });
+            return { id: activity.id };
+        } catch (err) {
+            if (err instanceof Error && /not found/i.test(err.message)) {
+                throw new NotFoundException(err.message);
+            }
+            throw err;
+        }
     }
 
     @Get(':id')

--- a/apps/api/src/activity-log/activity-log.module.ts
+++ b/apps/api/src/activity-log/activity-log.module.ts
@@ -3,12 +3,13 @@ import { ActivityLogModule as AgentActivityLogModule } from '@ever-works/agent/a
 import { DatabaseModule } from '@ever-works/agent/database';
 import { ActivityLogController } from './activity-log.controller';
 import { ActivityLogListener } from './activity-log.listener';
+import { PlatformSecretGuard } from './guards/platform-secret.guard';
 import { JitsuModule } from './jitsu.module';
 
 @Module({
     imports: [JitsuModule, AgentActivityLogModule, DatabaseModule],
     controllers: [ActivityLogController],
-    providers: [ActivityLogListener],
+    providers: [ActivityLogListener, PlatformSecretGuard],
     exports: [AgentActivityLogModule],
 })
 export class ActivityLogModule {}

--- a/apps/api/src/activity-log/dto/ingest-event.dto.spec.ts
+++ b/apps/api/src/activity-log/dto/ingest-event.dto.spec.ts
@@ -1,0 +1,73 @@
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        WEBSITE_USER_REGISTERED: 'website_user_registered',
+        WEBSITE_ITEM_SUBMITTED: 'website_item_submitted',
+        WEBSITE_REPORT_FILED: 'website_report_filed',
+        WEBSITE_REPORT_RESOLVED: 'website_report_resolved',
+    },
+}));
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { IngestEventDto } from './ingest-event.dto';
+
+function baseDto(over: Partial<IngestEventDto> = {}) {
+    return plainToInstance(IngestEventDto, {
+        workId: '11111111-1111-4111-8111-111111111111',
+        eventId: '22222222-2222-4222-8222-222222222222',
+        actionType: 'website_user_registered',
+        occurredAt: '2026-05-13T10:00:00.000Z',
+        summary: 'User signed up',
+        ...over,
+    });
+}
+
+describe('IngestEventDto validation', () => {
+    it('accepts a well-formed payload with the four allowed action types', async () => {
+        const types = [
+            'website_user_registered',
+            'website_item_submitted',
+            'website_report_filed',
+            'website_report_resolved',
+        ];
+        for (const actionType of types) {
+            const errors = await validate(baseDto({ actionType: actionType as never }));
+            expect(errors).toHaveLength(0);
+        }
+    });
+
+    it('rejects an actionType outside the allow-list (no WORK_DELETED smuggling)', async () => {
+        const errors = await validate(baseDto({ actionType: 'work_deleted' as never }));
+        expect(errors.find((e) => e.property === 'actionType')).toBeDefined();
+    });
+
+    it('rejects non-UUID workId / eventId', async () => {
+        let errors = await validate(baseDto({ workId: 'not-a-uuid' }));
+        expect(errors.find((e) => e.property === 'workId')).toBeDefined();
+        errors = await validate(baseDto({ eventId: '123' }));
+        expect(errors.find((e) => e.property === 'eventId')).toBeDefined();
+    });
+
+    it('rejects metadata larger than 8 KiB after JSON serialisation', async () => {
+        const blob = 'x'.repeat(9000);
+        const errors = await validate(baseDto({ metadata: { blob } }));
+        expect(errors.find((e) => e.property === 'metadata')).toBeDefined();
+    });
+
+    it('accepts metadata under the size cap', async () => {
+        const errors = await validate(
+            baseDto({ metadata: { itemId: 'i-1', actor: 'bob', adminUrl: 'https://x' } }),
+        );
+        expect(errors).toHaveLength(0);
+    });
+
+    it('accepts an omitted metadata field', async () => {
+        const errors = await validate(baseDto({ metadata: undefined }));
+        expect(errors).toHaveLength(0);
+    });
+
+    it('caps summary at 500 chars', async () => {
+        const errors = await validate(baseDto({ summary: 's'.repeat(501) }));
+        expect(errors.find((e) => e.property === 'summary')).toBeDefined();
+    });
+});

--- a/apps/api/src/activity-log/dto/ingest-event.dto.ts
+++ b/apps/api/src/activity-log/dto/ingest-event.dto.ts
@@ -1,0 +1,91 @@
+import {
+    IsEnum,
+    IsISO8601,
+    IsNotEmpty,
+    IsObject,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    Validate,
+    ValidatorConstraint,
+    type ValidatorConstraintInterface,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ActivityActionType } from '@ever-works/agent/entities';
+
+const METADATA_BYTE_CAP = 8 * 1024;
+
+@ValidatorConstraint({ name: 'metadataByteCap', async: false })
+class MetadataByteCapConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        if (value === undefined || value === null) return true;
+        if (typeof value !== 'object') return false;
+        try {
+            const serialized = JSON.stringify(value);
+            return Buffer.byteLength(serialized, 'utf8') <= METADATA_BYTE_CAP;
+        } catch {
+            return false;
+        }
+    }
+
+    defaultMessage(): string {
+        return `metadata must serialise to <= ${METADATA_BYTE_CAP} bytes`;
+    }
+}
+
+const WEBSITE_ACTION_TYPES = [
+    ActivityActionType.WEBSITE_USER_REGISTERED,
+    ActivityActionType.WEBSITE_ITEM_SUBMITTED,
+    ActivityActionType.WEBSITE_REPORT_FILED,
+    ActivityActionType.WEBSITE_REPORT_RESOLVED,
+] as const;
+
+type WebsiteActionType = (typeof WEBSITE_ACTION_TYPES)[number];
+
+export class IngestEventDto {
+    @ApiProperty({ description: 'Work ID this event belongs to' })
+    @IsUUID()
+    @IsNotEmpty()
+    workId: string;
+
+    @ApiProperty({
+        description:
+            'Client-generated UUID used for idempotency. Retries of the same eventId for the same workId return the existing row.',
+    })
+    @IsUUID()
+    @IsNotEmpty()
+    eventId: string;
+
+    @ApiProperty({
+        description: 'Event kind. Only WEBSITE_* action types are accepted by the ingest endpoint.',
+        enum: WEBSITE_ACTION_TYPES,
+    })
+    @IsEnum(WEBSITE_ACTION_TYPES, {
+        message: `actionType must be one of ${WEBSITE_ACTION_TYPES.join(', ')}`,
+    })
+    actionType: WebsiteActionType;
+
+    @ApiProperty({
+        description: 'ISO 8601 timestamp from the deployed site when the event occurred',
+    })
+    @IsISO8601()
+    occurredAt: string;
+
+    @ApiProperty({
+        description: 'Human-readable one-line summary shown in the feed',
+        maxLength: 500,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(500)
+    summary: string;
+
+    @ApiPropertyOptional({
+        description: `Free-form metadata (actor name, target id, admin URL, etc.). Capped at ${METADATA_BYTE_CAP} bytes after JSON serialisation.`,
+    })
+    @IsOptional()
+    @IsObject()
+    @Validate(MetadataByteCapConstraint)
+    metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/activity-log/guards/platform-secret.guard.spec.ts
+++ b/apps/api/src/activity-log/guards/platform-secret.guard.spec.ts
@@ -1,0 +1,63 @@
+import { ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { PlatformSecretGuard } from './platform-secret.guard';
+
+function ctxWithHeader(authorization?: string): ExecutionContext {
+    return {
+        switchToHttp: () => ({
+            getRequest: () => ({ headers: { authorization } }) as unknown,
+        }),
+    } as unknown as ExecutionContext;
+}
+
+describe('PlatformSecretGuard', () => {
+    let guard: PlatformSecretGuard;
+    const originalToken = process.env.PLATFORM_API_SECRET_TOKEN;
+
+    beforeEach(() => {
+        guard = new PlatformSecretGuard();
+        process.env.PLATFORM_API_SECRET_TOKEN = 'platform-shared-secret-value-32x';
+    });
+
+    afterAll(() => {
+        process.env.PLATFORM_API_SECRET_TOKEN = originalToken;
+    });
+
+    it('accepts a matching bearer token', () => {
+        const ctx = ctxWithHeader('Bearer platform-shared-secret-value-32x');
+        expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('rejects when the bearer token does not match', () => {
+        const ctx = ctxWithHeader('Bearer wrong-token');
+        expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects when the header is missing', () => {
+        const ctx = ctxWithHeader();
+        expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects when the header is not a bearer token', () => {
+        const ctx = ctxWithHeader('Basic dXNlcjpwYXNz');
+        expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('throws ServiceUnavailable when the platform token env var is missing', () => {
+        delete process.env.PLATFORM_API_SECRET_TOKEN;
+        const ctx = ctxWithHeader('Bearer anything');
+        expect(() => guard.canActivate(ctx)).toThrow(ServiceUnavailableException);
+    });
+
+    it('rejects when provided token has the same length but different bytes (constant-time)', () => {
+        // Same length as the expected token, but every byte different.
+        const same = 'X'.repeat('platform-shared-secret-value-32x'.length);
+        const ctx = ctxWithHeader(`Bearer ${same}`);
+        expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects when provided token has a different length', () => {
+        const ctx = ctxWithHeader('Bearer short');
+        expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+});

--- a/apps/api/src/activity-log/guards/platform-secret.guard.ts
+++ b/apps/api/src/activity-log/guards/platform-secret.guard.ts
@@ -1,0 +1,64 @@
+import {
+    CanActivate,
+    ExecutionContext,
+    Injectable,
+    Logger,
+    ServiceUnavailableException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { timingSafeEqual } from 'crypto';
+
+interface RequestLike {
+    headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Authenticates EW-120 ingest requests using the platform-wide bearer
+ * token already injected into every directory-web-template deploy as
+ * `PLATFORM_API_SECRET_TOKEN`. The template echoes the same value as
+ * `Authorization: Bearer <token>` when POSTing to the ingest endpoint.
+ *
+ * Comparison is constant-time (`timingSafeEqual`) so attackers can't
+ * recover the secret via timing side-channels.
+ */
+@Injectable()
+export class PlatformSecretGuard implements CanActivate {
+    private readonly logger = new Logger(PlatformSecretGuard.name);
+
+    canActivate(context: ExecutionContext): boolean {
+        const expected = process.env.PLATFORM_API_SECRET_TOKEN;
+        if (!expected) {
+            this.logger.error(
+                'PLATFORM_API_SECRET_TOKEN is not configured; rejecting ingest request',
+            );
+            throw new ServiceUnavailableException('Ingest endpoint not configured');
+        }
+
+        const req = context.switchToHttp().getRequest<RequestLike>();
+        const raw = req.headers['authorization'];
+        const header = Array.isArray(raw) ? raw[0] : raw;
+        if (typeof header !== 'string' || !header.startsWith('Bearer ')) {
+            throw new UnauthorizedException('Missing Bearer token');
+        }
+        const provided = header.slice('Bearer '.length).trim();
+
+        const expectedBuf = Buffer.from(expected, 'utf8');
+        const providedBuf = Buffer.from(provided, 'utf8');
+
+        // Always call `timingSafeEqual` against an equal-length buffer so
+        // the comparison cost is uniform regardless of the submitted
+        // token length. A naive `length !== length || !timingSafeEqual`
+        // short-circuit lets a timing attacker binary-search the secret's
+        // byte length by varying the provided token's length, because the
+        // observable code path differs (one branch runs the comparison,
+        // the other doesn't).
+        const lengthsMatch = expectedBuf.length === providedBuf.length;
+        const comparisonBuf = lengthsMatch ? providedBuf : Buffer.alloc(expectedBuf.length);
+        const bytesMatch = timingSafeEqual(expectedBuf, comparisonBuf);
+
+        if (!lengthsMatch || !bytesMatch) {
+            throw new UnauthorizedException('Invalid bearer token');
+        }
+        return true;
+    }
+}

--- a/apps/api/src/migrations/1778677529777-AddActivityLogIngestEventId.ts
+++ b/apps/api/src/migrations/1778677529777-AddActivityLogIngestEventId.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+/**
+ * Adds the `ingestEventId` column + partial unique index to the
+ * `activity_log` table for EW-120 push-based event ingestion.
+ *
+ * The deployed directory site POSTs user-facing events
+ * (signups, item submissions, reports) to
+ * `POST /api/activity-log/ingest`. Each request carries a client-generated
+ * `eventId` (UUID); the partial unique index on `(workId, ingestEventId)`
+ * makes the endpoint safely idempotent: retries from the website land on
+ * the same row instead of creating duplicates.
+ *
+ * Forward-only, additive. The column is nullable so existing rows remain
+ * valid; the index is partial so it only applies to ingested events.
+ */
+export class AddActivityLogIngestEventId1778677529777 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'activity_log',
+            new TableColumn({
+                name: 'ingestEventId',
+                type: 'varchar',
+                length: '64',
+                isNullable: true,
+            }),
+        );
+        await queryRunner.createIndex(
+            'activity_log',
+            new TableIndex({
+                name: 'idx_activity_log_work_ingest_event',
+                columnNames: ['workId', 'ingestEventId'],
+                isUnique: true,
+                where: '"ingestEventId" IS NOT NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropIndex('activity_log', 'idx_activity_log_work_ingest_event');
+        await queryRunner.dropColumn('activity_log', 'ingestEventId');
+    }
+}

--- a/apps/api/src/migrations/1778746463309-AddActivityFeedSync.ts
+++ b/apps/api/src/migrations/1778746463309-AddActivityFeedSync.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds the dual-mode Activity Feed sync surface to the `works` table
+ * (EW-120).
+ *
+ * - `activitySyncMode` — per-Work transport choice (`pull` | `push` |
+ *   `disabled`). Default `pull` so existing rows match the historic
+ *   architecture; site authors can flip via `works.yml`.
+ * - `platformSyncSecretEncrypted` — AES-256-GCM-encrypted per-Work HMAC
+ *   secret used by the pull transport to sign outbound requests to the
+ *   deployed directory site. NULL until the next deploy provisions it
+ *   lazily.
+ * - `platformSyncLastSuccessAt` / `platformSyncLastErrorAt` /
+ *   `platformSyncLastErrorMessage` — observability for the pull
+ *   transport, drives the degraded banner on the Activity Feed tab.
+ *
+ * Forward-only, additive. All non-mode columns are nullable; the mode
+ * column has a safe default. No backfill required.
+ *
+ * The `@TimestampColumn` decorator on the entity stores Dates as
+ * bigint ms — that's the canonical pattern across this codebase (see
+ * Work.lastGeneratedAt etc.) for portability between SQLite (no
+ * timestamptz) and Postgres.
+ */
+export class AddActivityFeedSync1778746463309 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumns('works', [
+            new TableColumn({
+                name: 'activitySyncMode',
+                type: 'varchar',
+                length: '16',
+                isNullable: false,
+                default: "'pull'",
+            }),
+            new TableColumn({
+                name: 'platformSyncSecretEncrypted',
+                type: 'text',
+                isNullable: true,
+            }),
+            new TableColumn({
+                name: 'platformSyncLastSuccessAt',
+                type: 'bigint',
+                isNullable: true,
+            }),
+            new TableColumn({
+                name: 'platformSyncLastErrorAt',
+                type: 'bigint',
+                isNullable: true,
+            }),
+            new TableColumn({
+                name: 'platformSyncLastErrorMessage',
+                type: 'text',
+                isNullable: true,
+            }),
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumns('works', [
+            'platformSyncLastErrorMessage',
+            'platformSyncLastErrorAt',
+            'platformSyncLastSuccessAt',
+            'platformSyncSecretEncrypted',
+            'activitySyncMode',
+        ]);
+    }
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('@ever-works/agent/database', () => ({ WorkRepository: class {} }));
 jest.mock('@ever-works/agent/entities', () => ({ Work: class {}, User: class {} }));
 jest.mock('@ever-works/agent/plugins', () => ({ PluginRegistryService: class {} }));
+jest.mock('@ever-works/agent/services', () => ({ PlatformSyncSecretService: class {} }));
 jest.mock('@ever-works/agent/facades', () => ({
     DeployFacadeService: class {},
     GitFacadeService: class {},
@@ -42,6 +43,9 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
          *  Defaults to an empty object (no PAT saved). Tests for the GHCR PAT
          *  flow override this with `{ readPackagesPat: '...' }`. */
         githubPluginSettings?: Record<string, unknown>;
+        /** EW-120 dual-mode Activity Feed sync. Defaults to `push` to keep
+         *  pre-dual-mode tests behaving as before. */
+        activitySyncMode?: 'pull' | 'push' | 'disabled';
     }) => {
         const work = {
             id: 'work-1',
@@ -49,6 +53,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             deployProvider: overrides.deployProvider ?? 'k8s',
             gitProvider: 'github',
             websiteTemplateId: 'directory-web-template',
+            activitySyncMode: overrides.activitySyncMode ?? 'push',
             user: { id: 'user-1' },
             getRepoOwner: () => 'acme',
             getDataRepo: () => 'acme/data',
@@ -105,6 +110,10 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             emit: jest.fn(),
         };
 
+        const platformSyncSecretService = {
+            getOrGenerate: jest.fn().mockResolvedValue('hex'.repeat(21) + 'h'), // 64 hex chars
+        };
+
         const service = new DeployService(
             deployFacade as any,
             gitFacade as any,
@@ -113,6 +122,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             websiteUpdateService as any,
             websiteTemplateResolver as any,
             eventEmitter as any,
+            platformSyncSecretService as any,
         );
 
         return {
@@ -123,6 +133,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             pluginRegistry,
             githubPlugin,
             eventEmitter,
+            platformSyncSecretService,
         };
     };
 
@@ -224,6 +235,121 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         );
         // No K8S_-prefixed extras (they only come from getDeploymentSecrets).
         expect(keys.filter((k: string) => k.startsWith('K8S_INGRESS'))).toEqual([]);
+    });
+
+    describe('Activity Feed dual-mode sync secrets (EW-120)', () => {
+        const originalUrl = process.env.PLATFORM_API_URL;
+        const originalToken = process.env.PLATFORM_API_SECRET_TOKEN;
+
+        afterEach(() => {
+            process.env.PLATFORM_API_URL = originalUrl;
+            process.env.PLATFORM_API_SECRET_TOKEN = originalToken;
+        });
+
+        it('always pushes WORK_ID alongside TENANT_ID (regardless of sync mode)', async () => {
+            const { service, githubPlugin } = buildService({
+                plugin: { id: 'legacy' },
+                activitySyncMode: 'disabled',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+            expect(byKey.TENANT_ID).toBe('work-1');
+            expect(byKey.WORK_ID).toBe('work-1');
+        });
+
+        describe('push mode', () => {
+            it('pushes PLATFORM_API_URL + PLATFORM_API_SECRET_TOKEN when env vars are set', async () => {
+                process.env.PLATFORM_API_URL = 'https://api.ever.works';
+                process.env.PLATFORM_API_SECRET_TOKEN = 'platform-shared-secret-value-32x';
+
+                const { service, githubPlugin, platformSyncSecretService } = buildService({
+                    plugin: { id: 'legacy' },
+                    activitySyncMode: 'push',
+                });
+
+                await service.deploy('work-1', 'user-1', {});
+
+                const { secrets } = captureCalls(githubPlugin);
+                const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+                expect(byKey.PLATFORM_API_URL).toBe('https://api.ever.works');
+                expect(byKey.PLATFORM_API_SECRET_TOKEN).toBe('platform-shared-secret-value-32x');
+                // Push-mode deploys must never invoke the per-Work HMAC secret service.
+                expect(platformSyncSecretService.getOrGenerate).not.toHaveBeenCalled();
+            });
+
+            it('skips the PLATFORM_API_* push when env vars are not configured', async () => {
+                delete process.env.PLATFORM_API_URL;
+                delete process.env.PLATFORM_API_SECRET_TOKEN;
+
+                const { service, githubPlugin } = buildService({
+                    plugin: { id: 'legacy' },
+                    activitySyncMode: 'push',
+                });
+
+                await service.deploy('work-1', 'user-1', {});
+
+                const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+                expect(keys).not.toContain('PLATFORM_API_URL');
+                expect(keys).not.toContain('PLATFORM_API_SECRET_TOKEN');
+                // Deploy succeeds regardless — WORK_ID + TENANT_ID landed.
+                expect(keys).toContain('WORK_ID');
+            });
+        });
+
+        describe('pull mode', () => {
+            it('pushes PLATFORM_SYNC_SECRET (per-Work HMAC) via the secret service', async () => {
+                const { service, githubPlugin, platformSyncSecretService } = buildService({
+                    plugin: { id: 'legacy' },
+                    activitySyncMode: 'pull',
+                });
+
+                await service.deploy('work-1', 'user-1', {});
+
+                expect(platformSyncSecretService.getOrGenerate).toHaveBeenCalledWith('work-1');
+                const byKey = Object.fromEntries(
+                    captureCalls(githubPlugin).secrets.map((s: any) => [s.key, s.value]),
+                );
+                expect(byKey.PLATFORM_SYNC_SECRET).toBe('hex'.repeat(21) + 'h');
+                // Pull-mode deploys must never push the push-mode bearer.
+                expect(byKey.PLATFORM_API_SECRET_TOKEN).toBeUndefined();
+            });
+
+            it('still completes the deploy when secret service throws', async () => {
+                const { service, platformSyncSecretService } = buildService({
+                    plugin: { id: 'legacy' },
+                    activitySyncMode: 'pull',
+                });
+                platformSyncSecretService.getOrGenerate.mockRejectedValueOnce(
+                    new Error('encryption key missing'),
+                );
+
+                await expect(service.deploy('work-1', 'user-1', {})).resolves.toBeDefined();
+            });
+        });
+
+        describe('disabled mode', () => {
+            it('pushes neither PLATFORM_API_* nor PLATFORM_SYNC_SECRET', async () => {
+                // Set env vars too — disabled mode must skip regardless of platform config.
+                process.env.PLATFORM_API_URL = 'https://api.ever.works';
+                process.env.PLATFORM_API_SECRET_TOKEN = 'platform-shared-secret-value-32x';
+
+                const { service, githubPlugin, platformSyncSecretService } = buildService({
+                    plugin: { id: 'legacy' },
+                    activitySyncMode: 'disabled',
+                });
+
+                await service.deploy('work-1', 'user-1', {});
+
+                const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+                expect(keys).not.toContain('PLATFORM_API_URL');
+                expect(keys).not.toContain('PLATFORM_API_SECRET_TOKEN');
+                expect(keys).not.toContain('PLATFORM_SYNC_SECRET');
+                expect(platformSyncSecretService.getOrGenerate).not.toHaveBeenCalled();
+            });
+        });
     });
 
     it('does not leak the plugin token (kubeconfig) into pushed secret values from getDeploymentSecrets', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -5,6 +5,7 @@ import { DeployFacadeService, GitFacadeService } from '@ever-works/agent/facades
 import { WorkRepository } from '@ever-works/agent/database';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
 import { Work, User } from '@ever-works/agent/entities';
+import { PlatformSyncSecretService } from '@ever-works/agent/services';
 import {
     WebsiteUpdateService,
     getWebsiteTemplateBranch,
@@ -50,6 +51,7 @@ export class DeployService {
         private readonly websiteUpdateService: WebsiteUpdateService,
         private readonly websiteTemplateResolver: WebsiteTemplateResolverService,
         private readonly eventEmitter: EventEmitter2,
+        private readonly platformSyncSecretService: PlatformSyncSecretService,
     ) {}
 
     /**
@@ -252,10 +254,62 @@ export class DeployService {
 
         await Promise.all([
             this.setSecret(ctx, 'TENANT_ID', work.id),
+            this.setSecret(ctx, 'WORK_ID', work.id),
             this.setSecret(ctx, 'DATA_REPOSITORY', work.getDataRepo()),
             this.setSecret(ctx, `${provider.toUpperCase()}_TOKEN`, deployToken),
             this.setSecret(ctx, 'DEPLOY_TOKEN', deployToken),
         ]);
+
+        // EW-120 dual-mode Activity Feed sync — push the secrets for the
+        // active transport only. Disabled mode pushes nothing.
+        //
+        //   push:    PLATFORM_API_URL + PLATFORM_API_SECRET_TOKEN so the
+        //            deployed site can POST events to /api/activity-log/ingest.
+        //   pull:    PLATFORM_SYNC_SECRET (per-Work HMAC, lazily provisioned
+        //            via `PlatformSyncSecretService.getOrGenerate`) so the
+        //            deployed site can verify incoming GET requests from
+        //            the platform's DirectoryWebsiteClient.
+        //   disabled: skipped entirely — neither transport runs.
+        //
+        // All branches are best-effort: a failure here logs an error and
+        // continues. The Activity Feed degrades to platform-only sources
+        // until the next successful deploy.
+        const syncMode = work.activitySyncMode ?? 'pull';
+        if (syncMode === 'push') {
+            const platformApiUrl = process.env.PLATFORM_API_URL;
+            const platformApiSecret = process.env.PLATFORM_API_SECRET_TOKEN;
+            if (platformApiUrl && platformApiSecret) {
+                try {
+                    await Promise.all([
+                        this.setSecret(ctx, 'PLATFORM_API_URL', platformApiUrl),
+                        this.setSecret(ctx, 'PLATFORM_API_SECRET_TOKEN', platformApiSecret),
+                    ]);
+                } catch (error) {
+                    this.logger.error(
+                        `Failed to push PLATFORM_API_* secrets for work ${work.id} on ${ctx.owner}/${ctx.repo}: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                }
+            } else {
+                this.logger.debug(
+                    `PLATFORM_API_URL / PLATFORM_API_SECRET_TOKEN not configured on platform; skipping push-mode ingest secret push for work ${work.id}`,
+                );
+            }
+        } else if (syncMode === 'pull') {
+            try {
+                const platformSyncSecret = await this.platformSyncSecretService.getOrGenerate(
+                    work.id,
+                );
+                await this.setSecret(ctx, 'PLATFORM_SYNC_SECRET', platformSyncSecret);
+            } catch (error) {
+                this.logger.error(
+                    `Failed to push PLATFORM_SYNC_SECRET for work ${work.id} on ${ctx.owner}/${ctx.repo}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
 
         // Plugin-specific extra secrets (k8s registry creds, namespace, etc.)
         // The plugin returns a Record<string, string> of secret name → value;

--- a/apps/api/src/works/activity-feed/__tests__/activity-feed.controller.spec.ts
+++ b/apps/api/src/works/activity-feed/__tests__/activity-feed.controller.spec.ts
@@ -1,0 +1,109 @@
+// Mock the agent-package barrels first so importing the controller does not
+// pull the real WorkOwnershipService / TypeORM entities. Mirrors the
+// convention in `activity-log.controller.spec.ts`.
+jest.mock('@ever-works/agent/services', () => ({
+    WorkOwnershipService: class {},
+}));
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/cache', () => ({ CACHE_MANAGER: Symbol('CACHE_MANAGER') }));
+jest.mock('@ever-works/agent/entities', () => ({
+    // Importing the controller transitively loads `activity-feed.service`
+    // which references these enum values at module top-level. Stub them
+    // with their actual string-enum values.
+    ActivityActionType: {
+        GENERATION: 'generation',
+        COMPARISON_GENERATION: 'comparison_generation',
+        DEPLOYMENT: 'deployment',
+        ITEM_ADDED: 'item_added',
+        ITEM_UPDATED: 'item_updated',
+        ITEM_REMOVED: 'item_removed',
+        SETTINGS_UPDATED: 'settings_updated',
+        WEBSITE_SETTINGS_UPDATED: 'website_settings_updated',
+        PROMPTS_UPDATED: 'prompts_updated',
+        WORKS_CONFIG_SYNC: 'works_config_sync',
+        PLUGIN_ENABLED: 'plugin_enabled',
+        PLUGIN_DISABLED: 'plugin_disabled',
+        PLUGIN_CONFIGURED: 'plugin_configured',
+        TEMPLATE_ADDED: 'template_added',
+        TEMPLATE_UPDATED: 'template_updated',
+        TEMPLATE_FORKED: 'template_forked',
+        TEMPLATE_ARCHIVED: 'template_archived',
+        TEMPLATE_DEFAULT_SET: 'template_default_set',
+        WORK_UPDATED: 'work_updated',
+        WORK_CREATED: 'work_created',
+        SCHEDULE_CREATED: 'schedule_created',
+        SCHEDULE_UPDATED: 'schedule_updated',
+        SCHEDULE_DELETED: 'schedule_deleted',
+        SCHEDULE_EXECUTED: 'schedule_executed',
+        COMMUNITY_PR_MERGED: 'community_pr_merged',
+        WEBSITE_USER_REGISTERED: 'website_user_registered',
+        WEBSITE_ITEM_SUBMITTED: 'website_item_submitted',
+        WEBSITE_REPORT_FILED: 'website_report_filed',
+        WEBSITE_REPORT_RESOLVED: 'website_report_resolved',
+    },
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import type { WorkOwnershipService } from '@ever-works/agent/services';
+import { ActivityFeedController } from '../activity-feed.controller';
+import type { ActivityFeedService } from '../activity-feed.service';
+import { FeedQueryDto } from '../dto/feed-query.dto';
+import type { AuthenticatedUser } from '@src/auth/types/auth.types';
+import type { FeedResponse } from '../dto/feed-response.dto';
+
+describe('ActivityFeedController', () => {
+    let ownershipService: jest.Mocked<Pick<WorkOwnershipService, 'ensureAccess'>>;
+    let activityFeedService: jest.Mocked<Pick<ActivityFeedService, 'compose'>>;
+    let controller: ActivityFeedController;
+
+    const auth: AuthenticatedUser = {
+        userId: 'user-1',
+        email: 'a@b.c',
+        username: 'a',
+        provider: 'jwt',
+        emailVerified: true,
+        isActive: true,
+        avatar: null,
+        iat: 0,
+        iss: '',
+        aud: '',
+    };
+
+    beforeEach(() => {
+        ownershipService = { ensureAccess: jest.fn() } as never;
+        activityFeedService = { compose: jest.fn() } as never;
+        controller = new ActivityFeedController(
+            ownershipService as unknown as WorkOwnershipService,
+            activityFeedService as unknown as ActivityFeedService,
+        );
+    });
+
+    it('enforces access via ownership service before composing', async () => {
+        const fakeResponse: FeedResponse = {
+            entries: [],
+            nextCursor: null,
+            serverTime: new Date().toISOString(),
+        };
+        ownershipService.ensureAccess.mockResolvedValue({} as never);
+        activityFeedService.compose.mockResolvedValue(fakeResponse);
+
+        const query = new FeedQueryDto();
+        query.limit = 10;
+        const result = await controller.getActivityFeed(auth, 'work-1', query);
+
+        expect(ownershipService.ensureAccess).toHaveBeenCalledWith('work-1', 'user-1');
+        expect(activityFeedService.compose).toHaveBeenCalledWith('work-1', 'user-1', query);
+        expect(result).toBe(fakeResponse);
+    });
+
+    it('propagates ForbiddenException from ownership service without calling compose', async () => {
+        ownershipService.ensureAccess.mockRejectedValue(new ForbiddenException('no access'));
+
+        const query = new FeedQueryDto();
+        await expect(controller.getActivityFeed(auth, 'work-1', query)).rejects.toThrow(
+            ForbiddenException,
+        );
+        expect(activityFeedService.compose).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/works/activity-feed/__tests__/activity-feed.service.spec.ts
+++ b/apps/api/src/works/activity-feed/__tests__/activity-feed.service.spec.ts
@@ -1,0 +1,357 @@
+// Mock agent-package barrels at module-load time so importing the service
+// doesn't drag in real TypeORM entities (which fail jest path resolution for
+// agent-internal `@src/items-generator/*` imports).
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        GENERATION: 'generation',
+        COMPARISON_GENERATION: 'comparison_generation',
+        DEPLOYMENT: 'deployment',
+        ITEM_ADDED: 'item_added',
+        ITEM_UPDATED: 'item_updated',
+        ITEM_REMOVED: 'item_removed',
+        SETTINGS_UPDATED: 'settings_updated',
+        WEBSITE_SETTINGS_UPDATED: 'website_settings_updated',
+        PROMPTS_UPDATED: 'prompts_updated',
+        WORKS_CONFIG_SYNC: 'works_config_sync',
+        PLUGIN_ENABLED: 'plugin_enabled',
+        PLUGIN_DISABLED: 'plugin_disabled',
+        PLUGIN_CONFIGURED: 'plugin_configured',
+        TEMPLATE_ADDED: 'template_added',
+        TEMPLATE_UPDATED: 'template_updated',
+        TEMPLATE_FORKED: 'template_forked',
+        TEMPLATE_ARCHIVED: 'template_archived',
+        TEMPLATE_DEFAULT_SET: 'template_default_set',
+        WORK_UPDATED: 'work_updated',
+        WORK_CREATED: 'work_created',
+        SCHEDULE_CREATED: 'schedule_created',
+        SCHEDULE_UPDATED: 'schedule_updated',
+        SCHEDULE_DELETED: 'schedule_deleted',
+        SCHEDULE_EXECUTED: 'schedule_executed',
+        COMMUNITY_PR_MERGED: 'community_pr_merged',
+        WEBSITE_USER_REGISTERED: 'website_user_registered',
+        WEBSITE_ITEM_SUBMITTED: 'website_item_submitted',
+        WEBSITE_REPORT_FILED: 'website_report_filed',
+        WEBSITE_REPORT_RESOLVED: 'website_report_resolved',
+    },
+    ActivityStatus: {
+        PENDING: 'pending',
+        IN_PROGRESS: 'in_progress',
+        COMPLETED: 'completed',
+        FAILED: 'failed',
+        CANCELLED: 'cancelled',
+    },
+}));
+
+import { ActivityActionType } from '@ever-works/agent/entities';
+import { ActivityFeedService } from '../activity-feed.service';
+import { FeedQueryDto } from '../dto/feed-query.dto';
+
+type ActivityLogMock = { findByWork: jest.Mock };
+type HistoryRepoMock = { findByWorkFiltered: jest.Mock };
+type WorkRepoMock = { findById: jest.Mock; updatePlatformSyncStatus: jest.Mock };
+type DirectoryClientMock = { fetchActivityFeed: jest.Mock };
+
+function makeWork(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'work-1',
+        activitySyncMode: 'push', // default for tests that don't care
+        website: 'https://example.com',
+        platformSyncLastSuccessAt: null,
+        ...overrides,
+    };
+}
+
+function makeActivityLog(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'al-1',
+        userId: 'user-1',
+        workId: 'work-1',
+        actionType: ActivityActionType.DEPLOYMENT,
+        action: 'deployment.completed',
+        status: 'completed',
+        summary: 'Deployed',
+        details: null,
+        createdAt: new Date('2026-05-12T10:00:00.000Z'),
+        updatedAt: new Date('2026-05-12T10:00:00.000Z'),
+        ...overrides,
+    };
+}
+
+function makeHistoryRow(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'h-1',
+        workId: 'work-1',
+        activityType: 'generation',
+        status: 'completed',
+        startedAt: new Date('2026-05-12T09:00:00.000Z'),
+        createdAt: new Date('2026-05-12T09:00:00.000Z'),
+        newItemsCount: 3,
+        updatedItemsCount: 1,
+        totalItemsCount: 10,
+        durationInSeconds: 42,
+        ...overrides,
+    };
+}
+
+describe('ActivityFeedService', () => {
+    let activityLogService: ActivityLogMock;
+    let historyRepo: HistoryRepoMock;
+    let workRepo: WorkRepoMock;
+    let directoryClient: DirectoryClientMock;
+    let service: ActivityFeedService;
+
+    beforeEach(() => {
+        activityLogService = { findByWork: jest.fn() };
+        historyRepo = { findByWorkFiltered: jest.fn() };
+        workRepo = {
+            findById: jest.fn().mockResolvedValue(makeWork()),
+            updatePlatformSyncStatus: jest.fn().mockResolvedValue(undefined),
+        };
+        directoryClient = { fetchActivityFeed: jest.fn() };
+        service = new ActivityFeedService(
+            activityLogService as never,
+            historyRepo as never,
+            workRepo as never,
+            directoryClient as never,
+        );
+    });
+
+    it('passes the FULL requested limit to each top-level source (no perSourceLimit division)', async () => {
+        // Codex P1 review fix (2026-05-13): the previous design divided
+        // `limit / sourceCount` per source, which could drop newer events
+        // from a dominant source. Pin the new contract: each source gets
+        // the caller's `limit` budget; `mergeEntries(..., limit)` still
+        // trims to the final budget.
+        activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+        historyRepo.findByWorkFiltered.mockResolvedValue([]);
+
+        const query = new FeedQueryDto();
+        query.limit = 50;
+        await service.compose('work-1', 'user-1', query);
+
+        const activityCall = activityLogService.findByWork.mock.calls[0][0] as { limit: number };
+        expect(activityCall.limit).toBe(50);
+        const historyCall = historyRepo.findByWorkFiltered.mock.calls[0];
+        // findByWorkFiltered(workId, limit, offset, types, before)
+        expect(historyCall[1]).toBe(50);
+    });
+
+    it('does NOT pass userId to ActivityLogService — member viewers see owner-attributed rows', async () => {
+        activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+
+        const query = new FeedQueryDto();
+        query.category = 'deployment';
+        await service.compose('work-1', 'member-not-owner', query);
+
+        const call = activityLogService.findByWork.mock.calls[0][0] as Record<string, unknown>;
+        expect(call.workId).toBe('work-1');
+        expect(call).not.toHaveProperty('userId');
+    });
+
+    describe('merging', () => {
+        it('merges sources sorted timestamp DESC and truncates to limit', async () => {
+            activityLogService.findByWork.mockResolvedValue({
+                activities: [
+                    makeActivityLog({
+                        id: 'al-new',
+                        createdAt: new Date('2026-05-12T12:00:00.000Z'),
+                    }),
+                ],
+                total: 1,
+            });
+            historyRepo.findByWorkFiltered.mockResolvedValue([
+                makeHistoryRow({
+                    id: 'h-old',
+                    startedAt: new Date('2026-05-12T08:00:00.000Z'),
+                }),
+                makeHistoryRow({
+                    id: 'h-mid',
+                    startedAt: new Date('2026-05-12T11:00:00.000Z'),
+                }),
+            ]);
+
+            const query = new FeedQueryDto();
+            query.limit = 2;
+            const response = await service.compose('work-1', 'user-1', query);
+
+            expect(response.entries.map((e) => e.timestamp)).toEqual([
+                '2026-05-12T12:00:00.000Z',
+                '2026-05-12T11:00:00.000Z',
+            ]);
+            expect(response.nextCursor).toBe('2026-05-12T11:00:00.000Z');
+        });
+
+        it('omits nextCursor when fewer entries than limit are returned', async () => {
+            activityLogService.findByWork.mockResolvedValue({
+                activities: [makeActivityLog()],
+                total: 1,
+            });
+            historyRepo.findByWorkFiltered.mockResolvedValue([]);
+
+            const response = await service.compose('work-1', 'user-1', new FeedQueryDto());
+            expect(response.nextCursor).toBeNull();
+        });
+    });
+
+    describe('push-mode category filtering (default)', () => {
+        beforeEach(() => {
+            workRepo.findById.mockResolvedValue(makeWork({ activitySyncMode: 'push' }));
+        });
+
+        it('users category queries activity-log with WEBSITE_USER_REGISTERED (single IN query)', async () => {
+            activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+            const query = new FeedQueryDto();
+            query.category = 'users';
+            await service.compose('work-1', 'user-1', query);
+
+            // One call (not per-type fan-out) with the type array.
+            expect(activityLogService.findByWork).toHaveBeenCalledTimes(1);
+            const call = activityLogService.findByWork.mock.calls[0][0] as {
+                workId: string;
+                actionType: string[];
+            };
+            expect(call.workId).toBe('work-1');
+            expect(call.actionType).toEqual([ActivityActionType.WEBSITE_USER_REGISTERED]);
+            expect(directoryClient.fetchActivityFeed).not.toHaveBeenCalled();
+        });
+
+        it('reports category queries both WEBSITE_REPORT_* types in a single IN query', async () => {
+            activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+            const query = new FeedQueryDto();
+            query.category = 'reports';
+            await service.compose('work-1', 'user-1', query);
+
+            // One call with the array of both types — not two parallel queries.
+            expect(activityLogService.findByWork).toHaveBeenCalledTimes(1);
+            const types = (
+                activityLogService.findByWork.mock.calls[0][0] as {
+                    actionType: string[];
+                }
+            ).actionType;
+            expect([...types].sort()).toEqual(
+                [
+                    ActivityActionType.WEBSITE_REPORT_FILED,
+                    ActivityActionType.WEBSITE_REPORT_RESOLVED,
+                ].sort(),
+            );
+            expect(directoryClient.fetchActivityFeed).not.toHaveBeenCalled();
+        });
+
+        it('never sets response.degraded in push mode', async () => {
+            activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+            historyRepo.findByWorkFiltered.mockResolvedValue([]);
+
+            const response = await service.compose('work-1', 'user-1', new FeedQueryDto());
+            expect(response.degraded).toBeUndefined();
+        });
+    });
+
+    describe('pull-mode routing (EW-120)', () => {
+        beforeEach(() => {
+            workRepo.findById.mockResolvedValue(makeWork({ activitySyncMode: 'pull' }));
+            activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+            historyRepo.findByWorkFiltered.mockResolvedValue([]);
+        });
+
+        it('users category invokes the directory client, NOT the activity-log query', async () => {
+            directoryClient.fetchActivityFeed.mockResolvedValue({ ok: true, entries: [] });
+
+            const query = new FeedQueryDto();
+            query.category = 'users';
+            await service.compose('work-1', 'user-1', query);
+
+            expect(directoryClient.fetchActivityFeed).toHaveBeenCalledTimes(1);
+            const call = directoryClient.fetchActivityFeed.mock.calls[0];
+            expect(call[1]).toEqual(expect.objectContaining({ types: ['users'] }));
+            // Activity-log query (now a single IN-array call) must NOT
+            // include WEBSITE_* — those are the directory-client's job in
+            // pull mode.
+            const flatTypes = activityLogService.findByWork.mock.calls.flatMap((c) => {
+                const t = (c[0] as { actionType?: string | string[] }).actionType;
+                return Array.isArray(t) ? t : t ? [t] : [];
+            });
+            expect(flatTypes).not.toContain(ActivityActionType.WEBSITE_USER_REGISTERED);
+        });
+
+        it('surfaces directory-site degraded reason in response.degraded.directorySite', async () => {
+            directoryClient.fetchActivityFeed.mockResolvedValue({
+                ok: false,
+                degraded: { reason: 'timeout', detail: 'after 5s' },
+            });
+
+            const query = new FeedQueryDto();
+            query.category = 'users';
+            const response = await service.compose('work-1', 'user-1', query);
+
+            expect(response.degraded?.directorySite?.reason).toBe('timeout');
+        });
+
+        it('writes platformSyncLastErrorMessage on degraded run', async () => {
+            directoryClient.fetchActivityFeed.mockResolvedValue({
+                ok: false,
+                degraded: { reason: 'unauthorized', detail: 'stale secret' },
+            });
+
+            const query = new FeedQueryDto();
+            query.category = 'users';
+            await service.compose('work-1', 'user-1', query);
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(workRepo.updatePlatformSyncStatus).toHaveBeenCalledWith(
+                'work-1',
+                expect.objectContaining({
+                    lastErrorMessage: expect.stringContaining('unauthorized'),
+                }),
+            );
+        });
+
+        it('writes platformSyncLastSuccessAt on successful run', async () => {
+            directoryClient.fetchActivityFeed.mockResolvedValue({ ok: true, entries: [] });
+
+            const query = new FeedQueryDto();
+            query.category = 'users';
+            await service.compose('work-1', 'user-1', query);
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(workRepo.updatePlatformSyncStatus).toHaveBeenCalledWith(
+                'work-1',
+                expect.objectContaining({
+                    lastSuccessAt: expect.any(Date),
+                    lastErrorMessage: null,
+                }),
+            );
+        });
+    });
+
+    describe('disabled-mode routing (EW-120)', () => {
+        beforeEach(() => {
+            workRepo.findById.mockResolvedValue(makeWork({ activitySyncMode: 'disabled' }));
+            activityLogService.findByWork.mockResolvedValue({ activities: [], total: 0 });
+            historyRepo.findByWorkFiltered.mockResolvedValue([]);
+        });
+
+        it('never queries the directory client', async () => {
+            const query = new FeedQueryDto();
+            query.category = 'users';
+            await service.compose('work-1', 'user-1', query);
+
+            expect(directoryClient.fetchActivityFeed).not.toHaveBeenCalled();
+        });
+
+        it('never sets response.degraded', async () => {
+            const response = await service.compose('work-1', 'user-1', new FeedQueryDto());
+            expect(response.degraded).toBeUndefined();
+        });
+    });
+
+    describe('defensive guards', () => {
+        it('returns an empty response when the work cannot be found', async () => {
+            workRepo.findById.mockResolvedValue(null);
+            const response = await service.compose('missing', 'user-1', new FeedQueryDto());
+            expect(response.entries).toEqual([]);
+        });
+    });
+});

--- a/apps/api/src/works/activity-feed/__tests__/directory-website-client.service.spec.ts
+++ b/apps/api/src/works/activity-feed/__tests__/directory-website-client.service.spec.ts
@@ -1,0 +1,262 @@
+// Mock agent-package barrels so the test doesn't pull TypeORM entity trees.
+jest.mock('@ever-works/agent/services', () => ({
+    PlatformSyncSecretService: class {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({
+    Work: class {},
+}));
+
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import type { AxiosError, AxiosResponse } from 'axios';
+import type { PlatformSyncSecretService } from '@ever-works/agent/services';
+import { DirectoryWebsiteClient } from '../directory-website-client.service';
+
+type HttpMock = { get: jest.Mock };
+
+interface WorkLike {
+    id: string;
+    website: string | null;
+    activitySyncMode: 'pull' | 'push' | 'disabled';
+    platformSyncSecretEncrypted: string | null;
+    platformSyncLastSuccessAt?: Date | null;
+}
+
+function makeWork(overrides: Partial<WorkLike> = {}): WorkLike {
+    return {
+        id: 'work-1',
+        website: 'https://demo.example.com',
+        activitySyncMode: 'pull',
+        platformSyncSecretEncrypted: 'envelope-base64',
+        ...overrides,
+    };
+}
+
+function makeAxiosError(overrides: Partial<AxiosError>): AxiosError {
+    return Object.assign(new Error('axios') as AxiosError, overrides);
+}
+
+function makeResponse(data: unknown): AxiosResponse {
+    return { data, status: 200, statusText: 'OK', headers: {}, config: {} as never };
+}
+
+describe('DirectoryWebsiteClient', () => {
+    let httpService: HttpMock;
+    let secretService: jest.Mocked<Pick<PlatformSyncSecretService, 'decryptForWork'>>;
+    let client: DirectoryWebsiteClient;
+
+    beforeEach(() => {
+        httpService = { get: jest.fn() };
+        secretService = { decryptForWork: jest.fn() } as never;
+        client = new DirectoryWebsiteClient(
+            httpService as unknown as HttpService,
+            secretService as unknown as PlatformSyncSecretService,
+        );
+    });
+
+    describe('preconditions', () => {
+        it.each(['push', 'disabled'] as const)(
+            'returns degraded:disabled when activitySyncMode = %s (non-pull)',
+            async (mode) => {
+                const work = makeWork({ activitySyncMode: mode });
+                const result = await client.fetchActivityFeed(work as never, {
+                    limit: 50,
+                    types: ['all'],
+                });
+                expect(result.ok).toBe(false);
+                if (!result.ok)
+                    expect(
+                        (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                    ).toBe('disabled');
+                expect(httpService.get).not.toHaveBeenCalled();
+            },
+        );
+
+        it('returns degraded:not_provisioned when work has no website URL', async () => {
+            const work = makeWork({ website: null });
+            const result = await client.fetchActivityFeed(work as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('not_provisioned');
+        });
+
+        it('returns degraded:not_provisioned when secret is null', async () => {
+            secretService.decryptForWork.mockReturnValue(null);
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('not_provisioned');
+        });
+
+        it('returns degraded:parse_error when secret decryption throws', async () => {
+            secretService.decryptForWork.mockImplementation(() => {
+                throw new Error('bad envelope');
+            });
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('parse_error');
+        });
+    });
+
+    describe('happy path', () => {
+        it('signs the request, fetches, and maps entries with correct categories', async () => {
+            secretService.decryptForWork.mockReturnValue('a'.repeat(64));
+            httpService.get.mockReturnValue(
+                of(
+                    makeResponse({
+                        entries: [
+                            {
+                                id: 'u-1',
+                                type: 'user_registered',
+                                timestamp: '2026-05-12T10:00:00.000Z',
+                                summary: 'Maria signed up',
+                                actor: { id: 'u-1', name: 'Maria' },
+                                target: {
+                                    id: 'u-1',
+                                    type: 'user',
+                                    name: 'Maria',
+                                    adminUrl: '/admin/users/u-1',
+                                },
+                            },
+                            {
+                                id: 'i-7',
+                                type: 'item_created',
+                                timestamp: '2026-05-12T09:00:00.000Z',
+                                summary: 'New item submitted',
+                                actor: null,
+                                target: {
+                                    id: 'i-7',
+                                    type: 'item',
+                                    name: 'Cool Tool',
+                                    adminUrl: '/admin/items/i-7',
+                                },
+                            },
+                        ],
+                        nextCursor: '2026-05-12T08:00:00.000Z',
+                        serverTime: new Date().toISOString(),
+                    }),
+                ),
+            );
+
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+                since: '2026-05-10T00:00:00.000Z',
+            });
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) return;
+            expect(result.entries).toHaveLength(2);
+            expect(result.entries[0].source).toBe('directory-site');
+            expect(result.entries[0].category).toBe('users');
+            expect(result.entries[1].category).toBe('submissions');
+            expect(result.nextCursor).toBe('2026-05-12T08:00:00.000Z');
+
+            // Verify signing headers are present.
+            const headers = httpService.get.mock.calls[0][1].headers;
+            expect(headers.Authorization).toMatch(/^Bearer [0-9a-f]{64}$/);
+            expect(headers['x-platform-ts']).toBeDefined();
+            expect(headers['User-Agent']).toMatch(/ever-works-platform/);
+        });
+
+        it('strips trailing slash from website URL', async () => {
+            secretService.decryptForWork.mockReturnValue('a'.repeat(64));
+            httpService.get.mockReturnValue(
+                of(makeResponse({ entries: [], serverTime: new Date().toISOString() })),
+            );
+            await client.fetchActivityFeed(
+                makeWork({ website: 'https://demo.example.com/' }) as never,
+                { limit: 50, types: ['all'] },
+            );
+            const url = httpService.get.mock.calls[0][0] as string;
+            expect(url).toMatch(/^https:\/\/demo\.example\.com\/api\/platform\/activity-feed/);
+            expect(url.startsWith('https://demo.example.com//')).toBe(false);
+        });
+    });
+
+    describe('error translation', () => {
+        beforeEach(() => {
+            secretService.decryptForWork.mockReturnValue('a'.repeat(64));
+        });
+
+        it('translates 401 into degraded:unauthorized without retrying', async () => {
+            httpService.get.mockReturnValue(
+                throwError(() =>
+                    makeAxiosError({ response: { status: 401 } as never, message: 'Unauthorized' }),
+                ),
+            );
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('unauthorized');
+            expect(httpService.get).toHaveBeenCalledTimes(1);
+        });
+
+        it('translates timeout into degraded:timeout', async () => {
+            httpService.get.mockReturnValue(
+                throwError(() => makeAxiosError({ code: 'ECONNABORTED', message: 'timeout' })),
+            );
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('timeout');
+        });
+
+        it('retries once on 5xx then returns upstream_5xx', async () => {
+            httpService.get.mockReturnValue(
+                throwError(() =>
+                    makeAxiosError({ response: { status: 503 } as never, message: 'unavailable' }),
+                ),
+            );
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('upstream_5xx');
+            expect(httpService.get).toHaveBeenCalledTimes(2);
+        });
+
+        it('rejects responses with malformed shape', async () => {
+            httpService.get.mockReturnValue(of(makeResponse({ entries: 'not-an-array' })));
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok)
+                expect(
+                    (result as { ok: false; degraded: { reason: string } }).degraded.reason,
+                ).toBe('parse_error');
+        });
+    });
+});

--- a/apps/api/src/works/activity-feed/activity-feed.controller.ts
+++ b/apps/api/src/works/activity-feed/activity-feed.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { WorkOwnershipService } from '@ever-works/agent/services';
+import { CurrentUser } from '@src/auth/decorators/user.decorator';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { ActivityFeedService } from './activity-feed.service';
+import { FeedQueryDto } from './dto/feed-query.dto';
+import type { FeedResponse } from './dto/feed-response.dto';
+
+@ApiTags('Activity Feed')
+@Controller('api')
+export class ActivityFeedController {
+    constructor(
+        private readonly ownershipService: WorkOwnershipService,
+        private readonly activityFeedService: ActivityFeedService,
+    ) {}
+
+    @Get('works/:id/activity-feed')
+    @ApiOperation({
+        summary: 'Get directory Activity Feed',
+        description:
+            'Merged timeline of platform activity-log entries and per-Work generation history. Deployed-site events (users / submissions / reports) are written to the activity log via the platform ingest endpoint. Used by the Activity Feed tab on the directory detail page (EW-120).',
+    })
+    @ApiParam({ name: 'id', description: 'Work ID' })
+    @ApiResponse({
+        status: 200,
+        description: 'Merged feed payload sorted by timestamp, newest first.',
+    })
+    async getActivityFeed(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+        @Query() query: FeedQueryDto,
+    ): Promise<FeedResponse> {
+        // Throws ForbiddenException / NotFoundException if the user lacks access.
+        await this.ownershipService.ensureAccess(id, auth.userId);
+        return this.activityFeedService.compose(id, auth.userId, query);
+    }
+}

--- a/apps/api/src/works/activity-feed/activity-feed.module.ts
+++ b/apps/api/src/works/activity-feed/activity-feed.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { ActivityLogModule } from '@ever-works/agent/activity-log';
+import { WorkModule } from '@ever-works/agent/services';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { AuthModule } from '@src/auth';
+import { ActivityFeedController } from './activity-feed.controller';
+import { ActivityFeedService } from './activity-feed.service';
+import { DirectoryWebsiteClient } from './directory-website-client.service';
+
+@Module({
+    imports: [
+        // Pull-transport HTTP client (EW-120). 5s timeout matches the
+        // hardcoded `REQUEST_TIMEOUT_MS` in `DirectoryWebsiteClient`;
+        // no redirects so we don't follow the deployed site to an
+        // attacker-controlled URL if a Work's `website` is later
+        // proxied.
+        HttpModule.register({ timeout: 5000, maxRedirects: 0 }),
+        ActivityLogModule,
+        WorkModule,
+        DatabaseModule,
+        AuthModule,
+    ],
+    controllers: [ActivityFeedController],
+    providers: [ActivityFeedService, DirectoryWebsiteClient],
+    exports: [ActivityFeedService],
+})
+export class ActivityFeedModule {}

--- a/apps/api/src/works/activity-feed/activity-feed.service.ts
+++ b/apps/api/src/works/activity-feed/activity-feed.service.ts
@@ -1,0 +1,404 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ActivityLogService } from '@ever-works/agent/activity-log';
+import { ActivityActionType } from '@ever-works/agent/entities';
+import type { ActivityLog, Work } from '@ever-works/agent/entities';
+import { WorkGenerationHistoryRepository, WorkRepository } from '@ever-works/agent/database';
+import type { WorkGenerationHistory } from '@ever-works/agent/entities';
+import { WorkHistoryActivityType } from '@ever-works/contracts/api';
+import type {
+    DirectorySiteEntry,
+    FeedCategory,
+    FeedEntry,
+    GenerationHistoryEntry,
+    PlatformActivityLogEntry,
+} from './dto/feed-entry.dto';
+import type { FeedDegradedReason, FeedResponse } from './dto/feed-response.dto';
+import type { FeedQueryDto } from './dto/feed-query.dto';
+import {
+    DirectoryWebsiteClient,
+    type DirectoryEntryType,
+} from './directory-website-client.service';
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Push-mode mapping: website-sourced categories are populated by activity-log
+ * rows ingested via `POST /api/activity-log/ingest`, so they appear as ordinary
+ * WEBSITE_* action types in the activity-log query.
+ */
+const ACTIVITY_LOG_TYPES_BY_CATEGORY: Record<FeedCategory, ActivityActionType[] | null> = {
+    all: null,
+    generation: [ActivityActionType.GENERATION, ActivityActionType.COMPARISON_GENERATION],
+    items: [
+        ActivityActionType.ITEM_ADDED,
+        ActivityActionType.ITEM_UPDATED,
+        ActivityActionType.ITEM_REMOVED,
+    ],
+    deployment: [ActivityActionType.DEPLOYMENT],
+    settings: [
+        ActivityActionType.SETTINGS_UPDATED,
+        ActivityActionType.WEBSITE_SETTINGS_UPDATED,
+        ActivityActionType.PROMPTS_UPDATED,
+        ActivityActionType.WORKS_CONFIG_SYNC,
+        ActivityActionType.PLUGIN_ENABLED,
+        ActivityActionType.PLUGIN_DISABLED,
+        ActivityActionType.PLUGIN_CONFIGURED,
+        ActivityActionType.TEMPLATE_ADDED,
+        ActivityActionType.TEMPLATE_UPDATED,
+        ActivityActionType.TEMPLATE_FORKED,
+        ActivityActionType.TEMPLATE_ARCHIVED,
+        ActivityActionType.TEMPLATE_DEFAULT_SET,
+        ActivityActionType.WORK_UPDATED,
+        ActivityActionType.WORK_CREATED,
+        ActivityActionType.SCHEDULE_CREATED,
+        ActivityActionType.SCHEDULE_UPDATED,
+        ActivityActionType.SCHEDULE_DELETED,
+        ActivityActionType.SCHEDULE_EXECUTED,
+    ],
+    comparisons: [ActivityActionType.COMPARISON_GENERATION],
+    communityPr: [ActivityActionType.COMMUNITY_PR_MERGED],
+    users: [ActivityActionType.WEBSITE_USER_REGISTERED],
+    submissions: [ActivityActionType.WEBSITE_ITEM_SUBMITTED],
+    reports: [ActivityActionType.WEBSITE_REPORT_FILED, ActivityActionType.WEBSITE_REPORT_RESOLVED],
+};
+
+/** Set of action types that represent website-ingested events (push transport). */
+const WEBSITE_ACTION_TYPES: ReadonlySet<ActivityActionType> = new Set([
+    ActivityActionType.WEBSITE_USER_REGISTERED,
+    ActivityActionType.WEBSITE_ITEM_SUBMITTED,
+    ActivityActionType.WEBSITE_REPORT_FILED,
+    ActivityActionType.WEBSITE_REPORT_RESOLVED,
+]);
+
+const HISTORY_TYPES_BY_CATEGORY: Record<FeedCategory, WorkHistoryActivityType[] | null> = {
+    all: null,
+    generation: [WorkHistoryActivityType.GENERATION],
+    items: [WorkHistoryActivityType.ITEM_ADDED, WorkHistoryActivityType.ITEM_UPDATED],
+    deployment: [],
+    settings: [],
+    comparisons: [
+        WorkHistoryActivityType.COMPARISON_ADDED,
+        WorkHistoryActivityType.COMPARISON_REMOVED,
+    ],
+    communityPr: [WorkHistoryActivityType.COMMUNITY_PR_MERGED],
+    users: [],
+    submissions: [],
+    reports: [],
+};
+
+/**
+ * Pull-mode mapping: website-sourced categories are populated by an on-demand
+ * fetch against the deployed site (DirectoryWebsiteClient). The values map to
+ * the upstream `types[]` filter.
+ */
+const DIRECTORY_TYPES_BY_CATEGORY: Record<FeedCategory, DirectoryEntryType[]> = {
+    all: ['all'],
+    generation: [],
+    items: ['items'],
+    deployment: [],
+    settings: [],
+    comparisons: [],
+    communityPr: [],
+    users: ['users'],
+    submissions: ['items'],
+    reports: ['reports'],
+};
+
+interface ComposeContext {
+    work: Work;
+    limit: number;
+    category: FeedCategory;
+    cursor?: string;
+}
+
+/**
+ * Aggregator for the per-Work Activity Feed (EW-120). Composes three sources:
+ *
+ *  1. Platform activity-log (always)
+ *  2. Per-Work generation history (always)
+ *  3. Deployed-site events — populated by **one of two** transports based on
+ *     `Work.activitySyncMode`:
+ *       - `pull`    → on-demand HMAC-signed GET via DirectoryWebsiteClient
+ *       - `push`    → ordinary activity-log rows ingested via the platform
+ *                     `/api/activity-log/ingest` endpoint (WEBSITE_* types)
+ *       - `disabled`→ never queried; users / submissions / reports chips empty
+ *
+ * Push-mode + Disabled-mode never set `response.degraded`. Pull-mode failures
+ * surface via `response.degraded.directorySite` so the web client renders the
+ * degraded banner with rotation / redeploy hints.
+ */
+@Injectable()
+export class ActivityFeedService {
+    private readonly logger = new Logger(ActivityFeedService.name);
+
+    constructor(
+        private readonly activityLogService: ActivityLogService,
+        private readonly generationHistoryRepository: WorkGenerationHistoryRepository,
+        private readonly workRepository: WorkRepository,
+        private readonly directoryClient: DirectoryWebsiteClient,
+    ) {}
+
+    async compose(workId: string, _userId: string, query: FeedQueryDto): Promise<FeedResponse> {
+        const work = await this.workRepository.findById(workId);
+        if (!work) {
+            // Controller's WorkOwnershipService.ensureAccess already rejects
+            // missing/forbidden Works upstream; this is a defence-in-depth
+            // fallback (no row → no events, no degraded).
+            return { entries: [], nextCursor: null, serverTime: new Date().toISOString() };
+        }
+
+        const limit = query.limit ?? DEFAULT_LIMIT;
+        const category = query.category ?? 'all';
+        const cursorTimestamp = parseCursor(query.cursor);
+        const ctx: ComposeContext = { work, limit, category, cursor: query.cursor };
+
+        const isPullMode = work.activitySyncMode === 'pull';
+        const isDisabled = work.activitySyncMode === 'disabled';
+
+        const activityLogTypes = ACTIVITY_LOG_TYPES_BY_CATEGORY[category];
+        const historyTypes = HISTORY_TYPES_BY_CATEGORY[category];
+        const directoryTypes = isPullMode ? DIRECTORY_TYPES_BY_CATEGORY[category] : [];
+
+        // In pull mode, the website chips are populated by DirectoryWebsiteClient,
+        // so the activity-log query should NOT return WEBSITE_* rows (any present
+        // would be stale push-mode leftovers from a prior mode flip).
+        const filteredActivityLogTypes = isPullMode
+            ? filterOutWebsiteTypes(activityLogTypes)
+            : activityLogTypes;
+
+        // Pass the FULL requested `limit` to each top-level source. The
+        // previous design divided `limit / sourceCount` per source, which
+        // could drop newer events from a dominant source — e.g. a deploy
+        // burst on activity-log alongside a quiet history would lose
+        // newer activity rows to older history rows after the merge.
+        // Fetching `limit` from each source means we have up to
+        // `limit * sources` candidate rows; `mergeEntries(..., limit)`
+        // still trims to the caller's budget. Codex P1 review on
+        // activity-feed.service.ts:101 (2026-05-13).
+        const [activityLogResults, historyEntries, directoryResult] = await Promise.all([
+            this.fetchActivityLog(ctx, limit, filteredActivityLogTypes, cursorTimestamp),
+            this.fetchHistory(ctx, limit, historyTypes, cursorTimestamp),
+            isPullMode && !isDisabled
+                ? this.fetchDirectorySite(ctx, limit, directoryTypes)
+                : Promise.resolve<{
+                      entries: DirectorySiteEntry[];
+                      degraded?: FeedDegradedReason;
+                  }>({ entries: [] }),
+        ]);
+
+        const merged = mergeEntries(
+            [...activityLogResults, ...historyEntries, ...directoryResult.entries],
+            limit,
+        );
+        const nextCursor =
+            merged.length === limit ? (merged[merged.length - 1]?.timestamp ?? null) : null;
+
+        // Best-effort observability for pull-mode runs — never blocks the response.
+        if (isPullMode) {
+            this.recordSyncStatus(work, directoryResult.degraded).catch((err) =>
+                this.logger.debug(`Failed to update platformSync* columns: ${err.message}`),
+            );
+        }
+
+        const response: FeedResponse = {
+            entries: merged,
+            nextCursor,
+            serverTime: new Date().toISOString(),
+        };
+        if (directoryResult.degraded) {
+            response.degraded = { directorySite: directoryResult.degraded };
+        }
+        return response;
+    }
+
+    private async fetchActivityLog(
+        ctx: ComposeContext,
+        limit: number,
+        types: ActivityActionType[] | null,
+        cursorTimestamp: number | null,
+    ): Promise<PlatformActivityLogEntry[]> {
+        if (types !== null && types.length === 0) {
+            return [];
+        }
+        // Single `IN (...)` query instead of N parallel per-type queries.
+        // Previously we fanned out one query per action type, which made
+        // the activity-log budget effectively `limit * types.length` —
+        // for the `settings` category that's 18× over-fetch. The
+        // repository now accepts an array (Codex P1 review followup).
+        //
+        // Note: bypasses the userId filter on purpose. Access is enforced
+        // upstream by WorkOwnershipService.ensureAccess (controller); the
+        // feed must surface every row scoped to the Work, including the
+        // owner-attributed website-ingested events for member viewers.
+        const { activities } = await this.activityLogService.findByWork({
+            workId: ctx.work.id,
+            actionType: types && types.length > 0 ? types : undefined,
+            limit,
+            offset: 0,
+            dateTo: cursorTimestamp ? new Date(cursorTimestamp) : undefined,
+        });
+        return activities.map(toActivityLogEntry);
+    }
+
+    private async fetchHistory(
+        ctx: ComposeContext,
+        limit: number,
+        types: WorkHistoryActivityType[] | null,
+        cursorTimestamp: number | null,
+    ): Promise<GenerationHistoryEntry[]> {
+        if (types !== null && types.length === 0) {
+            return [];
+        }
+        // Push the cursor predicate to the DB so older rows beyond `limit`
+        // aren't silently skipped when the top-N batch is all newer than
+        // the cursor.
+        const rows = await this.generationHistoryRepository.findByWorkFiltered(
+            ctx.work.id,
+            limit,
+            0,
+            types ?? undefined,
+            cursorTimestamp ? new Date(cursorTimestamp) : undefined,
+        );
+        return rows.map(toHistoryEntry);
+    }
+
+    private async fetchDirectorySite(
+        ctx: ComposeContext,
+        limit: number,
+        types: DirectoryEntryType[],
+    ): Promise<{ entries: DirectorySiteEntry[]; degraded?: FeedDegradedReason }> {
+        if (types.length === 0) {
+            return { entries: [] };
+        }
+        const result = await this.directoryClient.fetchActivityFeed(ctx.work, {
+            limit,
+            types,
+            since: ctx.cursor,
+        });
+        if (result.ok === true) {
+            return { entries: result.entries };
+        }
+        return {
+            entries: [],
+            degraded: {
+                ...result.degraded,
+                lastSuccessAt: ctx.work.platformSyncLastSuccessAt?.toISOString() ?? null,
+            },
+        };
+    }
+
+    private async recordSyncStatus(
+        work: Work,
+        degraded: FeedDegradedReason | undefined,
+    ): Promise<void> {
+        if (degraded) {
+            await this.workRepository.updatePlatformSyncStatus(work.id, {
+                lastErrorAt: new Date(),
+                lastErrorMessage: `${degraded.reason}: ${degraded.detail ?? ''}`.trim(),
+            });
+        } else {
+            await this.workRepository.updatePlatformSyncStatus(work.id, {
+                lastSuccessAt: new Date(),
+                lastErrorMessage: null,
+            });
+        }
+    }
+}
+
+function filterOutWebsiteTypes(types: ActivityActionType[] | null): ActivityActionType[] | null {
+    if (types === null) {
+        // `all` category — keep the "no filter" semantics but make the
+        // findByWork pass filter post-hoc by switching to an explicit
+        // allow-list of everything EXCEPT website types. We accept the
+        // verbosity here because the pull path is the legacy default and
+        // misrouting WEBSITE_* rows there would surface duplicates.
+        return Object.values(ActivityActionType).filter(
+            (t) => !WEBSITE_ACTION_TYPES.has(t),
+        ) as ActivityActionType[];
+    }
+    return types.filter((t) => !WEBSITE_ACTION_TYPES.has(t));
+}
+
+function toActivityLogEntry(log: ActivityLog): PlatformActivityLogEntry {
+    return {
+        id: log.id,
+        source: 'platform-activity-log',
+        type: log.actionType,
+        category: categoryForActivityLog(log.actionType),
+        timestamp: log.createdAt.toISOString(),
+        summary: log.summary,
+        status: log.status,
+        details: log.details ?? null,
+    };
+}
+
+function toHistoryEntry(row: WorkGenerationHistory): GenerationHistoryEntry {
+    const timestamp = (row.startedAt ?? row.createdAt ?? new Date()).toISOString();
+    return {
+        id: `hist-${row.id}`,
+        source: 'generation-history',
+        type: row.activityType,
+        category: categoryForHistory(row.activityType),
+        timestamp,
+        summary: summariseHistoryRow(row),
+        status: String(row.status),
+        runId: row.id,
+        newItemsCount: row.newItemsCount,
+        updatedItemsCount: row.updatedItemsCount,
+        totalItemsCount: row.totalItemsCount,
+        durationInSeconds: row.durationInSeconds ?? null,
+    };
+}
+
+function summariseHistoryRow(row: WorkGenerationHistory): string {
+    const counts: string[] = [];
+    if (row.newItemsCount > 0) counts.push(`${row.newItemsCount} new`);
+    if (row.updatedItemsCount > 0) counts.push(`${row.updatedItemsCount} updated`);
+    const countsPart = counts.length ? ` (${counts.join(', ')})` : '';
+    return `${row.activityType}${countsPart}`;
+}
+
+function categoryForActivityLog(type: ActivityActionType): FeedCategory {
+    if (type === ActivityActionType.GENERATION) return 'generation';
+    if (type === ActivityActionType.COMPARISON_GENERATION) return 'comparisons';
+    if (type === ActivityActionType.DEPLOYMENT) return 'deployment';
+    if (
+        type === ActivityActionType.ITEM_ADDED ||
+        type === ActivityActionType.ITEM_UPDATED ||
+        type === ActivityActionType.ITEM_REMOVED
+    ) {
+        return 'items';
+    }
+    if (type === ActivityActionType.COMMUNITY_PR_MERGED) return 'communityPr';
+    if (type === ActivityActionType.WEBSITE_USER_REGISTERED) return 'users';
+    if (type === ActivityActionType.WEBSITE_ITEM_SUBMITTED) return 'submissions';
+    if (
+        type === ActivityActionType.WEBSITE_REPORT_FILED ||
+        type === ActivityActionType.WEBSITE_REPORT_RESOLVED
+    ) {
+        return 'reports';
+    }
+    return 'settings';
+}
+
+function categoryForHistory(type: WorkHistoryActivityType): FeedCategory {
+    if (type === WorkHistoryActivityType.GENERATION) return 'generation';
+    if (
+        type === WorkHistoryActivityType.COMPARISON_ADDED ||
+        type === WorkHistoryActivityType.COMPARISON_REMOVED
+    ) {
+        return 'comparisons';
+    }
+    if (type === WorkHistoryActivityType.COMMUNITY_PR_MERGED) return 'communityPr';
+    return 'items';
+}
+
+function mergeEntries(entries: FeedEntry[], limit: number): FeedEntry[] {
+    return entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, limit);
+}
+
+function parseCursor(cursor: string | undefined): number | null {
+    if (!cursor) return null;
+    const t = Date.parse(cursor);
+    return Number.isFinite(t) ? t : null;
+}

--- a/apps/api/src/works/activity-feed/directory-website-client.service.ts
+++ b/apps/api/src/works/activity-feed/directory-website-client.service.ts
@@ -1,0 +1,241 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { createHmac } from 'crypto';
+import { firstValueFrom } from 'rxjs';
+import type { AxiosError, AxiosResponse } from 'axios';
+import type { Work } from '@ever-works/agent/entities';
+import { PlatformSyncSecretService } from '@ever-works/agent/services';
+import type { DirectorySiteEntry, FeedCategory, FeedEntry } from './dto/feed-entry.dto';
+import type { FeedDegradedReason } from './dto/feed-response.dto';
+
+const REQUEST_TIMEOUT_MS = 5000;
+const MAX_DRIFT_MS = 5 * 60 * 1000;
+
+export type DirectoryFeedFetchParams = {
+    since?: string;
+    limit: number;
+    types: DirectoryEntryType[];
+};
+
+export type DirectoryEntryType = 'users' | 'items' | 'reports' | 'all';
+
+export type DirectoryFeedResult =
+    | { ok: true; entries: DirectorySiteEntry[]; nextCursor: string | null }
+    | { ok: false; degraded: FeedDegradedReason };
+
+type UpstreamEntry = {
+    id: string;
+    type: DirectorySiteEntry['type'];
+    timestamp: string;
+    summary: string;
+    actor?: { id: string; name: string; email?: string | null } | null;
+    target: {
+        id: string;
+        type: DirectorySiteEntry['target']['type'];
+        name: string;
+        adminUrl: string;
+    };
+};
+
+type UpstreamResponse = {
+    entries: UpstreamEntry[];
+    nextCursor?: string | null;
+    serverTime: string;
+};
+
+/**
+ * Client for the deployed directory site's `/api/platform/activity-feed`
+ * endpoint. Handles HMAC signing, timeouts, retries, and graceful degradation
+ * — never throws: callers always get either a success payload or a typed
+ * `degraded` reason they can surface to the UI.
+ *
+ * See `docs/specs/features/activity-feed-per-directory/plan.md` §5.1 and §10.
+ */
+@Injectable()
+export class DirectoryWebsiteClient {
+    private readonly logger = new Logger(DirectoryWebsiteClient.name);
+
+    constructor(
+        private readonly httpService: HttpService,
+        private readonly secretService: PlatformSyncSecretService,
+    ) {}
+
+    async fetchActivityFeed(
+        work: Work,
+        params: DirectoryFeedFetchParams,
+    ): Promise<DirectoryFeedResult> {
+        // EW-120 dual-mode: this client is the pull transport. It must only
+        // run for `activitySyncMode === 'pull'`. Callers (ActivityFeedService)
+        // gate on the mode before invoking the client, but we re-check here
+        // to avoid silently hitting the network if a stale `Work` slipped
+        // through (e.g. mode flipped between authorisation and fetch).
+        if (work.activitySyncMode !== 'pull') {
+            return degraded('disabled');
+        }
+        if (!work.website) {
+            return degraded('not_provisioned', 'Work has no deployed website URL');
+        }
+
+        let secret: string | null;
+        try {
+            secret = this.secretService.decryptForWork(work);
+        } catch (err) {
+            this.logger.warn(
+                `decryptForWork failed for work ${work.id}: ${(err as Error).message}`,
+            );
+            return degraded('parse_error', 'Secret could not be decrypted');
+        }
+        if (!secret) {
+            return degraded('not_provisioned');
+        }
+
+        return this.fetchWithRetry(work, params, secret);
+    }
+
+    private async fetchWithRetry(
+        work: Work,
+        params: DirectoryFeedFetchParams,
+        secret: string,
+    ): Promise<DirectoryFeedResult> {
+        let lastDegraded: FeedDegradedReason = { reason: 'network' };
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+            const outcome = await this.tryOnce(work, params, secret);
+            if (outcome.ok === true) {
+                return outcome;
+            }
+            const reason = outcome.degraded as FeedDegradedReason;
+            if (isPermanent(reason.reason)) {
+                return outcome;
+            }
+            lastDegraded = reason;
+            // 200ms backoff before retry.
+            await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+        return { ok: false, degraded: lastDegraded };
+    }
+
+    private async tryOnce(
+        work: Work,
+        params: DirectoryFeedFetchParams,
+        secret: string,
+    ): Promise<DirectoryFeedResult> {
+        const timestamp = new Date().toISOString();
+        const queryString = serialiseQuery(params);
+        // The work ID binds the HMAC to a specific Work so a leaked signature
+        // can't be replayed against another Work hosted on the same domain.
+        const signature = sign(timestamp, queryString, work.id, secret);
+        const url = `${stripTrailingSlash(work.website!)}/api/platform/activity-feed${queryString ? `?${queryString}` : ''}`;
+
+        try {
+            const response = await firstValueFrom(
+                this.httpService.get<UpstreamResponse>(url, {
+                    headers: {
+                        Authorization: `Bearer ${signature}`,
+                        'x-platform-ts': timestamp,
+                        'User-Agent': 'ever-works-platform/activity-feed',
+                    },
+                    timeout: REQUEST_TIMEOUT_MS,
+                }),
+            );
+            return this.parseResponse(response);
+        } catch (err) {
+            return this.translateError(err as AxiosError, work.id);
+        }
+    }
+
+    private parseResponse(response: AxiosResponse<UpstreamResponse>): DirectoryFeedResult {
+        const body = response.data;
+        if (!body || !Array.isArray(body.entries)) {
+            return degraded('parse_error', 'Response shape unexpected');
+        }
+        const serverTime = body.serverTime ? Date.parse(body.serverTime) : NaN;
+        if (Number.isFinite(serverTime) && Math.abs(Date.now() - serverTime) > MAX_DRIFT_MS) {
+            return degraded('parse_error', 'Upstream server time drift exceeds 5 minutes');
+        }
+        const entries: FeedEntry[] = body.entries.map((entry) => mapEntry(entry));
+        return {
+            ok: true,
+            entries: entries as DirectorySiteEntry[],
+            nextCursor: body.nextCursor ?? null,
+        };
+    }
+
+    private translateError(err: AxiosError, workId: string): DirectoryFeedResult {
+        if (err.code === 'ECONNABORTED' || err.message?.includes('timeout')) {
+            return degraded('timeout');
+        }
+        const status = err.response?.status;
+        if (status === 401 || status === 403) {
+            this.logger.warn(
+                `directory-site rejected request for work ${workId} (status ${status}); secret may be stale`,
+            );
+            return degraded('unauthorized');
+        }
+        if (status && status >= 500) {
+            return degraded('upstream_5xx', `Upstream ${status}`);
+        }
+        if (status && status >= 400) {
+            return degraded('parse_error', `Upstream ${status}`);
+        }
+        return degraded('network', err.message);
+    }
+}
+
+function categoryFor(type: DirectorySiteEntry['type']): FeedCategory {
+    switch (type) {
+        case 'user_registered':
+            return 'users';
+        case 'item_created':
+        case 'item_status_changed':
+            return 'submissions';
+        case 'report_created':
+            return 'reports';
+    }
+}
+
+function mapEntry(entry: UpstreamEntry): DirectorySiteEntry {
+    return {
+        id: entry.id,
+        source: 'directory-site',
+        type: entry.type,
+        category: categoryFor(entry.type),
+        timestamp: entry.timestamp,
+        summary: entry.summary,
+        actor: entry.actor ?? null,
+        target: entry.target,
+    };
+}
+
+function serialiseQuery(params: DirectoryFeedFetchParams): string {
+    const pairs: [string, string][] = [];
+    if (params.since) {
+        pairs.push(['since', params.since]);
+    }
+    pairs.push(['limit', String(params.limit)]);
+    pairs.push(['types', params.types.join(',')]);
+    pairs.sort(([a], [b]) => a.localeCompare(b));
+    return pairs.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+}
+
+function sign(timestamp: string, queryString: string, workId: string, secret: string): string {
+    return createHmac('sha256', secret)
+        .update(`${timestamp}:${queryString}:${workId}`)
+        .digest('hex');
+}
+
+function stripTrailingSlash(url: string): string {
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function degraded(reason: FeedDegradedReason['reason'], detail?: string): DirectoryFeedResult {
+    return { ok: false, degraded: { reason, detail } };
+}
+
+function isPermanent(reason: FeedDegradedReason['reason']): boolean {
+    return (
+        reason === 'not_provisioned' ||
+        reason === 'disabled' ||
+        reason === 'unauthorized' ||
+        reason === 'parse_error'
+    );
+}

--- a/apps/api/src/works/activity-feed/dto/feed-entry.dto.ts
+++ b/apps/api/src/works/activity-feed/dto/feed-entry.dto.ts
@@ -1,0 +1,82 @@
+import type { ActivityActionType, ActivityStatus } from '@ever-works/agent/entities';
+import type { WorkHistoryActivityType } from '@ever-works/contracts/api';
+
+/**
+ * Categories surfaced as filter chips in the Activity Feed UI. Maps to a set
+ * of `type` values across the active feed sources (platform activity-log,
+ * work generation history, deployed-site events). The per-Work
+ * `activitySyncMode` (pull / push / disabled — EW-120) decides which of the
+ * website-sourced category populations is live. See
+ * `ActivityFeedService.compose`.
+ */
+export type FeedCategory =
+    | 'all'
+    | 'generation'
+    | 'items'
+    | 'deployment'
+    | 'settings'
+    | 'comparisons'
+    | 'communityPr'
+    | 'users'
+    | 'submissions'
+    | 'reports';
+
+export const FEED_CATEGORIES: readonly FeedCategory[] = [
+    'all',
+    'generation',
+    'items',
+    'deployment',
+    'settings',
+    'comparisons',
+    'communityPr',
+    'users',
+    'submissions',
+    'reports',
+];
+
+/**
+ * Discriminated union normalising the feed sources into a single shape the web
+ * client can render uniformly. `directory-site` entries only appear in
+ * pull-mode (`activitySyncMode === 'pull'`); push-mode rows arrive as ordinary
+ * `platform-activity-log` entries via the `/api/activity-log/ingest`
+ * endpoint.
+ */
+export type FeedEntry = PlatformActivityLogEntry | GenerationHistoryEntry | DirectorySiteEntry;
+
+interface FeedEntryBase {
+    id: string;
+    timestamp: string;
+    category: FeedCategory;
+    summary: string;
+}
+
+export interface PlatformActivityLogEntry extends FeedEntryBase {
+    source: 'platform-activity-log';
+    type: ActivityActionType;
+    status: ActivityStatus;
+    details?: Record<string, unknown> | null;
+}
+
+export interface GenerationHistoryEntry extends FeedEntryBase {
+    source: 'generation-history';
+    type: WorkHistoryActivityType;
+    status: string;
+    runId: string;
+    newItemsCount: number;
+    updatedItemsCount: number;
+    totalItemsCount: number;
+    durationInSeconds?: number | null;
+}
+
+/**
+ * Pull-mode entry produced by `DirectoryWebsiteClient` after an HMAC-signed
+ * fetch against the deployed directory site's `/api/platform/activity-feed`
+ * endpoint. The link target is the deployed site's admin URL (operator-side
+ * click-through), not a platform route.
+ */
+export interface DirectorySiteEntry extends FeedEntryBase {
+    source: 'directory-site';
+    type: 'user_registered' | 'item_created' | 'item_status_changed' | 'report_created';
+    actor: { id: string; name: string; email?: string | null } | null;
+    target: { id: string; type: 'user' | 'item' | 'report'; name: string; adminUrl: string };
+}

--- a/apps/api/src/works/activity-feed/dto/feed-query.dto.ts
+++ b/apps/api/src/works/activity-feed/dto/feed-query.dto.ts
@@ -1,0 +1,36 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { FEED_CATEGORIES, type FeedCategory } from './feed-entry.dto';
+
+export class FeedQueryDto {
+    @ApiPropertyOptional({
+        description:
+            'Cursor returned from a previous response. When present, results returned are older than this cursor.',
+    })
+    @IsOptional()
+    @IsString()
+    cursor?: string;
+
+    @ApiPropertyOptional({
+        description: 'Maximum number of entries to return (1-200).',
+        default: 50,
+        minimum: 1,
+        maximum: 200,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(200)
+    limit?: number;
+
+    @ApiPropertyOptional({
+        description: 'Filter chip selected in the UI. "all" disables filtering.',
+        enum: FEED_CATEGORIES,
+        default: 'all',
+    })
+    @IsOptional()
+    @IsEnum(FEED_CATEGORIES as unknown as Record<string, FeedCategory>)
+    category?: FeedCategory;
+}

--- a/apps/api/src/works/activity-feed/dto/feed-response.dto.ts
+++ b/apps/api/src/works/activity-feed/dto/feed-response.dto.ts
@@ -1,0 +1,29 @@
+import type { FeedEntry } from './feed-entry.dto';
+
+/**
+ * Pull-mode degraded reason — populated only when `activitySyncMode = 'pull'`
+ * and the platform's fetch against the deployed site failed. Push-mode and
+ * disabled Works never set this field. The web client surfaces it via the
+ * `DegradedBanner` component (EW-120).
+ */
+export interface FeedDegradedReason {
+    reason:
+        | 'not_provisioned'
+        | 'disabled'
+        | 'timeout'
+        | 'unauthorized'
+        | 'upstream_5xx'
+        | 'network'
+        | 'parse_error';
+    detail?: string;
+    lastSuccessAt?: string | null;
+}
+
+export interface FeedResponse {
+    entries: FeedEntry[];
+    nextCursor?: string | null;
+    serverTime: string;
+    degraded?: {
+        directorySite?: FeedDegradedReason;
+    };
+}

--- a/apps/api/src/works/works.controller.advanced-prompts-import.spec.ts
+++ b/apps/api/src/works/works.controller.advanced-prompts-import.spec.ts
@@ -137,6 +137,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.comparisons-misc.spec.ts
+++ b/apps/api/src/works/works.controller.comparisons-misc.spec.ts
@@ -145,6 +145,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 
@@ -596,6 +597,110 @@ describe('WorksController — comparisons + community-pr + source-validation end
                 } as any),
             ).rejects.toThrow('quota');
             expect(s.activityLogService.log).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('rotateActivitySyncSecret (EW-120)', () => {
+        const auth = { userId: 'auth-1' } as AuthenticatedUser;
+
+        // Pull the controller's `platformSyncSecretService` constructor stub
+        // out of the closure each test by replacing the makeController call
+        // with one that captures the mock. Simpler: use a fresh controller
+        // with a fresh stub per test.
+
+        function buildWithRotator(rotate: jest.Mock) {
+            const stubs = makeStubs();
+            stubs.activityLogService = { log: jest.fn().mockResolvedValue(undefined) };
+            const controller = new WorksController(
+                stubs.cacheManager as any,
+                stubs.cacheEntryRepository as any,
+                stubs.workQueryService as any,
+                stubs.workLifecycleService as any,
+                stubs.workGenerationService as any,
+                stubs.authService as any,
+                stubs.workDetailService as any,
+                stubs.workScheduleService as any,
+                stubs.workImportService as any,
+                stubs.repositoryManagementService as any,
+                stubs.workOwnershipService as any,
+                stubs.workAdvancedPromptsService as any,
+                stubs.workTaxonomyService as any,
+                stubs.generatorFormSchemaService as any,
+                stubs.itemHealthService as any,
+                stubs.communityPrProcessorService as any,
+                stubs.comparisonGenerationService as any,
+                stubs.workRepository as any,
+                stubs.sourceValidationService as any,
+                stubs.subscriptionService as any,
+                stubs.activityLogService as any,
+                stubs.templateCatalogService as any,
+                stubs.itemExportService as any,
+                stubs.itemImportService as any,
+                stubs.itemImportExecutor as any,
+                { rotate, getOrGenerate: jest.fn() } as any,
+            );
+            return { controller, stubs };
+        }
+
+        it('rotates the secret on pull-mode Works + emits the activity log', async () => {
+            const rotate = jest.fn().mockResolvedValue('new-secret-hex');
+            const { controller, stubs } = buildWithRotator(rotate);
+            stubs.workRepository.findById.mockResolvedValue({
+                id: 'work-1',
+                activitySyncMode: 'pull',
+            });
+
+            const result = await controller.rotateActivitySyncSecret(auth, 'work-1');
+
+            expect(rotate).toHaveBeenCalledWith('work-1');
+            expect(stubs.workOwnershipService.ensureAccess).toHaveBeenCalledWith(
+                'work-1',
+                'auth-1',
+            );
+            expect(result).toEqual({ status: 'success', redeployRequired: true });
+            // Activity-log write fires (best-effort, .catch() swallowed).
+            await new Promise((r) => setImmediate(r));
+            expect(stubs.activityLogService.log).toHaveBeenCalledWith(
+                expect.objectContaining({ action: 'work.activity_sync.secret_rotated' }),
+            );
+        });
+
+        it.each(['push', 'disabled'] as const)(
+            'returns 409 (mode-mismatch) when Work is in %s mode',
+            async (mode) => {
+                const rotate = jest.fn();
+                const { controller, stubs } = buildWithRotator(rotate);
+                stubs.workRepository.findById.mockResolvedValue({
+                    id: 'work-1',
+                    activitySyncMode: mode,
+                });
+
+                let captured: any;
+                try {
+                    await controller.rotateActivitySyncSecret(auth, 'work-1');
+                } catch (err) {
+                    captured = err;
+                }
+                expect(captured).toBeDefined();
+                const response = (captured as { getResponse: () => unknown }).getResponse() as {
+                    error: string;
+                    mode: string;
+                };
+                expect(response.error).toBe('mode-mismatch');
+                expect(response.mode).toBe(mode);
+                expect(rotate).not.toHaveBeenCalled();
+            },
+        );
+
+        it('returns 404 when the Work does not exist', async () => {
+            const rotate = jest.fn();
+            const { controller, stubs } = buildWithRotator(rotate);
+            stubs.workRepository.findById.mockResolvedValue(null);
+
+            await expect(controller.rotateActivitySyncSecret(auth, 'missing')).rejects.toThrow(
+                NotFoundException,
+            );
+            expect(rotate).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/api/src/works/works.controller.crud.spec.ts
+++ b/apps/api/src/works/works.controller.crud.spec.ts
@@ -165,6 +165,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.domain-repo.spec.ts
+++ b/apps/api/src/works/works.controller.domain-repo.spec.ts
@@ -144,6 +144,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.export.spec.ts
+++ b/apps/api/src/works/works.controller.export.spec.ts
@@ -152,6 +152,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.generation.spec.ts
+++ b/apps/api/src/works/works.controller.generation.spec.ts
@@ -128,6 +128,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.items.spec.ts
+++ b/apps/api/src/works/works.controller.items.spec.ts
@@ -134,6 +134,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.schedule.spec.ts
+++ b/apps/api/src/works/works.controller.schedule.spec.ts
@@ -134,6 +134,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.taxonomy.spec.ts
+++ b/apps/api/src/works/works.controller.taxonomy.spec.ts
@@ -140,6 +140,7 @@ function makeController(s: Stubs): WorksController {
         s.itemExportService as any,
         s.itemImportService as any,
         s.itemImportExecutor as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.ts
+++ b/apps/api/src/works/works.controller.ts
@@ -1,6 +1,7 @@
 import {
     BadRequestException,
     Body,
+    ConflictException,
     Controller,
     Delete,
     Get,
@@ -88,6 +89,7 @@ import {
     ItemHealthService,
     ItemSourceValidationSchedulerService,
     type SourceValidationSettingsDto,
+    PlatformSyncSecretService,
 } from '@ever-works/agent/services';
 import { ComparisonGenerationService } from '@ever-works/agent/comparison-generator';
 import { TemplateCatalogService } from '@ever-works/agent/template-catalog';
@@ -217,6 +219,7 @@ export class WorksController {
         private readonly itemExportService: ItemExportService,
         private readonly itemImportService: ItemImportService,
         private readonly itemImportExecutor: ItemImportExecutorService,
+        private readonly platformSyncSecretService: PlatformSyncSecretService,
     ) {}
 
     private async invalidateWorkCaches(workId: string): Promise<void> {
@@ -343,6 +346,47 @@ export class WorksController {
             })
             .catch(() => {});
         return result;
+    }
+
+    @Post('works/:id/activity-sync/rotate-secret')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Rotate the per-Work pull-transport HMAC secret (EW-120)',
+        description:
+            'Generates a fresh `PLATFORM_SYNC_SECRET` and persists it AES-256-GCM-encrypted on the Work row. The new value only reaches the deployed site at the next deploy — the response includes `redeployRequired: true` so the settings UI can surface that warning. Pull-mode Works only; 409 returned for push/disabled.',
+    })
+    @ApiParam({ name: 'id', description: 'Work ID' })
+    @ApiResponse({ status: 200, description: 'Secret rotated; redeploy required to propagate' })
+    @ApiResponse({ status: 403, description: 'Caller is not a Work owner / manager' })
+    @ApiResponse({ status: 409, description: 'Work is not in pull mode' })
+    async rotateActivitySyncSecret(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') id: string,
+    ) {
+        await this.workOwnershipService.ensureAccess(id, auth.userId);
+        const work = await this.workRepository.findById(id);
+        if (!work) {
+            throw new NotFoundException({ status: 'error', message: 'Work not found' });
+        }
+        if (work.activitySyncMode !== 'pull') {
+            throw new ConflictException({
+                error: 'mode-mismatch',
+                mode: work.activitySyncMode,
+                message: `Activity-sync secret rotation is only supported for pull-mode Works; current mode is "${work.activitySyncMode}".`,
+            });
+        }
+        await this.platformSyncSecretService.rotate(id);
+        this.activityLogService
+            .log({
+                userId: auth.userId,
+                workId: id,
+                actionType: ActivityActionType.WORK_UPDATED,
+                action: 'work.activity_sync.secret_rotated',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Rotated Activity Feed sync secret (pull transport)',
+            })
+            .catch(() => {});
+        return { status: 'success', redeployRequired: true };
     }
 
     @Get('works/:id/items')

--- a/apps/api/src/works/works.module.ts
+++ b/apps/api/src/works/works.module.ts
@@ -10,6 +10,7 @@ import { FacadesModule } from '@ever-works/agent/facades';
 import { SubscriptionsModule } from '@ever-works/agent/subscriptions';
 import { ActivityLogModule } from '@ever-works/agent/activity-log';
 import { ItemsGeneratorModule } from '@ever-works/agent/items-generator';
+import { ActivityFeedModule } from './activity-feed/activity-feed.module';
 
 // Controllers
 import { WorksController } from './works.controller';
@@ -36,6 +37,7 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         SubscriptionsModule,
         ActivityLogModule,
         ItemsGeneratorModule,
+        ActivityFeedModule,
     ],
     providers: [
         CacheEntryRepository,

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "نظرة عامة",
+                "activity": "Activity Feed",
                 "items": "العناصر",
                 "generator": "مولد",
                 "schedule": "جدولة",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "مستودع البيانات"
             },
             "activity": {
-                "title": "النشاط الحديث",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "لا يوجد نشاط بعد",
                 "created": "تم إنشاء العمل",
                 "workCreated": "تم إنشاء العمل بنجاح",
-                "justNow": "الآن"
+                "justNow": "الآن",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "عناصر العمل",
@@ -2170,6 +2209,40 @@
                     "save": "حفظ الملتزم",
                     "saved": "تم حفظ إعدادات الملتزم",
                     "saveFailed": "فشل في حفظ إعدادات الملتزم"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Преглед",
+                "activity": "Activity Feed",
                 "items": "Елементи",
                 "generator": "Генератор",
                 "schedule": "График",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Репозиторий за данни"
             },
             "activity": {
-                "title": "Последна активност",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Още няма активност",
                 "created": "Работа създадена",
                 "workCreated": "Работата беше създадена успешно",
-                "justNow": "Преди миг"
+                "justNow": "Преди миг",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Елементи в работата",
@@ -2170,6 +2209,40 @@
                     "save": "Съхрани комитъра",
                     "saved": "Настройките на комитъра са съхранени",
                     "saveFailed": "Грешка при съхраняване на настройките на комитъра"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Übersicht",
+                "activity": "Activity Feed",
                 "items": "Elemente",
                 "generator": "Generator",
                 "schedule": "Zeitplan",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Datenspeicher"
             },
             "activity": {
-                "title": "Aktuelle Aktivität",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Noch keine Aktivität",
                 "created": "Werk erstellt",
                 "workCreated": "Werk erfolgreich erstellt",
-                "justNow": "Gerade eben"
+                "justNow": "Gerade eben",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Werkeinträge",
@@ -2170,6 +2209,40 @@
                     "save": "Committer speichern",
                     "saved": "Committer-Einstellungen gespeichert",
                     "saveFailed": "Fehler beim Speichern der Committer-Einstellungen"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1040,6 +1040,7 @@
             },
             "tabs": {
                 "overview": "Overview",
+                "activity": "Activity Feed",
                 "items": "Items",
                 "generator": "Generator",
                 "schedule": "Schedule",
@@ -1471,11 +1472,49 @@
                 "dataRepository": "Data Repository"
             },
             "activity": {
-                "title": "Recent Activity",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "No activity yet",
                 "created": "Work Created",
                 "workCreated": "Work was successfully created",
-                "justNow": "Just now"
+                "justNow": "Just now",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Work Items",
@@ -2201,6 +2240,40 @@
                     "save": "Save Committer",
                     "saved": "Committer settings saved",
                     "saveFailed": "Failed to save committer settings"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Resumen",
+                "activity": "Activity Feed",
                 "items": "Elementos",
                 "generator": "Generador",
                 "schedule": "Programación",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Repositorio de datos"
             },
             "activity": {
-                "title": "Actividad reciente",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Aún no hay actividad",
                 "created": "Trabajo creado",
                 "workCreated": "El trabajo se creó exitosamente",
-                "justNow": "Ahora mismo"
+                "justNow": "Ahora mismo",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Elementos del trabajo",
@@ -2170,6 +2209,40 @@
                     "save": "Guardar committer",
                     "saved": "Configuración de committer guardada",
                     "saveFailed": "Error al guardar la configuración de committer"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Aperçu",
+                "activity": "Activity Feed",
                 "items": "Éléments",
                 "generator": "Générateur",
                 "schedule": "Programmation",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Dépôt de données"
             },
             "activity": {
-                "title": "Activité récente",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Aucune activité pour le moment",
                 "created": "Travail créé",
                 "workCreated": "Travail créé avec succès",
-                "justNow": "À l'instant"
+                "justNow": "À l'instant",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Éléments du travail",
@@ -2170,6 +2209,40 @@
                     "save": "Enregistrer le commiteur",
                     "saved": "Paramètres du commiteur enregistrés",
                     "saveFailed": "Échec de l'enregistrement des paramètres du commiteur"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "סקירה כללית",
+                "activity": "Activity Feed",
                 "items": "פריטים",
                 "generator": "מחולל",
                 "schedule": "לוח זמנים",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "מאגר נתונים"
             },
             "activity": {
-                "title": "פעילות אחרונה",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "עדיין אין פעילות",
                 "created": "עבודה נוצרה",
                 "workCreated": "העבודה נוצרה בהצלחה",
-                "justNow": "רק עכשיו"
+                "justNow": "רק עכשיו",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "פריטי העבודה",
@@ -2170,6 +2209,40 @@
                     "save": "שמור מבצע",
                     "saved": "הגדרות מבצע נשמרו",
                     "saveFailed": "נכשל בשמירת הגדרות מבצע"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "अवलोकन",
+                "activity": "Activity Feed",
                 "items": "आइटम",
                 "generator": "जनरेटर",
                 "schedule": "अनुसूची",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "डेटा रिपॉजिटरी"
             },
             "activity": {
-                "title": "हाल की गतिविधि",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "अभी तक कोई गतिविधि नहीं",
                 "created": "कार्य बनाई गई",
                 "workCreated": "कार्य सफलतापूर्वक बनाई गई",
-                "justNow": "अभी"
+                "justNow": "अभी",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "कार्य आइटम",
@@ -2170,6 +2209,40 @@
                     "save": "कमिटर सहेजें",
                     "saved": "कमिटर सेटिंग्स सहेजी गईं",
                     "saveFailed": "कमिटर सेटिंग्स सहेजने में विफल"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Ringkasan",
+                "activity": "Activity Feed",
                 "items": "Item",
                 "generator": "Generator",
                 "schedule": "Jadwal",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Repositori Data"
             },
             "activity": {
-                "title": "Aktivitas Terbaru",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Belum ada aktivitas",
                 "created": "Karya Dibuat",
                 "workCreated": "Karya berhasil dibuat",
-                "justNow": "Baru saja"
+                "justNow": "Baru saja",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Item Karya",
@@ -2170,6 +2209,40 @@
                     "save": "Simpan Committer",
                     "saved": "Pengaturan committer disimpan",
                     "saveFailed": "Gagal menyimpan pengaturan committer"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Panoramica",
+                "activity": "Activity Feed",
                 "items": "Elementi",
                 "generator": "Generatore",
                 "schedule": "Programmazione",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Repository dati"
             },
             "activity": {
-                "title": "Attività recente",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Nessuna attività ancora",
                 "created": "Lavori creata",
                 "workCreated": "Lavori creata con successo",
-                "justNow": "Proprio ora"
+                "justNow": "Proprio ora",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Elementi Lavori",
@@ -2170,6 +2209,40 @@
                     "save": "Salva Committer",
                     "saved": "Impostazioni committer salvate",
                     "saveFailed": "Impossibile salvare le impostazioni committer"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "概要",
+                "activity": "Activity Feed",
                 "items": "アイテム",
                 "generator": "ジェネレーター",
                 "schedule": "スケジュール",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "データリポジトリ"
             },
             "activity": {
-                "title": "最近のアクティビティ",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "まだアクティビティなし",
                 "created": "ワーク作成",
                 "workCreated": "ワークが正常に作成されました",
-                "justNow": "たった今"
+                "justNow": "たった今",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "ワーク項目",
@@ -2170,6 +2209,40 @@
                     "save": "コミッターを保存",
                     "saved": "コミッター設定が保存されました",
                     "saveFailed": "コミッター設定の保存に失敗しました"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "개요",
+                "activity": "Activity Feed",
                 "items": "항목",
                 "generator": "생성기",
                 "schedule": "스케줄",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "데이터 리포지토리"
             },
             "activity": {
-                "title": "최근 활동",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "아직 활동 없음",
                 "created": "워크 생성",
                 "workCreated": "워크가 성공적으로 생성되었습니다",
-                "justNow": "방금"
+                "justNow": "방금",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "워크 항목",
@@ -2170,6 +2209,40 @@
                     "save": "커미터 저장",
                     "saved": "커미터 설정이 저장되었습니다",
                     "saveFailed": "커미터 설정 저장 실패"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Overzicht",
+                "activity": "Activity Feed",
                 "items": "Items",
                 "generator": "Generator",
                 "schedule": "Planning",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Dat-repository"
             },
             "activity": {
-                "title": "Recente activiteit",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Nog geen activiteit",
                 "created": "Map aangemaakt",
                 "workCreated": "Map is succesvol aangemaakt",
-                "justNow": "Zojuist"
+                "justNow": "Zojuist",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Werk-items",
@@ -2170,6 +2209,40 @@
                     "save": "Committer opslaan",
                     "saved": "Committer-instellingen opgeslagen",
                     "saveFailed": "Kon committer-instellingen niet opslaan"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Przegląd",
+                "activity": "Activity Feed",
                 "items": "Elementy",
                 "generator": "Generator",
                 "schedule": "Harmonogram",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Repozytorium danych"
             },
             "activity": {
-                "title": "Ostatnia aktywność",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Brak aktywności",
                 "created": "Praca utworzony",
                 "workCreated": "Praca został pomyślnie utworzony",
-                "justNow": "Przed chwilą"
+                "justNow": "Przed chwilą",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Elementy pracy",
@@ -2170,6 +2209,40 @@
                     "save": "Zapisz autora",
                     "saved": "Ustawienia autora zapisane",
                     "saveFailed": "Nie udało się zapisać ustawień autora"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Visão Geral",
+                "activity": "Activity Feed",
                 "items": "Itens",
                 "generator": "Gerador",
                 "schedule": "Agendamento",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Repositório de Dados"
             },
             "activity": {
-                "title": "Atividade Recente",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Nenhuma atividade ainda",
                 "created": "Trabalho Criado",
                 "workCreated": "Trabalho criado com sucesso",
-                "justNow": "Agora mesmo"
+                "justNow": "Agora mesmo",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Itens do Trabalho",
@@ -2170,6 +2209,40 @@
                     "save": "Salvar Committer",
                     "saved": "Configurações do committer salvas",
                     "saveFailed": "Falha ao salvar configurações do committer"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Обзор",
+                "activity": "Activity Feed",
                 "items": "Элементы",
                 "generator": "Генератор",
                 "schedule": "Расписание",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Репозиторий данных"
             },
             "activity": {
-                "title": "Недавняя активность",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Активности пока нет",
                 "created": "Работа создан",
                 "workCreated": "Работа успешно создан",
-                "justNow": "Только что"
+                "justNow": "Только что",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Элементы работы",
@@ -2170,6 +2209,40 @@
                     "save": "Сохранить автора",
                     "saved": "Настройки автора сохранены",
                     "saveFailed": "Не удалось сохранить настройки автора"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "ภาพรวม",
+                "activity": "Activity Feed",
                 "items": "รายการ",
                 "generator": "เครื่องสร้าง",
                 "schedule": "กำหนดการ",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "คลังข้อมูล"
             },
             "activity": {
-                "title": "กิจกรรมล่าสุด",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "ยังไม่มีกิจกรรม",
                 "created": "สร้างงาน",
                 "workCreated": "สร้างงานเรียบร้อยแล้ว",
-                "justNow": "เมื่อครู่นี้"
+                "justNow": "เมื่อครู่นี้",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "รายการงาน",
@@ -2170,6 +2209,40 @@
                     "save": "บันทึก Committer",
                     "saved": "บันทึกการตั้งค่า Committer เรียบร้อยแล้ว",
                     "saveFailed": "ไม่สามารถบันทึกการตั้งค่า Committer ได้"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Genel Bakış",
+                "activity": "Activity Feed",
                 "items": "Öğeler",
                 "generator": "Oluşturucu",
                 "schedule": "Program",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Veri Deposu"
             },
             "activity": {
-                "title": "Son Etkinlik",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Henüz etkinlik yok",
                 "created": "İş Oluşturuldu",
                 "workCreated": "İş başarıyla oluşturuldu",
-                "justNow": "Az önce"
+                "justNow": "Az önce",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "İş Öğeleri",
@@ -2170,6 +2209,40 @@
                     "save": "Committer'ı Kaydet",
                     "saved": "Committer ayarları kaydedildi",
                     "saveFailed": "Committer ayarları kaydedilemedi"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Огляд",
+                "activity": "Activity Feed",
                 "items": "Елементи",
                 "generator": "Генератор",
                 "schedule": "Розклад",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Репозиторій даних"
             },
             "activity": {
-                "title": "Недавня активність",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Активності ще немає",
                 "created": "Робота створено",
                 "workCreated": "Робота успішно створено",
-                "justNow": "Щойно"
+                "justNow": "Щойно",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Елементи роботау",
@@ -2170,6 +2209,40 @@
                     "save": "Зберегти комітера",
                     "saved": "Налаштування комітера збережено",
                     "saveFailed": "Не вдалося зберегти налаштування комітера"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "Tổng quan",
+                "activity": "Activity Feed",
                 "items": "Mục",
                 "generator": "Trình tạo",
                 "schedule": "Lịch trình",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "Kho dữ liệu"
             },
             "activity": {
-                "title": "Hoạt động gần đây",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "Chưa có hoạt động",
                 "created": "Đã tạo công việc",
                 "workCreated": "Công việc đã được tạo thành công",
-                "justNow": "Vừa xong"
+                "justNow": "Vừa xong",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "Các Mục Danh Mục",
@@ -2170,6 +2209,40 @@
                     "save": "Lưu Người cam kết",
                     "saved": "Cài đặt người cam kết đã lưu",
                     "saveFailed": "Lưu cài đặt người cam kết thất bại"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1009,6 +1009,7 @@
             },
             "tabs": {
                 "overview": "概览",
+                "activity": "Activity Feed",
                 "items": "项目",
                 "generator": "生成器",
                 "schedule": "计划",
@@ -1440,11 +1441,49 @@
                 "dataRepository": "数据仓库"
             },
             "activity": {
-                "title": "最近活动",
+                "title": "Activity Feed",
+                "subtitle": "Everything that's happening on this directory",
                 "noActivity": "尚未有活动",
                 "created": "作品已创建",
                 "workCreated": "作品创建成功",
-                "justNow": "刚刚"
+                "justNow": "刚刚",
+                "empty": {
+                    "title": "No activity yet",
+                    "body": "Run a generation, add an item, or wait for visitors to see events here."
+                },
+                "actions": {
+                    "refresh": "Refresh",
+                    "viewAll": "View all"
+                },
+                "filters": {
+                    "label": "Filter by category",
+                    "all": "All",
+                    "generation": "Generation",
+                    "items": "Items",
+                    "deployment": "Deployment",
+                    "settings": "Settings",
+                    "comparisons": "Comparisons",
+                    "communityPr": "Community PR",
+                    "users": "Users",
+                    "submissions": "Submissions",
+                    "reports": "Reports"
+                },
+                "degraded": {
+                    "title": {
+                        "not_provisioned": "Deployed-site events not yet available",
+                        "disabled": "Deployed-site sync is turned off in Settings",
+                        "timeout": "Deployed-site events temporarily unavailable",
+                        "unauthorized": "Deployed-site rejected the request",
+                        "upstream_5xx": "Deployed-site is currently unreachable",
+                        "network": "Network error reaching the deployed site",
+                        "parse_error": "Unexpected response from the deployed site"
+                    },
+                    "lastSuccess": "Last successful sync: {time}",
+                    "lastSuccessNever": "Never synced. Will retry on next deploy."
+                },
+                "entry": {
+                    "itemsSummary": "{added, plural, =0 {} other {# added}} {updated, plural, =0 {} other {# updated}}"
+                }
             },
             "items": {
                 "title": "作品项目",
@@ -2170,6 +2209,40 @@
                     "save": "保存提交者",
                     "saved": "提交者设置已保存",
                     "saveFailed": "保存提交者设置失败"
+                },
+                "activitySync": {
+                    "title": "Activity Feed sync (EW-120)",
+                    "subtitle": "Choose how the platform learns about user-facing events from this directory's deployed site (signups, item submissions, reports).",
+                    "defaultBadge": "default",
+                    "modeLegend": "Activity Feed sync transport",
+                    "modes": {
+                        "pull": {
+                            "label": "Pull",
+                            "description": "Platform fetches the deployed site on demand using a per-Work HMAC secret. Requires the template to expose a `/_platform/events` endpoint."
+                        },
+                        "push": {
+                            "label": "Push",
+                            "description": "Deployed site POSTs each event to the platform with a shared bearer token. Lighter coupling — template only needs to fire four fetch calls."
+                        },
+                        "disabled": {
+                            "label": "Disabled",
+                            "description": "Website events are not surfaced in the feed. Platform activity-log + generation history still appear."
+                        }
+                    },
+                    "modeUpdated": "Switched to {mode} mode",
+                    "modeUpdateFailed": "Failed to update sync mode",
+                    "rotate": {
+                        "label": "Rotate sync secret",
+                        "description": "Generates a new HMAC secret. The deployed site will start using the new value only after the next deploy — redeploy required.",
+                        "action": "Rotate secret"
+                    },
+                    "rotateConfirm": "Rotate the Activity Feed sync secret? The deployed site will start failing until you trigger a redeploy.",
+                    "rotateSuccess": "Secret rotated. Redeploy this directory to propagate.",
+                    "rotateFailed": "Failed to rotate sync secret",
+                    "status": {
+                        "lastSuccess": "Last successful pull: {time}",
+                        "lastError": "Last error: {error}"
+                    }
                 }
             },
             "deploy": {

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/activity/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/activity/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { workAPI } from '@/lib/api';
+import { ActivityFeedClient } from '@/components/works/detail/activity/ActivityFeedClient';
+import type { FeedCategory } from '@/lib/api/works/activity-feed.types';
+import { FEED_CATEGORIES } from '@/lib/api/works/activity-feed.types';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.workDetail.activity');
+    return { title: t('title') };
+}
+
+type Params = {
+    params: Promise<{ id: string }>;
+    searchParams: Promise<{ category?: string }>;
+};
+
+function parseCategory(value: string | undefined): FeedCategory {
+    if (value && (FEED_CATEGORIES as readonly string[]).includes(value)) {
+        return value as FeedCategory;
+    }
+    return 'all';
+}
+
+export default async function WorkActivityPage({ params, searchParams }: Params) {
+    const { id } = await params;
+    const { category } = await searchParams;
+
+    try {
+        await workAPI.get(id);
+    } catch {
+        notFound();
+    }
+
+    return <ActivityFeedClient workId={id} initialCategory={parseCategory(category)} />;
+}

--- a/apps/web/src/app/actions/dashboard/activity-feed.ts
+++ b/apps/web/src/app/actions/dashboard/activity-feed.ts
@@ -1,0 +1,23 @@
+'use server';
+
+import {
+    activityFeedAPI,
+    type FeedResponse,
+    type GetActivityFeedParams,
+} from '@/lib/api/works/activity-feed';
+
+export async function getActivityFeed(
+    workId: string,
+    params?: GetActivityFeedParams,
+): Promise<{ success: true; data: FeedResponse } | { success: false; error: string }> {
+    try {
+        const data = await activityFeedAPI.get(workId, params);
+        return { success: true, data };
+    } catch (error) {
+        console.error(`Failed to get activity feed for work ${workId}:`, error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to get activity feed',
+        };
+    }
+}

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -24,7 +24,7 @@ import { ROUTES } from '@/lib/constants';
 import { redirect } from 'next/navigation';
 import { sanitizeName, sanitizeDescription, sanitizePrompt } from '@/lib/utils/sanitize';
 import { slugify } from '@ever-works/plugin';
-import { ApiResponseError } from '@/lib/api/server-api';
+import { ApiResponseError, serverMutation } from '@/lib/api/server-api';
 
 const readmeConfigSchema = z.object({
     header: z.string().optional(),
@@ -1069,6 +1069,55 @@ export async function updateCommunityPrSettings(
             success: false,
             error:
                 error instanceof Error ? error.message : 'Failed to update community PR settings',
+        };
+    }
+}
+
+export async function updateActivitySyncMode(workId: string, mode: 'pull' | 'push' | 'disabled') {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await workAPI.update(workId, { activitySyncMode: mode });
+        revalidatePath(`/works/${workId}/settings`);
+
+        return {
+            success: response.status === 'success',
+        };
+    } catch (error) {
+        console.error('Failed to update activity sync mode:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to update activity sync mode',
+        };
+    }
+}
+
+export async function rotateActivitySyncSecret(workId: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await serverMutation<{ status: string; redeployRequired: boolean }>({
+            endpoint: `/works/${workId}/activity-sync/rotate-secret`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+        revalidatePath(`/works/${workId}/settings`);
+        return {
+            success: response.status === 'success',
+            redeployRequired: response.redeployRequired ?? false,
+        };
+    } catch (error) {
+        console.error('Failed to rotate activity sync secret:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to rotate activity sync secret',
         };
     }
 }

--- a/apps/web/src/components/works/detail/WorkTabs.tsx
+++ b/apps/web/src/components/works/detail/WorkTabs.tsx
@@ -40,6 +40,26 @@ export function WorkTabs({ work }: WorkTabsProps) {
             isActive: pathname.endsWith(`/works/${work.id}`),
         },
         {
+            name: t('activity'),
+            href: ROUTES.DASHBOARD_WORK_ACTIVITY(work.id),
+            icon: (
+                <svg
+                    className="w-4 h-4 shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M3 12h3l3-9 6 18 3-9h3"
+                    />
+                </svg>
+            ),
+            isActive: pathname.includes('/activity'),
+        },
+        {
             name: t('items'),
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/items`,
             icon: (

--- a/apps/web/src/components/works/detail/activity/ActivityFeedClient.tsx
+++ b/apps/web/src/components/works/detail/activity/ActivityFeedClient.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
+import { useRouter, usePathname } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import { getActivityFeed } from '@/app/actions/dashboard/activity-feed';
+import type {
+    FeedCategory,
+    FeedDegradedReason,
+    FeedEntry,
+    FeedResponse,
+} from '@/lib/api/works/activity-feed.types';
+import { DegradedBanner } from './DegradedBanner';
+import { FeedFilterChips } from './FeedFilterChips';
+import { FeedRow } from './FeedRow';
+import { EmptyState } from './EmptyState';
+import { SkeletonList } from './SkeletonList';
+
+interface ActivityFeedClientProps {
+    workId: string;
+    initialCategory: FeedCategory;
+}
+
+const POLL_INTERVAL = 5000;
+const PAGE_LIMIT = 25;
+
+export function ActivityFeedClient({ workId, initialCategory }: ActivityFeedClientProps) {
+    const t = useTranslations('dashboard.workDetail.activity');
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const [category, setCategory] = useState<FeedCategory>(initialCategory);
+    const [entries, setEntries] = useState<FeedEntry[] | null>(null);
+    const [degraded, setDegraded] = useState<FeedDegradedReason | undefined>();
+    const [error, setError] = useState<string | null>(null);
+    const [refreshing, setRefreshing] = useState(false);
+    const requestIdRef = useRef(0);
+
+    const fetchFeed = useCallback(
+        async (cat: FeedCategory, silent = false): Promise<void> => {
+            if (!silent) setRefreshing(true);
+            const currentRequestId = ++requestIdRef.current;
+            try {
+                const result = await getActivityFeed(workId, {
+                    category: cat,
+                    limit: PAGE_LIMIT,
+                });
+                // Discard if a newer request has been issued in the meantime.
+                if (currentRequestId !== requestIdRef.current) return;
+                if (result.success) {
+                    const data: FeedResponse = result.data;
+                    setEntries(data.entries);
+                    // Pull-mode degraded reasons surface here; push-mode and
+                    // disabled responses leave the field undefined so the
+                    // banner stays hidden.
+                    setDegraded(data.degraded?.directorySite);
+                    setError(null);
+                } else {
+                    setError(result.error);
+                }
+            } finally {
+                if (!silent && currentRequestId === requestIdRef.current) {
+                    setRefreshing(false);
+                }
+            }
+        },
+        [workId],
+    );
+
+    // Initial fetch + refetch on category change.
+    useEffect(() => {
+        void fetchFeed(category, false);
+    }, [category, fetchFeed]);
+
+    // Polling — silent refresh, paused when tab is hidden. Mirrors the
+    // pattern used by /dashboard/activity (apps/web/src/app/[locale]/(dashboard)/activity/activity-client.tsx).
+    useEffect(() => {
+        let interval: ReturnType<typeof setInterval>;
+
+        const startPolling = () => {
+            interval = setInterval(() => {
+                if (!document.hidden) {
+                    void fetchFeed(category, true);
+                }
+            }, POLL_INTERVAL);
+        };
+
+        const handleVisibility = () => {
+            clearInterval(interval);
+            if (!document.hidden) {
+                void fetchFeed(category, true);
+                startPolling();
+            }
+        };
+
+        startPolling();
+        document.addEventListener('visibilitychange', handleVisibility);
+        return () => {
+            clearInterval(interval);
+            document.removeEventListener('visibilitychange', handleVisibility);
+        };
+    }, [category, fetchFeed]);
+
+    const handleCategoryChange = useCallback(
+        (next: FeedCategory) => {
+            setCategory(next);
+            const params = new URLSearchParams(Array.from(searchParams.entries()));
+            if (next === 'all') {
+                params.delete('category');
+            } else {
+                params.set('category', next);
+            }
+            const query = params.toString();
+            router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
+        },
+        [pathname, router, searchParams],
+    );
+
+    const handleManualRefresh = useCallback(() => {
+        void fetchFeed(category, false);
+    }, [category, fetchFeed]);
+
+    const isInitialLoading = entries === null && !error;
+    // When the pull-mode sync is permanently broken (template hasn't shipped
+    // the endpoint, or admin disabled it), dim the website-only chips so the
+    // user doesn't keep clicking into an empty Users/Submissions/Reports tab.
+    const isDirectorySyncBroken =
+        degraded?.reason === 'disabled' || degraded?.reason === 'not_provisioned';
+
+    return (
+        <div className="space-y-4">
+            <header className="flex items-start justify-between gap-4">
+                <div>
+                    <h1 className="text-xl font-semibold text-text dark:text-text-dark">
+                        {t('title')}
+                    </h1>
+                    <p className="mt-1 text-sm text-text-secondary dark:text-text-secondary-dark">
+                        {t('subtitle')}
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={handleManualRefresh}
+                    disabled={refreshing}
+                    className={cn(
+                        'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors',
+                        'border-border dark:border-border-dark',
+                        'bg-card dark:bg-card-primary-dark/30',
+                        'text-text-secondary dark:text-text-secondary-dark',
+                        'hover:bg-muted/30 dark:hover:bg-muted/10',
+                        refreshing && 'opacity-60 cursor-not-allowed',
+                    )}
+                    aria-label={t('actions.refresh')}
+                >
+                    <svg
+                        className={cn('h-3.5 w-3.5', refreshing && 'animate-spin')}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                        />
+                    </svg>
+                    {t('actions.refresh')}
+                </button>
+            </header>
+
+            <FeedFilterChips
+                value={category}
+                onChange={handleCategoryChange}
+                directorySiteDisabled={isDirectorySyncBroken}
+            />
+
+            {degraded && <DegradedBanner degraded={degraded} />}
+
+            {error && (
+                <div
+                    role="alert"
+                    className="rounded-md border border-error/30 bg-error/10 p-3 text-sm text-error"
+                >
+                    {error}
+                </div>
+            )}
+
+            {isInitialLoading && <SkeletonList />}
+
+            {!isInitialLoading && entries && entries.length === 0 && <EmptyState />}
+
+            {!isInitialLoading && entries && entries.length > 0 && (
+                <ul className="space-y-2">
+                    {entries.map((entry) => (
+                        <li key={`${entry.source}-${entry.id}`}>
+                            <FeedRow entry={entry} workId={workId} />
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/activity/ActivityFeedClient.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/activity/ActivityFeedClient.unit.spec.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockReplace = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ replace: mockReplace }),
+    usePathname: () => '/works/work-1/activity',
+    Link: ({ href, children, ...rest }: any) => (
+        <a href={typeof href === 'string' ? href : ''} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => mockSearchParams,
+}));
+
+const mockGetActivityFeed = vi.fn();
+vi.mock('@/app/actions/dashboard/activity-feed', () => ({
+    getActivityFeed: (...args: unknown[]) => mockGetActivityFeed(...args),
+}));
+
+import { ActivityFeedClient } from './ActivityFeedClient';
+
+function emptySuccess(over: Record<string, unknown> = {}) {
+    return {
+        success: true as const,
+        data: {
+            entries: [],
+            nextCursor: null,
+            serverTime: '2026-05-13T00:00:00.000Z',
+            ...over,
+        },
+    };
+}
+
+describe('ActivityFeedClient', () => {
+    beforeEach(() => {
+        mockReplace.mockReset();
+        mockGetActivityFeed.mockReset();
+    });
+
+    it('renders the empty state when the API returns zero entries', async () => {
+        mockGetActivityFeed.mockResolvedValue(emptySuccess());
+
+        render(<ActivityFeedClient workId="work-1" initialCategory="all" />);
+
+        await waitFor(() => {
+            expect(screen.getByText('empty.title')).toBeInTheDocument();
+        });
+        expect(mockGetActivityFeed).toHaveBeenCalledWith(
+            'work-1',
+            expect.objectContaining({ category: 'all', limit: 25 }),
+        );
+    });
+
+    it('surfaces the degraded banner when the API reports a pull-mode failure', async () => {
+        // Phase 5 (EW-120 dual-mode): pull-mode degraded reasons come back in
+        // `response.degraded.directorySite`. The banner uses its own scoped
+        // `useTranslations('...activity.degraded')` namespace, so the mocked
+        // `t(key)` echoes just the relative key.
+        mockGetActivityFeed.mockResolvedValue(
+            emptySuccess({
+                degraded: {
+                    directorySite: {
+                        reason: 'timeout',
+                        lastSuccessAt: '2026-05-12T10:00:00.000Z',
+                    },
+                },
+            }),
+        );
+
+        render(<ActivityFeedClient workId="work-1" initialCategory="all" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('status')).toBeInTheDocument();
+        });
+        expect(screen.getByText('title.timeout')).toBeInTheDocument();
+    });
+
+    it('updates URL when filter chip is clicked', async () => {
+        mockGetActivityFeed.mockResolvedValue(emptySuccess());
+
+        render(<ActivityFeedClient workId="work-1" initialCategory="all" />);
+        await waitFor(() => expect(mockGetActivityFeed).toHaveBeenCalledTimes(1));
+
+        const usersChip = await screen.findByRole('tab', { name: 'users' });
+        await userEvent.click(usersChip);
+
+        expect(mockReplace).toHaveBeenCalled();
+        const target = mockReplace.mock.calls[0][0] as string;
+        expect(target).toContain('category=users');
+    });
+
+    it('surfaces an error message when the action returns failure', async () => {
+        mockGetActivityFeed.mockResolvedValue({ success: false, error: 'API down' });
+
+        render(<ActivityFeedClient workId="work-1" initialCategory="all" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent('API down');
+        });
+    });
+
+    it('opens the initial category from props without forcing a URL update', async () => {
+        mockGetActivityFeed.mockResolvedValue(emptySuccess());
+
+        render(<ActivityFeedClient workId="work-1" initialCategory="deployment" />);
+
+        await waitFor(() => {
+            expect(mockGetActivityFeed).toHaveBeenCalledWith(
+                'work-1',
+                expect.objectContaining({ category: 'deployment' }),
+            );
+        });
+        // Mount must not call replace — only user-driven chip changes do.
+        expect(mockReplace).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/works/detail/activity/DegradedBanner.tsx
+++ b/apps/web/src/components/works/detail/activity/DegradedBanner.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { formatDistanceToNow } from 'date-fns';
+import { cn } from '@/lib/utils/cn';
+import type { FeedDegradedReason } from '@/lib/api/works/activity-feed.types';
+
+interface DegradedBannerProps {
+    degraded: FeedDegradedReason;
+}
+
+export function DegradedBanner({ degraded }: DegradedBannerProps) {
+    const t = useTranslations('dashboard.workDetail.activity.degraded');
+
+    const lastSuccessLabel = degraded.lastSuccessAt
+        ? t('lastSuccess', {
+              time: formatDistanceToNow(new Date(degraded.lastSuccessAt), { addSuffix: true }),
+          })
+        : t('lastSuccessNever');
+
+    return (
+        <div
+            role="status"
+            className={cn(
+                'rounded-md border p-3 mb-4',
+                'border-warning/30 bg-warning/10',
+                'text-warning-foreground dark:text-text-dark',
+            )}
+        >
+            <div className="flex items-start gap-3">
+                <svg
+                    className="h-5 w-5 shrink-0 text-warning"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"
+                    />
+                </svg>
+                <div className="flex-1 text-xs">
+                    <div className="font-medium">{t(`title.${degraded.reason}`)}</div>
+                    <div className="mt-0.5 text-text-secondary dark:text-text-secondary-dark">
+                        {lastSuccessLabel}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/activity/EmptyState.tsx
+++ b/apps/web/src/components/works/detail/activity/EmptyState.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+
+export function EmptyState() {
+    const t = useTranslations('dashboard.workDetail.activity');
+
+    return (
+        <div
+            className={cn(
+                'rounded-lg border border-dashed p-12 text-center',
+                'border-border dark:border-border-dark',
+                'bg-card/30 dark:bg-card-primary-dark/20',
+            )}
+        >
+            <svg
+                className="mx-auto h-12 w-12 text-text-muted dark:text-text-muted-dark/60"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+            >
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M3 12h3l3-9 6 18 3-9h3"
+                />
+            </svg>
+            <h3 className="mt-4 text-sm font-semibold text-text dark:text-text-dark">
+                {t('empty.title')}
+            </h3>
+            <p className="mt-1 text-sm text-text-secondary dark:text-text-secondary-dark">
+                {t('empty.body')}
+            </p>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/activity/FeedFilterChips.tsx
+++ b/apps/web/src/components/works/detail/activity/FeedFilterChips.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { FEED_CATEGORIES, type FeedCategory } from '@/lib/api/works/activity-feed.types';
+
+interface FeedFilterChipsProps {
+    value: FeedCategory;
+    onChange: (category: FeedCategory) => void;
+    /** When true, dim the website-sourced category chips. Used when pull-mode
+     *  sync is permanently broken (disabled / not_provisioned) so the user
+     *  doesn't keep clicking into empty Users/Submissions/Reports tabs. */
+    directorySiteDisabled?: boolean;
+}
+
+const DIRECTORY_CATEGORIES: ReadonlySet<FeedCategory> = new Set([
+    'users',
+    'submissions',
+    'reports',
+]);
+
+export function FeedFilterChips({ value, onChange, directorySiteDisabled }: FeedFilterChipsProps) {
+    const t = useTranslations('dashboard.workDetail.activity.filters');
+
+    return (
+        <div role="tablist" aria-label={t('label')} className="flex flex-wrap gap-1.5 mb-4">
+            {FEED_CATEGORIES.map((cat) => {
+                const isActive = cat === value;
+                const isDimmed = Boolean(directorySiteDisabled && DIRECTORY_CATEGORIES.has(cat));
+                return (
+                    <button
+                        key={cat}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        onClick={() => onChange(cat)}
+                        className={cn(
+                            'inline-flex items-center px-3 py-1 rounded-full text-xs font-medium transition-colors',
+                            'border',
+                            isActive
+                                ? 'bg-primary text-primary-foreground border-primary'
+                                : 'bg-card dark:bg-card-primary-dark/30 text-text-secondary dark:text-text-secondary-dark border-border dark:border-border-dark hover:bg-muted/30 dark:hover:bg-muted/10',
+                            isDimmed && 'opacity-50',
+                        )}
+                    >
+                        {t(cat)}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/activity/FeedFilterChips.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/activity/FeedFilterChips.unit.spec.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { FeedFilterChips } from './FeedFilterChips';
+
+describe('FeedFilterChips', () => {
+    it('renders one chip per category and marks the active one', () => {
+        render(<FeedFilterChips value="generation" onChange={() => undefined} />);
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs).toHaveLength(10);
+        const active = tabs.find((b) => b.getAttribute('aria-selected') === 'true');
+        expect(active).toBeDefined();
+        expect(active?.textContent).toBe('generation');
+    });
+
+    it('calls onChange with the clicked category', async () => {
+        const onChange = vi.fn();
+        render(<FeedFilterChips value="all" onChange={onChange} />);
+        const usersChip = screen.getByRole('tab', { name: 'users' });
+        await userEvent.click(usersChip);
+        expect(onChange).toHaveBeenCalledWith('users');
+    });
+
+    it('dims directory-site chips when directorySiteDisabled is true', () => {
+        // Phase 5 (EW-120 dual-mode): when pull-mode sync is permanently
+        // broken (disabled / not_provisioned), the website-only chips
+        // (users/submissions/reports) get dimmed so the user doesn't click
+        // into empty tabs.
+        render(<FeedFilterChips value="all" onChange={() => undefined} directorySiteDisabled />);
+        const dimmed = ['users', 'submissions', 'reports'];
+        for (const cat of dimmed) {
+            const chip = screen.getByRole('tab', { name: cat });
+            expect(chip.className).toContain('opacity-50');
+        }
+        // Non-directory chips are not dimmed.
+        const platform = screen.getByRole('tab', { name: 'deployment' });
+        expect(platform.className).not.toContain('opacity-50');
+    });
+});

--- a/apps/web/src/components/works/detail/activity/FeedRow.tsx
+++ b/apps/web/src/components/works/detail/activity/FeedRow.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { formatDistanceToNow } from 'date-fns';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import type { FeedEntry } from '@/lib/api/works/activity-feed.types';
+
+interface FeedRowProps {
+    entry: FeedEntry;
+    workId: string;
+}
+
+function IconForSource({ source }: { source: FeedEntry['source'] }) {
+    const colorClass =
+        source === 'platform-activity-log' ? 'text-info bg-info/10' : 'text-success bg-success/10';
+
+    return (
+        <span
+            className={cn(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+                colorClass,
+            )}
+            aria-hidden="true"
+        >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 12h3l3-9 6 18 3-9h3"
+                />
+            </svg>
+        </span>
+    );
+}
+
+function entryHref(entry: FeedEntry, workId: string): { href: string; external: boolean } {
+    if (entry.source === 'generation-history') {
+        return {
+            href: `${ROUTES.DASHBOARD_WORK_HISTORY(workId)}?run=${entry.runId}`,
+            external: false,
+        };
+    }
+    // Platform activity-log entries deep-link to the global activity view
+    // filtered to this entry; ActivityDetailModal embedding can come later.
+    return { href: `${ROUTES.DASHBOARD_ACTIVITY}?entry=${entry.id}`, external: false };
+}
+
+export function FeedRow({ entry, workId }: FeedRowProps) {
+    const t = useTranslations('dashboard.workDetail.activity');
+    const { href, external } = entryHref(entry, workId);
+    const relative = formatDistanceToNow(new Date(entry.timestamp), { addSuffix: true });
+
+    const content = (
+        <div
+            className={cn(
+                'flex items-start gap-3 rounded-md border p-3 transition-colors',
+                'border-border dark:border-border-dark',
+                'bg-card dark:bg-card-primary-dark/30',
+                'hover:bg-muted/30 dark:hover:bg-muted/10',
+            )}
+        >
+            <IconForSource source={entry.source} />
+            <div className="flex-1 min-w-0">
+                <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="text-sm font-medium text-text dark:text-text-dark truncate">
+                        {entry.summary}
+                    </span>
+                    <span className="text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+                        {relative}
+                    </span>
+                </div>
+                <div className="mt-1 flex items-center gap-2 text-xs text-text-secondary dark:text-text-secondary-dark">
+                    <span className="rounded-full bg-muted/40 dark:bg-muted/20 px-2 py-0.5 font-medium">
+                        {t(`filters.${entry.category}`)}
+                    </span>
+                    {entry.source === 'generation-history' && (
+                        <span>
+                            {t('entry.itemsSummary', {
+                                added: entry.newItemsCount,
+                                updated: entry.updatedItemsCount,
+                            })}
+                        </span>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+
+    if (external) {
+        return (
+            <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block focus:outline-none focus:ring-2 focus:ring-primary rounded-md"
+            >
+                {content}
+            </a>
+        );
+    }
+
+    return (
+        <Link
+            href={href}
+            className="block focus:outline-none focus:ring-2 focus:ring-primary rounded-md"
+        >
+            {content}
+        </Link>
+    );
+}

--- a/apps/web/src/components/works/detail/activity/SkeletonList.tsx
+++ b/apps/web/src/components/works/detail/activity/SkeletonList.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/lib/utils/cn';
+
+export function SkeletonList({ rows = 8 }: { rows?: number }) {
+    return (
+        <ul className="space-y-2" aria-busy="true" aria-hidden="true">
+            {Array.from({ length: rows }).map((_, idx) => (
+                <li
+                    key={idx}
+                    className={cn(
+                        'flex items-center gap-3 rounded-md border p-3',
+                        'border-border dark:border-border-dark',
+                        'bg-card dark:bg-card-primary-dark/30',
+                    )}
+                >
+                    <div className="h-8 w-8 rounded-full bg-muted dark:bg-muted/30 animate-pulse" />
+                    <div className="flex-1 space-y-2">
+                        <div className="h-3 w-2/3 rounded bg-muted dark:bg-muted/30 animate-pulse" />
+                        <div className="h-2 w-1/4 rounded bg-muted dark:bg-muted/30 animate-pulse" />
+                    </div>
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/apps/web/src/components/works/detail/overview/WorkActivity.tsx
+++ b/apps/web/src/components/works/detail/overview/WorkActivity.tsx
@@ -1,124 +1,77 @@
 'use client';
 
-import { cn } from '@/lib/utils/cn';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { formatDistanceToNow } from 'date-fns';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import { getActivityFeed } from '@/app/actions/dashboard/activity-feed';
+import type { FeedEntry } from '@/lib/api/works/activity-feed.types';
 
 interface WorkActivityProps {
     workId: string;
 }
 
-interface ActivityItem {
-    id: string;
-    type: 'created' | 'generated' | 'updated' | 'error';
-    title: string;
-    description: string;
-    timestamp: Date;
-}
+const OVERVIEW_LIMIT = 5;
+const POLL_INTERVAL = 5000;
 
+/**
+ * Compact "Recent activity" card shown on the Work Overview tab (EW-120).
+ *
+ * Pulls the top N entries from the same `/api/works/:id/activity-feed`
+ * aggregator the full Activity Feed tab uses, with the same polling +
+ * `document.hidden` pause pattern. The full tab is one click away via
+ * the "View all →" link.
+ */
 export function WorkActivity({ workId }: WorkActivityProps) {
     const t = useTranslations('dashboard.workDetail.activity');
 
-    // Mock activity data - in real app would fetch from API
-    const activities: ActivityItem[] = [
-        {
-            id: '1',
-            type: 'created',
-            title: t('created'),
-            description: t('workCreated'),
-            timestamp: new Date(),
-        },
-    ];
+    const [entries, setEntries] = useState<FeedEntry[] | null>(null);
+    const requestIdRef = useRef(0);
 
-    const getActivityIcon = (type: ActivityItem['type']) => {
-        switch (type) {
-            case 'created':
-                return (
-                    <div className="w-8 h-8 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center">
-                        <svg
-                            className="w-4 h-4 text-green-600 dark:text-green-400"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M12 4v16m8-8H4"
-                            />
-                        </svg>
-                    </div>
-                );
-            case 'generated':
-                return (
-                    <div className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
-                        <svg
-                            className="w-4 h-4 text-blue-600 dark:text-blue-400"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M13 10V3L4 14h7v7l9-11h-7z"
-                            />
-                        </svg>
-                    </div>
-                );
-            case 'updated':
-                return (
-                    <div className="w-8 h-8 rounded-full bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center">
-                        <svg
-                            className="w-4 h-4 text-yellow-600 dark:text-yellow-400"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                            />
-                        </svg>
-                    </div>
-                );
-            case 'error':
-                return (
-                    <div className="w-8 h-8 rounded-full bg-red-100 dark:bg-red-900 flex items-center justify-center">
-                        <svg
-                            className="w-4 h-4 text-red-600 dark:text-red-400"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                            />
-                        </svg>
-                    </div>
-                );
+    const fetchFeed = useCallback(async () => {
+        const currentRequestId = ++requestIdRef.current;
+        const result = await getActivityFeed(workId, { limit: OVERVIEW_LIMIT });
+        if (currentRequestId !== requestIdRef.current) return;
+        if (result.success) {
+            setEntries(result.data.entries);
+        } else {
+            // Resolve the skeleton on failure so the widget falls through
+            // to the empty state instead of spinning forever. Polling will
+            // retry every POLL_INTERVAL and recover if the API comes back.
+            setEntries((prev) => (prev === null ? [] : prev));
         }
-    };
+    }, [workId]);
 
-    const formatTimestamp = (date: Date) => {
-        const now = new Date();
-        const diff = now.getTime() - date.getTime();
-        const seconds = Math.floor(diff / 1000);
-        const minutes = Math.floor(seconds / 60);
-        const hours = Math.floor(minutes / 60);
-        const days = Math.floor(hours / 24);
+    useEffect(() => {
+        void fetchFeed();
+    }, [fetchFeed]);
 
-        if (days > 0) return `${days} day${days > 1 ? 's' : ''} ago`;
-        if (hours > 0) return `${hours} hour${hours > 1 ? 's' : ''} ago`;
-        if (minutes > 0) return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
-        return t('justNow');
-    };
+    useEffect(() => {
+        let interval: ReturnType<typeof setInterval>;
+        const startPolling = () => {
+            interval = setInterval(() => {
+                if (!document.hidden) void fetchFeed();
+            }, POLL_INTERVAL);
+        };
+        const handleVisibility = () => {
+            clearInterval(interval);
+            if (!document.hidden) {
+                void fetchFeed();
+                startPolling();
+            }
+        };
+        startPolling();
+        document.addEventListener('visibilitychange', handleVisibility);
+        return () => {
+            clearInterval(interval);
+            document.removeEventListener('visibilitychange', handleVisibility);
+        };
+    }, [fetchFeed]);
+
+    const isInitialLoading = entries === null;
+    const isEmpty = entries !== null && entries.length === 0;
 
     return (
         <div
@@ -128,33 +81,79 @@ export function WorkActivity({ workId }: WorkActivityProps) {
                 'border-card-border dark:border-border-secondary-dark',
             )}
         >
-            <h3 className="text-lg font-semibold text-text dark:text-text-dark mb-4">
-                {t('title')}
-            </h3>
+            <header className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <Link
+                    href={ROUTES.DASHBOARD_WORK_ACTIVITY(workId)}
+                    className="text-xs font-medium text-primary hover:underline"
+                >
+                    {t('actions.viewAll')} &rarr;
+                </Link>
+            </header>
 
-            {activities.length === 0 ? (
-                <p className="text-sm text-text-muted dark:text-text-muted-dark text-center py-8">
-                    {t('noActivity')}
-                </p>
-            ) : (
-                <div className="space-y-4">
-                    {activities.map((activity) => (
-                        <div key={activity.id} className="flex gap-3">
-                            {getActivityIcon(activity.type)}
-                            <div className="flex-1">
-                                <p className="text-sm font-medium text-text dark:text-text-dark">
-                                    {activity.title}
-                                </p>
-                                <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
-                                    {activity.description}
-                                </p>
-                                <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
-                                    {formatTimestamp(activity.timestamp)}
-                                </p>
+            {isInitialLoading && (
+                <div className="space-y-3" aria-busy="true" aria-hidden="true">
+                    {Array.from({ length: 3 }).map((_, idx) => (
+                        <div key={idx} className="flex items-center gap-3">
+                            <div className="h-8 w-8 rounded-full bg-muted dark:bg-muted/30 animate-pulse" />
+                            <div className="flex-1 space-y-2">
+                                <div className="h-3 w-2/3 rounded bg-muted dark:bg-muted/30 animate-pulse" />
+                                <div className="h-2 w-1/4 rounded bg-muted dark:bg-muted/30 animate-pulse" />
                             </div>
                         </div>
                     ))}
                 </div>
+            )}
+
+            {isEmpty && (
+                <p className="text-sm text-text-muted dark:text-text-muted-dark text-center py-8">
+                    {t('empty.title')}
+                </p>
+            )}
+
+            {!isInitialLoading && entries && entries.length > 0 && (
+                <ul className="space-y-3">
+                    {entries.map((entry) => (
+                        <li key={`${entry.source}-${entry.id}`} className="flex gap-3">
+                            <span
+                                className={cn(
+                                    'mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+                                    entry.source === 'platform-activity-log' &&
+                                        'bg-info/10 text-info',
+                                    entry.source === 'generation-history' &&
+                                        'bg-success/10 text-success',
+                                )}
+                                aria-hidden="true"
+                            >
+                                <svg
+                                    className="h-4 w-4"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M3 12h3l3-9 6 18 3-9h3"
+                                    />
+                                </svg>
+                            </span>
+                            <div className="flex-1 min-w-0">
+                                <p className="text-sm font-medium text-text dark:text-text-dark truncate">
+                                    {entry.summary}
+                                </p>
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
+                                    {formatDistanceToNow(new Date(entry.timestamp), {
+                                        addSuffix: true,
+                                    })}
+                                </p>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
             )}
         </div>
     );

--- a/apps/web/src/components/works/detail/overview/WorkActivity.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/overview/WorkActivity.unit.spec.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ href, children, ...rest }: any) => (
+        <a href={typeof href === 'string' ? href : ''} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+const mockGetActivityFeed = vi.fn();
+vi.mock('@/app/actions/dashboard/activity-feed', () => ({
+    getActivityFeed: (...args: unknown[]) => mockGetActivityFeed(...args),
+}));
+
+import { WorkActivity } from './WorkActivity';
+
+const baseResponse = (entries: unknown[]) => ({
+    success: true as const,
+    data: {
+        entries,
+        nextCursor: null,
+        serverTime: '2026-05-13T00:00:00.000Z',
+    },
+});
+
+describe('WorkActivity (overview widget)', () => {
+    beforeEach(() => {
+        mockGetActivityFeed.mockReset();
+    });
+
+    it('requests at most 5 entries from the aggregator', async () => {
+        mockGetActivityFeed.mockResolvedValue(baseResponse([]));
+        render(<WorkActivity workId="work-1" />);
+        await waitFor(() => expect(mockGetActivityFeed).toHaveBeenCalled());
+        expect(mockGetActivityFeed).toHaveBeenCalledWith('work-1', { limit: 5 });
+    });
+
+    it('shows empty state when there are no entries', async () => {
+        mockGetActivityFeed.mockResolvedValue(baseResponse([]));
+        render(<WorkActivity workId="work-1" />);
+        await waitFor(() => {
+            expect(screen.getByText('empty.title')).toBeInTheDocument();
+        });
+    });
+
+    it('renders entries with summary and links to the full feed', async () => {
+        mockGetActivityFeed.mockResolvedValue(
+            baseResponse([
+                {
+                    id: 'h-1',
+                    source: 'generation-history',
+                    type: 'generation',
+                    category: 'generation',
+                    timestamp: '2026-05-13T00:00:00.000Z',
+                    summary: 'Generation completed (12 added)',
+                    status: 'completed',
+                    runId: 'h-1',
+                    newItemsCount: 12,
+                    updatedItemsCount: 0,
+                    totalItemsCount: 12,
+                },
+            ]),
+        );
+
+        render(<WorkActivity workId="work-1" />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Generation completed (12 added)')).toBeInTheDocument();
+        });
+        const viewAll = screen.getByRole('link', { name: /actions\.viewAll/ });
+        expect(viewAll.getAttribute('href')).toBe('/works/work-1/activity');
+    });
+});

--- a/apps/web/src/components/works/detail/settings/ActivitySyncSettings.tsx
+++ b/apps/web/src/components/works/detail/settings/ActivitySyncSettings.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2 } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { cn } from '@/lib/utils';
+import { useSettings } from './SettingsContext';
+import { rotateActivitySyncSecret, updateActivitySyncMode } from '@/app/actions/dashboard/works';
+import { useRouter } from '@/i18n/navigation';
+import { toast } from 'sonner';
+
+type Mode = 'pull' | 'push' | 'disabled';
+const MODES: readonly Mode[] = ['pull', 'push', 'disabled'];
+
+/**
+ * EW-120 dual-mode Activity Feed sync settings.
+ *
+ * Renders a 3-mode radio + per-mode explainer, plus (for pull mode only) a
+ * "Rotate sync secret" button with a redeploy-required warning. The mode
+ * field is also writable via `works.yml` (`activity_sync.mode`); this UI is
+ * the convenience path. Both routes converge on `Work.activitySyncMode`.
+ */
+export function ActivitySyncSettings() {
+    const t = useTranslations('dashboard.workDetail.settings.activitySync');
+    const router = useRouter();
+    const { context } = useSettings();
+    const { work } = context;
+    const currentMode = (work.activitySyncMode ?? 'pull') as Mode;
+    const [pending, startTransition] = useTransition();
+    const [rotating, setRotating] = useState(false);
+
+    const handleModeChange = (next: Mode) => {
+        if (next === currentMode) return;
+        startTransition(async () => {
+            const result = await updateActivitySyncMode(work.id, next);
+            if (result.success) {
+                toast.success(t('modeUpdated', { mode: t(`modes.${next}.label`) }));
+                router.refresh();
+            } else {
+                toast.error(result.error || t('modeUpdateFailed'));
+            }
+        });
+    };
+
+    const handleRotate = async () => {
+        if (!confirm(t('rotateConfirm'))) return;
+        setRotating(true);
+        try {
+            const result = await rotateActivitySyncSecret(work.id);
+            if (result.success) {
+                toast.success(t('rotateSuccess'));
+                router.refresh();
+            } else {
+                toast.error(result.error || t('rotateFailed'));
+            }
+        } finally {
+            setRotating(false);
+        }
+    };
+
+    const lastSuccess = work.platformSyncLastSuccessAt
+        ? formatDistanceToNow(new Date(work.platformSyncLastSuccessAt), { addSuffix: true })
+        : null;
+    const lastError = work.platformSyncLastErrorMessage ?? null;
+
+    return (
+        <div
+            className={cn(
+                'rounded-lg border overflow-hidden',
+                'bg-card dark:bg-card-primary-dark/30',
+                'border-card-border dark:border-border-secondary-dark',
+            )}
+        >
+            <div className="px-5 py-3.5 border-b border-card-border dark:border-border-secondary-dark">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                    {t('subtitle')}
+                </p>
+            </div>
+
+            <div className="px-5 py-4 space-y-4">
+                <fieldset className="space-y-3" disabled={pending}>
+                    <legend className="sr-only">{t('modeLegend')}</legend>
+                    {MODES.map((mode) => (
+                        <label
+                            key={mode}
+                            className={cn(
+                                'flex items-start gap-3 rounded-md border p-3 cursor-pointer transition-colors',
+                                'border-border dark:border-border-dark',
+                                'hover:bg-muted/30 dark:hover:bg-muted/10',
+                                currentMode === mode &&
+                                    'border-primary/60 bg-primary/5 dark:bg-primary/10',
+                                pending && 'opacity-60 cursor-not-allowed',
+                            )}
+                        >
+                            <input
+                                type="radio"
+                                name="activitySyncMode"
+                                value={mode}
+                                checked={currentMode === mode}
+                                onChange={() => handleModeChange(mode)}
+                                disabled={pending}
+                                className="mt-0.5"
+                            />
+                            <div className="flex-1 min-w-0">
+                                <div className="text-xs font-medium text-text dark:text-text-dark">
+                                    {t(`modes.${mode}.label`)}
+                                    {mode === 'pull' && (
+                                        <span className="ml-2 text-[10px] uppercase tracking-wider text-text-muted">
+                                            {t('defaultBadge')}
+                                        </span>
+                                    )}
+                                </div>
+                                <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t(`modes.${mode}.description`)}
+                                </p>
+                            </div>
+                            {pending && currentMode !== mode && (
+                                <Loader2 className="h-4 w-4 animate-spin text-text-muted" />
+                            )}
+                        </label>
+                    ))}
+                </fieldset>
+
+                {currentMode === 'pull' && (
+                    <div className="pt-3 border-t border-card-border dark:border-border-secondary-dark space-y-3">
+                        <div>
+                            <h4 className="text-xs font-medium text-text dark:text-text-dark">
+                                {t('rotate.label')}
+                            </h4>
+                            <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('rotate.description')}
+                            </p>
+                            <button
+                                type="button"
+                                onClick={handleRotate}
+                                disabled={rotating || pending}
+                                className={cn(
+                                    'mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium',
+                                    'border border-warning/40 bg-warning/10 text-warning',
+                                    'hover:bg-warning/15 transition-colors',
+                                    (rotating || pending) && 'opacity-60 cursor-not-allowed',
+                                )}
+                            >
+                                {rotating && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                                {t('rotate.action')}
+                            </button>
+                        </div>
+
+                        {(lastSuccess || lastError) && (
+                            <div className="text-xs text-text-muted dark:text-text-muted-dark space-y-1">
+                                {lastSuccess && (
+                                    <div>{t('status.lastSuccess', { time: lastSuccess })}</div>
+                                )}
+                                {lastError && (
+                                    <div className="text-error">
+                                        {t('status.lastError', { error: lastError })}
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/settings/SettingsForm.tsx
+++ b/apps/web/src/components/works/detail/settings/SettingsForm.tsx
@@ -14,6 +14,7 @@ import { CommunityPrSettings } from './CommunityPrSettings';
 import { WebsiteConfigSettings } from './WebsiteConfigSettings';
 import { ItemImportExportSettings } from './ItemImportExportSettings';
 import { CommitterSettings } from './CommitterSettings';
+import { ActivitySyncSettings } from './ActivitySyncSettings';
 interface SettingsFormProps {
     work: Work;
     user: AuthUser;
@@ -49,6 +50,9 @@ export function SettingsForm({ work, user, initialRepositories }: SettingsFormPr
 
                 {/* Item Import & Export Settings (EW-533) */}
                 <ItemImportExportSettings workId={work.id} />
+
+                {/* Activity Feed sync mode (EW-120 dual-mode) */}
+                <ActivitySyncSettings />
 
                 {/* Git Committer Settings */}
                 <CommitterSettings />

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -94,6 +94,8 @@ export interface UpdateWorkDto {
     communityPrAutoClose?: boolean;
     committerName?: string | null;
     committerEmail?: string | null;
+    /** EW-120 Activity Feed sync transport. */
+    activitySyncMode?: 'pull' | 'push' | 'disabled';
 }
 
 export interface DeleteWorkDto {
@@ -204,6 +206,11 @@ export interface Work {
     // Git committer overrides
     committerName?: string | null;
     committerEmail?: string | null;
+    // EW-120 Activity Feed sync (dual-mode)
+    activitySyncMode?: 'pull' | 'push' | 'disabled';
+    platformSyncLastSuccessAt?: string | null;
+    platformSyncLastErrorAt?: string | null;
+    platformSyncLastErrorMessage?: string | null;
 }
 
 export interface WorksResponse {

--- a/apps/web/src/lib/api/works/activity-feed.ts
+++ b/apps/web/src/lib/api/works/activity-feed.ts
@@ -1,0 +1,18 @@
+import 'server-only';
+import { serverFetch } from '../server-api';
+import type { FeedResponse, GetActivityFeedParams } from './activity-feed.types';
+
+export * from './activity-feed.types';
+
+export const activityFeedAPI = {
+    get: async (workId: string, params?: GetActivityFeedParams): Promise<FeedResponse> => {
+        const search = new URLSearchParams();
+        if (params?.cursor) search.set('cursor', params.cursor);
+        if (params?.limit !== undefined) search.set('limit', String(params.limit));
+        if (params?.category) search.set('category', params.category);
+        const query = search.toString();
+        return serverFetch<FeedResponse>(
+            `/works/${workId}/activity-feed${query ? `?${query}` : ''}`,
+        );
+    },
+};

--- a/apps/web/src/lib/api/works/activity-feed.types.ts
+++ b/apps/web/src/lib/api/works/activity-feed.types.ts
@@ -1,0 +1,107 @@
+/**
+ * Client-safe types + constants for the EW-120 Activity Feed.
+ *
+ * Kept separate from `activity-feed.ts` (which is `server-only`) so client
+ * components and Vitest tests can import the type discriminants without
+ * pulling the `serverFetch` chain.
+ *
+ * Source of truth (mirrored by hand): `apps/api/src/works/activity-feed/dto/feed-entry.dto.ts`.
+ */
+
+export type FeedCategory =
+    | 'all'
+    | 'generation'
+    | 'items'
+    | 'deployment'
+    | 'settings'
+    | 'comparisons'
+    | 'communityPr'
+    | 'users'
+    | 'submissions'
+    | 'reports';
+
+export const FEED_CATEGORIES: readonly FeedCategory[] = [
+    'all',
+    'generation',
+    'items',
+    'deployment',
+    'settings',
+    'comparisons',
+    'communityPr',
+    'users',
+    'submissions',
+    'reports',
+];
+
+interface FeedEntryBase {
+    id: string;
+    timestamp: string;
+    category: FeedCategory;
+    summary: string;
+}
+
+export interface PlatformActivityLogEntry extends FeedEntryBase {
+    source: 'platform-activity-log';
+    type: string;
+    status: string;
+    details?: Record<string, unknown> | null;
+}
+
+export interface GenerationHistoryEntry extends FeedEntryBase {
+    source: 'generation-history';
+    type: string;
+    status: string;
+    runId: string;
+    newItemsCount: number;
+    updatedItemsCount: number;
+    totalItemsCount: number;
+    durationInSeconds?: number | null;
+}
+
+/**
+ * Pull-mode entry produced by `DirectoryWebsiteClient` after an HMAC-signed
+ * fetch against the deployed directory site. Only appears in feeds for Works
+ * whose `activitySyncMode === 'pull'`; push-mode equivalents arrive as
+ * ordinary `platform-activity-log` rows via the ingest endpoint.
+ */
+export interface DirectorySiteEntry extends FeedEntryBase {
+    source: 'directory-site';
+    type: 'user_registered' | 'item_created' | 'item_status_changed' | 'report_created';
+    actor: { id: string; name: string; email?: string | null } | null;
+    target: { id: string; type: 'user' | 'item' | 'report'; name: string; adminUrl: string };
+}
+
+export type FeedEntry = PlatformActivityLogEntry | GenerationHistoryEntry | DirectorySiteEntry;
+
+/**
+ * Pull-mode degraded reason — set by the platform aggregator when the
+ * HMAC-signed fetch against the deployed site failed. Push-mode and disabled
+ * Works never populate this field; the banner only renders for pull-mode.
+ */
+export interface FeedDegradedReason {
+    reason:
+        | 'not_provisioned'
+        | 'disabled'
+        | 'timeout'
+        | 'unauthorized'
+        | 'upstream_5xx'
+        | 'network'
+        | 'parse_error';
+    detail?: string;
+    lastSuccessAt?: string | null;
+}
+
+export interface FeedResponse {
+    entries: FeedEntry[];
+    nextCursor?: string | null;
+    serverTime: string;
+    degraded?: {
+        directorySite?: FeedDegradedReason;
+    };
+}
+
+export interface GetActivityFeedParams {
+    cursor?: string;
+    limit?: number;
+    category?: FeedCategory;
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -71,6 +71,7 @@ export const ROUTES = {
     DASHBOARD_WORKS: '/works',
     DASHBOARD_WORKS_NEW: '/works/new',
     DASHBOARD_WORK: (id: string) => `/works/${id}`,
+    DASHBOARD_WORK_ACTIVITY: (id: string) => `/works/${id}/activity`,
     DASHBOARD_WORK_ITEMS: (id: string) => `/works/${id}/items`,
     DASHBOARD_WORK_GENERATOR: (id: string) => `/works/${id}/generator`,
     DASHBOARD_WORK_SCHEDULE: (id: string) => `/works/${id}/generator/schedule`,

--- a/docs/specs/decisions/004-activity-feed-push-vs-pull.md
+++ b/docs/specs/decisions/004-activity-feed-push-vs-pull.md
@@ -1,0 +1,329 @@
+# ADR-004: Activity Feed Per Directory — Dual-Mode Sync (Pull + Push + Disabled)
+
+## Status
+
+**Accepted** — Implemented (PR EW-120). Supersedes the earlier
+"push-only" revision of this ADR.
+
+## Date
+
+- 2026-05-13 — Initial (push-only)
+- 2026-05-14 — Revised for dual-mode (pull / push / disabled)
+
+## Context
+
+[EW-120](https://evertech.atlassian.net/browse/EW-120) asks for an
+Activity Feed tab on each Work's detail page that aggregates:
+
+- **Platform-internal events** the platform already logs (generation
+  runs, deployments, item CRUD, settings changes, schedule executions,
+  community PRs).
+- **Per-Work generation history** from `work_generation_history` rows.
+- **Website-sourced events** that happen on the deployed directory
+  site after a generated site is live: end-user signups, item
+  submissions, and report filings/resolutions.
+
+The first two sources already live in the platform DB. The third
+does not — it lives in the deployed Next.js site (typically Vercel,
+sometimes k8s) under a different tenancy.
+
+The question is _how the platform learns about category 3_.
+
+## Decision history
+
+This decision flipped three times across the EW-120 PR. The current
+version is **dual-mode** — the platform supports both transports
+simultaneously and the directory's `works.yml` picks one per Work.
+
+1. **Initial implementation: pull (commits leading up to
+   `cd887279`)**. Platform fetches an HMAC-signed
+   `/_platform/events` endpoint on each deployed site. Worked
+   end-to-end but was flagged in review as "over-engineered": the
+   template has to ship a compatible endpoint, and older template
+   forks would surface a permanent degraded banner.
+2. **Pull reverted, push-only (commits `cd887279` → `0184ac6c`)**.
+   Deployed site POSTs each event to a new
+   `/api/activity-log/ingest` endpoint on the platform with a
+   shared `PLATFORM_API_SECRET_TOKEN`. Much smaller surface, no
+   platform-side egress, no per-Work secret management. Greptile
+   review approved.
+3. **Dual-mode added back (this revision)**. The user wanted both
+   options to coexist so site authors can choose:
+    - **Pull** is restored as the default to preserve historical
+      behaviour and to keep the "old way" available for directories
+      that already ship the template endpoint.
+    - **Push** stays as an opt-in for directories that prefer the
+      lighter-weight one-shot delivery model.
+    - **Disabled** lets an operator turn the website-sourced
+      categories off entirely.
+
+## Decision
+
+Each Work declares its transport via `activity_sync.mode` in
+`works.yml`:
+
+```yaml
+activity_sync:
+    mode: pull # pull | push | disabled (default: pull)
+```
+
+The platform projects the value onto `Work.activitySyncMode` and
+routes everywhere downstream by that field. The other transport's
+code paths are dormant and rejected with a clean error.
+
+## Mode decision matrix
+
+| Mode       | Platform polls site? | Ingest endpoint accepts? | Deploy pushes `PLATFORM_API_SECRET_TOKEN` | Deploy pushes `PLATFORM_SYNC_SECRET` | Website chips populated |
+| ---------- | -------------------- | ------------------------ | ----------------------------------------- | ------------------------------------ | ----------------------- |
+| `pull`     | yes, on demand       | **409 mode-mismatch**    | no                                        | yes                                  | yes (via pull fetch)    |
+| `push`     | no                   | yes (202)                | yes                                       | no                                   | yes (via ingest)        |
+| `disabled` | no                   | **409 mode-mismatch**    | no                                        | no                                   | no                      |
+
+Both transports remain user-facing for the operator; the failure
+mode is a clean 409 on the inactive surface, not a 500.
+
+## Pull transport
+
+When `activitySyncMode === 'pull'`:
+
+- `ActivityFeedService.compose` calls `DirectoryWebsiteClient` for
+  any `users / submissions / reports / all` category.
+- `DirectoryWebsiteClient` issues a `GET` against
+  `${work.website}/_platform/events?since=…&limit=…&category=…`
+  with `x-platform-timestamp` (ms epoch) + `x-platform-signature`
+  (HMAC-SHA256 over `${ts}.${method}.${path}.${query}` with the
+  per-Work secret).
+- The site verifies the bearer (5-minute clock-skew tolerance, replay
+  rejection, constant-time signature compare) before returning events.
+- 5s timeout, 0 redirects. Any failure becomes a typed
+  `FeedDegradedReason` and a `<DegradedBanner>` on the web side. The
+  `platformSyncLastSuccessAt` / `LastErrorAt` / `LastErrorMessage`
+  columns track outcomes for the banner's "last seen …" line.
+- Pull is **on-demand only** — fetch fires when the user opens the
+  Activity Feed tab. No background poller. (Originally considered a
+  BullMQ scheduled poller; rejected as unnecessary tail load —
+  on-demand is closer to the pre-revert design and scales to zero.)
+
+Per-Work secret lifecycle:
+
+- `PlatformSyncSecretService.getOrGenerate(workId)` runs on every
+  deploy via `DeployService.setRequiredSecrets`. First deploy
+  generates a fresh 32-byte secret, AES-256-GCM-encrypts with
+  `PLATFORM_ENCRYPTION_KEY`, persists to
+  `Work.platformSyncSecretEncrypted`. Subsequent deploys read and
+  decrypt the existing value.
+- Concurrent first-deploys are race-safe via the conditional
+  `setPlatformSyncSecretIfNull` UPDATE; the loser re-reads the
+  winner's value.
+- Rotation is **on-demand only**. `PlatformSyncSecretService.rotate(workId)`
+  generates a new secret + persists; the new value only reaches the
+  site at the next deploy. The admin UX layer is responsible for
+  surfacing the "redeploy required" warning.
+
+## Push transport
+
+When `activitySyncMode === 'push'`:
+
+- The deployed site POSTs each event to
+  `${PLATFORM_API_URL}/api/activity-log/ingest` with
+  `Authorization: Bearer ${PLATFORM_API_SECRET_TOKEN}`.
+- `PlatformSecretGuard` does constant-time bearer compare against
+  `process.env.PLATFORM_API_SECRET_TOKEN`. Same-length comparison
+  buffer regardless of input length, so the secret's byte length
+  isn't recoverable via timing.
+- `@Throttle({ limit: 60, ttl: 60_000 })` per-IP cap belt-and-braces
+  against a leaked token.
+- Idempotency: `activity_log.ingestEventId` column + partial unique
+  index on `(workId, ingestEventId) WHERE ingestEventId IS NOT NULL`.
+  Retries reuse the same `eventId`; race-recovery catches the unique
+  violation and re-queries.
+- The platform clamps `occurredAt > now` to "now" so a misbehaving
+  template can't park a row above every genuine event.
+
+### Push wire format
+
+```bash
+curl -X POST "${PLATFORM_API_URL}/api/activity-log/ingest" \
+  -H "Authorization: Bearer ${PLATFORM_API_SECRET_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data @- <<'EOF'
+{
+  "workId":     "11111111-1111-1111-1111-111111111111",
+  "eventId":    "22222222-2222-2222-2222-222222222222",
+  "actionType": "website_user_registered",
+  "occurredAt": "2026-05-13T10:00:00.000Z",
+  "summary":    "Alice signed up",
+  "metadata":   { "actor": "alice@example.com" }
+}
+EOF
+```
+
+Field rules (enforced by `IngestEventDto` + `class-validator`):
+
+| Field        | Type                | Notes                                                                                                          |
+| ------------ | ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `workId`     | UUID                | The Work ID — also pushed to the deployed site as the `WORK_ID` env var.                                       |
+| `eventId`    | UUID                | Client-generated; **must be stable across retries** for idempotency.                                           |
+| `actionType` | enum                | One of `website_user_registered`, `website_item_submitted`, `website_report_filed`, `website_report_resolved`. |
+| `occurredAt` | ISO 8601 string     | When the event actually happened (clamped to ≤ now + 5 min server-side).                                       |
+| `summary`    | string, ≤ 500 chars | Human-readable one-liner shown in the feed.                                                                    |
+| `metadata`   | object, ≤ 8 KiB     | Optional. Free-form. Capped after JSON serialisation.                                                          |
+
+Responses:
+
+| Status  | Meaning                                                                                                              |
+| ------- | -------------------------------------------------------------------------------------------------------------------- |
+| 202     | Accepted. Response body: `{ id: <activity-log row id> }`.                                                            |
+| 400     | Validation failed (missing field, bad UUID, unknown action type, etc.).                                              |
+| 401     | Missing / invalid bearer token.                                                                                      |
+| 404     | `workId` does not exist.                                                                                             |
+| **409** | **`{ error: 'mode-mismatch', mode, message }` — the Work's `activitySyncMode` is `pull` or `disabled`, not `push`.** |
+| 429     | Rate limit (60 req / min / IP).                                                                                      |
+| 503     | `PLATFORM_API_SECRET_TOKEN` is not configured on the platform.                                                       |
+
+## Disabled mode
+
+`activitySyncMode === 'disabled'`:
+
+- The feed renders only platform activity-log + generation history.
+- `users / submissions / reports` chips are empty.
+- Pull fetch is skipped. Ingest endpoint returns 409.
+- Deploy pushes neither `PLATFORM_SYNC_SECRET` nor
+  `PLATFORM_API_SECRET_TOKEN`.
+
+The mode is the explicit way for an operator to say "I don't want
+the platform to learn anything about my deployed site's user
+activity". It's not the same as "no events" — there's no UX
+contract that says the chips will eventually populate.
+
+## Mode flip mechanics
+
+Source of truth is `works.yml`; the DB column is the read path. On a
+mode flip:
+
+1. Operator edits `works.yml` (via PR to the data repo, or via the
+   eventual settings UI — deferred to follow-up).
+2. `WorksConfigSyncListener` picks up the change, parses
+   `activity_sync.mode`.
+3. `WorksConfigImportApplierService.applyActivitySyncMode` writes
+   `Work.activitySyncMode`.
+4. Next deploy invokes `DeployService.setRequiredSecrets`, which
+   pushes the new mode's secrets (and only the new mode's secrets).
+
+In between steps 3 and 4 there is a window where the
+DB-recorded mode is the new one but the deployed site still has the
+old transport's secret. Practical effects:
+
+- pull → push: pull fetches keep working (decrypt secret still on
+  the row) until the next deploy carries the bearer token.
+- push → pull: push 409s mode-mismatch (ingest endpoint reads the
+  new DB mode). The site's POSTs will fail until the next deploy
+  pushes `PLATFORM_SYNC_SECRET` and the site starts answering pulls.
+- Any → disabled: ingest 409s; pull fetches don't fire; feed is
+  immediately platform-only.
+
+The "next deploy" gap is acceptable for v1 — the operator triggered
+the flip and a redeploy is the expected follow-up. Document this
+explicitly in the eventual settings UI.
+
+## Schema additions
+
+`works` table (forward-only migration `1778746463309-AddActivityFeedSync`):
+
+| Column                         | Type                                | Notes                                                                                                                              |
+| ------------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `activitySyncMode`             | varchar(16) NOT NULL DEFAULT 'pull' | Enum: pull / push / disabled.                                                                                                      |
+| `platformSyncSecretEncrypted`  | text, nullable                      | Pull-mode only. AES-256-GCM envelope.                                                                                              |
+| `platformSyncLastSuccessAt`    | bigint, nullable                    | Pull-mode observability. `@TimestampColumn` (ms-epoch bigint, SQLite/Postgres portable, matches the rest of the codebase pattern). |
+| `platformSyncLastErrorAt`      | bigint, nullable                    | "                                                                                                                                  |
+| `platformSyncLastErrorMessage` | text, nullable                      | "                                                                                                                                  |
+
+`activity_log` table (forward-only migration
+`1778677529777-AddActivityLogIngestEventId`):
+
+| Column          | Type                 | Notes                                                                                        |
+| --------------- | -------------------- | -------------------------------------------------------------------------------------------- |
+| `ingestEventId` | varchar(64) nullable | Push-mode idempotency key. Partial unique index on `(workId, ingestEventId) WHERE NOT NULL`. |
+
+Also: 4 new enum values in `ActivityActionType`
+(`WEBSITE_USER_REGISTERED`, `WEBSITE_ITEM_SUBMITTED`,
+`WEBSITE_REPORT_FILED`, `WEBSITE_REPORT_RESOLVED`) — only ever
+written by the push ingest endpoint, only ever read for push-mode
+Works.
+
+## Consequences
+
+### Positive
+
+- **Site authors can choose**. Pull works for directories that
+  already shipped the template endpoint; push works for
+  directories that haven't (or prefer the lighter contract);
+  disabled works for directories that don't want platform-side
+  visibility.
+- **Both transports use existing platform machinery** — push reuses
+  the activity-log table + the existing per-Work feed query; pull
+  reuses the encrypted-secret + deploy-time GHA-secret-push paths
+  that already shipped (Phase 1 here).
+- **Mode flips are mostly transparent**. The DB and works.yml stay
+  in sync via the existing sync listener; deploys carry the right
+  secrets; the inactive transport returns a typed error.
+- **Member visibility preserved** (push-side fix, Phase 3). The
+  per-Work feed query bypasses `userId` so members see
+  owner-attributed website events.
+
+### Negative / trade-offs
+
+- **Surface area is larger.** Both code paths must be tested and
+  maintained. Mitigation: each mode is gated behind a single
+  `Work.activitySyncMode` check at the routing boundary; the
+  individual code paths (`DirectoryWebsiteClient` for pull,
+  `ingestFromWebsite` for push) are independent and don't share
+  state.
+- **Template-side coupling remains for pull-mode directories.** The
+  reviewer's original concern still applies for any Work choosing
+  `mode: pull`. Mitigation: push is opt-in, not default — but the
+  template still needs to support pull for directories that opt for
+  it. The eventual settings-UI page should explain this.
+- **Per-Work HMAC secret = ops surface.** `PLATFORM_ENCRYPTION_KEY`
+  must be set on the platform for pull mode to work. Without it,
+  pull-mode deploys log an error and skip the secret push; pull
+  fetches then degrade to `not_provisioned`. Push mode is unaffected
+  by this env.
+
+## Implementation map
+
+The PR delivers the dual-mode surface across 8 phases:
+
+1. **Phase 0** — Schema + works.yml plumbing + encryption-key config
+2. **Phase 1** — `PlatformSyncSecretService` + WorkRepository helpers
+   (resurrected from `a405cdc4`, adapted for the split lastError
+   columns; new `rotate()` for the settings-UI follow-up).
+3. **Phase 2** — `DirectoryWebsiteClient` + HMAC signing
+   (resurrected from `7add7cf5`, gated on `activitySyncMode === 'pull'`).
+4. **Phase 3** — `ActivityFeedService` routes by mode (pull → client
+    - status writes; push → activity-log with WEBSITE\_\* types;
+      disabled → neither, no degraded).
+5. **Phase 4** — Ingest endpoint returns 409 on mode-mismatch;
+   `DeployService.setRequiredSecrets` pushes only the active
+   transport's secrets.
+6. **Phase 5** — Web: resurrect `DegradedBanner`, chip dimming, and
+   the 21 `degraded.*` locale strings.
+7. **Phase 6** — Settings UI (mode select + rotate-secret button) —
+   **deferred to follow-up**. The mechanism already works via
+   `works.yml` edits + the existing `WorksConfigSyncListener` →
+   `applyActivitySyncMode` projection.
+8. **Phase 7** — This ADR rewrite.
+
+## Follow-up
+
+- **Settings UI page**: mode select (pull / push / disabled with
+  explainer copy) + "Rotate sync secret" button (pull-mode only,
+  with redeploy-required warning).
+- **Template-side (`directory-web-template`) wiring**:
+    - Pull mode: implement `/_platform/events` with HMAC verification
+      against `PLATFORM_SYNC_SECRET`.
+    - Push mode: 4 fetch call sites (post-signup, post-submission,
+      on-report-create, on-report-resolve) using the env-injected
+      `PLATFORM_API_URL` + `PLATFORM_API_SECRET_TOKEN`.
+    - Tracked as separate PRs in the template repo.
+- **Secret rotation runbook** for the operator handbook.

--- a/packages/agent/src/activity-log/activity-log.service.spec.ts
+++ b/packages/agent/src/activity-log/activity-log.service.spec.ts
@@ -1,5 +1,5 @@
 import { ActivityLogService } from './activity-log.service';
-import { ActivityStatus } from '../entities/activity-log.types';
+import { ActivityActionType, ActivityStatus } from '../entities/activity-log.types';
 import { GenerateStatusType } from '../entities/types';
 
 describe('ActivityLogService', () => {
@@ -29,6 +29,193 @@ describe('ActivityLogService', () => {
                     generateStatus: { status: GenerateStatusType.GENERATED },
                 }),
             ).toBe(ActivityStatus.COMPLETED);
+        });
+    });
+
+    describe('ingestFromWebsite (EW-120)', () => {
+        const buildService = (
+            existingByEvent: Record<string, unknown> | null = null,
+            work: { id: string; userId: string } | null = { id: 'work-1', userId: 'owner-1' },
+        ) => {
+            const created: Array<Record<string, unknown>> = [];
+            const repo = {
+                findByWorkAndIngestEventId: jest.fn().mockResolvedValue(existingByEvent),
+                create: jest.fn().mockImplementation((entry, overrides) => {
+                    const row = {
+                        id: 'al-' + (created.length + 1),
+                        ...entry,
+                        ...(overrides ?? {}),
+                    };
+                    created.push(row);
+                    return Promise.resolve(row);
+                }),
+            };
+            const workRepo = { findById: jest.fn().mockResolvedValue(work) };
+            const svc = new ActivityLogService(repo as never, workRepo as never, {} as never);
+            return { svc, repo, workRepo, created };
+        };
+
+        it('returns the existing row when the same eventId was already ingested', async () => {
+            const existing = { id: 'al-existing', ingestEventId: 'evt-1' };
+            const { svc, repo } = buildService(existing);
+
+            const result = await svc.ingestFromWebsite({
+                workId: 'work-1',
+                eventId: 'evt-1',
+                actionType: ActivityActionType.WEBSITE_USER_REGISTERED,
+                occurredAt: new Date('2026-05-13T10:00:00.000Z'),
+                summary: 'User signed up',
+            });
+
+            expect(result).toBe(existing);
+            expect(repo.findByWorkAndIngestEventId).toHaveBeenCalledWith('work-1', 'evt-1');
+            expect(repo.create).not.toHaveBeenCalled();
+        });
+
+        it('creates a new row attributed to the work owner on first ingest', async () => {
+            const { svc, repo, created } = buildService(null);
+
+            await svc.ingestFromWebsite({
+                workId: 'work-1',
+                eventId: 'evt-1',
+                actionType: ActivityActionType.WEBSITE_ITEM_SUBMITTED,
+                occurredAt: new Date('2026-05-13T10:00:00.000Z'),
+                summary: 'Item submitted',
+                metadata: { itemId: 'i-1', actor: 'bob' },
+            });
+
+            expect(repo.create).toHaveBeenCalledTimes(1);
+            const row = created[0];
+            expect(row.userId).toBe('owner-1');
+            expect(row.workId).toBe('work-1');
+            expect(row.actionType).toBe(ActivityActionType.WEBSITE_ITEM_SUBMITTED);
+            expect(row.status).toBe(ActivityStatus.COMPLETED);
+            expect(row.summary).toBe('Item submitted');
+            expect(row.ingestEventId).toBe('evt-1');
+            const metadata = row.metadata as Record<string, unknown>;
+            expect(metadata.itemId).toBe('i-1');
+            expect(metadata.occurredAt).toBe('2026-05-13T10:00:00.000Z');
+        });
+
+        it('sets createdAt to occurredAt so feed ordering reflects when the event happened', async () => {
+            const { svc, repo } = buildService(null);
+            // Clearly-past date so the future-timestamp clamp added for
+            // P2 review feedback can't interfere with this assertion.
+            const occurredAt = new Date('2024-01-15T10:00:00.000Z');
+
+            await svc.ingestFromWebsite({
+                workId: 'work-1',
+                eventId: 'evt-1',
+                actionType: ActivityActionType.WEBSITE_USER_REGISTERED,
+                occurredAt,
+                summary: 'User signed up',
+            });
+
+            // Repository.create receives the override as the second arg.
+            expect(repo.create).toHaveBeenCalledWith(
+                expect.objectContaining({ ingestEventId: 'evt-1' }),
+                { createdAt: occurredAt },
+            );
+        });
+
+        it('throws when the referenced work does not exist', async () => {
+            const { svc } = buildService(null, null);
+
+            await expect(
+                svc.ingestFromWebsite({
+                    workId: 'missing',
+                    eventId: 'evt-1',
+                    actionType: ActivityActionType.WEBSITE_REPORT_FILED,
+                    occurredAt: new Date(),
+                    summary: 'Report',
+                }),
+            ).rejects.toThrow(/work missing not found/i);
+        });
+
+        it('clamps a future occurredAt to "now" so a misbehaving template cannot pin a row to the top', async () => {
+            const { svc, repo } = buildService(null);
+            const future = new Date(Date.now() + 60 * 60 * 1000);
+            const before = Date.now();
+
+            await svc.ingestFromWebsite({
+                workId: 'work-1',
+                eventId: 'evt-1',
+                actionType: ActivityActionType.WEBSITE_USER_REGISTERED,
+                occurredAt: future,
+                summary: 'Future event',
+            });
+
+            const after = Date.now();
+            const overrides = repo.create.mock.calls[0][1] as { createdAt: Date };
+            expect(overrides.createdAt.getTime()).toBeGreaterThanOrEqual(before);
+            expect(overrides.createdAt.getTime()).toBeLessThanOrEqual(after);
+            // Original timestamp is preserved in metadata for forensics.
+            const created = repo.create.mock.calls[0][0] as { metadata: Record<string, unknown> };
+            expect(created.metadata.occurredAt).toBe(future.toISOString());
+        });
+
+        it('returns the winning row when a concurrent insert trips the unique index', async () => {
+            // Simulate the TOCTOU race: existence check sees null, then the
+            // INSERT fails with a Postgres unique_violation because a
+            // concurrent request beat us to it. The service must recover
+            // by re-reading and returning the winning row.
+            const winner = { id: 'al-winner', ingestEventId: 'evt-race' };
+            const findByWorkAndIngestEventId = jest
+                .fn()
+                .mockResolvedValueOnce(null)
+                .mockResolvedValueOnce(winner);
+            const create = jest.fn().mockRejectedValue(
+                Object.assign(new Error('duplicate key'), {
+                    driverError: { code: '23505' },
+                }),
+            );
+            const repo = { findByWorkAndIngestEventId, create };
+            const workRepo = {
+                findById: jest.fn().mockResolvedValue({ id: 'work-1', userId: 'owner-1' }),
+            };
+            const svc = new ActivityLogService(repo as never, workRepo as never, {} as never);
+
+            const result = await svc.ingestFromWebsite({
+                workId: 'work-1',
+                eventId: 'evt-race',
+                actionType: ActivityActionType.WEBSITE_USER_REGISTERED,
+                occurredAt: new Date('2026-05-13T10:00:00.000Z'),
+                summary: 'Raced signup',
+            });
+
+            expect(result).toBe(winner);
+            expect(findByWorkAndIngestEventId).toHaveBeenCalledTimes(2);
+        });
+
+        it.each([
+            ['SQLite SQLITE_CONSTRAINT', 'SQLITE_CONSTRAINT'],
+            ['MySQL ER_DUP_ENTRY', 'ER_DUP_ENTRY'],
+        ])('recovers from a %s unique-violation race (cross-DB)', async (_label, code) => {
+            // Pin the cross-driver code check — CI runs SQLite, so this
+            // also exercises the path that would fire in the test suite
+            // if a real concurrent race happened during a Jest run.
+            const winner = { id: 'al-winner', ingestEventId: 'evt-race' };
+            const repo = {
+                findByWorkAndIngestEventId: jest
+                    .fn()
+                    .mockResolvedValueOnce(null)
+                    .mockResolvedValueOnce(winner),
+                create: jest.fn().mockRejectedValue(Object.assign(new Error('dup'), { code })),
+            };
+            const workRepo = {
+                findById: jest.fn().mockResolvedValue({ id: 'work-1', userId: 'owner-1' }),
+            };
+            const svc = new ActivityLogService(repo as never, workRepo as never, {} as never);
+
+            const result = await svc.ingestFromWebsite({
+                workId: 'work-1',
+                eventId: 'evt-race',
+                actionType: ActivityActionType.WEBSITE_USER_REGISTERED,
+                occurredAt: new Date('2024-01-15T10:00:00.000Z'),
+                summary: 'Raced signup',
+            });
+
+            expect(result).toBe(winner);
         });
     });
 

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -92,13 +92,101 @@ export class ActivityLogService {
         });
     }
 
-    async log(entry: CreateActivityLogDto): Promise<ActivityLog> {
-        const activity = await this.repository.create(entry);
+    async log(entry: CreateActivityLogDto, overrides?: { createdAt?: Date }): Promise<ActivityLog> {
+        const activity = await this.repository.create(entry, overrides);
         this.dispatchAnalytics(activity);
         this.logger.debug(
             `Activity logged: [${entry.actionType}] ${entry.summary} (user: ${entry.userId})`,
         );
         return activity;
+    }
+
+    /**
+     * Persist an event POSTed by a deployed directory site (EW-120).
+     *
+     * Idempotent by `(workId, eventId)` — a retry from the website lands on
+     * the same row instead of creating duplicates. The attribution `userId`
+     * is the Work owner so the event surfaces in their per-Work Activity
+     * Feed without authenticating the end-user that triggered it.
+     */
+    async ingestFromWebsite(payload: {
+        workId: string;
+        eventId: string;
+        actionType: ActivityActionType;
+        occurredAt: Date;
+        summary: string;
+        metadata?: Record<string, unknown>;
+    }): Promise<ActivityLog> {
+        const existing = await this.repository.findByWorkAndIngestEventId(
+            payload.workId,
+            payload.eventId,
+        );
+        if (existing) {
+            return existing;
+        }
+
+        const work = await this.workRepository.findById(payload.workId);
+        if (!work) {
+            throw new Error(`Work ${payload.workId} not found`);
+        }
+
+        // Clamp future timestamps to "now" so a misbehaving template
+        // can't pin a row above every genuine event by sending
+        // `occurredAt: 2099-01-01`. The original value is preserved in
+        // `metadata.occurredAt` for forensics.
+        const now = new Date();
+        const createdAt = payload.occurredAt > now ? now : payload.occurredAt;
+
+        // Pin `createdAt` to the website's `occurredAt` so the feed
+        // orders by "when it happened" rather than "when the platform
+        // got around to recording it". TypeORM's @CreateDateColumn only
+        // auto-populates when the value is left undefined.
+        try {
+            return await this.log(
+                {
+                    userId: work.userId,
+                    workId: payload.workId,
+                    actionType: payload.actionType,
+                    action: `website.${payload.actionType}`,
+                    status: ActivityStatus.COMPLETED,
+                    summary: payload.summary,
+                    metadata: {
+                        ...(payload.metadata ?? {}),
+                        occurredAt: payload.occurredAt.toISOString(),
+                    },
+                    ingestEventId: payload.eventId,
+                },
+                { createdAt },
+            );
+        } catch (error) {
+            // The check-then-insert above isn't atomic: two concurrent
+            // retries with the same (workId, eventId) can both pass the
+            // existence check and race to INSERT. The second one trips the
+            // partial unique index. Treat that as the idempotent outcome
+            // it should have been and return the row that won the race.
+            if (this.isUniqueViolation(error)) {
+                const winner = await this.repository.findByWorkAndIngestEventId(
+                    payload.workId,
+                    payload.eventId,
+                );
+                if (winner) return winner;
+            }
+            throw error;
+        }
+    }
+
+    private isUniqueViolation(error: unknown): boolean {
+        if (!error || typeof error !== 'object') return false;
+        const driverCode = (error as { driverError?: { code?: string } }).driverError?.code;
+        const topCode = (error as { code?: string }).code;
+        // Cross-driver unique-constraint codes:
+        //   Postgres: 23505 (unique_violation)
+        //   MySQL:    ER_DUP_ENTRY (numeric 1062)
+        //   SQLite:   SQLITE_CONSTRAINT (CI runs SQLite, so this catches
+        //             the race in tests too)
+        // Same convention as NotificationService.isUniqueConstraintError.
+        const codes = ['23505', 'ER_DUP_ENTRY', 'SQLITE_CONSTRAINT'];
+        return codes.includes(driverCode as string) || codes.includes(topCode as string);
     }
 
     async updateStatus(
@@ -213,6 +301,26 @@ export class ActivityLogService {
         query: ActivityLogQueryOptions,
     ): Promise<{ activities: ActivityLog[]; total: number }> {
         return this.repository.findByUserId(query);
+    }
+
+    /**
+     * Per-Work activity lookup that bypasses the `userId` filter. Use for
+     * the work-scoped Activity Feed; access must have been verified
+     * upstream (controller layer). See repository docstring for context.
+     *
+     * `actionType` accepts an array — a single `IN (...)` query replaces
+     * the previous per-type fan-out so the feed aggregator can pass the
+     * full per-source limit without multiplying it by the number of
+     * action types in the category.
+     */
+    async findByWork(options: {
+        workId: string;
+        actionType?: ActivityActionType | ActivityActionType[];
+        dateTo?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{ activities: ActivityLog[]; total: number }> {
+        return this.repository.findByWork(options);
     }
 
     async countRunning(userId: string): Promise<number> {

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -632,6 +632,7 @@ describe('agent/config', () => {
                 'github',
                 'githubApp',
                 'isCli',
+                'platformSync',
                 'posthog',
                 'sentry',
                 'subscriptions',

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -274,4 +274,14 @@ export const config = {
             },
         },
     },
+
+    // EW-120 Activity Feed pull-mode plumbing — per-Work HMAC secret is
+    // encrypted at rest with this key. AES-256-GCM expects a 32-byte key;
+    // the consumer service decodes hex / base64 / utf8 in that order.
+    // Pull mode is the default transport (see Work.activitySyncMode).
+    platformSync: {
+        getEncryptionKey() {
+            return process.env.PLATFORM_ENCRYPTION_KEY || '';
+        },
+    },
 };

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -17,8 +17,14 @@ export class ActivityLogRepository {
         private readonly repository: Repository<ActivityLog>,
     ) {}
 
-    async create(data: CreateActivityLogDto): Promise<ActivityLog> {
-        const entry = this.repository.create(data);
+    async create(
+        data: CreateActivityLogDto,
+        overrides?: { createdAt?: Date },
+    ): Promise<ActivityLog> {
+        const entry = this.repository.create({
+            ...data,
+            ...(overrides?.createdAt ? { createdAt: overrides.createdAt } : {}),
+        });
         return this.repository.save(entry);
     }
 
@@ -39,6 +45,68 @@ export class ActivityLogRepository {
             where: { id, userId },
             relations: ['work'],
         });
+    }
+
+    async findByWorkAndIngestEventId(
+        workId: string,
+        ingestEventId: string,
+    ): Promise<ActivityLog | null> {
+        return this.repository.findOne({
+            where: { workId, ingestEventId },
+        });
+    }
+
+    /**
+     * Per-Work activity-log lookup that intentionally ignores `userId`.
+     *
+     * The Activity Feed tab is scoped by `workId` and access is enforced
+     * upstream by `WorkOwnershipService.ensureAccess` (controller layer).
+     * Filtering by `userId` here would drop rows attributed to other
+     * collaborators on the same Work — including the website-ingested
+     * rows that EW-120 attributes to the Work owner — making them
+     * invisible to members.
+     */
+    async findByWork(options: {
+        workId: string;
+        /**
+         * Filter by a single action type or a set of types (issues a single
+         * `IN (...)` query instead of N parallel queries). Accepting an
+         * array lets the feed aggregator avoid the per-type fan-out that
+         * previously multiplied the row budget.
+         */
+        actionType?: ActivityActionType | ActivityActionType[];
+        dateTo?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{ activities: ActivityLog[]; total: number }> {
+        const qb = this.repository
+            .createQueryBuilder('activity')
+            .leftJoinAndSelect('activity.work', 'work')
+            .where('activity.workId = :workId', { workId: options.workId })
+            .orderBy('activity.createdAt', 'DESC');
+
+        if (options.actionType) {
+            if (Array.isArray(options.actionType)) {
+                if (options.actionType.length > 0) {
+                    qb.andWhere('activity.actionType IN (:...actionTypes)', {
+                        actionTypes: options.actionType,
+                    });
+                }
+            } else {
+                qb.andWhere('activity.actionType = :actionType', {
+                    actionType: options.actionType,
+                });
+            }
+        }
+        if (options.dateTo) {
+            qb.andWhere('activity.createdAt <= :dateTo', { dateTo: options.dateTo });
+        }
+
+        const limit = Math.min(options.limit ?? 25, 100);
+        const offset = options.offset ?? 0;
+
+        const [activities, total] = await qb.take(limit).skip(offset).getManyAndCount();
+        return { activities, total };
     }
 
     async findLatestByUserWorkActionStatus(params: {

--- a/packages/agent/src/database/repositories/work-generation-history.repository.ts
+++ b/packages/agent/src/database/repositories/work-generation-history.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, MoreThan, Repository } from 'typeorm';
+import { Brackets, In, MoreThan, Repository } from 'typeorm';
 import { WorkGenerationHistory, GenerationMetrics } from '@src/entities';
 import { GenerateStatusType } from '@src/entities/types';
 import {
@@ -116,16 +116,54 @@ export class WorkGenerationHistoryRepository {
         limit = 20,
         offset = 0,
         activityTypes?: WorkHistoryActivityType[],
+        before?: Date,
     ) {
-        return this.repository.find({
-            where: {
-                workId,
-                ...(activityTypes?.length ? { activityType: In(activityTypes) } : {}),
-            },
-            order: { startedAt: 'DESC', createdAt: 'DESC' },
-            take: limit,
-            skip: offset,
-        });
+        // No-cursor path keeps the simple TypeORM find() so we don't
+        // regress query plans for existing callers.
+        if (!before) {
+            return this.repository.find({
+                where: {
+                    workId,
+                    ...(activityTypes?.length ? { activityType: In(activityTypes) } : {}),
+                },
+                order: { startedAt: 'DESC', createdAt: 'DESC' },
+                take: limit,
+                skip: offset,
+            });
+        }
+
+        // Cursor path — the predicate must run in SQL, not in memory.
+        // Otherwise, when every row in the top-N batch is newer than the
+        // cursor (the common steady-state pagination case), the filter
+        // returns 0 entries and the next-cursor advance silently skips
+        // the older rows beyond the limit.
+        //
+        // Ordering is `startedAt DESC, createdAt DESC`, so the effective
+        // "row timestamp" is `COALESCE(startedAt, createdAt)`. Direct
+        // COALESCE won't work here because the two columns are bigint
+        // vs. timestamptz — express the same semantics as an OR over the
+        // two columns instead.
+        const beforeMs = before.getTime();
+        const qb = this.repository
+            .createQueryBuilder('h')
+            .where('h.workId = :workId', { workId })
+            .orderBy('h.startedAt', 'DESC')
+            .addOrderBy('h.createdAt', 'DESC')
+            .take(limit)
+            .skip(offset);
+        if (activityTypes?.length) {
+            qb.andWhere('h.activityType IN (:...activityTypes)', { activityTypes });
+        }
+        qb.andWhere(
+            new Brackets((b) => {
+                b.where('h.startedAt IS NOT NULL AND h.startedAt < :beforeMs', {
+                    beforeMs,
+                }).orWhere('h.startedAt IS NULL AND h.createdAt < :beforeDate', {
+                    beforeDate: before,
+                });
+            }),
+        );
+        return qb.getMany();
     }
 
     async countByWork(workId: string, activityTypes?: WorkHistoryActivityType[]): Promise<number> {

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -207,6 +207,54 @@ export class WorkRepository {
         return await this.findById(id);
     }
 
+    /**
+     * Conditional UPDATE for the lazy bootstrap of `platformSyncSecretEncrypted`
+     * (EW-120 pull transport). Two concurrent deploys can both call
+     * `getOrGenerate` and both generate fresh plaintext; this method makes
+     * only one of them win by gating the write on the column still being NULL.
+     *
+     * Returns `true` if this caller wrote the value, `false` if another
+     * caller beat us to it (loser must re-read).
+     */
+    async setPlatformSyncSecretIfNull(workId: string, encrypted: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Work)
+            .set({ platformSyncSecretEncrypted: encrypted })
+            .where('id = :id', { id: workId })
+            .andWhere('platformSyncSecretEncrypted IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Update platform-sync observability columns after a pull-transport
+     * round-trip. Pass `lastSuccessAt` on success or
+     * `{ lastErrorAt, lastErrorMessage }` on failure — partial updates are
+     * fine, columns not in the payload are left unchanged.
+     */
+    async updatePlatformSyncStatus(
+        workId: string,
+        status: {
+            lastSuccessAt?: Date;
+            lastErrorAt?: Date;
+            lastErrorMessage?: string | null;
+        },
+    ): Promise<void> {
+        const patch: Partial<Work> = {};
+        if (status.lastSuccessAt !== undefined) {
+            patch.platformSyncLastSuccessAt = status.lastSuccessAt;
+        }
+        if (status.lastErrorAt !== undefined) {
+            patch.platformSyncLastErrorAt = status.lastErrorAt;
+        }
+        if (status.lastErrorMessage !== undefined) {
+            patch.platformSyncLastErrorMessage = status.lastErrorMessage;
+        }
+        if (Object.keys(patch).length === 0) return;
+        await this.repository.update(workId, patch);
+    }
+
     async increment(id: string, column: keyof Work, value: number): Promise<void> {
         await this.repository.increment({ id }, column as string, value);
     }

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -4,6 +4,7 @@ import {
     IsString,
     IsBoolean,
     IsEmail,
+    IsIn,
     ValidateNested,
     MaxLength,
 } from 'class-validator';
@@ -86,4 +87,13 @@ export class UpdateWorkDto {
     @IsEmail()
     @IsOptional()
     committerEmail?: string | null;
+
+    @ApiPropertyOptional({
+        description:
+            'EW-120 Activity Feed sync transport (pull / push / disabled). Source of truth is `activity_sync.mode` in works.yml; this field is the platform-side read path. Settings updates flow here then get round-tripped to works.yml by the WorksConfigRepositorySync flow.',
+        enum: ['pull', 'push', 'disabled'],
+    })
+    @IsOptional()
+    @IsIn(['pull', 'push', 'disabled'])
+    activitySyncMode?: 'pull' | 'push' | 'disabled';
 }

--- a/packages/agent/src/entities/__tests__/activity-log.types.spec.ts
+++ b/packages/agent/src/entities/__tests__/activity-log.types.spec.ts
@@ -74,10 +74,10 @@ describe('activity-log.types', () => {
         });
 
         it('has the expected total number of literal values (catch silent additions)', () => {
-            // 36 documented literals — pinned so any silent addition is a
-            // deliberate change.
+            // 40 documented literals — pinned so any silent addition is a
+            // deliberate change. Last bumped by EW-120 (4 WEBSITE_* values).
             const literals = Object.values(ActivityActionType).filter((v) => typeof v === 'string');
-            expect(literals).toHaveLength(36);
+            expect(literals).toHaveLength(40);
         });
 
         it('every literal value is unique (no accidental duplicate string)', () => {

--- a/packages/agent/src/entities/activity-log.entity.ts
+++ b/packages/agent/src/entities/activity-log.entity.ts
@@ -17,6 +17,10 @@ import type { ActivityActionType, ActivityStatus } from './activity-log.types';
 @Index(['userId', 'actionType'])
 @Index(['userId', 'workId'])
 @Index(['userId', 'status'])
+@Index('idx_activity_log_work_ingest_event', ['workId', 'ingestEventId'], {
+    unique: true,
+    where: '"ingestEventId" IS NOT NULL',
+})
 export class ActivityLog {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -53,6 +57,15 @@ export class ActivityLog {
 
     @Column({ type: 'simple-json', nullable: true })
     metadata?: Record<string, any>;
+
+    /**
+     * Idempotency key for events ingested from the deployed directory site
+     * via POST /api/activity-log/ingest (EW-120). The composite unique
+     * index on (workId, ingestEventId) prevents duplicate rows when the
+     * website retries a POST.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    ingestEventId?: string;
 
     @Column({ type: 'varchar', nullable: true })
     ipAddress?: string;

--- a/packages/agent/src/entities/activity-log.types.ts
+++ b/packages/agent/src/entities/activity-log.types.ts
@@ -60,6 +60,14 @@ export enum ActivityActionType {
 
     // Community
     COMMUNITY_PR_MERGED = 'community_pr_merged',
+
+    // Website-sourced events ingested from the deployed directory site
+    // via POST /api/activity-log/ingest (EW-120). The work owner sees
+    // these in the per-Work Activity Feed tab.
+    WEBSITE_USER_REGISTERED = 'website_user_registered',
+    WEBSITE_ITEM_SUBMITTED = 'website_item_submitted',
+    WEBSITE_REPORT_FILED = 'website_report_filed',
+    WEBSITE_REPORT_RESOLVED = 'website_report_resolved',
 }
 
 export enum ActivityStatus {
@@ -81,6 +89,7 @@ export interface CreateActivityLogDto {
     metadata?: Record<string, any>;
     ipAddress?: string;
     userAgent?: string;
+    ingestEventId?: string;
 }
 
 export interface ActivityLogQueryOptions {

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -206,6 +206,39 @@ export class Work {
     @TimestampColumn({ nullable: true })
     sourceValidationLastRunAt?: Date | null;
 
+    // Activity Feed Sync (EW-120) — per-Work transport for surfacing
+    // website-side events (signups, item submissions, reports) in the
+    // platform Activity Feed tab. See ADR-004.
+    //
+    //   pull     — platform fetches on-demand via DirectoryWebsiteClient
+    //              (HMAC-signed), using `platformSyncSecretEncrypted` as
+    //              the per-Work shared secret.
+    //   push     — deployed site POSTs each event to
+    //              /api/activity-log/ingest using the platform-wide
+    //              `PLATFORM_API_SECRET_TOKEN` bearer.
+    //   disabled — feed shows only platform-internal categories.
+    //
+    // Source-of-truth is the directory's `works.yml` activity_sync.mode;
+    // this column is the read path used everywhere on the platform.
+    @Column({ type: 'varchar', length: 16, default: 'pull' })
+    activitySyncMode: 'pull' | 'push' | 'disabled';
+
+    // Pull-mode only. AES-256-GCM-encrypted per-Work HMAC secret used by
+    // DirectoryWebsiteClient to sign outbound requests to the deployed
+    // site. NULL until the next deploy lazily provisions it.
+    @Column({ type: 'text', nullable: true })
+    platformSyncSecretEncrypted?: string | null;
+
+    // Pull-mode observability — drives the degraded banner UX.
+    @TimestampColumn({ nullable: true })
+    platformSyncLastSuccessAt?: Date | null;
+
+    @TimestampColumn({ nullable: true })
+    platformSyncLastErrorAt?: Date | null;
+
+    @Column({ type: 'text', nullable: true })
+    platformSyncLastErrorMessage?: string | null;
+
     // Timestamps
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/services/__tests__/platform-sync-secret.service.spec.ts
+++ b/packages/agent/src/services/__tests__/platform-sync-secret.service.spec.ts
@@ -1,0 +1,204 @@
+import { randomBytes } from 'crypto';
+import { PlatformSyncSecretService } from '../platform-sync-secret.service';
+import { WorkRepository } from '../../database/repositories/work.repository';
+import { Work } from '../../entities';
+
+type RepoMock = jest.Mocked<
+    Pick<
+        WorkRepository,
+        'findById' | 'setPlatformSyncSecretIfNull' | 'updatePlatformSyncStatus' | 'update'
+    >
+>;
+
+const VALID_KEY_HEX = randomBytes(32).toString('hex');
+
+function buildRepoMock(): RepoMock {
+    return {
+        findById: jest.fn(),
+        setPlatformSyncSecretIfNull: jest.fn(),
+        updatePlatformSyncStatus: jest.fn(),
+        update: jest.fn(),
+    } as unknown as RepoMock;
+}
+
+function makeWork(overrides: Partial<Work> = {}): Work {
+    const work = new Work();
+    work.id = 'work-1';
+    // EW-120 dual-mode: pull is the transport that uses this secret.
+    // `platformSyncEnabled` from a405cdc4 was replaced by `activitySyncMode`.
+    work.activitySyncMode = 'pull';
+    work.platformSyncSecretEncrypted = null;
+    Object.assign(work, overrides);
+    return work;
+}
+
+describe('PlatformSyncSecretService', () => {
+    let repo: RepoMock;
+    let service: PlatformSyncSecretService;
+    const ORIGINAL_ENV_KEY = process.env.PLATFORM_ENCRYPTION_KEY;
+
+    beforeEach(() => {
+        process.env.PLATFORM_ENCRYPTION_KEY = VALID_KEY_HEX;
+        repo = buildRepoMock();
+        service = new PlatformSyncSecretService(repo as unknown as WorkRepository);
+    });
+
+    afterEach(() => {
+        if (ORIGINAL_ENV_KEY === undefined) {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+        } else {
+            process.env.PLATFORM_ENCRYPTION_KEY = ORIGINAL_ENV_KEY;
+        }
+    });
+
+    describe('configuration validation', () => {
+        it('throws when PLATFORM_ENCRYPTION_KEY is missing', async () => {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+            service = new PlatformSyncSecretService(repo as unknown as WorkRepository);
+            repo.findById.mockResolvedValue(makeWork());
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(
+                /PLATFORM_ENCRYPTION_KEY is not set/,
+            );
+        });
+
+        it('throws when PLATFORM_ENCRYPTION_KEY is not hex', async () => {
+            process.env.PLATFORM_ENCRYPTION_KEY = 'not-hex-string!!';
+            service = new PlatformSyncSecretService(repo as unknown as WorkRepository);
+            repo.findById.mockResolvedValue(makeWork());
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(/must be a hex string/);
+        });
+
+        it('throws when key decodes to wrong byte length', async () => {
+            process.env.PLATFORM_ENCRYPTION_KEY = '00112233'; // 4 bytes, not 32
+            service = new PlatformSyncSecretService(repo as unknown as WorkRepository);
+            repo.findById.mockResolvedValue(makeWork());
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(
+                /must decode to 32 bytes/,
+            );
+        });
+    });
+
+    describe('getOrGenerate', () => {
+        it('generates, persists, and returns plaintext when no secret exists', async () => {
+            repo.findById.mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValue(true);
+
+            const plaintext = await service.getOrGenerate('work-1');
+
+            expect(plaintext).toMatch(/^[0-9a-f]{64}$/);
+            expect(repo.setPlatformSyncSecretIfNull).toHaveBeenCalledWith(
+                'work-1',
+                expect.any(String),
+            );
+            const [, encrypted] = repo.setPlatformSyncSecretIfNull.mock.calls[0];
+            expect(encrypted).not.toContain(plaintext);
+            expect(encrypted.length).toBeGreaterThan(0);
+        });
+
+        it('decrypts and returns existing secret without re-generating', async () => {
+            // Seed: first call generates so we have a valid envelope to reuse.
+            repo.findById.mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValue(true);
+            const original = await service.getOrGenerate('work-1');
+            const persistedEnvelope = repo.setPlatformSyncSecretIfNull.mock.calls[0][1];
+
+            // Second call: the work now has the encrypted secret.
+            repo.findById.mockResolvedValueOnce(
+                makeWork({ platformSyncSecretEncrypted: persistedEnvelope }),
+            );
+            repo.setPlatformSyncSecretIfNull.mockClear();
+
+            const second = await service.getOrGenerate('work-1');
+            expect(second).toBe(original);
+            expect(repo.setPlatformSyncSecretIfNull).not.toHaveBeenCalled();
+        });
+
+        it('on concurrent first-deploy race, the loser reads back the winner value', async () => {
+            // Step 1: produce a real winner envelope via a separate run so we
+            // have a known plaintext/ciphertext pair to assert against.
+            repo.findById.mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValueOnce(true);
+            const winnerSecret = await service.getOrGenerate('work-1');
+            const winnerEnvelope = repo.setPlatformSyncSecretIfNull.mock.calls[0][1];
+
+            // Step 2: reset BOTH mocks so winner-phase queue entries don't
+            // leak into the loser scenario.
+            repo.findById.mockReset();
+            repo.setPlatformSyncSecretIfNull.mockReset();
+
+            // Step 3: simulate loser — initial findById sees NULL → write
+            // fails (loser) → re-read returns the winner's envelope.
+            repo.findById
+                .mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }))
+                .mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: winnerEnvelope }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValueOnce(false);
+
+            const loserResult = await service.getOrGenerate('work-1');
+            expect(loserResult).toBe(winnerSecret);
+            // Loser must have attempted the write exactly once and not retried.
+            expect(repo.setPlatformSyncSecretIfNull).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws when the Work is missing', async () => {
+            repo.findById.mockResolvedValueOnce(null as unknown as Work);
+            await expect(service.getOrGenerate('missing')).rejects.toThrow(/Work not found/);
+        });
+
+        it('throws if race-loss reread finds no value (impossible-state guard)', async () => {
+            repo.findById
+                .mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }))
+                .mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValueOnce(false);
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(/race lost but no value/);
+        });
+    });
+
+    describe('decryptForWork', () => {
+        it('returns null when work has no secret', () => {
+            const work = makeWork({ platformSyncSecretEncrypted: null });
+            expect(service.decryptForWork(work)).toBeNull();
+        });
+
+        it('returns plaintext when work has an encrypted secret', async () => {
+            repo.findById.mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValue(true);
+            const plaintext = await service.getOrGenerate('work-1');
+            const envelope = repo.setPlatformSyncSecretIfNull.mock.calls[0][1];
+
+            const work = makeWork({ platformSyncSecretEncrypted: envelope });
+            expect(service.decryptForWork(work)).toBe(plaintext);
+        });
+
+        it('throws on tampered ciphertext (auth tag mismatch)', async () => {
+            repo.findById.mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValue(true);
+            await service.getOrGenerate('work-1');
+            const envelope = repo.setPlatformSyncSecretIfNull.mock.calls[0][1];
+
+            // Flip the last byte of the base64-decoded envelope.
+            const buf = Buffer.from(envelope, 'base64');
+            buf[buf.length - 1] ^= 0xff;
+            const tampered = buf.toString('base64');
+
+            expect(() =>
+                service.decryptForWork(makeWork({ platformSyncSecretEncrypted: tampered })),
+            ).toThrow(/decryption failed/);
+        });
+    });
+
+    describe('encryption properties', () => {
+        it('produces a different envelope for each call with the same plaintext (fresh IV)', async () => {
+            repo.findById
+                .mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }))
+                .mockResolvedValueOnce(makeWork({ platformSyncSecretEncrypted: null }));
+            repo.setPlatformSyncSecretIfNull.mockResolvedValue(true);
+
+            await service.getOrGenerate('work-1');
+            await service.getOrGenerate('work-2');
+
+            const env1 = repo.setPlatformSyncSecretIfNull.mock.calls[0][1];
+            const env2 = repo.setPlatformSyncSecretIfNull.mock.calls[1][1];
+            expect(env1).not.toBe(env2);
+        });
+    });
+});

--- a/packages/agent/src/services/__tests__/work-import.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-import.service.spec.ts
@@ -66,6 +66,7 @@ function createWorksConfigRestoreServiceMock() {
         applyPipelineSettings: jest.fn().mockResolvedValue(undefined),
         applyInitialSchedule: jest.fn().mockResolvedValue(undefined),
         applyScheduleOverrides: jest.fn().mockResolvedValue(undefined),
+        applyActivitySyncMode: jest.fn().mockResolvedValue(undefined),
         validateProviderSettings: jest.fn().mockResolvedValue(undefined),
         toResolved: jest.fn((worksConfig: any) => worksConfig ?? null),
     };

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -18,6 +18,7 @@ export * from './generator-form-schema.service';
 export * from './works-manifest.service';
 export * from './webhook-delivery.service';
 export * from './state-marker.service';
+export * from './platform-sync-secret.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/platform-sync-secret.service.ts
+++ b/packages/agent/src/services/platform-sync-secret.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { config } from '../config';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { Work } from '../entities';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH_BYTES = 32;
+const IV_LENGTH_BYTES = 12;
+const AUTH_TAG_LENGTH_BYTES = 16;
+const SECRET_LENGTH_BYTES = 32;
+
+/**
+ * Manages the per-Work `PLATFORM_SYNC_SECRET` used by the EW-120 Activity
+ * Feed pull transport.
+ *
+ * Each pull-mode Work has its own 32-byte random secret, stored
+ * AES-256-GCM-encrypted on `works.platformSyncSecretEncrypted` with the
+ * platform-side `PLATFORM_ENCRYPTION_KEY`. The plaintext is pushed into
+ * the deployed site's runtime env via the existing GHA-secret push path
+ * (`DeployService.setRequiredSecrets`); the platform's
+ * `DirectoryWebsiteClient` decrypts on every outbound fetch to sign the
+ * request, and the site verifies against the env value.
+ *
+ * Bootstrap is lazy: `getOrGenerate` is called by `DeployService` on each
+ * deploy for pull-mode Works (no-op for push/disabled). First deploy
+ * generates and persists; subsequent deploys read the existing value.
+ * Concurrent deploys are idempotent via the conditional UPDATE in
+ * `WorkRepository.setPlatformSyncSecretIfNull` — losers re-read.
+ *
+ * Rotation: `rotate()` writes a fresh secret unconditionally. The deployed
+ * site only learns the new value at the next deploy; admin UX should warn
+ * the operator that a redeploy is required.
+ */
+@Injectable()
+export class PlatformSyncSecretService {
+    private readonly logger = new Logger(PlatformSyncSecretService.name);
+    private cachedKey: Buffer | null = null;
+
+    constructor(private readonly workRepository: WorkRepository) {}
+
+    /**
+     * Lazily provision the per-Work secret. Returns the plaintext hex.
+     *
+     * Concurrency: two simultaneous calls for the same Work both generate
+     * a fresh value, but only one wins the conditional UPDATE; the loser
+     * re-reads and returns the persisted value.
+     */
+    async getOrGenerate(workId: string): Promise<string> {
+        const existing = await this.workRepository.findById(workId);
+        if (!existing) {
+            throw new Error(`Work not found: ${workId}`);
+        }
+        if (existing.platformSyncSecretEncrypted) {
+            return this.decrypt(existing.platformSyncSecretEncrypted);
+        }
+        const plaintext = randomBytes(SECRET_LENGTH_BYTES).toString('hex');
+        const encrypted = this.encrypt(plaintext);
+        const won = await this.workRepository.setPlatformSyncSecretIfNull(workId, encrypted);
+        if (won) {
+            return plaintext;
+        }
+        // Lost the race — another deploy generated it first. Read back.
+        const reread = await this.workRepository.findById(workId);
+        if (!reread?.platformSyncSecretEncrypted) {
+            throw new Error(
+                `Platform sync secret bootstrap race lost but no value found for work ${workId}`,
+            );
+        }
+        return this.decrypt(reread.platformSyncSecretEncrypted);
+    }
+
+    /**
+     * Rotate the per-Work secret unconditionally. Returns the new plaintext.
+     * The next deploy carries the new value to the site's GHA secret;
+     * pull-mode requests will keep using the OLD value until that deploy
+     * finishes — the caller (admin UX) is responsible for telling the
+     * operator to redeploy.
+     */
+    async rotate(workId: string): Promise<string> {
+        const existing = await this.workRepository.findById(workId);
+        if (!existing) {
+            throw new Error(`Work not found: ${workId}`);
+        }
+        const plaintext = randomBytes(SECRET_LENGTH_BYTES).toString('hex');
+        const encrypted = this.encrypt(plaintext);
+        await this.workRepository.update(workId, { platformSyncSecretEncrypted: encrypted });
+        this.logger.log(`Rotated platform sync secret for work ${workId} — redeploy required`);
+        return plaintext;
+    }
+
+    /**
+     * Decrypt the secret for a Work that already has one provisioned.
+     * Returns `null` if the Work has no secret yet — the caller (the pull
+     * client) should degrade gracefully and surface a "not provisioned"
+     * banner instead of crashing.
+     */
+    decryptForWork(work: Pick<Work, 'platformSyncSecretEncrypted'>): string | null {
+        if (!work.platformSyncSecretEncrypted) {
+            return null;
+        }
+        return this.decrypt(work.platformSyncSecretEncrypted);
+    }
+
+    private getKey(): Buffer {
+        if (this.cachedKey) {
+            return this.cachedKey;
+        }
+        const hex = config.platformSync.getEncryptionKey();
+        if (!hex) {
+            throw new Error(
+                'PLATFORM_ENCRYPTION_KEY is not set. Required for encrypting per-Work platform_sync_secret.',
+            );
+        }
+        if (!/^[0-9a-fA-F]+$/.test(hex)) {
+            throw new Error('PLATFORM_ENCRYPTION_KEY must be a hex string.');
+        }
+        const key = Buffer.from(hex, 'hex');
+        if (key.length !== KEY_LENGTH_BYTES) {
+            throw new Error(
+                `PLATFORM_ENCRYPTION_KEY must decode to ${KEY_LENGTH_BYTES} bytes (got ${key.length}).`,
+            );
+        }
+        this.cachedKey = key;
+        return key;
+    }
+
+    private encrypt(plaintext: string): string {
+        const key = this.getKey();
+        const iv = randomBytes(IV_LENGTH_BYTES);
+        const cipher = createCipheriv(ALGORITHM, key, iv);
+        const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+        const authTag = cipher.getAuthTag();
+        return Buffer.concat([iv, authTag, ciphertext]).toString('base64');
+    }
+
+    private decrypt(envelope: string): string {
+        const key = this.getKey();
+        const buf = Buffer.from(envelope, 'base64');
+        if (buf.length < IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES + 1) {
+            throw new Error('platform_sync_secret envelope is malformed (too short).');
+        }
+        const iv = buf.subarray(0, IV_LENGTH_BYTES);
+        const authTag = buf.subarray(IV_LENGTH_BYTES, IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES);
+        const ciphertext = buf.subarray(IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES);
+        const decipher = createDecipheriv(ALGORITHM, key, iv);
+        decipher.setAuthTag(authTag);
+        try {
+            return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+        } catch (err) {
+            this.logger.error('Failed to decrypt platform_sync_secret', err);
+            throw new Error('platform_sync_secret decryption failed (auth tag mismatch).');
+        }
+    }
+}

--- a/packages/agent/src/services/work-import.service.ts
+++ b/packages/agent/src/services/work-import.service.ts
@@ -339,6 +339,7 @@ export class WorkImportService {
                     user.id,
                     worksConfig,
                 );
+                await this.worksConfigRestoreService.applyActivitySyncMode(work.id, worksConfig);
             }
 
             const updateData: Partial<Work> = {
@@ -911,6 +912,7 @@ export class WorkImportService {
 
         await this.worksConfigRestoreService.applyScheduleOverrides(work, user, worksConfig);
         await this.worksConfigRestoreService.applyPipelineSettings(work.id, user.id, worksConfig);
+        await this.worksConfigRestoreService.applyActivitySyncMode(work.id, worksConfig);
 
         return this.importExecutor.importFromWorksConfig({
             work,
@@ -975,6 +977,7 @@ export class WorkImportService {
             user.id,
             parsedWorksConfig,
         );
+        await this.worksConfigRestoreService.applyActivitySyncMode(work.id, parsedWorksConfig);
 
         return this.worksConfigRestoreService.toResolved(parsedWorksConfig);
     }

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -457,6 +457,14 @@ export class WorkLifecycleService {
                 updateData.committerEmail = updateDto.committerEmail || null;
             }
 
+            // EW-120 dual-mode Activity Feed sync mode. Writing here flips
+            // the platform-side read path immediately; works.yml gets
+            // round-tripped by the next WorksConfigRepositorySync trigger
+            // (deploy / generation / explicit settings save).
+            if (updateDto.activitySyncMode !== undefined) {
+                updateData.activitySyncMode = updateDto.activitySyncMode;
+            }
+
             const updatedWork = await this.workRepository.update(id, updateData);
 
             if (!updatedWork) {

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -143,6 +143,7 @@ import { WorksConfigSyncListener } from '@src/works-config/services/works-config
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
+import { PlatformSyncSecretService } from './platform-sync-secret.service';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
 import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
 import { TemplateCatalogModule } from '../template-catalog/template-catalog.module';
@@ -214,6 +215,7 @@ describe('WorkModule', () => {
             PluginOperationsService,
             SettingsSchemaValidatorService,
             EverWorksDeployQuotaService,
+            PlatformSyncSecretService,
             EverWorksGitProvider,
         ];
 
@@ -222,9 +224,9 @@ describe('WorkModule', () => {
         });
 
         it('keeps the providers list at the documented shape (class providers + the EverWorks quota counter factory)', () => {
-            // 29 class providers + 1 factory provider object for the
-            // EVER_WORKS_DEPLOY_QUOTA_COUNTER token = 30 entries total.
-            // (EW-614 added EverWorksGitProvider.)
+            // 30 class providers + 1 factory provider object for the
+            // EVER_WORKS_DEPLOY_QUOTA_COUNTER token = 31 entries total.
+            // (EW-120 added PlatformSyncSecretService; EW-614 added EverWorksGitProvider.)
             expect(meta('providers')).toHaveLength(expectedProviders.length + 1);
         });
 
@@ -289,8 +291,10 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 27-entry shape (24 services + 3 re-exported modules)', () => {
-            expect(meta('exports')).toHaveLength(27);
+        it('keeps the exports list at the documented 28-entry shape (25 services + 3 re-exported modules)', () => {
+            // Bumped to 28 with the PlatformSyncSecretService resurrection for
+            // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
+            expect(meta('exports')).toHaveLength(28);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -31,6 +31,7 @@ import { WorksConfigRestoreService } from '@src/works-config/services/works-conf
 import { WorksConfigService } from '@src/works-config/services/works-config.service';
 import { WorksConfigSyncListener } from '@src/works-config/services/works-config-sync.listener';
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
+import { PlatformSyncSecretService } from './platform-sync-secret.service';
 import { ItemHealthService } from './item-health.service';
 import { ItemSourceValidationSchedulerService } from './item-source-validation-scheduler.service';
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
@@ -96,6 +97,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         PluginOperationsService,
         SettingsSchemaValidatorService,
         EverWorksDeployQuotaService,
+        PlatformSyncSecretService,
         // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
         // the platform GitHub org (`ever-works-cloud`) using a server-held
         // PAT, so users picking "Ever Works Git" don't need to bring their
@@ -139,6 +141,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigWriterService,
         WorksConfigProjectionService,
         WorksConfigRepositorySyncService,
+        PlatformSyncSecretService,
         CommunityPrModule,
         ComparisonGeneratorModule,
         TemplateCatalogModule,

--- a/packages/agent/src/works-config/__tests__/works-config-import-applier.service.spec.ts
+++ b/packages/agent/src/works-config/__tests__/works-config-import-applier.service.spec.ts
@@ -36,15 +36,18 @@ import { WorksConfigImportApplierService } from '../services/works-config-import
 describe('WorksConfigImportApplierService', () => {
     let pluginOperationsService: { enablePluginForWork: jest.Mock };
     let workScheduleService: { updateSchedule: jest.Mock };
+    let workRepository: { update: jest.Mock };
     let service: WorksConfigImportApplierService;
     let warnSpy: jest.SpyInstance;
 
     beforeEach(() => {
         pluginOperationsService = { enablePluginForWork: jest.fn().mockResolvedValue(undefined) };
         workScheduleService = { updateSchedule: jest.fn().mockResolvedValue(undefined) };
+        workRepository = { update: jest.fn().mockResolvedValue(undefined) };
         service = new WorksConfigImportApplierService(
             pluginOperationsService as never,
             workScheduleService as never,
+            workRepository as never,
         );
         warnSpy = jest
             .spyOn((service as unknown as { logger: { warn: jest.Mock } }).logger, 'warn')
@@ -53,6 +56,34 @@ describe('WorksConfigImportApplierService', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
+    });
+
+    describe('applyActivitySyncMode (EW-120)', () => {
+        it.each(['pull', 'push', 'disabled'] as const)(
+            'projects activity_sync.mode=%p onto the Work row',
+            async (mode) => {
+                await service.applyActivitySyncMode('work-1', { activitySyncMode: mode } as never);
+                expect(workRepository.update).toHaveBeenCalledWith('work-1', {
+                    activitySyncMode: mode,
+                });
+            },
+        );
+
+        it('is a no-op when activitySyncMode is missing from the parsed config', async () => {
+            await service.applyActivitySyncMode('work-1', {} as never);
+            await service.applyActivitySyncMode('work-1', null);
+            expect(workRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('swallows repository errors so the import flow keeps going', async () => {
+            workRepository.update.mockRejectedValueOnce(new Error('DB down'));
+            await expect(
+                service.applyActivitySyncMode('work-1', { activitySyncMode: 'push' } as never),
+            ).resolves.toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to apply activitySyncMode'),
+            );
+        });
     });
 
     describe('applyPipelineSettings', () => {

--- a/packages/agent/src/works-config/__tests__/works-config-projection.service.spec.ts
+++ b/packages/agent/src/works-config/__tests__/works-config-projection.service.spec.ts
@@ -45,6 +45,7 @@ describe('WorksConfigProjectionService', () => {
                 screenshot: 'screenshotone',
                 contentExtractor: 'firecrawl',
             },
+            activitySyncMode: null,
         });
     });
 
@@ -81,6 +82,7 @@ describe('WorksConfigProjectionService', () => {
             name: 'Compare Cloud Pricing',
             model: null,
             providers: { ai: 'openai', screenshot: 'screenshotone' },
+            activitySyncMode: null,
         });
     });
 
@@ -101,6 +103,29 @@ describe('WorksConfigProjectionService', () => {
             name: 'Compare Cloud Pricing',
             model: null,
             providers: null,
+            activitySyncMode: null,
+        });
+    });
+
+    it('projects work.activitySyncMode onto the write request when set (EW-120)', async () => {
+        const scheduleRepository = {
+            findByWorkId: jest.fn().mockResolvedValue({ providerOverrides: null }),
+        };
+        const workPluginRepository = {
+            findEnabledByWork: jest.fn().mockResolvedValue([]),
+            findActiveByCapability: jest.fn().mockResolvedValue(null),
+        };
+        const service = new WorksConfigProjectionService(
+            scheduleRepository as any,
+            workPluginRepository as any,
+        );
+        const workWithMode = { ...work, activitySyncMode: 'push' as const };
+
+        await expect(service.buildWriteRequest(workWithMode)).resolves.toEqual({
+            name: 'Compare Cloud Pricing',
+            model: null,
+            providers: null,
+            activitySyncMode: 'push',
         });
     });
 });

--- a/packages/agent/src/works-config/__tests__/works-config.service.spec.ts
+++ b/packages/agent/src/works-config/__tests__/works-config.service.spec.ts
@@ -69,6 +69,50 @@ name: My Site
         expect(absent.deployProvider).toBeUndefined();
     });
 
+    describe('activity_sync.mode (EW-120)', () => {
+        it.each([
+            ['pull', 'pull'],
+            ['push', 'push'],
+            ['disabled', 'disabled'],
+            ['  PUSH  ', 'push'],
+        ])('parses canonical activity_sync.mode = %p as %p', (input, expected) => {
+            const result = service.parse(`
+name: My Site
+activity_sync:
+  mode: ${input}
+`);
+            expect(result.activitySyncMode).toBe(expected);
+        });
+
+        it('tolerates camelCase activitySync.mode', () => {
+            const result = service.parse(`
+name: My Site
+activitySync:
+  mode: push
+`);
+            expect(result.activitySyncMode).toBe('push');
+        });
+
+        it('tolerates flat activity_sync_mode', () => {
+            const result = service.parse(`
+name: My Site
+activity_sync_mode: disabled
+`);
+            expect(result.activitySyncMode).toBe('disabled');
+        });
+
+        it('returns undefined when the field is absent or unrecognised', () => {
+            expect(service.parse('name: x').activitySyncMode).toBeUndefined();
+            expect(
+                service.parse(`
+name: x
+activity_sync:
+  mode: nonsense
+`).activitySyncMode,
+            ).toBeUndefined();
+        });
+    });
+
     it('supports object-based schedule config', () => {
         const result = service.parse(`
 prompt: Keep this repo up to date

--- a/packages/agent/src/works-config/services/works-config-import-applier.service.ts
+++ b/packages/agent/src/works-config/services/works-config-import-applier.service.ts
@@ -4,6 +4,7 @@ import { Work } from '@src/entities/work.entity';
 import { User } from '@src/entities/user.entity';
 import { PluginOperationsService } from '@src/plugins/services/plugin-operations.service';
 import { WorkScheduleService } from '@src/services/work-schedule.service';
+import { WorkRepository } from '@src/database/repositories/work.repository';
 
 @Injectable()
 export class WorksConfigImportApplierService {
@@ -12,7 +13,32 @@ export class WorksConfigImportApplierService {
     constructor(
         private readonly pluginOperationsService: PluginOperationsService,
         private readonly workScheduleService: WorkScheduleService,
+        private readonly workRepository: WorkRepository,
     ) {}
+
+    /**
+     * Project the `activity_sync.mode` field from a parsed `works.yml`
+     * onto the Work entity. EW-120 dual-mode transport: this is the read
+     * path used everywhere downstream (poller, ingest guard, feed router).
+     */
+    async applyActivitySyncMode(
+        workId: string,
+        worksConfig?: ParsedWorksConfig | ResolvedWorksConfig | null,
+    ): Promise<void> {
+        const mode = worksConfig?.activitySyncMode;
+        if (!mode) {
+            return;
+        }
+        try {
+            await this.workRepository.update(workId, { activitySyncMode: mode });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to apply activitySyncMode=${mode} for work ${workId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
 
     async applyPipelineSettings(
         workId: string,

--- a/packages/agent/src/works-config/services/works-config-projection.service.ts
+++ b/packages/agent/src/works-config/services/works-config-projection.service.ts
@@ -26,6 +26,7 @@ export class WorksConfigProjectionService {
             name: work.name,
             model: pipelineModel ?? null,
             providers: this.mergeProviders(activeProviders, scheduleProviders) ?? null,
+            activitySyncMode: work.activitySyncMode ?? null,
         };
     }
 

--- a/packages/agent/src/works-config/services/works-config-restore.service.ts
+++ b/packages/agent/src/works-config/services/works-config-restore.service.ts
@@ -89,4 +89,11 @@ export class WorksConfigRestoreService {
     ): Promise<void> {
         await this.applier.applyScheduleOverrides(work, user, worksConfig);
     }
+
+    async applyActivitySyncMode(
+        workId: string,
+        worksConfig?: ParsedWorksConfig | ResolvedWorksConfig | null,
+    ): Promise<void> {
+        await this.applier.applyActivitySyncMode(workId, worksConfig);
+    }
 }

--- a/packages/agent/src/works-config/services/works-config-writer.service.ts
+++ b/packages/agent/src/works-config/services/works-config-writer.service.ts
@@ -18,6 +18,11 @@ export type WorksConfigWriteRequest = Partial<Pick<CreateItemsGeneratorDto, 'nam
      * the works-config layer never branches on the value.
      */
     deployProvider?: string | null;
+    /**
+     * Activity Feed sync transport (EW-120). Written under
+     * `activity_sync.mode` in works.yml.
+     */
+    activitySyncMode?: 'pull' | 'push' | 'disabled' | null;
 };
 
 export type WriteWorksConfigOptions = {
@@ -88,6 +93,22 @@ export class WorksConfigWriterService {
             delete baseRaw.deploy_provider;
         }
 
+        const activitySyncMode = this.resolveActivitySyncMode({
+            requested: request.activitySyncMode,
+            imported: imported?.activitySyncMode,
+            existing:
+                (baseRaw.activity_sync as { mode?: unknown } | undefined)?.mode ??
+                (baseRaw.activitySync as { mode?: unknown } | undefined)?.mode,
+            workValue: options.work.activitySyncMode,
+        });
+        // Round-trip under the snake_case nested shape canonically; drop
+        // any legacy camelCase alias so we don't end up with both.
+        delete baseRaw.activitySync;
+        delete baseRaw.activity_sync_mode;
+        delete baseRaw.activitySyncMode;
+        const activitySyncBlock =
+            activitySyncMode !== undefined ? { mode: activitySyncMode } : undefined;
+
         return this.withoutUndefined({
             ...baseRaw,
             name: request.name || imported?.name || options.work.name,
@@ -97,7 +118,34 @@ export class WorksConfigWriterService {
             website_repo: websiteRepo,
             schedule: this.buildSchedule(options.work, imported),
             deployProvider,
+            activity_sync: activitySyncBlock,
         });
+    }
+
+    private resolveActivitySyncMode(args: {
+        requested?: 'pull' | 'push' | 'disabled' | null;
+        imported?: 'pull' | 'push' | 'disabled' | null;
+        existing?: unknown;
+        workValue?: 'pull' | 'push' | 'disabled';
+    }): 'pull' | 'push' | 'disabled' | undefined {
+        if (args.requested === null) return undefined;
+        if (
+            args.requested === 'pull' ||
+            args.requested === 'push' ||
+            args.requested === 'disabled'
+        ) {
+            return args.requested;
+        }
+        if (args.imported === 'pull' || args.imported === 'push' || args.imported === 'disabled') {
+            return args.imported;
+        }
+        const existing =
+            typeof args.existing === 'string' ? args.existing.trim().toLowerCase() : '';
+        if (existing === 'pull' || existing === 'push' || existing === 'disabled') {
+            return existing;
+        }
+        if (args.workValue) return args.workValue;
+        return undefined;
     }
 
     private resolveDeployProvider(args: {

--- a/packages/agent/src/works-config/services/works-config.service.ts
+++ b/packages/agent/src/works-config/services/works-config.service.ts
@@ -18,6 +18,13 @@ export interface WorksConfigSummary {
      * time; the works-config layer itself is provider-agnostic.
      */
     deployProvider?: string;
+    /**
+     * Activity Feed sync transport for this directory (EW-120). Read from
+     * `activity_sync.mode` in `works.yml`; values: `pull` (default),
+     * `push`, `disabled`. Reflected onto `Work.activitySyncMode` at apply
+     * time. See ADR-004.
+     */
+    activitySyncMode?: 'pull' | 'push' | 'disabled';
 }
 
 export interface ParsedWorksConfig extends WorksConfigSummary {
@@ -77,7 +84,28 @@ export class WorksConfigService {
                 ]),
             ),
             deployProvider: this.readString(raw, ['deployProvider', 'deploy_provider']),
+            activitySyncMode: this.readActivitySyncMode(raw),
         };
+    }
+
+    private readActivitySyncMode(
+        raw: Record<string, unknown>,
+    ): 'pull' | 'push' | 'disabled' | undefined {
+        // Accept snake_case (canonical works.yml style) + camelCase
+        // tolerance for hand-edited files.
+        const candidates: Array<unknown> = [
+            (raw.activity_sync as { mode?: unknown } | undefined)?.mode,
+            (raw.activitySync as { mode?: unknown } | undefined)?.mode,
+            raw.activity_sync_mode,
+            raw.activitySyncMode,
+        ];
+        for (const value of candidates) {
+            const normalized = typeof value === 'string' ? value.trim().toLowerCase() : undefined;
+            if (normalized === 'pull' || normalized === 'push' || normalized === 'disabled') {
+                return normalized;
+            }
+        }
+        return undefined;
     }
 
     private async loadRawFromRepository(


### PR DESCRIPTION
Cascading EW-120 Activity Feed (PR #740) plus the rest of develop to stage.

Includes:
- EW-120 dual-mode Activity Feed (HMAC-signed pull client, push-ingest endpoint, mode-aware service routing, settings UI, Phase 0-6 work).
- All other develop commits since the last stage cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)