### PR TITLE
feat(k8s-plugin): EW-616 UI — hide kubeconfig for platform-managed clusters

### DIFF
--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -129,7 +129,18 @@ describe('KubernetesPlugin metadata', () => {
 		const cs = plugin.settingsSchema.properties?.clusterSource as Record<string, unknown>;
 		expect(cs?.enum).toEqual(['k8s-works', 'k8s-gauzy', 'custom-kubeconfig']);
 		expect(cs?.default).toBe('custom-kubeconfig');
-		expect(cs?.['x-widget']).toBe('k8s-cluster-source');
+	});
+
+	it('hides kubeconfig + kubeContext when clusterSource is platform-managed (EW-616 UI)', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.kubeconfig?.['x-showIf']).toEqual({
+			field: 'clusterSource',
+			value: 'custom-kubeconfig'
+		});
+		expect(props.kubeContext?.['x-showIf']).toEqual({
+			field: 'clusterSource',
+			value: 'custom-kubeconfig'
+		});
 	});
 
 	it('registry sub-form is a oneOf with three branches (github default)', () => {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -152,8 +152,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				default: 'custom-kubeconfig',
 				title: 'Target cluster',
 				description:
-					"Where to deploy. 'k8s-works' = Ever Works shared customer cluster. 'k8s-gauzy' = Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org). 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org owning the website repo — see EW-616.",
-				'x-widget': 'k8s-cluster-source'
+					"Where to deploy. 'k8s-works' = Ever Works shared customer cluster. 'k8s-gauzy' = Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org). 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org owning the website repo — see EW-616. The form renderer's generic enum widget shows this as a Select."
 			},
 			kubeconfig: {
 				type: 'string',
@@ -162,12 +161,18 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 					"Paste the contents of your ~/.kube/config or a service-account-scoped equivalent. Only used when 'Target cluster' is 'custom-kubeconfig' — ignored otherwise.",
 				'x-secret': true,
 				'x-scope': 'user',
-				'x-widget': 'textarea'
+				'x-widget': 'textarea',
+				// EW-616: hide the kubeconfig field when the user picked a
+				// platform-managed cluster; the deploy service substitutes
+				// the platform's kubeconfig from env at deploy time.
+				'x-showIf': { field: 'clusterSource', value: 'custom-kubeconfig' }
 			},
 			kubeContext: {
 				type: 'string',
 				title: 'Context (optional)',
-				description: "Defaults to the kubeconfig's current-context."
+				description: "Defaults to the kubeconfig's current-context.",
+				// EW-616: only meaningful with a user-pasted kubeconfig.
+				'x-showIf': { field: 'clusterSource', value: 'custom-kubeconfig' }
 			},
 			namespace: {
 				type: 'string',


### PR DESCRIPTION
## Summary

Tiny schema-only follow-up to EW-616 (PR #753). The web app's
plugin-settings form already supports the \`x-showIf\` extension
for conditional field visibility, so this is a 4-line change:

- \`kubeconfig\` field: only render when
  \`clusterSource === 'custom-kubeconfig'\`
- \`kubeContext\` field: same
- Dropped the dead \`x-widget: 'k8s-cluster-source'\` hint
  (no custom widget registered for it; the enum dropdown is fine)

The form renderer reads these fields and renders the
\`clusterSource\` Select as before. When the user picks
\`k8s-works\` or \`k8s-gauzy\`, the textarea + context fields vanish.

Behaviour-wise: the deploy-time matrix in
\`DeployService.resolveDeployToken()\` (already merged) remains the
source of truth — the UI just stops asking for input it can't
use. No new validation in the UI.

## Test plan

- [x] k8s plugin test suite (Vitest) — 36/36 passing; updated
  schema test pins the new \`x-showIf\` shape on both fields.
- [ ] Manual: open k8s plugin settings, toggle the dropdown,
  verify the textarea + context fields show/hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)