### PR TITLE
feat(deploy): Cloudflare DNS automation for *.ever.works (EW-617 G5)

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -114,6 +114,17 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             getOrGenerate: jest.fn().mockResolvedValue('hex'.repeat(21) + 'h'), // 64 hex chars
         };
 
+        // EW-617 G5: DNS automation no-ops in tests (no env vars). The
+        // dns service still needs to be present so the constructor wires
+        // — `getProvider` returns null and `ensureWorkSubdomain` is a
+        // safe stub.
+        const dnsService = {
+            getProvider: jest.fn(() => null),
+            ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
+            ensureWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+            removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+        };
+
         const service = new DeployService(
             deployFacade as any,
             gitFacade as any,
@@ -123,6 +134,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             websiteTemplateResolver as any,
             eventEmitter as any,
             platformSyncSecretService as any,
+            dnsService as any,
         );
 
         return {
@@ -134,6 +146,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             githubPlugin,
             eventEmitter,
             platformSyncSecretService,
+            dnsService,
         };
     };
 
@@ -549,5 +562,71 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         );
 
         errorSpy.mockRestore();
+    });
+
+    describe('EW-617 G5 — ever-works subdomain templating', () => {
+        it('overrides ingressHost to ${slug}.ever.works when deployProvider=ever-works and DNS is configured', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, githubPlugin, dnsService } = buildService({
+                deployProvider: 'ever-works',
+                plugin: { id: 'k8s', getWorkflowFilenames: () => ['deploy_k8s.yaml'], getDeploymentSecrets },
+                settings: { kubeconfig: 'apiVersion: v1' },
+            });
+            // Pretend DNS env is set — service emits a fake provider that
+            // does nothing, but signals "active".
+            (dnsService.getProvider as jest.Mock).mockReturnValue({});
+
+            await service.deploy('work-1', 'user-1', {});
+
+            // The plugin's getDeploymentSecrets MUST have been called with
+            // settings carrying the templated ingressHost.
+            expect(getDeploymentSecrets).toHaveBeenCalledTimes(1);
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            expect(settingsArg.ingressHost).toBe('my-site.ever.works');
+            // Original settings still contain whatever was there.
+            expect(settingsArg.kubeconfig).toBe('apiVersion: v1');
+
+            expect(dnsService.ensureWorkSubdomain).toHaveBeenCalledWith('my-site');
+
+            // Tag the variable assertion onto the GA secrets path too —
+            // K8S_INGRESS_HOST is what the plugin returns from
+            // getDeploymentSecrets when settings.ingressHost is set.
+            // (Plugin is mocked here, so we only assert on the call.)
+            void githubPlugin; // silence unused
+        });
+
+        it('leaves settings unchanged for non-ever-works providers', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, dnsService } = buildService({
+                deployProvider: 'vercel',
+                plugin: { id: 'vercel', getWorkflowFilenames: () => ['deploy_vercel.yaml'], getDeploymentSecrets },
+                settings: { token: 'v1' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(getDeploymentSecrets).toHaveBeenCalledTimes(1);
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            expect(settingsArg.ingressHost).toBeUndefined();
+            expect(dnsService.ensureWorkSubdomain).not.toHaveBeenCalled();
+        });
+
+        it('no-ops the DNS override when env is unset (dnsService.getProvider returns null)', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, dnsService } = buildService({
+                deployProvider: 'ever-works',
+                plugin: { id: 'k8s', getWorkflowFilenames: () => ['deploy_k8s.yaml'], getDeploymentSecrets },
+                settings: {},
+            });
+            (dnsService.getProvider as jest.Mock).mockReturnValue(null);
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            // Without an active DNS provider we leave the settings alone —
+            // the k8s plugin's existing fallback hostname is used instead.
+            expect(settingsArg.ingressHost).toBeUndefined();
+            expect(dnsService.ensureWorkSubdomain).not.toHaveBeenCalled();
+        });
     });
 });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -569,7 +569,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             const getDeploymentSecrets = jest.fn().mockResolvedValue({});
             const { service, githubPlugin, dnsService } = buildService({
                 deployProvider: 'ever-works',
-                plugin: { id: 'k8s', getWorkflowFilenames: () => ['deploy_k8s.yaml'], getDeploymentSecrets },
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
                 settings: { kubeconfig: 'apiVersion: v1' },
             });
             // Pretend DNS env is set — service emits a fake provider that
@@ -599,7 +603,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             const getDeploymentSecrets = jest.fn().mockResolvedValue({});
             const { service, dnsService } = buildService({
                 deployProvider: 'vercel',
-                plugin: { id: 'vercel', getWorkflowFilenames: () => ['deploy_vercel.yaml'], getDeploymentSecrets },
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml'],
+                    getDeploymentSecrets,
+                },
                 settings: { token: 'v1' },
             });
 
@@ -615,7 +623,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             const getDeploymentSecrets = jest.fn().mockResolvedValue({});
             const { service, dnsService } = buildService({
                 deployProvider: 'ever-works',
-                plugin: { id: 'k8s', getWorkflowFilenames: () => ['deploy_k8s.yaml'], getDeploymentSecrets },
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
                 settings: {},
             });
             (dnsService.getProvider as jest.Mock).mockReturnValue(null);

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -6,6 +6,7 @@ import { WorkRepository } from '@ever-works/agent/database';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
 import { Work, User } from '@ever-works/agent/entities';
 import { PlatformSyncSecretService } from '@ever-works/agent/services';
+import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
 import {
     WebsiteUpdateService,
     getWebsiteTemplateBranch,
@@ -52,6 +53,7 @@ export class DeployService {
         private readonly websiteTemplateResolver: WebsiteTemplateResolverService,
         private readonly eventEmitter: EventEmitter2,
         private readonly platformSyncSecretService: PlatformSyncSecretService,
+        private readonly dnsService: EverWorksDnsService,
     ) {}
 
     /**
@@ -90,7 +92,14 @@ export class DeployService {
             withDelay: false,
         });
 
-        await this.setRequiredSecrets(ctx, token, work, plugin, settings);
+        // EW-617 G5: when the platform is the deploy target, template the
+        // ingress host as `${slug}.ever.works` (or whatever
+        // EVER_WORKS_DOMAIN says) and provision the Cloudflare CNAME so
+        // the user's directory is reachable at that subdomain without any
+        // manual DNS. If env vars are missing the DNS service no-ops; the
+        // k8s plugin's default LB hostname remains the fallback.
+        const deploySettings = await this.applyEverWorksSubdomain(work, settings);
+        await this.setRequiredSecrets(ctx, token, work, plugin, deploySettings);
         await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
@@ -234,6 +243,45 @@ export class DeployService {
 
     private async setVariable(ctx: RepoContext, key: string, value: string) {
         return this.setActionVariable({ key, value, owner: ctx.owner, repo: ctx.repo }, ctx.token);
+    }
+
+    /**
+     * EW-617 G5: when `deployProvider === 'ever-works'` AND the Cloudflare
+     * DNS env is configured, derive `ingressHost = ${slug}.ever.works`,
+     * merge it into the deploy settings (so the k8s plugin's
+     * `getDeploymentSecrets` picks it up as `K8S_INGRESS_HOST`), and
+     * provision the CNAME via Cloudflare. Returns a shallow copy of
+     * `settings` with the override applied; original object is not
+     * mutated so subsequent reads stay deterministic.
+     *
+     * No-ops cleanly when:
+     *  - the work is on a non-platform provider (Vercel, user's k8s), OR
+     *  - env vars are missing (dev / preview),
+     * letting the existing k8s plugin LB hostname remain the fallback.
+     */
+    private async applyEverWorksSubdomain(
+        work: Work,
+        settings: Record<string, unknown> | undefined,
+    ): Promise<Record<string, unknown> | undefined> {
+        if (work.deployProvider !== 'ever-works') {
+            return settings;
+        }
+        const provider = this.dnsService.getProvider();
+        if (!provider) {
+            return settings;
+        }
+
+        const ingressHost = this.dnsService.ingressHostFor(work.slug);
+
+        // Provision asynchronously — DNS propagation runs in parallel with
+        // the workflow dispatch. Errors are logged inside the service so
+        // they never abort the deploy.
+        void this.dnsService.ensureWorkSubdomain(work.slug);
+
+        return {
+            ...(settings ?? {}),
+            ingressHost,
+        };
     }
 
     private async setRequiredSecrets(

--- a/docs/specs/features/zero-friction-flow/g5-subdomain-dns.md
+++ b/docs/specs/features/zero-friction-flow/g5-subdomain-dns.md
@@ -7,6 +7,7 @@
 
 When a Work deploys via the Ever Works pipeline (`deployProvider ===
 'ever-works'`), the platform MUST automatically:
+
 1. Template the Kubernetes ingress host as `${work.slug}.ever.works`
    (so the work is reachable at a stable subdomain).
 2. Provision a Cloudflare CNAME pointing that hostname at the
@@ -21,10 +22,10 @@ cert.
 
 - **FR-G5-1** A new `CloudflareDnsProvider` class wraps the Cloudflare
   v4 REST API. Methods:
-  - `ensureWorkSubdomain(slug)` — idempotent upsert of a CNAME
-    `<slug>.<rootDomain> → <targetHostname>`.
-  - `removeWorkSubdomain(slug)` — best-effort delete; no-op when the
-    record doesn't exist.
+    - `ensureWorkSubdomain(slug)` — idempotent upsert of a CNAME
+      `<slug>.<rootDomain> → <targetHostname>`.
+    - `removeWorkSubdomain(slug)` — best-effort delete; no-op when the
+      record doesn't exist.
 - **FR-G5-2** Slugs that fail `^[a-z0-9]+(?:-[a-z0-9]+)*$` MUST be
   rejected before any HTTP call (same regex as `CreateWorkDto.slug`).
 - **FR-G5-3** A `EverWorksDnsService` (Nest-injectable) reads env on
@@ -34,15 +35,15 @@ cert.
 - **FR-G5-4** `DeployService.deploy()` MUST, when
   `work.deployProvider === 'ever-works'` AND `dnsService.getProvider()`
   is non-null:
-  1. Merge `ingressHost = ${slug}.${EVER_WORKS_DOMAIN || 'ever.works'}`
-     into the deploy settings before
-     `plugin.getDeploymentSecrets(settings)` runs (so the k8s plugin
-     picks it up as `K8S_INGRESS_HOST`).
-  2. Fire `dnsService.ensureWorkSubdomain(slug)` asynchronously —
-     errors are logged inside the service so they NEVER abort a
-     deploy.
-  3. Leave settings untouched for non-platform providers (Vercel,
-     user's k8s) AND when DNS env is unset.
+    1. Merge `ingressHost = ${slug}.${EVER_WORKS_DOMAIN || 'ever.works'}`
+       into the deploy settings before
+       `plugin.getDeploymentSecrets(settings)` runs (so the k8s plugin
+       picks it up as `K8S_INGRESS_HOST`).
+    2. Fire `dnsService.ensureWorkSubdomain(slug)` asynchronously —
+       errors are logged inside the service so they NEVER abort a
+       deploy.
+    3. Leave settings untouched for non-platform providers (Vercel,
+       user's k8s) AND when DNS env is unset.
 - **FR-G5-5** Authentication MUST be a Bearer token in the
   `Authorization` header. The token MUST be scoped (Cloudflare API
   token, DNS:Edit on the `ever.works` zone only — NOT a global API
@@ -64,12 +65,12 @@ cert.
 
 ## Configuration (operator runbook)
 
-| Env var                          | Required | Description                                                |
-| -------------------------------- | -------- | ---------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`           | yes      | Scoped token, **DNS:Edit on the `ever.works` zone only**.  |
-| `CLOUDFLARE_ZONE_ID`             | yes      | The `ever.works` zone id (32-char hex).                    |
-| `EVER_WORKS_DEPLOY_LB_HOSTNAME`  | yes      | k8s-works ingress LB hostname (e.g. `lb.k8s-works.svc`).   |
-| `EVER_WORKS_DOMAIN`              | no       | Root domain. Defaults to `ever.works`.                     |
+| Env var                         | Required | Description                                               |
+| ------------------------------- | -------- | --------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`          | yes      | Scoped token, **DNS:Edit on the `ever.works` zone only**. |
+| `CLOUDFLARE_ZONE_ID`            | yes      | The `ever.works` zone id (32-char hex).                   |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | yes      | k8s-works ingress LB hostname (e.g. `lb.k8s-works.svc`).  |
+| `EVER_WORKS_DOMAIN`             | no       | Root domain. Defaults to `ever.works`.                    |
 
 When any of the required vars is missing, the provider no-ops cleanly
 — deploys still succeed via the k8s plugin's existing LB hostname.
@@ -88,9 +89,9 @@ When any of the required vars is missing, the provider no-ops cleanly
 
 - A fresh Work with `slug=foo` and `deployProvider='ever-works'`
   deploys, and within ~2 min:
-  - `dig CNAME foo.ever.works` returns the configured LB hostname.
-  - `curl -sI https://foo.ever.works/` returns 200 with a valid TLS
-    chain.
+    - `dig CNAME foo.ever.works` returns the configured LB hostname.
+    - `curl -sI https://foo.ever.works/` returns 200 with a valid TLS
+      chain.
 - The same operation a second time (re-deploy) does not create a
   duplicate record — `ensureWorkSubdomain` is idempotent.
 

--- a/docs/specs/features/zero-friction-flow/g5-subdomain-dns.md
+++ b/docs/specs/features/zero-friction-flow/g5-subdomain-dns.md
@@ -1,0 +1,105 @@
+# EW-617 G5 — Subdomain ingress + Cloudflare DNS automation
+
+> Sub-task: **EW-622**. Parent epic: **EW-617**. Pairs with platform PRs
+> #752 (G6 default deploy provider), #758 (G4 quick-create).
+
+## Goal
+
+When a Work deploys via the Ever Works pipeline (`deployProvider ===
+'ever-works'`), the platform MUST automatically:
+1. Template the Kubernetes ingress host as `${work.slug}.ever.works`
+   (so the work is reachable at a stable subdomain).
+2. Provision a Cloudflare CNAME pointing that hostname at the
+   `k8s-works` cluster ingress load balancer.
+3. Tear the CNAME down when the Work is deleted.
+
+Net effect: a fresh Work with `slug=foo` is reachable at
+`https://foo.ever.works/` within ~2 min of deploy with a wildcard TLS
+cert.
+
+## Functional requirements
+
+- **FR-G5-1** A new `CloudflareDnsProvider` class wraps the Cloudflare
+  v4 REST API. Methods:
+  - `ensureWorkSubdomain(slug)` — idempotent upsert of a CNAME
+    `<slug>.<rootDomain> → <targetHostname>`.
+  - `removeWorkSubdomain(slug)` — best-effort delete; no-op when the
+    record doesn't exist.
+- **FR-G5-2** Slugs that fail `^[a-z0-9]+(?:-[a-z0-9]+)*$` MUST be
+  rejected before any HTTP call (same regex as `CreateWorkDto.slug`).
+- **FR-G5-3** A `EverWorksDnsService` (Nest-injectable) reads env on
+  first use and caches the result. It returns `null` from
+  `getProvider()` when DNS automation is not configured so all
+  consumers can no-op cleanly in dev/preview.
+- **FR-G5-4** `DeployService.deploy()` MUST, when
+  `work.deployProvider === 'ever-works'` AND `dnsService.getProvider()`
+  is non-null:
+  1. Merge `ingressHost = ${slug}.${EVER_WORKS_DOMAIN || 'ever.works'}`
+     into the deploy settings before
+     `plugin.getDeploymentSecrets(settings)` runs (so the k8s plugin
+     picks it up as `K8S_INGRESS_HOST`).
+  2. Fire `dnsService.ensureWorkSubdomain(slug)` asynchronously —
+     errors are logged inside the service so they NEVER abort a
+     deploy.
+  3. Leave settings untouched for non-platform providers (Vercel,
+     user's k8s) AND when DNS env is unset.
+- **FR-G5-5** Authentication MUST be a Bearer token in the
+  `Authorization` header. The token MUST be scoped (Cloudflare API
+  token, DNS:Edit on the `ever.works` zone only — NOT a global API
+  key).
+- **FR-G5-6** All CNAMEs MUST be created with `proxied: false` and
+  `ttl: 1` (auto). The ingress LB handles HTTPS termination via
+  cert-manager + the `*.ever.works` wildcard issuer (ops-managed).
+
+## Non-functional requirements
+
+- **NFR-G5-1** A flaky DNS API MUST NOT block deploys. The original
+  k8s plugin's LB hostname remains a working fallback while the CNAME
+  catches up.
+- **NFR-G5-2** No SDK dependency — the provider uses the global
+  `fetch` (Node 22+) so the bundle stays small and the test harness
+  can inject a mock `fetch`.
+- **NFR-G5-3** All log output MUST be redacted of the API token —
+  never log the `Authorization` header or its value.
+
+## Configuration (operator runbook)
+
+| Env var                          | Required | Description                                                |
+| -------------------------------- | -------- | ---------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`           | yes      | Scoped token, **DNS:Edit on the `ever.works` zone only**.  |
+| `CLOUDFLARE_ZONE_ID`             | yes      | The `ever.works` zone id (32-char hex).                    |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME`  | yes      | k8s-works ingress LB hostname (e.g. `lb.k8s-works.svc`).   |
+| `EVER_WORKS_DOMAIN`              | no       | Root domain. Defaults to `ever.works`.                     |
+
+When any of the required vars is missing, the provider no-ops cleanly
+— deploys still succeed via the k8s plugin's existing LB hostname.
+
+## Out of scope (other gaps / follow-ups)
+
+- Per-Work custom domain support (e.g. `foo.com → foo.ever.works`).
+  Tracked separately when there's customer demand.
+- DNS automation on Work delete is implemented in
+  `EverWorksDnsService.removeWorkSubdomain` but not yet wired into
+  `WorkLifecycleService.deleteWork` — follow-up sub-task.
+- Cert-manager wildcard issuer install on `k8s-works` is an ops task,
+  not code; documented separately in the cluster runbook.
+
+## Acceptance
+
+- A fresh Work with `slug=foo` and `deployProvider='ever-works'`
+  deploys, and within ~2 min:
+  - `dig CNAME foo.ever.works` returns the configured LB hostname.
+  - `curl -sI https://foo.ever.works/` returns 200 with a valid TLS
+    chain.
+- The same operation a second time (re-deploy) does not create a
+  duplicate record — `ensureWorkSubdomain` is idempotent.
+
+## Tests
+
+- `cloudflare-dns.provider.spec.ts` covers: create-new path, drift
+  detection + PUT update, idempotent already-in-sync path, slug
+  validation, delete + delete-missing, error envelope on 401, Bearer
+  header on every call, `EverWorksDnsService` env caching + override.
+- `deploy.service.spec.ts` extended with three new tests: ingressHost
+  override for ever-works + active DNS, no-override for non-platform
+  providers, no-override when env is unset.

--- a/packages/agent/src/ever-works-providers/__tests__/cloudflare-dns.provider.spec.ts
+++ b/packages/agent/src/ever-works-providers/__tests__/cloudflare-dns.provider.spec.ts
@@ -7,14 +7,16 @@ import {
 describe('CloudflareDnsProvider (EW-617 G5)', () => {
     type FetchCall = { url: string; init: RequestInit };
 
-    function buildProvider(opts: {
-        listResult?: any[];
-        createResult?: any;
-        updateResult?: any;
-        deleteOk?: boolean;
-        deleteStatus?: number;
-        deleteBody?: any;
-    } = {}) {
+    function buildProvider(
+        opts: {
+            listResult?: any[];
+            createResult?: any;
+            updateResult?: any;
+            deleteOk?: boolean;
+            deleteStatus?: number;
+            deleteBody?: any;
+        } = {},
+    ) {
         const calls: FetchCall[] = [];
         const fakeFetch = jest.fn(async (url: string, init: RequestInit) => {
             calls.push({ url, init });
@@ -167,10 +169,11 @@ describe('CloudflareDnsProvider (EW-617 G5)', () => {
     });
 
     it('throws CloudflareDnsError on a non-success API response', async () => {
-        const fakeFetch = jest.fn(async () =>
-            new Response(JSON.stringify({ success: false, errors: [{ code: 10000 }] }), {
-                status: 401,
-            }),
+        const fakeFetch = jest.fn(
+            async () =>
+                new Response(JSON.stringify({ success: false, errors: [{ code: 10000 }] }), {
+                    status: 401,
+                }),
         ) as any;
         const provider = new CloudflareDnsProvider(
             { apiToken: 'bad', zoneId: 'z', rootDomain: 'ever.works', targetHostname: 'lb' },

--- a/packages/agent/src/ever-works-providers/__tests__/cloudflare-dns.provider.spec.ts
+++ b/packages/agent/src/ever-works-providers/__tests__/cloudflare-dns.provider.spec.ts
@@ -1,0 +1,266 @@
+import {
+    CloudflareDnsError,
+    CloudflareDnsProvider,
+    EverWorksDnsService,
+} from '../cloudflare-dns.provider';
+
+describe('CloudflareDnsProvider (EW-617 G5)', () => {
+    type FetchCall = { url: string; init: RequestInit };
+
+    function buildProvider(opts: {
+        listResult?: any[];
+        createResult?: any;
+        updateResult?: any;
+        deleteOk?: boolean;
+        deleteStatus?: number;
+        deleteBody?: any;
+    } = {}) {
+        const calls: FetchCall[] = [];
+        const fakeFetch = jest.fn(async (url: string, init: RequestInit) => {
+            calls.push({ url, init });
+            const method = (init.method ?? 'GET').toUpperCase();
+            if (method === 'GET' && url.includes('/dns_records?')) {
+                return new Response(
+                    JSON.stringify({ success: true, result: opts.listResult ?? [] }),
+                    { status: 200 },
+                );
+            }
+            if (method === 'POST' && url.endsWith('/dns_records')) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: opts.createResult ?? {
+                            id: 'rec-new',
+                            type: 'CNAME',
+                            name: JSON.parse(init.body as string).name,
+                            content: JSON.parse(init.body as string).content,
+                        },
+                    }),
+                    { status: 200 },
+                );
+            }
+            if (method === 'PUT' && url.includes('/dns_records/')) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: opts.updateResult ?? {
+                            id: 'rec-existing',
+                            type: 'CNAME',
+                            name: JSON.parse(init.body as string).name,
+                            content: JSON.parse(init.body as string).content,
+                        },
+                    }),
+                    { status: 200 },
+                );
+            }
+            if (method === 'DELETE' && url.includes('/dns_records/')) {
+                if (opts.deleteOk === false) {
+                    return new Response(
+                        JSON.stringify({
+                            success: false,
+                            errors: opts.deleteBody ?? [{ code: 7003, message: 'no route' }],
+                        }),
+                        { status: opts.deleteStatus ?? 404 },
+                    );
+                }
+                return new Response(JSON.stringify({ success: true, result: { id: 'x' } }), {
+                    status: 200,
+                });
+            }
+            throw new Error(`Unexpected fetch ${method} ${url}`);
+        }) as any;
+
+        const provider = new CloudflareDnsProvider(
+            {
+                apiToken: 'tk',
+                zoneId: 'zone1',
+                rootDomain: 'ever.works',
+                targetHostname: 'k8s.lb.example',
+            },
+            fakeFetch,
+        );
+
+        return { provider, calls, fakeFetch };
+    }
+
+    it('creates a fresh CNAME when no record exists', async () => {
+        const { provider, calls } = buildProvider({ listResult: [] });
+        const result = await provider.ensureWorkSubdomain('ai-coding');
+
+        expect(result.name).toBe('ai-coding.ever.works');
+        expect(result.content).toBe('k8s.lb.example');
+        expect(calls).toHaveLength(2);
+        expect(calls[0].url).toContain('name=ai-coding.ever.works');
+        expect(calls[0].init.method).toBe('GET');
+        expect(calls[1].init.method).toBe('POST');
+        const body = JSON.parse(calls[1].init.body as string);
+        expect(body).toMatchObject({
+            type: 'CNAME',
+            name: 'ai-coding.ever.works',
+            content: 'k8s.lb.example',
+            proxied: false,
+            ttl: 1,
+        });
+    });
+
+    it('returns the existing record when content already matches', async () => {
+        const { provider, calls } = buildProvider({
+            listResult: [
+                {
+                    id: 'rec-existing',
+                    type: 'CNAME',
+                    name: 'ai-coding.ever.works',
+                    content: 'k8s.lb.example',
+                },
+            ],
+        });
+        const result = await provider.ensureWorkSubdomain('ai-coding');
+        expect(result.id).toBe('rec-existing');
+        // GET only — no POST/PUT.
+        expect(calls).toHaveLength(1);
+        expect(calls[0].init.method).toBe('GET');
+    });
+
+    it('PUTs an updated CNAME when the content drifted from target', async () => {
+        const { provider, calls } = buildProvider({
+            listResult: [
+                {
+                    id: 'rec-drifted',
+                    type: 'CNAME',
+                    name: 'ai-coding.ever.works',
+                    content: 'old.lb.example',
+                },
+            ],
+        });
+        const result = await provider.ensureWorkSubdomain('ai-coding');
+        expect(calls.map((c) => c.init.method)).toEqual(['GET', 'PUT']);
+        expect(calls[1].url).toContain('/dns_records/rec-drifted');
+        expect(result.content).toBe('k8s.lb.example');
+    });
+
+    it('rejects slugs that fail the DNS-safe regex', async () => {
+        const { provider } = buildProvider();
+        await expect(provider.ensureWorkSubdomain('NOT_OK')).rejects.toThrow(/Invalid slug/);
+    });
+
+    it('no-ops when removing a non-existent record', async () => {
+        const { provider, calls } = buildProvider({ listResult: [] });
+        await expect(provider.removeWorkSubdomain('gone')).resolves.toBeUndefined();
+        expect(calls).toHaveLength(1);
+        expect(calls[0].init.method).toBe('GET');
+    });
+
+    it('deletes the record when one exists', async () => {
+        const { provider, calls } = buildProvider({
+            listResult: [
+                {
+                    id: 'rec-to-go',
+                    type: 'CNAME',
+                    name: 'foo.ever.works',
+                    content: 'old.lb',
+                },
+            ],
+        });
+        await provider.removeWorkSubdomain('foo');
+        expect(calls.map((c) => c.init.method)).toEqual(['GET', 'DELETE']);
+        expect(calls[1].url).toContain('/dns_records/rec-to-go');
+    });
+
+    it('throws CloudflareDnsError on a non-success API response', async () => {
+        const fakeFetch = jest.fn(async () =>
+            new Response(JSON.stringify({ success: false, errors: [{ code: 10000 }] }), {
+                status: 401,
+            }),
+        ) as any;
+        const provider = new CloudflareDnsProvider(
+            { apiToken: 'bad', zoneId: 'z', rootDomain: 'ever.works', targetHostname: 'lb' },
+            fakeFetch,
+        );
+        await expect(provider.ensureWorkSubdomain('x')).rejects.toThrow(CloudflareDnsError);
+    });
+
+    it('sends bearer authorization on every request', async () => {
+        const { provider, calls } = buildProvider({ listResult: [] });
+        await provider.ensureWorkSubdomain('ai-coding');
+        for (const c of calls) {
+            expect((c.init.headers as Record<string, string>).Authorization).toBe('Bearer tk');
+        }
+    });
+});
+
+describe('EverWorksDnsService (EW-617 G5)', () => {
+    const ENV_KEYS = [
+        'CLOUDFLARE_API_TOKEN',
+        'CLOUDFLARE_ZONE_ID',
+        'EVER_WORKS_DOMAIN',
+        'EVER_WORKS_DEPLOY_LB_HOSTNAME',
+    ] as const;
+
+    const previous: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        for (const k of ENV_KEYS) {
+            previous[k] = process.env[k];
+            delete process.env[k];
+        }
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (previous[k] === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = previous[k];
+            }
+        }
+    });
+
+    it('returns null from getProvider() when env is unset (dev / preview)', () => {
+        const svc = new EverWorksDnsService();
+        expect(svc.getProvider()).toBeNull();
+    });
+
+    it('caches the null result so we do not re-read env per call', () => {
+        const svc = new EverWorksDnsService();
+        const a = svc.getProvider();
+        const b = svc.getProvider();
+        expect(a).toBe(b);
+        expect(a).toBeNull();
+    });
+
+    it('builds a provider once env is fully configured', () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'tk';
+        process.env.CLOUDFLARE_ZONE_ID = 'zone1';
+        process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'k8s.lb.example';
+
+        const svc = new EverWorksDnsService();
+        const provider = svc.getProvider();
+        expect(provider).toBeInstanceOf(CloudflareDnsProvider);
+    });
+
+    it('defaults rootDomain to "ever.works" when env is not overridden', () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'tk';
+        process.env.CLOUDFLARE_ZONE_ID = 'zone1';
+        process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'k8s.lb';
+        const svc = new EverWorksDnsService();
+        expect(svc.ingressHostFor('ai-coding')).toBe('ai-coding.ever.works');
+    });
+
+    it('respects EVER_WORKS_DOMAIN override for ingressHostFor', () => {
+        process.env.EVER_WORKS_DOMAIN = 'preview.ever.works';
+        const svc = new EverWorksDnsService();
+        expect(svc.ingressHostFor('ai-coding')).toBe('ai-coding.preview.ever.works');
+    });
+
+    it('swallows ensureWorkSubdomain errors so a flaky DNS does not abort deploys', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'tk';
+        process.env.CLOUDFLARE_ZONE_ID = 'zone1';
+        process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'k8s.lb';
+
+        const svc = new EverWorksDnsService();
+        const provider = svc.getProvider()!;
+        jest.spyOn(provider, 'ensureWorkSubdomain').mockRejectedValue(new Error('boom'));
+
+        await expect(svc.ensureWorkSubdomain('ai-coding')).resolves.toBeUndefined();
+    });
+});

--- a/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
+++ b/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
@@ -1,0 +1,282 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * EW-617 G5 — Cloudflare DNS provider for `*.ever.works`.
+ *
+ * Creates a CNAME record pointing `{slug}.ever.works` at the k8s-works
+ * cluster ingress load balancer when an Ever Works pipeline deploys a
+ * Work, and tears it down on Work delete. Operates against the
+ * Cloudflare v4 REST API with a scoped API token (DNS:Edit on the
+ * `ever.works` zone only).
+ *
+ * Configuration (operator runbook):
+ *
+ *   CLOUDFLARE_API_TOKEN          # scoped token, DNS:Edit on the zone
+ *   CLOUDFLARE_ZONE_ID            # `ever.works` zone id
+ *   EVER_WORKS_DOMAIN             # defaults to `ever.works`
+ *   EVER_WORKS_DEPLOY_LB_HOSTNAME # CNAME target — the k8s-works ingress LB
+ *
+ * The provider intentionally has no @nestjs/axios dependency — it uses
+ * the global `fetch` (Node 22+) so it can be tested with `fetch` mocks
+ * and stays small.
+ */
+
+export interface CloudflareDnsConfig {
+    apiToken: string;
+    zoneId: string;
+    /** e.g. 'ever.works' — used to validate target names + log. */
+    rootDomain: string;
+    /** Hostname the CNAME points at (k8s-works ingress LB). */
+    targetHostname: string;
+    /** Optional base URL override (tests, staging mirror). */
+    apiBaseUrl?: string;
+}
+
+export interface DnsRecordSnapshot {
+    id: string;
+    type: 'CNAME';
+    name: string;
+    content: string;
+}
+
+export class CloudflareDnsError extends Error {
+    constructor(
+        message: string,
+        readonly status: number,
+        readonly errors: unknown,
+    ) {
+        super(message);
+        this.name = 'CloudflareDnsError';
+    }
+}
+
+/**
+ * Pure (testable) Cloudflare client. Construct with a config; tests pass
+ * a custom `fetch` impl via the second arg.
+ */
+export class CloudflareDnsProvider {
+    private readonly logger = new Logger(CloudflareDnsProvider.name);
+    private readonly baseUrl: string;
+
+    constructor(
+        private readonly config: CloudflareDnsConfig,
+        private readonly fetchImpl: typeof fetch = fetch,
+    ) {
+        this.baseUrl = (config.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4').replace(
+            /\/$/,
+            '',
+        );
+    }
+
+    /**
+     * Ensure a CNAME record exists pointing `<slug>.<rootDomain>` at
+     * the configured target hostname. Idempotent: if a matching CNAME
+     * already exists, returns it; if a stale record (different target)
+     * exists, updates it in place. Always returns a snapshot for the
+     * caller to log / persist.
+     */
+    async ensureWorkSubdomain(slug: string): Promise<DnsRecordSnapshot> {
+        this.assertSlug(slug);
+        const fqdn = `${slug}.${this.config.rootDomain}`;
+        const target = this.config.targetHostname;
+
+        const existing = await this.findRecord(fqdn);
+        if (existing) {
+            if (existing.content === target && existing.type === 'CNAME') {
+                this.logger.log(`CloudflareDns CNAME already in sync ${fqdn} -> ${target}`);
+                return existing;
+            }
+            // Drifted record: same name, different content/type. Update.
+            const updated = await this.patchRecord(existing.id, {
+                type: 'CNAME',
+                name: fqdn,
+                content: target,
+                proxied: false,
+                ttl: 1, // 1 == 'auto' per Cloudflare docs
+            });
+            this.logger.log(
+                `CloudflareDns CNAME updated ${fqdn}: was ${existing.content} now ${target}`,
+            );
+            return updated;
+        }
+
+        const created = await this.createRecord({
+            type: 'CNAME',
+            name: fqdn,
+            content: target,
+            proxied: false,
+            ttl: 1,
+        });
+        this.logger.log(`CloudflareDns CNAME created ${fqdn} -> ${target}`);
+        return created;
+    }
+
+    /** Remove the CNAME for a Work — no-op if it never existed. */
+    async removeWorkSubdomain(slug: string): Promise<void> {
+        this.assertSlug(slug);
+        const fqdn = `${slug}.${this.config.rootDomain}`;
+        const existing = await this.findRecord(fqdn);
+        if (!existing) {
+            return;
+        }
+        await this.deleteRecord(existing.id);
+        this.logger.log(`CloudflareDns CNAME deleted ${fqdn}`);
+    }
+
+    // Internal helpers ------------------------------------------------------
+
+    private assertSlug(slug: string): void {
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+            throw new Error(`Invalid slug for Cloudflare DNS: ${slug}`);
+        }
+    }
+
+    private async findRecord(name: string): Promise<DnsRecordSnapshot | null> {
+        const url = new URL(`${this.baseUrl}/zones/${this.config.zoneId}/dns_records`);
+        url.searchParams.set('name', name);
+        url.searchParams.set('type', 'CNAME');
+        const json = await this.request<{ result: DnsRecordSnapshot[] }>(url.toString(), {
+            method: 'GET',
+        });
+        return json.result[0] ?? null;
+    }
+
+    private async createRecord(payload: {
+        type: 'CNAME';
+        name: string;
+        content: string;
+        proxied: boolean;
+        ttl: number;
+    }): Promise<DnsRecordSnapshot> {
+        const json = await this.request<{ result: DnsRecordSnapshot }>(
+            `${this.baseUrl}/zones/${this.config.zoneId}/dns_records`,
+            { method: 'POST', body: JSON.stringify(payload) },
+        );
+        return json.result;
+    }
+
+    private async patchRecord(
+        id: string,
+        payload: {
+            type: 'CNAME';
+            name: string;
+            content: string;
+            proxied: boolean;
+            ttl: number;
+        },
+    ): Promise<DnsRecordSnapshot> {
+        const json = await this.request<{ result: DnsRecordSnapshot }>(
+            `${this.baseUrl}/zones/${this.config.zoneId}/dns_records/${id}`,
+            { method: 'PUT', body: JSON.stringify(payload) },
+        );
+        return json.result;
+    }
+
+    private async deleteRecord(id: string): Promise<void> {
+        await this.request(`${this.baseUrl}/zones/${this.config.zoneId}/dns_records/${id}`, {
+            method: 'DELETE',
+        });
+    }
+
+    private async request<T = unknown>(url: string, init: RequestInit): Promise<T> {
+        const response = await this.fetchImpl(url, {
+            ...init,
+            headers: {
+                Authorization: `Bearer ${this.config.apiToken}`,
+                'Content-Type': 'application/json',
+                ...(init.headers ?? {}),
+            },
+        });
+        let body: any;
+        try {
+            body = await response.json();
+        } catch {
+            body = null;
+        }
+        if (!response.ok || (body && body.success === false)) {
+            throw new CloudflareDnsError(
+                `Cloudflare API ${init.method ?? 'GET'} ${url} failed: ${response.status}`,
+                response.status,
+                body?.errors ?? body ?? null,
+            );
+        }
+        return body as T;
+    }
+}
+
+/**
+ * Nest-injectable facade that owns the env reading + lazy-instantiation
+ * of the `CloudflareDnsProvider`. Returns `null` from `getProvider()`
+ * when DNS automation is not configured (env vars missing) so callers
+ * can no-op cleanly in dev.
+ */
+@Injectable()
+export class EverWorksDnsService {
+    private readonly logger = new Logger(EverWorksDnsService.name);
+    private cachedProvider: CloudflareDnsProvider | null | undefined;
+
+    getProvider(): CloudflareDnsProvider | null {
+        if (this.cachedProvider !== undefined) {
+            return this.cachedProvider;
+        }
+        const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+        const zoneId = process.env.CLOUDFLARE_ZONE_ID?.trim();
+        const targetHostname = process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME?.trim();
+        const rootDomain = process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+
+        if (!apiToken || !zoneId || !targetHostname) {
+            this.logger.debug(
+                'CloudflareDns not configured (missing CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID / EVER_WORKS_DEPLOY_LB_HOSTNAME) — skipping subdomain automation',
+            );
+            this.cachedProvider = null;
+            return null;
+        }
+
+        this.cachedProvider = new CloudflareDnsProvider({
+            apiToken,
+            zoneId,
+            rootDomain,
+            targetHostname,
+        });
+        return this.cachedProvider;
+    }
+
+    /** Compute the canonical ingress host for a given Work slug. */
+    ingressHostFor(slug: string): string {
+        const rootDomain = process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+        return `${slug}.${rootDomain}`;
+    }
+
+    async ensureWorkSubdomain(slug: string): Promise<void> {
+        const provider = this.getProvider();
+        if (!provider) return;
+        try {
+            await provider.ensureWorkSubdomain(slug);
+        } catch (cause) {
+            // DNS failures must not abort a deploy — the user can fix the
+            // record manually and the Work is still reachable via the LB
+            // hostname. Surface the error so ops can alert on it.
+            this.logger.error(
+                `Failed to ensure CNAME for ${slug}: ${(cause as Error).message}`,
+                cause instanceof Error ? cause.stack : undefined,
+            );
+        }
+    }
+
+    async removeWorkSubdomain(slug: string): Promise<void> {
+        const provider = this.getProvider();
+        if (!provider) return;
+        try {
+            await provider.removeWorkSubdomain(slug);
+        } catch (cause) {
+            this.logger.error(
+                `Failed to delete CNAME for ${slug}: ${(cause as Error).message}`,
+            );
+        }
+    }
+
+    /** Reset the cache — test-only hook so unit tests can re-read env. */
+    resetCacheForTest(): void {
+        this.cachedProvider = undefined;
+    }
+}

--- a/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
+++ b/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
@@ -269,9 +269,7 @@ export class EverWorksDnsService {
         try {
             await provider.removeWorkSubdomain(slug);
         } catch (cause) {
-            this.logger.error(
-                `Failed to delete CNAME for ${slug}: ${(cause as Error).message}`,
-            );
+            this.logger.error(`Failed to delete CNAME for ${slug}: ${(cause as Error).message}`);
         }
     }
 

--- a/packages/agent/src/ever-works-providers/index.ts
+++ b/packages/agent/src/ever-works-providers/index.ts
@@ -13,3 +13,10 @@ export {
     EverWorksDeployQuotaService,
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
 } from './ever-works-deploy-quota.service';
+export {
+    CloudflareDnsProvider,
+    CloudflareDnsError,
+    EverWorksDnsService,
+    type CloudflareDnsConfig,
+    type DnsRecordSnapshot,
+} from './cloudflare-dns.provider';

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -43,6 +43,7 @@ import {
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
     EverWorksDeployQuotaService,
     EverWorksGitProvider,
+    EverWorksDnsService,
     type EverWorksDeployQuotaCounter,
 } from '@src/ever-works-providers';
 import { WorkRepository } from '@src/database/repositories/work.repository';
@@ -103,6 +104,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         // PAT, so users picking "Ever Works Git" don't need to bring their
         // own GitHub. Consumed by `WorkLifecycleService.createWork`.
         EverWorksGitProvider,
+        EverWorksDnsService,
         {
             // The Ever Works Deploy quota service is repo-agnostic — it
             // takes a small `EverWorksDeployQuotaCounter` it can consult.


### PR DESCRIPTION
## Summary

When a Work deploys via the Ever Works pipeline, the platform now:
1. Templates the k8s ingress host as `${slug}.ever.works` automatically.
2. Provisions a Cloudflare CNAME pointing at the cluster ingress LB so the site is reachable at the subdomain.

Net effect: a fresh Work with `slug=foo` is reachable at `https://foo.ever.works/` within ~2 min of deploy, with wildcard TLS served by cert-manager's `*.ever.works` issuer on k8s-works.

**Provider**
- `CloudflareDnsProvider` — wraps Cloudflare v4 REST API: `ensureWorkSubdomain(slug)` (idempotent upsert), `removeWorkSubdomain(slug)` (best-effort delete), with internal drift detection (PUT a new CNAME when the existing record's content drifted from the LB target).
- Slug validation matches `CreateWorkDto.slug` regex.
- No SDK dependency — uses the global \`fetch\` (Node 22+) so the bundle stays small and tests can inject a mock.
- API token MUST be Cloudflare-scoped (DNS:Edit on \`ever.works\` zone only — **NOT** a global API key).

**Nest-injectable facade**
- \`EverWorksDnsService\` reads env once + caches. Returns \`null\` from \`getProvider()\` when DNS automation is not configured — all consumers no-op cleanly in dev/preview.
- Errors swallowed inside \`ensureWorkSubdomain\` — a flaky DNS API MUST NOT block a deploy. The k8s plugin's existing LB hostname remains a working fallback while the CNAME catches up.

**DeployService integration**
- New \`applyEverWorksSubdomain\` helper: when \`work.deployProvider === 'ever-works'\` AND DNS is configured, merges \`ingressHost = \${slug}.ever.works\` into deploy settings (so k8s plugin picks it up as \`K8S_INGRESS_HOST\`) and fires CNAME creation in parallel with workflow dispatch.
- Settings shallow-copied — original not mutated.
- Non-platform providers (Vercel, user's k8s) untouched.

**Configuration (operator runbook)**

| Env var | Required | Description |
|---|---|---|
| \`CLOUDFLARE_API_TOKEN\` | yes | Scoped token, DNS:Edit on zone |
| \`CLOUDFLARE_ZONE_ID\` | yes | \`ever.works\` zone id (32-char hex) |
| \`EVER_WORKS_DEPLOY_LB_HOSTNAME\` | yes | k8s-works ingress LB hostname |
| \`EVER_WORKS_DOMAIN\` | no | Root domain (default: \`ever.works\`) |

**Docs** — \`docs/specs/features/zero-friction-flow/g5-subdomain-dns.md\` captures FR-G5-1..6, NFR-G5-1..3, operator config, acceptance, out-of-scope.

## Tests

- \`cloudflare-dns.provider.spec.ts\` — 12 tests: create-new, drift-PUT, idempotent already-in-sync, slug validation, delete + missing-record no-op, 401 error envelope, Bearer header on every call, env caching + \`EVER_WORKS_DOMAIN\` override.
- \`deploy.service.spec.ts\` — 3 new tests: ingressHost override for ever-works + active DNS, no-override for non-platform providers, no-override when env unset.

## Out of scope (follow-ups)

- Wire \`removeWorkSubdomain\` into \`WorkLifecycleService.deleteWork\` — the provider method exists; the call-site is the next sub-task.
- Per-Work custom domain support (e.g. \`foo.com → foo.ever.works\`) — tracked separately when there's customer demand.
- Cert-manager wildcard issuer install on k8s-works — ops task, documented in cluster runbook separately.

Sub-task: EW-622. Parent epic: EW-617. Pairs with #752 (G6 default deploy provider) + #758 (G4 quick-create).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployments to "ever-works" provider now support automatic Cloudflare DNS subdomain configuration with ingress host templating to `${slug}.ever.works`
  * DNS automation is optional, configured via environment variables, and does not block deployments if DNS operations fail

* **Tests**
  * Added comprehensive test coverage for DNS provider integration and subdomain management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/759)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->