### PR TITLE
docs(specs): EW-616 k8s-cluster-source-matrix spec/plan/tasks

### DIFF
--- a/docs/specs/features/k8s-cluster-source-matrix/plan.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Kubernetes Cluster-Source Matrix (EW-616)
+
+> Translates the approved [`./spec.md`](./spec.md) into architecture and tech-choices.
+> The plan owns implementation details; the spec owns behaviour.
+
+**Feature ID**: `k8s-cluster-source-matrix`
+**Spec**: `./spec.md`
+**Status**: `Done`
+**Last updated**: 2026-05-14
+
+---
+
+## 1. Architecture Summary
+
+```mermaid
+flowchart TD
+    UI["Plugin settings form\n(apps/web — generic enum + x-showIf)"]
+    Schema["k8s plugin settingsSchema\n(packages/plugins/k8s/src/k8s.plugin.ts)"]
+    Facade["DeployFacadeService.getTokenFromSettings()\n(packages/agent/src/facades/deploy.facade.ts)"]
+    Validator["validateClusterSourceForOwner() +\nresolveKubeconfigForClusterSource()\n(apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts)"]
+    Service["DeployService.resolveDeployToken()\n(apps/api/src/plugins-capabilities/deploy/deploy.service.ts)"]
+    Env["API container env\n(EVER_WORKS_K8S_WORKS_KUBECONFIG /\n EVER_WORKS_K8S_GAUZY_KUBECONFIG)"]
+    Secret["GH Actions secret K8S_TOKEN\non website repo"]
+    Workflow["deploy_k8s.yaml on website repo"]
+
+    UI -->|saves clusterSource| Schema
+    Schema -->|plugin_settings table| Facade
+    Facade -->|token or PLATFORM_MANAGED sentinel| Service
+    Service --> Validator
+    Validator -->|valid combo| Service
+    Service -->|reads| Env
+    Service -->|pushes| Secret
+    Secret --> Workflow
+```
+
+## 2. Module-by-module changes
+
+### 2.1 `packages/plugins/k8s/src/types.ts`
+
+Added the `ClusterSource` type union and `clusterSource?: ClusterSource` field on `KubernetesSettings`. JSDoc explains each value, the env-var routing for platform-managed values, and links the back-compat default behaviour.
+
+### 2.2 `packages/plugins/k8s/src/k8s.plugin.ts`
+
+- New `clusterSource` property in `settingsSchema.properties` (enum, default `'custom-kubeconfig'`).
+- Replaced `required: ['kubeconfig']` with `allOf: [{ if: <clusterSource missing or custom-kubeconfig>, then: { required: ['kubeconfig'] } }]`.
+- Added `'x-showIf': { field: 'clusterSource', value: 'custom-kubeconfig' }` to both `kubeconfig` and `kubeContext` (form renderer hides them when the user picks a platform-managed source).
+- `validateConnection` short-circuits to `{ success: true, message: "Will deploy to platform-managed cluster '<x>'", details: { clusterSource } }` when the source is platform-managed (no live cluster check).
+- `coerceSettings` accepts `clusterSource` only when it's a valid enum value; invalid/garbage values silently coerce to back-compat default.
+- `getDeploymentSecrets` emits `K8S_CLUSTER_SOURCE` so the workflow has the chosen source as an env var (currently unused by the workflow; reserved for future templates and observability).
+
+### 2.3 `apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts` (new)
+
+Pure helpers, no DI. Three exports:
+
+- `validateClusterSourceForOwner(websiteOwner, clusterSource, { hasKubeconfig })` returns `null` on success or `{ code, message }` on failure. Three failure codes: `K8S_GAUZY_NOT_ALLOWED`, `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG`, `CUSTOM_KUBECONFIG_MISSING_KUBECONFIG`.
+- `resolveKubeconfigForClusterSource(clusterSource, userToken, env = process.env)` returns the right kubeconfig — env var for platform-managed sources, `userToken` for `custom-kubeconfig`. Throws if a platform-managed env var is missing/whitespace.
+- `allowedClusterSourcesFor(websiteOwner)` returns the ordered allow-list per owner class (for future per-Work UI filtering).
+
+Owner classification uses two predicates: `isEverWorksSharedOrg` (`ever-works` ∪ `ever-works-cloud`) and `isAdminOnlyOrg` (`ever-works` only). Both are case-insensitive and whitespace-trimmed.
+
+### 2.4 `apps/api/src/plugins-capabilities/deploy/deploy.service.ts`
+
+Added `resolveDeployToken(deployProvider, websiteOwner, settings, userToken)` called early in `deploy()`. For non-k8s providers it's a pass-through. For k8s:
+
+1. Discard the `PLATFORM_MANAGED_KUBECONFIG_SENTINEL` if it's the token (the facade emits it for un-provisioned platform-managed Works).
+2. `coerceClusterSource` from raw settings (back-compat: missing → `custom-kubeconfig`).
+3. Call `validateClusterSourceForOwner`. On failure: `logger.warn` + `throw new BadRequestException`.
+4. Call `resolveKubeconfigForClusterSource`. On thrown env-var-missing error: `logger.error` + `throw new InternalServerErrorException`.
+5. Return the resolved kubeconfig. The caller then pushes it as `K8S_TOKEN` via the existing `setRequiredSecrets` path.
+
+### 2.5 `packages/agent/src/facades/deploy.facade.ts`
+
+`getTokenFromSettings` now special-cases `pluginId === 'k8s'`: when `settings.clusterSource?.value ∈ { k8s-works, k8s-gauzy }`, return the user-pasted kubeconfig if present, else `PLATFORM_MANAGED_KUBECONFIG_SENTINEL`. This lets `resolvePluginAndTokenWithWork` consider the Work "configured" without a saved kubeconfig, so the deploy proceeds to `DeployService` for env-var substitution.
+
+The sentinel is `'__ever-works-platform-managed-kubeconfig__'` — a non-empty string that's deliberately unmistakable. It's exported so callers (and `DeployService.resolveDeployToken`) can pattern-match on it without duplicating the constant. The facades barrel re-exports it.
+
+### 2.6 Platform manifests (`.deploy/k8s/k8s-manifest.{dev,stage,prod}.yaml`)
+
+Each environment's manifest gets:
+
+- A new top-level `Secret` resource (`ever-works-platform-kubeconfigs[-{dev,stage}]`) with `data:` containing the base64-encoded kubeconfigs. The values are spliced in by `envsubst` from workflow env vars `EVER_WORKS_K8S_WORKS_KUBECONFIG_B64` and `EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64`.
+- Two new entries in the `ever-works-api` container's `env:` array, both using `valueFrom.secretKeyRef` pointing at the new Secret. Kubernetes auto-base64-decodes `Secret.data` when mounting via `secretKeyRef`, so the container receives the raw kubeconfig YAML in the env var.
+
+### 2.7 Platform workflows (`.github/workflows/deploy-do-{dev,stage,prod}.yml`)
+
+Each workflow's `env:` block on the "Apply manifest" step now passes `EVER_WORKS_K8S_WORKS_KUBECONFIG_B64` and `EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64` from repo-level GitHub Actions secrets to `envsubst`.
+
+### 2.8 GitHub Actions secrets (repo-level)
+
+Two new secrets on `ever-works/ever-works`:
+
+- `EVER_WORKS_K8S_WORKS_KUBECONFIG_B64` — `base64 -w0 < k8s-works-kubeconfig.yaml`
+- `EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64` — `base64 -w0 < k8s-gauzy-kubeconfig.yaml`
+
+These were provisioned out-of-band during EW-616 rollout. They are admin-controlled and the manifests reference them directly.
+
+## 3. Why base64?
+
+Multi-line kubeconfig YAML embedded as a value inside another YAML document is escaping-fragile (newlines inside double-quoted YAML scalars work, but trailing whitespace and stray quotes can corrupt the parse). `Secret.data` expects base64 — single-line, no escaping. `envsubst` is happy with single-line values. Kubernetes decodes the base64 transparently when mounting via `valueFrom.secretKeyRef`. The result is the kubeconfig YAML available to the app as a string env var, with no round-trip through the YAML parser.
+
+Alternative considered: `stringData` with raw multi-line content via `envsubst`. Rejected because the kubeconfig content can contain characters that break the outer YAML's quoting (e.g. inline keys that look like another YAML key starting with `apiVersion:`).
+
+## 4. Why a sentinel?
+
+`DeployFacadeService.resolvePluginAndTokenWithWork` exists to ensure a Work has a usable credential before kicking off a deploy. For platform-managed cluster sources, the facade has no useful credential to return — the credential lives in the API container's env, not in plugin_settings.
+
+The choices were:
+
+1. **Bypass the facade.** Have `DeployService.deploy` call settings directly for k8s. Rejected — duplicates settings logic outside the facade and breaks the abstraction every other deploy plugin uses.
+2. **Move clusterSource → env-var-substitution into the facade.** Rejected — the facade lives in `packages/agent/` and can't depend on the API-side validator. Pulling the validator into agent would couple the agent package to API-only concerns.
+3. **Sentinel.** Adopted. The facade returns a string the API knows to discard; the API does the real substitution. Cost: one extra constant and a defensive check. Benefit: facade contract unchanged, sentinel can never leak into a pushed secret (proven by the `does not leak the sentinel` test).
+
+## 5. Why `BadRequest` vs `InternalServerError`?
+
+- Matrix violations (`K8S_GAUZY_NOT_ALLOWED`, `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG`) are user-input problems — the user picked a `(websiteOwner, clusterSource)` pair that's not allowed. `400 Bad Request` is correct.
+- Missing platform env vars (`EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured`) are operator-side problems — the user picked a valid option and the platform isn't ready. `500 Internal Server Error` so on-call can distinguish it from real user errors. (Raised by reviewer Greptile during PR review; fix landed in the same PR.)
+
+## 6. Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as DeployController
+    participant DS as DeployService
+    participant DF as DeployFacade
+    participant Env as process.env (API container)
+    participant GH as GitHub Actions
+    participant K8s as Target cluster
+
+    U->>API: POST /api/deploy/work/:id
+    API->>DS: deploy(workId, userId, options)
+    DS->>DF: getPluginAndTokenAndSettings(...)
+    Note over DF: For k8s + platform-managed: token = sentinel
+    DF-->>DS: { plugin, token, work, settings }
+    DS->>DS: resolveDeployToken(deployProvider, websiteOwner, settings, token)
+    Note over DS: validateClusterSourceForOwner — reject on policy violation (400)
+    DS->>Env: read EVER_WORKS_K8S_*_KUBECONFIG
+    Note over DS: throw 500 if missing
+    DS-->>DS: effectiveDeployToken (real kubeconfig)
+    DS->>GH: push K8S_TOKEN secret to website repo
+    DS->>GH: dispatch deploy_k8s.yaml
+    GH->>K8s: kubectl apply (using K8S_TOKEN)
+    K8s-->>U: pod up at https://<slug>.ever.works/
+```
+
+## 7. Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Platform kubeconfig leaks into a customer's website repo as the `K8S_TOKEN` secret | The matrix forbids `Ever Works-shared GHCR + custom cluster` combos, which is the only path where a customer cluster would see the secret. |
+| Sentinel value leaks into a pushed secret if the facade invariant breaks in the future | `DeployService.resolveDeployToken` defensively strips it before the resolver; spec'd as FR-7 and pinned by `does not leak the sentinel` test. |
+| Missing env var silently succeeds with empty kubeconfig | `resolveKubeconfigForClusterSource` throws on `undefined` and on whitespace-only values; covered by 4 unit tests. |
+| Existing customer-org Works break after EW-616 deploys | Back-compat default (`coerceClusterSource` returns `custom-kubeconfig` for missing values) keeps them on the existing path. Covered by `back-compat: no clusterSource + customer-owned org + user kubeconfig → uses user kubeconfig` test. |
+| Long-lived platform kubeconfigs become a blast-radius problem if leaked | Out-of-scope follow-up to rotate to short-lived service-account tokens. Documented in spec §5. |
+
+## 8. Rollout
+
+EW-616 shipped in this order on 2026-05-14:
+
+1. PR [#753](https://github.com/ever-works/ever-works/pull/753) — matrix code, validator, tests. Merged to `develop` after two rounds of bot-review fixes (Codex P1 on facade-blocking-the-substitution, Greptile P1 on the 4xx-vs-5xx distinction).
+2. Cascade PRs [#762](https://github.com/ever-works/ever-works/pull/762) (develop→stage) and [#763](https://github.com/ever-works/ever-works/pull/763) (stage→main).
+3. GitHub Actions secrets pushed manually (base64-encoded kubeconfigs).
+4. PR [#751](https://github.com/ever-works/ever-works/pull/751) — EW-615 classic-PAT push (parent ticket).
+5. PR [#765](https://github.com/ever-works/ever-works/pull/765) — manifests + workflows wire the new env vars.
+6. PR [#766](https://github.com/ever-works/ever-works/pull/766) — UI conditional visibility via `x-showIf`.
+7. Cascade PRs [#767](https://github.com/ever-works/ever-works/pull/767) + [#768](https://github.com/ever-works/ever-works/pull/768).
+8. Production deploy completed at 2026-05-14 18:06 UTC. Both API pods (`ever-works-api-c6f765d45-{4zgq8,jj5lg}`) on `k8s-gauzy` confirmed to have both env vars mounted via `secretKeyRef`.

--- a/docs/specs/features/k8s-cluster-source-matrix/spec.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Kubernetes Cluster-Source Matrix (EW-616)
+
+> Behaviour-first spec per [Constitution Principle IX](../../../specs/memory/constitution.md#ix-specs-are-behaviour-first).
+> Describe **what** the system does, not how it's structured. Implementation lives in [`./plan.md`](./plan.md).
+
+**Feature ID**: `k8s-cluster-source-matrix`
+**Jira**: [EW-616](https://evertech.atlassian.net/browse/EW-616) (parent policy [EW-615](https://evertech.atlassian.net/browse/EW-615))
+**Status**: `Implemented`
+**Created**: 2026-05-14
+**Last updated**: 2026-05-14
+**Owner**: Ever Works Team
+
+**Shipped via**:
+
+- Platform code: [#753](https://github.com/ever-works/ever-works/pull/753) (matrix + validator + tests), [#751](https://github.com/ever-works/ever-works/pull/751) (EW-615 classic-PAT push), [#766](https://github.com/ever-works/ever-works/pull/766) (UI conditional visibility)
+- Platform infra: [#765](https://github.com/ever-works/ever-works/pull/765) (kubeconfigs as base64 GH secrets → k8s Secret → secretKeyRef on API container)
+- Cascades: [#762](https://github.com/ever-works/ever-works/pull/762) + [#763](https://github.com/ever-works/ever-works/pull/763) (round 1), [#767](https://github.com/ever-works/ever-works/pull/767) + [#768](https://github.com/ever-works/ever-works/pull/768) (round 2)
+
+**Builds on**: [k8s-deployment](../k8s-deployment/spec.md) — the original k8s plugin.
+
+---
+
+## 1. Overview
+
+Before EW-616, the k8s deploy plugin had a single way to configure a cluster: paste a `kubeconfig` YAML. That conflated three different operational paths into one form field:
+
+1. **Customer pastes their own kubeconfig** to deploy to their own cluster (BYOC).
+2. **Platform admin** wants to deploy to `k8s-gauzy`, the internal cluster, for the platform-owned Works.
+3. **Customer Cloud** users (Works whose website repo lives in the platform-owned `ever-works-cloud` GitHub org) should deploy to `k8s-works`, the shared customer cluster, without having to manage cluster credentials at all.
+
+The conflation created a real security problem: if a Work's website repo is in an Ever Works–shared GitHub org (`ever-works` or `ever-works-cloud`) and the user picks their own cluster, the platform's deploy workflow has to push an org-scoped classic PAT onto that customer cluster as an `imagePullSecret`. The customer can then run `kubectl get secret -o yaml` and recover a credential that lets them read every GHCR image in the shared org. This is cross-tenant credential exposure (recorded as the "cell C" policy on EW-615 / 2026-05-14).
+
+EW-616 splits the configuration into an explicit `clusterSource ∈ {k8s-works, k8s-gauzy, custom-kubeconfig}` dropdown, enforces a deploy-time matrix that rejects insecure combinations with a clear error, and substitutes the platform's kubeconfig from env vars for platform-managed cluster sources so the user never has to handle those credentials. Existing Works (with no `clusterSource` set) fall through to `custom-kubeconfig` so customer-org deploys keep working unchanged.
+
+---
+
+## 2. User Scenarios
+
+### 2.1 Primary scenarios
+
+- **Given** I open the Kubernetes plugin settings, **when** the form loads, **then** I see a new **Target cluster** dropdown with three options: `k8s-works` (Ever Works shared customer cluster), `k8s-gauzy` (Ever Works internal cluster — admin-only), and `custom-kubeconfig` (paste my own). The default is `custom-kubeconfig` for back-compat.
+- **Given** I pick `custom-kubeconfig`, **when** the form re-renders, **then** the **kubeconfig** textarea and the optional **Context** field are visible and **kubeconfig** is required to save.
+- **Given** I pick `k8s-works` or `k8s-gauzy`, **when** the form re-renders, **then** the **kubeconfig** textarea and **Context** field are hidden, the form can be saved without a kubeconfig, and **Save & verify** succeeds with the message *"Will deploy to platform-managed cluster '<name>'."* (no live cluster check — the platform owns the credentials).
+- **Given** my Work's website repo is in `ever-works-cloud` and I picked `clusterSource: 'k8s-works'`, **when** I deploy, **then** the deploy service substitutes `process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG` as the workflow's `K8S_TOKEN` secret, the dispatched `deploy_k8s.yaml` workflow uses it to talk to the shared customer cluster, and the deploy succeeds without me touching cluster credentials.
+- **Given** my Work's website repo is in `ever-works` (admin path) and I picked `clusterSource: 'k8s-gauzy'`, **when** I deploy, **then** the deploy service substitutes `process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG` and the deploy targets the internal platform cluster.
+- **Given** my Work's website repo is customer-owned (any org other than `ever-works` / `ever-works-cloud`) and I picked `clusterSource: 'custom-kubeconfig'`, **when** I deploy, **then** the platform reads my pasted kubeconfig (the existing path, unchanged) and `K8S_TOKEN` is exactly that value.
+
+### 2.2 Matrix enforcement (rejection paths)
+
+The deploy service rejects four of the nine `(websiteOwner, clusterSource)` combinations:
+
+| Website owner | `k8s-works` | `k8s-gauzy` | `custom-kubeconfig` |
+| --- | --- | --- | --- |
+| `ever-works` | ✅ | ✅ admin path | ❌ `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` |
+| `ever-works-cloud` | ✅ default | ❌ `K8S_GAUZY_NOT_ALLOWED` | ❌ `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` |
+| customer-owned org | ✅ | ❌ `K8S_GAUZY_NOT_ALLOWED` | ✅ BYOC default |
+
+- **Given** a customer Work in `ever-works-cloud` picks `custom-kubeconfig`, **when** the deploy starts, **then** the platform returns `400 Bad Request` with `code: CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` and a message that explains the cross-tenant exposure risk and the two valid alternatives (pick `k8s-works`, or move the Work to the customer's own org).
+- **Given** a customer Work in any non-`ever-works` org picks `k8s-gauzy`, **when** the deploy starts, **then** the platform returns `400 Bad Request` with `code: K8S_GAUZY_NOT_ALLOWED` explaining that `k8s-gauzy` is admin-only and pointing to the two valid alternatives.
+- **Given** any Work picks `custom-kubeconfig` but no kubeconfig is saved, **when** the deploy starts, **then** the platform returns `400 Bad Request` with `code: CUSTOM_KUBECONFIG_MISSING_KUBECONFIG`. (In practice the deploy facade rejects earlier with `NoDeployCredentialsError`; this is a defence-in-depth case.)
+- **Given** any Work picks `k8s-works` or `k8s-gauzy` but the corresponding `EVER_WORKS_K8S_*_KUBECONFIG` env var is missing on the platform's API container, **when** the deploy starts, **then** the platform returns `500 Internal Server Error` (not 4xx — the user picked a valid option; the platform is misconfigured) with the env-var name in the message so operators can fix the gap.
+
+### 2.3 Back-compat
+
+- **Given** a pre-EW-616 Work whose `clusterSource` was never set in plugin settings, **when** the deploy starts, **then** the platform coerces `clusterSource = 'custom-kubeconfig'` and the deploy proceeds exactly as it did before EW-616.
+- **Given** a customer-org Work that had a kubeconfig saved before EW-616, **when** the new form renders, **then** the dropdown shows `custom-kubeconfig` (the back-compat default) and the saved kubeconfig is still in the textarea.
+
+---
+
+## 3. Functional Requirements
+
+### 3.1 Schema additions
+
+- **FR-1.** The k8s plugin's `settingsSchema` MUST expose `clusterSource` as `type: 'string', enum: ['k8s-works', 'k8s-gauzy', 'custom-kubeconfig'], default: 'custom-kubeconfig'`.
+- **FR-2.** The schema MUST make `kubeconfig` conditionally required: only when `clusterSource === 'custom-kubeconfig'` (encoded as an `allOf` + `if/then` clause). For platform-managed values the kubeconfig field is optional.
+- **FR-3.** The schema MUST hide the `kubeconfig` and `kubeContext` fields when `clusterSource !== 'custom-kubeconfig'` using the existing `x-showIf: { field, value }` extension. The form renderer already handles this.
+
+### 3.2 Deploy-time enforcement
+
+- **FR-4.** `DeployService.deploy()` MUST call `validateClusterSourceForOwner(websiteOwner, clusterSource)` early in the flow. On a failure result, it MUST throw `BadRequestException` with the failure's `code` and `message`.
+- **FR-5.** For platform-managed cluster sources, `DeployService` MUST substitute the kubeconfig from the corresponding env var (`EVER_WORKS_K8S_WORKS_KUBECONFIG` / `EVER_WORKS_K8S_GAUZY_KUBECONFIG`) and use that as the `K8S_TOKEN` secret pushed to the website repo. The user-pasted `kubeconfig` (or sentinel) MUST be discarded.
+- **FR-6.** When a platform-managed cluster source is picked but the corresponding env var is missing/whitespace, `DeployService` MUST throw `InternalServerErrorException` (not `BadRequestException`) so HTTP responses distinguish operator errors from user input errors.
+
+### 3.3 Deploy-facade sentinel
+
+- **FR-7.** `DeployFacadeService.getTokenFromSettings('k8s', ...)` MUST return a non-empty sentinel string (`PLATFORM_MANAGED_KUBECONFIG_SENTINEL`) when `clusterSource ∈ {k8s-works, k8s-gauzy}` and no kubeconfig is saved, so the facade considers the Work "configured" and the deploy proceeds to `DeployService` for substitution. The sentinel MUST NOT leak into any pushed GitHub Actions secret on the website repo (`DeployService.resolveDeployToken()` discards it).
+
+### 3.4 Plugin-provided secrets
+
+- **FR-8.** `KubernetesPlugin.getDeploymentSecrets(settings)` MUST emit a `K8S_CLUSTER_SOURCE` env var alongside the existing ones, defaulting to `'custom-kubeconfig'` when missing. Workflow templates and downstream observers MAY use this to branch behaviour or for breadcrumbs.
+
+### 3.5 Allowed-sources helper for the UI
+
+- **FR-9.** A pure helper `allowedClusterSourcesFor(websiteOwner)` MUST return the list of `clusterSource` values that are valid for that owner, in UI-recommended order. The helper MUST be exported so the (future) web-side dropdown can drive a context-aware list — though the v1 UI uses the static enum and relies on the deploy-time validator for enforcement.
+
+### 3.6 Platform infrastructure
+
+- **FR-10.** The two kubeconfig env vars MUST be provisioned on the API container in all three environments (`dev`, `stage`, `prod`). The supplied mechanism is: base64-encoded GitHub Actions secrets (`EVER_WORKS_K8S_WORKS_KUBECONFIG_B64`, `EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64`) → `envsubst` into a Kubernetes `Secret.data` block → `valueFrom.secretKeyRef` on the API container. Base64 sidesteps the YAML-inside-YAML escaping trap with multi-line kubeconfig content; Kubernetes auto-decodes `Secret.data` when mounting via `secretKeyRef` so the container receives the raw kubeconfig YAML.
+
+---
+
+## 4. Non-Functional Requirements
+
+- **NFR-1. Security.** The kubeconfig env vars are platform-cluster-admin credentials. They MUST never be returned by any API response, logged with their value, or echoed to terminals. Operator-side probes (key-name listing, byte-length checks) are allowed; value-revealing probes (`printenv`, `kubectl get secret -o yaml | grep KUBECONFIG`) are not.
+- **NFR-2. Fail-closed.** Missing env vars MUST fail the deploy with a 5xx, not silently use a wrong kubeconfig or skip the substitution.
+- **NFR-3. Error-message clarity.** All four rejection reasons (`CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG`, `K8S_GAUZY_NOT_ALLOWED`, `CUSTOM_KUBECONFIG_MISSING_KUBECONFIG`, missing env var) MUST tell the user (or operator) both *why* the deploy was rejected and what valid alternatives exist.
+- **NFR-4. Owner string handling.** Owner comparisons MUST be case-insensitive and whitespace-trimmed — so `ever-works-cloud`, `EVER-WORKS-CLOUD`, and `  ever-works-cloud  ` resolve identically.
+
+---
+
+## 5. Out of Scope
+
+- **Per-Work UI filtering.** The v1 dropdown shows all three options regardless of the current Work's website repo; the deploy-time matrix is the source of truth. A follow-up could call `allowedClusterSourcesFor(websiteOwner)` to filter the dropdown options when the form is rendered in a Work-scoped context.
+- **Short-lived service-account tokens.** The platform kubeconfigs are long-lived cluster-admin. A separate hardening ticket should replace them with rotated service-account tokens scoped to the `ever-works` namespace.
+- **Per-cluster RBAC scoping.** The platform's kubeconfig is currently full cluster-admin on each managed cluster. A future ticket could scope it to per-namespace RBAC.
+- **GitHub-App installation tokens.** An alternative to classic PATs for the GHCR pull-secret was considered (EW-615 discussion). Out of scope here; classic PATs are the chosen path and are documented in [`reference-ghcr-classic-pat`](https://github.com/ever-works/workspace/blob/develop/knowledge/runbooks/EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md).
+- **End-to-end test against a real platform cluster.** Existing k8s plugin e2e tests (`packages/plugins/k8s/src/__tests__/e2e/`) run against `kind` and cover deploy + ingress; they do not exercise the new platform-managed cluster sources because that path is API-side, not plugin-side. Unit tests on `cluster-source-matrix.ts` + `DeployService` + `DeployFacadeService` cover the new behaviour.
+
+---
+
+## 6. Test Coverage
+
+- **`apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts`** — 19 tests covering all 9 matrix cells (3 owner classes × 3 cluster sources), case insensitivity, env-var substitution, and missing-env failures.
+- **`apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts`** — 6 EW-616 integration tests covering back-compat fall-through, env substitution, validation failures, the sentinel-discarding guarantee, and Vercel pass-through.
+- **`packages/agent/src/facades/__tests__/deploy.facade.spec.ts`** — 5 sentinel tests covering both platform-managed cluster sources, the user-kubeconfig-wins rule, and the no-sentinel-for-custom / no-sentinel-for-non-k8s rules.
+- **`packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts`** — 3 schema tests covering the conditional `required`, the cluster-source dropdown enum + default, and the `x-showIf` shape on the conditional fields.
+
+All test suites green at merge time: agent (4381) + api deploy module (170) + k8s plugin (142). The `facades.module.spec.ts` regression guard was updated to include the new `PLATFORM_MANAGED_KUBECONFIG_SENTINEL` export.
+
+---
+
+## 7. Related
+
+- Parent spec: [`k8s-deployment/spec.md`](../k8s-deployment/spec.md) — the original k8s plugin
+- Workspace runbook: [`EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md`](https://github.com/ever-works/workspace/blob/develop/knowledge/runbooks/EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md)
+- Workspace memory: [`reference-ever-works-github-orgs`](https://github.com/ever-works/workspace/blob/develop/knowledge/memory/reference_ever_works_github_orgs.md), [`reference-ever-works-k8s-clusters`](https://github.com/ever-works/workspace/blob/develop/knowledge/memory/reference_ever_works_k8s_clusters.md), [`reference-ghcr-classic-pat`](https://github.com/ever-works/workspace/blob/develop/knowledge/memory/reference_ghcr_classic_pat.md)
+- Jira: [EW-616](https://evertech.atlassian.net/browse/EW-616), [EW-615](https://evertech.atlassian.net/browse/EW-615)

--- a/docs/specs/features/k8s-cluster-source-matrix/tasks.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/tasks.md
@@ -1,0 +1,59 @@
+# Implementation Tasks: Kubernetes Cluster-Source Matrix (EW-616)
+
+> Backlog of discrete, completable units of work that implement [`./plan.md`](./plan.md).
+
+**Status**: `Done`
+**Last updated**: 2026-05-14
+
+---
+
+## Closed
+
+### Code
+
+- ✅ **T-1.** Add `ClusterSource` type + `clusterSource?` field to `KubernetesSettings`. — PR #753.
+- ✅ **T-2.** Add `clusterSource` enum + `allOf`/`if`/`then` conditional `required` + `x-showIf` on `kubeconfig`/`kubeContext` to the plugin schema. — PRs #753 (schema), #766 (`x-showIf`).
+- ✅ **T-3.** `coerceSettings` accepts `clusterSource` only when it's a valid enum value. — PR #753.
+- ✅ **T-4.** `validateConnection` short-circuits for platform-managed sources. — PR #753.
+- ✅ **T-5.** `getDeploymentSecrets` emits `K8S_CLUSTER_SOURCE`. — PR #753.
+- ✅ **T-6.** New `cluster-source-matrix.ts` with `validateClusterSourceForOwner`, `resolveKubeconfigForClusterSource`, `allowedClusterSourcesFor`, `isEverWorksSharedOrg`, `isAdminOnlyOrg`. — PR #753.
+- ✅ **T-7.** `DeployService.resolveDeployToken` calls validator + resolver, throws `BadRequestException` on policy violation, `InternalServerErrorException` on missing platform env var. — PRs #753 + #753's review-fix commit.
+- ✅ **T-8.** `DeployFacadeService.getTokenFromSettings` emits `PLATFORM_MANAGED_KUBECONFIG_SENTINEL` for k8s + platform-managed sources. — PR #753 review-fix commit.
+- ✅ **T-9.** `DeployService.resolveDeployToken` defensively strips the sentinel before validator/resolver. — PR #753 review-fix commit.
+
+### Tests
+
+- ✅ **T-10.** `cluster-source-matrix.spec.ts` — 19 tests: all 9 matrix cells, case-insensitivity, env-var substitution, missing-env failures. — PR #753.
+- ✅ **T-11.** Update `deploy.service.spec.ts` — 6 new EW-616 integration tests covering back-compat fall-through, env substitution, validation failures, sentinel-isolation, Vercel pass-through. — PR #753 + review-fix commit.
+- ✅ **T-12.** Update `deploy.facade.spec.ts` — 5 sentinel tests. — PR #753 review-fix commit.
+- ✅ **T-13.** Update `k8s.plugin.spec.ts` — 3 schema tests: dropdown enum, conditional `required`, `x-showIf` shape. — PRs #753 + #766.
+- ✅ **T-14.** Update `facades.module.spec.ts` regression-guard symbol list to include `PLATFORM_MANAGED_KUBECONFIG_SENTINEL`. — PR #753 final commit.
+
+### Infrastructure
+
+- ✅ **T-15.** Push two base64-encoded kubeconfig secrets to `ever-works/ever-works` GitHub repo: `EVER_WORKS_K8S_WORKS_KUBECONFIG_B64`, `EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64`. — Manual ops, recorded in PR #765 description.
+- ✅ **T-16.** Wire the two secrets into `deploy-do-{dev,stage,prod}.yml` workflow `env:` blocks. — PR #765.
+- ✅ **T-17.** Add `Secret` resource (`ever-works-platform-kubeconfigs[-{dev,stage}]`) to each `.deploy/k8s/k8s-manifest.*.yaml` with `data:` keys + `valueFrom.secretKeyRef` on the API container. — PR #765.
+
+### Release
+
+- ✅ **T-18.** Merge PR #753 to develop; cascade develop→stage (#762) → main (#763) for round-1 (matrix-only).
+- ✅ **T-19.** Merge PR #751 (EW-615 secrets) to develop.
+- ✅ **T-20.** Merge PR #765 (platform manifests + workflows) to develop.
+- ✅ **T-21.** Merge PR #766 (UI `x-showIf`) to develop.
+- ✅ **T-22.** Cascade develop→stage (#767) → main (#768) for round-2 (#751 + #765 + #766 bundled).
+- ✅ **T-23.** Verify prod deploy: both API pods on `k8s-gauzy` have both env vars mounted via `secretKeyRef`; `ever-works-platform-kubeconfigs` Secret exists with 2021-byte decoded values for both keys.
+
+### Documentation
+
+- ✅ **T-24.** Spec, plan, and tasks docs under `docs/specs/features/k8s-cluster-source-matrix/`. — This PR.
+- ✅ **T-25.** Update Workspace runbook `EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md` with: closed gotchas (EW-615/616 follow-up tickets), new behaviour (clusterSource dropdown, matrix enforcement, env-var routing, sentinel), new failure modes. — Companion PR on `ever-works/workspace`.
+
+---
+
+## Out of scope / follow-up tickets
+
+- **T-26.** Replace long-lived platform kubeconfigs with rotated, short-lived service-account tokens. New ticket.
+- **T-27.** Per-Work UI filtering: call `allowedClusterSourcesFor(websiteOwner)` to filter the dropdown options when the form is rendered in a Work-scoped context. New ticket.
+- **T-28.** RBAC scoping: the platform kubeconfigs are currently full cluster-admin. Scope them to the `ever-works` namespace only. New ticket.
+- **T-29.** GHCR auto-link reliability: pin the `org.opencontainers.image.source` label workaround so future template changes don't break auto-link. Workaround documented in the runbook.


### PR DESCRIPTION
## Summary

EW-616 shipped to prod (PR #753 + cascade chain). It had unit tests
and a Workspace runbook entry but no entry under
\`docs/specs/features/\`. This adds the missing spec.

## Contents

- \`spec.md\` — behaviour-first description: clusterSource dropdown,
  5-cell supported matrix (3 owners × 3 sources), back-compat,
  four failure modes, FRs, NFRs, out-of-scope, test coverage.
- \`plan.md\` — architecture diagram, module-by-module changes
  (schema, validator, deploy service, facade sentinel, platform
  manifests, workflow secrets), design rationale (why base64, why
  sentinel, why 5xx vs 4xx), sequence diagram, risk register,
  rollout log.
- \`tasks.md\` — T-1..T-25 done with PR links; T-26..T-29 follow-up
  ticket placeholders.

No code change. Pure docs.

## Test plan

- [x] No code changes — no tests to run.
- [ ] Reviewer can sanity-check the FR numbering and the test-coverage
  summary against the merged code in \`apps/api/src/plugins-capabilities/deploy/\`
  and \`packages/agent/src/facades/deploy.facade.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive feature specification for Kubernetes Cluster-Source Matrix, including cluster target selection options, deployment validation rules, and expected behaviors across different scenarios.
* Added detailed implementation plan documenting architecture, design decisions, flow diagrams, risk mitigation strategy, and production rollout checklist.
* Added task checklist recording implementation status and related dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/770)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->