### PR TITLE
chore(release): cascade develop → stage (EW-616 + earlier)

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
@@ -1,0 +1,143 @@
+import {
+    allowedClusterSourcesFor,
+    isAdminOnlyOrg,
+    isEverWorksSharedOrg,
+    resolveKubeconfigForClusterSource,
+    validateClusterSourceForOwner,
+} from './cluster-source-matrix';
+
+describe('cluster-source-matrix — EW-616 deploy matrix', () => {
+    describe('isEverWorksSharedOrg', () => {
+        it.each(['ever-works', 'EVER-WORKS', 'Ever-Works', '  ever-works  ', 'ever-works-cloud'])(
+            'returns true for %s',
+            (owner) => expect(isEverWorksSharedOrg(owner)).toBe(true),
+        );
+        it.each(['acme', 'octocat', 'ever-works-customer', ''])('returns false for %s', (owner) =>
+            expect(isEverWorksSharedOrg(owner)).toBe(false),
+        );
+    });
+
+    describe('isAdminOnlyOrg', () => {
+        it('matches only the legacy ever-works org', () => {
+            expect(isAdminOnlyOrg('ever-works')).toBe(true);
+            expect(isAdminOnlyOrg('EVER-WORKS')).toBe(true);
+            expect(isAdminOnlyOrg('ever-works-cloud')).toBe(false);
+            expect(isAdminOnlyOrg('acme')).toBe(false);
+        });
+    });
+
+    describe('allowedClusterSourcesFor — drives the UI dropdown', () => {
+        it('ever-works org → [k8s-works, k8s-gauzy] (admin path)', () => {
+            expect(allowedClusterSourcesFor('ever-works')).toEqual(['k8s-works', 'k8s-gauzy']);
+        });
+
+        it('ever-works-cloud org → [k8s-works] only', () => {
+            expect(allowedClusterSourcesFor('ever-works-cloud')).toEqual(['k8s-works']);
+        });
+
+        it('customer-owned org → [custom-kubeconfig, k8s-works]', () => {
+            expect(allowedClusterSourcesFor('acme')).toEqual(['custom-kubeconfig', 'k8s-works']);
+        });
+    });
+
+    describe('validateClusterSourceForOwner — the 9 matrix cells', () => {
+        const ok = null;
+
+        // Row 1: ever-works (admin path) — k8s-works ✓, k8s-gauzy ✓, custom ✗
+        it('ever-works + k8s-works ✓', () => {
+            expect(validateClusterSourceForOwner('ever-works', 'k8s-works')).toBe(ok);
+        });
+        it('ever-works + k8s-gauzy ✓ (admin path)', () => {
+            expect(validateClusterSourceForOwner('ever-works', 'k8s-gauzy')).toBe(ok);
+        });
+        it('ever-works + custom-kubeconfig ✗ (cell C — cross-tenant PAT exposure)', () => {
+            const result = validateClusterSourceForOwner('ever-works', 'custom-kubeconfig');
+            expect(result?.code).toBe('CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG');
+            expect(result?.message).toContain('ever-works');
+        });
+
+        // Row 2: ever-works-cloud (shared customer org) — only k8s-works
+        it('ever-works-cloud + k8s-works ✓ (the default for new customers)', () => {
+            expect(validateClusterSourceForOwner('ever-works-cloud', 'k8s-works')).toBe(ok);
+        });
+        it('ever-works-cloud + k8s-gauzy ✗ (admin-only cluster)', () => {
+            const result = validateClusterSourceForOwner('ever-works-cloud', 'k8s-gauzy');
+            expect(result?.code).toBe('K8S_GAUZY_NOT_ALLOWED');
+        });
+        it('ever-works-cloud + custom-kubeconfig ✗ (cell C)', () => {
+            const result = validateClusterSourceForOwner('ever-works-cloud', 'custom-kubeconfig');
+            expect(result?.code).toBe('CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG');
+        });
+
+        // Row 3: customer-owned org — k8s-works ✓, k8s-gauzy ✗, custom ✓
+        it('customer-owned + k8s-works ✓ (customer image on platform cluster)', () => {
+            expect(validateClusterSourceForOwner('acme', 'k8s-works')).toBe(ok);
+        });
+        it('customer-owned + k8s-gauzy ✗ (admin-only cluster)', () => {
+            const result = validateClusterSourceForOwner('acme', 'k8s-gauzy');
+            expect(result?.code).toBe('K8S_GAUZY_NOT_ALLOWED');
+            expect(result?.message).toContain('acme');
+        });
+        it('customer-owned + custom-kubeconfig ✓ (the BYOC default)', () => {
+            expect(validateClusterSourceForOwner('acme', 'custom-kubeconfig')).toBe(ok);
+        });
+
+        it('custom-kubeconfig + missing kubeconfig ✗ (operator error)', () => {
+            const result = validateClusterSourceForOwner('acme', 'custom-kubeconfig', {
+                hasKubeconfig: false,
+            });
+            expect(result?.code).toBe('CUSTOM_KUBECONFIG_MISSING_KUBECONFIG');
+        });
+
+        it('case insensitive: EVER-WORKS-CLOUD + custom-kubeconfig is rejected like ever-works-cloud', () => {
+            const result = validateClusterSourceForOwner('EVER-WORKS-CLOUD', 'custom-kubeconfig');
+            expect(result?.code).toBe('CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG');
+        });
+    });
+
+    describe('resolveKubeconfigForClusterSource — env-var substitution', () => {
+        it('k8s-works → reads EVER_WORKS_K8S_WORKS_KUBECONFIG', () => {
+            const env = { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'apiVersion: v1\nkind: Config\n' };
+            expect(resolveKubeconfigForClusterSource('k8s-works', 'user-kubeconfig', env)).toBe(
+                'apiVersion: v1\nkind: Config\n',
+            );
+        });
+
+        it('k8s-works → throws when env var is missing', () => {
+            expect(() => resolveKubeconfigForClusterSource('k8s-works', '', {})).toThrow(
+                /EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured/,
+            );
+        });
+
+        it('k8s-works → throws when env var is empty/whitespace', () => {
+            expect(() =>
+                resolveKubeconfigForClusterSource('k8s-works', '', {
+                    EVER_WORKS_K8S_WORKS_KUBECONFIG: '   ',
+                }),
+            ).toThrow();
+        });
+
+        it('k8s-gauzy → reads EVER_WORKS_K8S_GAUZY_KUBECONFIG', () => {
+            const env = { EVER_WORKS_K8S_GAUZY_KUBECONFIG: 'gauzy-kubeconfig' };
+            expect(resolveKubeconfigForClusterSource('k8s-gauzy', 'user-kubeconfig', env)).toBe(
+                'gauzy-kubeconfig',
+            );
+        });
+
+        it('k8s-gauzy → throws when env var is missing', () => {
+            expect(() => resolveKubeconfigForClusterSource('k8s-gauzy', '', {})).toThrow(
+                /EVER_WORKS_K8S_GAUZY_KUBECONFIG is not configured/,
+            );
+        });
+
+        it('custom-kubeconfig → passes through the user kubeconfig (env vars ignored)', () => {
+            const env = {
+                EVER_WORKS_K8S_WORKS_KUBECONFIG: 'platform-yaml',
+                EVER_WORKS_K8S_GAUZY_KUBECONFIG: 'gauzy-yaml',
+            };
+            expect(resolveKubeconfigForClusterSource('custom-kubeconfig', 'user-yaml', env)).toBe(
+                'user-yaml',
+            );
+        });
+    });
+});

--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
@@ -1,0 +1,157 @@
+/**
+ * EW-616 deploy matrix enforcement.
+ *
+ * Two independent dimensions:
+ *
+ *  - **Website repo owner** (and therefore the GHCR namespace the
+ *    image lives in): `ever-works`, `ever-works-cloud`, or
+ *    customer-owned.
+ *  - **Cluster source**: `k8s-works`, `k8s-gauzy`, `custom-kubeconfig`.
+ *
+ * Two rules combine to produce the supported set:
+ *
+ *  1. `k8s-gauzy` is admin-only — restricted to Works whose website
+ *     repo is in the `ever-works` GitHub org. This is the internal
+ *     platform cluster; real customers must not be allowed to deploy
+ *     onto it.
+ *
+ *  2. `custom-kubeconfig` cannot be combined with an Ever Works-shared
+ *     GHCR namespace (`ever-works` or `ever-works-cloud`). The cluster
+ *     would receive an org-scoped classic PAT as an `imagePullSecret`,
+ *     and `kubectl get secret -o yaml` on the customer's cluster could
+ *     recover it and use it to read every GHCR image in that shared
+ *     org. To use your own cluster, you must also bring your own GitHub
+ *     org so the credential only grants access to your own resources.
+ *
+ * The resulting 5 supported combinations:
+ *
+ * | Website owner            | k8s-works | k8s-gauzy        | custom-kubeconfig |
+ * | ------------------------ | --------- | ---------------- | ----------------- |
+ * | `ever-works`             | OK        | OK (admin path)  | rejected (rule 2) |
+ * | `ever-works-cloud`       | OK        | rejected (rule 1)| rejected (rule 2) |
+ * | customer-owned           | OK        | rejected (rule 1)| OK                |
+ *
+ * The full background is in the EW-615/EW-616 tickets and the
+ * `EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md` runbook.
+ */
+
+export type ClusterSource = 'k8s-works' | 'k8s-gauzy' | 'custom-kubeconfig';
+
+const EVER_WORKS_SHARED_ORGS = new Set(['ever-works', 'ever-works-cloud']);
+
+export function isEverWorksSharedOrg(websiteOwner: string): boolean {
+    return EVER_WORKS_SHARED_ORGS.has(websiteOwner.trim().toLowerCase());
+}
+
+export function isAdminOnlyOrg(websiteOwner: string): boolean {
+    return websiteOwner.trim().toLowerCase() === 'ever-works';
+}
+
+/**
+ * Allowed cluster sources for a given website-repo owner, in the order
+ * they should appear in the UI dropdown. The first entry is the
+ * recommended default. The UI's `x-widget: k8s-cluster-source` reads
+ * this to drive the conditional dropdown.
+ */
+export function allowedClusterSourcesFor(websiteOwner: string): readonly ClusterSource[] {
+    if (isAdminOnlyOrg(websiteOwner)) {
+        return ['k8s-works', 'k8s-gauzy'];
+    }
+    if (isEverWorksSharedOrg(websiteOwner)) {
+        return ['k8s-works'];
+    }
+    return ['custom-kubeconfig', 'k8s-works'];
+}
+
+export interface ClusterSourceValidationFailure {
+    readonly code:
+        | 'K8S_GAUZY_NOT_ALLOWED'
+        | 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG'
+        | 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG';
+    readonly message: string;
+}
+
+/**
+ * Validate a (websiteOwner, clusterSource) pair against the deploy
+ * matrix. Returns a failure record when the pair is rejected,
+ * `null` otherwise. The caller decides how to surface the failure
+ * (HTTP exception in the controller, logger.error in batch flows, etc).
+ *
+ * Pure / side-effect-free so it can be unit-tested without DI.
+ */
+export function validateClusterSourceForOwner(
+    websiteOwner: string,
+    clusterSource: ClusterSource,
+    options: { hasKubeconfig: boolean } = { hasKubeconfig: true },
+): ClusterSourceValidationFailure | null {
+    if (clusterSource === 'k8s-gauzy' && !isAdminOnlyOrg(websiteOwner)) {
+        return {
+            code: 'K8S_GAUZY_NOT_ALLOWED',
+            message:
+                `'k8s-gauzy' is the Ever Works internal platform cluster ` +
+                `and is restricted to Works in the 'ever-works' GitHub org. ` +
+                `The website repo for this Work is in '${websiteOwner}'. ` +
+                `Pick 'k8s-works' instead, or move the Work to the 'ever-works' org.`,
+        };
+    }
+
+    if (clusterSource === 'custom-kubeconfig' && isEverWorksSharedOrg(websiteOwner)) {
+        return {
+            code: 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG',
+            message:
+                `Cannot deploy a Work in the '${websiteOwner}' organisation to a customer-provided cluster. ` +
+                `The cluster's imagePullSecret would contain an org-scoped PAT that grants read access ` +
+                `to every GHCR image in '${websiteOwner}' (cross-tenant exposure). ` +
+                `To use your own cluster, move this Work to your own GitHub org first, ` +
+                `or pick 'k8s-works' as the target cluster.`,
+        };
+    }
+
+    if (clusterSource === 'custom-kubeconfig' && !options.hasKubeconfig) {
+        return {
+            code: 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG',
+            message:
+                `Target cluster is 'custom-kubeconfig' but no kubeconfig is saved on the Kubernetes plugin. ` +
+                `Paste a kubeconfig in plugin settings, or pick a platform-managed cluster.`,
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Resolve the kubeconfig YAML to push as the workflow's `K8S_TOKEN`
+ * secret. For platform-managed cluster sources, this reads the right
+ * env var; for `custom-kubeconfig`, it returns the user-pasted token.
+ *
+ * Throws when a platform-managed source is requested but the platform
+ * has not provisioned the corresponding env var (operator bug).
+ *
+ * The env-var lookup is injected so unit tests can avoid touching
+ * `process.env` directly.
+ */
+export function resolveKubeconfigForClusterSource(
+    clusterSource: ClusterSource,
+    userKubeconfig: string,
+    env: NodeJS.ProcessEnv = process.env,
+): string {
+    if (clusterSource === 'k8s-works') {
+        const value = env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+        if (!value || !value.trim()) {
+            throw new Error(
+                "Cluster source is 'k8s-works' but EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured on the platform.",
+            );
+        }
+        return value;
+    }
+    if (clusterSource === 'k8s-gauzy') {
+        const value = env.EVER_WORKS_K8S_GAUZY_KUBECONFIG;
+        if (!value || !value.trim()) {
+            throw new Error(
+                "Cluster source is 'k8s-gauzy' but EVER_WORKS_K8S_GAUZY_KUBECONFIG is not configured on the platform.",
+            );
+        }
+        return value;
+    }
+    return userKubeconfig;
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -39,6 +39,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         token?: string;
         settings?: Record<string, unknown>;
         deployProvider?: string;
+        /** Owner returned by `work.getRepoOwner('website')`. Defaults to
+         *  the customer-owned org `'acme'` so most tests run on the
+         *  permissive EW-616 cell. Tests that exercise the platform-owned
+         *  orgs override this. */
+        websiteOwner?: string;
         /** Settings returned by deployFacade.getOtherPluginSettings('github', ...).
          *  Defaults to an empty object (no PAT saved). Tests for the GHCR PAT
          *  flow override this with `{ readPackagesPat: '...' }`. */
@@ -47,6 +52,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
          *  pre-dual-mode tests behaving as before. */
         activitySyncMode?: 'pull' | 'push' | 'disabled';
     }) => {
+        const websiteOwner = overrides.websiteOwner ?? 'acme';
         const work = {
             id: 'work-1',
             slug: 'my-site',
@@ -55,9 +61,9 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             websiteTemplateId: 'directory-web-template',
             activitySyncMode: overrides.activitySyncMode ?? 'push',
             user: { id: 'user-1' },
-            getRepoOwner: () => 'acme',
-            getDataRepo: () => 'acme/data',
-            getWebsiteRepo: () => 'acme-site',
+            getRepoOwner: () => websiteOwner,
+            getDataRepo: () => `${websiteOwner}/data`,
+            getWebsiteRepo: () => `${websiteOwner}-site`,
             resolveCommitter: () => ({ name: 'a', email: 'a@b' }),
         };
 
@@ -549,5 +555,160 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         );
 
         errorSpy.mockRestore();
+    });
+
+    describe('EW-616 cluster-source enforcement + kubeconfig substitution', () => {
+        const k8sPlugin = {
+            id: 'k8s',
+            getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+            getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+        };
+
+        const originalEnv = process.env;
+
+        beforeEach(() => {
+            process.env = { ...originalEnv };
+            delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+            delete process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG;
+        });
+
+        afterEach(() => {
+            process.env = originalEnv;
+        });
+
+        it('back-compat: no clusterSource + customer-owned org + user kubeconfig → uses user kubeconfig as K8S_TOKEN', async () => {
+            const { service, githubPlugin } = buildService({
+                plugin: k8sPlugin,
+                token: 'user-pasted-yaml',
+                settings: {},
+                websiteOwner: 'acme',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const k8sToken = secrets.find((s: any) => s.key === 'K8S_TOKEN');
+            expect(k8sToken?.value).toBe('user-pasted-yaml');
+        });
+
+        it('k8s-works + ever-works-cloud → substitutes EVER_WORKS_K8S_WORKS_KUBECONFIG as K8S_TOKEN', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'platform-yaml';
+            const { service, githubPlugin } = buildService({
+                plugin: k8sPlugin,
+                token: 'user-pasted-yaml-should-be-ignored',
+                settings: { clusterSource: 'k8s-works' },
+                websiteOwner: 'ever-works-cloud',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const k8sToken = secrets.find((s: any) => s.key === 'K8S_TOKEN');
+            expect(k8sToken?.value).toBe('platform-yaml');
+        });
+
+        it('k8s-gauzy + ever-works → substitutes EVER_WORKS_K8S_GAUZY_KUBECONFIG (admin path)', async () => {
+            process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG = 'gauzy-yaml';
+            const { service, githubPlugin } = buildService({
+                plugin: k8sPlugin,
+                token: 'user-yaml-ignored',
+                settings: { clusterSource: 'k8s-gauzy' },
+                websiteOwner: 'ever-works',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            expect(secrets.find((s: any) => s.key === 'K8S_TOKEN')?.value).toBe('gauzy-yaml');
+        });
+
+        it('rejects ever-works-cloud + custom-kubeconfig with a BadRequest (cell C)', async () => {
+            const { service } = buildService({
+                plugin: k8sPlugin,
+                settings: { clusterSource: 'custom-kubeconfig' },
+                websiteOwner: 'ever-works-cloud',
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
+                /cross-tenant exposure/i,
+            );
+        });
+
+        it('rejects customer-owned + k8s-gauzy with a BadRequest (admin-only)', async () => {
+            const { service } = buildService({
+                plugin: k8sPlugin,
+                settings: { clusterSource: 'k8s-gauzy' },
+                websiteOwner: 'acme',
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
+                /'k8s-gauzy' is the Ever Works internal platform cluster/,
+            );
+        });
+
+        it('rejects k8s-works with InternalServerError when EVER_WORKS_K8S_WORKS_KUBECONFIG is not provisioned (operator gap, not user error)', async () => {
+            // env var intentionally absent
+            const { service } = buildService({
+                plugin: k8sPlugin,
+                settings: { clusterSource: 'k8s-works' },
+                websiteOwner: 'ever-works-cloud',
+            });
+
+            const InternalServerErrorException =
+                require('@nestjs/common').InternalServerErrorException;
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toBeInstanceOf(
+                InternalServerErrorException,
+            );
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
+                /EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured/,
+            );
+        });
+
+        it('discards the PLATFORM_MANAGED sentinel token from the facade when substituting kubeconfig', async () => {
+            // When the user picked a platform-managed source without
+            // pasting a kubeconfig, DeployFacade returns a sentinel token.
+            // DeployService.resolveDeployToken() must ignore it and read
+            // the platform env var instead.
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'real-platform-yaml';
+            const sentinel = '__ever-works-platform-managed-kubeconfig__';
+            const { service, githubPlugin } = buildService({
+                plugin: k8sPlugin,
+                token: sentinel,
+                settings: { clusterSource: 'k8s-works' },
+                websiteOwner: 'ever-works-cloud',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const k8sToken = secrets.find((s: any) => s.key === 'K8S_TOKEN');
+            expect(k8sToken?.value).toBe('real-platform-yaml');
+            // The sentinel must never leak into any pushed secret.
+            for (const s of secrets) {
+                expect(s.value).not.toBe(sentinel);
+            }
+        });
+
+        it('skips matrix enforcement entirely for non-k8s providers', async () => {
+            const { service, githubPlugin } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                // these would trip the k8s matrix but vercel must not care
+                settings: { clusterSource: 'k8s-gauzy' },
+                websiteOwner: 'ever-works-cloud',
+                token: 'vercel-deploy-token',
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).resolves.toBe(true);
+
+            const { secrets } = captureCalls(githubPlugin);
+            expect(secrets.find((s: any) => s.key === 'VERCEL_TOKEN')?.value).toBe(
+                'vercel-deploy-token',
+            );
+        });
     });
 });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -1,7 +1,16 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+    BadRequestException,
+    Injectable,
+    InternalServerErrorException,
+    Logger,
+} from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomBytes } from 'crypto';
-import { DeployFacadeService, GitFacadeService } from '@ever-works/agent/facades';
+import {
+    DeployFacadeService,
+    GitFacadeService,
+    PLATFORM_MANAGED_KUBECONFIG_SENTINEL,
+} from '@ever-works/agent/facades';
 import { WorkRepository } from '@ever-works/agent/database';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
 import { Work, User } from '@ever-works/agent/entities';
@@ -14,6 +23,28 @@ import {
 import { DeploymentDispatchedEvent } from '@ever-works/agent/events';
 import type { IDeploymentPlugin } from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
+import {
+    ClusterSource,
+    resolveKubeconfigForClusterSource,
+    validateClusterSourceForOwner,
+} from './cluster-source-matrix';
+
+const VALID_CLUSTER_SOURCES: readonly ClusterSource[] = [
+    'k8s-works',
+    'k8s-gauzy',
+    'custom-kubeconfig',
+];
+
+function coerceClusterSource(value: unknown): ClusterSource {
+    if (typeof value === 'string' && (VALID_CLUSTER_SOURCES as readonly string[]).includes(value)) {
+        return value as ClusterSource;
+    }
+    // Back-compat: Works that pre-date the EW-616 dropdown have no
+    // `clusterSource` set in their plugin settings. Treat them as
+    // `custom-kubeconfig` so they keep working as long as their
+    // website repo is not in an Ever Works-shared org.
+    return 'custom-kubeconfig';
+}
 
 /**
  * Default workflow filenames to dispatch when a deployment plugin does not
@@ -81,6 +112,20 @@ export class DeployService {
 
         const websiteOwner = work.getRepoOwner('website');
         const websiteRepo = work.getWebsiteRepo();
+
+        // EW-616: enforce the deploy matrix for k8s deploys.
+        // - `k8s-gauzy` is admin-only (ever-works org).
+        // - Ever Works-shared GHCR + customer-provided cluster is rejected
+        //   to avoid cross-tenant credential exposure.
+        // The resolved kubeconfig replaces the user-pasted one for
+        // platform-managed sources.
+        const effectiveDeployToken = this.resolveDeployToken(
+            work.deployProvider,
+            websiteOwner,
+            settings ?? {},
+            token,
+        );
+
         const ctx = await this.createRepoContext(websiteOwner, websiteRepo, gitToken);
 
         await this.enableWorkflows({
@@ -90,7 +135,7 @@ export class DeployService {
             withDelay: false,
         });
 
-        await this.setRequiredSecrets(ctx, token, work, plugin, settings);
+        await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, settings);
         await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
@@ -212,6 +257,55 @@ export class DeployService {
                 status: 'error',
                 message: error instanceof Error ? error.message : 'Unknown error',
             };
+        }
+    }
+
+    /**
+     * EW-616: Apply the deploy-matrix validation for the k8s provider and
+     * substitute the platform's kubeconfig env var when the user picked a
+     * platform-managed cluster source. For non-k8s providers (Vercel, etc.)
+     * this is a pass-through and the validation is skipped.
+     */
+    private resolveDeployToken(
+        deployProvider: string | undefined,
+        websiteOwner: string,
+        settings: Record<string, unknown>,
+        userToken: string,
+    ): string {
+        if (deployProvider !== 'k8s') {
+            return userToken;
+        }
+
+        // EW-616: the deploy facade returns a sentinel string when the
+        // user picked a platform-managed cluster without pasting a
+        // kubeconfig. Treat it as "no kubeconfig" for the validator and
+        // discard it before resolution so it can never leak into the
+        // pushed `K8S_TOKEN` secret on the website repo.
+        const realUserToken = userToken === PLATFORM_MANAGED_KUBECONFIG_SENTINEL ? '' : userToken;
+
+        const clusterSource = coerceClusterSource(settings.clusterSource);
+        const failure = validateClusterSourceForOwner(websiteOwner, clusterSource, {
+            hasKubeconfig: Boolean(realUserToken && realUserToken.trim()),
+        });
+        if (failure) {
+            this.logger.warn(
+                `EW-616 deploy-matrix violation [${failure.code}]: ${failure.message}`,
+            );
+            throw new BadRequestException(failure.message);
+        }
+
+        try {
+            return resolveKubeconfigForClusterSource(clusterSource, realUserToken);
+        } catch (error) {
+            // The only failure path here is a missing platform-managed
+            // env var (`EVER_WORKS_K8S_WORKS_KUBECONFIG` /
+            // `EVER_WORKS_K8S_GAUZY_KUBECONFIG`). The user picked a
+            // valid option — this is a platform-provisioning gap, so
+            // surface it as 5xx, not 4xx, so on-call can distinguish it
+            // from genuine user-input errors.
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.error(`Cluster-source resolution failed for ${websiteOwner}: ${message}`);
+            throw new InternalServerErrorException(message);
         }
     }
 

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -1,4 +1,4 @@
-import { DeployFacadeService } from '../deploy.facade';
+import { DeployFacadeService, PLATFORM_MANAGED_KUBECONFIG_SENTINEL } from '../deploy.facade';
 
 describe('DeployFacadeService', () => {
     const createService = (args: {
@@ -100,6 +100,70 @@ describe('DeployFacadeService', () => {
             id: 'k8s',
             enabled: true,
             configured: false,
+        });
+    });
+
+    describe('EW-616 platform-managed kubeconfig sentinel', () => {
+        it('returns the sentinel for k8s + clusterSource=k8s-works when no kubeconfig is saved', async () => {
+            const { service } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works' } },
+            });
+
+            await expect(
+                service.getDeployToken({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toBe(PLATFORM_MANAGED_KUBECONFIG_SENTINEL);
+            await expect(
+                service.isConfigured({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toBe(true);
+        });
+
+        it('returns the sentinel for k8s + clusterSource=k8s-gauzy when no kubeconfig is saved', async () => {
+            const { service } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-gauzy' } },
+            });
+
+            await expect(
+                service.getDeployToken({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toBe(PLATFORM_MANAGED_KUBECONFIG_SENTINEL);
+        });
+
+        it('prefers a user-pasted kubeconfig over the sentinel when both are present', async () => {
+            const { service } = createService({
+                deployProvider: 'k8s',
+                settings: {
+                    clusterSource: { value: 'k8s-works' },
+                    kubeconfig: { value: 'apiVersion: v1\nkind: Config\n' },
+                },
+            });
+
+            await expect(
+                service.getDeployToken({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toContain('apiVersion: v1');
+        });
+
+        it('does NOT return the sentinel for clusterSource=custom-kubeconfig — back-compat path still requires a real kubeconfig', async () => {
+            const { service } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'custom-kubeconfig' } },
+            });
+
+            await expect(
+                service.getDeployToken({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toBeNull();
+        });
+
+        it('does NOT return the sentinel for non-k8s plugins even with a clusterSource setting', async () => {
+            const { service } = createService({
+                deployProvider: 'vercel',
+                pluginId: 'vercel',
+                settings: { clusterSource: { value: 'k8s-works' } },
+            });
+
+            await expect(
+                service.getDeployToken({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toBeNull();
         });
     });
 });

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -167,6 +167,7 @@ describe('FacadesModule + barrel re-exports', () => {
                     'OAuthFacadeService',
                     'OAuthNotSupportedError',
                     'OAuthProviderNotFoundError',
+                    'PLATFORM_MANAGED_KUBECONFIG_SENTINEL',
                     'PromptFacadeService',
                     'ProviderNotFoundError',
                     'ScreenshotFacadeError',

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -782,6 +782,24 @@ export class DeployFacadeService implements IDeployFacade {
                 includeSecrets: true,
             });
 
+            // EW-616: for the k8s plugin, when the user picked a
+            // platform-managed cluster (`k8s-works` / `k8s-gauzy`) the
+            // pasted kubeconfig is intentionally empty —
+            // `DeployService.resolveDeployToken()` substitutes the
+            // platform's kubeconfig from `EVER_WORKS_K8S_*_KUBECONFIG`
+            // env vars at deploy time. Return a non-empty sentinel here
+            // so the facade considers the work "configured" and lets the
+            // deploy proceed; the sentinel is discarded downstream.
+            if (pluginId === 'k8s') {
+                const clusterSource = settings.clusterSource?.value as string | undefined;
+                if (clusterSource === 'k8s-works' || clusterSource === 'k8s-gauzy') {
+                    return (
+                        (settings.kubeconfig?.value as string) ||
+                        PLATFORM_MANAGED_KUBECONFIG_SENTINEL
+                    );
+                }
+            }
+
             // Look for provider primary credential fields.
             // Vercel uses apiToken; Kubernetes uses kubeconfig; other
             // providers commonly use token/accessToken.
@@ -797,3 +815,16 @@ export class DeployFacadeService implements IDeployFacade {
         }
     }
 }
+
+/**
+ * Sentinel value returned by `getTokenFromSettings` for k8s deploys
+ * targeting a platform-managed cluster (`k8s-works` / `k8s-gauzy`).
+ * The deploy facade only checks that a token is non-empty before
+ * deciding the work is "configured", so any unique string works.
+ * `DeployService.resolveDeployToken()` discards this sentinel and
+ * substitutes the real platform kubeconfig from
+ * `EVER_WORKS_K8S_*_KUBECONFIG` env vars at deploy time.
+ *
+ * Exported so callers (or tests) can pattern-match on it if needed.
+ */
+export const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -73,6 +73,7 @@ export {
     NoDeployProviderError,
     DeployProviderNotFoundError,
     NoDeployCredentialsError,
+    PLATFORM_MANAGED_KUBECONFIG_SENTINEL,
     type DeployFacadeFullOptions,
 } from './deploy.facade';
 

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -115,8 +115,21 @@ describe('KubernetesPlugin metadata', () => {
 		expect(s?.['x-widget']).toBe('textarea');
 	});
 
-	it('only requires kubeconfig (registry has a default)', () => {
-		expect(plugin.settingsSchema.required).toEqual(['kubeconfig']);
+	it('makes kubeconfig conditionally required only when clusterSource is custom-kubeconfig', () => {
+		// Top-level `required` is no longer hard-coded — instead an
+		// `allOf` clause requires `kubeconfig` only when the user picked
+		// `custom-kubeconfig` (the back-compat default).
+		expect(plugin.settingsSchema.required).toBeUndefined();
+		const allOf = plugin.settingsSchema.allOf;
+		expect(allOf).toHaveLength(1);
+		expect(allOf?.[0].then?.required).toEqual(['kubeconfig']);
+	});
+
+	it('exposes the cluster-source dropdown enum (EW-616)', () => {
+		const cs = plugin.settingsSchema.properties?.clusterSource as Record<string, unknown>;
+		expect(cs?.enum).toEqual(['k8s-works', 'k8s-gauzy', 'custom-kubeconfig']);
+		expect(cs?.default).toBe('custom-kubeconfig');
+		expect(cs?.['x-widget']).toBe('k8s-cluster-source');
 	});
 
 	it('registry sub-form is a oneOf with three branches (github default)', () => {
@@ -156,6 +169,17 @@ describe('KubernetesPlugin.validateConnection', () => {
 		const r = await plugin.validateConnection({});
 		expect(r.success).toBe(false);
 		expect(r.message).toMatch(/paste a kubeconfig/i);
+	});
+
+	it('skips kubeconfig validation for platform-managed cluster sources (EW-616)', async () => {
+		const works = await plugin.validateConnection({ clusterSource: 'k8s-works' });
+		expect(works.success).toBe(true);
+		expect(works.message).toMatch(/platform-managed cluster 'k8s-works'/);
+		expect((works.details as { clusterSource?: string })?.clusterSource).toBe('k8s-works');
+
+		const gauzy = await plugin.validateConnection({ clusterSource: 'k8s-gauzy' });
+		expect(gauzy.success).toBe(true);
+		expect(gauzy.message).toMatch(/platform-managed cluster 'k8s-gauzy'/);
 	});
 
 	it('returns rich cluster details on success', async () => {
@@ -202,6 +226,20 @@ describe('KubernetesPlugin.getDeploymentSecrets', () => {
 	it('always sets K8S_NAMESPACE (defaulting to ever-works)', async () => {
 		const out = await plugin.getDeploymentSecrets({});
 		expect(out.K8S_NAMESPACE).toBe('ever-works');
+	});
+
+	it('emits K8S_CLUSTER_SOURCE (defaulting to custom-kubeconfig for back-compat) (EW-616)', async () => {
+		expect((await plugin.getDeploymentSecrets({})).K8S_CLUSTER_SOURCE).toBe('custom-kubeconfig');
+		expect((await plugin.getDeploymentSecrets({ clusterSource: 'k8s-works' })).K8S_CLUSTER_SOURCE).toBe(
+			'k8s-works'
+		);
+		expect((await plugin.getDeploymentSecrets({ clusterSource: 'k8s-gauzy' })).K8S_CLUSTER_SOURCE).toBe(
+			'k8s-gauzy'
+		);
+		// Garbage values fall through to the back-compat default.
+		expect((await plugin.getDeploymentSecrets({ clusterSource: 'nope' })).K8S_CLUSTER_SOURCE).toBe(
+			'custom-kubeconfig'
+		);
 	});
 
 	it('passes optional fields through when set', async () => {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -36,12 +36,19 @@ import {
 	type DnsResolver
 } from './domain.handler.js';
 import type {
+	ClusterSource,
 	IngressClassDescriptor,
 	KubernetesSettings,
 	RegistryConfig,
 	RegistryDeployContext,
 	ResolvedImageVisibility
 } from './types.js';
+
+const VALID_CLUSTER_SOURCES: readonly ClusterSource[] = ['k8s-works', 'k8s-gauzy', 'custom-kubeconfig'];
+
+function isClusterSource(value: unknown): value is ClusterSource {
+	return typeof value === 'string' && (VALID_CLUSTER_SOURCES as readonly string[]).includes(value);
+}
 
 const DEFAULT_NAMESPACE = 'ever-works';
 const DEFAULT_REPLICAS = 1;
@@ -139,10 +146,20 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 	readonly settingsSchema: JsonSchema = {
 		type: 'object',
 		properties: {
+			clusterSource: {
+				type: 'string',
+				enum: ['k8s-works', 'k8s-gauzy', 'custom-kubeconfig'],
+				default: 'custom-kubeconfig',
+				title: 'Target cluster',
+				description:
+					"Where to deploy. 'k8s-works' = Ever Works shared customer cluster. 'k8s-gauzy' = Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org). 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org owning the website repo — see EW-616.",
+				'x-widget': 'k8s-cluster-source'
+			},
 			kubeconfig: {
 				type: 'string',
 				title: 'kubeconfig',
-				description: 'Paste the contents of your ~/.kube/config or a service-account-scoped equivalent.',
+				description:
+					"Paste the contents of your ~/.kube/config or a service-account-scoped equivalent. Only used when 'Target cluster' is 'custom-kubeconfig' — ignored otherwise.",
 				'x-secret': true,
 				'x-scope': 'user',
 				'x-widget': 'textarea'
@@ -181,7 +198,21 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				maximum: 10
 			}
 		},
-		required: ['kubeconfig']
+		// `kubeconfig` is only required when `clusterSource === 'custom-kubeconfig'`
+		// (the default for back-compat). When `clusterSource` is a platform-managed
+		// value the platform substitutes the kubeconfig at deploy time and the
+		// pasted field is ignored. See EW-616.
+		allOf: [
+			{
+				if: {
+					anyOf: [
+						{ not: { required: ['clusterSource'] } },
+						{ properties: { clusterSource: { const: 'custom-kubeconfig' } } }
+					]
+				},
+				then: { required: ['kubeconfig'] }
+			}
+		]
 	};
 
 	private context?: PluginContext;
@@ -276,6 +307,19 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 
 	async validateConnection(settings: Record<string, unknown>): Promise<ConnectionValidationResult> {
 		const cfg = this.coerceSettings(settings);
+		const clusterSource: ClusterSource = cfg.clusterSource ?? 'custom-kubeconfig';
+
+		// Platform-managed cluster sources don't use the pasted kubeconfig —
+		// the platform substitutes the right one at deploy time. There is
+		// nothing to verify here from the user's session.
+		if (clusterSource !== 'custom-kubeconfig') {
+			return {
+				success: true,
+				message: `Will deploy to platform-managed cluster '${clusterSource}'.`,
+				details: { clusterSource }
+			};
+		}
+
 		if (!cfg.kubeconfig || !cfg.kubeconfig.trim()) {
 			return { success: false, message: 'Paste a kubeconfig before validating.' };
 		}
@@ -614,7 +658,8 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 	async getDeploymentSecrets(settings: Record<string, unknown>): Promise<Record<string, string>> {
 		const cfg = this.coerceSettings(settings);
 		const out: Record<string, string> = {
-			K8S_NAMESPACE: cfg.namespace?.trim() || DEFAULT_NAMESPACE
+			K8S_NAMESPACE: cfg.namespace?.trim() || DEFAULT_NAMESPACE,
+			K8S_CLUSTER_SOURCE: cfg.clusterSource ?? 'custom-kubeconfig'
 		};
 		if (cfg.kubeContext) out.K8S_KUBE_CONTEXT = cfg.kubeContext;
 		if (cfg.ingressClass) out.K8S_INGRESS_CLASS = cfg.ingressClass;
@@ -649,6 +694,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 
 	private coerceSettings(raw: Record<string, unknown>): KubernetesSettings {
 		const out: KubernetesSettings = {};
+		if (isClusterSource(raw.clusterSource)) out.clusterSource = raw.clusterSource;
 		if (typeof raw.kubeconfig === 'string') out.kubeconfig = raw.kubeconfig;
 		if (typeof raw.kubeContext === 'string') out.kubeContext = raw.kubeContext;
 		if (typeof raw.namespace === 'string') out.namespace = raw.namespace;

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -46,10 +46,45 @@ export type RegistryKind = RegistryConfig['kind'];
 export type ResolvedImageVisibility = 'public' | 'private';
 
 /**
+ * Where the kubeconfig used to talk to the target cluster comes from.
+ *
+ * - `'k8s-works'`        — Ever Works shared customer cluster. The
+ *                          platform substitutes
+ *                          `process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG`
+ *                          for the `K8S_TOKEN` GitHub Actions secret at
+ *                          deploy time. The `kubeconfig` field below is
+ *                          ignored.
+ * - `'k8s-gauzy'`        — Ever Works internal platform cluster. Same
+ *                          shape as `'k8s-works'` but uses
+ *                          `process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG`.
+ *                          Only allowed when the Work's website repo is
+ *                          in the `ever-works` org (admin/internal
+ *                          path).
+ * - `'custom-kubeconfig'`— Customer pastes their own kubeconfig in the
+ *                          `kubeconfig` field below. Only allowed when
+ *                          the Work's website repo is NOT in an Ever
+ *                          Works-shared org (the cell C exclusion).
+ *
+ * Validation of the (website-repo-owner, clusterSource) combination
+ * happens in `DeployService.deploy()`. See the EW-615/EW-616 tickets
+ * and `Workspace/knowledge/runbooks/EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md`
+ * for the full supported-matrix table.
+ */
+export type ClusterSource = 'k8s-works' | 'k8s-gauzy' | 'custom-kubeconfig';
+
+/**
  * Plugin settings as stored in `plugin_settings`.
  */
 export interface KubernetesSettings {
-	/** Full kubeconfig YAML. Stored encrypted; never returned by the API. */
+	/** Where the kubeconfig for the target cluster comes from. Defaults
+	 *  to `'custom-kubeconfig'` so existing Works (which pre-date this
+	 *  field and have a user-pasted `kubeconfig`) keep working without
+	 *  re-saving their settings. */
+	clusterSource?: ClusterSource;
+	/** Full kubeconfig YAML. Stored encrypted; never returned by the API.
+	 *  Required when `clusterSource === 'custom-kubeconfig'`. Ignored
+	 *  when `clusterSource` is a platform-managed value — the platform
+	 *  substitutes the right env var at deploy time. */
 	kubeconfig?: string;
 	/** Override the kubeconfig's `current-context`. */
 	kubeContext?: string;


### PR DESCRIPTION
## Summary

Cascades the latest `develop` to `stage` ahead of a production cut.
Includes:

- **EW-616** — k8s deploy matrix enforcement (PR #753, just merged)
- Any other develop-only commits since the last cascade

## Test plan

- [x] CI on develop is green (PR #753 merged with all checks passing)
- [ ] CI on this cascade PR comes back green
- [ ] Spot-check that no new schema migrations were missed since the last stage cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)