### PR TITLE
chore: cascade develop → stage (EW-617 zero-friction flow + EW-616 cluster source matrix)

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { AuthService } from './services/auth.service';
+import { AnonymousAuthService } from './services/anonymous-auth.service';
 import { ApiKeyService } from './services/api-key.service';
 import { AuthController } from './controllers/auth.controller';
 import { ApiKeysController } from './controllers/api-keys.controller';
@@ -24,6 +25,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
     imports: [DatabaseModule, HttpModule, ActivityLogModule],
     providers: [
         AuthService,
+        AnonymousAuthService,
         ApiKeyService,
         AuthProviderService,
         AuthSyncService,
@@ -45,6 +47,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
     controllers: [OAuthController, AuthController, ApiKeysController],
     exports: [
         AuthService,
+        AnonymousAuthService,
         ApiKeyService,
         AuthSessionGuard,
         AUTH_PROVIDER,

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { AuthService } from './services/auth.service';
 import { AnonymousAuthService } from './services/anonymous-auth.service';
 import { ClaimAccountService } from './services/claim-account.service';
 import { ApiKeyService } from './services/api-key.service';
+import { CaptchaVerifierService } from './services/captcha-verifier.service';
 import { AuthController } from './controllers/auth.controller';
 import { ApiKeysController } from './controllers/api-keys.controller';
 import { OAuthController } from './controllers/oauth.controller';
@@ -29,6 +30,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
         AnonymousAuthService,
         ClaimAccountService,
         ApiKeyService,
+        CaptchaVerifierService,
         AuthProviderService,
         AuthSyncService,
         SocialAuthService,
@@ -52,6 +54,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
         AnonymousAuthService,
         ClaimAccountService,
         ApiKeyService,
+        CaptchaVerifierService,
         AuthSessionGuard,
         AUTH_PROVIDER,
         AUTH_RUNTIME_INSTANCE,

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { AuthService } from './services/auth.service';
 import { AnonymousAuthService } from './services/anonymous-auth.service';
+import { ClaimAccountService } from './services/claim-account.service';
 import { ApiKeyService } from './services/api-key.service';
 import { AuthController } from './controllers/auth.controller';
 import { ApiKeysController } from './controllers/api-keys.controller';
@@ -26,6 +27,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
     providers: [
         AuthService,
         AnonymousAuthService,
+        ClaimAccountService,
         ApiKeyService,
         AuthProviderService,
         AuthSyncService,
@@ -48,6 +50,7 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
     exports: [
         AuthService,
         AnonymousAuthService,
+        ClaimAccountService,
         ApiKeyService,
         AuthSessionGuard,
         AUTH_PROVIDER,

--- a/apps/api/src/auth/controllers/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth.controller.spec.ts
@@ -9,6 +9,7 @@ jest.mock('@ever-works/agent/activity-log', () => ({
 
 import { AuthController } from './auth.controller';
 import type { AuthService } from '../services/auth.service';
+import type { AnonymousAuthService } from '../services/anonymous-auth.service';
 import type { SocialAuthService } from '../services/social-auth.service';
 import type { ActivityLogService } from '@ever-works/agent/activity-log';
 import type { AuthProvider } from '../providers/auth-provider.abstract';
@@ -31,6 +32,7 @@ describe('AuthController', () => {
         >
     >;
     let socialAuth: jest.Mocked<Pick<SocialAuthService, 'getConfiguredProviders'>>;
+    let anonymousAuth: jest.Mocked<Pick<AnonymousAuthService, 'createAnonymousUser'>>;
     let activityLog: jest.Mocked<Pick<ActivityLogService, 'log'>>;
     let authProvider: jest.Mocked<
         Pick<
@@ -59,6 +61,7 @@ describe('AuthController', () => {
             validatePasswordResetToken: jest.fn(),
         } as any;
         socialAuth = { getConfiguredProviders: jest.fn() } as any;
+        anonymousAuth = { createAnonymousUser: jest.fn() } as any;
         activityLog = { log: jest.fn().mockResolvedValue(undefined) } as any;
         authProvider = {
             signUpEmail: jest.fn(),
@@ -72,9 +75,65 @@ describe('AuthController', () => {
         controller = new AuthController(
             authService as unknown as AuthService,
             socialAuth as unknown as SocialAuthService,
+            anonymousAuth as unknown as AnonymousAuthService,
             activityLog as unknown as ActivityLogService,
             authProvider as unknown as AuthProvider,
         );
+    });
+
+    describe('anonymous (POST /api/auth/anonymous) — EW-617 G2', () => {
+        it('mints an anonymous session and logs the creation', async () => {
+            const tokenResponse = {
+                access_token: 'tok-anon-1',
+                user: {
+                    id: 'u-anon-1',
+                    email: null,
+                    username: 'anon-deadbeef',
+                    isAnonymous: true,
+                    anonymousExpiresAt: '2026-05-21T00:00:00.000Z',
+                },
+            };
+            anonymousAuth.createAnonymousUser.mockResolvedValue(tokenResponse as any);
+
+            const req = {
+                ip: '1.2.3.4',
+                headers: { 'user-agent': 'jest-agent', 'x-forwarded-for': '10.0.0.1, 1.2.3.4' },
+            };
+
+            const result = await (controller as any).anonymous(req);
+
+            expect(anonymousAuth.createAnonymousUser).toHaveBeenCalledWith({
+                ipAddress: '1.2.3.4',
+                userAgent: 'jest-agent',
+            });
+            expect(result).toEqual(tokenResponse);
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u-anon-1',
+                    action: 'user.anonymous_created',
+                    ipAddress: '1.2.3.4',
+                    userAgent: 'jest-agent',
+                }),
+            );
+        });
+
+        it('falls back to x-forwarded-for first hop when req.ip is missing', async () => {
+            anonymousAuth.createAnonymousUser.mockResolvedValue({
+                access_token: 'tok',
+                user: { id: 'u', email: null, username: 'anon-x', isAnonymous: true },
+            } as any);
+
+            const req = {
+                headers: { 'x-forwarded-for': ' 8.8.8.8 , 9.9.9.9 ' },
+            };
+
+            await (controller as any).anonymous(req);
+
+            expect(anonymousAuth.createAnonymousUser).toHaveBeenCalledWith({
+                ipAddress: '8.8.8.8',
+                userAgent: null,
+            });
+        });
     });
 
     describe('getConfiguredProviders (GET /api/auth/providers)', () => {

--- a/apps/api/src/auth/controllers/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth.controller.spec.ts
@@ -10,6 +10,7 @@ jest.mock('@ever-works/agent/activity-log', () => ({
 import { AuthController } from './auth.controller';
 import type { AuthService } from '../services/auth.service';
 import type { AnonymousAuthService } from '../services/anonymous-auth.service';
+import type { ClaimAccountService } from '../services/claim-account.service';
 import type { SocialAuthService } from '../services/social-auth.service';
 import type { ActivityLogService } from '@ever-works/agent/activity-log';
 import type { AuthProvider } from '../providers/auth-provider.abstract';
@@ -33,6 +34,7 @@ describe('AuthController', () => {
     >;
     let socialAuth: jest.Mocked<Pick<SocialAuthService, 'getConfiguredProviders'>>;
     let anonymousAuth: jest.Mocked<Pick<AnonymousAuthService, 'createAnonymousUser'>>;
+    let claimAccount: jest.Mocked<Pick<ClaimAccountService, 'claim'>>;
     let activityLog: jest.Mocked<Pick<ActivityLogService, 'log'>>;
     let authProvider: jest.Mocked<
         Pick<
@@ -62,6 +64,7 @@ describe('AuthController', () => {
         } as any;
         socialAuth = { getConfiguredProviders: jest.fn() } as any;
         anonymousAuth = { createAnonymousUser: jest.fn() } as any;
+        claimAccount = { claim: jest.fn() } as any;
         activityLog = { log: jest.fn().mockResolvedValue(undefined) } as any;
         authProvider = {
             signUpEmail: jest.fn(),
@@ -76,9 +79,75 @@ describe('AuthController', () => {
             authService as unknown as AuthService,
             socialAuth as unknown as SocialAuthService,
             anonymousAuth as unknown as AnonymousAuthService,
+            claimAccount as unknown as ClaimAccountService,
             activityLog as unknown as ActivityLogService,
             authProvider as unknown as AuthProvider,
         );
+    });
+
+    describe('claim (POST /api/auth/claim) — EW-617 G3', () => {
+        it('delegates to claimAccountService and logs activity', async () => {
+            const claimed = {
+                id: 'u-anon-1',
+                email: 'jane@example.com',
+                username: 'jane-doe',
+                emailVerified: false,
+            };
+            claimAccount.claim.mockResolvedValue(claimed);
+
+            const req = {
+                user: { userId: 'u-anon-1' },
+                ip: '1.2.3.4',
+                headers: { 'user-agent': 'jest-agent' },
+            };
+
+            const result = await (controller as any).claimAccount(req, {
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+                username: 'jane-doe',
+            });
+
+            expect(claimAccount.claim).toHaveBeenCalledWith({
+                userId: 'u-anon-1',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+                username: 'jane-doe',
+                emailVerificationCallbackUrl: undefined,
+            });
+            expect(result).toEqual(claimed);
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u-anon-1',
+                    action: 'user.account_claimed',
+                    ipAddress: '1.2.3.4',
+                    userAgent: 'jest-agent',
+                }),
+            );
+        });
+
+        it('passes through emailVerificationCallbackUrl when provided', async () => {
+            claimAccount.claim.mockResolvedValue({
+                id: 'u-1',
+                email: 'a@b.com',
+                username: 'a',
+                emailVerified: false,
+            });
+
+            await (controller as any).claimAccount(
+                { user: { userId: 'u-1' }, headers: {} },
+                {
+                    email: 'a@b.com',
+                    password: 'MySecure123!',
+                    emailVerificationCallbackUrl: 'https://app.ever.works/welcome',
+                },
+            );
+
+            expect(claimAccount.claim).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    emailVerificationCallbackUrl: 'https://app.ever.works/welcome',
+                }),
+            );
+        });
     });
 
     describe('anonymous (POST /api/auth/anonymous) — EW-617 G2', () => {

--- a/apps/api/src/auth/controllers/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth.controller.ts
@@ -21,7 +21,8 @@ import {
 } from '@nestjs/swagger';
 import { AuthService } from '../services/auth.service';
 import { AnonymousAuthService } from '../services/anonymous-auth.service';
-import { RegisterDto, LoginDto, UpdatePasswordDto } from '../dto/auth.dto';
+import { ClaimAccountService } from '../services/claim-account.service';
+import { RegisterDto, LoginDto, UpdatePasswordDto, ClaimAccountDto } from '../dto/auth.dto';
 import { VerifyEmailDto, ForgotPasswordDto, ResetPasswordDto } from '../dto/email-verification.dto';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
 import { AuthSessionGuard } from '../guards/auth-session.guard';
@@ -44,6 +45,7 @@ export class AuthController {
         private authService: AuthService,
         private readonly socialAuthService: SocialAuthService,
         private readonly anonymousAuthService: AnonymousAuthService,
+        private readonly claimAccountService: ClaimAccountService,
         private activityLogService: ActivityLogService,
         @Inject(AUTH_PROVIDER)
         private readonly authProvider: AuthProvider,
@@ -138,6 +140,63 @@ export class AuthController {
             .catch(() => {});
 
         return response;
+    }
+
+    @UseGuards(AuthSessionGuard)
+    @Post('claim')
+    // EW-617 G3: convert an anonymous user (G2) into a regular account.
+    // Throttled to dampen brute-force attempts at squatting taken emails.
+    @Throttle({ default: { limit: 10, ttl: 60 * 60 * 1000 } })
+    @HttpCode(HttpStatus.OK)
+    @ApiBearerAuth('JWT-auth')
+    @ApiOperation({
+        summary: 'Claim an anonymous account',
+        description:
+            'Converts an anonymous (zero-friction) account into a regular credentialed account. Attaches email + password, clears the TTL, fires verification email. The bearer token from POST /api/auth/anonymous stays valid.',
+    })
+    @ApiResponse({ status: 200, description: 'Account claimed, verification email sent' })
+    @ApiResponse({ status: 403, description: 'Account is not anonymous' })
+    @ApiResponse({
+        status: 409,
+        description: 'Email already in use by a different account',
+    })
+    async claimAccount(@Request() req, @Body() claimDto: ClaimAccountDto) {
+        const userId = req.user?.userId;
+        if (!userId) {
+            return { message: 'unauthorized' };
+        }
+
+        const claimed = await this.claimAccountService.claim({
+            userId,
+            email: claimDto.email,
+            password: claimDto.password,
+            username: claimDto.username,
+            emailVerificationCallbackUrl: claimDto.emailVerificationCallbackUrl,
+        });
+
+        const ipAddress =
+            (typeof req.ip === 'string' && req.ip) ||
+            (typeof req.headers['x-forwarded-for'] === 'string'
+                ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
+                : null);
+        const userAgent =
+            typeof req.headers['user-agent'] === 'string'
+                ? (req.headers['user-agent'] as string)
+                : null;
+
+        this.activityLogService
+            .log({
+                userId: claimed.id,
+                actionType: ActivityActionType.USER_LOGIN,
+                action: 'user.account_claimed',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Anonymous user claimed account',
+                ipAddress,
+                userAgent,
+            })
+            .catch(() => {});
+
+        return claimed;
     }
 
     @Public()

--- a/apps/api/src/auth/controllers/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth.controller.ts
@@ -20,6 +20,7 @@ import {
     ApiQuery,
 } from '@nestjs/swagger';
 import { AuthService } from '../services/auth.service';
+import { AnonymousAuthService } from '../services/anonymous-auth.service';
 import { RegisterDto, LoginDto, UpdatePasswordDto } from '../dto/auth.dto';
 import { VerifyEmailDto, ForgotPasswordDto, ResetPasswordDto } from '../dto/email-verification.dto';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
@@ -30,6 +31,7 @@ import { ActivityActionType, ActivityStatus } from '@ever-works/agent/entities';
 import { AUTH_PROVIDER } from '../providers/auth-provider.constants';
 import { AuthProvider } from '../providers/auth-provider.abstract';
 import { Inject } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { toHeaders } from '../providers/request-headers';
 import { SocialAuthService } from '../services/social-auth.service';
 
@@ -41,6 +43,7 @@ export class AuthController {
     constructor(
         private authService: AuthService,
         private readonly socialAuthService: SocialAuthService,
+        private readonly anonymousAuthService: AnonymousAuthService,
         private activityLogService: ActivityLogService,
         @Inject(AUTH_PROVIDER)
         private readonly authProvider: AuthProvider,
@@ -89,6 +92,50 @@ export class AuthController {
                 }`,
             );
         }
+
+        return response;
+    }
+
+    @Public()
+    @Post('anonymous')
+    // EW-617 G2: zero-friction onboarding entrypoint. Rate-limited per IP to
+    // prevent abuse; G7 will layer on stricter limits + captcha when needed.
+    @Throttle({ default: { limit: 5, ttl: 60 * 60 * 1000 } })
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({
+        summary: 'Create an anonymous (zero-friction) user',
+        description:
+            'Mints a temporary User row + session token. The row + its Works are wiped automatically after ANONYMOUS_USER_TTL_DAYS (default 7) days unless the user calls POST /api/auth/claim first.',
+    })
+    @ApiResponse({ status: 201, description: 'Anonymous session issued' })
+    @ApiResponse({ status: 429, description: 'Rate limit exceeded for this IP' })
+    async anonymous(@Request() req) {
+        const ipAddress =
+            (typeof req.ip === 'string' && req.ip) ||
+            (typeof req.headers['x-forwarded-for'] === 'string'
+                ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
+                : null);
+        const userAgent =
+            typeof req.headers['user-agent'] === 'string'
+                ? (req.headers['user-agent'] as string)
+                : null;
+
+        const response = await this.anonymousAuthService.createAnonymousUser({
+            ipAddress,
+            userAgent,
+        });
+
+        this.activityLogService
+            .log({
+                userId: response.user.id,
+                actionType: ActivityActionType.USER_LOGIN,
+                action: 'user.anonymous_created',
+                status: ActivityStatus.COMPLETED,
+                summary: 'Anonymous user created (zero-friction flow)',
+                ipAddress,
+                userAgent,
+            })
+            .catch(() => {});
 
         return response;
     }

--- a/apps/api/src/auth/dto/auth.dto.ts
+++ b/apps/api/src/auth/dto/auth.dto.ts
@@ -68,6 +68,44 @@ export class UpdatePasswordDto {
     newPassword: string;
 }
 
+/**
+ * EW-617 G3: payload for `POST /api/auth/claim`. Anonymous users send
+ * this with their anon session bearer token to convert into a regular
+ * account; reuses the same password rules as `RegisterDto`.
+ */
+export class ClaimAccountDto {
+    @ApiProperty({ description: 'Email address to attach', example: 'john@example.com' })
+    @IsEmail()
+    @IsNotEmpty()
+    email: string;
+
+    @ApiProperty({
+        description:
+            'Password (min 6 chars, must contain lowercase letter and number/special char)',
+        example: 'MySecure123!',
+        minLength: 6,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MinLength(6)
+    @Matches(/^[^.\n](?=.*[a-z])(?=.*[\d\w]).*$/, {
+        message:
+            'Password must contain at least 1 lowercase letter and 1 number or special character',
+    })
+    password: string;
+
+    @ApiPropertyOptional({ description: 'Username to use after claim (defaults to current anon username)' })
+    @IsString()
+    @IsOptional()
+    @MinLength(3)
+    username?: string;
+
+    @ApiPropertyOptional({ description: 'Callback URL for email verification redirect' })
+    @IsString()
+    @IsOptional()
+    emailVerificationCallbackUrl?: string;
+}
+
 export class OAuthCallbackDto {
     @ApiProperty({ description: 'Authorization code from OAuth provider' })
     @IsString()

--- a/apps/api/src/auth/services/anonymous-auth.service.spec.ts
+++ b/apps/api/src/auth/services/anonymous-auth.service.spec.ts
@@ -1,0 +1,121 @@
+jest.mock('@ever-works/agent/database', () => ({ UserRepository: class {} }));
+jest.mock('@ever-works/agent/entities', () => ({ AuthSession: class {} }));
+
+import { AnonymousAuthService } from './anonymous-auth.service';
+
+describe('AnonymousAuthService (EW-617 G2)', () => {
+    const buildService = () => {
+        const created: any[] = [];
+        const userRepository = {
+            create: jest.fn(async (data: any) => {
+                const row = { id: `u-${created.length + 1}`, ...data };
+                created.push(row);
+                return row;
+            }),
+        } as any;
+
+        const savedSessions: any[] = [];
+        const sessionRepo = {
+            save: jest.fn(async (data: any) => {
+                savedSessions.push(data);
+                return data;
+            }),
+        };
+
+        const dataSource = {
+            getRepository: jest.fn(() => sessionRepo),
+        } as any;
+
+        const authProvider = {} as any;
+
+        const service = new AnonymousAuthService(userRepository, dataSource, authProvider);
+
+        return { service, userRepository, sessionRepo, savedSessions, created };
+    };
+
+    afterEach(() => {
+        delete process.env.ANONYMOUS_USER_TTL_DAYS;
+    });
+
+    it('creates a User row with isAnonymous=true and a future expiry', async () => {
+        const { service, userRepository, created } = buildService();
+
+        const before = Date.now();
+        const response = await service.createAnonymousUser();
+        const after = Date.now();
+
+        expect(userRepository.create).toHaveBeenCalledTimes(1);
+        const insertedUser = created[0];
+        expect(insertedUser.isAnonymous).toBe(true);
+        expect(insertedUser.email).toBeNull();
+        expect(insertedUser.password).toBeNull();
+        expect(insertedUser.registrationProvider).toBe('anonymous');
+        expect(insertedUser.username).toMatch(/^anon-[0-9a-f]{8}$/);
+
+        const expiresAtMs = (insertedUser.anonymousExpiresAt as Date).getTime();
+        const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+        expect(expiresAtMs).toBeGreaterThanOrEqual(before + sevenDaysMs - 1000);
+        expect(expiresAtMs).toBeLessThanOrEqual(after + sevenDaysMs + 1000);
+
+        expect(response.user.isAnonymous).toBe(true);
+        expect(response.user.email).toBeNull();
+        expect(response.user.anonymousExpiresAt).toBe(
+            (insertedUser.anonymousExpiresAt as Date).toISOString(),
+        );
+    });
+
+    it('persists an AuthSession with a generated token bound to the user', async () => {
+        const { service, savedSessions } = buildService();
+
+        const response = await service.createAnonymousUser({
+            ipAddress: '1.2.3.4',
+            userAgent: 'test-agent',
+        });
+
+        expect(savedSessions).toHaveLength(1);
+        const session = savedSessions[0];
+        expect(session.userId).toBe(response.user.id);
+        expect(session.token).toBe(response.access_token);
+        expect(session.token.length).toBeGreaterThan(20); // base64url(32 bytes) >= 43 chars
+        expect(session.ipAddress).toBe('1.2.3.4');
+        expect(session.userAgent).toBe('test-agent');
+    });
+
+    it('respects ANONYMOUS_USER_TTL_DAYS when set', async () => {
+        process.env.ANONYMOUS_USER_TTL_DAYS = '1';
+        const { service, created } = buildService();
+
+        const before = Date.now();
+        await service.createAnonymousUser();
+        const after = Date.now();
+
+        const oneDayMs = 24 * 60 * 60 * 1000;
+        const ttl = (created[0].anonymousExpiresAt as Date).getTime();
+        expect(ttl).toBeGreaterThanOrEqual(before + oneDayMs - 1000);
+        expect(ttl).toBeLessThanOrEqual(after + oneDayMs + 1000);
+    });
+
+    it('falls back to 7 days when ANONYMOUS_USER_TTL_DAYS is garbage', async () => {
+        process.env.ANONYMOUS_USER_TTL_DAYS = 'not-a-number';
+        const { service, created } = buildService();
+
+        const before = Date.now();
+        await service.createAnonymousUser();
+        const after = Date.now();
+
+        const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+        const ttl = (created[0].anonymousExpiresAt as Date).getTime();
+        expect(ttl).toBeGreaterThanOrEqual(before + sevenDaysMs - 1000);
+        expect(ttl).toBeLessThanOrEqual(after + sevenDaysMs + 1000);
+    });
+
+    it('mints unique usernames + tokens across consecutive calls', async () => {
+        const { service } = buildService();
+
+        const a = await service.createAnonymousUser();
+        const b = await service.createAnonymousUser();
+
+        expect(a.user.username).not.toBe(b.user.username);
+        expect(a.access_token).not.toBe(b.access_token);
+    });
+});

--- a/apps/api/src/auth/services/anonymous-auth.service.ts
+++ b/apps/api/src/auth/services/anonymous-auth.service.ts
@@ -1,0 +1,88 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { randomBytes, randomUUID } from 'node:crypto';
+import { UserRepository } from '@ever-works/agent/database';
+import { AuthSession } from '@ever-works/agent/entities';
+import type { TokenResponse } from '../types/auth.types';
+import { AUTH_PROVIDER } from '../providers/auth-provider.constants';
+import { AuthProvider } from '../providers/auth-provider.abstract';
+
+/**
+ * EW-617 G2 — Anonymous (zero-friction) user creation.
+ *
+ * Spawns a fresh `User` row with `isAnonymous=true` + a TTL, then issues an
+ * `AuthSession` token so the rest of the API treats them like any other
+ * authenticated user. No email/password is collected. The row + its Works
+ * are wiped by the `anonymous-user-cleanup` Trigger.dev schedule once the
+ * TTL elapses.
+ *
+ * Claim-account (EW-617 G3) flips `isAnonymous=false`, clears the TTL,
+ * and attaches credentials.
+ */
+@Injectable()
+export class AnonymousAuthService {
+    private readonly logger = new Logger(AnonymousAuthService.name);
+
+    constructor(
+        private readonly userRepository: UserRepository,
+        @InjectDataSource() private readonly dataSource: DataSource,
+        @Inject(AUTH_PROVIDER)
+        private readonly authProvider: AuthProvider,
+    ) {}
+
+    /** Default TTL (7 days) — tunable via env var. */
+    private getTtlMs(): number {
+        const days = Number(process.env.ANONYMOUS_USER_TTL_DAYS || '7');
+        if (!Number.isFinite(days) || days <= 0) {
+            return 7 * 24 * 60 * 60 * 1000;
+        }
+        return days * 24 * 60 * 60 * 1000;
+    }
+
+    async createAnonymousUser(opts: {
+        ipAddress?: string | null;
+        userAgent?: string | null;
+    } = {}): Promise<TokenResponse> {
+        const expiresAt = new Date(Date.now() + this.getTtlMs());
+        const username = `anon-${randomBytes(4).toString('hex')}`;
+
+        const user = await this.userRepository.create({
+            username,
+            email: null,
+            password: null,
+            isAnonymous: true,
+            anonymousExpiresAt: expiresAt,
+            registrationProvider: 'anonymous',
+            emailVerified: false,
+            isActive: true,
+        });
+
+        this.logger.log(
+            `anonymous user created id=${user.id} username=${username} expiresAt=${expiresAt.toISOString()}`,
+        );
+
+        // Mint a session token directly — Better Auth's signup flow requires
+        // an email/password, so we bypass it for anon users and write the
+        // session row by hand. Same shape the rest of the API consumes.
+        const session = await this.dataSource.getRepository(AuthSession).save({
+            id: randomUUID(),
+            userId: user.id,
+            token: randomBytes(32).toString('base64url'),
+            expiresAt,
+            ipAddress: opts.ipAddress ?? null,
+            userAgent: opts.userAgent ?? null,
+        });
+
+        return {
+            access_token: session.token,
+            user: {
+                id: user.id,
+                email: null,
+                username: user.username,
+                isAnonymous: true,
+                anonymousExpiresAt: expiresAt.toISOString(),
+            },
+        };
+    }
+}

--- a/apps/api/src/auth/services/captcha-verifier.service.spec.ts
+++ b/apps/api/src/auth/services/captcha-verifier.service.spec.ts
@@ -1,0 +1,133 @@
+import { CaptchaVerifierService } from './captcha-verifier.service';
+
+describe('CaptchaVerifierService (EW-617 G7)', () => {
+    const ENV_KEYS = ['CAPTCHA_PROVIDER', 'CAPTCHA_SECRET', 'CAPTCHA_VERIFY_URL'] as const;
+    const previous: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        for (const k of ENV_KEYS) {
+            previous[k] = process.env[k];
+            delete process.env[k];
+        }
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (previous[k] === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = previous[k];
+            }
+        }
+    });
+
+    function buildSvc(fetchImpl?: typeof fetch) {
+        const fakeFetch = fetchImpl ?? (jest.fn() as any);
+        const svc = new CaptchaVerifierService(fakeFetch);
+        svc.resetCacheForTest();
+        return { svc, fakeFetch };
+    }
+
+    it('returns success+skipped when no provider is configured (dev/preview default)', async () => {
+        const { svc, fakeFetch } = buildSvc();
+        const result = await svc.verify({ token: 'whatever' });
+        expect(result).toEqual({ success: true, skipped: true });
+        expect(fakeFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty token even when provider is enabled', async () => {
+        process.env.CAPTCHA_PROVIDER = 'turnstile';
+        process.env.CAPTCHA_SECRET = 'tk';
+        const { svc, fakeFetch } = buildSvc();
+        const result = await svc.verify({ token: '' });
+        expect(result.success).toBe(false);
+        expect(result.skipped).toBe(false);
+        expect(result.errorCodes).toContain('missing-input-response');
+        expect(fakeFetch).not.toHaveBeenCalled();
+    });
+
+    it('POSTs to the Turnstile verify URL with secret+response and parses success', async () => {
+        process.env.CAPTCHA_PROVIDER = 'turnstile';
+        process.env.CAPTCHA_SECRET = 'sec';
+        const fakeFetch = jest.fn(
+            async (url: string, init: RequestInit) =>
+                new Response(JSON.stringify({ success: true, hostname: 'ever.works' }), {
+                    status: 200,
+                }),
+        ) as any;
+        const { svc } = buildSvc(fakeFetch);
+
+        const result = await svc.verify({ token: 'tok-1', remoteIp: '1.2.3.4' });
+
+        expect(result).toEqual({
+            success: true,
+            skipped: false,
+            errorCodes: undefined,
+            hostname: 'ever.works',
+        });
+        expect(fakeFetch).toHaveBeenCalledTimes(1);
+        const [url, init] = fakeFetch.mock.calls[0];
+        expect(url).toBe('https://challenges.cloudflare.com/turnstile/v0/siteverify');
+        expect(init.method).toBe('POST');
+        const body = new URLSearchParams(init.body as string);
+        expect(body.get('secret')).toBe('sec');
+        expect(body.get('response')).toBe('tok-1');
+        expect(body.get('remoteip')).toBe('1.2.3.4');
+    });
+
+    it('treats success=false from provider as a failed verify (no throw)', async () => {
+        process.env.CAPTCHA_PROVIDER = 'turnstile';
+        process.env.CAPTCHA_SECRET = 'sec';
+        const fakeFetch = jest.fn(
+            async () =>
+                new Response(
+                    JSON.stringify({ success: false, 'error-codes': ['invalid-input-response'] }),
+                    {
+                        status: 200,
+                    },
+                ),
+        ) as any;
+        const { svc } = buildSvc(fakeFetch);
+
+        const result = await svc.verify({ token: 'tok-2' });
+        expect(result.success).toBe(false);
+        expect(result.errorCodes).toEqual(['invalid-input-response']);
+    });
+
+    it('falls open (success=true skipped) when the verifier throws — provider outage', async () => {
+        process.env.CAPTCHA_PROVIDER = 'turnstile';
+        process.env.CAPTCHA_SECRET = 'sec';
+        const fakeFetch = jest.fn(async () => {
+            throw new Error('econnreset');
+        }) as any;
+        const { svc } = buildSvc(fakeFetch);
+
+        const result = await svc.verify({ token: 'tok-3' });
+        expect(result.success).toBe(true);
+        expect(result.skipped).toBe(true);
+        expect(result.errorCodes).toEqual(['verifier-exception']);
+    });
+
+    it('lets CAPTCHA_VERIFY_URL override the default for staging mirrors', async () => {
+        process.env.CAPTCHA_PROVIDER = 'turnstile';
+        process.env.CAPTCHA_SECRET = 'sec';
+        process.env.CAPTCHA_VERIFY_URL = 'https://staging-verify.local/siteverify';
+        const fakeFetch = jest.fn(
+            async () => new Response(JSON.stringify({ success: true })),
+        ) as any;
+        const { svc } = buildSvc(fakeFetch);
+
+        await svc.verify({ token: 't' });
+        expect(fakeFetch.mock.calls[0][0]).toBe('https://staging-verify.local/siteverify');
+    });
+
+    it('treats unknown provider as disabled (no verify URL resolves)', async () => {
+        process.env.CAPTCHA_PROVIDER = 'invented';
+        process.env.CAPTCHA_SECRET = 'sec';
+        const { svc, fakeFetch } = buildSvc();
+        expect(svc.isEnabled()).toBe(false);
+        const result = await svc.verify({ token: 't' });
+        expect(result).toEqual({ success: true, skipped: true });
+        expect(fakeFetch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/auth/services/captcha-verifier.service.ts
+++ b/apps/api/src/auth/services/captcha-verifier.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * EW-617 G7 — Cloudflare Turnstile (or any compatible /siteverify
+ * provider) token verifier.
+ *
+ * Wraps a single POST to the verify endpoint with a server-side secret
+ * and returns a normalized `VerifyResult`. Used by:
+ *  - `POST /api/auth/anonymous` (gates landing → anon-user creation)
+ *  - `POST /api/works/quick-create` (gates Generate-now from landing)
+ *
+ * When `CAPTCHA_PROVIDER` is unset (default in dev) the verifier
+ * returns success without an HTTP call, so the existing per-IP
+ * throttles (G2/G4) remain the only line of defense in dev/preview.
+ * Production sets `CAPTCHA_PROVIDER=turnstile` + `CAPTCHA_SECRET`.
+ *
+ * Provider-agnostic: the verify URL and the JSON shape used by
+ * Cloudflare Turnstile, hCaptcha, and reCAPTCHA v3 are all close
+ * enough that one impl covers them — the only thing that differs is
+ * the response field for the score (we don't read it; the boolean
+ * `success` is enough for our threat model).
+ */
+
+export interface CaptchaConfig {
+    /** 'turnstile' | 'hcaptcha' | 'recaptcha' — `null` means disabled. */
+    readonly provider: string | null;
+    readonly secret: string | null;
+    /** Optional override (tests use a mock; staging may mirror). */
+    readonly verifyUrl: string | null;
+}
+
+export interface CaptchaVerifyInput {
+    readonly token: string | null | undefined;
+    readonly remoteIp?: string | null;
+}
+
+export interface CaptchaVerifyResult {
+    readonly success: boolean;
+    readonly skipped: boolean;
+    readonly errorCodes?: readonly string[];
+    readonly hostname?: string;
+}
+
+const DEFAULT_VERIFY_URLS: Record<string, string> = {
+    turnstile: 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+    hcaptcha: 'https://hcaptcha.com/siteverify',
+    recaptcha: 'https://www.google.com/recaptcha/api/siteverify',
+};
+
+@Injectable()
+export class CaptchaVerifierService {
+    private readonly logger = new Logger(CaptchaVerifierService.name);
+    private cachedConfig: CaptchaConfig | undefined;
+
+    constructor(private readonly fetchImpl: typeof fetch = fetch) {}
+
+    /** Read env once and cache. Test hook: `resetCacheForTest`. */
+    getConfig(): CaptchaConfig {
+        if (this.cachedConfig !== undefined) return this.cachedConfig;
+        const provider = process.env.CAPTCHA_PROVIDER?.trim().toLowerCase() || null;
+        const secret = process.env.CAPTCHA_SECRET?.trim() || null;
+        const verifyUrl =
+            process.env.CAPTCHA_VERIFY_URL?.trim() ||
+            (provider ? (DEFAULT_VERIFY_URLS[provider] ?? null) : null);
+        this.cachedConfig = { provider, secret, verifyUrl };
+        return this.cachedConfig;
+    }
+
+    isEnabled(): boolean {
+        const c = this.getConfig();
+        return Boolean(c.provider && c.secret && c.verifyUrl);
+    }
+
+    async verify(input: CaptchaVerifyInput): Promise<CaptchaVerifyResult> {
+        if (!this.isEnabled()) {
+            // No captcha configured — let traffic through. The
+            // upstream endpoint's per-IP throttle still applies.
+            return { success: true, skipped: true };
+        }
+
+        if (!input.token || typeof input.token !== 'string') {
+            return { success: false, skipped: false, errorCodes: ['missing-input-response'] };
+        }
+
+        const config = this.getConfig();
+        const body = new URLSearchParams({
+            secret: config.secret!,
+            response: input.token,
+        });
+        if (input.remoteIp) {
+            body.set('remoteip', input.remoteIp);
+        }
+
+        try {
+            const response = await this.fetchImpl(config.verifyUrl!, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString(),
+            });
+            const json = (await response.json().catch(() => ({}))) as {
+                success?: boolean;
+                'error-codes'?: string[];
+                hostname?: string;
+            };
+            const success = response.ok && json.success === true;
+            if (!success) {
+                this.logger.warn(
+                    `captcha verify failed status=${response.status} codes=${(
+                        json['error-codes'] ?? []
+                    ).join(',')}`,
+                );
+            }
+            return {
+                success,
+                skipped: false,
+                errorCodes: json['error-codes'],
+                hostname: json.hostname,
+            };
+        } catch (cause) {
+            // Provider outage: do NOT block legitimate traffic. Throttles
+            // remain the safety net; ops will see the warn log + alert
+            // on the elevated rate.
+            this.logger.warn(
+                `captcha verify threw (treating as success to avoid blocking): ${
+                    (cause as Error).message
+                }`,
+            );
+            return { success: true, skipped: true, errorCodes: ['verifier-exception'] };
+        }
+    }
+
+    /** Test-only — flush the env cache so a new `CAPTCHA_*` env can be read. */
+    resetCacheForTest(): void {
+        this.cachedConfig = undefined;
+    }
+}

--- a/apps/api/src/auth/services/claim-account.service.spec.ts
+++ b/apps/api/src/auth/services/claim-account.service.spec.ts
@@ -1,0 +1,238 @@
+jest.mock('@ever-works/agent/database', () => ({ UserRepository: class {} }));
+
+import {
+    BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    NotFoundException,
+} from '@nestjs/common';
+import { ClaimAccountService } from './claim-account.service';
+
+describe('ClaimAccountService (EW-617 G3)', () => {
+    const buildService = () => {
+        const findByIdResults: any = {};
+        const findByEmailResults: any = {};
+        const updates: any[] = [];
+
+        const userRepository = {
+            findById: jest.fn(async (id: string) => findByIdResults[id] ?? null),
+            findByEmail: jest.fn(async (email: string) => findByEmailResults[email] ?? null),
+            update: jest.fn(async (id: string, data: any) => {
+                updates.push({ id, ...data });
+                const base = findByIdResults[id] ?? { id };
+                return { ...base, ...data };
+            }),
+        } as any;
+
+        const authSyncService = {
+            getCredentialPasswordHash: jest.fn().mockResolvedValue('hashed-pw'),
+        } as any;
+
+        const authService = {
+            sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const authProvider = {
+            setPassword: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const service = new ClaimAccountService(
+            userRepository,
+            authSyncService,
+            authService,
+            authProvider,
+        );
+
+        return {
+            service,
+            userRepository,
+            authSyncService,
+            authService,
+            authProvider,
+            findByIdResults,
+            findByEmailResults,
+            updates,
+        };
+    };
+
+    const anonUser = (overrides: any = {}) => ({
+        id: 'u-1',
+        username: 'anon-deadbeef',
+        email: null,
+        password: null,
+        isAnonymous: true,
+        anonymousExpiresAt: new Date('2026-05-21T00:00:00.000Z'),
+        emailVerified: false,
+        ...overrides,
+    });
+
+    it('flips the anon user to a regular account and fires verification email', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+
+        const result = await ctx.service.claim({
+            userId: 'u-1',
+            email: 'Jane@Example.com',
+            password: 'MySecure123!',
+        });
+
+        // Password set via auth provider
+        expect(ctx.authProvider.setPassword).toHaveBeenCalledWith('u-1', 'MySecure123!');
+
+        // User row updated atomically
+        expect(ctx.updates).toHaveLength(1);
+        const updatePayload = ctx.updates[0];
+        expect(updatePayload.email).toBe('jane@example.com'); // normalized
+        expect(updatePayload.isAnonymous).toBe(false);
+        expect(updatePayload.anonymousExpiresAt).toBeNull();
+        expect(updatePayload.registrationProvider).toBe('local');
+        expect(updatePayload.emailVerified).toBe(false);
+        expect(updatePayload.username).toBe('anon-deadbeef'); // kept
+
+        // Verification email pipeline kicked off
+        expect(ctx.authService.sendVerificationEmail).toHaveBeenCalledWith('u-1', undefined);
+
+        // Public response shape
+        expect(result).toEqual({
+            id: 'u-1',
+            email: 'jane@example.com',
+            username: 'anon-deadbeef',
+            emailVerified: false,
+        });
+    });
+
+    it('respects a custom username when long enough', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+
+        await ctx.service.claim({
+            userId: 'u-1',
+            email: 'jane@example.com',
+            password: 'MySecure123!',
+            username: 'jane-doe',
+        });
+
+        expect(ctx.updates[0].username).toBe('jane-doe');
+    });
+
+    it('rejects too-short usernames', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+
+        await expect(
+            ctx.service.claim({
+                userId: 'u-1',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+                username: 'jd',
+            }),
+        ).rejects.toThrow(BadRequestException);
+    });
+
+    it('returns 404 when the user does not exist', async () => {
+        const ctx = buildService();
+
+        await expect(
+            ctx.service.claim({
+                userId: 'ghost',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+            }),
+        ).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns 403 when the user is already a regular account', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser({ isAnonymous: false });
+
+        await expect(
+            ctx.service.claim({
+                userId: 'u-1',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+            }),
+        ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('returns 409 when the email belongs to a different user', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+        ctx.findByEmailResults['jane@example.com'] = { id: 'u-someone-else', email: 'jane@example.com' };
+
+        await expect(
+            ctx.service.claim({
+                userId: 'u-1',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+            }),
+        ).rejects.toThrow(ConflictException);
+
+        // Confirm we never wrote anything
+        expect(ctx.authProvider.setPassword).not.toHaveBeenCalled();
+        expect(ctx.updates).toHaveLength(0);
+    });
+
+    it('allows claim when findByEmail returns the same user (e.g. retry)', async () => {
+        const ctx = buildService();
+        const sameUser = anonUser();
+        ctx.findByIdResults['u-1'] = sameUser;
+        ctx.findByEmailResults['jane@example.com'] = sameUser;
+
+        await ctx.service.claim({
+            userId: 'u-1',
+            email: 'jane@example.com',
+            password: 'MySecure123!',
+        });
+
+        expect(ctx.updates).toHaveLength(1);
+    });
+
+    it('does not throw if the verification email fails (logged + continued)', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+        ctx.authService.sendVerificationEmail.mockRejectedValue(new Error('SMTP down'));
+
+        await expect(
+            ctx.service.claim({
+                userId: 'u-1',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+            }),
+        ).resolves.toMatchObject({ id: 'u-1' });
+    });
+
+    it('throws when auth provider does not seat a credential hash', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+        ctx.authSyncService.getCredentialPasswordHash.mockResolvedValue(null);
+
+        await expect(
+            ctx.service.claim({
+                userId: 'u-1',
+                email: 'jane@example.com',
+                password: 'MySecure123!',
+            }),
+        ).rejects.toThrow(BadRequestException);
+
+        // The credential set was attempted but no User update should happen
+        expect(ctx.authProvider.setPassword).toHaveBeenCalled();
+        expect(ctx.updates).toHaveLength(0);
+    });
+
+    it('passes through the email verification callback URL', async () => {
+        const ctx = buildService();
+        ctx.findByIdResults['u-1'] = anonUser();
+
+        await ctx.service.claim({
+            userId: 'u-1',
+            email: 'jane@example.com',
+            password: 'MySecure123!',
+            emailVerificationCallbackUrl: 'https://app.ever.works/welcome',
+        });
+
+        expect(ctx.authService.sendVerificationEmail).toHaveBeenCalledWith(
+            'u-1',
+            'https://app.ever.works/welcome',
+        );
+    });
+});

--- a/apps/api/src/auth/services/claim-account.service.ts
+++ b/apps/api/src/auth/services/claim-account.service.ts
@@ -1,0 +1,138 @@
+import {
+    BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    Inject,
+    Injectable,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
+import { UserRepository } from '@ever-works/agent/database';
+import { AUTH_PROVIDER } from '../providers/auth-provider.constants';
+import { AuthProvider } from '../providers/auth-provider.abstract';
+import { AuthSyncService } from '../providers/auth-sync.service';
+import { AuthService } from './auth.service';
+
+export interface ClaimAccountInput {
+    userId: string;
+    email: string;
+    password: string;
+    username?: string;
+    emailVerificationCallbackUrl?: string;
+}
+
+/**
+ * EW-617 G3 — Claim-Account flow.
+ *
+ * Converts an anonymous (zero-friction) `User` row into a regular,
+ * credentialed account without losing any of their existing Works.
+ *
+ * Steps (all in one HTTP call):
+ *  1. Verify the caller's session is anonymous (G2 introduced
+ *     `is_anonymous`).
+ *  2. Reject the request if the email is already taken by a different
+ *     user. Policy: never auto-merge — that's a footgun. Ask the user
+ *     to sign in with the existing account instead.
+ *  3. Hash the password via the existing credential adapter
+ *     (`AuthProvider.setPassword`) so the new account can sign in via
+ *     `/login`.
+ *  4. Flip `is_anonymous=false`, clear `anonymous_expires_at`, persist
+ *     the email + (optional) new username, set
+ *     `registration_provider='local'`.
+ *  5. Delegate to `AuthService.sendVerificationEmail` so the
+ *     verification mail goes through the existing pipeline.
+ *
+ * The original anon session token stays valid — the user remains
+ * signed in. Works ownership is by `userId`, which doesn't change, so
+ * no Work transfer step is needed.
+ */
+@Injectable()
+export class ClaimAccountService {
+    private readonly logger = new Logger(ClaimAccountService.name);
+
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly authSyncService: AuthSyncService,
+        private readonly authService: AuthService,
+        @Inject(AUTH_PROVIDER)
+        private readonly authProvider: AuthProvider,
+    ) {}
+
+    async claim(input: ClaimAccountInput): Promise<{
+        id: string;
+        email: string;
+        username: string;
+        emailVerified: boolean;
+    }> {
+        const user = await this.userRepository.findById(input.userId);
+        if (!user) {
+            throw new NotFoundException('User not found');
+        }
+
+        if (!user.isAnonymous) {
+            throw new ForbiddenException('Account is not anonymous');
+        }
+
+        const normalizedEmail = input.email.trim().toLowerCase();
+        const existingByEmail = await this.userRepository.findByEmail(normalizedEmail);
+        if (existingByEmail && existingByEmail.id !== user.id) {
+            throw new ConflictException(
+                'Email is already in use by another account. Please sign in with the existing account instead.',
+            );
+        }
+
+        const username = input.username?.trim() || user.username;
+        if (username.length < 3) {
+            throw new BadRequestException('Username must be at least 3 characters');
+        }
+
+        // 1. Hash + persist credentials via Better Auth's adapter so the
+        //    user can sign in via /api/auth/login like any other account.
+        await this.authProvider.setPassword(user.id, input.password);
+        const passwordHash = await this.authSyncService.getCredentialPasswordHash(user.id);
+        if (!passwordHash) {
+            throw new BadRequestException('Failed to attach credentials');
+        }
+
+        // 2. Flip the user out of anonymous mode in a single update so
+        //    code racing on isAnonymous sees a consistent shape.
+        const updated = await this.userRepository.update(user.id, {
+            email: normalizedEmail,
+            username,
+            password: passwordHash,
+            isAnonymous: false,
+            anonymousExpiresAt: null,
+            registrationProvider: 'local',
+            emailVerified: false,
+        });
+
+        if (!updated) {
+            throw new BadRequestException('Failed to update user');
+        }
+
+        // 3. Verification email goes through the existing pipeline.
+        //    Catch here so a flaky mailer doesn't break the claim —
+        //    the user can request a resend via /api/auth/send-verification.
+        try {
+            await this.authService.sendVerificationEmail(
+                updated.id,
+                input.emailVerificationCallbackUrl,
+            );
+        } catch (cause) {
+            this.logger.warn(
+                `Failed to send verification email for claimed user ${updated.id}: ${(cause as Error).message}`,
+            );
+        }
+
+        this.logger.log(
+            `anonymous user ${user.id} claimed account email=${normalizedEmail} username=${username}`,
+        );
+
+        return {
+            id: updated.id,
+            email: updated.email!,
+            username: updated.username,
+            emailVerified: updated.emailVerified,
+        };
+    }
+}

--- a/apps/api/src/auth/types/auth.types.ts
+++ b/apps/api/src/auth/types/auth.types.ts
@@ -1,6 +1,8 @@
 export interface AuthTokenPayload {
     sub: string;
-    email: string;
+    // EW-617 G2: anonymous (zero-friction) users have a null email until
+    // they claim the account via POST /api/auth/claim.
+    email: string | null;
     provider: string;
     username: string;
     emailVerified: boolean;
@@ -9,11 +11,13 @@ export interface AuthTokenPayload {
     iat: number;
     iss: string;
     aud: string;
+    // EW-617 G2: set to `true` for anonymous JWTs.
+    isAnonymous?: boolean;
 }
 
 export interface AuthenticatedUser {
     userId: string;
-    email: string;
+    email: string | null;
     username: string;
     provider: string;
     emailVerified: boolean;
@@ -22,13 +26,18 @@ export interface AuthenticatedUser {
     iat: number;
     iss: string;
     aud: string;
+    // EW-617 G2: downstream services can gate behavior on this flag
+    // (e.g. quotas, claim-account UI nag, OAuth restrictions).
+    isAnonymous?: boolean;
 }
 
 export interface TokenResponse {
     access_token: string;
     user: {
         id: string;
-        email: string;
+        email: string | null;
         username: string;
+        isAnonymous?: boolean;
+        anonymousExpiresAt?: string | null;
     };
 }

--- a/apps/api/src/integrations/github-app/github-app-onboarding.service.ts
+++ b/apps/api/src/integrations/github-app/github-app-onboarding.service.ts
@@ -168,10 +168,12 @@ export class GitHubAppOnboardingService {
                 lastLoginAt: new Date(),
             });
         } else {
-            const nextEmail =
-                input.email && user.email.endsWith('@users.noreply.ever.works')
-                    ? input.email
-                    : user.email;
+            // EW-617 G2: existing rows may now have null email (anonymous
+            // users who connected GitHub before claiming an account). Treat
+            // null the same as the placeholder noreply address — overwrite.
+            const isPlaceholderEmail =
+                !user.email || user.email.endsWith('@users.noreply.ever.works');
+            const nextEmail = input.email && isPlaceholderEmail ? input.email : user.email;
             user = await this.userRepository.update(user.id, {
                 username: user.username || input.login,
                 avatar: input.avatarUrl || user.avatar,

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -22,6 +22,21 @@ export class MailService {
     constructor(private readonly mailerService: MailerService) {}
 
     /**
+     * EW-617 G2: anonymous users have no email and must never receive
+     * transactional mail. All mail handlers early-return when the recipient
+     * has no email; in practice they shouldn't fire for anon users at all
+     * (we don't emit UserCreated/UserConfirmed/etc. for them) but the guard
+     * keeps the type-system honest and prevents accidental sends.
+     */
+    private requireEmail(email: string | null, context: string): string | null {
+        if (!email) {
+            this.logger.debug(`Skipping ${context}: recipient has no email (anonymous user?)`);
+            return null;
+        }
+        return email;
+    }
+
+    /**
      * Get branding context for email templates
      */
     private getBrandingContext() {
@@ -40,8 +55,12 @@ export class MailService {
     async sendSignupConfirmation(data: UserCreatedEvent): Promise<void> {
         try {
             const appName = config.branding.appName();
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Confirm your ${appName} account`,
                 template: 'signup-confirmation',
                 context: {
@@ -68,8 +87,12 @@ export class MailService {
             const resetUrl = data.resetUrl;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Reset your ${appName} password`,
                 template: 'forgot-password',
                 context: {
@@ -97,8 +120,12 @@ export class MailService {
             const secureAccountUrl = data.secureAccountUrl;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Your ${appName} password has been changed`,
                 template: 'password-changed',
                 context: {
@@ -129,8 +156,12 @@ export class MailService {
             const dashboardUrl = data.dashboardUrl || `${config.webAppUrl()}/works/new`;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `Welcome to ${appName}!`,
                 template: 'welcome',
                 context: {
@@ -157,8 +188,12 @@ export class MailService {
             const secureAccountUrl = data.secureAccountUrl;
             const appName = config.branding.appName();
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: `New login to your ${appName} account`,
                 template: 'new-device-login',
                 context: {
@@ -191,8 +226,12 @@ export class MailService {
             const deleteUrl = data.deleteUrl;
             const keepAccountUrl = data.keepAccountUrl;
 
+            const recipient = this.requireEmail(data.user.email, 'mail to user');
+            if (!recipient) {
+                return;
+            }
             await this.mailerService.sendMail({
-                to: data.user.email,
+                to: recipient,
                 subject: 'Confirm account deletion',
                 template: 'account-deletion',
                 context: {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -120,6 +120,17 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             getOrGenerate: jest.fn().mockResolvedValue('hex'.repeat(21) + 'h'), // 64 hex chars
         };
 
+        // EW-617 G5: DNS automation no-ops in tests (no env vars). The
+        // dns service still needs to be present so the constructor wires
+        // — `getProvider` returns null and `ensureWorkSubdomain` is a
+        // safe stub.
+        const dnsService = {
+            getProvider: jest.fn(() => null),
+            ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
+            ensureWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+            removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+        };
+
         const service = new DeployService(
             deployFacade as any,
             gitFacade as any,
@@ -129,6 +140,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             websiteTemplateResolver as any,
             eventEmitter as any,
             platformSyncSecretService as any,
+            dnsService as any,
         );
 
         return {
@@ -140,6 +152,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             githubPlugin,
             eventEmitter,
             platformSyncSecretService,
+            dnsService,
         };
     };
 
@@ -555,6 +568,84 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         );
 
         errorSpy.mockRestore();
+    });
+
+    describe('EW-617 G5 — ever-works subdomain templating', () => {
+        it('overrides ingressHost to ${slug}.ever.works when deployProvider=ever-works and DNS is configured', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, githubPlugin, dnsService } = buildService({
+                deployProvider: 'ever-works',
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                settings: { kubeconfig: 'apiVersion: v1' },
+            });
+            // Pretend DNS env is set — service emits a fake provider that
+            // does nothing, but signals "active".
+            (dnsService.getProvider as jest.Mock).mockReturnValue({});
+
+            await service.deploy('work-1', 'user-1', {});
+
+            // The plugin's getDeploymentSecrets MUST have been called with
+            // settings carrying the templated ingressHost.
+            expect(getDeploymentSecrets).toHaveBeenCalledTimes(1);
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            expect(settingsArg.ingressHost).toBe('my-site.ever.works');
+            // Original settings still contain whatever was there.
+            expect(settingsArg.kubeconfig).toBe('apiVersion: v1');
+
+            expect(dnsService.ensureWorkSubdomain).toHaveBeenCalledWith('my-site');
+
+            // Tag the variable assertion onto the GA secrets path too —
+            // K8S_INGRESS_HOST is what the plugin returns from
+            // getDeploymentSecrets when settings.ingressHost is set.
+            // (Plugin is mocked here, so we only assert on the call.)
+            void githubPlugin; // silence unused
+        });
+
+        it('leaves settings unchanged for non-ever-works providers', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, dnsService } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml'],
+                    getDeploymentSecrets,
+                },
+                settings: { token: 'v1' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(getDeploymentSecrets).toHaveBeenCalledTimes(1);
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            expect(settingsArg.ingressHost).toBeUndefined();
+            expect(dnsService.ensureWorkSubdomain).not.toHaveBeenCalled();
+        });
+
+        it('no-ops the DNS override when env is unset (dnsService.getProvider returns null)', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, dnsService } = buildService({
+                deployProvider: 'ever-works',
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                settings: {},
+            });
+            (dnsService.getProvider as jest.Mock).mockReturnValue(null);
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            // Without an active DNS provider we leave the settings alone —
+            // the k8s plugin's existing fallback hostname is used instead.
+            expect(settingsArg.ingressHost).toBeUndefined();
+            expect(dnsService.ensureWorkSubdomain).not.toHaveBeenCalled();
+        });
     });
 
     describe('default deployProvider fallback (EW-617 G6)', () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -557,6 +557,45 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         errorSpy.mockRestore();
     });
 
+    describe('default deployProvider fallback (EW-617 G6)', () => {
+        // When work.deployProvider is null/empty (e.g. older row pre-migration
+        // or anonymous quick-create that hasn't picked a provider yet), the
+        // service must fall back to 'ever-works', not the legacy 'vercel'.
+        it("sets DEPLOY_PROVIDER='ever-works' when work.deployProvider is falsy", async () => {
+            const { service, githubPlugin } = buildService({
+                deployProvider: '',
+                plugin: {
+                    id: 'ever-works',
+                    getWorkflowFilenames: () => ['deploy_ever_works.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { variables } = captureCalls(githubPlugin);
+            const deployProviderVar = variables.find((v: any) => v.key === 'DEPLOY_PROVIDER');
+            expect(deployProviderVar?.value).toBe('ever-works');
+        });
+
+        it('uses work.deployProvider when explicitly set (no override)', async () => {
+            const { service, githubPlugin } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml', 'deploy_prod.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { variables } = captureCalls(githubPlugin);
+            const deployProviderVar = variables.find((v: any) => v.key === 'DEPLOY_PROVIDER');
+            expect(deployProviderVar?.value).toBe('vercel');
+        });
+    });
+
     describe('EW-616 cluster-source enforcement + kubeconfig substitution', () => {
         const k8sPlugin = {
             id: 'k8s',

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -337,7 +337,7 @@ export class DeployService {
         plugin?: IDeploymentPlugin,
         settings?: Record<string, unknown>,
     ) {
-        const provider = work.deployProvider || 'vercel';
+        const provider = work.deployProvider || 'ever-works';
         try {
             await this.setVariable(ctx, 'DEPLOY_PROVIDER', provider);
         } catch (error) {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -15,6 +15,7 @@ import { WorkRepository } from '@ever-works/agent/database';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
 import { Work, User } from '@ever-works/agent/entities';
 import { PlatformSyncSecretService } from '@ever-works/agent/services';
+import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
 import {
     WebsiteUpdateService,
     getWebsiteTemplateBranch,
@@ -83,6 +84,7 @@ export class DeployService {
         private readonly websiteTemplateResolver: WebsiteTemplateResolverService,
         private readonly eventEmitter: EventEmitter2,
         private readonly platformSyncSecretService: PlatformSyncSecretService,
+        private readonly dnsService: EverWorksDnsService,
     ) {}
 
     /**
@@ -135,7 +137,14 @@ export class DeployService {
             withDelay: false,
         });
 
-        await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, settings);
+        // EW-617 G5: when the platform is the deploy target, template the
+        // ingress host as `${slug}.ever.works` (or whatever
+        // EVER_WORKS_DOMAIN says) and provision the Cloudflare CNAME so
+        // the user's directory is reachable at that subdomain without any
+        // manual DNS. If env vars are missing the DNS service no-ops; the
+        // k8s plugin's default LB hostname remains the fallback.
+        const deploySettings = await this.applyEverWorksSubdomain(work, settings);
+        await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, deploySettings);
         await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
@@ -328,6 +337,45 @@ export class DeployService {
 
     private async setVariable(ctx: RepoContext, key: string, value: string) {
         return this.setActionVariable({ key, value, owner: ctx.owner, repo: ctx.repo }, ctx.token);
+    }
+
+    /**
+     * EW-617 G5: when `deployProvider === 'ever-works'` AND the Cloudflare
+     * DNS env is configured, derive `ingressHost = ${slug}.ever.works`,
+     * merge it into the deploy settings (so the k8s plugin's
+     * `getDeploymentSecrets` picks it up as `K8S_INGRESS_HOST`), and
+     * provision the CNAME via Cloudflare. Returns a shallow copy of
+     * `settings` with the override applied; original object is not
+     * mutated so subsequent reads stay deterministic.
+     *
+     * No-ops cleanly when:
+     *  - the work is on a non-platform provider (Vercel, user's k8s), OR
+     *  - env vars are missing (dev / preview),
+     * letting the existing k8s plugin LB hostname remain the fallback.
+     */
+    private async applyEverWorksSubdomain(
+        work: Work,
+        settings: Record<string, unknown> | undefined,
+    ): Promise<Record<string, unknown> | undefined> {
+        if (work.deployProvider !== 'ever-works') {
+            return settings;
+        }
+        const provider = this.dnsService.getProvider();
+        if (!provider) {
+            return settings;
+        }
+
+        const ingressHost = this.dnsService.ingressHostFor(work.slug);
+
+        // Provision asynchronously — DNS propagation runs in parallel with
+        // the workflow dispatch. Errors are logged inside the service so
+        // they never abort the deploy.
+        void this.dnsService.ensureWorkSubdomain(work.slug);
+
+        return {
+            ...(settings ?? {}),
+            ingressHost,
+        };
     }
 
     private async setRequiredSecrets(

--- a/apps/api/src/works/works.controller.quick-create.spec.ts
+++ b/apps/api/src/works/works.controller.quick-create.spec.ts
@@ -1,0 +1,207 @@
+// Mock the agent runtime tree at module scope so importing the controller does
+// not pull in the agent's NestJS DI graph.
+jest.mock('@ever-works/agent/dto', () => ({}));
+jest.mock('@ever-works/agent/items-generator', () => ({
+    CreateItemsGeneratorDto: class CreateItemsGeneratorDto {
+        name?: string;
+        prompt?: string;
+        model?: string;
+    },
+}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/agent/comparison-generator', () => ({}));
+jest.mock('@ever-works/agent/template-catalog', () => ({}));
+jest.mock('@ever-works/agent/generators', () => ({
+    getDefaultWebsiteTemplateId: jest.fn(() => 'default-template'),
+}));
+jest.mock('@ever-works/agent/community-pr', () => ({}));
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/cache', () => ({ CACHE_MANAGER: 'CACHE_MANAGER' }));
+jest.mock('@ever-works/agent/entities', () => ({
+    ActivityActionType: {
+        WORK_CREATED: 'WORK_CREATED',
+        GENERATION: 'GENERATION',
+    },
+    ActivityStatus: { COMPLETED: 'COMPLETED', IN_PROGRESS: 'IN_PROGRESS' },
+}));
+jest.mock('@ever-works/agent/subscriptions', () => ({}));
+jest.mock('@ever-works/agent/activity-log', () => ({}));
+jest.mock('../auth', () => ({
+    AuthService: class {},
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { WorksController } from './works.controller';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+const auth: AuthenticatedUser = { userId: 'auth-1' } as any;
+
+function makeController(overrides: {
+    createWorkResult?: unknown;
+    generateResult?: unknown;
+    generateThrows?: Error;
+}) {
+    const createWork = jest.fn().mockResolvedValue(
+        overrides.createWorkResult ?? {
+            status: 'success',
+            work: { id: 'w-1', slug: 'my-slug', name: 'My Slug' },
+        },
+    );
+    const generateItems = overrides.generateThrows
+        ? jest.fn().mockRejectedValue(overrides.generateThrows)
+        : jest.fn().mockResolvedValue(
+              overrides.generateResult ?? {
+                  status: 'pending',
+                  historyId: 'gen-1',
+                  message: 'Generation started',
+              },
+          );
+
+    const activityLog = { log: jest.fn().mockResolvedValue(undefined) };
+    const authService = { getUser: jest.fn().mockResolvedValue({ id: 'user-1' }) };
+
+    const controller = new WorksController(
+        { wrap: jest.fn() } as any,
+        { typeormAdapter: { deleteUnscopedEntriesLike: jest.fn() } } as any,
+        {} as any,
+        { createWork } as any,
+        { generateItems, updateItemsGenerator: jest.fn(), cancelGeneration: jest.fn() } as any,
+        authService as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        activityLog as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+    );
+
+    return { controller, createWork, generateItems, activityLog, authService };
+}
+
+const baseDto = {
+    slug: 'ai-coding-assistants',
+    name: 'AI Coding Assistants',
+    description: 'A curated directory of AI coding assistants',
+    prompt: 'AI coding assistants directory with reviews and pricing',
+    organization: false,
+};
+
+describe('WorksController.quickCreateWork (EW-617 G4)', () => {
+    it('creates the work then kicks off generation and returns the combined response', async () => {
+        const { controller, createWork, generateItems, activityLog } = makeController({});
+
+        const result = await (controller as any).quickCreateWork(auth, baseDto);
+
+        expect(createWork).toHaveBeenCalledTimes(1);
+        const createDtoArg = createWork.mock.calls[0][0];
+        expect(createDtoArg).toMatchObject({
+            slug: 'ai-coding-assistants',
+            name: 'AI Coding Assistants',
+            description: 'A curated directory of AI coding assistants',
+            organization: false,
+            gitProvider: 'github',
+        });
+        // Prompt is NOT passed to createWork — it belongs in the generator DTO.
+        expect(createDtoArg.prompt).toBeUndefined();
+
+        expect(generateItems).toHaveBeenCalledTimes(1);
+        const [workId, generatorDto, , awaitCompletion] = generateItems.mock.calls[0];
+        expect(workId).toBe('w-1');
+        expect(generatorDto.prompt).toBe(baseDto.prompt);
+        expect(generatorDto.name).toBe(baseDto.name);
+        expect(awaitCompletion).toBe(false);
+
+        expect(result).toEqual({
+            status: 'pending',
+            work: { id: 'w-1', slug: 'my-slug', name: 'My Slug' },
+            generation: { historyId: 'gen-1', message: 'Generation started' },
+        });
+
+        expect(activityLog.log).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: 'user-1',
+                workId: 'w-1',
+                action: 'work.quick_create',
+            }),
+        );
+    });
+
+    it('passes through provider overrides when supplied', async () => {
+        const { controller, createWork } = makeController({});
+
+        await (controller as any).quickCreateWork(auth, {
+            ...baseDto,
+            deployProvider: 'k8s',
+            storageProvider: 'ever-works-git',
+            gitProvider: 'gitlab',
+            websiteTemplateId: 'modern',
+            model: 'claude-3-haiku',
+        });
+
+        expect(createWork).toHaveBeenCalledTimes(1);
+        const createDtoArg = createWork.mock.calls[0][0];
+        expect(createDtoArg.deployProvider).toBe('k8s');
+        expect(createDtoArg.storageProvider).toBe('ever-works-git');
+        expect(createDtoArg.gitProvider).toBe('gitlab');
+        expect(createDtoArg.websiteTemplateId).toBe('modern');
+    });
+
+    it('forwards model to the generator DTO but never to createWork', async () => {
+        const { controller, createWork, generateItems } = makeController({});
+
+        await (controller as any).quickCreateWork(auth, { ...baseDto, model: 'gpt-4o-mini' });
+
+        const generatorDto = generateItems.mock.calls[0][1];
+        expect(generatorDto.model).toBe('gpt-4o-mini');
+        expect(createWork.mock.calls[0][0].model).toBeUndefined();
+    });
+
+    it('throws BadRequestException when createWork returns a non-success status', async () => {
+        const { controller } = makeController({
+            createWorkResult: { status: 'error', work: null },
+        });
+
+        await expect((controller as any).quickCreateWork(auth, baseDto)).rejects.toThrow(
+            BadRequestException,
+        );
+    });
+
+    it('bubbles up generation errors after creating the work (caller polls or retries)', async () => {
+        const { controller, createWork } = makeController({
+            generateThrows: new Error('queue full'),
+        });
+
+        await expect((controller as any).quickCreateWork(auth, baseDto)).rejects.toThrow(
+            'queue full',
+        );
+        // The work was created — caller can retry just the generation step
+        // via POST /works/:id/generate.
+        expect(createWork).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults organization to false when omitted', async () => {
+        const { controller, createWork } = makeController({});
+
+        const dto: any = { ...baseDto };
+        delete dto.organization;
+        await (controller as any).quickCreateWork(auth, dto);
+
+        expect(createWork.mock.calls[0][0].organization).toBe(false);
+    });
+});

--- a/apps/api/src/works/works.controller.ts
+++ b/apps/api/src/works/works.controller.ts
@@ -31,6 +31,7 @@ import {
 } from '@nestjs/swagger';
 import {
     CreateWorkDto,
+    QuickCreateWorkDto,
     UpdateWorkDto,
     UpdateWorkAdvancedPromptsDto,
     CreateCategoryDto,
@@ -307,6 +308,88 @@ export class WorksController {
     async createWork(@CurrentUser() auth: AuthenticatedUser, @Body() createWorkDto: CreateWorkDto) {
         const user = await this.authService.getUser(auth.userId);
         return this.workLifecycleService.createWork(createWorkDto, user);
+    }
+
+    @Post('works/quick-create')
+    @HttpCode(HttpStatus.ACCEPTED)
+    // EW-617 G4: one-call combined create-Work + start-generation for the
+    // wizard's "Generate now" button. Throttled because each call kicks off
+    // an AI pipeline + repo provisioning — same per-IP envelope as the
+    // existing /works/:id/generate path.
+    @Throttle({ default: { limit: 10, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Quick-create + generate a work',
+        description:
+            'Creates a Work using onboarding defaults and immediately kicks off AI item generation in a single request. Returns the new work id + generation history id; the client polls /works/:id/generation-history for status.',
+    })
+    @ApiResponse({ status: 202, description: 'Work created and generation started' })
+    @ApiResponse({ status: 400, description: 'Invalid input data' })
+    @ApiResponse({ status: 409, description: 'Slug already taken' })
+    async quickCreateWork(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() dto: QuickCreateWorkDto,
+    ): Promise<{
+        status: 'pending';
+        work: { id: string; slug: string; name: string };
+        generation: { historyId: string; message: string };
+    }> {
+        const user = await this.authService.getUser(auth.userId);
+
+        // 1. Create the Work via the existing pipeline. Provider defaults
+        //    (storage/deploy/git) are resolved from the user's
+        //    onboardingState inside createWork — no special handling here.
+        const createDto: CreateWorkDto = Object.assign(new CreateWorkDto(), {
+            slug: dto.slug,
+            name: dto.name,
+            description: dto.description,
+            owner: dto.owner,
+            organization: dto.organization ?? false,
+            gitProvider: dto.gitProvider ?? 'github',
+            deployProvider: dto.deployProvider,
+            storageProvider: dto.storageProvider,
+            websiteTemplateId: dto.websiteTemplateId,
+            readmeConfig: dto.readmeConfig,
+        });
+        const created = await this.workLifecycleService.createWork(createDto, user);
+        if (!created || created.status !== 'success' || !created.work) {
+            throw new BadRequestException('Failed to create work');
+        }
+        const work = created.work;
+
+        this.activityLogService
+            .log({
+                userId: user.id,
+                workId: work.id,
+                actionType: ActivityActionType.WORK_CREATED,
+                action: 'work.quick_create',
+                status: ActivityStatus.COMPLETED,
+                summary: `Quick-create kicked off generation for ${work.slug}`,
+            })
+            .catch(() => {});
+
+        // 2. Kick off generation async — the standard generation pipeline
+        //    handles persistence + dispatch.  awaitCompletion=false means
+        //    we return immediately with the historyId for status polling.
+        const generatorDto = Object.assign(new CreateItemsGeneratorDto(), {
+            name: dto.name,
+            prompt: dto.prompt,
+            ...(dto.model ? { model: dto.model } : {}),
+        });
+        const generation = await this.workGenerationService.generateItems(
+            work.id,
+            generatorDto,
+            user,
+            false,
+        );
+
+        return {
+            status: 'pending',
+            work: { id: work.id, slug: work.slug, name: work.name },
+            generation: {
+                historyId: generation.historyId ?? '',
+                message: generation.message ?? 'Generation started',
+            },
+        };
     }
 
     @Get('works/:id')

--- a/apps/web/e2e/zero-friction-flow.spec.ts
+++ b/apps/web/e2e/zero-friction-flow.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * EW-617 — zero-friction prompt → deployed Work E2E.
+ *
+ * Covers the full happy path described in EW-617 acceptance criteria:
+ *
+ *   ever.works/  → prompt textarea → Generate
+ *     ↓ URL fragment hand-off
+ *   app.ever.works/onboarding#prompt=…
+ *     ↓ wizard reads hash, mints anon user, jumps to Generate-now
+ *   POST /api/works/quick-create  →  202 + work.id + generation.historyId
+ *     ↓ poll
+ *   GET /api/works/:id/generation-history  →  status transitions
+ *     ↓
+ *   GET https://<slug>.ever.works/  →  200 (after Cloudflare CNAME + cluster ready)
+ *
+ * Tests are marked `.skip` until every upstream PR has merged:
+ *   #752 G6  · #756 G2  · #757 G3  · #758 G4  · #759 G5  ·
+ *   #760 G8  · #761 G7  ·  ever-works-website#37 G1
+ *
+ * Once those land, flip the `.skip` to `.describe` on the suites you
+ * want active in CI. Each spec uses Playwright's network mocking so
+ * the wizard contract is exercised even before the deploy pipeline is
+ * live in CI environments.
+ */
+
+const APP_URL = process.env.PLAYWRIGHT_APP_URL || 'http://localhost:3000';
+const WEBSITE_URL = process.env.PLAYWRIGHT_WEBSITE_URL || 'http://localhost:4000';
+
+test.describe.skip('EW-617 zero-friction flow — UI surface', () => {
+    test('landing page renders prompt textarea + Generate button', async ({ page }) => {
+        await page.goto(`${WEBSITE_URL}/`);
+        await expect(page.getByTestId('landing-prompt-form')).toBeVisible();
+        await expect(page.getByTestId('landing-prompt-input')).toBeVisible();
+        await expect(page.getByTestId('landing-prompt-submit')).toBeDisabled();
+    });
+
+    test('typing a prompt enables submit and redirects to app with hash fragment', async ({
+        page,
+    }) => {
+        await page.goto(`${WEBSITE_URL}/`);
+        const input = page.getByTestId('landing-prompt-input');
+        await input.fill('AI coding assistants directory');
+        const submit = page.getByTestId('landing-prompt-submit');
+        await expect(submit).toBeEnabled();
+
+        // Capture the navigation target — full-page redirect to app.
+        const [redirected] = await Promise.all([
+            page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+            submit.click(),
+        ]);
+
+        expect(redirected?.url() ?? page.url()).toMatch(
+            /\/onboarding#prompt=AI%20coding%20assistants%20directory$/,
+        );
+    });
+
+    test('wizard mounts on fragment URL and lands on Generate-now step', async ({ page }) => {
+        await page.goto(`${APP_URL}/onboarding#prompt=AI%20coding%20assistants`);
+
+        // The wizard's mount effect (G4) reads the hash, calls setPrompt,
+        // jumps to the final step, and strips the param via
+        // history.replaceState.
+        await expect(page.getByTestId('onboarding-generate-now')).toBeVisible();
+        // URL should no longer contain the prompt param after hydration.
+        await expect(page).toHaveURL(/\/onboarding$/);
+    });
+});
+
+test.describe.skip('EW-617 zero-friction flow — API contract', () => {
+    test('POST /api/auth/anonymous returns 201 + anon user shape', async ({ request }) => {
+        const response = await request.post(`${APP_URL}/api/auth/anonymous`);
+        expect(response.status()).toBe(201);
+        const body = await response.json();
+        expect(body).toMatchObject({
+            access_token: expect.any(String),
+            user: {
+                id: expect.any(String),
+                email: null,
+                username: expect.stringMatching(/^anon-[0-9a-f]{8}$/),
+                isAnonymous: true,
+                anonymousExpiresAt: expect.any(String),
+            },
+        });
+    });
+
+    test('POST /api/auth/anonymous is throttled at 5/hour per IP', async ({ request }) => {
+        // Six rapid requests from the same IP — the 6th MUST be 429.
+        const attempts = await Promise.all(
+            Array.from({ length: 6 }, () => request.post(`${APP_URL}/api/auth/anonymous`)),
+        );
+        const statuses = attempts.map((r) => r.status());
+        // First 5 succeed, 6th hits the throttle.
+        expect(statuses.slice(0, 5).every((s) => s === 201)).toBe(true);
+        expect(statuses[5]).toBe(429);
+    });
+
+    test('POST /api/works/quick-create returns 202 + work + generation.historyId', async ({
+        request,
+    }) => {
+        // Mint an anon session first.
+        const session = await request.post(`${APP_URL}/api/auth/anonymous`).then((r) => r.json());
+
+        const response = await request.post(`${APP_URL}/api/works/quick-create`, {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+            data: {
+                slug: `e2e-${Date.now().toString(36)}`,
+                name: 'E2E AI Coding Assistants',
+                description: 'E2E test work',
+                prompt: 'AI coding assistants',
+                organization: false,
+            },
+        });
+        expect(response.status()).toBe(202);
+        const body = await response.json();
+        expect(body).toMatchObject({
+            status: 'pending',
+            work: {
+                id: expect.any(String),
+                slug: expect.any(String),
+                name: expect.any(String),
+            },
+            generation: {
+                historyId: expect.any(String),
+                message: expect.any(String),
+            },
+        });
+    });
+
+    test('POST /api/auth/claim flips an anon user into a registered one', async ({ request }) => {
+        const session = await request.post(`${APP_URL}/api/auth/anonymous`).then((r) => r.json());
+
+        const suffix = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+        const claim = await request.post(`${APP_URL}/api/auth/claim`, {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+            data: {
+                email: `claim-${suffix}@test.local`,
+                password: 'SecurePass1!',
+            },
+        });
+        expect(claim.status()).toBe(200);
+        const body = await claim.json();
+        expect(body).toMatchObject({
+            id: session.user.id,
+            email: expect.stringMatching(/^claim-/),
+            emailVerified: false,
+        });
+
+        // Re-attempt with the same email should now 409 (a different
+        // anon user trying to claim the same email).
+        const session2 = await request.post(`${APP_URL}/api/auth/anonymous`).then((r) => r.json());
+        const dup = await request.post(`${APP_URL}/api/auth/claim`, {
+            headers: { Authorization: `Bearer ${session2.access_token}` },
+            data: {
+                email: `claim-${suffix}@test.local`,
+                password: 'SecurePass1!',
+            },
+        });
+        expect(dup.status()).toBe(409);
+    });
+});
+
+test.describe.skip('EW-617 zero-friction flow — full UI journey', () => {
+    test('landing → app → Generate now → polling', async ({ page, context }) => {
+        // Block the actual deploy workflow dispatch in this test — we only
+        // want to assert the wizard wiring + API contracts. Real CI runs
+        // the full pipeline in a separate stage.
+        await context.route('**/api/works/quick-create', async (route) => {
+            await route.fulfill({
+                status: 202,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    status: 'pending',
+                    work: { id: 'w-e2e-1', slug: 'ai-coding-assistants', name: 'AI Coding' },
+                    generation: { historyId: 'gen-e2e-1', message: 'Generation started' },
+                }),
+            });
+        });
+
+        // 1. Landing page
+        await page.goto(`${WEBSITE_URL}/`);
+        await page.getByTestId('landing-prompt-input').fill('AI coding assistants');
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+            page.getByTestId('landing-prompt-submit').click(),
+        ]);
+
+        // 2. Wizard auto-hydrates from the URL fragment.
+        await expect(page.getByTestId('onboarding-generate-now')).toBeVisible();
+        await expect(page).toHaveURL(/\/onboarding$/);
+
+        // 3. Generate now — captured by route mock above.
+        await page.getByTestId('onboarding-generate-now').click();
+
+        // 4. Wizard closes (onLeave fires after a successful response).
+        // Assert the modal is gone within the timeout.
+        await expect(page.getByTestId('onboarding-generate-now')).toBeHidden({
+            timeout: 10_000,
+        });
+    });
+});

--- a/apps/web/src/app/actions/works/quick-create.ts
+++ b/apps/web/src/app/actions/works/quick-create.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import {
+    worksAPI,
+    type QuickCreateWorkRequest,
+    type QuickCreateWorkResponse,
+} from '@/lib/api/works';
+import type { ActionResult } from '@/app/actions/plugins';
+
+/**
+ * EW-617 G4 — server action that the wizard's `CreateWorkStep` calls when
+ * the user clicks "Generate now". Mirrors the existing onboarding action
+ * shape (success-or-error envelope) so callers can `if (!result.success)`
+ * uniformly.
+ */
+export async function quickCreateWorkAction(
+    body: QuickCreateWorkRequest,
+): Promise<ActionResult<QuickCreateWorkResponse>> {
+    try {
+        const data = await worksAPI.quickCreate(body);
+        return { success: true, data };
+    } catch (error) {
+        console.error('Failed to quick-create work:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to start generation',
+        };
+    }
+}

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -91,6 +91,44 @@ export function EverWorksOnboardingWizard({
             void completeOnboarding();
         },
     });
+
+    // EW-617 G4 + G1 — landing-page hand-off. When the wizard mounts and
+    // the URL carries `?prompt=…` (or hash `#prompt=…`, used as a poor-man's
+    // signed-token transport), seed the wizard state and jump straight to
+    // the final step so the user sees "Generate now" without scrolling
+    // through choices. We do this once per mount; subsequent renders read
+    // from the persisted state.
+    const promptHydratedRef = useRef(false);
+    useEffect(() => {
+        if (!mounted || promptHydratedRef.current) return;
+        if (flow.state.prompt) {
+            // Already hydrated from server state — no URL work needed.
+            promptHydratedRef.current = true;
+            return;
+        }
+        if (typeof window === 'undefined') return;
+        const url = new URL(window.location.href);
+        const fromQuery = url.searchParams.get('prompt');
+        const fromHash = readHashParam(url.hash, 'prompt');
+        const raw = (fromQuery || fromHash || '').trim();
+        if (!raw) return;
+
+        promptHydratedRef.current = true;
+        flow.setPrompt(raw);
+        // Skip to the final step so the user lands on "Generate now".
+        const createIndex = flow.steps.findIndex((s) => s.kind === 'create-work');
+        if (createIndex >= 0) {
+            flow.jumpTo(createIndex);
+        }
+
+        // Strip the prompt from the URL so a reload doesn't re-trigger the
+        // hand-off (and so we don't leak the prompt to analytics referers).
+        url.searchParams.delete('prompt');
+        if (fromHash) {
+            url.hash = stripHashParam(url.hash, 'prompt');
+        }
+        window.history.replaceState({}, '', url.toString());
+    }, [mounted, flow]);
 
     const refreshConnections = async (pluginId?: string) => {
         const target = pluginId ? plugins.filter((p) => p.pluginId === pluginId) : plugins;
@@ -386,7 +424,40 @@ function StepBody({
                 />
             );
         case 'create-work':
-            return <CreateWorkStep onLeave={() => flow.finish()} />;
+            return (
+                <CreateWorkStep
+                    onLeave={() => flow.finish()}
+                    prompt={flow.state.prompt}
+                    onQuickCreate={
+                        flow.state.prompt
+                            ? async (prompt) => {
+                                  // EW-617 G4: anonymous + claimed users alike
+                                  // can one-click finish. The endpoint reads
+                                  // provider defaults from onboarding state.
+                                  const { quickCreateWorkAction } =
+                                      await import('@/app/actions/works/quick-create');
+                                  const slug = slugifyPrompt(prompt);
+                                  const result = await quickCreateWorkAction({
+                                      slug,
+                                      name: deriveNameFromPrompt(prompt),
+                                      description: prompt.slice(0, 500),
+                                      prompt,
+                                      organization: false,
+                                      deployProvider: flow.state.deploy.choice,
+                                      storageProvider: flow.state.storage.choice,
+                                  });
+                                  if (!result.success) {
+                                      throw new Error(result.error ?? 'Failed to start generation');
+                                  }
+                                  return {
+                                      workSlug: result.data?.work.slug,
+                                      generationHistoryId: result.data?.generation.historyId,
+                                  };
+                              }
+                            : undefined
+                    }
+                />
+            );
         default:
             return null;
     }
@@ -396,6 +467,56 @@ function StepBody({
 
 function isConfigKind(kind: WizardStep['kind']): boolean {
     return kind === 'ai-config' || kind === 'storage-config' || kind === 'deploy-config';
+}
+
+// EW-617 G4: extract `prompt=…` from a URL hash fragment. The landing
+// page (G1) hands off via fragment so the prompt never hits the server
+// access logs as a querystring. We parse defensively; bad input returns
+// `null` and we fall back to the existing /works/new flow.
+function readHashParam(hash: string, key: string): string | null {
+    if (!hash) return null;
+    const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+    try {
+        const params = new URLSearchParams(raw);
+        return params.get(key);
+    } catch {
+        return null;
+    }
+}
+
+function stripHashParam(hash: string, key: string): string {
+    if (!hash) return '';
+    const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+    try {
+        const params = new URLSearchParams(raw);
+        params.delete(key);
+        const remaining = params.toString();
+        return remaining ? `#${remaining}` : '';
+    } catch {
+        return hash;
+    }
+}
+
+// EW-617 G4: derive a DNS-safe slug from the user's prompt.
+// The slug column has the same `^[a-z0-9]+(?:-[a-z0-9]+)*$` constraint
+// as `CreateWorkDto.slug`, so we strip everything else and bound the
+// length. Adds a short timestamp suffix so two users typing the same
+// prompt don't collide.
+function slugifyPrompt(prompt: string): string {
+    const base = prompt
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 40);
+    const suffix = Math.random().toString(36).slice(2, 8);
+    return base ? `${base}-${suffix}` : `quick-${suffix}`;
+}
+
+// Pull the first ~80 chars of the prompt as a display name. Title-cased
+// so it looks like a name in the dashboard list.
+function deriveNameFromPrompt(prompt: string): string {
+    const head = prompt.slice(0, 80).trim();
+    return head.charAt(0).toUpperCase() + head.slice(1);
 }
 
 function pluginIdForStep(

--- a/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
@@ -1,44 +1,117 @@
 'use client';
 
-import { ArrowRight, FolderPlus } from 'lucide-react';
+import { useState } from 'react';
+import { ArrowRight, FolderPlus, Sparkles } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 
 export interface CreateWorkStepProps {
     readonly onLeave: () => void;
+    /**
+     * EW-617 G4: when a prompt is present (from the landing page `?prompt=…`
+     * handoff, or typed into the wizard), this step swaps the
+     * "Create your first work" link for a one-click "Generate now" button.
+     * The button calls `onQuickCreate(prompt)` and shows progress; the
+     * parent owns the API call so this component stays I/O-free.
+     */
+    readonly prompt?: string;
+    readonly onQuickCreate?: (prompt: string) => Promise<{
+        readonly workSlug?: string;
+        readonly generationHistoryId?: string;
+    } | void>;
 }
 
 /**
- * Final step — navigates the user into the Create Work flow. The wizard
- * closes once the user clicks the action; the parent fires the
+ * Final step — either:
+ *  1. (legacy) navigates the user into the /works/new form, or
+ *  2. (EW-617 G4) one-click "Generate now" when a `prompt` is set,
+ *     calling `onQuickCreate(prompt)` which posts to
+ *     `POST /api/works/quick-create` and returns the new work id +
+ *     generation history id for status polling.
+ *
+ * The wizard closes once the action fires; the parent emits the
  * `onboarding_completed` telemetry event and marks the server flag.
  */
-export function CreateWorkStep({ onLeave }: CreateWorkStepProps) {
+export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkStepProps) {
+    const trimmedPrompt = prompt?.trim() ?? '';
+    const hasPrompt = trimmedPrompt.length > 0 && Boolean(onQuickCreate);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleQuickCreate = async () => {
+        if (!onQuickCreate || submitting) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            await onQuickCreate(trimmedPrompt);
+            onLeave();
+        } catch (cause) {
+            const message = cause instanceof Error ? cause.message : String(cause);
+            setError(message || 'Generation failed to start. Please try again.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
     return (
         <div className="space-y-5 max-w-lg">
             <div className="flex items-start gap-4">
                 <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-surface-secondary dark:bg-white/5">
-                    <FolderPlus className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    {hasPrompt ? (
+                        <Sparkles className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    ) : (
+                        <FolderPlus className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    )}
                 </div>
                 <div>
                     <h3 className="text-lg font-semibold text-text dark:text-text-dark">
-                        Create your first work
+                        {hasPrompt ? 'Ready to generate' : 'Create your first work'}
                     </h3>
                     <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
-                        You&apos;re all set. Hit the button below to start building — your choices
-                        above are saved and any new work will pick them up.
+                        {hasPrompt
+                            ? 'We saved your wizard choices. One click and we’ll generate the directory from your prompt — repos, items, and deploy all in one go.'
+                            : "You're all set. Hit the button below to start building — your choices above are saved and any new work will pick them up."}
                     </p>
+                    {hasPrompt ? (
+                        <p className="mt-3 rounded-md border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/30 px-3 py-2 text-sm text-text dark:text-text-dark">
+                            <span className="font-medium">Prompt:</span> {trimmedPrompt}
+                        </p>
+                    ) : null}
                 </div>
             </div>
             <div className="rounded-xl border border-dashed border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/30 p-5">
-                <Link
-                    href={ROUTES.DASHBOARD_WORKS_NEW}
-                    onClick={onLeave}
-                    className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
-                >
-                    Create your first work
-                    <ArrowRight className="w-4 h-4" />
-                </Link>
+                {hasPrompt ? (
+                    <>
+                        <button
+                            type="button"
+                            onClick={handleQuickCreate}
+                            disabled={submitting}
+                            data-testid="onboarding-generate-now"
+                            className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            {submitting ? 'Generating…' : 'Generate now'}
+                            <Sparkles className="w-4 h-4" />
+                        </button>
+                        {error ? (
+                            <p
+                                role="alert"
+                                className="mt-3 text-sm text-red-600 dark:text-red-400"
+                                data-testid="onboarding-generate-error"
+                            >
+                                {error}
+                            </p>
+                        ) : null}
+                    </>
+                ) : (
+                    <Link
+                        href={ROUTES.DASHBOARD_WORKS_NEW}
+                        onClick={onLeave}
+                        className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
+                    >
+                        Create your first work
+                        <ArrowRight className="w-4 h-4" />
+                    </Link>
+                )}
             </div>
         </div>
     );

--- a/apps/web/src/components/onboarding/useOnboardingFlow.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.ts
@@ -71,6 +71,7 @@ type FlowAction =
     | { type: 'setAiChoice'; value: OnboardingAiChoice }
     | { type: 'setStorageChoice'; value: OnboardingStorageChoice }
     | { type: 'setDeployChoice'; value: OnboardingDeployChoice }
+    | { type: 'setPrompt'; value: string }
     | { type: 'recordSkip'; stepId: string }
     | { type: 'setPluginsReviewed'; value: boolean }
     | { type: 'mergeServerState'; value: OnboardingWizardStateV2 }
@@ -124,6 +125,17 @@ function reduce(state: FlowReducerState, action: FlowAction): FlowReducerState {
             return {
                 ...state,
                 state: { ...state.state, deploy: { choice: action.value } },
+            };
+        case 'setPrompt':
+            // EW-617 G4: prompt carried from landing-page input through the
+            // wizard into the quick-create endpoint. Trimmed empty strings
+            // map back to `undefined` so we don't persist whitespace.
+            return {
+                ...state,
+                state: {
+                    ...state.state,
+                    prompt: action.value.trim() || undefined,
+                },
             };
         case 'recordSkip': {
             if (state.state.skippedSteps.includes(action.stepId)) return state;
@@ -181,6 +193,7 @@ export interface UseOnboardingFlowResult {
     readonly setStorageChoice: (value: OnboardingStorageChoice) => void;
     readonly setDeployChoice: (value: OnboardingDeployChoice) => void;
     readonly setPluginsReviewed: (value: boolean) => void;
+    readonly setPrompt: (value: string) => void;
     readonly goNext: () => void;
     readonly goBack: () => void;
     readonly skip: () => void;
@@ -291,6 +304,14 @@ export function useOnboardingFlow({
         [],
     );
 
+    const setPrompt = useCallback(
+        (value: string) => {
+            trackEvent('onboarding_prompt_set', { hasValue: Boolean(value.trim()) });
+            dispatch({ type: 'setPrompt', value });
+        },
+        [trackEvent],
+    );
+
     const refresh = useCallback(() => {
         const stepKind = currentStep?.kind ?? 'welcome';
         trackEvent('onboarding_plugin_refresh_clicked', { stepKind });
@@ -340,6 +361,7 @@ export function useOnboardingFlow({
         setStorageChoice,
         setDeployChoice,
         setPluginsReviewed,
+        setPrompt,
         goNext,
         goBack,
         skip,
@@ -352,7 +374,7 @@ export function useOnboardingFlow({
 
 function stripVersion(state: OnboardingWizardStateV2) {
     // The patch endpoint deep-merges by field; `version` is server-managed.
-    const { lastStep, ai, storage, deploy, skippedSteps, pluginsReviewed } = state;
+    const { lastStep, ai, storage, deploy, skippedSteps, pluginsReviewed, prompt } = state;
     return {
         lastStep,
         ai: { choice: ai.choice },
@@ -360,6 +382,7 @@ function stripVersion(state: OnboardingWizardStateV2) {
         deploy: { choice: deploy.choice },
         skippedSteps: [...skippedSteps],
         pluginsReviewed,
+        ...(prompt ? { prompt } : {}),
     };
 }
 

--- a/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
@@ -165,6 +165,18 @@ describe('reduce', () => {
         expect(next.state.pluginsReviewed).toBe(true);
     });
 
+    // EW-617 G4: prompt round-trip through the reducer.
+    it('setPrompt stores the trimmed value and clears on whitespace-only input', () => {
+        const set = reduce(initialReducerState(), {
+            type: 'setPrompt',
+            value: '  AI coding assistants directory   ',
+        });
+        expect(set.state.prompt).toBe('AI coding assistants directory');
+
+        const cleared = reduce(set, { type: 'setPrompt', value: '   ' });
+        expect(cleared.state.prompt).toBeUndefined();
+    });
+
     it('mergeServerState replaces state and clamps the current step index', () => {
         const start = { ...initialReducerState(), stepIndex: 8 };
         const next = reduce(start, {

--- a/apps/web/src/lib/api/works.ts
+++ b/apps/web/src/lib/api/works.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+import { serverMutation } from './server-api';
+
+/**
+ * EW-617 G4 — server-side client for `POST /api/works/quick-create`.
+ *
+ * Wraps the wizard's "Generate now" button: takes the prompt + the user's
+ * onboarding choices and asks the API to create a Work + start AI
+ * generation in one round-trip. Returns the new work id + the generation
+ * history id so the client can navigate + poll.
+ */
+export interface QuickCreateWorkRequest {
+    readonly slug: string;
+    readonly name: string;
+    readonly description: string;
+    readonly prompt: string;
+    readonly organization?: boolean;
+    readonly owner?: string;
+    readonly gitProvider?: string;
+    readonly deployProvider?: string;
+    readonly storageProvider?: string;
+    readonly websiteTemplateId?: string;
+    readonly model?: string;
+}
+
+export interface QuickCreateWorkResponse {
+    readonly status: 'pending';
+    readonly work: { readonly id: string; readonly slug: string; readonly name: string };
+    readonly generation: { readonly historyId: string; readonly message: string };
+}
+
+export const worksAPI = {
+    quickCreate(body: QuickCreateWorkRequest) {
+        return serverMutation<QuickCreateWorkResponse>({
+            endpoint: '/works/quick-create',
+            data: body,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+};

--- a/apps/web/src/lib/auth/middleware.ts
+++ b/apps/web/src/lib/auth/middleware.ts
@@ -4,17 +4,20 @@ import { getAuthAccessCookie } from './cookies';
 
 export type AuthUser = {
     id: string;
-    email: string;
+    // EW-617 G2: anonymous (zero-friction) users have no email until they
+    // claim the account via POST /api/auth/claim.
+    email: string | null;
     username: string;
     emailVerified: boolean;
     avatar: string | null;
     provider?: string | null;
     isActive?: boolean;
+    isAnonymous?: boolean;
 };
 
 export type JwtPayload = {
     sub: string;
-    email: string;
+    email: string | null;
     provider: string;
     username: string;
     emailVerified: boolean;
@@ -24,6 +27,8 @@ export type JwtPayload = {
     iss: string;
     aud: string;
     exp: number;
+    // EW-617 G2: set to `true` for anonymous JWTs.
+    isAnonymous?: boolean;
 };
 
 function isLikelyJwt(token: string) {

--- a/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
+++ b/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
@@ -1,0 +1,157 @@
+# Zero-friction flow runbook (EW-617)
+
+> Companion to the EW-617 spec series. Lives in the platform repo so
+> it ships with the code; mirrored to
+> `Workspace/knowledge/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md` on
+> the next Workspace sync.
+
+## What's wired up
+
+| Gap | What it does                                      | PR / status                   |
+| --- | ------------------------------------------------- | ----------------------------- |
+| G1  | Landing prompt + URL hand-off                     | ever-works-website#37         |
+| G2  | Anonymous (TTL) users + cleanup task              | platform #756                 |
+| G3  | Claim-account flow                                | platform #757 (stacked on G2) |
+| G4  | Wizard "Generate now" + `/api/works/quick-create` | platform #758                 |
+| G5  | `*.ever.works` subdomain + Cloudflare DNS         | platform #759                 |
+| G6  | Default `deployProvider = 'ever-works'`           | platform #752                 |
+| G7  | Captcha + global caps                             | tracked, follow-up            |
+| G8  | Funnel telemetry + this runbook                   | platform (this PR)            |
+
+## End-to-end demo
+
+```
+1. Open https://ever.works/ in a fresh-incognito window.
+2. Type a directory description into the hero textarea.
+3. Click Generate.
+   → Browser redirects to https://app.ever.works/onboarding#prompt=…
+4. Wizard mounts:
+   - Reads the prompt out of the URL fragment.
+   - Mints a temporary user via POST /api/auth/anonymous (G2).
+   - Jumps to the final "Generate now" step.
+5. Click Generate now.
+   → POST /api/works/quick-create (G4) creates the Work and starts
+     generation. Response: { work, generation.historyId }.
+6. Background: the agent pushes 3 repos to ever-works-cloud (EW-614),
+   the deploy workflow runs (G5), Cloudflare CNAME is provisioned, and
+   the site comes up at https://<slug>.ever.works/.
+7. Optional: post-deploy banner offers Claim Account
+   (POST /api/auth/claim, G3).
+```
+
+## Debugging by stage
+
+Each stage emits a `[zero-friction]` JSON log line via
+`ZeroFrictionFunnelService.emit` (G8). All eight events share a
+`correlationId` so a single `correlationId=…` filter follows one user
+across services. Until the emit call sites land in their respective
+PRs, fall back to the per-component logs below.
+
+### Stage 1 — landing prompt (G1)
+
+- Browser console: form submit posts no XHR; it just sets
+  `window.location.href`. Open Network → Doc to see the redirect.
+- If the form doesn't appear: confirm the website build deployed
+  `LandingPromptForm` — check the rendered HTML in DevTools for
+  `data-testid="landing-prompt-form"`.
+
+### Stage 2 — anon user (G2)
+
+- `POST /api/auth/anonymous` should return 201 with `{ access_token,
+user.isAnonymous: true }`.
+- 429 → the per-IP throttle (5/hour) tripped. Log in or wait.
+- 500 → check `AnonymousAuthService` logs; common cause is the
+  `users` table not yet having `is_anonymous` / `anonymous_expires_at`
+  columns. Run the G2 migration step or set
+  `database.autoMigrate=true` in dev.
+
+### Stage 3 — wizard finished (G4)
+
+- The wizard reads the URL fragment on mount via the
+  `EverWorksOnboardingWizard` effect. If the prompt doesn't pre-fill,
+  the most likely cause is a hash-fragment URL encoding issue — open
+  DevTools and inspect `window.location.hash` before any redirect.
+
+### Stage 4 — work created (G4)
+
+- `POST /api/works/quick-create` returns 202 with `{ status:
+'pending', work, generation }`. The work id from the response is
+  what to use for downstream polling.
+- 400 → slug regex failed. The wizard derives slug from the prompt;
+  if it produced an invalid slug log a bug.
+
+### Stage 5 — repos pushed (EW-614)
+
+- Search `WorkLifecycleService` logs for
+  `EverWorksGitProvider.createRepository` lines. Three repos should be
+  created in `ever-works-cloud`.
+
+### Stage 6 — deploy started (G5)
+
+- `DeployService.deploy` logs the workflow dispatch. The
+  `K8S_INGRESS_HOST` Action variable should be set to
+  `${slug}.ever.works`.
+- Cloudflare CNAME provisioning: search
+  `CloudflareDns CNAME created/updated` in
+  `EverWorksDnsService` logs.
+
+### Stage 7 — deploy ready
+
+- `DeploymentVerifierService` polls the cluster for `Ready`. The site
+  should respond on `https://<slug>.ever.works/` within ~2 min after
+  the workflow finishes.
+
+### Stage 8 — claim account (G3)
+
+- Authenticated `POST /api/auth/claim` with `{ email, password }`.
+  409 → email already taken by a different user.
+  403 → the caller's session is already non-anonymous.
+
+## Rolling back per gap
+
+| Gap | Roll-back                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| G1  | Revert ever-works-website#37 and redeploy the website. The platform side keeps working — wizard hash-hydration is a no-op when no `prompt` is in the URL.    |
+| G2  | Revert platform #756. Existing anonymous rows orphan in the DB; safe to leave (the nightly cleanup task still runs once the schema columns exist).           |
+| G3  | Revert platform #757. Anonymous users stay anonymous; they can sign up normally via `/register`.                                                             |
+| G4  | Revert platform #758. The wizard falls back to the legacy `/works/new` hand-off automatically (the "Generate now" button only renders when `prompt` is set). |
+| G5  | Unset `CLOUDFLARE_API_TOKEN` (or rotate it). `EverWorksDnsService.getProvider()` returns null and the deploy pipeline reverts to the LB hostname fallback.   |
+| G6  | Revert platform #752. New rows go back to defaulting `deployProvider='vercel'`; existing rows are untouched.                                                 |
+| G7  | (Not yet wired.)                                                                                                                                             |
+| G8  | Revert this PR. `[zero-friction]` log lines disappear; nothing else breaks.                                                                                  |
+
+## Configuration cheat-sheet
+
+| Env var                         | Owned by | Notes                                                                     |
+| ------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `ANONYMOUS_USER_TTL_DAYS`       | G2       | Default 7. Garbage values fall back to 7.                                 |
+| `CLOUDFLARE_API_TOKEN`          | G5       | Scoped: DNS:Edit on the `ever.works` zone only. Never the global key.     |
+| `CLOUDFLARE_ZONE_ID`            | G5       | 32-char hex.                                                              |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | G5       | Cluster ingress LB DNS name. Required for DNS automation.                 |
+| `EVER_WORKS_DOMAIN`             | G5       | Defaults to `ever.works`.                                                 |
+| `DEPLOY_EVER_WORKS_ENABLED`     | EW-608   | Gates the `ever-works` deploy provider end-to-end.                        |
+| `NEXT_PUBLIC_APP_URL`           | G1       | Where the landing page sends users. Defaults to `https://app.ever.works`. |
+
+## Dashboards
+
+- PostHog board for the funnel: TBD (G8 wires emit calls; dashboard
+  follow-up).
+- Cloudflare → `ever.works` zone → DNS records: shows the CNAME pool.
+- k8s-works → ingress → `*.ever.works` cert: verify cert-manager is
+  serving the wildcard.
+
+## Known sharp edges
+
+- The 6-char random suffix on quick-create slugs is meant to dodge
+  collisions across users typing the same prompt — but two users
+  hitting the same suffix is still ~one-in-a-million per attempt. The
+  Cloudflare PUT path handles that gracefully (idempotent update) but
+  the platform write hits a unique-constraint error first; ops will
+  see a 409 from `POST /api/works/quick-create`. Resolve by retrying;
+  long-term fix is a stronger suffix or a server-side UUID slug.
+- Anonymous users created during a DB outage that prevented the
+  `users.is_anonymous` column from being created may end up with
+  null email but `isAnonymous=false` (the default). Detection query:
+  `SELECT id FROM users WHERE email IS NULL AND is_anonymous = false`.
+  Repair: set `is_anonymous=true` and seed an `anonymous_expires_at`
+  in the past so the nightly cleanup picks them up.

--- a/docs/specs/features/plugins-capabilities/spec.md
+++ b/docs/specs/features/plugins-capabilities/spec.md
@@ -146,7 +146,7 @@ true`.
   secrets on every dispatch (`TENANT_ID = work.id`, `DATA_REPOSITORY =
 work.getDataRepo()`, `<PROVIDER>_TOKEN = deployToken`, `DEPLOY_TOKEN =
 deployToken`) and one repository variable (`DEPLOY_PROVIDER =
-work.deployProvider || 'vercel'`). `DEPLOY_PROVIDER` is set as a
+work.deployProvider || 'ever-works'`). `DEPLOY_PROVIDER` is set as a
   variable, not a secret, because GitHub Actions templates need it
   available in `if:` conditions.
 - **FR-11** The deploy service MUST set two optional secrets when their

--- a/docs/specs/features/zero-friction-flow/e2e-tests.md
+++ b/docs/specs/features/zero-friction-flow/e2e-tests.md
@@ -1,0 +1,74 @@
+# EW-617 — Zero-friction flow E2E tests
+
+> Parent epic: **EW-617**. Tracks the cross-cutting Playwright suite
+> that exercises the full prompt → deployed Work happy path once all
+> sub-task PRs land.
+
+## Goal
+
+Provide one end-to-end test file that proves the EW-617 acceptance
+criteria from a fresh-incognito browser:
+
+```
+ever.works/  → type prompt → Generate
+  ↓ URL fragment hand-off
+app.ever.works/onboarding#prompt=…
+  ↓ wizard reads hash, mints anon user, jumps to Generate-now
+POST /api/works/quick-create  →  202 + work.id + generation.historyId
+  ↓ poll
+GET /api/works/:id/generation-history  →  status transitions
+  ↓
+GET https://<slug>.ever.works/  →  200 (after CNAME + cluster ready)
+```
+
+## Status
+
+The suite at `apps/web/e2e/zero-friction-flow.spec.ts` is **gated as
+`.skip` in three describes** until the upstream PRs all merge:
+
+| PR                    | Gap                              | Status |
+| --------------------- | -------------------------------- | ------ |
+| #752                  | G6 default deploy provider       | open   |
+| #756                  | G2 anonymous auth                | open   |
+| #757                  | G3 claim-account (stacked on G2) | open   |
+| #758                  | G4 quick-create + wizard         | open   |
+| #759                  | G5 Cloudflare DNS                | open   |
+| #760                  | G8 telemetry + runbook           | open   |
+| #761                  | G7 captcha verifier              | open   |
+| ever-works-website#37 | G1 landing prompt                | open   |
+
+Once each lands, flip the `.skip` on the matching `test.describe` to
+activate it in CI. Each spec uses Playwright's route mocking where
+needed so the wizard contract is exercised even when the deploy
+pipeline isn't live in the CI environment.
+
+## Test sections
+
+1. **UI surface** — landing page renders, submit gating, fragment URL
+   hand-off, wizard hydration.
+2. **API contract** — `POST /api/auth/anonymous` returns the right
+   shape, throttling kicks in at 5/hour, `POST /api/works/quick-create`
+   returns 202 with the right body shape, `POST /api/auth/claim`
+   flips an anon user and rejects duplicate-email collisions with 409.
+3. **Full UI journey** — landing → app → Generate-now → wizard
+   closes. Uses route mocking for the quick-create endpoint so the
+   test runs even when the actual AI pipeline isn't connected.
+
+## Environment
+
+| Var                      | Default                 | Purpose                           |
+| ------------------------ | ----------------------- | --------------------------------- |
+| `PLAYWRIGHT_APP_URL`     | `http://localhost:3000` | The app under test (Next.js dev). |
+| `PLAYWRIGHT_WEBSITE_URL` | `http://localhost:4000` | The website (landing page).       |
+
+Production smoke runs hit `https://app.ever.works` /
+`https://ever.works` — set the envs in the workflow secrets.
+
+## Out of scope
+
+- The actual cluster deploy verification (cert-manager wildcard,
+  Cloudflare propagation) — those run as a separate ops smoke spec
+  outside this E2E suite, on a real cluster + DNS zone.
+- Visual regression of the wizard step — covered separately by
+  Playwright's screenshot snapshots in the existing
+  `dashboard-comprehensive.spec.ts`.

--- a/docs/specs/features/zero-friction-flow/g4-quick-create.md
+++ b/docs/specs/features/zero-friction-flow/g4-quick-create.md
@@ -1,0 +1,77 @@
+# EW-617 G4 — Wizard "Generate now" + `POST /api/works/quick-create`
+
+> Sub-task: **EW-621**. Parent epic: **EW-617**.
+>
+> Companion gaps (separate PRs): G6 #752 (merged-ready), G2 #756 (anon
+> auth), G3 #757 (claim-account), G1/G5/G7/G8 planned.
+
+## Goal
+
+Replace the wizard's hand-off to `/works/new` with a single "Generate now"
+button that creates a Work and starts AI generation in one API call. When
+a prompt is carried over from the landing page (G1), the wizard jumps
+straight to this final step.
+
+## Functional requirements
+
+- **FR-G4-1** `OnboardingWizardStateV2` gains an optional `prompt: string`
+  field, persisted server-side alongside the existing
+  `ai`/`storage`/`deploy` choices. The patch endpoint accepts it via
+  `OnboardingStatePatchRequest.state.prompt`.
+- **FR-G4-2** A new `POST /api/works/quick-create` endpoint (authenticated
+  by `AuthSessionGuard`, throttled 10/min per IP) accepts
+  `QuickCreateWorkDto { slug, name, description, prompt, organization?,
+owner?, gitProvider?, deployProvider?, storageProvider?,
+websiteTemplateId?, model?, readmeConfig? }` and: 1. Calls `WorkLifecycleService.createWork` with the subset that maps to
+  `CreateWorkDto`. Provider defaults (`storage`/`deploy`/`git`) are
+  resolved from the user's onboarding state inside `createWork` — the
+  endpoint forwards explicit overrides only. 2. Calls `WorkGenerationService.generateItems(workId, { name, prompt,
+model? }, user, /*awaitCompletion*/ false)` to dispatch generation
+  asynchronously. 3. Returns `202 Accepted` with `{ status: 'pending', work: { id, slug,
+name }, generation: { historyId, message } }`.
+- **FR-G4-3** When `createWork` returns a non-success status the endpoint
+  MUST throw `BadRequestException` and not attempt to start generation.
+- **FR-G4-4** Generation errors after a successful create MUST bubble up
+  unmodified — the caller can retry generation via
+  `POST /works/:id/generate` against the new work id.
+- **FR-G4-5** `CreateWorkStep` MUST render "Generate now" only when a
+  non-empty `prompt` is available and an `onQuickCreate` callback is
+  passed. Otherwise it renders the legacy "Create your first work" link
+  to `/works/new`. The component MUST be I/O-free; the parent owns the
+  fetch.
+- **FR-G4-6** On wizard mount, the parent MUST read `?prompt=…` from
+  the URL query OR from the `#prompt=…` URL fragment, seed
+  `flow.setPrompt(...)`, jump to the `create-work` step, and strip the
+  parameter from the URL via `history.replaceState`. Fragment transport
+  is preferred (lands client-side only, never hits server logs).
+
+## Non-functional requirements
+
+- **NFR-G4-1** Slug + name derivation on the client MUST be deterministic
+  enough for the server's validation to pass without bouncing: slug is
+  `^[a-z0-9]+(?:-[a-z0-9]+)*$`, max 46 chars, and SHOULD include a short
+  randomized suffix to dodge collisions across users typing the same
+  prompt.
+- **NFR-G4-2** The "Generate now" button MUST disable itself while the
+  request is in flight and surface API errors inline (no global toast)
+  so the user can retry without losing wizard context.
+- **NFR-G4-3** Prompt MUST be bounded to 5000 chars on the wire (matches
+  `CreateItemsGeneratorDto.prompt`).
+
+## Out of scope (other gaps)
+
+- G1 — landing-page input + signed-token URL handoff (EW-618).
+- G3 — claim-account banner shown after a successful quick-create
+  (EW-620, in flight as #757).
+- G7 — captcha / global cap (EW-624).
+- G8 — funnel telemetry for the quick-create event (EW-625).
+
+## Acceptance
+
+- A logged-in (or anonymous, post-G2) user with `prompt` populated on
+  their wizard state can click "Generate now" and receive a 202 with a
+  pending generation history id. Polling `GET
+/works/:id/generation-history` shows the run progressing.
+- Landing on `app.ever.works/onboarding#prompt=AI%20coding%20assistants`
+  drops the user on the `create-work` step with the prompt pre-filled
+  and the URL cleaned to `app.ever.works/onboarding`.

--- a/docs/specs/features/zero-friction-flow/g5-subdomain-dns.md
+++ b/docs/specs/features/zero-friction-flow/g5-subdomain-dns.md
@@ -1,0 +1,106 @@
+# EW-617 G5 — Subdomain ingress + Cloudflare DNS automation
+
+> Sub-task: **EW-622**. Parent epic: **EW-617**. Pairs with platform PRs
+> #752 (G6 default deploy provider), #758 (G4 quick-create).
+
+## Goal
+
+When a Work deploys via the Ever Works pipeline (`deployProvider ===
+'ever-works'`), the platform MUST automatically:
+
+1. Template the Kubernetes ingress host as `${work.slug}.ever.works`
+   (so the work is reachable at a stable subdomain).
+2. Provision a Cloudflare CNAME pointing that hostname at the
+   `k8s-works` cluster ingress load balancer.
+3. Tear the CNAME down when the Work is deleted.
+
+Net effect: a fresh Work with `slug=foo` is reachable at
+`https://foo.ever.works/` within ~2 min of deploy with a wildcard TLS
+cert.
+
+## Functional requirements
+
+- **FR-G5-1** A new `CloudflareDnsProvider` class wraps the Cloudflare
+  v4 REST API. Methods:
+    - `ensureWorkSubdomain(slug)` — idempotent upsert of a CNAME
+      `<slug>.<rootDomain> → <targetHostname>`.
+    - `removeWorkSubdomain(slug)` — best-effort delete; no-op when the
+      record doesn't exist.
+- **FR-G5-2** Slugs that fail `^[a-z0-9]+(?:-[a-z0-9]+)*$` MUST be
+  rejected before any HTTP call (same regex as `CreateWorkDto.slug`).
+- **FR-G5-3** A `EverWorksDnsService` (Nest-injectable) reads env on
+  first use and caches the result. It returns `null` from
+  `getProvider()` when DNS automation is not configured so all
+  consumers can no-op cleanly in dev/preview.
+- **FR-G5-4** `DeployService.deploy()` MUST, when
+  `work.deployProvider === 'ever-works'` AND `dnsService.getProvider()`
+  is non-null:
+    1. Merge `ingressHost = ${slug}.${EVER_WORKS_DOMAIN || 'ever.works'}`
+       into the deploy settings before
+       `plugin.getDeploymentSecrets(settings)` runs (so the k8s plugin
+       picks it up as `K8S_INGRESS_HOST`).
+    2. Fire `dnsService.ensureWorkSubdomain(slug)` asynchronously —
+       errors are logged inside the service so they NEVER abort a
+       deploy.
+    3. Leave settings untouched for non-platform providers (Vercel,
+       user's k8s) AND when DNS env is unset.
+- **FR-G5-5** Authentication MUST be a Bearer token in the
+  `Authorization` header. The token MUST be scoped (Cloudflare API
+  token, DNS:Edit on the `ever.works` zone only — NOT a global API
+  key).
+- **FR-G5-6** All CNAMEs MUST be created with `proxied: false` and
+  `ttl: 1` (auto). The ingress LB handles HTTPS termination via
+  cert-manager + the `*.ever.works` wildcard issuer (ops-managed).
+
+## Non-functional requirements
+
+- **NFR-G5-1** A flaky DNS API MUST NOT block deploys. The original
+  k8s plugin's LB hostname remains a working fallback while the CNAME
+  catches up.
+- **NFR-G5-2** No SDK dependency — the provider uses the global
+  `fetch` (Node 22+) so the bundle stays small and the test harness
+  can inject a mock `fetch`.
+- **NFR-G5-3** All log output MUST be redacted of the API token —
+  never log the `Authorization` header or its value.
+
+## Configuration (operator runbook)
+
+| Env var                         | Required | Description                                               |
+| ------------------------------- | -------- | --------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`          | yes      | Scoped token, **DNS:Edit on the `ever.works` zone only**. |
+| `CLOUDFLARE_ZONE_ID`            | yes      | The `ever.works` zone id (32-char hex).                   |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | yes      | k8s-works ingress LB hostname (e.g. `lb.k8s-works.svc`).  |
+| `EVER_WORKS_DOMAIN`             | no       | Root domain. Defaults to `ever.works`.                    |
+
+When any of the required vars is missing, the provider no-ops cleanly
+— deploys still succeed via the k8s plugin's existing LB hostname.
+
+## Out of scope (other gaps / follow-ups)
+
+- Per-Work custom domain support (e.g. `foo.com → foo.ever.works`).
+  Tracked separately when there's customer demand.
+- DNS automation on Work delete is implemented in
+  `EverWorksDnsService.removeWorkSubdomain` but not yet wired into
+  `WorkLifecycleService.deleteWork` — follow-up sub-task.
+- Cert-manager wildcard issuer install on `k8s-works` is an ops task,
+  not code; documented separately in the cluster runbook.
+
+## Acceptance
+
+- A fresh Work with `slug=foo` and `deployProvider='ever-works'`
+  deploys, and within ~2 min:
+    - `dig CNAME foo.ever.works` returns the configured LB hostname.
+    - `curl -sI https://foo.ever.works/` returns 200 with a valid TLS
+      chain.
+- The same operation a second time (re-deploy) does not create a
+  duplicate record — `ensureWorkSubdomain` is idempotent.
+
+## Tests
+
+- `cloudflare-dns.provider.spec.ts` covers: create-new path, drift
+  detection + PUT update, idempotent already-in-sync path, slug
+  validation, delete + delete-missing, error envelope on 401, Bearer
+  header on every call, `EverWorksDnsService` env caching + override.
+- `deploy.service.spec.ts` extended with three new tests: ingressHost
+  override for ever-works + active DNS, no-override for non-platform
+  providers, no-override when env is unset.

--- a/docs/specs/features/zero-friction-flow/g7-captcha-quotas.md
+++ b/docs/specs/features/zero-friction-flow/g7-captcha-quotas.md
@@ -1,0 +1,104 @@
+# EW-617 G7 — Captcha + global caps
+
+> Sub-task: **EW-624**. Parent epic: **EW-617**.
+
+## Goal
+
+Add a second layer of abuse protection on top of the per-IP throttles
+already in place on `POST /api/auth/anonymous` (G2) and
+`POST /api/works/quick-create` (G4). Two complementary mechanisms:
+
+1. **Captcha** (Cloudflare Turnstile or compatible) gates submissions
+   from the landing page when the platform is under attack or simply
+   when the operator wants belt-and-suspenders coverage.
+2. **Global caps** (hourly + daily, env-configurable) put a hard
+   ceiling on anon-user creates + quick-create deploys regardless of
+   distribution across IPs.
+
+## Functional requirements
+
+- **FR-G7-1** A new `CaptchaVerifierService` POSTs to a provider
+  `/siteverify` endpoint with the server secret + the user-supplied
+  token + the remote IP, and returns a normalized `VerifyResult`. The
+  service is provider-agnostic — Turnstile, hCaptcha, and reCAPTCHA v3
+  all use compatible shapes and we don't read the score (the boolean
+  `success` is enough for our threat model).
+- **FR-G7-2** When `CAPTCHA_PROVIDER` is unset (default in dev /
+  preview), the service short-circuits with `success: true, skipped:
+true` — no HTTP call. The existing per-IP throttles remain the only
+  defense, which is intentional for development ergonomics.
+- **FR-G7-3** When the verifier provider returns an outage (network
+  error / 5xx), the service falls open with `success: true, skipped:
+true, errorCodes: ['verifier-exception']`. **A flaky captcha MUST
+  NOT block legitimate traffic.** Ops can spot the elevated rate via
+  the `skipped: true` log warns.
+- **FR-G7-4** Empty / missing token returns `success: false,
+errorCodes: ['missing-input-response']` without making the network
+  call.
+- **FR-G7-5** Call sites that need captcha verification (currently
+  scoped to the two zero-friction entry points) MUST:
+    1. Read the user-supplied token from a documented header
+       (`x-captcha-token`) or body field (`captchaToken`).
+    2. Call `captchaVerifier.verify({ token, remoteIp })`.
+    3. On `success: false`, return 401 with a JSON body that names the
+       `errorCodes` so the client can re-render the widget.
+
+## Non-functional requirements
+
+- **NFR-G7-1** No SDK dependency — uses the global `fetch` (Node 22+).
+- **NFR-G7-2** Env reads happen exactly once per process; the cache is
+  resettable via `resetCacheForTest()` for unit tests.
+- **NFR-G7-3** Verifier URL is overridable via `CAPTCHA_VERIFY_URL` so
+  staging / preview can mirror the provider on a local proxy when
+  needed.
+
+## Configuration
+
+| Env var              | Required           | Description                                                       |
+| -------------------- | ------------------ | ----------------------------------------------------------------- |
+| `CAPTCHA_PROVIDER`   | yes for production | One of `turnstile`, `hcaptcha`, `recaptcha`. Unset = disabled.    |
+| `CAPTCHA_SECRET`     | yes for production | Provider-side secret token (server-only).                         |
+| `CAPTCHA_VERIFY_URL` | no                 | Override the default verify URL (tests / staging mirrors).        |
+| `CAPTCHA_SITE_KEY`   | (web-side)         | Public site key. Lives on the website / app; not read by the API. |
+
+## Global caps (deferred)
+
+Global caps are documented here for design completeness but are NOT
+wired in this PR. The shape we'll adopt:
+
+- `EVER_WORKS_ANON_GLOBAL_HOURLY_CAP` — total anon-user creates per
+  hour across all IPs. Default unset (no global cap; per-IP throttle
+  applies).
+- `EVER_WORKS_ANON_GLOBAL_DAILY_CAP` — total anon-user creates per
+  day.
+- `EVER_WORKS_QUICK_CREATE_GLOBAL_HOURLY_CAP` — total quick-create
+  invocations per hour.
+
+Implementation will piggyback on `@nestjs/throttler`'s storage
+abstraction so the cap is shared across pods, with Redis as the
+backing store (which we'll need to introduce). Tracked as a follow-up
+sub-task under EW-624.
+
+## Tests
+
+- `captcha-verifier.service.spec.ts` covers:
+    - disabled provider returns success+skipped without an HTTP call,
+    - missing token returns failure with `missing-input-response`,
+    - turnstile success path POSTs to the official URL with the
+      expected body fields,
+    - provider-level `success: false` propagates as a failed verify,
+    - verifier exception falls open with `verifier-exception`,
+    - `CAPTCHA_VERIFY_URL` override is honored,
+    - unknown provider is treated as disabled (defense in depth).
+
+## Out of scope (follow-ups)
+
+- Wire `captchaVerifier.verify(...)` into `POST /api/auth/anonymous`
+  and `POST /api/works/quick-create`. Those endpoints land in #756 /
+  #758 — the wire-up PR depends on both merging first so we don't
+  conflict.
+- Add a captcha widget to the landing form
+  (ever-works-website#37 land first).
+- Wire the global caps (Redis dependency).
+- Configurable failure mode: today the service falls open on
+  verifier outage. Some operators may want a "fail closed" toggle.

--- a/docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md
+++ b/docs/specs/features/zero-friction-flow/g8-telemetry-runbook.md
@@ -1,0 +1,72 @@
+# EW-617 G8 — Funnel telemetry + ops runbook
+
+> Sub-task: **EW-625**. Parent epic: **EW-617**.
+
+## Goal
+
+Make the zero-friction prompt → deployed Work flow observable so we can
+answer:
+
+- How many visitors who type a prompt actually end up with a deployed
+  site? (top-of-funnel conversion)
+- Where do users drop off — at anon-auth, at wizard finish, at deploy?
+- How long does the median Work take from prompt to live URL?
+- How often does claim-account follow within 24 / 72 hours?
+
+## Functional requirements
+
+- **FR-G8-1** A canonical TypeScript schema for funnel events lives in
+  `@ever-works/contracts/telemetry`. Event names are pinned in
+  `ZERO_FRICTION_FUNNEL_EVENTS` and each payload extends
+  `FunnelEventBase` with a numeric `funnelStep` (1..8).
+- **FR-G8-2** A `correlationId` is minted on the landing page (G1) at
+  prompt submit, carried via the URL fragment alongside the prompt,
+  picked up by the wizard (G4) into `OnboardingWizardStateV2.promptCorrelationId`,
+  and reused by every downstream emit through `deploy-ready`.
+  Lets ops trace a single user end-to-end across async task runs.
+- **FR-G8-3** `ZeroFrictionFunnelService.emit(payload)` writes a single
+  structured log line tagged `[zero-friction]` with the full JSON
+  payload. Stage 1 stays log-based so we ship the schema without taking
+  a PostHog/OpenTelemetry dependency; stage 2 swaps the log sink for
+  real telemetry without changing call sites.
+- **FR-G8-4** PII rules: no raw IPs, no raw user agents, no email
+  addresses, no full prompts. `ipPrefix` is `/24` (IPv4) / `/48`
+  (IPv6); `clientKind` is the UA family bucket only.
+
+## Emit sites (one row per funnel step)
+
+| Step | Event                                 | Where to emit                                                         | Status     |
+| ---- | ------------------------------------- | --------------------------------------------------------------------- | ---------- |
+| 1    | `zero_friction.landing_prompt_submit` | website: `LandingPromptForm.onSubmit`                                 | wiring TBD |
+| 2    | `zero_friction.anon_user_created`     | platform: `AnonymousAuthService.createAnonymousUser`                  | wiring TBD |
+| 3    | `zero_friction.wizard_finished`       | platform: `EverWorksOnboardingWizard` (just before quick-create call) | wiring TBD |
+| 4    | `zero_friction.work_created`          | platform: `WorksController.quickCreateWork` (after `createWork`)      | wiring TBD |
+| 5    | `zero_friction.repos_pushed`          | platform: `WorkLifecycleService.createWork` (EW-614 path)             | wiring TBD |
+| 6    | `zero_friction.deploy_started`        | platform: `DeployService.deploy` (right before workflow dispatch)     | wiring TBD |
+| 7    | `zero_friction.deploy_ready`          | platform: `DeploymentVerifierService` (poll succeeds)                 | wiring TBD |
+| 8    | `zero_friction.claim_account`         | platform: `ClaimAccountService.claim` (on success)                    | wiring TBD |
+
+"wiring TBD" means the schema + service exist; the actual
+`funnelService.emit(...)` call sites are deliberately deferred so each
+upstream PR (#756 G2, #757 G3, #758 G4, #759 G5, ever-works-website#37
+G1) can add its emit independently without merge conflicts.
+
+## Ops runbook
+
+The runbook proper — how to demo, debug, and roll back each gap —
+lives at `docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md` (this PR).
+It's mirrored to `Workspace/knowledge/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md`
+on the next Workspace sync so it shows up in the bot's runbook index.
+
+## Tests
+
+- `zero-friction-funnel.service.spec.ts` (3 tests): single-line JSON
+  log output, timestamp back-fill when caller omits it, fallback
+  key=value line when JSON.stringify throws on a circular payload.
+
+## Out of scope (follow-ups)
+
+- Wire the actual `emit(...)` call sites — done in the matching PRs
+  (#756/#757/#758/#759/ever-works-website#37) as they land.
+- PostHog dashboard JSON + alert rules.
+- OpenTelemetry exporter (replaces the log sink in stage 2).

--- a/docs/specs/features/zero-friction-flow/spec.md
+++ b/docs/specs/features/zero-friction-flow/spec.md
@@ -1,0 +1,117 @@
+# Zero-friction prompt → deployed Work flow
+
+> Epic: **EW-617** &nbsp;|&nbsp; Sub-tasks: EW-618 (G1), EW-619 (G2), EW-620 (G3), EW-621 (G4), EW-622 (G5), EW-623 (G6), EW-624 (G7), EW-625 (G8)
+>
+> Status: G6 merged (#752). G2 in-flight (this PR).
+
+## Goal
+
+A first-time visitor lands on `https://ever.works/`, types a prompt
+describing the website / directory they want, clicks **Generate**, and
+ends up on `https://app.ever.works/` already signed in as an
+**anonymous / temporary user**. The Onboarding Wizard auto-runs with
+all defaults; a single **Generate now** button creates the Work, which
+is then:
+
+- Published as 3 **private** repos under the `ever-works-cloud` GitHub org
+- Deployed to **k8s-works** with auto-provisioned DNS + TLS
+- Served at `https://{slug}.ever.works/`
+
+**The user provides nothing — not even an email — to try the platform
+end-to-end.** Later they can _Claim Account_ and attach credentials to
+keep their Work.
+
+## Gap breakdown
+
+Each gap is tracked as a sub-task under EW-617 and shipped as its own
+PR.
+
+| #  | Title                                                          | Jira    | Status   |
+|----|----------------------------------------------------------------|---------|----------|
+| G1 | Landing-page prompt input + handoff to app.ever.works          | EW-618  | Planned  |
+| G2 | Anonymous / temporary user auth                                | EW-619  | This PR  |
+| G3 | Claim-Account flow (anon → registered)                         | EW-620  | Planned  |
+| G4 | Wizard "Finish & Generate with Defaults" + `/api/works/quick-create` | EW-621 | Planned |
+| G5 | Subdomain ingress + Cloudflare DNS automation                  | EW-622  | Planned  |
+| G6 | Default `work.deployProvider` `'vercel'` → `'ever-works'`      | EW-623  | Merged (#752) |
+| G7 | Quotas + abuse protection                                      | EW-624  | Planned  |
+| G8 | Telemetry events + ops runbook                                 | EW-625  | Planned  |
+
+## G2 — Anonymous / temporary user auth
+
+### Functional requirements
+
+- **FR-G2-1** The `users` table MUST allow `email` and `password` to be
+  NULL when `is_anonymous = true`. Existing rows are unaffected.
+- **FR-G2-2** Two new columns on `users`: `is_anonymous BOOLEAN`
+  (default `false`) and `anonymous_expires_at TIMESTAMPTZ` (nullable).
+- **FR-G2-3** `POST /api/auth/anonymous` MUST mint a fresh `User` row
+  with `is_anonymous=true`, `email=NULL`, `password=NULL`,
+  `registration_provider='anonymous'`, `anonymous_expires_at = now +
+  ANONYMOUS_USER_TTL_DAYS` (default 7), then issue an `AuthSession`
+  token and return `{ access_token, user }` in the same shape as
+  `POST /api/auth/register`.
+- **FR-G2-4** `POST /api/auth/anonymous` MUST be rate-limited per IP
+  (default: 5 requests per hour). EW-624 (G7) will harden this with
+  captcha + global caps.
+- **FR-G2-5** The `AuthenticatedUser` type used downstream MUST carry
+  an optional `isAnonymous` flag so services can gate behavior
+  (quota path, claim-account UI, OAuth-only endpoints).
+- **FR-G2-6** Existing endpoints guarded by `AuthSessionGuard` MUST
+  accept anonymous session tokens — no guard changes are required
+  because the guard already issues a session regardless of identity.
+  Services that require a real email (e.g. transactional mail) MUST
+  reject anonymous users explicitly.
+- **FR-G2-7** A nightly Trigger.dev schedule `anonymous-user-cleanup`
+  (cron `17 3 * * *`) MUST find users with `is_anonymous=true AND
+  anonymous_expires_at < now` and delete them. The existing `work.user`
+  `ON DELETE CASCADE` removes their Works. A single delete failure
+  MUST log + continue so one stuck row cannot block the batch.
+- **FR-G2-8** The web-side `JwtPayload` type MUST expose `isAnonymous`
+  so layouts/components can render the claim-account nag.
+
+### Non-functional requirements
+
+- **NFR-G2-1** Anonymous user creation MUST be a single round-trip; no
+  Better Auth signup ceremony, no email verification mail.
+- **NFR-G2-2** Generated `username` MUST be DNS-/log-safe and not leak
+  IP/UA: pattern `anon-<8 hex chars>`.
+- **NFR-G2-3** `User.asCommitter()` MUST keep returning a parseable
+  email even when both `email` and `committerEmail` are null — fallback
+  to `anon-<userId>@anonymous.ever.works`. Real commits MUST NOT happen
+  on this fallback (claim-account flow lands before any repo write).
+
+### Out of scope (deferred to other gaps)
+
+- Landing-page prompt UI (G1).
+- Claim-account endpoint (G3).
+- Quick-create wizard (G4).
+- Subdomain DNS (G5).
+- Captcha / abuse hardening (G7).
+- Telemetry event emission (G8).
+
+## Acceptance (E2E, after all gaps land)
+
+A fresh-incognito user, with no account, no GitHub, no Vercel
+connection, no email:
+
+1. Lands on `https://ever.works/`.
+2. Types "AI coding assistants directory" into the prompt input.
+3. Clicks **Generate**.
+4. Is redirected to `https://app.ever.works/onboarding` already signed
+   in as an anonymous user.
+5. Wizard auto-completes with all defaults; user clicks one
+   **Generate now** button.
+6. Within ~3 min, 3 private repos appear in `ever-works-cloud` GitHub
+   org.
+7. Within ~5 min, `https://ai-coding-assistants.ever.works/` serves the
+   generated site over HTTPS.
+8. Optional: clicks **Claim account**, enters email + password, keeps
+   the Work.
+
+## References
+
+- Audit + gap breakdown: `EW-617`.
+- Wizard v2 defaults: `docs/specs/features/onboarding-wizard-v2/spec.md`.
+- `ever-works-cloud` org PAT lifecycle: `EW-614`.
+- k8s-works deploy pipeline: `docs/specs/features/k8s-deployment/`.

--- a/docs/specs/features/zero-friction-flow/spec.md
+++ b/docs/specs/features/zero-friction-flow/spec.md
@@ -2,7 +2,7 @@
 
 > Epic: **EW-617** &nbsp;|&nbsp; Sub-tasks: EW-618 (G1), EW-619 (G2), EW-620 (G3), EW-621 (G4), EW-622 (G5), EW-623 (G6), EW-624 (G7), EW-625 (G8)
 >
-> Status: G6 merged (#752). G2 in-flight (this PR).
+> Status: G6 merged (#752). G2 PR #756 open. G3 (this PR) builds on G2.
 
 ## Goal
 
@@ -30,12 +30,54 @@ PR.
 |----|----------------------------------------------------------------|---------|----------|
 | G1 | Landing-page prompt input + handoff to app.ever.works          | EW-618  | Planned  |
 | G2 | Anonymous / temporary user auth                                | EW-619  | This PR  |
-| G3 | Claim-Account flow (anon → registered)                         | EW-620  | Planned  |
+| G3 | Claim-Account flow (anon → registered)                         | EW-620  | This PR  |
 | G4 | Wizard "Finish & Generate with Defaults" + `/api/works/quick-create` | EW-621 | Planned |
 | G5 | Subdomain ingress + Cloudflare DNS automation                  | EW-622  | Planned  |
 | G6 | Default `work.deployProvider` `'vercel'` → `'ever-works'`      | EW-623  | Merged (#752) |
 | G7 | Quotas + abuse protection                                      | EW-624  | Planned  |
 | G8 | Telemetry events + ops runbook                                 | EW-625  | Planned  |
+
+## G3 — Claim-Account flow (anonymous → registered)
+
+### Functional requirements
+
+- **FR-G3-1** `POST /api/auth/claim` MUST require an authenticated
+  session (via `AuthSessionGuard`) and MUST reject (403) when the
+  caller's `User` row is not `is_anonymous = true`. This prevents
+  hijacking an already-registered account.
+- **FR-G3-2** The endpoint accepts `{ email, password, username?,
+  emailVerificationCallbackUrl? }` (validated by `ClaimAccountDto`
+  with the same password rules as `RegisterDto`).
+- **FR-G3-3** If `email` (normalized to lowercase, trimmed) matches a
+  different existing user, the endpoint MUST return 409 Conflict.
+  Auto-merging is intentionally forbidden — it's a footgun. The
+  client UI should redirect to `/login` instead.
+- **FR-G3-4** On success the service MUST in a single update set
+  `email`, `username` (defaulting to the existing anon username),
+  `password` (hash), `is_anonymous=false`, clear
+  `anonymous_expires_at`, set `registration_provider='local'`, reset
+  `email_verified=false`.
+- **FR-G3-5** A verification email MUST be triggered via
+  `AuthService.sendVerificationEmail` so the existing pipeline
+  (`UserCreatedEvent` → `MailService`) handles it. A failure to send
+  MUST NOT roll back the claim — the user can request resend via
+  `POST /api/auth/send-verification`.
+- **FR-G3-6** The caller's existing session token MUST stay valid.
+  Works ownership is by `user_id`, which doesn't change, so no Work
+  transfer is needed.
+- **FR-G3-7** The endpoint MUST be throttled (default: 10/hour per
+  IP) to dampen email-squatting brute force.
+
+### Non-functional requirements
+
+- **NFR-G3-1** Email comparison MUST be case-insensitive and
+  whitespace-trimmed.
+- **NFR-G3-2** Password hashing MUST go through the same Better Auth
+  credential adapter used by `/register` so `/login` works without
+  any additional sync step.
+- **NFR-G3-3** When username is omitted the existing `anon-<hex>`
+  value is kept rather than auto-derived from email — the user can
+  edit it via `PUT /api/auth/profile` later.
 
 ## G2 — Anonymous / temporary user auth
 

--- a/packages/agent/src/account-transfer/github-sync.service.ts
+++ b/packages/agent/src/account-transfer/github-sync.service.ts
@@ -137,7 +137,10 @@ export class GitHubSyncService {
             });
 
             const user = await this.userRepository.findById(userId);
-            const committer = user ? { name: user.username, email: user.email } : undefined;
+            const committer =
+                user && user.email
+                    ? { name: user.username, email: user.email }
+                    : undefined;
 
             // Clone or pull the repo
             const dir = await this.gitFacade.cloneOrPull(
@@ -182,7 +185,10 @@ export class GitHubSyncService {
 
         try {
             const user = await this.userRepository.findById(userId);
-            const committer = user ? { name: user.username, email: user.email } : undefined;
+            const committer =
+                user && user.email
+                    ? { name: user.username, email: user.email }
+                    : undefined;
 
             const dir = await this.gitFacade.cloneOrPull(
                 { owner: config.repoOwner, repo: config.repoName, committer },
@@ -227,7 +233,10 @@ export class GitHubSyncService {
 
         try {
             const user = await this.userRepository.findById(userId);
-            const committer = user ? { name: user.username, email: user.email } : undefined;
+            const committer =
+                user && user.email
+                    ? { name: user.username, email: user.email }
+                    : undefined;
 
             const dir = await this.gitFacade.cloneOrPull(
                 { owner: config.repoOwner, repo: config.repoName, committer },

--- a/packages/agent/src/database/repositories/user.repository.ts
+++ b/packages/agent/src/database/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, LessThan, Repository } from 'typeorm';
 import { User } from '../../entities/user.entity';
 import { config } from '../../config';
 import { randomUUID } from 'node:crypto';
@@ -57,6 +57,30 @@ export class UserRepository {
         );
 
         return (result.affected || 0) > 0;
+    }
+
+    /**
+     * EW-617 G2: anonymous user TTL cleanup.
+     * Returns all rows where `isAnonymous=true AND anonymousExpiresAt < now`.
+     * Caller (Trigger.dev nightly task) is expected to delete them; ON DELETE
+     * CASCADE on `work.userId` removes the orphan Works.
+     */
+    async findExpiredAnonymous(now: Date = new Date()): Promise<User[]> {
+        return await this.repository.find({
+            where: {
+                isAnonymous: true,
+                anonymousExpiresAt: LessThan(now),
+            },
+        });
+    }
+
+    /**
+     * EW-617 G2: hard-delete an anonymous user. Cascades to its Works via
+     * `work.user` ON DELETE CASCADE. Safe to call only after the row has been
+     * verified `isAnonymous=true` to avoid wiping a real account by mistake.
+     */
+    async deleteAnonymous(id: string): Promise<void> {
+        await this.repository.delete({ id, isAnonymous: true });
     }
 
     async createOrGetLocalUser(): Promise<User> {

--- a/packages/agent/src/dto/index.ts
+++ b/packages/agent/src/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './create-work.dto';
+export * from './quick-create-work.dto';
 export * from './generate-data.dto';
 export * from './update-work.dto';
 export * from './work-advanced-prompts.dto';

--- a/packages/agent/src/dto/quick-create-work.dto.ts
+++ b/packages/agent/src/dto/quick-create-work.dto.ts
@@ -1,0 +1,131 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+    IsBoolean,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    Matches,
+    MaxLength,
+    ValidateNested,
+} from 'class-validator';
+import { MarkdownReadmeConfigDto } from './create-work.dto';
+import { sanitizeDescription, sanitizeName, sanitizePrompt } from '../utils/sanitize.util';
+
+/**
+ * EW-617 G4 — payload for `POST /api/works/quick-create`.
+ *
+ * Combines the fields needed to create a Work (subset of
+ * `CreateWorkDto`) plus a `prompt` so the server can kick off AI
+ * generation in the same request. The wizard's "Generate now" button
+ * sends this; the response carries both the new `workId` and the
+ * `generationHistoryId` the client polls.
+ *
+ * Provider defaults (storage/deploy/git) are read from the user's
+ * `onboardingState` server-side, so the client doesn't need to repeat
+ * the wizard choices here. Override only when the user picked something
+ * non-default (e.g. user-github with their own repo).
+ */
+export class QuickCreateWorkDto {
+    @ApiProperty({
+        description: 'URL-friendly identifier (lowercase letters, numbers, hyphens only)',
+        example: 'ai-coding-assistants',
+    })
+    @IsString()
+    @IsNotEmpty()
+    @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+        message: 'Slug can only contain lowercase letters, numbers, and hyphens',
+    })
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    slug: string;
+
+    @ApiProperty({
+        description: 'Display name for the work',
+        example: 'AI Coding Assistants',
+        maxLength: 100,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    @Transform(({ value }) => (typeof value === 'string' ? sanitizeName(value, 100) : value))
+    name: string;
+
+    @ApiProperty({
+        description: 'Brief description of the work',
+        maxLength: 500,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(500)
+    @Transform(({ value }) => (typeof value === 'string' ? sanitizeDescription(value, 500) : value))
+    description: string;
+
+    @ApiProperty({
+        description: 'Generation prompt — the user input from the landing page or wizard',
+        example: 'AI coding assistants directory with reviews and pricing',
+        maxLength: 5000,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(5000)
+    @Transform(({ value }) => (typeof value === 'string' ? sanitizePrompt(value, 5000) : value))
+    prompt: string;
+
+    @ApiPropertyOptional({ description: 'Whether the owner is an organization' })
+    @IsOptional()
+    @IsBoolean()
+    organization?: boolean;
+
+    @ApiPropertyOptional({ description: 'Repository owner (defaults to user)' })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    owner?: string;
+
+    @ApiPropertyOptional({
+        description: 'Override the git provider (default: from onboarding state, then "github")',
+    })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    gitProvider?: string;
+
+    @ApiPropertyOptional({
+        description: 'Override deploy provider (default: from onboarding state, then "ever-works")',
+    })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    deployProvider?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Override storage provider (default: from onboarding state, then "user-github")',
+    })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    storageProvider?: string;
+
+    @ApiPropertyOptional({ description: 'Website template identifier (default: "classic")' })
+    @IsOptional()
+    @IsString()
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    websiteTemplateId?: string;
+
+    @ApiPropertyOptional({
+        description: 'AI model override (defaults to the provider plugin default)',
+    })
+    @IsOptional()
+    @IsString()
+    model?: string;
+
+    @ApiPropertyOptional({
+        description: 'Optional README configuration',
+        type: MarkdownReadmeConfigDto,
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => MarkdownReadmeConfigDto)
+    readmeConfig?: MarkdownReadmeConfigDto;
+}

--- a/packages/agent/src/entities/user.entity.ts
+++ b/packages/agent/src/entities/user.entity.ts
@@ -39,14 +39,28 @@ export class User {
     @Column()
     username: string;
 
-    @Column({ unique: true })
-    email: string;
+    // EW-617 G2: anonymous (zero-friction) users have no email/password until
+    // they claim the account via POST /api/auth/claim. Existing rows keep
+    // their non-null values; new anonymous rows persist NULLs here.
+    @Column({ unique: true, nullable: true })
+    email: string | null;
 
-    @Column()
-    password: string;
+    @Column({ nullable: true })
+    password: string | null;
 
     @Column({ default: 'local' })
-    registrationProvider: string; // 'local', 'github', 'google' - how user initially signed up
+    registrationProvider: string; // 'local', 'github', 'google', 'anonymous' - how user initially signed up
+
+    // EW-617 G2: zero-friction anonymous users.
+    // `isAnonymous=true` rows have nullable email/password and live until
+    // `anonymousExpiresAt`. The nightly cleanup task deletes expired rows
+    // and cascades to their Works. Claim-account flow flips this to false
+    // and clears the TTL.
+    @Column({ default: false })
+    isAnonymous: boolean;
+
+    @TimestampColumn({ nullable: true })
+    anonymousExpiresAt?: Date | null;
 
     @Column({ nullable: true })
     avatar: string;
@@ -138,9 +152,14 @@ export class User {
     local: boolean = false;
 
     asCommitter(): { name: string; email: string } {
+        // Anonymous users have null email; only happens before claim-account.
+        // Repo-touching paths (git commit, deploy) require a real email, so
+        // we surface a parseable but obviously-synthetic address that won't
+        // collide with anything real and signals 'fix before commit'.
+        const fallbackEmail = `anon-${this.id}@anonymous.ever.works`;
         return {
             name: this.committerName || this.username,
-            email: this.committerEmail || this.email,
+            email: this.committerEmail || this.email || fallbackEmail,
         };
     }
 }

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -64,7 +64,7 @@ export class Work {
     @Column({ default: 'user-github' })
     storageProvider: string; // 'ever-works-git' | 'user-github' | 'user-gitlab' | 'user-git'
 
-    @Column({ default: 'vercel', nullable: true })
+    @Column({ default: 'ever-works', nullable: true })
     deployProvider?: string; // 'ever-works' | 'vercel' | 'k8s' | 'netlify' | ...
 
     @Column({ nullable: true })

--- a/packages/agent/src/ever-works-providers/__tests__/cloudflare-dns.provider.spec.ts
+++ b/packages/agent/src/ever-works-providers/__tests__/cloudflare-dns.provider.spec.ts
@@ -1,0 +1,269 @@
+import {
+    CloudflareDnsError,
+    CloudflareDnsProvider,
+    EverWorksDnsService,
+} from '../cloudflare-dns.provider';
+
+describe('CloudflareDnsProvider (EW-617 G5)', () => {
+    type FetchCall = { url: string; init: RequestInit };
+
+    function buildProvider(
+        opts: {
+            listResult?: any[];
+            createResult?: any;
+            updateResult?: any;
+            deleteOk?: boolean;
+            deleteStatus?: number;
+            deleteBody?: any;
+        } = {},
+    ) {
+        const calls: FetchCall[] = [];
+        const fakeFetch = jest.fn(async (url: string, init: RequestInit) => {
+            calls.push({ url, init });
+            const method = (init.method ?? 'GET').toUpperCase();
+            if (method === 'GET' && url.includes('/dns_records?')) {
+                return new Response(
+                    JSON.stringify({ success: true, result: opts.listResult ?? [] }),
+                    { status: 200 },
+                );
+            }
+            if (method === 'POST' && url.endsWith('/dns_records')) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: opts.createResult ?? {
+                            id: 'rec-new',
+                            type: 'CNAME',
+                            name: JSON.parse(init.body as string).name,
+                            content: JSON.parse(init.body as string).content,
+                        },
+                    }),
+                    { status: 200 },
+                );
+            }
+            if (method === 'PUT' && url.includes('/dns_records/')) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: opts.updateResult ?? {
+                            id: 'rec-existing',
+                            type: 'CNAME',
+                            name: JSON.parse(init.body as string).name,
+                            content: JSON.parse(init.body as string).content,
+                        },
+                    }),
+                    { status: 200 },
+                );
+            }
+            if (method === 'DELETE' && url.includes('/dns_records/')) {
+                if (opts.deleteOk === false) {
+                    return new Response(
+                        JSON.stringify({
+                            success: false,
+                            errors: opts.deleteBody ?? [{ code: 7003, message: 'no route' }],
+                        }),
+                        { status: opts.deleteStatus ?? 404 },
+                    );
+                }
+                return new Response(JSON.stringify({ success: true, result: { id: 'x' } }), {
+                    status: 200,
+                });
+            }
+            throw new Error(`Unexpected fetch ${method} ${url}`);
+        }) as any;
+
+        const provider = new CloudflareDnsProvider(
+            {
+                apiToken: 'tk',
+                zoneId: 'zone1',
+                rootDomain: 'ever.works',
+                targetHostname: 'k8s.lb.example',
+            },
+            fakeFetch,
+        );
+
+        return { provider, calls, fakeFetch };
+    }
+
+    it('creates a fresh CNAME when no record exists', async () => {
+        const { provider, calls } = buildProvider({ listResult: [] });
+        const result = await provider.ensureWorkSubdomain('ai-coding');
+
+        expect(result.name).toBe('ai-coding.ever.works');
+        expect(result.content).toBe('k8s.lb.example');
+        expect(calls).toHaveLength(2);
+        expect(calls[0].url).toContain('name=ai-coding.ever.works');
+        expect(calls[0].init.method).toBe('GET');
+        expect(calls[1].init.method).toBe('POST');
+        const body = JSON.parse(calls[1].init.body as string);
+        expect(body).toMatchObject({
+            type: 'CNAME',
+            name: 'ai-coding.ever.works',
+            content: 'k8s.lb.example',
+            proxied: false,
+            ttl: 1,
+        });
+    });
+
+    it('returns the existing record when content already matches', async () => {
+        const { provider, calls } = buildProvider({
+            listResult: [
+                {
+                    id: 'rec-existing',
+                    type: 'CNAME',
+                    name: 'ai-coding.ever.works',
+                    content: 'k8s.lb.example',
+                },
+            ],
+        });
+        const result = await provider.ensureWorkSubdomain('ai-coding');
+        expect(result.id).toBe('rec-existing');
+        // GET only — no POST/PUT.
+        expect(calls).toHaveLength(1);
+        expect(calls[0].init.method).toBe('GET');
+    });
+
+    it('PUTs an updated CNAME when the content drifted from target', async () => {
+        const { provider, calls } = buildProvider({
+            listResult: [
+                {
+                    id: 'rec-drifted',
+                    type: 'CNAME',
+                    name: 'ai-coding.ever.works',
+                    content: 'old.lb.example',
+                },
+            ],
+        });
+        const result = await provider.ensureWorkSubdomain('ai-coding');
+        expect(calls.map((c) => c.init.method)).toEqual(['GET', 'PUT']);
+        expect(calls[1].url).toContain('/dns_records/rec-drifted');
+        expect(result.content).toBe('k8s.lb.example');
+    });
+
+    it('rejects slugs that fail the DNS-safe regex', async () => {
+        const { provider } = buildProvider();
+        await expect(provider.ensureWorkSubdomain('NOT_OK')).rejects.toThrow(/Invalid slug/);
+    });
+
+    it('no-ops when removing a non-existent record', async () => {
+        const { provider, calls } = buildProvider({ listResult: [] });
+        await expect(provider.removeWorkSubdomain('gone')).resolves.toBeUndefined();
+        expect(calls).toHaveLength(1);
+        expect(calls[0].init.method).toBe('GET');
+    });
+
+    it('deletes the record when one exists', async () => {
+        const { provider, calls } = buildProvider({
+            listResult: [
+                {
+                    id: 'rec-to-go',
+                    type: 'CNAME',
+                    name: 'foo.ever.works',
+                    content: 'old.lb',
+                },
+            ],
+        });
+        await provider.removeWorkSubdomain('foo');
+        expect(calls.map((c) => c.init.method)).toEqual(['GET', 'DELETE']);
+        expect(calls[1].url).toContain('/dns_records/rec-to-go');
+    });
+
+    it('throws CloudflareDnsError on a non-success API response', async () => {
+        const fakeFetch = jest.fn(
+            async () =>
+                new Response(JSON.stringify({ success: false, errors: [{ code: 10000 }] }), {
+                    status: 401,
+                }),
+        ) as any;
+        const provider = new CloudflareDnsProvider(
+            { apiToken: 'bad', zoneId: 'z', rootDomain: 'ever.works', targetHostname: 'lb' },
+            fakeFetch,
+        );
+        await expect(provider.ensureWorkSubdomain('x')).rejects.toThrow(CloudflareDnsError);
+    });
+
+    it('sends bearer authorization on every request', async () => {
+        const { provider, calls } = buildProvider({ listResult: [] });
+        await provider.ensureWorkSubdomain('ai-coding');
+        for (const c of calls) {
+            expect((c.init.headers as Record<string, string>).Authorization).toBe('Bearer tk');
+        }
+    });
+});
+
+describe('EverWorksDnsService (EW-617 G5)', () => {
+    const ENV_KEYS = [
+        'CLOUDFLARE_API_TOKEN',
+        'CLOUDFLARE_ZONE_ID',
+        'EVER_WORKS_DOMAIN',
+        'EVER_WORKS_DEPLOY_LB_HOSTNAME',
+    ] as const;
+
+    const previous: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        for (const k of ENV_KEYS) {
+            previous[k] = process.env[k];
+            delete process.env[k];
+        }
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (previous[k] === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = previous[k];
+            }
+        }
+    });
+
+    it('returns null from getProvider() when env is unset (dev / preview)', () => {
+        const svc = new EverWorksDnsService();
+        expect(svc.getProvider()).toBeNull();
+    });
+
+    it('caches the null result so we do not re-read env per call', () => {
+        const svc = new EverWorksDnsService();
+        const a = svc.getProvider();
+        const b = svc.getProvider();
+        expect(a).toBe(b);
+        expect(a).toBeNull();
+    });
+
+    it('builds a provider once env is fully configured', () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'tk';
+        process.env.CLOUDFLARE_ZONE_ID = 'zone1';
+        process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'k8s.lb.example';
+
+        const svc = new EverWorksDnsService();
+        const provider = svc.getProvider();
+        expect(provider).toBeInstanceOf(CloudflareDnsProvider);
+    });
+
+    it('defaults rootDomain to "ever.works" when env is not overridden', () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'tk';
+        process.env.CLOUDFLARE_ZONE_ID = 'zone1';
+        process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'k8s.lb';
+        const svc = new EverWorksDnsService();
+        expect(svc.ingressHostFor('ai-coding')).toBe('ai-coding.ever.works');
+    });
+
+    it('respects EVER_WORKS_DOMAIN override for ingressHostFor', () => {
+        process.env.EVER_WORKS_DOMAIN = 'preview.ever.works';
+        const svc = new EverWorksDnsService();
+        expect(svc.ingressHostFor('ai-coding')).toBe('ai-coding.preview.ever.works');
+    });
+
+    it('swallows ensureWorkSubdomain errors so a flaky DNS does not abort deploys', async () => {
+        process.env.CLOUDFLARE_API_TOKEN = 'tk';
+        process.env.CLOUDFLARE_ZONE_ID = 'zone1';
+        process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'k8s.lb';
+
+        const svc = new EverWorksDnsService();
+        const provider = svc.getProvider()!;
+        jest.spyOn(provider, 'ensureWorkSubdomain').mockRejectedValue(new Error('boom'));
+
+        await expect(svc.ensureWorkSubdomain('ai-coding')).resolves.toBeUndefined();
+    });
+});

--- a/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
+++ b/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
@@ -1,0 +1,280 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * EW-617 G5 — Cloudflare DNS provider for `*.ever.works`.
+ *
+ * Creates a CNAME record pointing `{slug}.ever.works` at the k8s-works
+ * cluster ingress load balancer when an Ever Works pipeline deploys a
+ * Work, and tears it down on Work delete. Operates against the
+ * Cloudflare v4 REST API with a scoped API token (DNS:Edit on the
+ * `ever.works` zone only).
+ *
+ * Configuration (operator runbook):
+ *
+ *   CLOUDFLARE_API_TOKEN          # scoped token, DNS:Edit on the zone
+ *   CLOUDFLARE_ZONE_ID            # `ever.works` zone id
+ *   EVER_WORKS_DOMAIN             # defaults to `ever.works`
+ *   EVER_WORKS_DEPLOY_LB_HOSTNAME # CNAME target — the k8s-works ingress LB
+ *
+ * The provider intentionally has no @nestjs/axios dependency — it uses
+ * the global `fetch` (Node 22+) so it can be tested with `fetch` mocks
+ * and stays small.
+ */
+
+export interface CloudflareDnsConfig {
+    apiToken: string;
+    zoneId: string;
+    /** e.g. 'ever.works' — used to validate target names + log. */
+    rootDomain: string;
+    /** Hostname the CNAME points at (k8s-works ingress LB). */
+    targetHostname: string;
+    /** Optional base URL override (tests, staging mirror). */
+    apiBaseUrl?: string;
+}
+
+export interface DnsRecordSnapshot {
+    id: string;
+    type: 'CNAME';
+    name: string;
+    content: string;
+}
+
+export class CloudflareDnsError extends Error {
+    constructor(
+        message: string,
+        readonly status: number,
+        readonly errors: unknown,
+    ) {
+        super(message);
+        this.name = 'CloudflareDnsError';
+    }
+}
+
+/**
+ * Pure (testable) Cloudflare client. Construct with a config; tests pass
+ * a custom `fetch` impl via the second arg.
+ */
+export class CloudflareDnsProvider {
+    private readonly logger = new Logger(CloudflareDnsProvider.name);
+    private readonly baseUrl: string;
+
+    constructor(
+        private readonly config: CloudflareDnsConfig,
+        private readonly fetchImpl: typeof fetch = fetch,
+    ) {
+        this.baseUrl = (config.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4').replace(
+            /\/$/,
+            '',
+        );
+    }
+
+    /**
+     * Ensure a CNAME record exists pointing `<slug>.<rootDomain>` at
+     * the configured target hostname. Idempotent: if a matching CNAME
+     * already exists, returns it; if a stale record (different target)
+     * exists, updates it in place. Always returns a snapshot for the
+     * caller to log / persist.
+     */
+    async ensureWorkSubdomain(slug: string): Promise<DnsRecordSnapshot> {
+        this.assertSlug(slug);
+        const fqdn = `${slug}.${this.config.rootDomain}`;
+        const target = this.config.targetHostname;
+
+        const existing = await this.findRecord(fqdn);
+        if (existing) {
+            if (existing.content === target && existing.type === 'CNAME') {
+                this.logger.log(`CloudflareDns CNAME already in sync ${fqdn} -> ${target}`);
+                return existing;
+            }
+            // Drifted record: same name, different content/type. Update.
+            const updated = await this.patchRecord(existing.id, {
+                type: 'CNAME',
+                name: fqdn,
+                content: target,
+                proxied: false,
+                ttl: 1, // 1 == 'auto' per Cloudflare docs
+            });
+            this.logger.log(
+                `CloudflareDns CNAME updated ${fqdn}: was ${existing.content} now ${target}`,
+            );
+            return updated;
+        }
+
+        const created = await this.createRecord({
+            type: 'CNAME',
+            name: fqdn,
+            content: target,
+            proxied: false,
+            ttl: 1,
+        });
+        this.logger.log(`CloudflareDns CNAME created ${fqdn} -> ${target}`);
+        return created;
+    }
+
+    /** Remove the CNAME for a Work — no-op if it never existed. */
+    async removeWorkSubdomain(slug: string): Promise<void> {
+        this.assertSlug(slug);
+        const fqdn = `${slug}.${this.config.rootDomain}`;
+        const existing = await this.findRecord(fqdn);
+        if (!existing) {
+            return;
+        }
+        await this.deleteRecord(existing.id);
+        this.logger.log(`CloudflareDns CNAME deleted ${fqdn}`);
+    }
+
+    // Internal helpers ------------------------------------------------------
+
+    private assertSlug(slug: string): void {
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+            throw new Error(`Invalid slug for Cloudflare DNS: ${slug}`);
+        }
+    }
+
+    private async findRecord(name: string): Promise<DnsRecordSnapshot | null> {
+        const url = new URL(`${this.baseUrl}/zones/${this.config.zoneId}/dns_records`);
+        url.searchParams.set('name', name);
+        url.searchParams.set('type', 'CNAME');
+        const json = await this.request<{ result: DnsRecordSnapshot[] }>(url.toString(), {
+            method: 'GET',
+        });
+        return json.result[0] ?? null;
+    }
+
+    private async createRecord(payload: {
+        type: 'CNAME';
+        name: string;
+        content: string;
+        proxied: boolean;
+        ttl: number;
+    }): Promise<DnsRecordSnapshot> {
+        const json = await this.request<{ result: DnsRecordSnapshot }>(
+            `${this.baseUrl}/zones/${this.config.zoneId}/dns_records`,
+            { method: 'POST', body: JSON.stringify(payload) },
+        );
+        return json.result;
+    }
+
+    private async patchRecord(
+        id: string,
+        payload: {
+            type: 'CNAME';
+            name: string;
+            content: string;
+            proxied: boolean;
+            ttl: number;
+        },
+    ): Promise<DnsRecordSnapshot> {
+        const json = await this.request<{ result: DnsRecordSnapshot }>(
+            `${this.baseUrl}/zones/${this.config.zoneId}/dns_records/${id}`,
+            { method: 'PUT', body: JSON.stringify(payload) },
+        );
+        return json.result;
+    }
+
+    private async deleteRecord(id: string): Promise<void> {
+        await this.request(`${this.baseUrl}/zones/${this.config.zoneId}/dns_records/${id}`, {
+            method: 'DELETE',
+        });
+    }
+
+    private async request<T = unknown>(url: string, init: RequestInit): Promise<T> {
+        const response = await this.fetchImpl(url, {
+            ...init,
+            headers: {
+                Authorization: `Bearer ${this.config.apiToken}`,
+                'Content-Type': 'application/json',
+                ...(init.headers ?? {}),
+            },
+        });
+        let body: any;
+        try {
+            body = await response.json();
+        } catch {
+            body = null;
+        }
+        if (!response.ok || (body && body.success === false)) {
+            throw new CloudflareDnsError(
+                `Cloudflare API ${init.method ?? 'GET'} ${url} failed: ${response.status}`,
+                response.status,
+                body?.errors ?? body ?? null,
+            );
+        }
+        return body as T;
+    }
+}
+
+/**
+ * Nest-injectable facade that owns the env reading + lazy-instantiation
+ * of the `CloudflareDnsProvider`. Returns `null` from `getProvider()`
+ * when DNS automation is not configured (env vars missing) so callers
+ * can no-op cleanly in dev.
+ */
+@Injectable()
+export class EverWorksDnsService {
+    private readonly logger = new Logger(EverWorksDnsService.name);
+    private cachedProvider: CloudflareDnsProvider | null | undefined;
+
+    getProvider(): CloudflareDnsProvider | null {
+        if (this.cachedProvider !== undefined) {
+            return this.cachedProvider;
+        }
+        const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+        const zoneId = process.env.CLOUDFLARE_ZONE_ID?.trim();
+        const targetHostname = process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME?.trim();
+        const rootDomain = process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+
+        if (!apiToken || !zoneId || !targetHostname) {
+            this.logger.debug(
+                'CloudflareDns not configured (missing CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID / EVER_WORKS_DEPLOY_LB_HOSTNAME) — skipping subdomain automation',
+            );
+            this.cachedProvider = null;
+            return null;
+        }
+
+        this.cachedProvider = new CloudflareDnsProvider({
+            apiToken,
+            zoneId,
+            rootDomain,
+            targetHostname,
+        });
+        return this.cachedProvider;
+    }
+
+    /** Compute the canonical ingress host for a given Work slug. */
+    ingressHostFor(slug: string): string {
+        const rootDomain = process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+        return `${slug}.${rootDomain}`;
+    }
+
+    async ensureWorkSubdomain(slug: string): Promise<void> {
+        const provider = this.getProvider();
+        if (!provider) return;
+        try {
+            await provider.ensureWorkSubdomain(slug);
+        } catch (cause) {
+            // DNS failures must not abort a deploy — the user can fix the
+            // record manually and the Work is still reachable via the LB
+            // hostname. Surface the error so ops can alert on it.
+            this.logger.error(
+                `Failed to ensure CNAME for ${slug}: ${(cause as Error).message}`,
+                cause instanceof Error ? cause.stack : undefined,
+            );
+        }
+    }
+
+    async removeWorkSubdomain(slug: string): Promise<void> {
+        const provider = this.getProvider();
+        if (!provider) return;
+        try {
+            await provider.removeWorkSubdomain(slug);
+        } catch (cause) {
+            this.logger.error(`Failed to delete CNAME for ${slug}: ${(cause as Error).message}`);
+        }
+    }
+
+    /** Reset the cache — test-only hook so unit tests can re-read env. */
+    resetCacheForTest(): void {
+        this.cachedProvider = undefined;
+    }
+}

--- a/packages/agent/src/ever-works-providers/index.ts
+++ b/packages/agent/src/ever-works-providers/index.ts
@@ -13,3 +13,10 @@ export {
     EverWorksDeployQuotaService,
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
 } from './ever-works-deploy-quota.service';
+export {
+    CloudflareDnsProvider,
+    CloudflareDnsError,
+    EverWorksDnsService,
+    type CloudflareDnsConfig,
+    type DnsRecordSnapshot,
+} from './cloudflare-dns.provider';

--- a/packages/agent/src/services/__tests__/anonymous-user-cleanup.service.spec.ts
+++ b/packages/agent/src/services/__tests__/anonymous-user-cleanup.service.spec.ts
@@ -1,0 +1,69 @@
+import { AnonymousUserCleanupService } from '../anonymous-user-cleanup.service';
+
+describe('AnonymousUserCleanupService (EW-617 G2)', () => {
+    const buildService = () => {
+        const userRepository = {
+            findExpiredAnonymous: jest.fn(),
+            deleteAnonymous: jest.fn().mockResolvedValue(undefined),
+        } as any;
+        const service = new AnonymousUserCleanupService(userRepository);
+        return { service, userRepository };
+    };
+
+    it('returns an empty summary when no expired anonymous users exist', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([]);
+
+        const summary = await service.purgeExpired();
+
+        expect(summary).toEqual({ scanned: 0, deleted: 0, failed: 0, failures: [] });
+        expect(userRepository.deleteAnonymous).not.toHaveBeenCalled();
+    });
+
+    it('deletes every expired anonymous user and counts successes', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([
+            { id: 'u-1' },
+            { id: 'u-2' },
+            { id: 'u-3' },
+        ]);
+
+        const summary = await service.purgeExpired();
+
+        expect(userRepository.deleteAnonymous).toHaveBeenCalledTimes(3);
+        expect(userRepository.deleteAnonymous).toHaveBeenNthCalledWith(1, 'u-1');
+        expect(userRepository.deleteAnonymous).toHaveBeenNthCalledWith(2, 'u-2');
+        expect(userRepository.deleteAnonymous).toHaveBeenNthCalledWith(3, 'u-3');
+        expect(summary).toEqual({ scanned: 3, deleted: 3, failed: 0, failures: [] });
+    });
+
+    it('continues past a single delete failure and reports it', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([
+            { id: 'u-1' },
+            { id: 'u-stuck' },
+            { id: 'u-3' },
+        ]);
+        userRepository.deleteAnonymous
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error('fk constraint'))
+            .mockResolvedValueOnce(undefined);
+
+        const summary = await service.purgeExpired();
+
+        expect(summary.scanned).toBe(3);
+        expect(summary.deleted).toBe(2);
+        expect(summary.failed).toBe(1);
+        expect(summary.failures).toEqual([{ userId: 'u-stuck', error: 'fk constraint' }]);
+    });
+
+    it('passes the `now` argument through to the repository for testability', async () => {
+        const { service, userRepository } = buildService();
+        userRepository.findExpiredAnonymous.mockResolvedValue([]);
+
+        const fixedNow = new Date('2026-05-14T03:17:00.000Z');
+        await service.purgeExpired(fixedNow);
+
+        expect(userRepository.findExpiredAnonymous).toHaveBeenCalledWith(fixedNow);
+    });
+});

--- a/packages/agent/src/services/__tests__/zero-friction-funnel.service.spec.ts
+++ b/packages/agent/src/services/__tests__/zero-friction-funnel.service.spec.ts
@@ -1,0 +1,64 @@
+import { ZeroFrictionFunnelService } from '../zero-friction-funnel.service';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
+
+describe('ZeroFrictionFunnelService (EW-617 G8)', () => {
+    let svc: ZeroFrictionFunnelService;
+    let logCalls: string[];
+
+    beforeEach(() => {
+        svc = new ZeroFrictionFunnelService();
+        logCalls = [];
+        jest.spyOn((svc as any).logger, 'log').mockImplementation((msg: string) => {
+            logCalls.push(msg);
+        });
+    });
+
+    it('emits a single-line JSON log tagged [zero-friction]', () => {
+        svc.emit({
+            funnelStep: 2,
+            event: ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED,
+            correlationId: 'corr-1',
+            timestamp: '2026-05-14T19:00:00.000Z',
+            anonUserId: 'u-1',
+            anonymousExpiresAt: '2026-05-21T19:00:00.000Z',
+            ipPrefix: '1.2.3.0/24',
+        });
+
+        expect(logCalls).toHaveLength(1);
+        expect(logCalls[0]).toContain('[zero-friction]');
+        const json = logCalls[0].replace(/^\[zero-friction\]\s*/, '');
+        const parsed = JSON.parse(json);
+        expect(parsed.event).toBe('zero_friction.anon_user_created');
+        expect(parsed.funnelStep).toBe(2);
+        expect(parsed.correlationId).toBe('corr-1');
+        expect(parsed.anonUserId).toBe('u-1');
+        expect(parsed.timestamp).toBe('2026-05-14T19:00:00.000Z');
+    });
+
+    it('back-fills timestamp when the caller omits it', () => {
+        const before = Date.now();
+        svc.emit({
+            funnelStep: 4,
+            event: ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED,
+            correlationId: 'corr-9',
+            timestamp: '' as any,
+            userId: 'u-1',
+            workId: 'w-1',
+            workSlug: 'foo',
+            viaQuickCreate: true,
+        });
+        const after = Date.now();
+
+        const parsed = JSON.parse(logCalls[0].replace(/^\[zero-friction\]\s*/, ''));
+        const ts = new Date(parsed.timestamp).getTime();
+        expect(ts).toBeGreaterThanOrEqual(before - 100);
+        expect(ts).toBeLessThanOrEqual(after + 100);
+    });
+
+    it('falls back to a key=value line if JSON.stringify throws', () => {
+        const circular: any = { funnelStep: 1, event: 'x', correlationId: 'corr-2' };
+        circular.self = circular;
+        svc.emit(circular as any);
+        expect(logCalls[0]).toMatch(/event=x correlationId=corr-2/);
+    });
+});

--- a/packages/agent/src/services/anonymous-user-cleanup.service.ts
+++ b/packages/agent/src/services/anonymous-user-cleanup.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UserRepository } from '../database';
+
+export interface AnonymousUserCleanupSummary {
+    scanned: number;
+    deleted: number;
+    failed: number;
+    failures: Array<{ userId: string; error: string }>;
+}
+
+/**
+ * EW-617 G2 — nightly purge of expired anonymous users.
+ *
+ * The companion `anonymous-user-cleanup` Trigger.dev schedule (in
+ * `packages/tasks/src/tasks/trigger/`) calls `purgeExpired()` once a day.
+ * Each user row deletion cascades to their Works via the existing
+ * `work.user` ON DELETE CASCADE.
+ *
+ * The service is intentionally idempotent and resilient: a single row
+ * delete failure logs + continues so one stuck row doesn't block the rest
+ * of the batch.
+ */
+@Injectable()
+export class AnonymousUserCleanupService {
+    private readonly logger = new Logger(AnonymousUserCleanupService.name);
+
+    constructor(private readonly userRepository: UserRepository) {}
+
+    async purgeExpired(now: Date = new Date()): Promise<AnonymousUserCleanupSummary> {
+        const expired = await this.userRepository.findExpiredAnonymous(now);
+        const summary: AnonymousUserCleanupSummary = {
+            scanned: expired.length,
+            deleted: 0,
+            failed: 0,
+            failures: [],
+        };
+
+        if (expired.length === 0) {
+            return summary;
+        }
+
+        this.logger.log(`anonymous-user-cleanup found ${expired.length} expired user(s)`);
+
+        for (const user of expired) {
+            try {
+                await this.userRepository.deleteAnonymous(user.id);
+                summary.deleted += 1;
+            } catch (cause) {
+                summary.failed += 1;
+                const error = cause instanceof Error ? cause.message : String(cause);
+                summary.failures.push({ userId: user.id, error });
+                this.logger.error(
+                    `Failed to delete expired anonymous user ${user.id}: ${error}`,
+                );
+            }
+        }
+
+        this.logger.log(
+            `anonymous-user-cleanup deleted=${summary.deleted} failed=${summary.failed} of ${summary.scanned}`,
+        );
+
+        return summary;
+    }
+}

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -20,6 +20,7 @@ export * from './webhook-delivery.service';
 export * from './state-marker.service';
 export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
+export * from './zero-friction-funnel.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -18,6 +18,7 @@ export * from './generator-form-schema.service';
 export * from './works-manifest.service';
 export * from './webhook-delivery.service';
 export * from './state-marker.service';
+export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -123,6 +123,7 @@ import { WorkLifecycleService } from './work-lifecycle.service';
 import { WorkGenerationService } from './work-generation.service';
 import { WorkScheduleService } from './work-schedule.service';
 import { WorkScheduleDispatcherService } from './work-schedule-dispatcher.service';
+import { AnonymousUserCleanupService } from './anonymous-user-cleanup.service';
 import { WorkMemberService } from './work-member.service';
 import { WorkInvitationService } from './work-invitation.service';
 import { WorkImportService } from './work-import.service';
@@ -195,6 +196,7 @@ describe('WorkModule', () => {
             WorkDetailService,
             WorkScheduleService,
             WorkScheduleDispatcherService,
+            AnonymousUserCleanupService,
             WorkMemberService,
             WorkInvitationService,
             WorkImportService,
@@ -291,10 +293,12 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 28-entry shape (25 services + 3 re-exported modules)', () => {
+        it('keeps the exports list at the documented 29-entry shape (26 services + 3 re-exported modules)', () => {
             // Bumped to 28 with the PlatformSyncSecretService resurrection for
             // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
-            expect(meta('exports')).toHaveLength(28);
+            // Bumped to 29 with AnonymousUserCleanupService for EW-617 G2
+            // (nightly cleanup of expired anonymous Users).
+            expect(meta('exports')).toHaveLength(29);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -145,6 +145,7 @@ import { WorksConfigWriterService } from '@src/works-config/services/works-confi
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { EverWorksDnsService } from '../ever-works-providers/cloudflare-dns.provider';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
 import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
 import { TemplateCatalogModule } from '../template-catalog/template-catalog.module';
@@ -219,6 +220,7 @@ describe('WorkModule', () => {
             EverWorksDeployQuotaService,
             PlatformSyncSecretService,
             EverWorksGitProvider,
+            EverWorksDnsService,
         ];
 
         it.each(expectedProviders)('declares %p as a provider', (provider) => {
@@ -275,10 +277,13 @@ describe('WorkModule', () => {
                     provider === SettingsSchemaValidatorService ||
                     provider === PluginOperationsService ||
                     provider === EverWorksDeployQuotaService ||
-                    provider === EverWorksGitProvider
+                    provider === EverWorksGitProvider ||
+                    provider === EverWorksDnsService
                 ) {
                     // EW-614: EverWorksGitProvider is consumed inside the
                     // module (by WorkLifecycleService.createWork); not exported.
+                    // EW-617 G5: EverWorksDnsService is consumed by DeployService;
+                    // not exported through WorkModule.
                     expect(exports).not.toContain(provider);
                 } else {
                     expect(exports).toContain(provider);

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -145,6 +145,7 @@ import { WorksConfigWriterService } from '@src/works-config/services/works-confi
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { EverWorksDnsService } from '../ever-works-providers/cloudflare-dns.provider';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
 import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
@@ -221,6 +222,7 @@ describe('WorkModule', () => {
             PlatformSyncSecretService,
             EverWorksGitProvider,
             EverWorksDnsService,
+            ZeroFrictionFunnelService,
         ];
 
         it.each(expectedProviders)('declares %p as a provider', (provider) => {
@@ -298,12 +300,13 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 29-entry shape (26 services + 3 re-exported modules)', () => {
+        it('keeps the exports list at the documented 30-entry shape (27 services + 3 re-exported modules)', () => {
             // Bumped to 28 with the PlatformSyncSecretService resurrection for
             // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
             // Bumped to 29 with AnonymousUserCleanupService for EW-617 G2
             // (nightly cleanup of expired anonymous Users).
-            expect(meta('exports')).toHaveLength(29);
+            // Bumped to 30 with the EW-617 G8 ZeroFrictionFunnelService.
+            expect(meta('exports')).toHaveLength(30);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -16,6 +16,7 @@ import { WorkLifecycleService } from './work-lifecycle.service';
 import { WorkGenerationService } from './work-generation.service';
 import { WorkScheduleService } from './work-schedule.service';
 import { WorkScheduleDispatcherService } from './work-schedule-dispatcher.service';
+import { AnonymousUserCleanupService } from './anonymous-user-cleanup.service';
 import { WorkMemberService } from './work-member.service';
 import { WorkInvitationService } from './work-invitation.service';
 import { WorkImportService } from './work-import.service';
@@ -77,6 +78,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorkDetailService,
         WorkScheduleService,
         WorkScheduleDispatcherService,
+        AnonymousUserCleanupService,
         WorkMemberService,
         WorkInvitationService,
         WorkImportService,
@@ -125,6 +127,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorkDetailService,
         WorkScheduleService,
         WorkScheduleDispatcherService,
+        AnonymousUserCleanupService,
         WorkMemberService,
         WorkInvitationService,
         WorkImportService,

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -33,6 +33,7 @@ import { WorksConfigService } from '@src/works-config/services/works-config.serv
 import { WorksConfigSyncListener } from '@src/works-config/services/works-config-sync.listener';
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { ItemHealthService } from './item-health.service';
 import { ItemSourceValidationSchedulerService } from './item-source-validation-scheduler.service';
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
@@ -101,6 +102,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         SettingsSchemaValidatorService,
         EverWorksDeployQuotaService,
         PlatformSyncSecretService,
+        ZeroFrictionFunnelService,
         // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
         // the platform GitHub org (`ever-works-cloud`) using a server-held
         // PAT, so users picking "Ever Works Git" don't need to bring their
@@ -147,6 +149,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigProjectionService,
         WorksConfigRepositorySyncService,
         PlatformSyncSecretService,
+        ZeroFrictionFunnelService,
         CommunityPrModule,
         ComparisonGeneratorModule,
         TemplateCatalogModule,

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -44,6 +44,7 @@ import {
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
     EverWorksDeployQuotaService,
     EverWorksGitProvider,
+    EverWorksDnsService,
     type EverWorksDeployQuotaCounter,
 } from '@src/ever-works-providers';
 import { WorkRepository } from '@src/database/repositories/work.repository';
@@ -105,6 +106,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         // PAT, so users picking "Ever Works Git" don't need to bring their
         // own GitHub. Consumed by `WorkLifecycleService.createWork`.
         EverWorksGitProvider,
+        EverWorksDnsService,
         {
             // The Ever Works Deploy quota service is repo-agnostic — it
             // takes a small `EverWorksDeployQuotaCounter` it can consult.

--- a/packages/agent/src/services/zero-friction-funnel.service.ts
+++ b/packages/agent/src/services/zero-friction-funnel.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { ZeroFrictionFunnelPayload } from '@ever-works/contracts/telemetry';
+
+/**
+ * EW-617 G8 — funnel emit service.
+ *
+ * Stage one keeps the emit surface tiny: every event lands as a single
+ * structured Nest log line tagged `[zero-friction]` + the event name.
+ * The existing platform log pipeline picks that up; downstream the ops
+ * team can either grep raw logs, build a PostHog "Insights" view from
+ * the JSON, or wire a custom OpenTelemetry exporter later.
+ *
+ * Why not call PostHog directly here?
+ *   - PostHogModule today only exposes an `isInitialized` flag — no
+ *     `capture()` helper yet.
+ *   - Adding the dependency cleanly would require either client
+ *     instantiation logic or a global module hookup, neither of which
+ *     I want to do in the same PR that defines the schema.
+ *
+ * A follow-up PR can swap the log call for a real PostHog/Open-
+ * Telemetry sink without changing any of the emit call sites.
+ */
+@Injectable()
+export class ZeroFrictionFunnelService {
+    private readonly logger = new Logger('ZeroFrictionFunnel');
+
+    emit(payload: ZeroFrictionFunnelPayload): void {
+        // Pin the timestamp here so call sites can omit it (it's not
+        // very useful for them to set their own).
+        const enriched = {
+            ...payload,
+            timestamp: payload.timestamp || new Date().toISOString(),
+        };
+        // Single JSON log line so downstream log aggregation can parse
+        // each event without regex acrobatics.
+        try {
+            this.logger.log(`[zero-friction] ${JSON.stringify(enriched)}`);
+        } catch {
+            // JSON serialisation failures shouldn't take down the request.
+            this.logger.log(
+                `[zero-friction] event=${enriched.event} correlationId=${enriched.correlationId}`,
+            );
+        }
+    }
+}

--- a/packages/agent/src/user-research/prompts.ts
+++ b/packages/agent/src/user-research/prompts.ts
@@ -68,7 +68,11 @@ export function buildSeedPrompt(user: User, socials: string[]): string {
     const lines: string[] = [];
     lines.push(`User to research:`);
     lines.push(`- Name: ${user.username}`);
-    lines.push(`- Email: ${user.email}`);
+    // EW-617 G2: anonymous users have no email until they claim the account;
+    // user-research only runs after onboarding so this is mostly defensive.
+    if (user.email) {
+        lines.push(`- Email: ${user.email}`);
+    }
     if (user.registrationProvider && user.registrationProvider !== 'local') {
         lines.push(`- OAuth provider: ${user.registrationProvider}`);
     }
@@ -80,7 +84,7 @@ export function buildSeedPrompt(user: User, socials: string[]): string {
     if (socials.length > 0) {
         lines.push(`- Linked social profiles: ${socials.join(', ')}`);
     }
-    const domain = user.email.split('@')[1];
+    const domain = user.email?.split('@')[1];
     if (domain) {
         lines.push(`- Email domain: ${domain}`);
     }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -38,6 +38,11 @@
 			"types": "./dist/api/index.d.ts",
 			"import": "./dist/api/index.js",
 			"require": "./dist/api/index.cjs"
+		},
+		"./telemetry": {
+			"types": "./dist/telemetry/index.d.ts",
+			"import": "./dist/telemetry/index.js",
+			"require": "./dist/telemetry/index.cjs"
 		}
 	},
 	"files": [

--- a/packages/contracts/src/api/onboarding/wizard-state.ts
+++ b/packages/contracts/src/api/onboarding/wizard-state.ts
@@ -20,6 +20,13 @@ export interface OnboardingWizardStateV2 {
 	readonly deploy: { readonly choice: OnboardingDeployChoice };
 	readonly skippedSteps: readonly string[];
 	readonly pluginsReviewed: boolean;
+	/**
+	 * EW-617 G4: prompt carried over from the landing-page input
+	 * (`ever.works/?prompt=…`) so the wizard's "Generate now" step can
+	 * kick off generation without re-asking the user. Bounded by the
+	 * same 5000-char limit as `CreateItemsGeneratorDto.prompt`.
+	 */
+	readonly prompt?: string;
 }
 
 /** Wire shape of `GET /api/onboarding/state`. */
@@ -42,6 +49,7 @@ export interface OnboardingStatePatchRequest {
 		readonly deploy: Partial<{ choice: OnboardingDeployChoice }>;
 		readonly skippedSteps: readonly string[];
 		readonly pluginsReviewed: boolean;
+		readonly prompt: string;
 	}>;
 }
 

--- a/packages/contracts/src/telemetry/index.ts
+++ b/packages/contracts/src/telemetry/index.ts
@@ -1,0 +1,1 @@
+export * from './zero-friction-funnel.js';

--- a/packages/contracts/src/telemetry/zero-friction-funnel.ts
+++ b/packages/contracts/src/telemetry/zero-friction-funnel.ts
@@ -1,0 +1,138 @@
+/**
+ * EW-617 G8 — wire format for the zero-friction prompt → deployed Work
+ * funnel events.
+ *
+ * These types pin the canonical event names + payload shapes so the
+ * emit sites (G1 landing form, G2 anon auth, G3 claim, G4 quick-create,
+ * deploy.service.ts, etc.) all agree on the schema and downstream
+ * consumers (PostHog dashboards, log queries, the OpenTelemetry sink)
+ * can rely on stable fields.
+ *
+ * Emit sites in scope:
+ *
+ *   landing-prompt-submit       — website  (G1) — apps/web/components/global/LandingPromptForm.tsx
+ *   anon-user-created           — platform (G2) — apps/api/.../anonymous-auth.service.ts
+ *   wizard-finished             — platform (G4) — apps/web/components/onboarding/EverWorksOnboardingWizard.tsx
+ *   work-created                — platform (G4) — apps/api/.../works.controller.ts (quickCreateWork)
+ *   repos-pushed                — platform       — packages/agent/src/services/work-lifecycle.service.ts (EW-614 path)
+ *   deploy-started              — platform       — apps/api/.../deploy.service.ts (deploy())
+ *   deploy-ready                — platform       — apps/api/.../tasks/deployment-verifier.service.ts
+ *   claim-account               — platform (G3) — apps/api/.../claim-account.service.ts
+ *
+ * Bumping the schema version is a follow-up PR; for now treat the
+ * shapes as additive (clients should ignore unknown fields).
+ */
+
+export const ZERO_FRICTION_FUNNEL_EVENTS = {
+	LANDING_PROMPT_SUBMIT: 'zero_friction.landing_prompt_submit',
+	ANON_USER_CREATED: 'zero_friction.anon_user_created',
+	WIZARD_FINISHED: 'zero_friction.wizard_finished',
+	WORK_CREATED: 'zero_friction.work_created',
+	REPOS_PUSHED: 'zero_friction.repos_pushed',
+	DEPLOY_STARTED: 'zero_friction.deploy_started',
+	DEPLOY_READY: 'zero_friction.deploy_ready',
+	CLAIM_ACCOUNT: 'zero_friction.claim_account'
+} as const;
+
+export type ZeroFrictionFunnelEvent = (typeof ZERO_FRICTION_FUNNEL_EVENTS)[keyof typeof ZERO_FRICTION_FUNNEL_EVENTS];
+
+export interface FunnelEventBase {
+	/** ISO 8601 timestamp the event was emitted. */
+	readonly timestamp: string;
+	/**
+	 * Correlation id that survives across the full funnel. Origin: G1
+	 * mints a UUID v4 on submit, carries it via the URL fragment
+	 * (`#prompt=…&corrId=…`), G4 reads it into wizard state, every
+	 * downstream emit reuses it. Lets ops trace a single user across
+	 * multiple services + asynchronous task runs.
+	 */
+	readonly correlationId: string;
+	/**
+	 * Numeric step (1..8) so PostHog can build a funnel without
+	 * hard-coding event ordering. Pinned at the top of each interface
+	 * below.
+	 */
+	readonly funnelStep: number;
+}
+
+export interface LandingPromptSubmitEvent extends FunnelEventBase {
+	readonly funnelStep: 1;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.LANDING_PROMPT_SUBMIT;
+	readonly promptLength: number;
+	/** UA family for top-of-funnel segmentation; never raw UA string. */
+	readonly clientKind: 'browser' | 'crawler' | 'unknown';
+	readonly referer?: string | null;
+}
+
+export interface AnonUserCreatedEvent extends FunnelEventBase {
+	readonly funnelStep: 2;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED;
+	readonly anonUserId: string;
+	readonly anonymousExpiresAt: string;
+	/** Truncated /24 (IPv4) or /48 (IPv6) so we never persist raw IPs. */
+	readonly ipPrefix: string | null;
+}
+
+export interface WizardFinishedEvent extends FunnelEventBase {
+	readonly funnelStep: 3;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WIZARD_FINISHED;
+	readonly userId: string;
+	readonly isAnonymous: boolean;
+	/** Choices captured at the moment Generate-now was clicked. */
+	readonly aiChoice: string;
+	readonly storageChoice: string;
+	readonly deployChoice: string;
+}
+
+export interface WorkCreatedEvent extends FunnelEventBase {
+	readonly funnelStep: 4;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED;
+	readonly userId: string;
+	readonly workId: string;
+	readonly workSlug: string;
+	/** True when the row was created via /api/works/quick-create. */
+	readonly viaQuickCreate: boolean;
+}
+
+export interface ReposPushedEvent extends FunnelEventBase {
+	readonly funnelStep: 5;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.REPOS_PUSHED;
+	readonly workId: string;
+	/** `ever-works-cloud/<slug>-data`, `<slug>-website`, `<slug>-mcp`. */
+	readonly repos: readonly string[];
+}
+
+export interface DeployStartedEvent extends FunnelEventBase {
+	readonly funnelStep: 6;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_STARTED;
+	readonly workId: string;
+	readonly deployProvider: string;
+	readonly ingressHost: string | null;
+}
+
+export interface DeployReadyEvent extends FunnelEventBase {
+	readonly funnelStep: 7;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY;
+	readonly workId: string;
+	readonly websiteUrl: string;
+	/** Milliseconds from `deploy-started` to `deploy-ready`. */
+	readonly elapsedMs: number;
+}
+
+export interface ClaimAccountEvent extends FunnelEventBase {
+	readonly funnelStep: 8;
+	readonly event: typeof ZERO_FRICTION_FUNNEL_EVENTS.CLAIM_ACCOUNT;
+	readonly userId: string;
+	/** True if the user came in via the zero-friction flow + claimed. */
+	readonly viaZeroFriction: boolean;
+}
+
+export type ZeroFrictionFunnelPayload =
+	| LandingPromptSubmitEvent
+	| AnonUserCreatedEvent
+	| WizardFinishedEvent
+	| WorkCreatedEvent
+	| ReposPushedEvent
+	| DeployStartedEvent
+	| DeployReadyEvent
+	| ClaimAccountEvent;

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-	entry: ['src/index.ts', 'src/item/index.ts', 'src/domain/index.ts', 'src/form/index.ts', 'src/api/index.ts'],
+	entry: [
+		'src/index.ts',
+		'src/item/index.ts',
+		'src/domain/index.ts',
+		'src/form/index.ts',
+		'src/api/index.ts',
+		'src/telemetry/index.ts'
+	],
 	format: ['esm', 'cjs'],
 	dts: true,
 	clean: true,

--- a/packages/tasks/src/tasks/trigger/anonymous-user-cleanup.task.ts
+++ b/packages/tasks/src/tasks/trigger/anonymous-user-cleanup.task.ts
@@ -1,0 +1,32 @@
+import { schedules } from '@trigger.dev/sdk';
+import { NestFactory } from '@nestjs/core';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { AnonymousUserCleanupService } from '@ever-works/agent/services';
+import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
+
+/**
+ * EW-617 G2 — nightly purge of expired anonymous users.
+ *
+ * Runs every day at 03:17 UTC (off-peak, deliberately staggered from the
+ * other scheduled jobs to avoid a coincident burst on the database). The
+ * service consults `users.is_anonymous=true AND users.anonymous_expires_at <
+ * now`, then deletes each row; cascade on `work.userId` removes the orphan
+ * Works.
+ */
+export const anonymousUserCleanupTask = schedules.task({
+    id: 'anonymous-user-cleanup',
+    cron: '17 3 * * *',
+    run: async () => {
+        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+
+        appContext.useLogger(createTriggerLogger('AnonymousUserCleanup'));
+
+        try {
+            const cleanup = appContext.get(AnonymousUserCleanupService);
+            const summary = await cleanup.purgeExpired();
+            return summary;
+        } finally {
+            await appContext.close();
+        }
+    },
+});

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -1,3 +1,4 @@
+export * from './anonymous-user-cleanup.task';
 export * from './user-research-rerun-dispatcher.task';
 export * from './work-generation.task';
 export * from './work-import.task';


### PR DESCRIPTION
## Summary
Cascade develop → stage with the full EW-617 zero-friction flow shipped today plus EW-616 follow-up fixes already on develop.

EW-617 ships behind feature flags + .skip-gated E2E — all gaps are behind `is_anonymous` / explicit configuration and won't activate on stage without the corresponding env wiring.

### EW-617 PRs included
- #752 — G6: default `work.deployProvider` → `ever-works`
- #756 — G2: anonymous (TTL) user auth foundation + cleanup
- #757 — G3: claim-account flow (anon → registered)
- #758 — G4: `POST /api/works/quick-create` + wizard hash hand-off
- #759 — G5: Cloudflare DNS subdomain provisioning
- #760 — G8: zero-friction telemetry funnel (8-event schema)
- #761 — G7: captcha verifier service (Turnstile/hCaptcha)
- #764 — E2E: cross-cutting Playwright suite (.skip-gated)
- ever-works/ever-works-website#37 — G1: landing prompt input

### Deferred wire-ups (post-cascade)
- Captcha → POST /api/auth/anonymous + POST /api/works/quick-create
- Funnel emit() at 8 named call sites
- DNS cleanup in WorkLifecycleService.deleteWork

## Test plan
- [ ] CI green on stage
- [ ] No regressions in existing auth / works flows (everything is additive)
- [ ] Anonymous TTL cleanup task picks up on stage Trigger.dev (cron `17 3 * * *`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)