### PR TITLE
chore: cascade develop → stage (EW-617 captcha/funnel/DNS wire-ups)

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AnonymousAuthService } from './services/anonymous-auth.service';
 import { ClaimAccountService } from './services/claim-account.service';
 import { ApiKeyService } from './services/api-key.service';
 import { CaptchaVerifierService } from './services/captcha-verifier.service';
+import { ZeroFrictionFunnelService } from '@ever-works/agent/services';
 import { AuthController } from './controllers/auth.controller';
 import { ApiKeysController } from './controllers/api-keys.controller';
 import { OAuthController } from './controllers/oauth.controller';
@@ -31,6 +32,10 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
         ClaimAccountService,
         ApiKeyService,
         CaptchaVerifierService,
+        // EW-617 G8: registered here (not imported from WorkModule) to keep
+        // AuthModule free of a WorkModule dependency. The service is stateless
+        // (a logger wrapper), so the duplicate instance is harmless.
+        ZeroFrictionFunnelService,
         AuthProviderService,
         AuthSyncService,
         SocialAuthService,

--- a/apps/api/src/auth/controllers/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth.controller.spec.ts
@@ -6,11 +6,15 @@ jest.mock('@ever-works/agent/entities', () => ({
 jest.mock('@ever-works/agent/activity-log', () => ({
     ActivityLogService: class ActivityLogService {},
 }));
+jest.mock('@ever-works/agent/services', () => ({
+    ZeroFrictionFunnelService: class ZeroFrictionFunnelService {},
+}));
 
 import { AuthController } from './auth.controller';
 import type { AuthService } from '../services/auth.service';
 import type { AnonymousAuthService } from '../services/anonymous-auth.service';
 import type { ClaimAccountService } from '../services/claim-account.service';
+import type { CaptchaVerifierService } from '../services/captcha-verifier.service';
 import type { SocialAuthService } from '../services/social-auth.service';
 import type { ActivityLogService } from '@ever-works/agent/activity-log';
 import type { AuthProvider } from '../providers/auth-provider.abstract';
@@ -35,6 +39,8 @@ describe('AuthController', () => {
     let socialAuth: jest.Mocked<Pick<SocialAuthService, 'getConfiguredProviders'>>;
     let anonymousAuth: jest.Mocked<Pick<AnonymousAuthService, 'createAnonymousUser'>>;
     let claimAccount: jest.Mocked<Pick<ClaimAccountService, 'claim'>>;
+    let captchaVerifier: jest.Mocked<Pick<CaptchaVerifierService, 'isEnabled' | 'verify'>>;
+    let funnel: { emit: jest.Mock };
     let activityLog: jest.Mocked<Pick<ActivityLogService, 'log'>>;
     let authProvider: jest.Mocked<
         Pick<
@@ -65,6 +71,12 @@ describe('AuthController', () => {
         socialAuth = { getConfiguredProviders: jest.fn() } as any;
         anonymousAuth = { createAnonymousUser: jest.fn() } as any;
         claimAccount = { claim: jest.fn() } as any;
+        // Default: captcha disabled (no-op) so existing tests pass through.
+        captchaVerifier = {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any;
+        funnel = { emit: jest.fn() };
         activityLog = { log: jest.fn().mockResolvedValue(undefined) } as any;
         authProvider = {
             signUpEmail: jest.fn(),
@@ -80,6 +92,8 @@ describe('AuthController', () => {
             socialAuth as unknown as SocialAuthService,
             anonymousAuth as unknown as AnonymousAuthService,
             claimAccount as unknown as ClaimAccountService,
+            captchaVerifier as unknown as CaptchaVerifierService,
+            funnel as any,
             activityLog as unknown as ActivityLogService,
             authProvider as unknown as AuthProvider,
         );

--- a/apps/api/src/auth/controllers/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth.controller.ts
@@ -10,6 +10,7 @@ import {
     HttpCode,
     HttpStatus,
     Logger,
+    BadRequestException,
 } from '@nestjs/common';
 import {
     ApiTags,
@@ -22,6 +23,9 @@ import {
 import { AuthService } from '../services/auth.service';
 import { AnonymousAuthService } from '../services/anonymous-auth.service';
 import { ClaimAccountService } from '../services/claim-account.service';
+import { CaptchaVerifierService } from '../services/captcha-verifier.service';
+import { ZeroFrictionFunnelService } from '@ever-works/agent/services';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import { RegisterDto, LoginDto, UpdatePasswordDto, ClaimAccountDto } from '../dto/auth.dto';
 import { VerifyEmailDto, ForgotPasswordDto, ResetPasswordDto } from '../dto/email-verification.dto';
 import { UpdateProfileDto } from '../dto/update-profile.dto';
@@ -46,10 +50,29 @@ export class AuthController {
         private readonly socialAuthService: SocialAuthService,
         private readonly anonymousAuthService: AnonymousAuthService,
         private readonly claimAccountService: ClaimAccountService,
+        private readonly captchaVerifier: CaptchaVerifierService,
+        private readonly funnel: ZeroFrictionFunnelService,
         private activityLogService: ActivityLogService,
         @Inject(AUTH_PROVIDER)
         private readonly authProvider: AuthProvider,
     ) {}
+
+    /**
+     * EW-617 G8 — best-effort /24 (IPv4) or /48 (IPv6) prefix for telemetry.
+     * Truncating to a prefix means we never persist raw IPs in funnel events.
+     */
+    private truncateIp(ip: string | null): string | null {
+        if (!ip) return null;
+        if (ip.includes('.')) {
+            const parts = ip.split('.');
+            if (parts.length === 4) return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
+            return null;
+        }
+        // IPv6 — keep first 3 hextets (~/48), drop the rest.
+        const v6 = ip.split(':');
+        if (v6.length >= 3) return `${v6[0]}:${v6[1]}:${v6[2]}::/48`;
+        return null;
+    }
 
     @Public()
     @Get('providers')
@@ -101,7 +124,8 @@ export class AuthController {
     @Public()
     @Post('anonymous')
     // EW-617 G2: zero-friction onboarding entrypoint. Rate-limited per IP to
-    // prevent abuse; G7 will layer on stricter limits + captcha when needed.
+    // prevent abuse; G7 layers on optional captcha when CAPTCHA_PROVIDER +
+    // CAPTCHA_SECRET are configured (no-op in dev).
     @Throttle({ default: { limit: 5, ttl: 60 * 60 * 1000 } })
     @HttpCode(HttpStatus.CREATED)
     @ApiOperation({
@@ -110,8 +134,12 @@ export class AuthController {
             'Mints a temporary User row + session token. The row + its Works are wiped automatically after ANONYMOUS_USER_TTL_DAYS (default 7) days unless the user calls POST /api/auth/claim first.',
     })
     @ApiResponse({ status: 201, description: 'Anonymous session issued' })
+    @ApiResponse({ status: 400, description: 'Captcha verification failed' })
     @ApiResponse({ status: 429, description: 'Rate limit exceeded for this IP' })
-    async anonymous(@Request() req) {
+    async anonymous(
+        @Request() req,
+        @Body() body?: { captchaToken?: string; correlationId?: string },
+    ) {
         const ipAddress =
             (typeof req.ip === 'string' && req.ip) ||
             (typeof req.headers['x-forwarded-for'] === 'string'
@@ -121,6 +149,19 @@ export class AuthController {
             typeof req.headers['user-agent'] === 'string'
                 ? (req.headers['user-agent'] as string)
                 : null;
+
+        // EW-617 G7: captcha gate. The verifier no-ops when CAPTCHA_PROVIDER
+        // is unset (dev/preview), so this is a hard requirement only on
+        // properly configured environments.
+        if (this.captchaVerifier.isEnabled()) {
+            const result = await this.captchaVerifier.verify({
+                token: body?.captchaToken,
+                remoteIp: ipAddress,
+            });
+            if (!result.success) {
+                throw new BadRequestException('captcha verification failed');
+            }
+        }
 
         const response = await this.anonymousAuthService.createAnonymousUser({
             ipAddress,
@@ -138,6 +179,19 @@ export class AuthController {
                 userAgent,
             })
             .catch(() => {});
+
+        // EW-617 G8 — funnel step 2: anon-user created.
+        if (body?.correlationId) {
+            this.funnel.emit({
+                event: ZERO_FRICTION_FUNNEL_EVENTS.ANON_USER_CREATED,
+                funnelStep: 2,
+                timestamp: new Date().toISOString(),
+                correlationId: body.correlationId,
+                anonUserId: response.user.id,
+                anonymousExpiresAt: String(response.user.anonymousExpiresAt ?? ''),
+                ipPrefix: this.truncateIp(ipAddress),
+            });
+        }
 
         return response;
     }
@@ -195,6 +249,18 @@ export class AuthController {
                 userAgent,
             })
             .catch(() => {});
+
+        // EW-617 G8 — funnel step 8: claim-account (anon → registered).
+        if (claimDto.correlationId) {
+            this.funnel.emit({
+                event: ZERO_FRICTION_FUNNEL_EVENTS.CLAIM_ACCOUNT,
+                funnelStep: 8,
+                timestamp: new Date().toISOString(),
+                correlationId: claimDto.correlationId,
+                userId: claimed.id,
+                viaZeroFriction: true,
+            });
+        }
 
         return claimed;
     }

--- a/apps/api/src/auth/dto/auth.dto.ts
+++ b/apps/api/src/auth/dto/auth.dto.ts
@@ -94,7 +94,9 @@ export class ClaimAccountDto {
     })
     password: string;
 
-    @ApiPropertyOptional({ description: 'Username to use after claim (defaults to current anon username)' })
+    @ApiPropertyOptional({
+        description: 'Username to use after claim (defaults to current anon username)',
+    })
     @IsString()
     @IsOptional()
     @MinLength(3)
@@ -104,6 +106,14 @@ export class ClaimAccountDto {
     @IsString()
     @IsOptional()
     emailVerificationCallbackUrl?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Optional UUID v4 minted at funnel entry (landing page → wizard). Threaded into the zero-friction telemetry funnel; ignored when absent.',
+    })
+    @IsString()
+    @IsOptional()
+    correlationId?: string;
 }
 
 export class OAuthCallbackDto {

--- a/apps/api/src/works/works.controller.advanced-prompts-import.spec.ts
+++ b/apps/api/src/works/works.controller.advanced-prompts-import.spec.ts
@@ -138,6 +138,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.comparisons-misc.spec.ts
+++ b/apps/api/src/works/works.controller.comparisons-misc.spec.ts
@@ -146,6 +146,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 
@@ -638,6 +643,11 @@ describe('WorksController — comparisons + community-pr + source-validation end
                 stubs.itemImportService as any,
                 stubs.itemImportExecutor as any,
                 { rotate, getOrGenerate: jest.fn() } as any,
+                {
+                    isEnabled: jest.fn().mockReturnValue(false),
+                    verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+                } as any,
+                { emit: jest.fn() } as any,
             );
             return { controller, stubs };
         }

--- a/apps/api/src/works/works.controller.crud.spec.ts
+++ b/apps/api/src/works/works.controller.crud.spec.ts
@@ -166,6 +166,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.domain-repo.spec.ts
+++ b/apps/api/src/works/works.controller.domain-repo.spec.ts
@@ -145,6 +145,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.export.spec.ts
+++ b/apps/api/src/works/works.controller.export.spec.ts
@@ -153,6 +153,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.generation.spec.ts
+++ b/apps/api/src/works/works.controller.generation.spec.ts
@@ -129,6 +129,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.items.spec.ts
+++ b/apps/api/src/works/works.controller.items.spec.ts
@@ -135,6 +135,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.quick-create.spec.ts
+++ b/apps/api/src/works/works.controller.quick-create.spec.ts
@@ -89,6 +89,11 @@ function makeController(overrides: {
         {} as any,
         {} as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 
     return { controller, createWork, generateItems, activityLog, authService };

--- a/apps/api/src/works/works.controller.schedule.spec.ts
+++ b/apps/api/src/works/works.controller.schedule.spec.ts
@@ -135,6 +135,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.taxonomy.spec.ts
+++ b/apps/api/src/works/works.controller.taxonomy.spec.ts
@@ -141,6 +141,11 @@ function makeController(s: Stubs): WorksController {
         s.itemImportService as any,
         s.itemImportExecutor as any,
         { rotate: jest.fn(), getOrGenerate: jest.fn() } as any,
+        {
+            isEnabled: jest.fn().mockReturnValue(false),
+            verify: jest.fn().mockResolvedValue({ success: true, skipped: true }),
+        } as any,
+        { emit: jest.fn() } as any,
     );
 }
 

--- a/apps/api/src/works/works.controller.ts
+++ b/apps/api/src/works/works.controller.ts
@@ -13,6 +13,7 @@ import {
     Post,
     Put,
     Query,
+    Req,
     Res,
     Logger,
     UseGuards,
@@ -111,6 +112,9 @@ import { getDefaultWebsiteTemplateId } from '@ever-works/agent/generators';
 import { CommunityPrProcessorService } from '@ever-works/agent/community-pr';
 import { WorkRepository } from '@ever-works/agent/database';
 import { AuthService, CurrentUser, AuthSessionGuard } from '../auth';
+import { CaptchaVerifierService } from '../auth/services/captcha-verifier.service';
+import { ZeroFrictionFunnelService } from '@ever-works/agent/services';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
 import { GenerateWorkDetailDto } from './dto/generate-detail.dto';
 import { GenerateManualComparisonDto } from './dto/generate-manual-comparison.dto';
@@ -221,6 +225,8 @@ export class WorksController {
         private readonly itemImportService: ItemImportService,
         private readonly itemImportExecutor: ItemImportExecutorService,
         private readonly platformSyncSecretService: PlatformSyncSecretService,
+        private readonly captchaVerifier: CaptchaVerifierService,
+        private readonly funnel: ZeroFrictionFunnelService,
     ) {}
 
     private async invalidateWorkCaches(workId: string): Promise<void> {
@@ -328,11 +334,27 @@ export class WorksController {
     async quickCreateWork(
         @CurrentUser() auth: AuthenticatedUser,
         @Body() dto: QuickCreateWorkDto,
+        @Req() req?: { ip?: string; headers?: Record<string, string | string[] | undefined> },
     ): Promise<{
         status: 'pending';
         work: { id: string; slug: string; name: string };
         generation: { historyId: string; message: string };
     }> {
+        // EW-617 G7: captcha gate. No-ops in dev when CAPTCHA_PROVIDER is unset.
+        if (this.captchaVerifier.isEnabled()) {
+            const fwd = req?.headers?.['x-forwarded-for'];
+            const ipAddress =
+                (typeof req?.ip === 'string' && req.ip) ||
+                (typeof fwd === 'string' ? fwd.split(',')[0].trim() : null);
+            const result = await this.captchaVerifier.verify({
+                token: dto.captchaToken,
+                remoteIp: ipAddress,
+            });
+            if (!result.success) {
+                throw new BadRequestException('captcha verification failed');
+            }
+        }
+
         const user = await this.authService.getUser(auth.userId);
 
         // 1. Create the Work via the existing pipeline. Provider defaults
@@ -366,6 +388,20 @@ export class WorksController {
                 summary: `Quick-create kicked off generation for ${work.slug}`,
             })
             .catch(() => {});
+
+        // EW-617 G8 — funnel step 4: work created (via quick-create).
+        if (dto.correlationId) {
+            this.funnel.emit({
+                event: ZERO_FRICTION_FUNNEL_EVENTS.WORK_CREATED,
+                funnelStep: 4,
+                timestamp: new Date().toISOString(),
+                correlationId: dto.correlationId,
+                userId: user.id,
+                workId: work.id,
+                workSlug: work.slug,
+                viaQuickCreate: true,
+            });
+        }
 
         // 2. Kick off generation async — the standard generation pipeline
         //    handles persistence + dispatch.  awaitCompletion=false means

--- a/packages/agent/src/dto/quick-create-work.dto.ts
+++ b/packages/agent/src/dto/quick-create-work.dto.ts
@@ -128,4 +128,20 @@ export class QuickCreateWorkDto {
     @ValidateNested()
     @Type(() => MarkdownReadmeConfigDto)
     readmeConfig?: MarkdownReadmeConfigDto;
+
+    @ApiPropertyOptional({
+        description:
+            'Captcha token (Cloudflare Turnstile / hCaptcha / reCAPTCHA). Required only when CAPTCHA_PROVIDER + CAPTCHA_SECRET are configured server-side; ignored in dev where captcha is disabled.',
+    })
+    @IsOptional()
+    @IsString()
+    captchaToken?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Optional UUID v4 minted at funnel entry (landing page → wizard). Threaded into the zero-friction telemetry funnel so ops can correlate `landing_prompt_submit` → `work_created` → `deploy_ready` across services.',
+    })
+    @IsOptional()
+    @IsString()
+    correlationId?: string;
 }

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -54,6 +54,12 @@ interface MockDeps {
     userRepo: { findById: jest.Mock };
     quota: { assertWithinQuota: jest.Mock };
     everWorksGit: { isEnabled: jest.Mock; createRepository: jest.Mock };
+    everWorksDns: {
+        getProvider: jest.Mock;
+        ensureWorkSubdomain: jest.Mock;
+        removeWorkSubdomain: jest.Mock;
+        ingressHostFor: jest.Mock;
+    };
     eventEmitter: { emit: jest.Mock };
 }
 
@@ -90,6 +96,14 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
 
     const eventEmitter = { emit: jest.fn() };
 
+    // EW-617 G5: DNS provider mock — no-op by default.
+    const everWorksDns = {
+        getProvider: jest.fn().mockReturnValue(null),
+        ensureWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+        removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+        ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
+    };
+
     const service = new WorkLifecycleService(
         workRepo as never,
         userRepo as never,
@@ -103,10 +117,14 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
         {} as never,
         quota as never,
         everWorksGit as never,
+        everWorksDns as never,
         eventEmitter as never,
     );
 
-    return { service, deps: { workRepo, userRepo, quota, everWorksGit, eventEmitter } };
+    return {
+        service,
+        deps: { workRepo, userRepo, quota, everWorksGit, everWorksDns, eventEmitter },
+    };
 }
 
 describe('WorkLifecycleService.createWork — provider defaults + quota', () => {

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -103,6 +103,14 @@ describe('WorkLifecycleService', () => {
         eventEmitter = {
             emit: jest.fn(),
         };
+        // EW-617 G5: DNS provider mock — no-op by default so tests that
+        // don't deploy to ever-works see no extra calls.
+        const everWorksDns = {
+            getProvider: jest.fn().mockReturnValue(null),
+            ensureWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+            removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
+            ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
+        } as never;
 
         service = new WorkLifecycleService(
             workRepository,
@@ -117,6 +125,7 @@ describe('WorkLifecycleService', () => {
             websiteRepositoryState,
             everWorksDeployQuota,
             everWorksGit,
+            everWorksDns,
             eventEmitter as never,
         );
     });

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -37,6 +37,7 @@ import { TemplateCatalogService } from '../template-catalog/template-catalog.ser
 import { WorkWebsiteRepositoryStateService } from './work-website-repository-state.service';
 import {
     EverWorksDeployQuotaService,
+    EverWorksDnsService,
     EverWorksGitDisabledError,
     EverWorksGitMisconfiguredError,
     EverWorksGitProvider,
@@ -92,6 +93,7 @@ export class WorkLifecycleService {
         private readonly websiteRepositoryState: WorkWebsiteRepositoryStateService,
         private readonly everWorksDeployQuota: EverWorksDeployQuotaService,
         private readonly everWorksGit: EverWorksGitProvider,
+        private readonly everWorksDns: EverWorksDnsService,
         private readonly eventEmitter: EventEmitter2,
     ) {}
 
@@ -767,6 +769,15 @@ export class WorkLifecycleService {
                 this.markdownGenerator.cleanup(work),
                 this.websiteGenerator.cleanup(work),
             ]).catch((error) => this.logger.error('Failed to cleanup repositories:', error));
+
+            // EW-617 G5: tear down the platform-managed CNAME so the slug is
+            // immediately reusable. Only applies when the work deployed to
+            // `ever-works` — for other providers ensureWorkSubdomain was never
+            // called so the DNS record won't exist. No-ops when Cloudflare env
+            // is not configured (dev).
+            if (work.deployProvider === 'ever-works') {
+                await this.everWorksDns.removeWorkSubdomain(work.slug);
+            }
 
             return {
                 status: 'success',

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -105,6 +105,7 @@ jest.mock('@src/ever-works-providers', () => ({
     EVER_WORKS_DEPLOY_QUOTA_COUNTER: Symbol('EVER_WORKS_DEPLOY_QUOTA_COUNTER'),
     EverWorksDeployQuotaService: class EverWorksDeployQuotaService {},
     EverWorksGitProvider: class EverWorksGitProvider {},
+    EverWorksDnsService: class EverWorksDnsService {},
 }));
 jest.mock('@src/database/repositories/work.repository', () => ({
     WorkRepository: class WorkRepository {},
@@ -115,6 +116,7 @@ import {
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
     EverWorksDeployQuotaService,
     EverWorksGitProvider,
+    EverWorksDnsService,
 } from '@src/ever-works-providers';
 import { WorkDetailService } from './work-detail.service';
 import { WorkOwnershipService } from './work-ownership.service';
@@ -146,7 +148,6 @@ import { PluginOperationsService } from '../plugins/services/plugin-operations.s
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
 import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
-import { EverWorksDnsService } from '../ever-works-providers/cloudflare-dns.provider';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
 import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
 import { TemplateCatalogModule } from '../template-catalog/template-catalog.module';


### PR DESCRIPTION
## Summary
Cascade develop → stage for EW-617 follow-up wire-up PR #776.

Wires the deferred captcha + funnel emit + DNS cleanup surfaces into their consumers. All safe-by-default — captcha no-ops when env unset, funnel emits only with correlationId, DNS cleanup only fires for `ever-works` provider.

## Test plan
- [ ] CI green on stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)