### PR TITLE
feat(telemetry): zero-friction funnel events + ops runbook (EW-617 G8)

### DIFF
--- a/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
+++ b/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
@@ -1,0 +1,149 @@
+# Zero-friction flow runbook (EW-617)
+
+> Companion to the EW-617 spec series. Lives in the platform repo so
+> it ships with the code; mirrored to
+> `Workspace/knowledge/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md` on
+> the next Workspace sync.
+
+## What's wired up
+
+| Gap | What it does                                       | PR / status                                |
+| --- | -------------------------------------------------- | ------------------------------------------ |
+| G1  | Landing prompt + URL hand-off                      | ever-works-website#37                       |
+| G2  | Anonymous (TTL) users + cleanup task               | platform #756                               |
+| G3  | Claim-account flow                                 | platform #757 (stacked on G2)               |
+| G4  | Wizard "Generate now" + `/api/works/quick-create`  | platform #758                               |
+| G5  | `*.ever.works` subdomain + Cloudflare DNS          | platform #759                               |
+| G6  | Default `deployProvider = 'ever-works'`            | platform #752                               |
+| G7  | Captcha + global caps                              | tracked, follow-up                          |
+| G8  | Funnel telemetry + this runbook                    | platform (this PR)                          |
+
+## End-to-end demo
+
+```
+1. Open https://ever.works/ in a fresh-incognito window.
+2. Type a directory description into the hero textarea.
+3. Click Generate.
+   → Browser redirects to https://app.ever.works/onboarding#prompt=…
+4. Wizard mounts:
+   - Reads the prompt out of the URL fragment.
+   - Mints a temporary user via POST /api/auth/anonymous (G2).
+   - Jumps to the final "Generate now" step.
+5. Click Generate now.
+   → POST /api/works/quick-create (G4) creates the Work and starts
+     generation. Response: { work, generation.historyId }.
+6. Background: the agent pushes 3 repos to ever-works-cloud (EW-614),
+   the deploy workflow runs (G5), Cloudflare CNAME is provisioned, and
+   the site comes up at https://<slug>.ever.works/.
+7. Optional: post-deploy banner offers Claim Account
+   (POST /api/auth/claim, G3).
+```
+
+## Debugging by stage
+
+Each stage emits a `[zero-friction]` JSON log line via
+`ZeroFrictionFunnelService.emit` (G8). All eight events share a
+`correlationId` so a single `correlationId=…` filter follows one user
+across services. Until the emit call sites land in their respective
+PRs, fall back to the per-component logs below.
+
+### Stage 1 — landing prompt (G1)
+- Browser console: form submit posts no XHR; it just sets
+  `window.location.href`. Open Network → Doc to see the redirect.
+- If the form doesn't appear: confirm the website build deployed
+  `LandingPromptForm` — check the rendered HTML in DevTools for
+  `data-testid="landing-prompt-form"`.
+
+### Stage 2 — anon user (G2)
+- `POST /api/auth/anonymous` should return 201 with `{ access_token,
+  user.isAnonymous: true }`.
+- 429 → the per-IP throttle (5/hour) tripped. Log in or wait.
+- 500 → check `AnonymousAuthService` logs; common cause is the
+  `users` table not yet having `is_anonymous` / `anonymous_expires_at`
+  columns. Run the G2 migration step or set
+  `database.autoMigrate=true` in dev.
+
+### Stage 3 — wizard finished (G4)
+- The wizard reads the URL fragment on mount via the
+  `EverWorksOnboardingWizard` effect. If the prompt doesn't pre-fill,
+  the most likely cause is a hash-fragment URL encoding issue — open
+  DevTools and inspect `window.location.hash` before any redirect.
+
+### Stage 4 — work created (G4)
+- `POST /api/works/quick-create` returns 202 with `{ status:
+  'pending', work, generation }`. The work id from the response is
+  what to use for downstream polling.
+- 400 → slug regex failed. The wizard derives slug from the prompt;
+  if it produced an invalid slug log a bug.
+
+### Stage 5 — repos pushed (EW-614)
+- Search `WorkLifecycleService` logs for
+  `EverWorksGitProvider.createRepository` lines. Three repos should be
+  created in `ever-works-cloud`.
+
+### Stage 6 — deploy started (G5)
+- `DeployService.deploy` logs the workflow dispatch. The
+  `K8S_INGRESS_HOST` Action variable should be set to
+  `${slug}.ever.works`.
+- Cloudflare CNAME provisioning: search
+  `CloudflareDns CNAME created/updated` in
+  `EverWorksDnsService` logs.
+
+### Stage 7 — deploy ready
+- `DeploymentVerifierService` polls the cluster for `Ready`. The site
+  should respond on `https://<slug>.ever.works/` within ~2 min after
+  the workflow finishes.
+
+### Stage 8 — claim account (G3)
+- Authenticated `POST /api/auth/claim` with `{ email, password }`.
+  409 → email already taken by a different user.
+  403 → the caller's session is already non-anonymous.
+
+## Rolling back per gap
+
+| Gap | Roll-back                                                                                                                                                  |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| G1  | Revert ever-works-website#37 and redeploy the website. The platform side keeps working — wizard hash-hydration is a no-op when no `prompt` is in the URL.   |
+| G2  | Revert platform #756. Existing anonymous rows orphan in the DB; safe to leave (the nightly cleanup task still runs once the schema columns exist).          |
+| G3  | Revert platform #757. Anonymous users stay anonymous; they can sign up normally via `/register`.                                                            |
+| G4  | Revert platform #758. The wizard falls back to the legacy `/works/new` hand-off automatically (the "Generate now" button only renders when `prompt` is set). |
+| G5  | Unset `CLOUDFLARE_API_TOKEN` (or rotate it). `EverWorksDnsService.getProvider()` returns null and the deploy pipeline reverts to the LB hostname fallback.   |
+| G6  | Revert platform #752. New rows go back to defaulting `deployProvider='vercel'`; existing rows are untouched.                                                |
+| G7  | (Not yet wired.)                                                                                                                                            |
+| G8  | Revert this PR. `[zero-friction]` log lines disappear; nothing else breaks.                                                                                 |
+
+## Configuration cheat-sheet
+
+| Env var                          | Owned by | Notes                                                                  |
+| -------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `ANONYMOUS_USER_TTL_DAYS`        | G2       | Default 7. Garbage values fall back to 7.                              |
+| `CLOUDFLARE_API_TOKEN`           | G5       | Scoped: DNS:Edit on the `ever.works` zone only. Never the global key.  |
+| `CLOUDFLARE_ZONE_ID`             | G5       | 32-char hex.                                                            |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME`  | G5       | Cluster ingress LB DNS name. Required for DNS automation.              |
+| `EVER_WORKS_DOMAIN`              | G5       | Defaults to `ever.works`.                                              |
+| `DEPLOY_EVER_WORKS_ENABLED`      | EW-608   | Gates the `ever-works` deploy provider end-to-end.                     |
+| `NEXT_PUBLIC_APP_URL`            | G1       | Where the landing page sends users. Defaults to `https://app.ever.works`. |
+
+## Dashboards
+
+- PostHog board for the funnel: TBD (G8 wires emit calls; dashboard
+  follow-up).
+- Cloudflare → `ever.works` zone → DNS records: shows the CNAME pool.
+- k8s-works → ingress → `*.ever.works` cert: verify cert-manager is
+  serving the wildcard.
+
+## Known sharp edges
+
+- The 6-char random suffix on quick-create slugs is meant to dodge
+  collisions across users typing the same prompt — but two users
+  hitting the same suffix is still ~one-in-a-million per attempt. The
+  Cloudflare PUT path handles that gracefully (idempotent update) but
+  the platform write hits a unique-constraint error first; ops will
+  see a 409 from `POST /api/works/quick-create`. Resolve by retrying;
+  long-term fix is a stronger suffix or a server-side UUID slug.
+- Anonymous users created during a DB outage that prevented the
+  `users.is_anonymous` column from being created may end up with
+  null email but `isAnonymous=false` (the default). Detection query:
+  `SELECT id FROM users WHERE email IS NULL AND is_anonymous = false`.
+  Repair: set `is_anonymous=true` and seed an `anonymous_expires_at`
+  in the past so the nightly cleanup picks them up.

--- a/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
+++ b/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
@@ -7,16 +7,16 @@
 
 ## What's wired up
 
-| Gap | What it does                                       | PR / status                                |
-| --- | -------------------------------------------------- | ------------------------------------------ |
-| G1  | Landing prompt + URL hand-off                      | ever-works-website#37                       |
-| G2  | Anonymous (TTL) users + cleanup task               | platform #756                               |
-| G3  | Claim-account flow                                 | platform #757 (stacked on G2)               |
-| G4  | Wizard "Generate now" + `/api/works/quick-create`  | platform #758                               |
-| G5  | `*.ever.works` subdomain + Cloudflare DNS          | platform #759                               |
-| G6  | Default `deployProvider = 'ever-works'`            | platform #752                               |
-| G7  | Captcha + global caps                              | tracked, follow-up                          |
-| G8  | Funnel telemetry + this runbook                    | platform (this PR)                          |
+| Gap | What it does                                      | PR / status                   |
+| --- | ------------------------------------------------- | ----------------------------- |
+| G1  | Landing prompt + URL hand-off                     | ever-works-website#37         |
+| G2  | Anonymous (TTL) users + cleanup task              | platform #756                 |
+| G3  | Claim-account flow                                | platform #757 (stacked on G2) |
+| G4  | Wizard "Generate now" + `/api/works/quick-create` | platform #758                 |
+| G5  | `*.ever.works` subdomain + Cloudflare DNS         | platform #759                 |
+| G6  | Default `deployProvider = 'ever-works'`           | platform #752                 |
+| G7  | Captcha + global caps                             | tracked, follow-up            |
+| G8  | Funnel telemetry + this runbook                   | platform (this PR)            |
 
 ## End-to-end demo
 
@@ -48,6 +48,7 @@ across services. Until the emit call sites land in their respective
 PRs, fall back to the per-component logs below.
 
 ### Stage 1 — landing prompt (G1)
+
 - Browser console: form submit posts no XHR; it just sets
   `window.location.href`. Open Network → Doc to see the redirect.
 - If the form doesn't appear: confirm the website build deployed
@@ -55,8 +56,9 @@ PRs, fall back to the per-component logs below.
   `data-testid="landing-prompt-form"`.
 
 ### Stage 2 — anon user (G2)
+
 - `POST /api/auth/anonymous` should return 201 with `{ access_token,
-  user.isAnonymous: true }`.
+user.isAnonymous: true }`.
 - 429 → the per-IP throttle (5/hour) tripped. Log in or wait.
 - 500 → check `AnonymousAuthService` logs; common cause is the
   `users` table not yet having `is_anonymous` / `anonymous_expires_at`
@@ -64,24 +66,28 @@ PRs, fall back to the per-component logs below.
   `database.autoMigrate=true` in dev.
 
 ### Stage 3 — wizard finished (G4)
+
 - The wizard reads the URL fragment on mount via the
   `EverWorksOnboardingWizard` effect. If the prompt doesn't pre-fill,
   the most likely cause is a hash-fragment URL encoding issue — open
   DevTools and inspect `window.location.hash` before any redirect.
 
 ### Stage 4 — work created (G4)
+
 - `POST /api/works/quick-create` returns 202 with `{ status:
-  'pending', work, generation }`. The work id from the response is
+'pending', work, generation }`. The work id from the response is
   what to use for downstream polling.
 - 400 → slug regex failed. The wizard derives slug from the prompt;
   if it produced an invalid slug log a bug.
 
 ### Stage 5 — repos pushed (EW-614)
+
 - Search `WorkLifecycleService` logs for
   `EverWorksGitProvider.createRepository` lines. Three repos should be
   created in `ever-works-cloud`.
 
 ### Stage 6 — deploy started (G5)
+
 - `DeployService.deploy` logs the workflow dispatch. The
   `K8S_INGRESS_HOST` Action variable should be set to
   `${slug}.ever.works`.
@@ -90,39 +96,41 @@ PRs, fall back to the per-component logs below.
   `EverWorksDnsService` logs.
 
 ### Stage 7 — deploy ready
+
 - `DeploymentVerifierService` polls the cluster for `Ready`. The site
   should respond on `https://<slug>.ever.works/` within ~2 min after
   the workflow finishes.
 
 ### Stage 8 — claim account (G3)
+
 - Authenticated `POST /api/auth/claim` with `{ email, password }`.
   409 → email already taken by a different user.
   403 → the caller's session is already non-anonymous.
 
 ## Rolling back per gap
 
-| Gap | Roll-back                                                                                                                                                  |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| G1  | Revert ever-works-website#37 and redeploy the website. The platform side keeps working — wizard hash-hydration is a no-op when no `prompt` is in the URL.   |
-| G2  | Revert platform #756. Existing anonymous rows orphan in the DB; safe to leave (the nightly cleanup task still runs once the schema columns exist).          |
-| G3  | Revert platform #757. Anonymous users stay anonymous; they can sign up normally via `/register`.                                                            |
+| Gap | Roll-back                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| G1  | Revert ever-works-website#37 and redeploy the website. The platform side keeps working — wizard hash-hydration is a no-op when no `prompt` is in the URL.    |
+| G2  | Revert platform #756. Existing anonymous rows orphan in the DB; safe to leave (the nightly cleanup task still runs once the schema columns exist).           |
+| G3  | Revert platform #757. Anonymous users stay anonymous; they can sign up normally via `/register`.                                                             |
 | G4  | Revert platform #758. The wizard falls back to the legacy `/works/new` hand-off automatically (the "Generate now" button only renders when `prompt` is set). |
 | G5  | Unset `CLOUDFLARE_API_TOKEN` (or rotate it). `EverWorksDnsService.getProvider()` returns null and the deploy pipeline reverts to the LB hostname fallback.   |
-| G6  | Revert platform #752. New rows go back to defaulting `deployProvider='vercel'`; existing rows are untouched.                                                |
-| G7  | (Not yet wired.)                                                                                                                                            |
-| G8  | Revert this PR. `[zero-friction]` log lines disappear; nothing else breaks.                                                                                 |
+| G6  | Revert platform #752. New rows go back to defaulting `deployProvider='vercel'`; existing rows are untouched.                                                 |
+| G7  | (Not yet wired.)                                                                                                                                             |
+| G8  | Revert this PR. `[zero-friction]` log lines disappear; nothing else breaks.                                                                                  |
 
 ## Configuration cheat-sheet
 
-| Env var                          | Owned by | Notes                                                                  |
-| -------------------------------- | -------- | ---------------------------------------------------------------------- |
-| `ANONYMOUS_USER_TTL_DAYS`        | G2       | Default 7. Garbage values fall back to 7.                              |
-| `CLOUDFLARE_API_TOKEN`           | G5       | Scoped: DNS:Edit on the `ever.works` zone only. Never the global key.  |
-| `CLOUDFLARE_ZONE_ID`             | G5       | 32-char hex.                                                            |
-| `EVER_WORKS_DEPLOY_LB_HOSTNAME`  | G5       | Cluster ingress LB DNS name. Required for DNS automation.              |
-| `EVER_WORKS_DOMAIN`              | G5       | Defaults to `ever.works`.                                              |
-| `DEPLOY_EVER_WORKS_ENABLED`      | EW-608   | Gates the `ever-works` deploy provider end-to-end.                     |
-| `NEXT_PUBLIC_APP_URL`            | G1       | Where the landing page sends users. Defaults to `https://app.ever.works`. |
+| Env var                         | Owned by | Notes                                                                     |
+| ------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `ANONYMOUS_USER_TTL_DAYS`       | G2       | Default 7. Garbage values fall back to 7.                                 |
+| `CLOUDFLARE_API_TOKEN`          | G5       | Scoped: DNS:Edit on the `ever.works` zone only. Never the global key.     |
+| `CLOUDFLARE_ZONE_ID`            | G5       | 32-char hex.                                                              |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | G5       | Cluster ingress LB DNS name. Required for DNS automation.                 |
+| `EVER_WORKS_DOMAIN`             | G5       | Defaults to `ever.works`.                                                 |
+| `DEPLOY_EVER_WORKS_ENABLED`     | EW-608   | Gates the `ever-works` deploy provider end-to-end.                        |
+| `NEXT_PUBLIC_APP_URL`           | G1       | Where the landing page sends users. Defaults to `https://app.ever.works`. |
 
 ## Dashboards
 

--- a/docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md
+++ b/docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md
@@ -1,0 +1,72 @@
+# EW-617 G8 — Funnel telemetry + ops runbook
+
+> Sub-task: **EW-625**. Parent epic: **EW-617**.
+
+## Goal
+
+Make the zero-friction prompt → deployed Work flow observable so we can
+answer:
+
+- How many visitors who type a prompt actually end up with a deployed
+  site? (top-of-funnel conversion)
+- Where do users drop off — at anon-auth, at wizard finish, at deploy?
+- How long does the median Work take from prompt to live URL?
+- How often does claim-account follow within 24 / 72 hours?
+
+## Functional requirements
+
+- **FR-G8-1** A canonical TypeScript schema for funnel events lives in
+  `@ever-works/contracts/telemetry`. Event names are pinned in
+  `ZERO_FRICTION_FUNNEL_EVENTS` and each payload extends
+  `FunnelEventBase` with a numeric `funnelStep` (1..8).
+- **FR-G8-2** A `correlationId` is minted on the landing page (G1) at
+  prompt submit, carried via the URL fragment alongside the prompt,
+  picked up by the wizard (G4) into `OnboardingWizardStateV2.promptCorrelationId`,
+  and reused by every downstream emit through `deploy-ready`.
+  Lets ops trace a single user end-to-end across async task runs.
+- **FR-G8-3** `ZeroFrictionFunnelService.emit(payload)` writes a single
+  structured log line tagged `[zero-friction]` with the full JSON
+  payload. Stage 1 stays log-based so we ship the schema without taking
+  a PostHog/OpenTelemetry dependency; stage 2 swaps the log sink for
+  real telemetry without changing call sites.
+- **FR-G8-4** PII rules: no raw IPs, no raw user agents, no email
+  addresses, no full prompts. `ipPrefix` is `/24` (IPv4) / `/48`
+  (IPv6); `clientKind` is the UA family bucket only.
+
+## Emit sites (one row per funnel step)
+
+| Step | Event                                 | Where to emit                                                          | Status        |
+| ---- | ------------------------------------- | ---------------------------------------------------------------------- | ------------- |
+| 1    | `zero_friction.landing_prompt_submit` | website: `LandingPromptForm.onSubmit`                                  | wiring TBD    |
+| 2    | `zero_friction.anon_user_created`     | platform: `AnonymousAuthService.createAnonymousUser`                   | wiring TBD    |
+| 3    | `zero_friction.wizard_finished`       | platform: `EverWorksOnboardingWizard` (just before quick-create call)  | wiring TBD    |
+| 4    | `zero_friction.work_created`          | platform: `WorksController.quickCreateWork` (after `createWork`)       | wiring TBD    |
+| 5    | `zero_friction.repos_pushed`          | platform: `WorkLifecycleService.createWork` (EW-614 path)              | wiring TBD    |
+| 6    | `zero_friction.deploy_started`        | platform: `DeployService.deploy` (right before workflow dispatch)      | wiring TBD    |
+| 7    | `zero_friction.deploy_ready`          | platform: `DeploymentVerifierService` (poll succeeds)                  | wiring TBD    |
+| 8    | `zero_friction.claim_account`         | platform: `ClaimAccountService.claim` (on success)                     | wiring TBD    |
+
+"wiring TBD" means the schema + service exist; the actual
+`funnelService.emit(...)` call sites are deliberately deferred so each
+upstream PR (#756 G2, #757 G3, #758 G4, #759 G5, ever-works-website#37
+G1) can add its emit independently without merge conflicts.
+
+## Ops runbook
+
+The runbook proper — how to demo, debug, and roll back each gap —
+lives at `docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md` (this PR).
+It's mirrored to `Workspace/knowledge/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md`
+on the next Workspace sync so it shows up in the bot's runbook index.
+
+## Tests
+
+- `zero-friction-funnel.service.spec.ts` (3 tests): single-line JSON
+  log output, timestamp back-fill when caller omits it, fallback
+  key=value line when JSON.stringify throws on a circular payload.
+
+## Out of scope (follow-ups)
+
+- Wire the actual `emit(...)` call sites — done in the matching PRs
+  (#756/#757/#758/#759/ever-works-website#37) as they land.
+- PostHog dashboard JSON + alert rules.
+- OpenTelemetry exporter (replaces the log sink in stage 2).

--- a/docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md
+++ b/docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md
@@ -35,16 +35,16 @@ answer:
 
 ## Emit sites (one row per funnel step)
 
-| Step | Event                                 | Where to emit                                                          | Status        |
-| ---- | ------------------------------------- | ---------------------------------------------------------------------- | ------------- |
-| 1    | `zero_friction.landing_prompt_submit` | website: `LandingPromptForm.onSubmit`                                  | wiring TBD    |
-| 2    | `zero_friction.anon_user_created`     | platform: `AnonymousAuthService.createAnonymousUser`                   | wiring TBD    |
-| 3    | `zero_friction.wizard_finished`       | platform: `EverWorksOnboardingWizard` (just before quick-create call)  | wiring TBD    |
-| 4    | `zero_friction.work_created`          | platform: `WorksController.quickCreateWork` (after `createWork`)       | wiring TBD    |
-| 5    | `zero_friction.repos_pushed`          | platform: `WorkLifecycleService.createWork` (EW-614 path)              | wiring TBD    |
-| 6    | `zero_friction.deploy_started`        | platform: `DeployService.deploy` (right before workflow dispatch)      | wiring TBD    |
-| 7    | `zero_friction.deploy_ready`          | platform: `DeploymentVerifierService` (poll succeeds)                  | wiring TBD    |
-| 8    | `zero_friction.claim_account`         | platform: `ClaimAccountService.claim` (on success)                     | wiring TBD    |
+| Step | Event                                 | Where to emit                                                         | Status     |
+| ---- | ------------------------------------- | --------------------------------------------------------------------- | ---------- |
+| 1    | `zero_friction.landing_prompt_submit` | website: `LandingPromptForm.onSubmit`                                 | wiring TBD |
+| 2    | `zero_friction.anon_user_created`     | platform: `AnonymousAuthService.createAnonymousUser`                  | wiring TBD |
+| 3    | `zero_friction.wizard_finished`       | platform: `EverWorksOnboardingWizard` (just before quick-create call) | wiring TBD |
+| 4    | `zero_friction.work_created`          | platform: `WorksController.quickCreateWork` (after `createWork`)      | wiring TBD |
+| 5    | `zero_friction.repos_pushed`          | platform: `WorkLifecycleService.createWork` (EW-614 path)             | wiring TBD |
+| 6    | `zero_friction.deploy_started`        | platform: `DeployService.deploy` (right before workflow dispatch)     | wiring TBD |
+| 7    | `zero_friction.deploy_ready`          | platform: `DeploymentVerifierService` (poll succeeds)                 | wiring TBD |
+| 8    | `zero_friction.claim_account`         | platform: `ClaimAccountService.claim` (on success)                    | wiring TBD |
 
 "wiring TBD" means the schema + service exist; the actual
 `funnelService.emit(...)` call sites are deliberately deferred so each

--- a/packages/agent/src/services/__tests__/zero-friction-funnel.service.spec.ts
+++ b/packages/agent/src/services/__tests__/zero-friction-funnel.service.spec.ts
@@ -1,0 +1,64 @@
+import { ZeroFrictionFunnelService } from '../zero-friction-funnel.service';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
+
+describe('ZeroFrictionFunnelService (EW-617 G8)', () => {
+    let svc: ZeroFrictionFunnelService;
+    let logCalls: string[];
+
+    beforeEach(() => {
+        svc = new ZeroFrictionFunnelService();
+        logCalls = [];
+        jest.spyOn((svc as any).logger, 'log').mockImplementation((msg: string) => {
+            logCalls.push(msg);
+        });
+    });
+
+    it('emits a single-line JSON log tagged [zero-friction]', () => {
+        svc.emit({
+            funnelStep: 2,
+            event: ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED,
+            correlationId: 'corr-1',
+            timestamp: '2026-05-14T19:00:00.000Z',
+            anonUserId: 'u-1',
+            anonymousExpiresAt: '2026-05-21T19:00:00.000Z',
+            ipPrefix: '1.2.3.0/24',
+        });
+
+        expect(logCalls).toHaveLength(1);
+        expect(logCalls[0]).toContain('[zero-friction]');
+        const json = logCalls[0].replace(/^\[zero-friction\]\s*/, '');
+        const parsed = JSON.parse(json);
+        expect(parsed.event).toBe('zero_friction.anon_user_created');
+        expect(parsed.funnelStep).toBe(2);
+        expect(parsed.correlationId).toBe('corr-1');
+        expect(parsed.anonUserId).toBe('u-1');
+        expect(parsed.timestamp).toBe('2026-05-14T19:00:00.000Z');
+    });
+
+    it('back-fills timestamp when the caller omits it', () => {
+        const before = Date.now();
+        svc.emit({
+            funnelStep: 4,
+            event: ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED,
+            correlationId: 'corr-9',
+            timestamp: '' as any,
+            userId: 'u-1',
+            workId: 'w-1',
+            workSlug: 'foo',
+            viaQuickCreate: true,
+        });
+        const after = Date.now();
+
+        const parsed = JSON.parse(logCalls[0].replace(/^\[zero-friction\]\s*/, ''));
+        const ts = new Date(parsed.timestamp).getTime();
+        expect(ts).toBeGreaterThanOrEqual(before - 100);
+        expect(ts).toBeLessThanOrEqual(after + 100);
+    });
+
+    it('falls back to a key=value line if JSON.stringify throws', () => {
+        const circular: any = { funnelStep: 1, event: 'x', correlationId: 'corr-2' };
+        circular.self = circular;
+        svc.emit(circular as any);
+        expect(logCalls[0]).toMatch(/event=x correlationId=corr-2/);
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -19,6 +19,7 @@ export * from './works-manifest.service';
 export * from './webhook-delivery.service';
 export * from './state-marker.service';
 export * from './platform-sync-secret.service';
+export * from './zero-friction-funnel.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -144,6 +144,7 @@ import { WorksConfigWriterService } from '@src/works-config/services/works-confi
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
 import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
 import { TemplateCatalogModule } from '../template-catalog/template-catalog.module';
@@ -217,6 +218,7 @@ describe('WorkModule', () => {
             EverWorksDeployQuotaService,
             PlatformSyncSecretService,
             EverWorksGitProvider,
+            ZeroFrictionFunnelService,
         ];
 
         it.each(expectedProviders)('declares %p as a provider', (provider) => {
@@ -291,10 +293,11 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 28-entry shape (25 services + 3 re-exported modules)', () => {
+        it('keeps the exports list at the documented 29-entry shape (26 services + 3 re-exported modules)', () => {
             // Bumped to 28 with the PlatformSyncSecretService resurrection for
             // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
-            expect(meta('exports')).toHaveLength(28);
+            // Bumped to 29 with the EW-617 G8 ZeroFrictionFunnelService.
+            expect(meta('exports')).toHaveLength(29);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -32,6 +32,7 @@ import { WorksConfigService } from '@src/works-config/services/works-config.serv
 import { WorksConfigSyncListener } from '@src/works-config/services/works-config-sync.listener';
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { ItemHealthService } from './item-health.service';
 import { ItemSourceValidationSchedulerService } from './item-source-validation-scheduler.service';
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
@@ -98,6 +99,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         SettingsSchemaValidatorService,
         EverWorksDeployQuotaService,
         PlatformSyncSecretService,
+        ZeroFrictionFunnelService,
         // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
         // the platform GitHub org (`ever-works-cloud`) using a server-held
         // PAT, so users picking "Ever Works Git" don't need to bring their
@@ -142,6 +144,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigProjectionService,
         WorksConfigRepositorySyncService,
         PlatformSyncSecretService,
+        ZeroFrictionFunnelService,
         CommunityPrModule,
         ComparisonGeneratorModule,
         TemplateCatalogModule,

--- a/packages/agent/src/services/zero-friction-funnel.service.ts
+++ b/packages/agent/src/services/zero-friction-funnel.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { ZeroFrictionFunnelPayload } from '@ever-works/contracts/telemetry';
+
+/**
+ * EW-617 G8 — funnel emit service.
+ *
+ * Stage one keeps the emit surface tiny: every event lands as a single
+ * structured Nest log line tagged `[zero-friction]` + the event name.
+ * The existing platform log pipeline picks that up; downstream the ops
+ * team can either grep raw logs, build a PostHog "Insights" view from
+ * the JSON, or wire a custom OpenTelemetry exporter later.
+ *
+ * Why not call PostHog directly here?
+ *   - PostHogModule today only exposes an `isInitialized` flag — no
+ *     `capture()` helper yet.
+ *   - Adding the dependency cleanly would require either client
+ *     instantiation logic or a global module hookup, neither of which
+ *     I want to do in the same PR that defines the schema.
+ *
+ * A follow-up PR can swap the log call for a real PostHog/Open-
+ * Telemetry sink without changing any of the emit call sites.
+ */
+@Injectable()
+export class ZeroFrictionFunnelService {
+    private readonly logger = new Logger('ZeroFrictionFunnel');
+
+    emit(payload: ZeroFrictionFunnelPayload): void {
+        // Pin the timestamp here so call sites can omit it (it's not
+        // very useful for them to set their own).
+        const enriched = {
+            ...payload,
+            timestamp: payload.timestamp || new Date().toISOString(),
+        };
+        // Single JSON log line so downstream log aggregation can parse
+        // each event without regex acrobatics.
+        try {
+            this.logger.log(`[zero-friction] ${JSON.stringify(enriched)}`);
+        } catch {
+            // JSON serialisation failures shouldn't take down the request.
+            this.logger.log(
+                `[zero-friction] event=${enriched.event} correlationId=${enriched.correlationId}`,
+            );
+        }
+    }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -38,6 +38,11 @@
 			"types": "./dist/api/index.d.ts",
 			"import": "./dist/api/index.js",
 			"require": "./dist/api/index.cjs"
+		},
+		"./telemetry": {
+			"types": "./dist/telemetry/index.d.ts",
+			"import": "./dist/telemetry/index.js",
+			"require": "./dist/telemetry/index.cjs"
 		}
 	},
 	"files": [

--- a/packages/contracts/src/telemetry/index.ts
+++ b/packages/contracts/src/telemetry/index.ts
@@ -1,0 +1,1 @@
+export * from './zero-friction-funnel.js';

--- a/packages/contracts/src/telemetry/zero-friction-funnel.ts
+++ b/packages/contracts/src/telemetry/zero-friction-funnel.ts
@@ -24,116 +24,115 @@
  */
 
 export const ZERO_FRICTION_FUNNEL_EVENTS = {
-    LANDING_PROMPT_SUBMIT: 'zero_friction.landing_prompt_submit',
-    ANON_USER_CREATED: 'zero_friction.anon_user_created',
-    WIZARD_FINISHED: 'zero_friction.wizard_finished',
-    WORK_CREATED: 'zero_friction.work_created',
-    REPOS_PUSHED: 'zero_friction.repos_pushed',
-    DEPLOY_STARTED: 'zero_friction.deploy_started',
-    DEPLOY_READY: 'zero_friction.deploy_ready',
-    CLAIM_ACCOUNT: 'zero_friction.claim_account',
+	LANDING_PROMPT_SUBMIT: 'zero_friction.landing_prompt_submit',
+	ANON_USER_CREATED: 'zero_friction.anon_user_created',
+	WIZARD_FINISHED: 'zero_friction.wizard_finished',
+	WORK_CREATED: 'zero_friction.work_created',
+	REPOS_PUSHED: 'zero_friction.repos_pushed',
+	DEPLOY_STARTED: 'zero_friction.deploy_started',
+	DEPLOY_READY: 'zero_friction.deploy_ready',
+	CLAIM_ACCOUNT: 'zero_friction.claim_account'
 } as const;
 
-export type ZeroFrictionFunnelEvent =
-    (typeof ZERO_FRICTION_FUNNEL_EVENTS)[keyof typeof ZERO_FRICTION_FUNNEL_EVENTS];
+export type ZeroFrictionFunnelEvent = (typeof ZERO_FRICTION_FUNNEL_EVENTS)[keyof typeof ZERO_FRICTION_FUNNEL_EVENTS];
 
 export interface FunnelEventBase {
-    /** ISO 8601 timestamp the event was emitted. */
-    readonly timestamp: string;
-    /**
-     * Correlation id that survives across the full funnel. Origin: G1
-     * mints a UUID v4 on submit, carries it via the URL fragment
-     * (`#prompt=…&corrId=…`), G4 reads it into wizard state, every
-     * downstream emit reuses it. Lets ops trace a single user across
-     * multiple services + asynchronous task runs.
-     */
-    readonly correlationId: string;
-    /**
-     * Numeric step (1..8) so PostHog can build a funnel without
-     * hard-coding event ordering. Pinned at the top of each interface
-     * below.
-     */
-    readonly funnelStep: number;
+	/** ISO 8601 timestamp the event was emitted. */
+	readonly timestamp: string;
+	/**
+	 * Correlation id that survives across the full funnel. Origin: G1
+	 * mints a UUID v4 on submit, carries it via the URL fragment
+	 * (`#prompt=…&corrId=…`), G4 reads it into wizard state, every
+	 * downstream emit reuses it. Lets ops trace a single user across
+	 * multiple services + asynchronous task runs.
+	 */
+	readonly correlationId: string;
+	/**
+	 * Numeric step (1..8) so PostHog can build a funnel without
+	 * hard-coding event ordering. Pinned at the top of each interface
+	 * below.
+	 */
+	readonly funnelStep: number;
 }
 
 export interface LandingPromptSubmitEvent extends FunnelEventBase {
-    readonly funnelStep: 1;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.LANDING_PROMPT_SUBMIT;
-    readonly promptLength: number;
-    /** UA family for top-of-funnel segmentation; never raw UA string. */
-    readonly clientKind: 'browser' | 'crawler' | 'unknown';
-    readonly referer?: string | null;
+	readonly funnelStep: 1;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.LANDING_PROMPT_SUBMIT;
+	readonly promptLength: number;
+	/** UA family for top-of-funnel segmentation; never raw UA string. */
+	readonly clientKind: 'browser' | 'crawler' | 'unknown';
+	readonly referer?: string | null;
 }
 
 export interface AnonUserCreatedEvent extends FunnelEventBase {
-    readonly funnelStep: 2;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED;
-    readonly anonUserId: string;
-    readonly anonymousExpiresAt: string;
-    /** Truncated /24 (IPv4) or /48 (IPv6) so we never persist raw IPs. */
-    readonly ipPrefix: string | null;
+	readonly funnelStep: 2;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED;
+	readonly anonUserId: string;
+	readonly anonymousExpiresAt: string;
+	/** Truncated /24 (IPv4) or /48 (IPv6) so we never persist raw IPs. */
+	readonly ipPrefix: string | null;
 }
 
 export interface WizardFinishedEvent extends FunnelEventBase {
-    readonly funnelStep: 3;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WIZARD_FINISHED;
-    readonly userId: string;
-    readonly isAnonymous: boolean;
-    /** Choices captured at the moment Generate-now was clicked. */
-    readonly aiChoice: string;
-    readonly storageChoice: string;
-    readonly deployChoice: string;
+	readonly funnelStep: 3;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WIZARD_FINISHED;
+	readonly userId: string;
+	readonly isAnonymous: boolean;
+	/** Choices captured at the moment Generate-now was clicked. */
+	readonly aiChoice: string;
+	readonly storageChoice: string;
+	readonly deployChoice: string;
 }
 
 export interface WorkCreatedEvent extends FunnelEventBase {
-    readonly funnelStep: 4;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED;
-    readonly userId: string;
-    readonly workId: string;
-    readonly workSlug: string;
-    /** True when the row was created via /api/works/quick-create. */
-    readonly viaQuickCreate: boolean;
+	readonly funnelStep: 4;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED;
+	readonly userId: string;
+	readonly workId: string;
+	readonly workSlug: string;
+	/** True when the row was created via /api/works/quick-create. */
+	readonly viaQuickCreate: boolean;
 }
 
 export interface ReposPushedEvent extends FunnelEventBase {
-    readonly funnelStep: 5;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.REPOS_PUSHED;
-    readonly workId: string;
-    /** `ever-works-cloud/<slug>-data`, `<slug>-website`, `<slug>-mcp`. */
-    readonly repos: readonly string[];
+	readonly funnelStep: 5;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.REPOS_PUSHED;
+	readonly workId: string;
+	/** `ever-works-cloud/<slug>-data`, `<slug>-website`, `<slug>-mcp`. */
+	readonly repos: readonly string[];
 }
 
 export interface DeployStartedEvent extends FunnelEventBase {
-    readonly funnelStep: 6;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_STARTED;
-    readonly workId: string;
-    readonly deployProvider: string;
-    readonly ingressHost: string | null;
+	readonly funnelStep: 6;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_STARTED;
+	readonly workId: string;
+	readonly deployProvider: string;
+	readonly ingressHost: string | null;
 }
 
 export interface DeployReadyEvent extends FunnelEventBase {
-    readonly funnelStep: 7;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY;
-    readonly workId: string;
-    readonly websiteUrl: string;
-    /** Milliseconds from `deploy-started` to `deploy-ready`. */
-    readonly elapsedMs: number;
+	readonly funnelStep: 7;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY;
+	readonly workId: string;
+	readonly websiteUrl: string;
+	/** Milliseconds from `deploy-started` to `deploy-ready`. */
+	readonly elapsedMs: number;
 }
 
 export interface ClaimAccountEvent extends FunnelEventBase {
-    readonly funnelStep: 8;
-    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.CLAIM_ACCOUNT;
-    readonly userId: string;
-    /** True if the user came in via the zero-friction flow + claimed. */
-    readonly viaZeroFriction: boolean;
+	readonly funnelStep: 8;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.CLAIM_ACCOUNT;
+	readonly userId: string;
+	/** True if the user came in via the zero-friction flow + claimed. */
+	readonly viaZeroFriction: boolean;
 }
 
 export type ZeroFrictionFunnelPayload =
-    | LandingPromptSubmitEvent
-    | AnonUserCreatedEvent
-    | WizardFinishedEvent
-    | WorkCreatedEvent
-    | ReposPushedEvent
-    | DeployStartedEvent
-    | DeployReadyEvent
-    | ClaimAccountEvent;
+	| LandingPromptSubmitEvent
+	| AnonUserCreatedEvent
+	| WizardFinishedEvent
+	| WorkCreatedEvent
+	| ReposPushedEvent
+	| DeployStartedEvent
+	| DeployReadyEvent
+	| ClaimAccountEvent;

--- a/packages/contracts/src/telemetry/zero-friction-funnel.ts
+++ b/packages/contracts/src/telemetry/zero-friction-funnel.ts
@@ -1,0 +1,139 @@
+/**
+ * EW-617 G8 — wire format for the zero-friction prompt → deployed Work
+ * funnel events.
+ *
+ * These types pin the canonical event names + payload shapes so the
+ * emit sites (G1 landing form, G2 anon auth, G3 claim, G4 quick-create,
+ * deploy.service.ts, etc.) all agree on the schema and downstream
+ * consumers (PostHog dashboards, log queries, the OpenTelemetry sink)
+ * can rely on stable fields.
+ *
+ * Emit sites in scope:
+ *
+ *   landing-prompt-submit       — website  (G1) — apps/web/components/global/LandingPromptForm.tsx
+ *   anon-user-created           — platform (G2) — apps/api/.../anonymous-auth.service.ts
+ *   wizard-finished             — platform (G4) — apps/web/components/onboarding/EverWorksOnboardingWizard.tsx
+ *   work-created                — platform (G4) — apps/api/.../works.controller.ts (quickCreateWork)
+ *   repos-pushed                — platform       — packages/agent/src/services/work-lifecycle.service.ts (EW-614 path)
+ *   deploy-started              — platform       — apps/api/.../deploy.service.ts (deploy())
+ *   deploy-ready                — platform       — apps/api/.../tasks/deployment-verifier.service.ts
+ *   claim-account               — platform (G3) — apps/api/.../claim-account.service.ts
+ *
+ * Bumping the schema version is a follow-up PR; for now treat the
+ * shapes as additive (clients should ignore unknown fields).
+ */
+
+export const ZERO_FRICTION_FUNNEL_EVENTS = {
+    LANDING_PROMPT_SUBMIT: 'zero_friction.landing_prompt_submit',
+    ANON_USER_CREATED: 'zero_friction.anon_user_created',
+    WIZARD_FINISHED: 'zero_friction.wizard_finished',
+    WORK_CREATED: 'zero_friction.work_created',
+    REPOS_PUSHED: 'zero_friction.repos_pushed',
+    DEPLOY_STARTED: 'zero_friction.deploy_started',
+    DEPLOY_READY: 'zero_friction.deploy_ready',
+    CLAIM_ACCOUNT: 'zero_friction.claim_account',
+} as const;
+
+export type ZeroFrictionFunnelEvent =
+    (typeof ZERO_FRICTION_FUNNEL_EVENTS)[keyof typeof ZERO_FRICTION_FUNNEL_EVENTS];
+
+export interface FunnelEventBase {
+    /** ISO 8601 timestamp the event was emitted. */
+    readonly timestamp: string;
+    /**
+     * Correlation id that survives across the full funnel. Origin: G1
+     * mints a UUID v4 on submit, carries it via the URL fragment
+     * (`#prompt=…&corrId=…`), G4 reads it into wizard state, every
+     * downstream emit reuses it. Lets ops trace a single user across
+     * multiple services + asynchronous task runs.
+     */
+    readonly correlationId: string;
+    /**
+     * Numeric step (1..8) so PostHog can build a funnel without
+     * hard-coding event ordering. Pinned at the top of each interface
+     * below.
+     */
+    readonly funnelStep: number;
+}
+
+export interface LandingPromptSubmitEvent extends FunnelEventBase {
+    readonly funnelStep: 1;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.LANDING_PROMPT_SUBMIT;
+    readonly promptLength: number;
+    /** UA family for top-of-funnel segmentation; never raw UA string. */
+    readonly clientKind: 'browser' | 'crawler' | 'unknown';
+    readonly referer?: string | null;
+}
+
+export interface AnonUserCreatedEvent extends FunnelEventBase {
+    readonly funnelStep: 2;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED;
+    readonly anonUserId: string;
+    readonly anonymousExpiresAt: string;
+    /** Truncated /24 (IPv4) or /48 (IPv6) so we never persist raw IPs. */
+    readonly ipPrefix: string | null;
+}
+
+export interface WizardFinishedEvent extends FunnelEventBase {
+    readonly funnelStep: 3;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WIZARD_FINISHED;
+    readonly userId: string;
+    readonly isAnonymous: boolean;
+    /** Choices captured at the moment Generate-now was clicked. */
+    readonly aiChoice: string;
+    readonly storageChoice: string;
+    readonly deployChoice: string;
+}
+
+export interface WorkCreatedEvent extends FunnelEventBase {
+    readonly funnelStep: 4;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED;
+    readonly userId: string;
+    readonly workId: string;
+    readonly workSlug: string;
+    /** True when the row was created via /api/works/quick-create. */
+    readonly viaQuickCreate: boolean;
+}
+
+export interface ReposPushedEvent extends FunnelEventBase {
+    readonly funnelStep: 5;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.REPOS_PUSHED;
+    readonly workId: string;
+    /** `ever-works-cloud/<slug>-data`, `<slug>-website`, `<slug>-mcp`. */
+    readonly repos: readonly string[];
+}
+
+export interface DeployStartedEvent extends FunnelEventBase {
+    readonly funnelStep: 6;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_STARTED;
+    readonly workId: string;
+    readonly deployProvider: string;
+    readonly ingressHost: string | null;
+}
+
+export interface DeployReadyEvent extends FunnelEventBase {
+    readonly funnelStep: 7;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY;
+    readonly workId: string;
+    readonly websiteUrl: string;
+    /** Milliseconds from `deploy-started` to `deploy-ready`. */
+    readonly elapsedMs: number;
+}
+
+export interface ClaimAccountEvent extends FunnelEventBase {
+    readonly funnelStep: 8;
+    readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.CLAIM_ACCOUNT;
+    readonly userId: string;
+    /** True if the user came in via the zero-friction flow + claimed. */
+    readonly viaZeroFriction: boolean;
+}
+
+export type ZeroFrictionFunnelPayload =
+    | LandingPromptSubmitEvent
+    | AnonUserCreatedEvent
+    | WizardFinishedEvent
+    | WorkCreatedEvent
+    | ReposPushedEvent
+    | DeployStartedEvent
+    | DeployReadyEvent
+    | ClaimAccountEvent;

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-	entry: ['src/index.ts', 'src/item/index.ts', 'src/domain/index.ts', 'src/form/index.ts', 'src/api/index.ts'],
+	entry: [
+		'src/index.ts',
+		'src/item/index.ts',
+		'src/domain/index.ts',
+		'src/form/index.ts',
+		'src/api/index.ts',
+		'src/telemetry/index.ts'
+	],
 	format: ['esm', 'cjs'],
 	dts: true,
 	clean: true,


### PR DESCRIPTION
## Summary

Lays the observability foundation for the EW-617 zero-friction flow: a single canonical schema for all 8 funnel events, an emit service that writes structured log lines today (swappable for PostHog / OpenTelemetry later), and a complete ops runbook covering demo, debugging, and rollback per gap.

**Schema** — \`@ever-works/contracts/telemetry\`
- \`ZERO_FRICTION_FUNNEL_EVENTS\` pins the 8 canonical names: \`landing_prompt_submit\` (1) → \`anon_user_created\` (2) → \`wizard_finished\` (3) → \`work_created\` (4) → \`repos_pushed\` (5) → \`deploy_started\` (6) → \`deploy_ready\` (7) → \`claim_account\` (8).
- Each payload extends \`FunnelEventBase\` with numeric \`funnelStep\` for PostHog funnels + a \`correlationId\` minted on the landing page so a single user can be traced end-to-end across async task runs.
- **PII rules baked into the types**: no raw IPs (\`ipPrefix\` /24 or /48), no raw user agents (\`clientKind\` family bucket), no emails, no full prompts (only \`promptLength\`).

**Service**
- \`ZeroFrictionFunnelService.emit(payload)\` writes one \`[zero-friction] {…JSON…}\` log line per event.
- Stays log-based for stage 1 to ship the schema without taking a PostHog/OpenTelemetry dependency. Stage 2 swaps the sink without touching call sites.
- Fallback path: circular-payload-safe (emits key=value line if JSON.stringify throws).

**Emit call sites**
- Deliberately deferred to the matching upstream PRs (#756 G2, #757 G3, #758 G4, #759 G5, ever-works-website#37 G1) so each PR adds its own emit without merge conflicts. Each site is named in the spec's emit-sites table.

**Docs**
- \`docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md\` — FR-G8-1..4, emit-sites table, out-of-scope.
- \`docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md\` — new ops runbook: end-to-end demo, debugging-by-stage, rollback recipes per gap, config cheat-sheet, dashboard pointers, "known sharp edges" (quick-create slug suffix collision, anon-user repair query). Mirrored to \`Workspace/knowledge/runbooks/\` on next Workspace sync.

**Build**
- \`packages/contracts/package.json\` + \`tsup.config.ts\` add the \`./telemetry\` subpath export so \`@ever-works/contracts/telemetry\` resolves in agent / api / web.

## Tests

- \`zero-friction-funnel.service.spec.ts\` — 3 tests: single-line JSON log output, timestamp back-fill, circular-payload fallback.

Sub-task: EW-625. Parent epic: EW-617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)