### PR TITLE
feat(web): wire Turnstile captcha into wizard quick-create (EW-617 G7 client)

### DIFF
--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -13,6 +13,7 @@ import { ChoiceStep } from './steps/ChoiceStep';
 import { ConfigStep } from './steps/ConfigStep';
 import { PluginsCatalogStep } from './steps/PluginsCatalogStep';
 import { CreateWorkStep } from './steps/CreateWorkStep';
+import { useTurnstile } from './use-turnstile';
 import { AI_ICONS, DEPLOY_ICONS, STORAGE_ICONS } from './brand-icons';
 import { trackOnboardingEvent } from '@/app/actions/onboarding/track';
 import { completeOnboarding, patchOnboardingState } from '@/app/actions/onboarding/state';
@@ -69,6 +70,24 @@ export function EverWorksOnboardingWizard({
     const [connections, setConnections] = useState(initialConnections);
     const [deviceAuthStatuses, setDeviceAuthStatuses] = useState(initialDeviceAuthStatuses);
     const [isStatusLoading, setIsStatusLoading] = useState(false);
+
+    // EW-617 G7 — Turnstile token producer. Renders a hidden Managed
+    // widget once at wizard mount; getToken() executes on demand
+    // before each captcha-gated API call. No-ops cleanly when the
+    // server's CAPTCHA_PROVIDER is unset.
+    const turnstile = useTurnstile();
+
+    // EW-617 G8 — correlation UUID minted on wizard mount, threaded
+    // into telemetry events server-side so ops can trace the full
+    // funnel (landing → wizard → work created → deploy ready).
+    const correlationId = useMemo(() => {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+        // Fallback for environments without crypto.randomUUID — only
+        // used in legacy browsers / older Node test envs.
+        return `corr-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    }, []);
 
     const flow = useOnboardingFlow({
         initial: initialState,
@@ -195,6 +214,8 @@ export function EverWorksOnboardingWizard({
                                 connections={connections}
                                 deviceAuthStatuses={deviceAuthStatuses}
                                 isStatusLoading={isStatusLoading}
+                                turnstile={turnstile}
+                                correlationId={correlationId}
                             />
                         </div>
                         <WizardFooter
@@ -325,6 +346,8 @@ function StepBody({
     connections,
     deviceAuthStatuses,
     isStatusLoading,
+    turnstile,
+    correlationId,
 }: {
     step: WizardStep;
     flow: ReturnType<typeof useOnboardingFlow>;
@@ -333,6 +356,8 @@ function StepBody({
     connections: Record<string, OAuthConnectionInfo | GitProviderConnectionInfo | null>;
     deviceAuthStatuses: Record<string, PluginDeviceAuthStatus | null>;
     isStatusLoading: boolean;
+    turnstile: ReturnType<typeof useTurnstile>;
+    correlationId: string;
 }) {
     switch (step.kind) {
         case 'welcome':
@@ -434,6 +459,10 @@ function StepBody({
                                   // EW-617 G4: anonymous + claimed users alike
                                   // can one-click finish. The endpoint reads
                                   // provider defaults from onboarding state.
+                                  // EW-617 G7: fetch a fresh Turnstile token
+                                  // right before the call. Empty when captcha
+                                  // is disabled — server is OK with that.
+                                  const captchaToken = await turnstile.getToken();
                                   const { quickCreateWorkAction } =
                                       await import('@/app/actions/works/quick-create');
                                   const slug = slugifyPrompt(prompt);
@@ -445,6 +474,8 @@ function StepBody({
                                       organization: false,
                                       deployProvider: flow.state.deploy.choice,
                                       storageProvider: flow.state.storage.choice,
+                                      captchaToken: captchaToken || undefined,
+                                      correlationId,
                                   });
                                   if (!result.success) {
                                       throw new Error(result.error ?? 'Failed to start generation');

--- a/apps/web/src/components/onboarding/use-turnstile.ts
+++ b/apps/web/src/components/onboarding/use-turnstile.ts
@@ -1,0 +1,172 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * EW-617 G7 — Cloudflare Turnstile (Managed mode) client hook.
+ *
+ * Loads the Turnstile script once (idempotent: re-mounting components
+ * reuses the global script), renders a hidden Turnstile widget in
+ * `execution: 'execute'` mode, and exposes `getToken()` so the caller
+ * can request a fresh token immediately before each captcha-gated
+ * API call.
+ *
+ * Why programmatic execute (vs auto-render):
+ *   - The wizard has multiple gated calls (`/api/auth/anonymous`,
+ *     `/api/works/quick-create`) at different moments. A single
+ *     widget with on-demand `execute()` produces one fresh token per
+ *     call, which is what Turnstile expects (tokens are single-use
+ *     with a ~5min TTL).
+ *   - Managed-mode UX: clean traffic gets an invisible verification,
+ *     suspicious traffic gets an interactive challenge in the
+ *     widget's hidden iframe (the iframe pops up only when needed).
+ *
+ * Empty / unset sitekey ⇒ hook resolves `getToken()` with an empty
+ * string immediately and lets the server fall through to its no-op
+ * captcha path. This keeps dev/preview environments unblocked.
+ */
+
+// Public Turnstile sitekey for the `ever.works` / `app.ever.works` /
+// `appstage.ever.works` Managed widget (EW-617 G7, created
+// 2026-05-15). Cloudflare validates the calling hostname against the
+// widget's allowed-domains list, so the sitekey is safe to embed.
+export const TURNSTILE_SITEKEY = '0x4AAAAAADQBelkvZYTPpR4t';
+
+const TURNSTILE_SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+const CONTAINER_ID = 'ew617-turnstile-container';
+
+type TurnstileRenderOptions = {
+    sitekey: string;
+    appearance: 'always' | 'execute' | 'interaction-only';
+    execution: 'render' | 'execute';
+    size: 'normal' | 'compact' | 'invisible';
+    callback?: (token: string) => void;
+    'error-callback'?: (errorCode: string) => void;
+    'expired-callback'?: () => void;
+    retry?: 'auto' | 'never';
+};
+
+declare global {
+    interface Window {
+        turnstile?: {
+            render: (container: HTMLElement | string, options: TurnstileRenderOptions) => string;
+            execute: (widgetId: string) => void;
+            reset: (widgetId: string) => void;
+            remove: (widgetId: string) => void;
+            getResponse: (widgetId: string) => string | undefined;
+        };
+        onTurnstileLoad?: () => void;
+    }
+}
+
+/**
+ * Returns `getToken()` that resolves to a fresh Turnstile token (or
+ * empty string if no sitekey is configured, captcha is server-disabled,
+ * or the script failed to load). Errors during execution resolve as
+ * empty too — never throw, since the server gracefully no-ops when
+ * `CAPTCHA_PROVIDER` is unset.
+ */
+export function useTurnstile(sitekey: string = TURNSTILE_SITEKEY) {
+    const widgetIdRef = useRef<string | null>(null);
+    const pendingResolveRef = useRef<((token: string) => void) | null>(null);
+    const [ready, setReady] = useState(false);
+
+    // Lazy-load the Turnstile script once. The Cloudflare API auto-detects
+    // duplicate loads, but we still guard against multiple <script> tags.
+    useEffect(() => {
+        if (!sitekey) return;
+        if (typeof window === 'undefined') return;
+
+        const existing = document.querySelector(`script[src^="${TURNSTILE_SCRIPT_SRC}"]`);
+        if (existing) {
+            // Already loaded by another mount — just check if API is up.
+            if (window.turnstile) {
+                setReady(true);
+                return;
+            }
+            existing.addEventListener('load', () => setReady(true), { once: true });
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.src = `${TURNSTILE_SCRIPT_SRC}?render=explicit`;
+        script.async = true;
+        script.defer = true;
+        script.addEventListener('load', () => setReady(true), { once: true });
+        document.head.appendChild(script);
+    }, [sitekey]);
+
+    // Render an invisible widget once the script is ready. We keep one
+    // widget alive for the lifetime of the hook and re-use it via
+    // execute()/reset() for each call.
+    useEffect(() => {
+        if (!ready || !sitekey) return;
+        if (typeof window === 'undefined' || !window.turnstile) return;
+        if (widgetIdRef.current) return;
+
+        let container = document.getElementById(CONTAINER_ID);
+        if (!container) {
+            container = document.createElement('div');
+            container.id = CONTAINER_ID;
+            container.style.position = 'absolute';
+            container.style.left = '-9999px';
+            container.style.top = '-9999px';
+            document.body.appendChild(container);
+        }
+
+        widgetIdRef.current = window.turnstile.render(container, {
+            sitekey,
+            appearance: 'execute',
+            execution: 'execute',
+            size: 'invisible',
+            retry: 'auto',
+            callback: (token: string) => {
+                pendingResolveRef.current?.(token);
+                pendingResolveRef.current = null;
+            },
+            'error-callback': () => {
+                pendingResolveRef.current?.('');
+                pendingResolveRef.current = null;
+            },
+            'expired-callback': () => {
+                if (widgetIdRef.current) window.turnstile?.reset(widgetIdRef.current);
+            },
+        });
+
+        return () => {
+            if (widgetIdRef.current && window.turnstile) {
+                window.turnstile.remove(widgetIdRef.current);
+                widgetIdRef.current = null;
+            }
+        };
+    }, [ready, sitekey]);
+
+    const getToken = useCallback((): Promise<string> => {
+        if (!sitekey) return Promise.resolve('');
+        if (typeof window === 'undefined' || !window.turnstile || !widgetIdRef.current) {
+            // Script not loaded yet or no widget — let the server fall back.
+            return Promise.resolve('');
+        }
+        return new Promise<string>((resolve) => {
+            pendingResolveRef.current = resolve;
+            try {
+                window.turnstile!.reset(widgetIdRef.current!);
+                window.turnstile!.execute(widgetIdRef.current!);
+            } catch {
+                pendingResolveRef.current = null;
+                resolve('');
+            }
+            // Safety net: if Turnstile never calls back, resolve empty
+            // after 10s so the user isn't stuck. The server's per-IP
+            // throttle is still in effect.
+            setTimeout(() => {
+                if (pendingResolveRef.current === resolve) {
+                    pendingResolveRef.current = null;
+                    resolve('');
+                }
+            }, 10_000);
+        });
+    }, [sitekey]);
+
+    return { getToken, ready };
+}

--- a/apps/web/src/lib/api/works.ts
+++ b/apps/web/src/lib/api/works.ts
@@ -21,6 +21,12 @@ export interface QuickCreateWorkRequest {
     readonly storageProvider?: string;
     readonly websiteTemplateId?: string;
     readonly model?: string;
+    /** EW-617 G7 — Cloudflare Turnstile token; verified server-side
+     *  when `CAPTCHA_PROVIDER` is set on the API. */
+    readonly captchaToken?: string;
+    /** EW-617 G8 — funnel correlation UUID minted at wizard mount.
+     *  Threaded into telemetry events. */
+    readonly correlationId?: string;
 }
 
 export interface QuickCreateWorkResponse {


### PR DESCRIPTION
## Summary
Completes the captcha gate end-to-end. Server-side verification has been live since PR #761 + #776; this PR adds the client widget that mints fresh Turnstile tokens before each gated API call.

### Client wiring
- **`useTurnstile` hook** (`apps/web/src/components/onboarding/use-turnstile.ts`)
  - Loads the Turnstile script once (idempotent; safe on re-mount)
  - Renders a hidden invisible widget in Managed mode (Cloudflare picks invisible vs interactive based on traffic risk)
  - Exposes `getToken()` that returns a fresh single-use token per call
  - Resolves `''` on missing sitekey, script failure, or 10s timeout — server's no-op path handles empty tokens gracefully so dev stays unblocked
- **Wizard**: mounts `useTurnstile()` + mints a correlation UUID at mount, threads both down to `StepBody` and on to the create-work step
- **`quickCreateWorkAction`** + **`QuickCreateWorkRequest`**: accept `captchaToken` + `correlationId` and forward to the API

### Configuration
- Sitekey `0x4AAAAAADQBelkvZYTPpR4t` is the public Turnstile widget id for `ever.works` / `app.ever.works` / `appstage.ever.works` (Managed mode). Hardcoded as a constant — Cloudflare validates the calling hostname against the widget's allowed-domains list, so the sitekey is safe to embed in client code.
- GH secrets set today (so the server gate goes live on next deploy):
  - `CAPTCHA_PROVIDER=turnstile`
  - `CAPTCHA_SECRET=…` (saved to `Workspace/.config/turnstile.env` for ops reference)
  - `NEXT_PUBLIC_TURNSTILE_SITEKEY=…` (saved for future swap to runtime config)

### Test plan
- [x] `tsc --noEmit` clean across apps/web
- [ ] After merge: stage deploy lands; visit `https://appstage.ever.works/onboarding?prompt=test`, click Generate, verify the request body carries `captchaToken` and the API returns 202
- [ ] Network tab confirms a request to `challenges.cloudflare.com/turnstile/v0/api.js` after wizard mount
- [ ] No regression for already-authenticated users on the create-work step

## Follow-up
- Make the sitekey runtime-configurable via `NEXT_PUBLIC_TURNSTILE_SITEKEY` build-arg in the web Dockerfile (deferred — current hardcode covers all 3 envs since they share the same Cloudflare widget).
- Funnel emit sites still deferred: `LANDING_PROMPT_SUBMIT`, `WIZARD_FINISHED`, `REPOS_PUSHED`, `DEPLOY_STARTED`, `DEPLOY_READY` (tracked as separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CAPTCHA verification is now integrated into the onboarding wizard's quick-create account creation flow.
  * Session correlation tracking has been added, with unique identifiers assigned to each onboarding instance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/788)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->