### PR TITLE
feat(auth): anonymous (zero-friction) user auth (EW-617 G2)

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { AuthService } from './services/auth.service';
+import { AnonymousAuthService } from './services/anonymous-auth.service';
 import { ApiKeyService } from './services/api-key.service';
 import { AuthController } from './controllers/auth.controller';
 import { ApiKeysController } from './controllers/api-keys.controller';
@@ -24,6 +25,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
     imports: [DatabaseModule, HttpModule, ActivityLogModule],
     providers: [
         AuthService,
+        AnonymousAuthService,
         ApiKeyService,
         AuthProviderService,
         AuthSyncService,
@@ -45,6 +47,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
     controllers: [OAuthController, AuthController, ApiKeysController],
     exports: [
         AuthService,
+        AnonymousAuthService,
         ApiKeyService,
         AuthSessionGuard,
         AUTH_PROVIDER,

--- a/apps/api/src/auth/controllers/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth.controller.spec.ts
@@ -9,6 +9,7 @@ jest.mock('@ever-works/agent/activity-log', () => ({
 
 import { AuthController } from './auth.controller';
 import type { AuthService } from '../services/auth.service';
+import type { AnonymousAuthService } from '../services/anonymous-auth.service';
 import type { SocialAuthService } from '../services/social-auth.service';
 import type { ActivityLogService } from '@ever-works/agent/activity-log';
 import type { AuthProvider } from '../providers/auth-provider.abstract';
@@ -31,6 +32,7 @@ describe('AuthController', () => {
         >
     >;
     let socialAuth: jest.Mocked<Pick<SocialAuthService, 'getConfiguredProviders'>>;
+    let anonymousAuth: jest.Mocked<Pick<AnonymousAuthService, 'createAnonymousUser'>>;
     let activityLog: jest.Mocked<Pick<ActivityLogService, 'log'>>;
     let authProvider: jest.Mocked<
         Pick<
@@ -59,6 +61,7 @@ describe('AuthController', () => {
             validatePasswordResetToken: jest.fn(),
         } as any;
         socialAuth = { getConfiguredProviders: jest.fn() } as any;
+        anonymousAuth = { createAnonymousUser: jest.fn() } as any;
         activityLog = { log: jest.fn().mockResolvedValue(undefined) } as any;
         authProvider = {
             signUpEmail: jest.fn(),
@@ -72,9 +75,65 @@ describe('AuthController', () => {
         controller = new AuthController(
             authService as unknown as AuthService,
             socialAuth as unknown as SocialAuthService,
+            anonymousAuth as unknown as AnonymousAuthService,
             activityLog as unknown as ActivityLogService,
             authProvider as unknown as AuthProvider,
         );
+    });
+
+    describe('anonymous (POST /api/auth/anonymous) — EW-617 G2', () => {
+        it('mints an anonymous session and logs the creation', async () => {
+            const tokenResponse = {
+                access_token: 'tok-anon-1',
+                user: {
+                    id: 'u-anon-1',
+                    email: null,
+                    username: 'anon-deadbeef',
+                    isAnonymous: true,
+                    anonymousExpiresAt: '2026-05-21T00:00:00.000Z',
+                },
+            };
+            anonymousAuth.createAnonymousUser.mockResolvedValue(tokenResponse as any);
+
+            const req = {
+                ip: '1.2.3.4',
+                headers: { 'user-agent': 'jest-agent', 'x-forwarded-for': '10.0.0.1, 1.2.3.4' },
+            };
+
+            const result = await (controller as any).anonymous(req);
+
+            expect(anonymousAuth.createAnonymousUser).toHaveBeenCalledWith({
+                ipAddress: '1.2.3.4',
+                userAgent: 'jest-agent',
+            });
+            expect(result).toEqual(tokenResponse);
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u-anon-1',
+                    action: 'user.anonymous_created',
+                    ipAddress: '1.2.3.4',
+                    userAgent: 'jest-agent',
+                }),
+            );
+        });
+
+        it('falls back to x-forwarded-for first hop when req.ip is missing', async () => {
+            anonymousAuth.createAnonymousUser.mockResolvedValue({
+                access_token: 'tok',
+                user: { id: 'u', email: null, username: 'anon-x', isAnonymous: true },
+            } as any);
+
+            const req = {
+                headers: { 'x-forwarded-for': ' 8.8.8.8 , 9.9.9.9 ' },
+            };
+
+            await (controller as any).anonymous(req);
+
+            expect(anonymousAuth.createAnonymousUser).toHaveBeenCalledWith({
+                ipAddress: '8.8.8.8',
+                userAgent: null,
+            });
+        });
     });
 
     describe('getConfiguredProviders (GET /api/auth/providers)', () => {

--- a/apps/api/src/auth/controllers/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth.controller.ts
@@ -20,6 +20,7 @@ import {
     ApiQuery,
 } from '@nestjs/swagger';
 import { AuthService } from '../services/auth.service';
+import { AnonymousAuthService } from '../services/anonymous-auth.service';
 import { RegisterDto, LoginDto, UpdatePasswordDto } from '../dto/auth.dto';
 import { VerifyEmailDto, ForgotPasswordDto, ResetPasswordDto } from '../dto/email-verification.dto';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
@@ -30,6 +31,7 @@ import { ActivityActionType, ActivityStatus } from '@ever-works/agent/entities';
 import { AUTH_PROVIDER } from '../providers/auth-provider.constants';
 import { AuthProvider } from '../providers/auth-provider.abstract';
 import { Inject } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { toHeaders } from '../providers/request-headers';
 import { SocialAuthService } from '../services/social-auth.service';
 
@@ -41,6 +43,7 @@ export class AuthController {
     constructor(
         private authService: AuthService,
         private readonly socialAuthService: SocialAuthService,
+        private readonly anonymousAuthService: AnonymousAuthService,
         private activityLogService: ActivityLogService,
         @Inject(AUTH_PROVIDER)
         private readonly authProvider: AuthProvider,
@@ -89,6 +92,50 @@ export class AuthController {
                 }`,
             );
         }
+
+        return response;
+    }
+
+    @Public()
+    @Post('anonymous')
+    // EW-617 G2: zero-friction onboarding entrypoint. Rate-limited per IP to
+    // prevent abuse; G7 will layer on stricter limits + captcha when needed.
+    @Throttle({ default: { limit: 5, ttl: 60 * 60 * 1000 } })
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({
+        summary: 'Create an anonymous (zero-friction) user',
+        description:
+            'Mints a temporary User row + session token. The row + its Works are wiped automatically after ANONYMOUS_USER_TTL_DAYS (default 7) days unless the user calls POST /api/auth/claim first.',
+    })
+    @ApiResponse({ status: 201, description: 'Anonymous session issued' })
+    @ApiResponse({ status: 429, description: 'Rate limit exceeded for this IP' })
+    async anonymous(@Request() req) {
+        const ipAddress =
+            (typeof req.ip === 'string' && req.ip) ||
+            (typeof req.headers['x-forwarded-for'] === 'string'
+                ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
+                : null);
+        const userAgent =
+            typeof req.headers['user-agent'] === 'string'
+                ? (req.headers['user-agent'] as string)
+                : null;
+
+        const response = await this.anonymousAuthService.createAnonymousUser({
+            ipAddress,
+            userAgent,
+        });
+
+        this.activityLogService
+            .log({
+                userId: response.user.id,
+                actionType: ActivityActionType.USER_LOGIN,
+                action: 'user.anonymous_created',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Anonymous user created (zero-friction flow)',
+                ipAddress,
+                userAgent,
+            })
+            .catch(() => {});
 
         return response;
     }

--- a/apps/api/src/auth/services/anonymous-auth.service.spec.ts
+++ b/apps/api/src/auth/services/anonymous-auth.service.spec.ts
@@ -1,0 +1,121 @@
+jest.mock('@ever-works/agent/database', () => ({ UserRepository: class {} }));
+jest.mock('@ever-works/agent/entities', () => ({ AuthSession: class {} }));
+
+import { AnonymousAuthService } from './anonymous-auth.service';
+
+describe('AnonymousAuthService (EW-617 G2)', () => {
+    const buildService = () => {
+        const created: any[] = [];
+        const userRepository = {
+            create: jest.fn(async (data: any) => {
+                const row = { id: `u-${created.length + 1}`, ...data };
+                created.push(row);
+                return row;
+            }),
+        } as any;
+
+        const savedSessions: any[] = [];
+        const sessionRepo = {
+            save: jest.fn(async (data: any) => {
+                savedSessions.push(data);
+                return data;
+            }),
+        };
+
+        const dataSource = {
+            getRepository: jest.fn(() => sessionRepo),
+        } as any;
+
+        const authProvider = {} as any;
+
+        const service = new AnonymousAuthService(userRepository, dataSource, authProvider);
+
+        return { service, userRepository, sessionRepo, savedSessions, created };
+    };
+
+    afterEach(() => {
+        delete process.env.ANONYMOUS_USER_TTL_DAYS;
+    });
+
+    it('creates a User row with isAnonymous=true and a future expiry', async () => {
+        const { service, userRepository, created } = buildService();
+
+        const before = Date.now();
+        const response = await service.createAnonymousUser();
+        const after = Date.now();
+
+        expect(userRepository.create).toHaveBeenCalledTimes(1);
+        const insertedUser = created[0];
+        expect(insertedUser.isAnonymous).toBe(true);
+        expect(insertedUser.email).toBeNull();
+        expect(insertedUser.password).toBeNull();
+        expect(insertedUser.registrationProvider).toBe('anonymous');
+        expect(insertedUser.username).toMatch(/^anon-[0-9a-f]{8}$/);
+
+        const expiresAtMs = (insertedUser.anonymousExpiresAt as Date).getTime();
+        const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+        expect(expiresAtMs).toBeGreaterThanOrEqual(before + sevenDaysMs - 1000);
+        expect(expiresAtMs).toBeLessThanOrEqual(after + sevenDaysMs + 1000);
+
+        expect(response.user.isAnonymous).toBe(true);
+        expect(response.user.email).toBeNull();
+        expect(response.user.anonymousExpiresAt).toBe(
+            (insertedUser.anonymousExpiresAt as Date).toISOString(),
+        );
+    });
+
+    it('persists an AuthSession with a generated token bound to the user', async () => {
+        const { service, savedSessions } = buildService();
+
+        const response = await service.createAnonymousUser({
+            ipAddress: '1.2.3.4',
+            userAgent: 'test-agent',
+        });
+
+        expect(savedSessions).toHaveLength(1);
+        const session = savedSessions[0];
+        expect(session.userId).toBe(response.user.id);
+        expect(session.token).toBe(response.access_token);
+        expect(session.token.length).toBeGreaterThan(20); // base64url(32 bytes) >= 43 chars
+        expect(session.ipAddress).toBe('1.2.3.4');
+        expect(session.userAgent).toBe('test-agent');
+    });
+
+    it('respects ANONYMOUS_USER_TTL_DAYS when set', async () => {
+        process.env.ANONYMOUS_USER_TTL_DAYS = '1';
+        const { service, created } = buildService();
+
+        const before = Date.now();
+        await service.createAnonymousUser();
+        const after = Date.now();
+
+        const oneDayMs = 24 * 60 * 60 * 1000;
+        const ttl = (created[0].anonymousExpiresAt as Date).getTime();
+        expect(ttl).toBeGreaterThanOrEqual(before + oneDayMs - 1000);
+        expect(ttl).toBeLessThanOrEqual(after + oneDayMs + 1000);
+    });
+
+    it('falls back to 7 days when ANONYMOUS_USER_TTL_DAYS is garbage', async () => {
+        process.env.ANONYMOUS_USER_TTL_DAYS = 'not-a-number';
+        const { service, created } = buildService();
+
+        const before = Date.now();
+        await service.createAnonymousUser();
+        const after = Date.now();
+
+        const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+        const ttl = (created[0].anonymousExpiresAt as Date).getTime();
+        expect(ttl).toBeGreaterThanOrEqual(before + sevenDaysMs - 1000);
+        expect(ttl).toBeLessThanOrEqual(after + sevenDaysMs + 1000);
+    });
+
+    it('mints unique usernames + tokens across consecutive calls', async () => {
+        const { service } = buildService();
+
+        const a = await service.createAnonymousUser();
+        const b = await service.createAnonymousUser();
+
+        expect(a.user.username).not.toBe(b.user.username);
+        expect(a.access_token).not.toBe(b.access_token);
+    });
+});

--- a/apps/api/src/auth/services/anonymous-auth.service.ts
+++ b/apps/api/src/auth/services/anonymous-auth.service.ts
@@ -1,0 +1,88 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { UserRepository } from '@ever-works/agent/database';
+import { AuthSession } from '@ever-works/agent/entities';
+import type { TokenResponse } from '../types/auth.types';
+import { AUTH_PROVIDER } from '../providers/auth-provider.constants';
+import { AuthProvider } from '../providers/auth-provider.abstract';
+
+/**
+ * EW-617 G2 — Anonymous (zero-friction) user creation.
+ *
+ * Spawns a fresh `User` row with `isAnonymous=true` + a TTL, then issues an
+ * `AuthSession` token so the rest of the API treats them like any other
+ * authenticated user. No email/password is collected. The row + its Works
+ * are wiped by the `anonymous-user-cleanup` Trigger.dev schedule once the
+ * TTL elapses.
+ *
+ * Claim-account (EW-617 G3) flips `isAnonymous=false`, clears the TTL,
+ * and attaches credentials.
+ */
+@Injectable()
+export class AnonymousAuthService {
+    private readonly logger = new Logger(AnonymousAuthService.name);
+
+    constructor(
+        private readonly userRepository: UserRepository,
+        @InjectDataSource() private readonly dataSource: DataSource,
+        @Inject(AUTH_PROVIDER)
+        private readonly authProvider: AuthProvider,
+    ) {}
+
+    /** Default TTL (7 days) — tunable via env var. */
+    private getTtlMs(): number {
+        const days = Number(process.env.ANONYMOUS_USER_TTL_DAYS || '7');
+        if (!Number.isFinite(days) || days <= 0) {
+            return 7 * 24 * 60 * 60 * 1000;
+        }
+        return days * 24 * 60 * 60 * 1000;
+    }
+
+    async createAnonymousUser(opts: {
+        ipAddress?: string | null;
+        userAgent?: string | null;
+    } = {}): Promise<TokenResponse> {
+        const expiresAt = new Date(Date.now() + this.getTtlMs());
+        const username = `anon-${randomBytes(4).toString('hex')}`;
+
+        const user = await this.userRepository.create({
+            username,
+            email: null,
+            password: null,
+            isAnonymous: true,
+            anonymousExpiresAt: expiresAt,
+            registrationProvider: 'anonymous',
+            emailVerified: false,
+            isActive: true,
+        });
+
+        this.logger.log(
+            `anonymous user created id=${user.id} username=${username} expiresAt=${expiresAt.toISOString()}`,
+        );
+
+        // Mint a session token directly — Better Auth's signup flow requires
+        // an email/password, so we bypass it for anon users and write the
+        // session row by hand. Same shape the rest of the API consumes.
+        const session = await this.dataSource.getRepository(AuthSession).save({
+            id: randomUUID(),
+            userId: user.id,
+            token: randomBytes(32).toString('base64url'),
+            expiresAt,
+            ipAddress: opts.ipAddress ?? null,
+            userAgent: opts.userAgent ?? null,
+        });
+
+        return {
+            access_token: session.token,
+            user: {
+                id: user.id,
+                email: null,
+                username: user.username,
+                isAnonymous: true,
+                anonymousExpiresAt: expiresAt.toISOString(),
+            },
+        };
+    }
+}

--- a/apps/api/src/auth/types/auth.types.ts
+++ b/apps/api/src/auth/types/auth.types.ts
@@ -1,6 +1,8 @@
 export interface AuthTokenPayload {
     sub: string;
-    email: string;
+    // EW-617 G2: anonymous (zero-friction) users have a null email until
+    // they claim the account via POST /api/auth/claim.
+    email: string | null;
     provider: string;
     username: string;
     emailVerified: boolean;
@@ -9,11 +11,13 @@ export interface AuthTokenPayload {
     iat: number;
     iss: string;
     aud: string;
+    // EW-617 G2: set to `true` for anonymous JWTs.
+    isAnonymous?: boolean;
 }
 
 export interface AuthenticatedUser {
     userId: string;
-    email: string;
+    email: string | null;
     username: string;
     provider: string;
     emailVerified: boolean;
@@ -22,13 +26,18 @@ export interface AuthenticatedUser {
     iat: number;
     iss: string;
     aud: string;
+    // EW-617 G2: downstream services can gate behavior on this flag
+    // (e.g. quotas, claim-account UI nag, OAuth restrictions).
+    isAnonymous?: boolean;
 }
 
 export interface TokenResponse {
     access_token: string;
     user: {
         id: string;
-        email: string;
+        email: string | null;
         username: string;
+        isAnonymous?: boolean;
+        anonymousExpiresAt?: string | null;
     };
 }

--- a/apps/api/src/integrations/github-app/github-app-onboarding.service.ts
+++ b/apps/api/src/integrations/github-app/github-app-onboarding.service.ts
@@ -168,10 +168,12 @@ export class GitHubAppOnboardingService {
                 lastLoginAt: new Date(),
             });
         } else {
-            const nextEmail =
-                input.email && user.email.endsWith('@users.noreply.ever.works')
-                    ? input.email
-                    : user.email;
+            // EW-617 G2: existing rows may now have null email (anonymous
+            // users who connected GitHub before claiming an account). Treat
+            // null the same as the placeholder noreply address — overwrite.
+            const isPlaceholderEmail =
+                !user.email || user.email.endsWith('@users.noreply.ever.works');
+            const nextEmail = input.email && isPlaceholderEmail ? input.email : user.email;
             user = await this.userRepository.update(user.id, {
                 username: user.username || input.login,
                 avatar: input.avatarUrl || user.avatar,

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -22,6 +22,21 @@ export class MailService {
     constructor(private readonly mailerService: MailerService) {}
 
     /**
+     * EW-617 G2: anonymous users have no email and must never receive
+     * transactional mail. All mail handlers early-return when the recipient
+     * has no email; in practice they shouldn't fire for anon users at all
+     * (we don't emit UserCreated/UserConfirmed/etc. for them) but the guard
+     * keeps the type-system honest and prevents accidental sends.
+     */
+    private requireEmail(email: string | null, context: string): string | null {
+        if (!email) {
+            this.logger.debug(`Skipping ${context}: recipient has no email (anonymous user?)`);
+            return null;
+        }
+        return email;
+    }
+
+    /**
      * Get branding context for email templates
      */
     private getBrandingContext() {
@@ -40,8 +55,12 @@ export class MailService {
     async sendSignupConfirmation(data: UserCreatedEvent): Promise<void> {
         try {
             const appName = config.branding.appName();
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Confirm your ${appName} account`,
                 template: 'signup-confirmation',
                 context: {
@@ -68,8 +87,12 @@ export class MailService {
             const resetUrl = data.resetUrl;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Reset your ${appName} password`,
                 template: 'forgot-password',
                 context: {
@@ -97,8 +120,12 @@ export class MailService {
             const secureAccountUrl = data.secureAccountUrl;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Your ${appName} password has been changed`,
                 template: 'password-changed',
                 context: {
@@ -129,8 +156,12 @@ export class MailService {
             const dashboardUrl = data.dashboardUrl || `${config.webAppUrl()}/works/new`;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Welcome to ${appName}!`,
                 template: 'welcome',
                 context: {
@@ -157,8 +188,12 @@ export class MailService {
             const secureAccountUrl = data.secureAccountUrl;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `New login to your ${appName} account`,
                 template: 'new-device-login',
                 context: {
@@ -191,8 +226,12 @@ export class MailService {
             const deleteUrl = data.deleteUrl;
             const keepAccountUrl = data.keepAccountUrl;
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: 'Confirm account deletion',
                 template: 'account-deletion',
                 context: {

--- a/apps/web/src/lib/auth/middleware.ts
+++ b/apps/web/src/lib/auth/middleware.ts
@@ -4,17 +4,20 @@ import { getAuthAccessCookie } from './cookies';
 
 export type AuthUser = {
     id: string;
-    email: string;
+    // EW-617 G2: anonymous (zero-friction) users have no email until they
+    // claim the account via POST /api/auth/claim.
+    email: string | null;
     username: string;
     emailVerified: boolean;
     avatar: string | null;
     provider?: string | null;
     isActive?: boolean;
+    isAnonymous?: boolean;
 };
 
 export type JwtPayload = {
     sub: string;
-    email: string;
+    email: string | null;
     provider: string;
     username: string;
     emailVerified: boolean;
@@ -24,6 +27,8 @@ export type JwtPayload = {
     iss: string;
     aud: string;
     exp: number;
+    // EW-617 G2: set to `true` for anonymous JWTs.
+    isAnonymous?: boolean;
 };
 
 function isLikelyJwt(token: string) {

--- a/docs/specs/features/zero-friction-flow/spec.md
+++ b/docs/specs/features/zero-friction-flow/spec.md
@@ -1,0 +1,117 @@
+# Zero-friction prompt → deployed Work flow
+
+> Epic: **EW-617** &nbsp;|&nbsp; Sub-tasks: EW-618 (G1), EW-619 (G2), EW-620 (G3), EW-621 (G4), EW-622 (G5), EW-623 (G6), EW-624 (G7), EW-625 (G8)
+>
+> Status: G6 merged (#752). G2 in-flight (this PR).
+
+## Goal
+
+A first-time visitor lands on `https://ever.works/`, types a prompt
+describing the website / directory they want, clicks **Generate**, and
+ends up on `https://app.ever.works/` already signed in as an
+**anonymous / temporary user**. The Onboarding Wizard auto-runs with
+all defaults; a single **Generate now** button creates the Work, which
+is then:
+
+- Published as 3 **private** repos under the `ever-works-cloud` GitHub org
+- Deployed to **k8s-works** with auto-provisioned DNS + TLS
+- Served at `https://{slug}.ever.works/`
+
+**The user provides nothing — not even an email — to try the platform
+end-to-end.** Later they can _Claim Account_ and attach credentials to
+keep their Work.
+
+## Gap breakdown
+
+Each gap is tracked as a sub-task under EW-617 and shipped as its own
+PR.
+
+| #  | Title                                                          | Jira    | Status   |
+|----|----------------------------------------------------------------|---------|----------|
+| G1 | Landing-page prompt input + handoff to app.ever.works          | EW-618  | Planned  |
+| G2 | Anonymous / temporary user auth                                | EW-619  | This PR  |
+| G3 | Claim-Account flow (anon → registered)                         | EW-620  | Planned  |
+| G4 | Wizard "Finish & Generate with Defaults" + `/api/works/quick-create` | EW-621 | Planned |
+| G5 | Subdomain ingress + Cloudflare DNS automation                  | EW-622  | Planned  |
+| G6 | Default `work.deployProvider` `'vercel'` → `'ever-works'`      | EW-623  | Merged (#752) |
+| G7 | Quotas + abuse protection                                      | EW-624  | Planned  |
+| G8 | Telemetry events + ops runbook                                 | EW-625  | Planned  |
+
+## G2 — Anonymous / temporary user auth
+
+### Functional requirements
+
+- **FR-G2-1** The `users` table MUST allow `email` and `password` to be
+  NULL when `is_anonymous = true`. Existing rows are unaffected.
+- **FR-G2-2** Two new columns on `users`: `is_anonymous BOOLEAN`
+  (default `false`) and `anonymous_expires_at TIMESTAMPTZ` (nullable).
+- **FR-G2-3** `POST /api/auth/anonymous` MUST mint a fresh `User` row
+  with `is_anonymous=true`, `email=NULL`, `password=NULL`,
+  `registration_provider='anonymous'`, `anonymous_expires_at = now +
+  ANONYMOUS_USER_TTL_DAYS` (default 7), then issue an `AuthSession`
+  token and return `{ access_token, user }` in the same shape as
+  `POST /api/auth/register`.
+- **FR-G2-4** `POST /api/auth/anonymous` MUST be rate-limited per IP
+  (default: 5 requests per hour). EW-624 (G7) will harden this with
+  captcha + global caps.
+- **FR-G2-5** The `AuthenticatedUser` type used downstream MUST carry
+  an optional `isAnonymous` flag so services can gate behavior
+  (quota path, claim-account UI, OAuth-only endpoints).
+- **FR-G2-6** Existing endpoints guarded by `AuthSessionGuard` MUST
+  accept anonymous session tokens — no guard changes are required
+  because the guard already issues a session regardless of identity.
+  Services that require a real email (e.g. transactional mail) MUST
+  reject anonymous users explicitly.
+- **FR-G2-7** A nightly Trigger.dev schedule `anonymous-user-cleanup`
+  (cron `17 3 * * *`) MUST find users with `is_anonymous=true AND
+  anonymous_expires_at < now` and delete them. The existing `work.user`
+  `ON DELETE CASCADE` removes their Works. A single delete failure
+  MUST log + continue so one stuck row cannot block the batch.
+- **FR-G2-8** The web-side `JwtPayload` type MUST expose `isAnonymous`
+  so layouts/components can render the claim-account nag.
+
+### Non-functional requirements
+
+- **NFR-G2-1** Anonymous user creation MUST be a single round-trip; no
+  Better Auth signup ceremony, no email verification mail.
+- **NFR-G2-2** Generated `username` MUST be DNS-/log-safe and not leak
+  IP/UA: pattern `anon-<8 hex chars>`.
+- **NFR-G2-3** `User.asCommitter()` MUST keep returning a parseable
+  email even when both `email` and `committerEmail` are null — fallback
+  to `anon-<userId>@anonymous.ever.works`. Real commits MUST NOT happen
+  on this fallback (claim-account flow lands before any repo write).
+
+### Out of scope (deferred to other gaps)
+
+- Landing-page prompt UI (G1).
+- Claim-account endpoint (G3).
+- Quick-create wizard (G4).
+- Subdomain DNS (G5).
+- Captcha / abuse hardening (G7).
+- Telemetry event emission (G8).
+
+## Acceptance (E2E, after all gaps land)
+
+A fresh-incognito user, with no account, no GitHub, no Vercel
+connection, no email:
+
+1. Lands on `https://ever.works/`.
+2. Types "AI coding assistants directory" into the prompt input.
+3. Clicks **Generate**.
+4. Is redirected to `https://app.ever.works/onboarding` already signed
+   in as an anonymous user.
+5. Wizard auto-completes with all defaults; user clicks one
+   **Generate now** button.
+6. Within ~3 min, 3 private repos appear in `ever-works-cloud` GitHub
+   org.
+7. Within ~5 min, `https://ai-coding-assistants.ever.works/` serves the
+   generated site over HTTPS.
+8. Optional: clicks **Claim account**, enters email + password, keeps
+   the Work.
+
+## References
+
+- Audit + gap breakdown: `EW-617`.
+- Wizard v2 defaults: `docs/specs/features/onboarding-wizard-v2/spec.md`.
+- `ever-works-cloud` org PAT lifecycle: `EW-614`.
+- k8s-works deploy pipeline: `docs/specs/features/k8s-deployment/`.

--- a/packages/agent/src/account-transfer/github-sync.service.ts
+++ b/packages/agent/src/account-transfer/github-sync.service.ts
@@ -137,7 +137,10 @@ export class GitHubSyncService {
             });
 
             const user = await this.userRepository.findById(userId);
-            const committer = user ? { name: user.username, email: user.email } : undefined;
+            const committer =
+                user && user.email
+                    ? { name: user.username, email: user.email }
+                    : undefined;
 
             // Clone or pull the repo
             const dir = await this.gitFacade.cloneOrPull(
@@ -182,7 +185,10 @@ export class GitHubSyncService {
 
         try {
             const user = await this.userRepository.findById(userId);
-            const committer = user ? { name: user.username, email: user.email } : undefined;
+            const committer =
+                user && user.email
+                    ? { name: user.username, email: user.email }
+                    : undefined;
 
             const dir = await this.gitFacade.cloneOrPull(
                 { owner: config.repoOwner, repo: config.repoName, committer },
@@ -227,7 +233,10 @@ export class GitHubSyncService {
 
         try {
             const user = await this.userRepository.findById(userId);
-            const committer = user ? { name: user.username, email: user.email } : undefined;
+            const committer =
+                user && user.email
+                    ? { name: user.username, email: user.email }
+                    : undefined;
 
             const dir = await this.gitFacade.cloneOrPull(
                 { owner: config.repoOwner, repo: config.repoName, committer },

--- a/packages/agent/src/database/repositories/user.repository.ts
+++ b/packages/agent/src/database/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, LessThan, Repository } from 'typeorm';
 import { User } from '../../entities/user.entity';
 import { config } from '../../config';
 import { randomUUID } from 'node:crypto';
@@ -57,6 +57,30 @@ export class UserRepository {
         );
 
         return (result.affected || 0) > 0;
+    }
+
+    /**
+     * EW-617 G2: anonymous user TTL cleanup.
+     * Returns all rows where `isAnonymous=true AND anonymousExpiresAt < now`.
+     * Caller (Trigger.dev nightly task) is expected to delete them; ON DELETE
+     * CASCADE on `work.userId` removes the orphan Works.
+     */
+    async findExpiredAnonymous(now: Date = new Date()): Promise<User[]> {
+        return await this.repository.find({
+            where: {
+                isAnonymous: true,
+                anonymousExpiresAt: LessThan(now),
+            },
+        });
+    }
+
+    /**
+     * EW-617 G2: hard-delete an anonymous user. Cascades to its Works via
+     * `work.user` ON DELETE CASCADE. Safe to call only after the row has been
+     * verified `isAnonymous=true` to avoid wiping a real account by mistake.
+     */
+    async deleteAnonymous(id: string): Promise<void> {
+        await this.repository.delete({ id, isAnonymous: true });
     }
 
     async createOrGetLocalUser(): Promise<User> {

--- a/packages/agent/src/entities/user.entity.ts
+++ b/packages/agent/src/entities/user.entity.ts
@@ -39,14 +39,28 @@ export class User {
     @Column()
     username: string;
 
-    @Column({ unique: true })
-    email: string;
+    // EW-617 G2: anonymous (zero-friction) users have no email/password until
+    // they claim the account via POST /api/auth/claim. Existing rows keep
+    // their non-null values; new anonymous rows persist NULLs here.
+    @Column({ unique: true, nullable: true })
+    email: string | null;
 
-    @Column()
-    password: string;
+    @Column({ nullable: true })
+    password: string | null;
 
     @Column({ default: 'local' })
-    registrationProvider: string; // 'local', 'github', 'google' - how user initially signed up
+    registrationProvider: string; // 'local', 'github', 'google', 'anonymous' - how user initially signed up
+
+    // EW-617 G2: zero-friction anonymous users.
+    // `isAnonymous=true` rows have nullable email/password and live until
+    // `anonymousExpiresAt`. The nightly cleanup task deletes expired rows
+    // and cascades to their Works. Claim-account flow flips this to false
+    // and clears the TTL.
+    @Column({ default: false })
+    isAnonymous: boolean;
+
+    @TimestampColumn({ nullable: true })
+    anonymousExpiresAt?: Date | null;
 
     @Column({ nullable: true })
     avatar: string;
@@ -138,9 +152,14 @@ export class User {
     local: boolean = false;
 
     asCommitter(): { name: string; email: string } {
+        // Anonymous users have null email; only happens before claim-account.
+        // Repo-touching paths (git commit, deploy) require a real email, so
+        // we surface a parseable but obviously-synthetic address that won't
+        // collide with anything real and signals 'fix before commit'.
+        const fallbackEmail = `anon-${this.id}@anonymous.ever.works`;
         return {
             name: this.committerName || this.username,
-            email: this.committerEmail || this.email,
+            email: this.committerEmail || this.email || fallbackEmail,
         };
     }
 }

--- a/packages/agent/src/services/__tests__/anonymous-user-cleanup.service.spec.ts
+++ b/packages/agent/src/services/__tests__/anonymous-user-cleanup.service.spec.ts
@@ -1,0 +1,69 @@
+import { AnonymousUserCleanupService } from '../anonymous-user-cleanup.service';
+
+describe('AnonymousUserCleanupService (EW-617 G2)', () => {
+    const buildService = () => {
+        const userRepository = {
+            findExpiredAnonymous: jest.fn(),
+            deleteAnonymous: jest.fn().mockResolvedValue(undefined),
+        } as any;
+        const service = new AnonymousUserCleanupService(userRepository);
+        return { service, userRepository };
+    };
+
+    it('returns an empty summary when no expired anonymous users exist', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([]);
+
+        const summary = await service.purgeExpired();
+
+        expect(summary).toEqual({ scanned: 0, deleted: 0, failed: 0, failures: [] });
+        expect(userRepository.deleteAnonymous).not.toHaveBeenCalled();
+    });
+
+    it('deletes every expired anonymous user and counts successes', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([
+            { id: 'u-1' },
+            { id: 'u-2' },
+            { id: 'u-3' },
+        ]);
+
+        const summary = await service.purgeExpired();
+
+        expect(userRepository.deleteAnonymous).toHaveBeenCalledTimes(3);
+        expect(userRepository.deleteAnonymous).toHaveBeenNthCalledWith(1, 'u-1');
+        expect(userRepository.deleteAnonymous).toHaveBeenNthCalledWith(2, 'u-2');
+        expect(userRepository.deleteAnonymous).toHaveBeenNthCalledWith(3, 'u-3');
+        expect(summary).toEqual({ scanned: 3, deleted: 3, failed: 0, failures: [] });
+    });
+
+    it('continues past a single delete failure and reports it', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([
+            { id: 'u-1' },
+            { id: 'u-stuck' },
+            { id: 'u-3' },
+        ]);
+        userRepository.deleteAnonymous
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error('fk constraint'))
+            .mockResolvedValueOnce(undefined);
+
+        const summary = await service.purgeExpired();
+
+        expect(summary.scanned).toBe(3);
+        expect(summary.deleted).toBe(2);
+        expect(summary.failed).toBe(1);
+        expect(summary.failures).toEqual([{ userId: 'u-stuck', error: 'fk constraint' }]);
+    });
+
+    it('passes the `now` argument through to the repository for testability', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([]);
+
+        const fixedNow = new Date('2026-05-14T03:17:00.000Z');
+        await service.purgeExpired(fixedNow);
+
+        expect(userRepository.findExpiredAnonymous).toHaveBeenCalledWith(fixedNow);
+    });
+});

--- a/packages/agent/src/services/anonymous-user-cleanup.service.ts
+++ b/packages/agent/src/services/anonymous-user-cleanup.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UserRepository } from '../database';
+
+export interface AnonymousUserCleanupSummary {
+    scanned: number;
+    deleted: number;
+    failed: number;
+    failures: Array<{ userId: string; error: string }>;
+}
+
+/**
+ * EW-617 G2 — nightly purge of expired anonymous users.
+ *
+ * The companion `anonymous-user-cleanup` Trigger.dev schedule (in
+ * `packages/tasks/src/tasks/trigger/`) calls `purgeExpired()` once a day.
+ * Each user row deletion cascades to their Works via the existing
+ * `work.user` ON DELETE CASCADE.
+ *
+ * The service is intentionally idempotent and resilient: a single row
+ * delete failure logs + continues so one stuck row doesn't block the rest
+ * of the batch.
+ */
+@Injectable()
+export class AnonymousUserCleanupService {
+    private readonly logger = new Logger(AnonymousUserCleanupService.name);
+
+    constructor(private readonly userRepository: UserRepository) {}
+
+    async purgeExpired(now: Date = new Date()): Promise<AnonymousUserCleanupSummary> {
+        const expired = await this.userRepository.findExpiredAnonymous(now);
+        const summary: AnonymousUserCleanupSummary = {
+            scanned: expired.length,
+            deleted: 0,
+            failed: 0,
+            failures: [],
+        };
+
+        if (expired.length === 0) {
+            return summary;
+        }
+
+        this.logger.log(`anonymous-user-cleanup found ${expired.length} expired user(s)`);
+
+        for (const user of expired) {
+            try {
+                await this.userRepository.deleteAnonymous(user.id);
+                summary.deleted += 1;
+            } catch (cause) {
+                summary.failed += 1;
+                const error = cause instanceof Error ? cause.message : String(cause);
+                summary.failures.push({ userId: user.id, error });
+                this.logger.error(
+                    `Failed to delete expired anonymous user ${user.id}: ${error}`,
+                );
+            }
+        }
+
+        this.logger.log(
+            `anonymous-user-cleanup deleted=${summary.deleted} failed=${summary.failed} of ${summary.scanned}`,
+        );
+
+        return summary;
+    }
+}

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -18,6 +18,7 @@ export * from './generator-form-schema.service';
 export * from './works-manifest.service';
 export * from './webhook-delivery.service';
 export * from './state-marker.service';
+export * from './anonymous-user-cleanup.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -16,6 +16,7 @@ import { WorkLifecycleService } from './work-lifecycle.service';
 import { WorkGenerationService } from './work-generation.service';
 import { WorkScheduleService } from './work-schedule.service';
 import { WorkScheduleDispatcherService } from './work-schedule-dispatcher.service';
+import { AnonymousUserCleanupService } from './anonymous-user-cleanup.service';
 import { WorkMemberService } from './work-member.service';
 import { WorkInvitationService } from './work-invitation.service';
 import { WorkImportService } from './work-import.service';
@@ -76,6 +77,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorkDetailService,
         WorkScheduleService,
         WorkScheduleDispatcherService,
+        AnonymousUserCleanupService,
         WorkMemberService,
         WorkInvitationService,
         WorkImportService,
@@ -123,6 +125,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorkDetailService,
         WorkScheduleService,
         WorkScheduleDispatcherService,
+        AnonymousUserCleanupService,
         WorkMemberService,
         WorkInvitationService,
         WorkImportService,

--- a/packages/agent/src/user-research/prompts.ts
+++ b/packages/agent/src/user-research/prompts.ts
@@ -68,7 +68,11 @@ export function buildSeedPrompt(user: User, socials: string[]): string {
     const lines: string[] = [];
     lines.push(`User to research:`);
     lines.push(`- Name: ${user.username}`);
-    lines.push(`- Email: ${user.email}`);
+    // EW-617 G2: anonymous users have no email until they claim the account;
+    // user-research only runs after onboarding so this is mostly defensive.
+    if (user.email) {
+        lines.push(`- Email: ${user.email}`);
+    }
     if (user.registrationProvider && user.registrationProvider !== 'local') {
         lines.push(`- OAuth provider: ${user.registrationProvider}`);
     }
@@ -80,7 +84,7 @@ export function buildSeedPrompt(user: User, socials: string[]): string {
     if (socials.length > 0) {
         lines.push(`- Linked social profiles: ${socials.join(', ')}`);
     }
-    const domain = user.email.split('@')[1];
+    const domain = user.email?.split('@')[1];
     if (domain) {
         lines.push(`- Email domain: ${domain}`);
     }

--- a/packages/tasks/src/tasks/trigger/anonymous-user-cleanup.task.ts
+++ b/packages/tasks/src/tasks/trigger/anonymous-user-cleanup.task.ts
@@ -1,0 +1,32 @@
+import { schedules } from '@trigger.dev/sdk';
+import { NestFactory } from '@nestjs/core';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { AnonymousUserCleanupService } from '@ever-works/agent/services';
+import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
+
+/**
+ * EW-617 G2 — nightly purge of expired anonymous users.
+ *
+ * Runs every day at 03:17 UTC (off-peak, deliberately staggered from the
+ * other scheduled jobs to avoid a coincident burst on the database). The
+ * service consults `users.is_anonymous=true AND users.anonymous_expires_at <
+ * now`, then deletes each row; cascade on `work.userId` removes the orphan
+ * Works.
+ */
+export const anonymousUserCleanupTask = schedules.task({
+    id: 'anonymous-user-cleanup',
+    cron: '17 3 * * *',
+    run: async () => {
+        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+
+        appContext.useLogger(createTriggerLogger('AnonymousUserCleanup'));
+
+        try {
+            const cleanup = appContext.get(AnonymousUserCleanupService);
+            const summary = await cleanup.purgeExpired();
+            return summary;
+        } finally {
+            await appContext.close();
+        }
+    },
+});

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -1,3 +1,4 @@
+export * from './anonymous-user-cleanup.task';
 export * from './user-research-rerun-dispatcher.task';
 export * from './work-generation.task';
 export * from './work-import.task';


### PR DESCRIPTION
## Summary

Foundation for the EW-617 zero-friction prompt-to-Work flow. Adds a temporary-user identity that lives for `ANONYMOUS_USER_TTL_DAYS` (default 7) without an email/password, then auto-purges via a nightly Trigger.dev schedule. G3 (claim-account), G4 (quick-create wizard), G1 (landing prompt), and G7 (captcha/quotas) all build on this.

**Schema**
- New columns: `users.is_anonymous BOOLEAN` (default `false`), `users.anonymous_expires_at TIMESTAMPTZ` (nullable)
- `users.email` and `users.password` are now nullable. Existing rows keep their non-null values; new anonymous rows persist NULLs here.
- `User.asCommitter()` falls back to `anon-<userId>@anonymous.ever.works` when both `committerEmail` and `email` are null — repo writes shouldn't land before claim, but the fallback keeps it parseable.

**API**
- `POST /api/auth/anonymous` (Public, throttled 5/hour per IP) returns `{ access_token, user: { id, email: null, username, isAnonymous, anonymousExpiresAt } }` in the same shape as `/register` and `/login`.
- `AnonymousAuthService` mints the User row + an `AuthSession` directly — no Better Auth signup ceremony, no verification mail.
- `AuthTokenPayload` / `AuthenticatedUser` / `TokenResponse` / web `JwtPayload` all gain optional `isAnonymous`. No guard changes are needed: anonymous tokens satisfy `AuthSessionGuard` like any other valid session.

**Cleanup**
- `AnonymousUserCleanupService.purgeExpired()` deletes expired rows; existing `work.user` `ON DELETE CASCADE` removes their Works.
- Per-row failures log + continue so one stuck row can't block the batch.
- New schedule \`anonymous-user-cleanup\` runs \`17 3 * * *\` UTC (staggered off-peak).

**Defensive null-email handling**
- \`mail.service.ts\` early-returns when recipient has no email.
- \`github-app-onboarding.service.ts\` treats null email like the \`@users.noreply\` placeholder.
- \`user-research/prompts.ts\` and \`account-transfer/github-sync.service.ts\` skip the email line when null.

**Docs**
- \`docs/specs/features/zero-friction-flow/spec.md\` captures EW-617 gap breakdown + the G2 FRs/NFRs.

Sub-task: EW-619. Parent epic: EW-617. Builds on PR #752 (G6, merged).

## Test plan

- [ ] CI green: \`apps/api\` Jest — new \`anonymous-auth.service.spec.ts\` (5 tests) + \`auth.controller.spec.ts\` additions (2 anon tests)
- [ ] CI green: \`packages/agent\` Jest — new \`anonymous-user-cleanup.service.spec.ts\` (4 tests)
- [ ] CI green: full \`pnpm type-check\` (the null-email type widening compiles across the monorepo)
- [ ] Manual: \`curl -X POST .../api/auth/anonymous\` returns 201 with \`access_token\` + \`isAnonymous: true\`
- [ ] Manual: \`GET /api/auth/profile\` with the returned token returns the anon user

## Out of scope (follow-up PRs)

- G3 claim-account endpoint (anon → registered) — EW-620
- G4 quick-create wizard — EW-621
- G1 landing-page prompt input + URL handoff — EW-618
- G5 subdomain + Cloudflare DNS — EW-622
- G7 captcha + global caps — EW-624
- G8 funnel telemetry — EW-625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anonymous user creation, enabling zero-friction onboarding for visitors
  * Temporary anonymous sessions automatically expire and are cleaned up daily
  * Anonymous user creation is rate-limited to 5 requests per hour per IP address

* **Documentation**
  * Added feature specification for zero-friction flow workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/756)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->