### PR TITLE
feat(works): /api/works/quick-create + wizard 'Generate now' (EW-617 G4)

### DIFF
--- a/apps/api/src/works/works.controller.quick-create.spec.ts
+++ b/apps/api/src/works/works.controller.quick-create.spec.ts
@@ -195,7 +195,7 @@ describe('WorksController.quickCreateWork (EW-617 G4)', () => {
         expect(createWork).toHaveBeenCalledTimes(1);
     });
 
-    it("defaults organization to false when omitted", async () => {
+    it('defaults organization to false when omitted', async () => {
         const { controller, createWork } = makeController({});
 
         const dto: any = { ...baseDto };

--- a/apps/api/src/works/works.controller.quick-create.spec.ts
+++ b/apps/api/src/works/works.controller.quick-create.spec.ts
@@ -1,0 +1,207 @@
+// Mock the agent runtime tree at module scope so importing the controller does
+// not pull in the agent's NestJS DI graph.
+jest.mock('@ever-works/agent/dto', () => ({}));
+jest.mock('@ever-works/agent/items-generator', () => ({
+    CreateItemsGeneratorDto: class CreateItemsGeneratorDto {
+        name?: string;
+        prompt?: string;
+        model?: string;
+    },
+}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/agent/comparison-generator', () => ({}));
+jest.mock('@ever-works/agent/template-catalog', () => ({}));
+jest.mock('@ever-works/agent/generators', () => ({
+    getDefaultWebsiteTemplateId: jest.fn(() => 'default-template'),
+}));
+jest.mock('@ever-works/agent/community-pr', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/cache', () => ({ CACHE_MANAGER: 'CACHE_MANAGER' }));
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        WORK_CREATED: 'WORK_CREATED',
+        GENERATION: 'GENERATION',
+    },
+    ActivityStatus: { COMPLETED: 'COMPLETED', IN_PROGRESS: 'IN_PROGRESS' },
+}));
+jest.mock('@ever-works/agent/subscriptions', () => ({}));
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('../auth', () => ({
+    AuthService: class {},
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { WorksController } from './works.controller';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+const auth: AuthenticatedUser = { userId: 'auth-1' } as any;
+
+function makeController(overrides: {
+    createWorkResult?: unknown;
+    generateResult?: unknown;
+    generateThrows?: Error;
+}) {
+    const createWork = jest.fn().mockResolvedValue(
+        overrides.createWorkResult ?? {
+            status: 'success',
+            work: { id: 'w-1', slug: 'my-slug', name: 'My Slug' },
+        },
+    );
+    const generateItems = overrides.generateThrows
+        ? jest.fn().mockRejectedValue(overrides.generateThrows)
+        : jest.fn().mockResolvedValue(
+              overrides.generateResult ?? {
+                  status: 'pending',
+                  historyId: 'gen-1',
+                  message: 'Generation started',
+              },
+          );
+
+    const activityLog = { log: jest.fn().mockResolvedValue(undefined) };
+    const authService = { getUser: jest.fn().mockResolvedValue({ id: 'user-1' }) };
+
+    const controller = new WorksController(
+        { wrap: jest.fn() } as any,
+        { typeormAdapter: { deleteUnscopedEntriesLike: jest.fn() } } as any,
+        {} as any,
+        { createWork } as any,
+        { generateItems, updateItemsGenerator: jest.fn(), cancelGeneration: jest.fn() } as any,
+        authService as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        activityLog as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+    );
+
+    return { controller, createWork, generateItems, activityLog, authService };
+}
+
+const baseDto = {
+    slug: 'ai-coding-assistants',
+    name: 'AI Coding Assistants',
+    description: 'A curated directory of AI coding assistants',
+    prompt: 'AI coding assistants directory with reviews and pricing',
+    organization: false,
+};
+
+describe('WorksController.quickCreateWork (EW-617 G4)', () => {
+    it('creates the work then kicks off generation and returns the combined response', async () => {
+        const { controller, createWork, generateItems, activityLog } = makeController({});
+
+        const result = await (controller as any).quickCreateWork(auth, baseDto);
+
+        expect(createWork).toHaveBeenCalledTimes(1);
+        const createDtoArg = createWork.mock.calls[0][0];
+        expect(createDtoArg).toMatchObject({
+            slug: 'ai-coding-assistants',
+            name: 'AI Coding Assistants',
+            description: 'A curated directory of AI coding assistants',
+            organization: false,
+            gitProvider: 'github',
+        });
+        // Prompt is NOT passed to createWork — it belongs in the generator DTO.
+        expect(createDtoArg.prompt).toBeUndefined();
+
+        expect(generateItems).toHaveBeenCalledTimes(1);
+        const [workId, generatorDto, , awaitCompletion] = generateItems.mock.calls[0];
+        expect(workId).toBe('w-1');
+        expect(generatorDto.prompt).toBe(baseDto.prompt);
+        expect(generatorDto.name).toBe(baseDto.name);
+        expect(awaitCompletion).toBe(false);
+
+        expect(result).toEqual({
+            status: 'pending',
+            work: { id: 'w-1', slug: 'my-slug', name: 'My Slug' },
+            generation: { historyId: 'gen-1', message: 'Generation started' },
+        });
+
+        expect(activityLog.log).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: 'user-1',
+                workId: 'w-1',
+                action: 'work.quick_create',
+            }),
+        );
+    });
+
+    it('passes through provider overrides when supplied', async () => {
+        const { controller, createWork } = makeController({});
+
+        await (controller as any).quickCreateWork(auth, {
+            ...baseDto,
+            deployProvider: 'k8s',
+            storageProvider: 'ever-works-git',
+            gitProvider: 'gitlab',
+            websiteTemplateId: 'modern',
+            model: 'claude-3-haiku',
+        });
+
+        expect(createWork).toHaveBeenCalledTimes(1);
+        const createDtoArg = createWork.mock.calls[0][0];
+        expect(createDtoArg.deployProvider).toBe('k8s');
+        expect(createDtoArg.storageProvider).toBe('ever-works-git');
+        expect(createDtoArg.gitProvider).toBe('gitlab');
+        expect(createDtoArg.websiteTemplateId).toBe('modern');
+    });
+
+    it('forwards model to the generator DTO but never to createWork', async () => {
+        const { controller, createWork, generateItems } = makeController({});
+
+        await (controller as any).quickCreateWork(auth, { ...baseDto, model: 'gpt-4o-mini' });
+
+        const generatorDto = generateItems.mock.calls[0][1];
+        expect(generatorDto.model).toBe('gpt-4o-mini');
+        expect(createWork.mock.calls[0][0].model).toBeUndefined();
+    });
+
+    it('throws BadRequestException when createWork returns a non-success status', async () => {
+        const { controller } = makeController({
+            createWorkResult: { status: 'error', work: null },
+        });
+
+        await expect((controller as any).quickCreateWork(auth, baseDto)).rejects.toThrow(
+            BadRequestException,
+        );
+    });
+
+    it('bubbles up generation errors after creating the work (caller polls or retries)', async () => {
+        const { controller, createWork } = makeController({
+            generateThrows: new Error('queue full'),
+        });
+
+        await expect((controller as any).quickCreateWork(auth, baseDto)).rejects.toThrow(
+            'queue full',
+        );
+        // The work was created — caller can retry just the generation step
+        // via POST /works/:id/generate.
+        expect(createWork).toHaveBeenCalledTimes(1);
+    });
+
+    it("defaults organization to false when omitted", async () => {
+        const { controller, createWork } = makeController({});
+
+        const dto: any = { ...baseDto };
+        delete dto.organization;
+        await (controller as any).quickCreateWork(auth, dto);
+
+        expect(createWork.mock.calls[0][0].organization).toBe(false);
+    });
+});

--- a/apps/api/src/works/works.controller.ts
+++ b/apps/api/src/works/works.controller.ts
@@ -31,6 +31,7 @@ import {
 } from '@nestjs/swagger';
 import {
     CreateWorkDto,
+    QuickCreateWorkDto,
     UpdateWorkDto,
     UpdateWorkAdvancedPromptsDto,
     CreateCategoryDto,
@@ -307,6 +308,88 @@ export class WorksController {
     async createWork(@CurrentUser() auth: AuthenticatedUser, @Body() createWorkDto: CreateWorkDto) {
         const user = await this.authService.getUser(auth.userId);
         return this.workLifecycleService.createWork(createWorkDto, user);
+    }
+
+    @Post('works/quick-create')
+    @HttpCode(HttpStatus.ACCEPTED)
+    // EW-617 G4: one-call combined create-Work + start-generation for the
+    // wizard's "Generate now" button. Throttled because each call kicks off
+    // an AI pipeline + repo provisioning — same per-IP envelope as the
+    // existing /works/:id/generate path.
+    @Throttle({ default: { limit: 10, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Quick-create + generate a work',
+        description:
+            'Creates a Work using onboarding defaults and immediately kicks off AI item generation in a single request. Returns the new work id + generation history id; the client polls /works/:id/generation-history for status.',
+    })
+    @ApiResponse({ status: 202, description: 'Work created and generation started' })
+    @ApiResponse({ status: 400, description: 'Invalid input data' })
+    @ApiResponse({ status: 409, description: 'Slug already taken' })
+    async quickCreateWork(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() dto: QuickCreateWorkDto,
+    ): Promise<{
+        status: 'pending';
+        work: { id: string; slug: string; name: string };
+        generation: { historyId: string; message: string };
+    }> {
+        const user = await this.authService.getUser(auth.userId);
+
+        // 1. Create the Work via the existing pipeline. Provider defaults
+        //    (storage/deploy/git) are resolved from the user's
+        //    onboardingState inside createWork — no special handling here.
+        const createDto: CreateWorkDto = Object.assign(new CreateWorkDto(), {
+            slug: dto.slug,
+            name: dto.name,
+            description: dto.description,
+            owner: dto.owner,
+            organization: dto.organization ?? false,
+            gitProvider: dto.gitProvider ?? 'github',
+            deployProvider: dto.deployProvider,
+            storageProvider: dto.storageProvider,
+            websiteTemplateId: dto.websiteTemplateId,
+            readmeConfig: dto.readmeConfig,
+        });
+        const created = await this.workLifecycleService.createWork(createDto, user);
+        if (!created || created.status !== 'success' || !created.work) {
+            throw new BadRequestException('Failed to create work');
+        }
+        const work = created.work;
+
+        this.activityLogService
+            .log({
+                userId: user.id,
+                workId: work.id,
+                actionType: ActivityActionType.WORK_CREATED,
+                action: 'work.quick_create',
+                status: ActivityStatus.COMPLETED,
+                summary: `Quick-create kicked off generation for ${work.slug}`,
+            })
+            .catch(() => {});
+
+        // 2. Kick off generation async — the standard generation pipeline
+        //    handles persistence + dispatch.  awaitCompletion=false means
+        //    we return immediately with the historyId for status polling.
+        const generatorDto = Object.assign(new CreateItemsGeneratorDto(), {
+            name: dto.name,
+            prompt: dto.prompt,
+            ...(dto.model ? { model: dto.model } : {}),
+        });
+        const generation = await this.workGenerationService.generateItems(
+            work.id,
+            generatorDto,
+            user,
+            false,
+        );
+
+        return {
+            status: 'pending',
+            work: { id: work.id, slug: work.slug, name: work.name },
+            generation: {
+                historyId: generation.historyId ?? '',
+                message: generation.message ?? 'Generation started',
+            },
+        };
     }
 
     @Get('works/:id')

--- a/apps/web/src/app/actions/works/quick-create.ts
+++ b/apps/web/src/app/actions/works/quick-create.ts
@@ -1,6 +1,10 @@
 'use server';
 
-import { worksAPI, type QuickCreateWorkRequest, type QuickCreateWorkResponse } from '@/lib/api/works';
+import {
+    worksAPI,
+    type QuickCreateWorkRequest,
+    type QuickCreateWorkResponse,
+} from '@/lib/api/works';
 import type { ActionResult } from '@/app/actions/plugins';
 
 /**

--- a/apps/web/src/app/actions/works/quick-create.ts
+++ b/apps/web/src/app/actions/works/quick-create.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { worksAPI, type QuickCreateWorkRequest, type QuickCreateWorkResponse } from '@/lib/api/works';
+import type { ActionResult } from '@/app/actions/plugins';
+
+/**
+ * EW-617 G4 — server action that the wizard's `CreateWorkStep` calls when
+ * the user clicks "Generate now". Mirrors the existing onboarding action
+ * shape (success-or-error envelope) so callers can `if (!result.success)`
+ * uniformly.
+ */
+export async function quickCreateWorkAction(
+    body: QuickCreateWorkRequest,
+): Promise<ActionResult<QuickCreateWorkResponse>> {
+    try {
+        const data = await worksAPI.quickCreate(body);
+        return { success: true, data };
+    } catch (error) {
+        console.error('Failed to quick-create work:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to start generation',
+        };
+    }
+}

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -91,6 +91,44 @@ export function EverWorksOnboardingWizard({
             void completeOnboarding();
         },
     });
+
+    // EW-617 G4 + G1 — landing-page hand-off. When the wizard mounts and
+    // the URL carries `?prompt=…` (or hash `#prompt=…`, used as a poor-man's
+    // signed-token transport), seed the wizard state and jump straight to
+    // the final step so the user sees "Generate now" without scrolling
+    // through choices. We do this once per mount; subsequent renders read
+    // from the persisted state.
+    const promptHydratedRef = useRef(false);
+    useEffect(() => {
+        if (!mounted || promptHydratedRef.current) return;
+        if (flow.state.prompt) {
+            // Already hydrated from server state — no URL work needed.
+            promptHydratedRef.current = true;
+            return;
+        }
+        if (typeof window === 'undefined') return;
+        const url = new URL(window.location.href);
+        const fromQuery = url.searchParams.get('prompt');
+        const fromHash = readHashParam(url.hash, 'prompt');
+        const raw = (fromQuery || fromHash || '').trim();
+        if (!raw) return;
+
+        promptHydratedRef.current = true;
+        flow.setPrompt(raw);
+        // Skip to the final step so the user lands on "Generate now".
+        const createIndex = flow.steps.findIndex((s) => s.kind === 'create-work');
+        if (createIndex >= 0) {
+            flow.jumpTo(createIndex);
+        }
+
+        // Strip the prompt from the URL so a reload doesn't re-trigger the
+        // hand-off (and so we don't leak the prompt to analytics referers).
+        url.searchParams.delete('prompt');
+        if (fromHash) {
+            url.hash = stripHashParam(url.hash, 'prompt');
+        }
+        window.history.replaceState({}, '', url.toString());
+    }, [mounted, flow]);
 
     const refreshConnections = async (pluginId?: string) => {
         const target = pluginId ? plugins.filter((p) => p.pluginId === pluginId) : plugins;
@@ -386,7 +424,43 @@ function StepBody({
                 />
             );
         case 'create-work':
-            return <CreateWorkStep onLeave={() => flow.finish()} />;
+            return (
+                <CreateWorkStep
+                    onLeave={() => flow.finish()}
+                    prompt={flow.state.prompt}
+                    onQuickCreate={
+                        flow.state.prompt
+                            ? async (prompt) => {
+                                  // EW-617 G4: anonymous + claimed users alike
+                                  // can one-click finish. The endpoint reads
+                                  // provider defaults from onboarding state.
+                                  const { quickCreateWorkAction } = await import(
+                                      '@/app/actions/works/quick-create'
+                                  );
+                                  const slug = slugifyPrompt(prompt);
+                                  const result = await quickCreateWorkAction({
+                                      slug,
+                                      name: deriveNameFromPrompt(prompt),
+                                      description: prompt.slice(0, 500),
+                                      prompt,
+                                      organization: false,
+                                      deployProvider: flow.state.deploy.choice,
+                                      storageProvider: flow.state.storage.choice,
+                                  });
+                                  if (!result.success) {
+                                      throw new Error(
+                                          result.error ?? 'Failed to start generation',
+                                      );
+                                  }
+                                  return {
+                                      workSlug: result.data?.work.slug,
+                                      generationHistoryId: result.data?.generation.historyId,
+                                  };
+                              }
+                            : undefined
+                    }
+                />
+            );
         default:
             return null;
     }
@@ -396,6 +470,56 @@ function StepBody({
 
 function isConfigKind(kind: WizardStep['kind']): boolean {
     return kind === 'ai-config' || kind === 'storage-config' || kind === 'deploy-config';
+}
+
+// EW-617 G4: extract `prompt=…` from a URL hash fragment. The landing
+// page (G1) hands off via fragment so the prompt never hits the server
+// access logs as a querystring. We parse defensively; bad input returns
+// `null` and we fall back to the existing /works/new flow.
+function readHashParam(hash: string, key: string): string | null {
+    if (!hash) return null;
+    const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+    try {
+        const params = new URLSearchParams(raw);
+        return params.get(key);
+    } catch {
+        return null;
+    }
+}
+
+function stripHashParam(hash: string, key: string): string {
+    if (!hash) return '';
+    const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+    try {
+        const params = new URLSearchParams(raw);
+        params.delete(key);
+        const remaining = params.toString();
+        return remaining ? `#${remaining}` : '';
+    } catch {
+        return hash;
+    }
+}
+
+// EW-617 G4: derive a DNS-safe slug from the user's prompt.
+// The slug column has the same `^[a-z0-9]+(?:-[a-z0-9]+)*$` constraint
+// as `CreateWorkDto.slug`, so we strip everything else and bound the
+// length. Adds a short timestamp suffix so two users typing the same
+// prompt don't collide.
+function slugifyPrompt(prompt: string): string {
+    const base = prompt
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 40);
+    const suffix = Math.random().toString(36).slice(2, 8);
+    return base ? `${base}-${suffix}` : `quick-${suffix}`;
+}
+
+// Pull the first ~80 chars of the prompt as a display name. Title-cased
+// so it looks like a name in the dashboard list.
+function deriveNameFromPrompt(prompt: string): string {
+    const head = prompt.slice(0, 80).trim();
+    return head.charAt(0).toUpperCase() + head.slice(1);
 }
 
 function pluginIdForStep(

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -434,9 +434,8 @@ function StepBody({
                                   // EW-617 G4: anonymous + claimed users alike
                                   // can one-click finish. The endpoint reads
                                   // provider defaults from onboarding state.
-                                  const { quickCreateWorkAction } = await import(
-                                      '@/app/actions/works/quick-create'
-                                  );
+                                  const { quickCreateWorkAction } =
+                                      await import('@/app/actions/works/quick-create');
                                   const slug = slugifyPrompt(prompt);
                                   const result = await quickCreateWorkAction({
                                       slug,

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -448,9 +448,7 @@ function StepBody({
                                       storageProvider: flow.state.storage.choice,
                                   });
                                   if (!result.success) {
-                                      throw new Error(
-                                          result.error ?? 'Failed to start generation',
-                                      );
+                                      throw new Error(result.error ?? 'Failed to start generation');
                                   }
                                   return {
                                       workSlug: result.data?.work.slug,

--- a/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
@@ -1,44 +1,117 @@
 'use client';
 
-import { ArrowRight, FolderPlus } from 'lucide-react';
+import { useState } from 'react';
+import { ArrowRight, FolderPlus, Sparkles } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 
 export interface CreateWorkStepProps {
     readonly onLeave: () => void;
+    /**
+     * EW-617 G4: when a prompt is present (from the landing page `?prompt=…`
+     * handoff, or typed into the wizard), this step swaps the
+     * "Create your first work" link for a one-click "Generate now" button.
+     * The button calls `onQuickCreate(prompt)` and shows progress; the
+     * parent owns the API call so this component stays I/O-free.
+     */
+    readonly prompt?: string;
+    readonly onQuickCreate?: (prompt: string) => Promise<{
+        readonly workSlug?: string;
+        readonly generationHistoryId?: string;
+    } | void>;
 }
 
 /**
- * Final step — navigates the user into the Create Work flow. The wizard
- * closes once the user clicks the action; the parent fires the
+ * Final step — either:
+ *  1. (legacy) navigates the user into the /works/new form, or
+ *  2. (EW-617 G4) one-click "Generate now" when a `prompt` is set,
+ *     calling `onQuickCreate(prompt)` which posts to
+ *     `POST /api/works/quick-create` and returns the new work id +
+ *     generation history id for status polling.
+ *
+ * The wizard closes once the action fires; the parent emits the
  * `onboarding_completed` telemetry event and marks the server flag.
  */
-export function CreateWorkStep({ onLeave }: CreateWorkStepProps) {
+export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkStepProps) {
+    const trimmedPrompt = prompt?.trim() ?? '';
+    const hasPrompt = trimmedPrompt.length > 0 && Boolean(onQuickCreate);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleQuickCreate = async () => {
+        if (!onQuickCreate || submitting) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            await onQuickCreate(trimmedPrompt);
+            onLeave();
+        } catch (cause) {
+            const message = cause instanceof Error ? cause.message : String(cause);
+            setError(message || 'Generation failed to start. Please try again.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
     return (
         <div className="space-y-5 max-w-lg">
             <div className="flex items-start gap-4">
                 <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-surface-secondary dark:bg-white/5">
-                    <FolderPlus className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    {hasPrompt ? (
+                        <Sparkles className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    ) : (
+                        <FolderPlus className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    )}
                 </div>
                 <div>
                     <h3 className="text-lg font-semibold text-text dark:text-text-dark">
-                        Create your first work
+                        {hasPrompt ? 'Ready to generate' : 'Create your first work'}
                     </h3>
                     <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
-                        You&apos;re all set. Hit the button below to start building — your choices
-                        above are saved and any new work will pick them up.
+                        {hasPrompt
+                            ? 'We saved your wizard choices. One click and we’ll generate the directory from your prompt — repos, items, and deploy all in one go.'
+                            : "You're all set. Hit the button below to start building — your choices above are saved and any new work will pick them up."}
                     </p>
+                    {hasPrompt ? (
+                        <p className="mt-3 rounded-md border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/30 px-3 py-2 text-sm text-text dark:text-text-dark">
+                            <span className="font-medium">Prompt:</span> {trimmedPrompt}
+                        </p>
+                    ) : null}
                 </div>
             </div>
             <div className="rounded-xl border border-dashed border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/30 p-5">
-                <Link
-                    href={ROUTES.DASHBOARD_WORKS_NEW}
-                    onClick={onLeave}
-                    className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
-                >
-                    Create your first work
-                    <ArrowRight className="w-4 h-4" />
-                </Link>
+                {hasPrompt ? (
+                    <>
+                        <button
+                            type="button"
+                            onClick={handleQuickCreate}
+                            disabled={submitting}
+                            data-testid="onboarding-generate-now"
+                            className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            {submitting ? 'Generating…' : 'Generate now'}
+                            <Sparkles className="w-4 h-4" />
+                        </button>
+                        {error ? (
+                            <p
+                                role="alert"
+                                className="mt-3 text-sm text-red-600 dark:text-red-400"
+                                data-testid="onboarding-generate-error"
+                            >
+                                {error}
+                            </p>
+                        ) : null}
+                    </>
+                ) : (
+                    <Link
+                        href={ROUTES.DASHBOARD_WORKS_NEW}
+                        onClick={onLeave}
+                        className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
+                    >
+                        Create your first work
+                        <ArrowRight className="w-4 h-4" />
+                    </Link>
+                )}
             </div>
         </div>
     );

--- a/apps/web/src/components/onboarding/useOnboardingFlow.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.ts
@@ -71,6 +71,7 @@ type FlowAction =
     | { type: 'setAiChoice'; value: OnboardingAiChoice }
     | { type: 'setStorageChoice'; value: OnboardingStorageChoice }
     | { type: 'setDeployChoice'; value: OnboardingDeployChoice }
+    | { type: 'setPrompt'; value: string }
     | { type: 'recordSkip'; stepId: string }
     | { type: 'setPluginsReviewed'; value: boolean }
     | { type: 'mergeServerState'; value: OnboardingWizardStateV2 }
@@ -124,6 +125,17 @@ function reduce(state: FlowReducerState, action: FlowAction): FlowReducerState {
             return {
                 ...state,
                 state: { ...state.state, deploy: { choice: action.value } },
+            };
+        case 'setPrompt':
+            // EW-617 G4: prompt carried from landing-page input through the
+            // wizard into the quick-create endpoint. Trimmed empty strings
+            // map back to `undefined` so we don't persist whitespace.
+            return {
+                ...state,
+                state: {
+                    ...state.state,
+                    prompt: action.value.trim() || undefined,
+                },
             };
         case 'recordSkip': {
             if (state.state.skippedSteps.includes(action.stepId)) return state;
@@ -181,6 +193,7 @@ export interface UseOnboardingFlowResult {
     readonly setStorageChoice: (value: OnboardingStorageChoice) => void;
     readonly setDeployChoice: (value: OnboardingDeployChoice) => void;
     readonly setPluginsReviewed: (value: boolean) => void;
+    readonly setPrompt: (value: string) => void;
     readonly goNext: () => void;
     readonly goBack: () => void;
     readonly skip: () => void;
@@ -291,6 +304,14 @@ export function useOnboardingFlow({
         [],
     );
 
+    const setPrompt = useCallback(
+        (value: string) => {
+            trackEvent('onboarding_prompt_set', { hasValue: Boolean(value.trim()) });
+            dispatch({ type: 'setPrompt', value });
+        },
+        [trackEvent],
+    );
+
     const refresh = useCallback(() => {
         const stepKind = currentStep?.kind ?? 'welcome';
         trackEvent('onboarding_plugin_refresh_clicked', { stepKind });
@@ -340,6 +361,7 @@ export function useOnboardingFlow({
         setStorageChoice,
         setDeployChoice,
         setPluginsReviewed,
+        setPrompt,
         goNext,
         goBack,
         skip,
@@ -352,7 +374,7 @@ export function useOnboardingFlow({
 
 function stripVersion(state: OnboardingWizardStateV2) {
     // The patch endpoint deep-merges by field; `version` is server-managed.
-    const { lastStep, ai, storage, deploy, skippedSteps, pluginsReviewed } = state;
+    const { lastStep, ai, storage, deploy, skippedSteps, pluginsReviewed, prompt } = state;
     return {
         lastStep,
         ai: { choice: ai.choice },
@@ -360,6 +382,7 @@ function stripVersion(state: OnboardingWizardStateV2) {
         deploy: { choice: deploy.choice },
         skippedSteps: [...skippedSteps],
         pluginsReviewed,
+        ...(prompt ? { prompt } : {}),
     };
 }
 

--- a/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
@@ -165,6 +165,18 @@ describe('reduce', () => {
         expect(next.state.pluginsReviewed).toBe(true);
     });
 
+    // EW-617 G4: prompt round-trip through the reducer.
+    it('setPrompt stores the trimmed value and clears on whitespace-only input', () => {
+        const set = reduce(initialReducerState(), {
+            type: 'setPrompt',
+            value: '  AI coding assistants directory   ',
+        });
+        expect(set.state.prompt).toBe('AI coding assistants directory');
+
+        const cleared = reduce(set, { type: 'setPrompt', value: '   ' });
+        expect(cleared.state.prompt).toBeUndefined();
+    });
+
     it('mergeServerState replaces state and clamps the current step index', () => {
         const start = { ...initialReducerState(), stepIndex: 8 };
         const next = reduce(start, {

--- a/apps/web/src/lib/api/works.ts
+++ b/apps/web/src/lib/api/works.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+import { serverMutation } from './server-api';
+
+/**
+ * EW-617 G4 — server-side client for `POST /api/works/quick-create`.
+ *
+ * Wraps the wizard's "Generate now" button: takes the prompt + the user's
+ * onboarding choices and asks the API to create a Work + start AI
+ * generation in one round-trip. Returns the new work id + the generation
+ * history id so the client can navigate + poll.
+ */
+export interface QuickCreateWorkRequest {
+    readonly slug: string;
+    readonly name: string;
+    readonly description: string;
+    readonly prompt: string;
+    readonly organization?: boolean;
+    readonly owner?: string;
+    readonly gitProvider?: string;
+    readonly deployProvider?: string;
+    readonly storageProvider?: string;
+    readonly websiteTemplateId?: string;
+    readonly model?: string;
+}
+
+export interface QuickCreateWorkResponse {
+    readonly status: 'pending';
+    readonly work: { readonly id: string; readonly slug: string; readonly name: string };
+    readonly generation: { readonly historyId: string; readonly message: string };
+}
+
+export const worksAPI = {
+    quickCreate(body: QuickCreateWorkRequest) {
+        return serverMutation<QuickCreateWorkResponse>({
+            endpoint: '/works/quick-create',
+            data: body,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+};

--- a/docs/specs/features/zero-friction-flow/g4-quick-create.md
+++ b/docs/specs/features/zero-friction-flow/g4-quick-create.md
@@ -22,15 +22,12 @@ straight to this final step.
   by `AuthSessionGuard`, throttled 10/min per IP) accepts
   `QuickCreateWorkDto { slug, name, description, prompt, organization?,
 owner?, gitProvider?, deployProvider?, storageProvider?,
-websiteTemplateId?, model?, readmeConfig? }` and:
-    1. Calls `WorkLifecycleService.createWork` with the subset that maps to
-       `CreateWorkDto`. Provider defaults (`storage`/`deploy`/`git`) are
-       resolved from the user's onboarding state inside `createWork` — the
-       endpoint forwards explicit overrides only.
-    2. Calls `WorkGenerationService.generateItems(workId, { name, prompt,
+websiteTemplateId?, model?, readmeConfig? }` and: 1. Calls `WorkLifecycleService.createWork` with the subset that maps to
+  `CreateWorkDto`. Provider defaults (`storage`/`deploy`/`git`) are
+  resolved from the user's onboarding state inside `createWork` — the
+  endpoint forwards explicit overrides only. 2. Calls `WorkGenerationService.generateItems(workId, { name, prompt,
 model? }, user, /*awaitCompletion*/ false)` to dispatch generation
-       asynchronously.
-    3. Returns `202 Accepted` with `{ status: 'pending', work: { id, slug,
+  asynchronously. 3. Returns `202 Accepted` with `{ status: 'pending', work: { id, slug,
 name }, generation: { historyId, message } }`.
 - **FR-G4-3** When `createWork` returns a non-success status the endpoint
   MUST throw `BadRequestException` and not attempt to start generation.

--- a/docs/specs/features/zero-friction-flow/g4-quick-create.md
+++ b/docs/specs/features/zero-friction-flow/g4-quick-create.md
@@ -1,0 +1,80 @@
+# EW-617 G4 — Wizard "Generate now" + `POST /api/works/quick-create`
+
+> Sub-task: **EW-621**. Parent epic: **EW-617**.
+>
+> Companion gaps (separate PRs): G6 #752 (merged-ready), G2 #756 (anon
+> auth), G3 #757 (claim-account), G1/G5/G7/G8 planned.
+
+## Goal
+
+Replace the wizard's hand-off to `/works/new` with a single "Generate now"
+button that creates a Work and starts AI generation in one API call. When
+a prompt is carried over from the landing page (G1), the wizard jumps
+straight to this final step.
+
+## Functional requirements
+
+- **FR-G4-1** `OnboardingWizardStateV2` gains an optional `prompt: string`
+  field, persisted server-side alongside the existing
+  `ai`/`storage`/`deploy` choices. The patch endpoint accepts it via
+  `OnboardingStatePatchRequest.state.prompt`.
+- **FR-G4-2** A new `POST /api/works/quick-create` endpoint (authenticated
+  by `AuthSessionGuard`, throttled 10/min per IP) accepts
+  `QuickCreateWorkDto { slug, name, description, prompt, organization?,
+  owner?, gitProvider?, deployProvider?, storageProvider?,
+  websiteTemplateId?, model?, readmeConfig? }` and:
+  1. Calls `WorkLifecycleService.createWork` with the subset that maps to
+     `CreateWorkDto`. Provider defaults (`storage`/`deploy`/`git`) are
+     resolved from the user's onboarding state inside `createWork` — the
+     endpoint forwards explicit overrides only.
+  2. Calls `WorkGenerationService.generateItems(workId, { name, prompt,
+     model? }, user, /*awaitCompletion*/ false)` to dispatch generation
+     asynchronously.
+  3. Returns `202 Accepted` with `{ status: 'pending', work: { id, slug,
+     name }, generation: { historyId, message } }`.
+- **FR-G4-3** When `createWork` returns a non-success status the endpoint
+  MUST throw `BadRequestException` and not attempt to start generation.
+- **FR-G4-4** Generation errors after a successful create MUST bubble up
+  unmodified — the caller can retry generation via
+  `POST /works/:id/generate` against the new work id.
+- **FR-G4-5** `CreateWorkStep` MUST render "Generate now" only when a
+  non-empty `prompt` is available and an `onQuickCreate` callback is
+  passed. Otherwise it renders the legacy "Create your first work" link
+  to `/works/new`. The component MUST be I/O-free; the parent owns the
+  fetch.
+- **FR-G4-6** On wizard mount, the parent MUST read `?prompt=…` from
+  the URL query OR from the `#prompt=…` URL fragment, seed
+  `flow.setPrompt(...)`, jump to the `create-work` step, and strip the
+  parameter from the URL via `history.replaceState`. Fragment transport
+  is preferred (lands client-side only, never hits server logs).
+
+## Non-functional requirements
+
+- **NFR-G4-1** Slug + name derivation on the client MUST be deterministic
+  enough for the server's validation to pass without bouncing: slug is
+  `^[a-z0-9]+(?:-[a-z0-9]+)*$`, max 46 chars, and SHOULD include a short
+  randomized suffix to dodge collisions across users typing the same
+  prompt.
+- **NFR-G4-2** The "Generate now" button MUST disable itself while the
+  request is in flight and surface API errors inline (no global toast)
+  so the user can retry without losing wizard context.
+- **NFR-G4-3** Prompt MUST be bounded to 5000 chars on the wire (matches
+  `CreateItemsGeneratorDto.prompt`).
+
+## Out of scope (other gaps)
+
+- G1 — landing-page input + signed-token URL handoff (EW-618).
+- G3 — claim-account banner shown after a successful quick-create
+  (EW-620, in flight as #757).
+- G7 — captcha / global cap (EW-624).
+- G8 — funnel telemetry for the quick-create event (EW-625).
+
+## Acceptance
+
+- A logged-in (or anonymous, post-G2) user with `prompt` populated on
+  their wizard state can click "Generate now" and receive a 202 with a
+  pending generation history id. Polling `GET
+  /works/:id/generation-history` shows the run progressing.
+- Landing on `app.ever.works/onboarding#prompt=AI%20coding%20assistants`
+  drops the user on the `create-work` step with the prompt pre-filled
+  and the URL cleaned to `app.ever.works/onboarding`.

--- a/docs/specs/features/zero-friction-flow/g4-quick-create.md
+++ b/docs/specs/features/zero-friction-flow/g4-quick-create.md
@@ -21,17 +21,17 @@ straight to this final step.
 - **FR-G4-2** A new `POST /api/works/quick-create` endpoint (authenticated
   by `AuthSessionGuard`, throttled 10/min per IP) accepts
   `QuickCreateWorkDto { slug, name, description, prompt, organization?,
-  owner?, gitProvider?, deployProvider?, storageProvider?,
-  websiteTemplateId?, model?, readmeConfig? }` and:
-  1. Calls `WorkLifecycleService.createWork` with the subset that maps to
-     `CreateWorkDto`. Provider defaults (`storage`/`deploy`/`git`) are
-     resolved from the user's onboarding state inside `createWork` — the
-     endpoint forwards explicit overrides only.
-  2. Calls `WorkGenerationService.generateItems(workId, { name, prompt,
-     model? }, user, /*awaitCompletion*/ false)` to dispatch generation
-     asynchronously.
-  3. Returns `202 Accepted` with `{ status: 'pending', work: { id, slug,
-     name }, generation: { historyId, message } }`.
+owner?, gitProvider?, deployProvider?, storageProvider?,
+websiteTemplateId?, model?, readmeConfig? }` and:
+    1. Calls `WorkLifecycleService.createWork` with the subset that maps to
+       `CreateWorkDto`. Provider defaults (`storage`/`deploy`/`git`) are
+       resolved from the user's onboarding state inside `createWork` — the
+       endpoint forwards explicit overrides only.
+    2. Calls `WorkGenerationService.generateItems(workId, { name, prompt,
+model? }, user, /*awaitCompletion*/ false)` to dispatch generation
+       asynchronously.
+    3. Returns `202 Accepted` with `{ status: 'pending', work: { id, slug,
+name }, generation: { historyId, message } }`.
 - **FR-G4-3** When `createWork` returns a non-success status the endpoint
   MUST throw `BadRequestException` and not attempt to start generation.
 - **FR-G4-4** Generation errors after a successful create MUST bubble up
@@ -74,7 +74,7 @@ straight to this final step.
 - A logged-in (or anonymous, post-G2) user with `prompt` populated on
   their wizard state can click "Generate now" and receive a 202 with a
   pending generation history id. Polling `GET
-  /works/:id/generation-history` shows the run progressing.
+/works/:id/generation-history` shows the run progressing.
 - Landing on `app.ever.works/onboarding#prompt=AI%20coding%20assistants`
   drops the user on the `create-work` step with the prompt pre-filled
   and the URL cleaned to `app.ever.works/onboarding`.

--- a/packages/agent/src/dto/index.ts
+++ b/packages/agent/src/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './create-work.dto';
+export * from './quick-create-work.dto';
 export * from './generate-data.dto';
 export * from './update-work.dto';
 export * from './work-advanced-prompts.dto';

--- a/packages/agent/src/dto/quick-create-work.dto.ts
+++ b/packages/agent/src/dto/quick-create-work.dto.ts
@@ -91,8 +91,7 @@ export class QuickCreateWorkDto {
     gitProvider?: string;
 
     @ApiPropertyOptional({
-        description:
-            'Override deploy provider (default: from onboarding state, then "ever-works")',
+        description: 'Override deploy provider (default: from onboarding state, then "ever-works")',
     })
     @IsOptional()
     @IsString()

--- a/packages/agent/src/dto/quick-create-work.dto.ts
+++ b/packages/agent/src/dto/quick-create-work.dto.ts
@@ -1,0 +1,132 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+    IsBoolean,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    Matches,
+    MaxLength,
+    ValidateNested,
+} from 'class-validator';
+import { MarkdownReadmeConfigDto } from './create-work.dto';
+import { sanitizeDescription, sanitizeName, sanitizePrompt } from '../utils/sanitize.util';
+
+/**
+ * EW-617 G4 — payload for `POST /api/works/quick-create`.
+ *
+ * Combines the fields needed to create a Work (subset of
+ * `CreateWorkDto`) plus a `prompt` so the server can kick off AI
+ * generation in the same request. The wizard's "Generate now" button
+ * sends this; the response carries both the new `workId` and the
+ * `generationHistoryId` the client polls.
+ *
+ * Provider defaults (storage/deploy/git) are read from the user's
+ * `onboardingState` server-side, so the client doesn't need to repeat
+ * the wizard choices here. Override only when the user picked something
+ * non-default (e.g. user-github with their own repo).
+ */
+export class QuickCreateWorkDto {
+    @ApiProperty({
+        description: 'URL-friendly identifier (lowercase letters, numbers, hyphens only)',
+        example: 'ai-coding-assistants',
+    })
+    @IsString()
+    @IsNotEmpty()
+    @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+        message: 'Slug can only contain lowercase letters, numbers, and hyphens',
+    })
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    slug: string;
+
+    @ApiProperty({
+        description: 'Display name for the work',
+        example: 'AI Coding Assistants',
+        maxLength: 100,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    @Transform(({ value }) => (typeof value === 'string' ? sanitizeName(value, 100) : value))
+    name: string;
+
+    @ApiProperty({
+        description: 'Brief description of the work',
+        maxLength: 500,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(500)
+    @Transform(({ value }) => (typeof value === 'string' ? sanitizeDescription(value, 500) : value))
+    description: string;
+
+    @ApiProperty({
+        description: 'Generation prompt — the user input from the landing page or wizard',
+        example: 'AI coding assistants directory with reviews and pricing',
+        maxLength: 5000,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(5000)
+    @Transform(({ value }) => (typeof value === 'string' ? sanitizePrompt(value, 5000) : value))
+    prompt: string;
+
+    @ApiPropertyOptional({ description: 'Whether the owner is an organization' })
+    @IsOptional()
+    @IsBoolean()
+    organization?: boolean;
+
+    @ApiPropertyOptional({ description: 'Repository owner (defaults to user)' })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    owner?: string;
+
+    @ApiPropertyOptional({
+        description: 'Override the git provider (default: from onboarding state, then "github")',
+    })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    gitProvider?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Override deploy provider (default: from onboarding state, then "ever-works")',
+    })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    deployProvider?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Override storage provider (default: from onboarding state, then "user-github")',
+    })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    storageProvider?: string;
+
+    @ApiPropertyOptional({ description: 'Website template identifier (default: "classic")' })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    websiteTemplateId?: string;
+
+    @ApiPropertyOptional({
+        description: 'AI model override (defaults to the provider plugin default)',
+    })
+    @IsOptional()
+    @IsString()
+    model?: string;
+
+    @ApiPropertyOptional({
+        description: 'Optional README configuration',
+        type: MarkdownReadmeConfigDto,
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => MarkdownReadmeConfigDto)
+    readmeConfig?: MarkdownReadmeConfigDto;
+}

--- a/packages/contracts/src/api/onboarding/wizard-state.ts
+++ b/packages/contracts/src/api/onboarding/wizard-state.ts
@@ -20,6 +20,13 @@ export interface OnboardingWizardStateV2 {
 	readonly deploy: { readonly choice: OnboardingDeployChoice };
 	readonly skippedSteps: readonly string[];
 	readonly pluginsReviewed: boolean;
+	/**
+	 * EW-617 G4: prompt carried over from the landing-page input
+	 * (`ever.works/?prompt=…`) so the wizard's "Generate now" step can
+	 * kick off generation without re-asking the user. Bounded by the
+	 * same 5000-char limit as `CreateItemsGeneratorDto.prompt`.
+	 */
+	readonly prompt?: string;
 }
 
 /** Wire shape of `GET /api/onboarding/state`. */
@@ -42,6 +49,7 @@ export interface OnboardingStatePatchRequest {
 		readonly deploy: Partial<{ choice: OnboardingDeployChoice }>;
 		readonly skippedSteps: readonly string[];
 		readonly pluginsReviewed: boolean;
+		readonly prompt: string;
 	}>;
 }
 


### PR DESCRIPTION
## Summary

Replaces the wizard's hand-off to `/works/new` with a single **Generate now** button that creates a Work + starts AI generation in one round-trip. When a prompt is carried over from the landing page (G1's URL hand-off), the wizard now jumps straight to this final step and pre-fills the prompt.

**API**
- New endpoint `POST /api/works/quick-create` (throttled 10/min per IP). Calls `WorkLifecycleService.createWork` (which resolves provider defaults from the user's onboarding state) then `WorkGenerationService.generateItems(workId, {name, prompt}, user, false)` to dispatch generation async.
- Returns 202 with `{ status: 'pending', work: { id, slug, name }, generation: { historyId, message } }` — client can navigate + poll.
- `QuickCreateWorkDto` exported from `@ever-works/agent/dto`.

**Wizard state**
- `OnboardingWizardStateV2.prompt?: string` + matching `OnboardingStatePatchRequest.state.prompt` — landing prompt carries through the wizard. Reducer trims whitespace; empty strings clear back to undefined.
- `useOnboardingFlow` exposes new `setPrompt(value)` action.

**UI**
- `CreateWorkStep` renders **Generate now** when a prompt is present and `onQuickCreate` is provided; otherwise keeps the legacy "Create your first work" link. Component stays I/O-free — parent owns the fetch + error surface.
- `EverWorksOnboardingWizard` mounts a one-shot URL hydration effect: reads `?prompt=` or `#prompt=` (fragment preferred — never hits server logs), seeds `flow.setPrompt`, jumps to the create-work step, strips the param via `history.replaceState`.
- Client slug/name derivation lives in the wizard parent. Slug bounded to 46 chars + 6-char random suffix to dodge collisions.

**Server action**
- `quickCreateWorkAction` (`apps/web/src/app/actions/works/quick-create.ts`) is the success-or-error envelope the wizard calls. Mirrors the existing onboarding action shape.
- `worksAPI.quickCreate` (`apps/web/src/lib/api/works.ts`) wraps `serverMutation`.

**Docs** — `docs/specs/features/zero-friction-flow/g4-quick-create.md` captures FR-G4-1..6 + NFR-G4-1..3 + acceptance criteria.

## Tests

- `works.controller.quick-create.spec.ts` — 6 tests: happy-path delegation, provider overrides forwarded, model on generator only, 400 when createWork fails, generation errors bubble after work creation, default organization=false.
- `useOnboardingFlow.unit.spec.ts` — added reducer test for setPrompt round-trip (trim + whitespace-clears-to-undefined).

## Base branch

Targets **`develop`** directly. Independent of #756 (G2 anon auth) / #757 (G3 claim-account) — quick-create works for both anon and registered users. Pairs naturally with #752 (G6 deploy-provider default) which is already open.

## Test plan

- [ ] CI green: `apps/api` Jest — new `works.controller.quick-create.spec.ts`
- [ ] CI green: `apps/web` Vitest — extended `useOnboardingFlow.unit.spec.ts`
- [ ] CI green: full `pnpm type-check`
- [ ] Manual: open wizard, type prompt → choices auto-default → Generate now → 202 + dashboard navigation
- [ ] Manual: visit `app.ever.works/onboarding#prompt=AI%20coding%20assistants` → wizard lands on Generate now with prompt pre-filled, URL cleaned

Sub-task: EW-621. Parent epic: EW-617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Generate now" quick-create button in the onboarding wizard to create a work and start AI generation in a single step
  * Support for pre-filling the wizard with a prompt via URL parameter
  * New quick-create endpoint that creates a work with onboarding defaults and initiates generation asynchronously

* **Documentation**
  * Added specification for the zero-friction quick-create onboarding flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/758)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->