### PR TITLE
feat(deploy): provision EW-617 env vars across dev/stage/prod (CF DNS + deploy flag + captcha placeholder)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -204,6 +204,30 @@ spec:
                   name: ever-works-platform-kubeconfigs-dev
                   key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
+            # EW-617 — zero-friction Ever Works deploy provider.
+            # Gates the 'ever-works' choice in the deploy facade; default is
+            # vercel until this is on. Also turns the subdomain DNS
+            # automation live when paired with the CLOUDFLARE_* secrets.
+            - name: DEPLOY_EVER_WORKS_ENABLED
+              value: "$DEPLOY_EVER_WORKS_ENABLED"
+            - name: EVER_WORKS_DOMAIN
+              value: "$EVER_WORKS_DOMAIN"
+            - name: EVER_WORKS_DEPLOY_LB_HOSTNAME
+              value: "$EVER_WORKS_DEPLOY_LB_HOSTNAME"
+            - name: CLOUDFLARE_API_TOKEN
+              value: "$CLOUDFLARE_API_TOKEN"
+            - name: CLOUDFLARE_ZONE_ID
+              value: "$CLOUDFLARE_ZONE_ID"
+
+            # EW-617 G7 — captcha verifier. Provider-agnostic
+            # (Turnstile/hCaptcha/reCAPTCHA). No-ops when CAPTCHA_PROVIDER
+            # is empty so we can ship the env wiring without enabling
+            # captcha at the same time.
+            - name: CAPTCHA_PROVIDER
+              value: "$CAPTCHA_PROVIDER"
+            - name: CAPTCHA_SECRET
+              value: "$CAPTCHA_SECRET"
+
           resources:
             requests:
               memory: "512Mi"

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -214,6 +214,30 @@ spec:
                   name: ever-works-platform-kubeconfigs
                   key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
+            # EW-617 — zero-friction Ever Works deploy provider.
+            # Gates the 'ever-works' choice in the deploy facade; default is
+            # vercel until this is on. Also turns the subdomain DNS
+            # automation live when paired with the CLOUDFLARE_* secrets.
+            - name: DEPLOY_EVER_WORKS_ENABLED
+              value: "$DEPLOY_EVER_WORKS_ENABLED"
+            - name: EVER_WORKS_DOMAIN
+              value: "$EVER_WORKS_DOMAIN"
+            - name: EVER_WORKS_DEPLOY_LB_HOSTNAME
+              value: "$EVER_WORKS_DEPLOY_LB_HOSTNAME"
+            - name: CLOUDFLARE_API_TOKEN
+              value: "$CLOUDFLARE_API_TOKEN"
+            - name: CLOUDFLARE_ZONE_ID
+              value: "$CLOUDFLARE_ZONE_ID"
+
+            # EW-617 G7 — captcha verifier. Provider-agnostic
+            # (Turnstile/hCaptcha/reCAPTCHA). No-ops when CAPTCHA_PROVIDER
+            # is empty so we can ship the env wiring without enabling
+            # captcha at the same time.
+            - name: CAPTCHA_PROVIDER
+              value: "$CAPTCHA_PROVIDER"
+            - name: CAPTCHA_SECRET
+              value: "$CAPTCHA_SECRET"
+
           resources:
             requests:
               memory: "512Mi"

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -204,6 +204,30 @@ spec:
                   name: ever-works-platform-kubeconfigs-stage
                   key: EVER_WORKS_K8S_GAUZY_KUBECONFIG
 
+            # EW-617 — zero-friction Ever Works deploy provider.
+            # Gates the 'ever-works' choice in the deploy facade; default is
+            # vercel until this is on. Also turns the subdomain DNS
+            # automation live when paired with the CLOUDFLARE_* secrets.
+            - name: DEPLOY_EVER_WORKS_ENABLED
+              value: "$DEPLOY_EVER_WORKS_ENABLED"
+            - name: EVER_WORKS_DOMAIN
+              value: "$EVER_WORKS_DOMAIN"
+            - name: EVER_WORKS_DEPLOY_LB_HOSTNAME
+              value: "$EVER_WORKS_DEPLOY_LB_HOSTNAME"
+            - name: CLOUDFLARE_API_TOKEN
+              value: "$CLOUDFLARE_API_TOKEN"
+            - name: CLOUDFLARE_ZONE_ID
+              value: "$CLOUDFLARE_ZONE_ID"
+
+            # EW-617 G7 — captcha verifier. Provider-agnostic
+            # (Turnstile/hCaptcha/reCAPTCHA). No-ops when CAPTCHA_PROVIDER
+            # is empty so we can ship the env wiring without enabling
+            # captcha at the same time.
+            - name: CAPTCHA_PROVIDER
+              value: "$CAPTCHA_PROVIDER"
+            - name: CAPTCHA_SECRET
+              value: "$CAPTCHA_SECRET"
+
           resources:
             requests:
               memory: "512Mi"

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -132,6 +132,24 @@ jobs:
           EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
           EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
 
+          # EW-617 — Ever Works zero-friction deploy + DNS automation.
+          # DEPLOY_EVER_WORKS_ENABLED gates the 'ever-works' deploy
+          # provider choice. CLOUDFLARE_* drive the subdomain DNS
+          # automation. EVER_WORKS_DEPLOY_LB_HOSTNAME is the anchor record
+          # that {slug}.ever.works CNAMEs target (resolves to the
+          # k8s-works ingress LB at 157.230.74.11).
+          DEPLOY_EVER_WORKS_ENABLED: 'true'
+          EVER_WORKS_DOMAIN: ever.works
+          EVER_WORKS_DEPLOY_LB_HOSTNAME: lb.ever.works
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+
+          # EW-617 G7 — captcha verifier. Empty defaults keep captcha
+          # disabled; flip CAPTCHA_PROVIDER + CAPTCHA_SECRET when the
+          # Turnstile widget is provisioned + client integration ships.
+          CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
+          CAPTCHA_SECRET: ${{ secrets.CAPTCHA_SECRET }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -135,6 +135,24 @@ jobs:
           EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
           EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
 
+          # EW-617 — Ever Works zero-friction deploy + DNS automation.
+          # DEPLOY_EVER_WORKS_ENABLED gates the 'ever-works' deploy
+          # provider choice. CLOUDFLARE_* drive the subdomain DNS
+          # automation. EVER_WORKS_DEPLOY_LB_HOSTNAME is the anchor record
+          # that {slug}.ever.works CNAMEs target (resolves to the
+          # k8s-works ingress LB at 157.230.74.11).
+          DEPLOY_EVER_WORKS_ENABLED: 'true'
+          EVER_WORKS_DOMAIN: ever.works
+          EVER_WORKS_DEPLOY_LB_HOSTNAME: lb.ever.works
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+
+          # EW-617 G7 — captcha verifier. Empty defaults keep captcha
+          # disabled; flip CAPTCHA_PROVIDER + CAPTCHA_SECRET when the
+          # Turnstile widget is provisioned + client integration ships.
+          CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
+          CAPTCHA_SECRET: ${{ secrets.CAPTCHA_SECRET }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -132,6 +132,24 @@ jobs:
           EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
           EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
 
+          # EW-617 — Ever Works zero-friction deploy + DNS automation.
+          # DEPLOY_EVER_WORKS_ENABLED gates the 'ever-works' deploy
+          # provider choice. CLOUDFLARE_* drive the subdomain DNS
+          # automation. EVER_WORKS_DEPLOY_LB_HOSTNAME is the anchor record
+          # that {slug}.ever.works CNAMEs target (resolves to the
+          # k8s-works ingress LB at 157.230.74.11).
+          DEPLOY_EVER_WORKS_ENABLED: 'true'
+          EVER_WORKS_DOMAIN: ever.works
+          EVER_WORKS_DEPLOY_LB_HOSTNAME: lb.ever.works
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+
+          # EW-617 G7 — captcha verifier. Empty defaults keep captcha
+          # disabled; flip CAPTCHA_PROVIDER + CAPTCHA_SECRET when the
+          # Turnstile widget is provisioned + client integration ships.
+          CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
+          CAPTCHA_SECRET: ${{ secrets.CAPTCHA_SECRET }}
+
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version

--- a/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
+++ b/docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md
@@ -125,12 +125,58 @@ user.isAnonymous: true }`.
 | Env var                         | Owned by | Notes                                                                     |
 | ------------------------------- | -------- | ------------------------------------------------------------------------- |
 | `ANONYMOUS_USER_TTL_DAYS`       | G2       | Default 7. Garbage values fall back to 7.                                 |
+| `CAPTCHA_PROVIDER`              | G7       | `turnstile` / `hcaptcha` / `recaptcha` or empty (disabled).               |
+| `CAPTCHA_SECRET`                | G7       | Server-side secret for the provider's `/siteverify`.                      |
 | `CLOUDFLARE_API_TOKEN`          | G5       | Scoped: DNS:Edit on the `ever.works` zone only. Never the global key.     |
 | `CLOUDFLARE_ZONE_ID`            | G5       | 32-char hex.                                                              |
 | `EVER_WORKS_DEPLOY_LB_HOSTNAME` | G5       | Cluster ingress LB DNS name. Required for DNS automation.                 |
 | `EVER_WORKS_DOMAIN`             | G5       | Defaults to `ever.works`.                                                 |
 | `DEPLOY_EVER_WORKS_ENABLED`     | EW-608   | Gates the `ever-works` deploy provider end-to-end.                        |
 | `NEXT_PUBLIC_APP_URL`           | G1       | Where the landing page sends users. Defaults to `https://app.ever.works`. |
+
+### Live values (dev / stage / prod, as of 2026-05-15)
+
+| Env var                         | Value (or source)                                              |
+| ------------------------------- | -------------------------------------------------------------- |
+| `DEPLOY_EVER_WORKS_ENABLED`     | `true` (inlined in deploy-do-{dev,stage,prod}.yml)             |
+| `EVER_WORKS_DOMAIN`             | `ever.works` (inlined in workflows)                            |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | `lb.ever.works` → A `157.230.74.11` (k8s-works ingress LB)     |
+| `CLOUDFLARE_API_TOKEN`          | GH secret `CLOUDFLARE_API_TOKEN` (Zone:DNS edit on ever.works) |
+| `CLOUDFLARE_ZONE_ID`            | GH secret `CLOUDFLARE_ZONE_ID` → `14b28d7fd73db5679d4280e4278ec6cf` |
+| `CAPTCHA_PROVIDER`              | GH secret `CAPTCHA_PROVIDER` — **empty** until Turnstile widget + client wiring ship |
+| `CAPTCHA_SECRET`                | GH secret `CAPTCHA_SECRET` — **empty** until Turnstile widget + client wiring ship   |
+
+### Deploy mechanism
+
+Env vars land in pods via the `envsubst` step in
+`.github/workflows/deploy-do-{dev,stage,prod}.yml` against the
+`.deploy/k8s/k8s-manifest.{dev,stage,prod}.yaml` placeholders. Each
+workflow's `env:` map maps GH secrets / inline values → `$VAR` →
+container env. Adding a new env var = (a) declare `- name: VAR / value:
+"$VAR"` in the 3 manifest YAMLs, (b) pass `VAR: ${{ secrets.VAR }}` (or
+inline) in the 3 workflow YAMLs, (c) `gh secret set VAR --repo
+ever-works/ever-works`.
+
+### DNS anchor record
+
+`lb.ever.works → A 157.230.74.11` is the anchor that all customer
+`{slug}.ever.works` CNAMEs point at. Created via the Cloudflare API
+2026-05-15 (PR ${{TBD}}). To rotate the LB IP, update this A record
+once; every existing CNAME inherits the new target. The k8s-works
+LoadBalancer Service (`ingress-nginx/ingress-nginx-controller`) does not
+expose a hostname, only an IP, which is why the anchor record exists in
+the first place.
+
+### Cloudflare token security note
+
+The token currently in GH secrets has broader scope than strictly
+needed (Zone:DNS edit on ever.works is the only operation
+`EverWorksDnsService` performs, but the token currently used can also
+read other zones in the account). **Follow-up**: rotate to a
+zone-scoped token via the Cloudflare dashboard → My Profile → API
+Tokens → "Create Token" → "Edit zone DNS" template scoped to
+`ever.works` only. Update the `CLOUDFLARE_API_TOKEN` GH secret with
+the new value; the platform code path is unchanged.
 
 ## Dashboards
 


### PR DESCRIPTION
## Summary
Adds the seven EW-617 env vars to the platform API deployment manifests and deploy workflows on dev, stage, and prod. Most light up immediately (DNS automation, ever-works deploy provider). Captcha is plumbed but intentionally left empty until the Turnstile widget + client integration ship in the follow-up PR — empty values keep `CaptchaVerifierService` in its no-op mode so existing flows aren't broken.

### Env vars added (api container, all 3 envs)
| Var | Source | Value / disposition |
|---|---|---|
| `DEPLOY_EVER_WORKS_ENABLED` | inline workflow | `'true'` |
| `EVER_WORKS_DOMAIN` | inline workflow | `ever.works` |
| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | inline workflow | `lb.ever.works` |
| `CLOUDFLARE_API_TOKEN` | GH secret | Zone:DNS edit on `ever.works` |
| `CLOUDFLARE_ZONE_ID` | GH secret | `14b28d7fd73db5679d4280e4278ec6cf` |
| `CAPTCHA_PROVIDER` | GH secret | **empty** (no-op until widget ships) |
| `CAPTCHA_SECRET` | GH secret | **empty** (no-op until widget ships) |

### DNS anchor record (one-time, set via Cloudflare API)
- `lb.ever.works`  A  `157.230.74.11`  (k8s-works ingress LB, proxied=off)
- All customer `{slug}.ever.works` CNAMEs target this record. Created 2026-05-15.

### Files touched
- 3 manifests: `.deploy/k8s/k8s-manifest.{dev,stage,prod}.yaml`
- 3 workflows: `.github/workflows/deploy-do-{dev,stage,prod}.yml`
- 1 runbook: `docs/runbooks/EVER_WORKS_ZERO_FRICTION_FLOW.md`

### What still needs to ship for full zero-friction
- Turnstile widget creation (Cloudflare dashboard) + sitekey
- Client-side captcha widget in apps/web wizard (passes `captchaToken`)
- Then flip `CAPTCHA_PROVIDER` + `CAPTCHA_SECRET` GH secrets

## Test plan
- [x] No code changes — only deploy config + docs; agent tests aren't affected.
- [ ] CI green on dev/stage/prod workflows (after merge).
- [ ] After merge to develop: `kubectl describe deploy ever-works-api-dev` shows the new env vars under `Containers.ever-works-api-dev.Environment` once the next deploy lands.
- [ ] Smoke test on stage: create a Work with `deployProvider='ever-works'` and verify a CNAME record `{slug}.ever.works → lb.ever.works` is created in Cloudflare.

## Follow-up tickets (open separately)
- Rotate `CLOUDFLARE_API_TOKEN` to a zone-scoped token (see runbook).
- Create Turnstile widget for `ever.works` + `app.ever.works` + `appstage.ever.works`.
- Wire client captcha widget into apps/web wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CAPTCHA verification capability with flexible provider configuration.
  * Enabled automated deployment with DNS and domain management capabilities.

* **Documentation**
  * Added configuration runbook documentation for deployment automation with security best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/783)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->