### PR TITLE
chore(deploy): EW-616 wire platform kubeconfigs into k8s manifests

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -1,4 +1,18 @@
 ---
+# EW-616: Platform-managed kubeconfigs for k8s deploys to shared clusters.
+# Stored as base64 in GH Actions secrets; Kubernetes decodes Secret.data
+# values automatically when mounting via `secretKeyRef`, so the container
+# receives the raw kubeconfig YAML in the env var.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ever-works-platform-kubeconfigs-dev
+type: Opaque
+data:
+  EVER_WORKS_K8S_WORKS_KUBECONFIG: "$EVER_WORKS_K8S_WORKS_KUBECONFIG_B64"
+  EVER_WORKS_K8S_GAUZY_KUBECONFIG: "$EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64"
+
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -177,6 +191,18 @@ spec:
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
             - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
+            # EW-616 — platform-managed kubeconfigs.
+            - name: EVER_WORKS_K8S_WORKS_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-dev
+                  key: EVER_WORKS_K8S_WORKS_KUBECONFIG
+            - name: EVER_WORKS_K8S_GAUZY_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-dev
+                  key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -1,4 +1,18 @@
 ---
+# EW-616: Platform-managed kubeconfigs for k8s deploys to shared clusters.
+# Stored as base64 in GH Actions secrets; Kubernetes decodes Secret.data
+# values automatically when mounting via `secretKeyRef`, so the container
+# receives the raw kubeconfig YAML in the env var.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ever-works-platform-kubeconfigs
+type: Opaque
+data:
+  EVER_WORKS_K8S_WORKS_KUBECONFIG: "$EVER_WORKS_K8S_WORKS_KUBECONFIG_B64"
+  EVER_WORKS_K8S_GAUZY_KUBECONFIG: "$EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64"
+
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -182,6 +196,23 @@ spec:
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
             - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
+            # EW-616 — platform-managed kubeconfigs for the k8s deploy
+            # plugin's `clusterSource ∈ {k8s-works, k8s-gauzy}` paths.
+            # Mounted from the `ever-works-platform-kubeconfigs` Secret
+            # (defined at the top of this manifest). Kubernetes
+            # auto-base64-decodes Secret.data when mounting via
+            # secretKeyRef, so the container sees raw kubeconfig YAML.
+            - name: EVER_WORKS_K8S_WORKS_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs
+                  key: EVER_WORKS_K8S_WORKS_KUBECONFIG
+            - name: EVER_WORKS_K8S_GAUZY_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs
+                  key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -1,4 +1,18 @@
 ---
+# EW-616: Platform-managed kubeconfigs for k8s deploys to shared clusters.
+# Stored as base64 in GH Actions secrets; Kubernetes decodes Secret.data
+# values automatically when mounting via `secretKeyRef`, so the container
+# receives the raw kubeconfig YAML in the env var.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ever-works-platform-kubeconfigs-stage
+type: Opaque
+data:
+  EVER_WORKS_K8S_WORKS_KUBECONFIG: "$EVER_WORKS_K8S_WORKS_KUBECONFIG_B64"
+  EVER_WORKS_K8S_GAUZY_KUBECONFIG: "$EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64"
+
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -177,6 +191,18 @@ spec:
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
             - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
+            # EW-616 — platform-managed kubeconfigs.
+            - name: EVER_WORKS_K8S_WORKS_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-stage
+                  key: EVER_WORKS_K8S_WORKS_KUBECONFIG
+            - name: EVER_WORKS_K8S_GAUZY_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-stage
+                  key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
           resources:
             requests:

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -128,6 +128,10 @@ jobs:
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
+          # EW-616 — kubeconfigs for platform-managed clusterSource values.
+          EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -128,6 +128,13 @@ jobs:
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
+          # EW-616 — kubeconfigs for platform-managed `clusterSource`
+          # values on the k8s deploy plugin. Both are base64-encoded
+          # so envsubst can splice them into Secret.data fields without
+          # newline trouble; Kubernetes auto-decodes when mounting.
+          EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -128,6 +128,10 @@ jobs:
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
+          # EW-616 — kubeconfigs for platform-managed clusterSource values.
+          EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version


### PR DESCRIPTION
## Summary

Follow-up to PR #753 (EW-616). That PR added `DeployService` code
that reads `EVER_WORKS_K8S_WORKS_KUBECONFIG` /
`EVER_WORKS_K8S_GAUZY_KUBECONFIG` from the API container's env at
deploy time. This PR actually provisions those env vars so the
\`clusterSource ∈ {k8s-works, k8s-gauzy}\` paths stop failing with
500.

## Wiring

GH Actions secrets → envsubst → k8s Secret → container env:

1. **Repo-level secrets** (pushed before this PR opened):
   - `EVER_WORKS_K8S_WORKS_KUBECONFIG_B64` — base64-encoded
     contents of the k8s-works kubeconfig
   - `EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64` — same for k8s-gauzy

2. **Workflows** (`deploy-do-{dev,stage,prod}.yml`) — pass both
   secrets into the envsubst env block.

3. **Manifests** (`k8s-manifest.{dev,stage,prod}.yaml`):
   - New top-level `Secret` resource
     (`ever-works-platform-kubeconfigs[-{dev,stage}]`) with the
     two base64 values in `data:`.
   - The API container references each via
     `valueFrom.secretKeyRef`. K8s auto-decodes the base64 when
     mounting, so the app sees raw kubeconfig YAML in the env var.

Base64-via-`Secret.data` (rather than raw multiline via
`stringData` + envsubst) avoids the YAML-inside-YAML escaping
trap.

## Test plan

- [ ] dev CI cascade lands; verify dev API pod has both env vars
  populated (length-only probe — they're secrets)
- [ ] stage cascade same
- [ ] prod cascade same
- [ ] Smoke test on prod: create a Work in \`ever-works-cloud\`,
  set k8s plugin's \`clusterSource: 'k8s-works'\`, trigger deploy
  — expect success instead of EW-616's intentional 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)