### PR TITLE
chore(release): cascade stage → main (CI fix PR #780)

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -26,6 +26,11 @@ module.exports = {
     testTimeout: 30000,
     moduleNameMapper: {
         '^@src/generators/(.*)$': '<rootDir>/../../../packages/agent/src/generators/$1/index.ts',
+        // Items-generator's source lives under @ever-works/agent, but
+        // entities import it via the api `@src/...` alias. Map it through
+        // so cross-package tests (claim-account.service.spec,
+        // deploy.e2e.spec, etc.) can load entities without TS2307.
+        '^@src/items-generator/(.*)$': '<rootDir>/../../../packages/agent/src/items-generator/$1',
         '^@src/(.*)$': '<rootDir>/$1',
         // Map workspace packages to their source TypeScript files for testing
         '^@ever-works/plugin$': '<rootDir>/../../../packages/plugin/src/index.ts',

--- a/apps/api/src/auth/services/anonymous-auth.service.ts
+++ b/apps/api/src/auth/services/anonymous-auth.service.ts
@@ -40,10 +40,12 @@ export class AnonymousAuthService {
         return days * 24 * 60 * 60 * 1000;
     }
 
-    async createAnonymousUser(opts: {
-        ipAddress?: string | null;
-        userAgent?: string | null;
-    } = {}): Promise<TokenResponse> {
+    async createAnonymousUser(
+        opts: {
+            ipAddress?: string | null;
+            userAgent?: string | null;
+        } = {},
+    ): Promise<TokenResponse> {
         const expiresAt = new Date(Date.now() + this.getTtlMs());
         const username = `anon-${randomBytes(4).toString('hex')}`;
 

--- a/apps/api/src/auth/services/claim-account.service.spec.ts
+++ b/apps/api/src/auth/services/claim-account.service.spec.ts
@@ -157,7 +157,10 @@ describe('ClaimAccountService (EW-617 G3)', () => {
     it('returns 409 when the email belongs to a different user', async () => {
         const ctx = buildService();
         ctx.findByIdResults['u-1'] = anonUser();
-        ctx.findByEmailResults['jane@example.com'] = { id: 'u-someone-else', email: 'jane@example.com' };
+        ctx.findByEmailResults['jane@example.com'] = {
+            id: 'u-someone-else',
+            email: 'jane@example.com',
+        };
 
         await expect(
             ctx.service.claim({

--- a/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
@@ -139,6 +139,9 @@ describe('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + real 
         const platformSyncSecretService = {
             getOrGenerate: jest.fn().mockResolvedValue('platform-sync-secret'),
         };
+        // 9th DI arg added on develop post-EW-616 — Ever Works DNS service.
+        // No deploy path under test reaches it, so a typeless stub is fine.
+        const dnsService = {};
 
         const prevEnv = { ...process.env };
         delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
@@ -154,6 +157,7 @@ describe('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + real 
             websiteTemplateResolver as any,
             eventEmitter,
             platformSyncSecretService as any,
+            dnsService as any,
         );
 
         const restoreEnv = () => {

--- a/apps/api/src/works/works.controller.quick-create.spec.ts
+++ b/apps/api/src/works/works.controller.quick-create.spec.ts
@@ -1,6 +1,11 @@
 // Mock the agent runtime tree at module scope so importing the controller does
 // not pull in the agent's NestJS DI graph.
-jest.mock('@ever-works/agent/dto', () => ({}));
+jest.mock('@ever-works/agent/dto', () => ({
+    // The controller's `quickCreateWork` does `new CreateWorkDto()` and
+    // assigns fields onto it via `Object.assign`. A bare-class stub is
+    // enough — class-validator decorators aren't exercised in unit tests.
+    CreateWorkDto: class CreateWorkDto {},
+}));
 jest.mock('@ever-works/agent/items-generator', () => ({
     CreateItemsGeneratorDto: class CreateItemsGeneratorDto {
         name?: string;

--- a/apps/web/src/components/works/detail/settings/CommitterSettings.tsx
+++ b/apps/web/src/components/works/detail/settings/CommitterSettings.tsx
@@ -33,9 +33,11 @@ export function CommitterSettings() {
         });
     };
 
-    // Placeholders show the auth defaults (actual fallback includes user-level settings)
-    const defaultName = user.username;
-    const defaultEmail = user.email;
+    // Placeholders show the auth defaults (actual fallback includes user-level settings).
+    // Better Auth's `user.email` is typed `string | null`; the Input
+    // component's `placeholder` accepts `string | undefined`, so coerce.
+    const defaultName = user.username ?? undefined;
+    const defaultEmail = user.email ?? undefined;
 
     return (
         <div

--- a/docs/specs/features/k8s-cluster-source-matrix/plan.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/plan.md
@@ -145,13 +145,13 @@ sequenceDiagram
 
 ## 7. Risks and mitigations
 
-| Risk | Mitigation |
-| --- | --- |
-| Platform kubeconfig leaks into a customer's website repo as the `K8S_TOKEN` secret | The matrix forbids `Ever Works-shared GHCR + custom cluster` combos, which is the only path where a customer cluster would see the secret. |
-| Sentinel value leaks into a pushed secret if the facade invariant breaks in the future | `DeployService.resolveDeployToken` defensively strips it before the resolver; spec'd as FR-7 and pinned by `does not leak the sentinel` test. |
-| Missing env var silently succeeds with empty kubeconfig | `resolveKubeconfigForClusterSource` throws on `undefined` and on whitespace-only values; covered by 4 unit tests. |
-| Existing customer-org Works break after EW-616 deploys | Back-compat default (`coerceClusterSource` returns `custom-kubeconfig` for missing values) keeps them on the existing path. Covered by `back-compat: no clusterSource + customer-owned org + user kubeconfig → uses user kubeconfig` test. |
-| Long-lived platform kubeconfigs become a blast-radius problem if leaked | Out-of-scope follow-up to rotate to short-lived service-account tokens. Documented in spec §5. |
+| Risk                                                                                   | Mitigation                                                                                                                                                                                                                                 |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Platform kubeconfig leaks into a customer's website repo as the `K8S_TOKEN` secret     | The matrix forbids `Ever Works-shared GHCR + custom cluster` combos, which is the only path where a customer cluster would see the secret.                                                                                                 |
+| Sentinel value leaks into a pushed secret if the facade invariant breaks in the future | `DeployService.resolveDeployToken` defensively strips it before the resolver; spec'd as FR-7 and pinned by `does not leak the sentinel` test.                                                                                              |
+| Missing env var silently succeeds with empty kubeconfig                                | `resolveKubeconfigForClusterSource` throws on `undefined` and on whitespace-only values; covered by 4 unit tests.                                                                                                                          |
+| Existing customer-org Works break after EW-616 deploys                                 | Back-compat default (`coerceClusterSource` returns `custom-kubeconfig` for missing values) keeps them on the existing path. Covered by `back-compat: no clusterSource + customer-owned org + user kubeconfig → uses user kubeconfig` test. |
+| Long-lived platform kubeconfigs become a blast-radius problem if leaked                | Out-of-scope follow-up to rotate to short-lived service-account tokens. Documented in spec §5.                                                                                                                                             |
 
 ## 8. Rollout
 

--- a/docs/specs/features/k8s-cluster-source-matrix/spec.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/spec.md
@@ -40,7 +40,7 @@ EW-616 splits the configuration into an explicit `clusterSource ∈ {k8s-works, 
 
 - **Given** I open the Kubernetes plugin settings, **when** the form loads, **then** I see a new **Target cluster** dropdown with three options: `k8s-works` (Ever Works shared customer cluster), `k8s-gauzy` (Ever Works internal cluster — admin-only), and `custom-kubeconfig` (paste my own). The default is `custom-kubeconfig` for back-compat.
 - **Given** I pick `custom-kubeconfig`, **when** the form re-renders, **then** the **kubeconfig** textarea and the optional **Context** field are visible and **kubeconfig** is required to save.
-- **Given** I pick `k8s-works` or `k8s-gauzy`, **when** the form re-renders, **then** the **kubeconfig** textarea and **Context** field are hidden, the form can be saved without a kubeconfig, and **Save & verify** succeeds with the message *"Will deploy to platform-managed cluster '<name>'."* (no live cluster check — the platform owns the credentials).
+- **Given** I pick `k8s-works` or `k8s-gauzy`, **when** the form re-renders, **then** the **kubeconfig** textarea and **Context** field are hidden, the form can be saved without a kubeconfig, and **Save & verify** succeeds with the message _"Will deploy to platform-managed cluster '<name>'."_ (no live cluster check — the platform owns the credentials).
 - **Given** my Work's website repo is in `ever-works-cloud` and I picked `clusterSource: 'k8s-works'`, **when** I deploy, **then** the deploy service substitutes `process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG` as the workflow's `K8S_TOKEN` secret, the dispatched `deploy_k8s.yaml` workflow uses it to talk to the shared customer cluster, and the deploy succeeds without me touching cluster credentials.
 - **Given** my Work's website repo is in `ever-works` (admin path) and I picked `clusterSource: 'k8s-gauzy'`, **when** I deploy, **then** the deploy service substitutes `process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG` and the deploy targets the internal platform cluster.
 - **Given** my Work's website repo is customer-owned (any org other than `ever-works` / `ever-works-cloud`) and I picked `clusterSource: 'custom-kubeconfig'`, **when** I deploy, **then** the platform reads my pasted kubeconfig (the existing path, unchanged) and `K8S_TOKEN` is exactly that value.
@@ -49,11 +49,11 @@ EW-616 splits the configuration into an explicit `clusterSource ∈ {k8s-works, 
 
 The deploy service rejects four of the nine `(websiteOwner, clusterSource)` combinations:
 
-| Website owner | `k8s-works` | `k8s-gauzy` | `custom-kubeconfig` |
-| --- | --- | --- | --- |
-| `ever-works` | ✅ | ✅ admin path | ❌ `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` |
-| `ever-works-cloud` | ✅ default | ❌ `K8S_GAUZY_NOT_ALLOWED` | ❌ `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` |
-| customer-owned org | ✅ | ❌ `K8S_GAUZY_NOT_ALLOWED` | ✅ BYOC default |
+| Website owner      | `k8s-works` | `k8s-gauzy`                | `custom-kubeconfig`                               |
+| ------------------ | ----------- | -------------------------- | ------------------------------------------------- |
+| `ever-works`       | ✅          | ✅ admin path              | ❌ `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` |
+| `ever-works-cloud` | ✅ default  | ❌ `K8S_GAUZY_NOT_ALLOWED` | ❌ `CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` |
+| customer-owned org | ✅          | ❌ `K8S_GAUZY_NOT_ALLOWED` | ✅ BYOC default                                   |
 
 - **Given** a customer Work in `ever-works-cloud` picks `custom-kubeconfig`, **when** the deploy starts, **then** the platform returns `400 Bad Request` with `code: CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG` and a message that explains the cross-tenant exposure risk and the two valid alternatives (pick `k8s-works`, or move the Work to the customer's own org).
 - **Given** a customer Work in any non-`ever-works` org picks `k8s-gauzy`, **when** the deploy starts, **then** the platform returns `400 Bad Request` with `code: K8S_GAUZY_NOT_ALLOWED` explaining that `k8s-gauzy` is admin-only and pointing to the two valid alternatives.
@@ -103,7 +103,7 @@ The deploy service rejects four of the nine `(websiteOwner, clusterSource)` comb
 
 - **NFR-1. Security.** The kubeconfig env vars are platform-cluster-admin credentials. They MUST never be returned by any API response, logged with their value, or echoed to terminals. Operator-side probes (key-name listing, byte-length checks) are allowed; value-revealing probes (`printenv`, `kubectl get secret -o yaml | grep KUBECONFIG`) are not.
 - **NFR-2. Fail-closed.** Missing env vars MUST fail the deploy with a 5xx, not silently use a wrong kubeconfig or skip the substitution.
-- **NFR-3. Error-message clarity.** All four rejection reasons (`CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG`, `K8S_GAUZY_NOT_ALLOWED`, `CUSTOM_KUBECONFIG_MISSING_KUBECONFIG`, missing env var) MUST tell the user (or operator) both *why* the deploy was rejected and what valid alternatives exist.
+- **NFR-3. Error-message clarity.** All four rejection reasons (`CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG`, `K8S_GAUZY_NOT_ALLOWED`, `CUSTOM_KUBECONFIG_MISSING_KUBECONFIG`, missing env var) MUST tell the user (or operator) both _why_ the deploy was rejected and what valid alternatives exist.
 - **NFR-4. Owner string handling.** Owner comparisons MUST be case-insensitive and whitespace-trimmed — so `ever-works-cloud`, `EVER-WORKS-CLOUD`, and `  ever-works-cloud  ` resolve identically.
 
 ---

--- a/docs/specs/features/zero-friction-flow/spec.md
+++ b/docs/specs/features/zero-friction-flow/spec.md
@@ -26,16 +26,16 @@ keep their Work.
 Each gap is tracked as a sub-task under EW-617 and shipped as its own
 PR.
 
-| #  | Title                                                          | Jira    | Status   |
-|----|----------------------------------------------------------------|---------|----------|
-| G1 | Landing-page prompt input + handoff to app.ever.works          | EW-618  | Planned  |
-| G2 | Anonymous / temporary user auth                                | EW-619  | This PR  |
-| G3 | Claim-Account flow (anon → registered)                         | EW-620  | This PR  |
-| G4 | Wizard "Finish & Generate with Defaults" + `/api/works/quick-create` | EW-621 | Planned |
-| G5 | Subdomain ingress + Cloudflare DNS automation                  | EW-622  | Planned  |
-| G6 | Default `work.deployProvider` `'vercel'` → `'ever-works'`      | EW-623  | Merged (#752) |
-| G7 | Quotas + abuse protection                                      | EW-624  | Planned  |
-| G8 | Telemetry events + ops runbook                                 | EW-625  | Planned  |
+| #   | Title                                                                | Jira   | Status        |
+| --- | -------------------------------------------------------------------- | ------ | ------------- |
+| G1  | Landing-page prompt input + handoff to app.ever.works                | EW-618 | Planned       |
+| G2  | Anonymous / temporary user auth                                      | EW-619 | This PR       |
+| G3  | Claim-Account flow (anon → registered)                               | EW-620 | This PR       |
+| G4  | Wizard "Finish & Generate with Defaults" + `/api/works/quick-create` | EW-621 | Planned       |
+| G5  | Subdomain ingress + Cloudflare DNS automation                        | EW-622 | Planned       |
+| G6  | Default `work.deployProvider` `'vercel'` → `'ever-works'`            | EW-623 | Merged (#752) |
+| G7  | Quotas + abuse protection                                            | EW-624 | Planned       |
+| G8  | Telemetry events + ops runbook                                       | EW-625 | Planned       |
 
 ## G3 — Claim-Account flow (anonymous → registered)
 
@@ -46,7 +46,7 @@ PR.
   caller's `User` row is not `is_anonymous = true`. This prevents
   hijacking an already-registered account.
 - **FR-G3-2** The endpoint accepts `{ email, password, username?,
-  emailVerificationCallbackUrl? }` (validated by `ClaimAccountDto`
+emailVerificationCallbackUrl? }` (validated by `ClaimAccountDto`
   with the same password rules as `RegisterDto`).
 - **FR-G3-3** If `email` (normalized to lowercase, trimmed) matches a
   different existing user, the endpoint MUST return 409 Conflict.
@@ -90,7 +90,7 @@ PR.
 - **FR-G2-3** `POST /api/auth/anonymous` MUST mint a fresh `User` row
   with `is_anonymous=true`, `email=NULL`, `password=NULL`,
   `registration_provider='anonymous'`, `anonymous_expires_at = now +
-  ANONYMOUS_USER_TTL_DAYS` (default 7), then issue an `AuthSession`
+ANONYMOUS_USER_TTL_DAYS` (default 7), then issue an `AuthSession`
   token and return `{ access_token, user }` in the same shape as
   `POST /api/auth/register`.
 - **FR-G2-4** `POST /api/auth/anonymous` MUST be rate-limited per IP
@@ -106,7 +106,7 @@ PR.
   reject anonymous users explicitly.
 - **FR-G2-7** A nightly Trigger.dev schedule `anonymous-user-cleanup`
   (cron `17 3 * * *`) MUST find users with `is_anonymous=true AND
-  anonymous_expires_at < now` and delete them. The existing `work.user`
+anonymous_expires_at < now` and delete them. The existing `work.user`
   `ON DELETE CASCADE` removes their Works. A single delete failure
   MUST log + continue so one stuck row cannot block the batch.
 - **FR-G2-8** The web-side `JwtPayload` type MUST expose `isAnonymous`

--- a/packages/agent/src/account-transfer/github-sync.service.ts
+++ b/packages/agent/src/account-transfer/github-sync.service.ts
@@ -138,9 +138,7 @@ export class GitHubSyncService {
 
             const user = await this.userRepository.findById(userId);
             const committer =
-                user && user.email
-                    ? { name: user.username, email: user.email }
-                    : undefined;
+                user && user.email ? { name: user.username, email: user.email } : undefined;
 
             // Clone or pull the repo
             const dir = await this.gitFacade.cloneOrPull(
@@ -186,9 +184,7 @@ export class GitHubSyncService {
         try {
             const user = await this.userRepository.findById(userId);
             const committer =
-                user && user.email
-                    ? { name: user.username, email: user.email }
-                    : undefined;
+                user && user.email ? { name: user.username, email: user.email } : undefined;
 
             const dir = await this.gitFacade.cloneOrPull(
                 { owner: config.repoOwner, repo: config.repoName, committer },
@@ -234,9 +230,7 @@ export class GitHubSyncService {
         try {
             const user = await this.userRepository.findById(userId);
             const committer =
-                user && user.email
-                    ? { name: user.username, email: user.email }
-                    : undefined;
+                user && user.email ? { name: user.username, email: user.email } : undefined;
 
             const dir = await this.gitFacade.cloneOrPull(
                 { owner: config.repoOwner, repo: config.repoName, committer },

--- a/packages/agent/src/entities/user.entity.ts
+++ b/packages/agent/src/entities/user.entity.ts
@@ -42,10 +42,13 @@ export class User {
     // EW-617 G2: anonymous (zero-friction) users have no email/password until
     // they claim the account via POST /api/auth/claim. Existing rows keep
     // their non-null values; new anonymous rows persist NULLs here.
-    @Column({ unique: true, nullable: true })
+    // Explicit `type: 'varchar'` because TS reflect-metadata flattens
+    // `string | null` to `Object`, which better-sqlite3 (used by internal
+    // CLI tests) refuses with DataTypeNotSupportedError.
+    @Column({ type: 'varchar', unique: true, nullable: true })
     email: string | null;
 
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     password: string | null;
 
     @Column({ default: 'local' })

--- a/packages/agent/src/services/anonymous-user-cleanup.service.ts
+++ b/packages/agent/src/services/anonymous-user-cleanup.service.ts
@@ -49,9 +49,7 @@ export class AnonymousUserCleanupService {
                 summary.failed += 1;
                 const error = cause instanceof Error ? cause.message : String(cause);
                 summary.failures.push({ userId: user.id, error });
-                this.logger.error(
-                    `Failed to delete expired anonymous user ${user.id}: ${error}`,
-                );
+                this.logger.error(`Failed to delete expired anonymous user ${user.id}: ${error}`);
             }
         }
 


### PR DESCRIPTION
## Summary

Cascades stage to main for production release. Bundles PR #780 (CreateWorkDto mock + User entity explicit varchar). Both fixes are test/schema-metadata only with no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)