### PR TITLE
chore(release): cascade stage → main (EW-615/616 follow-ups)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -1,4 +1,18 @@
 ---
+# EW-616: Platform-managed kubeconfigs for k8s deploys to shared clusters.
+# Stored as base64 in GH Actions secrets; Kubernetes decodes Secret.data
+# values automatically when mounting via `secretKeyRef`, so the container
+# receives the raw kubeconfig YAML in the env var.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ever-works-platform-kubeconfigs-dev
+type: Opaque
+data:
+  EVER_WORKS_K8S_WORKS_KUBECONFIG: "$EVER_WORKS_K8S_WORKS_KUBECONFIG_B64"
+  EVER_WORKS_K8S_GAUZY_KUBECONFIG: "$EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64"
+
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -177,6 +191,18 @@ spec:
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
             - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
+            # EW-616 — platform-managed kubeconfigs.
+            - name: EVER_WORKS_K8S_WORKS_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-dev
+                  key: EVER_WORKS_K8S_WORKS_KUBECONFIG
+            - name: EVER_WORKS_K8S_GAUZY_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-dev
+                  key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -1,4 +1,18 @@
 ---
+# EW-616: Platform-managed kubeconfigs for k8s deploys to shared clusters.
+# Stored as base64 in GH Actions secrets; Kubernetes decodes Secret.data
+# values automatically when mounting via `secretKeyRef`, so the container
+# receives the raw kubeconfig YAML in the env var.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ever-works-platform-kubeconfigs
+type: Opaque
+data:
+  EVER_WORKS_K8S_WORKS_KUBECONFIG: "$EVER_WORKS_K8S_WORKS_KUBECONFIG_B64"
+  EVER_WORKS_K8S_GAUZY_KUBECONFIG: "$EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64"
+
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -182,6 +196,23 @@ spec:
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
             - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
+            # EW-616 — platform-managed kubeconfigs for the k8s deploy
+            # plugin's `clusterSource ∈ {k8s-works, k8s-gauzy}` paths.
+            # Mounted from the `ever-works-platform-kubeconfigs` Secret
+            # (defined at the top of this manifest). Kubernetes
+            # auto-base64-decodes Secret.data when mounting via
+            # secretKeyRef, so the container sees raw kubeconfig YAML.
+            - name: EVER_WORKS_K8S_WORKS_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs
+                  key: EVER_WORKS_K8S_WORKS_KUBECONFIG
+            - name: EVER_WORKS_K8S_GAUZY_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs
+                  key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
           resources:
             requests:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -1,4 +1,18 @@
 ---
+# EW-616: Platform-managed kubeconfigs for k8s deploys to shared clusters.
+# Stored as base64 in GH Actions secrets; Kubernetes decodes Secret.data
+# values automatically when mounting via `secretKeyRef`, so the container
+# receives the raw kubeconfig YAML in the env var.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ever-works-platform-kubeconfigs-stage
+type: Opaque
+data:
+  EVER_WORKS_K8S_WORKS_KUBECONFIG: "$EVER_WORKS_K8S_WORKS_KUBECONFIG_B64"
+  EVER_WORKS_K8S_GAUZY_KUBECONFIG: "$EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64"
+
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -177,6 +191,18 @@ spec:
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_PAT"
             - name: EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY
               value: "$EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY"
+
+            # EW-616 — platform-managed kubeconfigs.
+            - name: EVER_WORKS_K8S_WORKS_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-stage
+                  key: EVER_WORKS_K8S_WORKS_KUBECONFIG
+            - name: EVER_WORKS_K8S_GAUZY_KUBECONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: ever-works-platform-kubeconfigs-stage
+                  key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
           resources:
             requests:

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -128,6 +128,10 @@ jobs:
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
+          # EW-616 — kubeconfigs for platform-managed clusterSource values.
+          EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -128,6 +128,13 @@ jobs:
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
+          # EW-616 — kubeconfigs for platform-managed `clusterSource`
+          # values on the k8s deploy plugin. Both are base64-encoded
+          # so envsubst can splice them into Secret.data fields without
+          # newline trouble; Kubernetes auto-decodes when mounting.
+          EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -128,6 +128,10 @@ jobs:
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
+          # EW-616 — kubeconfigs for platform-managed clusterSource values.
+          EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
+          EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -433,15 +433,48 @@ export class DeployService {
     }
 
     /**
-     * For k8s deploys, push the GitHub `read:packages` PAT (if the user
-     * has saved one on their GitHub plugin settings) as a separate GitHub
-     * Actions secret. The `deploy_k8s.yaml` workflow prefers this over
-     * the workflow's built-in `GITHUB_TOKEN` for the imagePullSecret
-     * because `GITHUB_TOKEN` does not have `packages:read` for GHCR
-     * images owned by a different repo than the workflow itself.
+     * For k8s deploys, push GHCR image-pull credentials to the website
+     * repo as GitHub Actions secrets, so the `deploy_k8s.yaml` workflow
+     * can mint a Kubernetes `<work-slug>-pull` imagePullSecret that
+     * kubelet uses to fetch the private container image.
      *
-     * For non-k8s providers, or when the user hasn't saved a PAT, this
-     * is a no-op. The Vercel path doesn't read this secret.
+     * Three secrets are written (when a credential is available):
+     *
+     *   - `REGISTRY_PASSWORD` — classic GitHub PAT (`ghp_…`). The
+     *     workflow's docker-registry secret step uses this first.
+     *     Classic PATs honor org membership directly and bypass the
+     *     fragile package↔repo auto-link required by fine-grained
+     *     PATs. See `Workspace/knowledge/runbooks/EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md`
+     *     gotcha #1 for the full why.
+     *   - `REGISTRY_USERNAME` — the PAT owner's GitHub login. Without
+     *     this, the workflow defaults to `github.actor` which may be
+     *     the platform's deploy bot rather than the PAT owner.
+     *   - `GITHUB_READ_PACKAGES_TOKEN` — fine-grained PAT, legacy slot
+     *     kept for back-compat. Workflow uses it as a fallback when
+     *     `REGISTRY_PASSWORD` is unset.
+     *
+     * Source priority per PAT:
+     *
+     *   1. The user's GitHub plugin settings (`readPackagesPatClassic`
+     *      for the classic PAT, `readPackagesPat` for the fine-grained
+     *      one). Required for Works that push to a customer-owned
+     *      GitHub org — cells B/D of the EW-615 deploy matrix.
+     *   2. Platform-side env vars when the website repo owner matches
+     *      an Ever Works org — `EVER_WORKS_GITHUB_PAT_CLASSIC` /
+     *      `EVER_WORKS_GITHUB_PAT` for `ever-works` org,
+     *      `EVER_WORKS_CUSTOMERS_GITHUB_PAT_CLASSIC` /
+     *      `EVER_WORKS_CUSTOMERS_GITHUB_PAT` for `ever-works-cloud`.
+     *      Covers cells A/C — the customer doesn't supply any PAT.
+     *   3. If neither source has a value, that secret is skipped. The
+     *      workflow has its own fallback chain
+     *      (REGISTRY_PASSWORD → GITHUB_READ_PACKAGES_TOKEN → DEPLOY_TOKEN
+     *      → GITHUB_TOKEN), so a fully-skipped path still attempts pull
+     *      with the workflow's auto-issued GITHUB_TOKEN — which works
+     *      only when the package lives in the same repo as the workflow.
+     *
+     * For non-k8s providers this is a no-op. Errors are logged but
+     * never thrown — a failed secret push degrades to "image pull may
+     * 403" rather than blocking the whole deploy.
      */
     private async setKubernetesGhcrPullSecret(ctx: RepoContext, work: Work, userId: string) {
         if (work.deployProvider !== 'k8s') {
@@ -452,28 +485,103 @@ export class DeployService {
                 userId,
                 workId: work.id,
             });
-            const pat =
+            const userClassic =
+                typeof githubSettings?.readPackagesPatClassic === 'string'
+                    ? githubSettings.readPackagesPatClassic.trim()
+                    : '';
+            const userFineGrained =
                 typeof githubSettings?.readPackagesPat === 'string'
                     ? githubSettings.readPackagesPat.trim()
                     : '';
-            if (!pat) {
+
+            // Platform-side fallback by website repo owner.
+            const platformDefaults = this.getPlatformGhcrCredentials(ctx.owner);
+
+            const classicPat = userClassic || platformDefaults.classic;
+            const fineGrainedPat = userFineGrained || platformDefaults.fineGrained;
+            const registryUsername =
+                userClassic || userFineGrained
+                    ? platformDefaults.username // fall back to platform login if user didn't tell us their own
+                    : platformDefaults.username;
+
+            const writes: Promise<unknown>[] = [];
+            const written: string[] = [];
+
+            if (classicPat) {
+                writes.push(this.setSecret(ctx, 'REGISTRY_PASSWORD', classicPat));
+                written.push('REGISTRY_PASSWORD');
+                if (registryUsername) {
+                    writes.push(this.setSecret(ctx, 'REGISTRY_USERNAME', registryUsername));
+                    written.push('REGISTRY_USERNAME');
+                }
+            }
+
+            if (fineGrainedPat) {
+                writes.push(this.setSecret(ctx, 'GITHUB_READ_PACKAGES_TOKEN', fineGrainedPat));
+                written.push('GITHUB_READ_PACKAGES_TOKEN');
+            }
+
+            if (writes.length === 0) {
                 // Workflow falls back to GITHUB_TOKEN; that works when the
                 // image and the workflow are in the same repo (the default
                 // case for the generated website's own GHCR image).
                 return;
             }
-            await this.setSecret(ctx, 'GITHUB_READ_PACKAGES_TOKEN', pat);
+
+            await Promise.all(writes);
             this.logger.log(
-                `Pushed GITHUB_READ_PACKAGES_TOKEN to ${ctx.owner}/${ctx.repo} for k8s GHCR pull`,
+                `Pushed GHCR pull credentials to ${ctx.owner}/${ctx.repo} for k8s deploy: ${written.join(', ')}`,
             );
         } catch (error) {
             // Don't block the deploy on this — the workflow has a safe
             // fallback. Just log so operators can debug if pulls fail.
             this.logger.warn(
-                `Failed to push GITHUB_READ_PACKAGES_TOKEN for ${ctx.owner}/${ctx.repo}: ${
+                `Failed to push GHCR pull credentials for ${ctx.owner}/${ctx.repo}: ${
                     error instanceof Error ? error.message : String(error)
                 }`,
             );
+        }
+    }
+
+    /**
+     * Look up platform-side GHCR credentials for a website-repo owner.
+     * These are used as a fallback when the customer hasn't entered
+     * their own PATs in the GitHub plugin settings — the typical case
+     * for Works that publish to an Ever Works-shared GitHub org
+     * (cells A and C of the EW-615 deploy matrix).
+     *
+     * The platform reads these from env vars at boot (sourced from
+     * the DO k8s Secret `ever-works-secrets` in prod, or
+     * `Workspace/.config/ever-works.env` in local dev). Missing env
+     * vars are treated as "no platform default available", and the
+     * caller degrades accordingly.
+     *
+     * Adding a new Ever Works-shared org: extend the switch below
+     * with a new case and provision the matching env vars. Document
+     * in `Workspace/.config/ever-works.env`.
+     */
+    private getPlatformGhcrCredentials(websiteRepoOwner: string): {
+        classic: string;
+        fineGrained: string;
+        username: string;
+    } {
+        const empty = { classic: '', fineGrained: '', username: '' };
+        const username = (process.env.EVER_WORKS_GITHUB_PAT_OWNER || '').trim();
+        switch (websiteRepoOwner.toLowerCase()) {
+            case 'ever-works':
+                return {
+                    classic: (process.env.EVER_WORKS_GITHUB_PAT_CLASSIC || '').trim(),
+                    fineGrained: (process.env.EVER_WORKS_GITHUB_PAT || '').trim(),
+                    username,
+                };
+            case 'ever-works-cloud':
+                return {
+                    classic: (process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT_CLASSIC || '').trim(),
+                    fineGrained: (process.env.EVER_WORKS_CUSTOMERS_GITHUB_PAT || '').trim(),
+                    username,
+                };
+            default:
+                return empty;
         }
     }
 

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -79,12 +79,21 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 			},
 			readPackagesPat: {
 				type: 'string',
-				title: 'Read packages PAT',
+				title: 'Read packages PAT (fine-grained)',
 				description:
-					'Used by the Kubernetes deploy provider to pull private GHCR images. Click "Connect" to authorize via GitHub (recommended — least-privilege token with `read:packages` + `write:packages` only) or paste a fine-grained PAT manually. Leave blank if your generated website repo is public.',
+					'Fine-grained PAT used by the Kubernetes deploy provider to pull private GHCR images. Click "Connect" to authorize via GitHub (recommended — least-privilege token with `read:packages` + `write:packages` only) or paste a fine-grained PAT manually. Leave blank if your generated website repo is public OR if you supply a classic PAT below. Note: GHCR has known compatibility issues with fine-grained PATs when packages are not explicitly repo-linked — the classic PAT below is more reliable.',
 				'x-secret': true,
 				'x-scope': 'user',
 				'x-widget': 'github-packages-oauth'
+			},
+			readPackagesPatClassic: {
+				type: 'string',
+				title: 'Read packages PAT (classic)',
+				description:
+					'Classic GitHub PAT (`ghp_…`) used as the GHCR image-pull credential when deploying private container images to Kubernetes. Required when your generated website repo + GHCR image is private. Classic PATs honor org membership directly and avoid the repo-package link requirement that breaks fine-grained PATs for org-level packages. Required scopes: `repo`, `read:packages`, `write:packages`, `delete:packages`. Leave blank if your image is public or if you publish to one of the Ever Works-shared GitHub orgs (`ever-works`, `ever-works-cloud`) — the platform provides classic PATs for those.',
+				'x-secret': true,
+				'x-scope': 'user',
+				'x-widget': 'password'
 			}
 		}
 	};

--- a/packages/plugins/github/src/types.ts
+++ b/packages/plugins/github/src/types.ts
@@ -5,8 +5,21 @@ export interface GitHubSettings {
 	/** Fine-grained GitHub PAT with `read:packages` scope.
 	 * Used by the Kubernetes deploy provider to mint an imagePullSecret
 	 * for private GHCR images. Optional — only required when the
-	 * generated website repo (and therefore its GHCR image) is private. */
+	 * generated website repo (and therefore its GHCR image) is private.
+	 * Note: GHCR has known compatibility issues with fine-grained PATs
+	 * when packages are not explicitly repo-linked (`org.opencontainers.image.source`
+	 * auto-link does not fire reliably). Prefer `readPackagesPatClassic`. */
 	readonly readPackagesPat?: string;
+	/** Classic GitHub PAT (`ghp_…`) with `repo` + `read:packages` +
+	 * `write:packages` + `delete:packages` scopes. Used as the GHCR
+	 * image-pull credential when deploying private images to Kubernetes.
+	 * Classic PATs honor org membership directly and avoid the repo-package
+	 * link requirement that breaks fine-grained PATs for org-level packages.
+	 * The platform provides classic PATs for Works that publish to
+	 * `ever-works` / `ever-works-cloud` orgs — this field is only needed
+	 * for customer-owned GitHub orgs (cells B and D of the deploy matrix,
+	 * see EW-615). */
+	readonly readPackagesPatClassic?: string;
 }
 
 export interface GitHubWorkflow {

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -129,7 +129,18 @@ describe('KubernetesPlugin metadata', () => {
 		const cs = plugin.settingsSchema.properties?.clusterSource as Record<string, unknown>;
 		expect(cs?.enum).toEqual(['k8s-works', 'k8s-gauzy', 'custom-kubeconfig']);
 		expect(cs?.default).toBe('custom-kubeconfig');
-		expect(cs?.['x-widget']).toBe('k8s-cluster-source');
+	});
+
+	it('hides kubeconfig + kubeContext when clusterSource is platform-managed (EW-616 UI)', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.kubeconfig?.['x-showIf']).toEqual({
+			field: 'clusterSource',
+			value: 'custom-kubeconfig'
+		});
+		expect(props.kubeContext?.['x-showIf']).toEqual({
+			field: 'clusterSource',
+			value: 'custom-kubeconfig'
+		});
 	});
 
 	it('registry sub-form is a oneOf with three branches (github default)', () => {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -152,8 +152,7 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 				default: 'custom-kubeconfig',
 				title: 'Target cluster',
 				description:
-					"Where to deploy. 'k8s-works' = Ever Works shared customer cluster. 'k8s-gauzy' = Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org). 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org owning the website repo — see EW-616.",
-				'x-widget': 'k8s-cluster-source'
+					"Where to deploy. 'k8s-works' = Ever Works shared customer cluster. 'k8s-gauzy' = Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org). 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org owning the website repo — see EW-616. The form renderer's generic enum widget shows this as a Select."
 			},
 			kubeconfig: {
 				type: 'string',
@@ -162,12 +161,18 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 					"Paste the contents of your ~/.kube/config or a service-account-scoped equivalent. Only used when 'Target cluster' is 'custom-kubeconfig' — ignored otherwise.",
 				'x-secret': true,
 				'x-scope': 'user',
-				'x-widget': 'textarea'
+				'x-widget': 'textarea',
+				// EW-616: hide the kubeconfig field when the user picked a
+				// platform-managed cluster; the deploy service substitutes
+				// the platform's kubeconfig from env at deploy time.
+				'x-showIf': { field: 'clusterSource', value: 'custom-kubeconfig' }
 			},
 			kubeContext: {
 				type: 'string',
 				title: 'Context (optional)',
-				description: "Defaults to the kubeconfig's current-context."
+				description: "Defaults to the kubeconfig's current-context.",
+				// EW-616: only meaningful with a user-pasted kubeconfig.
+				'x-showIf': { field: 'clusterSource', value: 'custom-kubeconfig' }
 			},
 			namespace: {
 				type: 'string',


### PR DESCRIPTION
## Summary

Cascades stage to main for production release. Bundles:

- EW-615 — k8s plugin pushes REGISTRY_PASSWORD/USERNAME from
  classic PAT — PR #751
- EW-616 platform env wiring — kubeconfigs as base64 GH secrets
  → k8s Secret → secretKeyRef on API container — PR #765
- EW-616 UI follow-up — hide kubeconfig/kubeContext fields when
  clusterSource is platform-managed (via x-showIf) — PR #766

## Test plan

- [x] develop CI green
- [x] stage cascade green (PR #767)
- [ ] this cascade CI green
- [ ] post-merge: prod deploy succeeds; API pods on k8s-gauzy
  have EVER_WORKS_K8S_WORKS_KUBECONFIG +
  EVER_WORKS_K8S_GAUZY_KUBECONFIG env vars (key-name probe only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)