### PR TITLE
chore: cascade develop → stage (EW-617 G8 funnel emits finale)

### DIFF
--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -50,7 +50,7 @@ jobs:
           # API ENV
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           WEB_URL: https://appdev.ever.works
-          ALLOWED_ORIGINS: https://appdev.ever.works,https://apidev.ever.works
+          ALLOWED_ORIGINS: https://appdev.ever.works,https://apidev.ever.works,https://ever.works
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
           # Trigger.dev

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -50,7 +50,7 @@ jobs:
           # API ENV
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           WEB_URL: https://app.ever.works
-          ALLOWED_ORIGINS: https://app.ever.works,https://api.ever.works
+          ALLOWED_ORIGINS: https://app.ever.works,https://api.ever.works,https://ever.works
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
           # Trigger.dev

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -50,7 +50,7 @@ jobs:
           # API ENV
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           WEB_URL: https://appstage.ever.works
-          ALLOWED_ORIGINS: https://appstage.ever.works,https://apistage.ever.works
+          ALLOWED_ORIGINS: https://appstage.ever.works,https://apistage.ever.works,https://ever.works
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
           # Trigger.dev

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -28,6 +28,7 @@ import { ActivityLogModule } from './activity-log/activity-log.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
 import { TemplateCatalogModule } from './template-catalog/template-catalog.module';
 import { WorkProposalsModule } from './work-proposals/work-proposals.module';
+import { TelemetryModule } from './telemetry/telemetry.module';
 import {
     PluginsModule as AgentPluginsModule,
     PluginBootstrapService,
@@ -79,6 +80,7 @@ import { DatabaseModule } from '@ever-works/agent/database';
         OnboardingModule,
         TemplateCatalogModule,
         WorkProposalsModule,
+        TelemetryModule,
     ],
     providers: [
         {

--- a/apps/api/src/migrations/1779000000000-AddWorkLastDeployCorrelationId.ts
+++ b/apps/api/src/migrations/1779000000000-AddWorkLastDeployCorrelationId.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * EW-617 G8 — persist the funnel correlation id on the work row so the
+ * async DEPLOY_READY poller can emit the funnel event with the same id
+ * the rest of the flow used (LANDING_PROMPT_SUBMIT → WORK_CREATED →
+ * REPOS_PUSHED → DEPLOY_STARTED → DEPLOY_READY).
+ *
+ * Nullable; no backfill needed. Existing rows + non-funnel creates skip
+ * the emit and that's intentional.
+ */
+export class AddWorkLastDeployCorrelationId1779000000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'works',
+            new TableColumn({
+                name: 'lastDeployCorrelationId',
+                type: 'varchar',
+                length: '64',
+                isNullable: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('works', 'lastDeployCorrelationId');
+    }
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -1,7 +1,10 @@
 jest.mock('@ever-works/agent/database', () => ({ WorkRepository: class {} }));
 jest.mock('@ever-works/agent/entities', () => ({ Work: class {}, User: class {} }));
 jest.mock('@ever-works/agent/plugins', () => ({ PluginRegistryService: class {} }));
-jest.mock('@ever-works/agent/services', () => ({ PlatformSyncSecretService: class {} }));
+jest.mock('@ever-works/agent/services', () => ({
+    PlatformSyncSecretService: class {},
+    ZeroFrictionFunnelService: class {},
+}));
 jest.mock('@ever-works/agent/facades', () => ({
     DeployFacadeService: class {},
     GitFacadeService: class {},
@@ -131,6 +134,9 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
         };
 
+        // EW-617 G8: funnel emit sink — no-op stub by default.
+        const funnel = { emit: jest.fn() };
+
         const service = new DeployService(
             deployFacade as any,
             gitFacade as any,
@@ -141,6 +147,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             eventEmitter as any,
             platformSyncSecretService as any,
             dnsService as any,
+            funnel as any,
         );
 
         return {
@@ -153,6 +160,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             eventEmitter,
             platformSyncSecretService,
             dnsService,
+            funnel,
         };
     };
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -14,8 +14,9 @@ import {
 import { WorkRepository } from '@ever-works/agent/database';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
 import { Work, User } from '@ever-works/agent/entities';
-import { PlatformSyncSecretService } from '@ever-works/agent/services';
+import { PlatformSyncSecretService, ZeroFrictionFunnelService } from '@ever-works/agent/services';
 import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import {
     WebsiteUpdateService,
     getWebsiteTemplateBranch,
@@ -85,6 +86,7 @@ export class DeployService {
         private readonly eventEmitter: EventEmitter2,
         private readonly platformSyncSecretService: PlatformSyncSecretService,
         private readonly dnsService: EverWorksDnsService,
+        private readonly funnel: ZeroFrictionFunnelService,
     ) {}
 
     /**
@@ -93,7 +95,7 @@ export class DeployService {
     async deploy(
         workId: string,
         userId: string,
-        options: { teamScope?: string },
+        options: { teamScope?: string; correlationId?: string },
     ): Promise<boolean> {
         const { plugin, token, work, settings } =
             await this.deployFacade.getPluginAndTokenAndSettings({
@@ -148,6 +150,26 @@ export class DeployService {
         await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
+
+        // EW-617 G8 — funnel step 6: deploy started. Emit just before the
+        // dispatch so the timestamp lines up with the workflow kick-off,
+        // not the secret-pushing prep. Gated on correlationId so non-funnel
+        // deploys (dashboard "Deploy" button, batch jobs) stay quiet.
+        if (options.correlationId) {
+            const ingressHostValue =
+                deploySettings && typeof deploySettings.ingressHost === 'string'
+                    ? deploySettings.ingressHost
+                    : null;
+            this.funnel.emit({
+                event: ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_STARTED,
+                funnelStep: 6,
+                timestamp: new Date().toISOString(),
+                correlationId: options.correlationId,
+                workId,
+                deployProvider: work.deployProvider || 'ever-works',
+                ingressHost: ingressHostValue,
+            });
+        }
 
         const dispatched = await this.dispatchWithRetry(work, user, gitToken, plugin);
 

--- a/apps/api/src/telemetry/dto/funnel-event.dto.ts
+++ b/apps/api/src/telemetry/dto/funnel-event.dto.ts
@@ -1,0 +1,90 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    IsIn,
+    IsInt,
+    IsISO8601,
+    IsObject,
+    IsOptional,
+    IsString,
+    Matches,
+    Max,
+    MaxLength,
+    Min,
+} from 'class-validator';
+import {
+    ZERO_FRICTION_FUNNEL_EVENTS,
+    type ZeroFrictionFunnelEvent,
+} from '@ever-works/contracts/telemetry';
+
+const ALLOWED_EVENT_NAMES: readonly ZeroFrictionFunnelEvent[] = Object.values(
+    ZERO_FRICTION_FUNNEL_EVENTS,
+);
+
+/**
+ * EW-617 G8 — wire format for `POST /api/telemetry/funnel`.
+ *
+ * The endpoint accepts client-emitted funnel events (G1 landing page,
+ * G3 claim banner, anything that runs purely in the browser). The shape
+ * mirrors the union of `ZeroFrictionFunnelPayload` variants, but the DTO
+ * validates only the cross-cutting envelope fields. Per-event extras
+ * are forwarded as-is via the additional-fields-permitting `extra` map,
+ * which is merged back onto the payload before it hits the funnel sink.
+ *
+ * Validation is intentionally strict on the envelope (event name in the
+ * allowed set, correlationId roughly UUID-shaped, timestamp ISO-8601,
+ * funnelStep 1..8) so spurious posts get a 400 instead of polluting the
+ * downstream log/PostHog feeds.
+ */
+export class FunnelEventDto {
+    @ApiProperty({
+        description: 'One of the canonical zero-friction funnel event names.',
+        enum: ALLOWED_EVENT_NAMES,
+    })
+    @IsString()
+    @IsIn(ALLOWED_EVENT_NAMES as readonly string[])
+    event: ZeroFrictionFunnelEvent;
+
+    @ApiProperty({ description: 'Funnel step (1..8).', minimum: 1, maximum: 8 })
+    @IsInt()
+    @Min(1)
+    @Max(8)
+    funnelStep: number;
+
+    @ApiProperty({ description: 'ISO 8601 timestamp the event was emitted.' })
+    @IsISO8601()
+    timestamp: string;
+
+    @ApiProperty({
+        description:
+            'Funnel correlation id. UUID v4 in practice, but we accept any 8-64 char hex/uuid-ish string.',
+    })
+    @IsString()
+    @Matches(/^[A-Za-z0-9_-]{8,64}$/, {
+        message: 'correlationId must be 8-64 chars, alphanumeric/_-',
+    })
+    correlationId: string;
+
+    @ApiPropertyOptional({
+        description: 'Free-form per-event payload. Forwarded verbatim to the funnel sink.',
+        type: Object,
+    })
+    @IsOptional()
+    @IsObject()
+    extra?: Record<string, unknown>;
+
+    @ApiPropertyOptional({
+        description: 'Optional pass-through for the event-specific `workId` field.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(64)
+    workId?: string;
+
+    @ApiPropertyOptional({
+        description: 'Optional pass-through for the event-specific `userId` field.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(64)
+    userId?: string;
+}

--- a/apps/api/src/telemetry/telemetry.controller.spec.ts
+++ b/apps/api/src/telemetry/telemetry.controller.spec.ts
@@ -1,0 +1,85 @@
+jest.mock('@ever-works/agent/services', () => ({ ZeroFrictionFunnelService: class {} }));
+
+import { BadRequestException } from '@nestjs/common';
+import { TelemetryController } from './telemetry.controller';
+import { FunnelEventDto } from './dto/funnel-event.dto';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
+
+/**
+ * EW-617 G8 — controller-level tests for `POST /api/telemetry/funnel`.
+ *
+ * These tests cover only the in-controller logic (size guard, allow-list
+ * guard, sink fan-out). DTO validation is exercised by NestJS's global
+ * ValidationPipe in the e2e layer and isn't re-tested here.
+ */
+describe('TelemetryController', () => {
+    const validDto = (overrides: Partial<FunnelEventDto> = {}): FunnelEventDto => ({
+        event: ZERO_FRICTION_FUNNEL_EVENTS.LANDING_PROMPT_SUBMIT,
+        funnelStep: 1,
+        timestamp: '2026-05-15T10:00:00.000Z',
+        correlationId: 'abcd1234-uuid-like-1234',
+        extra: { promptLength: 42, clientKind: 'browser' },
+        ...overrides,
+    });
+
+    const buildController = () => {
+        const funnel = { emit: jest.fn() };
+        const controller = new TelemetryController(funnel as never);
+        return { controller, funnel };
+    };
+
+    it('accepts a valid event and returns 204 (no return value)', async () => {
+        const { controller, funnel } = buildController();
+        const result = await controller.ingestFunnelEvent(validDto(), { rawBody: '{}' });
+        expect(result).toBeUndefined();
+        expect(funnel.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards the payload to the funnel sink with envelope + extras merged', async () => {
+        const { controller, funnel } = buildController();
+        await controller.ingestFunnelEvent(
+            validDto({ workId: 'w-123', extra: { repos: ['o/r'] } }),
+            { rawBody: '{}' },
+        );
+        const arg = funnel.emit.mock.calls[0][0];
+        expect(arg.event).toBe(ZERO_FRICTION_FUNNEL_EVENTS.LANDING_PROMPT_SUBMIT);
+        expect(arg.funnelStep).toBe(1);
+        expect(arg.correlationId).toBe('abcd1234-uuid-like-1234');
+        expect(arg.workId).toBe('w-123');
+        expect(arg.repos).toEqual(['o/r']);
+    });
+
+    it('rejects an unknown event name with 400', async () => {
+        const { controller, funnel } = buildController();
+        await expect(
+            controller.ingestFunnelEvent(
+                validDto({ event: 'zero_friction.totally_fake' as never }),
+                { rawBody: '{}' },
+            ),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(funnel.emit).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oversized payload (>4KB rawBody) with 400', async () => {
+        const { controller, funnel } = buildController();
+        const huge = 'x'.repeat(5 * 1024);
+        await expect(
+            controller.ingestFunnelEvent(validDto(), { rawBody: huge }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(funnel.emit).not.toHaveBeenCalled();
+    });
+
+    it('calls funnel.emit exactly once per accepted request', async () => {
+        const { controller, funnel } = buildController();
+        await controller.ingestFunnelEvent(validDto(), { rawBody: '{}' });
+        await controller.ingestFunnelEvent(
+            validDto({
+                event: ZERO_FRICTION_FUNNEL_EVENTS.CLAIM_ACCOUNT,
+                funnelStep: 8,
+                correlationId: 'aaaaaaaa-bbbb-cccc-dddd',
+            }),
+            { rawBody: '{}' },
+        );
+        expect(funnel.emit).toHaveBeenCalledTimes(2);
+    });
+});

--- a/apps/api/src/telemetry/telemetry.controller.ts
+++ b/apps/api/src/telemetry/telemetry.controller.ts
@@ -1,0 +1,97 @@
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    HttpCode,
+    HttpStatus,
+    Post,
+    Req,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { Public } from '../auth/decorators/public.decorator';
+import { ZeroFrictionFunnelService } from '@ever-works/agent/services';
+import {
+    ZERO_FRICTION_FUNNEL_EVENTS,
+    type ZeroFrictionFunnelEvent,
+    type ZeroFrictionFunnelPayload,
+} from '@ever-works/contracts/telemetry';
+import { FunnelEventDto } from './dto/funnel-event.dto';
+
+/** Hard cap on the wire payload size — 4 KB is plenty for any single
+ *  funnel event; anything larger is almost certainly abuse or a bug. */
+const MAX_PAYLOAD_BYTES = 4 * 1024;
+
+const ALLOWED_EVENT_NAMES = new Set<ZeroFrictionFunnelEvent>(
+    Object.values(ZERO_FRICTION_FUNNEL_EVENTS),
+);
+
+/**
+ * EW-617 G8 — public client-side telemetry sink.
+ *
+ * Mirror of the server-side `ZeroFrictionFunnelService.emit` surface for
+ * events that originate in the browser (G1 landing prompt submit, the
+ * eventual G3 claim CTA click etc). Public + throttled aggressively —
+ * 60 requests / minute / IP is far above the legitimate funnel rate and
+ * far below what would matter for log volume.
+ *
+ * CORS: relies on the global `ALLOWED_ORIGINS` env var (configured in
+ * `apps/api/src/main.ts`). Production envs already set this to the
+ * `ever.works` / `app.ever.works` / `appstage.ever.works` family.
+ */
+@ApiTags('Telemetry')
+@Controller('api/telemetry')
+export class TelemetryController {
+    constructor(private readonly funnel: ZeroFrictionFunnelService) {}
+
+    @Public()
+    @Post('funnel')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @Throttle({ default: { limit: 60, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Submit a zero-friction funnel event from the client',
+        description:
+            'Public endpoint used by client-side funnel emit sites (landing form, claim banner). The body must match one of the canonical funnel event shapes; unknown event names + oversized payloads are rejected with 400.',
+    })
+    @ApiResponse({ status: 204, description: 'Event accepted and forwarded to the funnel sink' })
+    @ApiResponse({ status: 400, description: 'Invalid event name / oversized payload / bad shape' })
+    async ingestFunnelEvent(
+        @Body() dto: FunnelEventDto,
+        @Req() req?: { rawBody?: string },
+    ): Promise<void> {
+        // Size guard. `rawBody` is captured by main.ts's body-parser verify
+        // hook so we have the exact wire bytes. Even if the captured rawBody
+        // is missing for some reason (e.g. a test posts pre-parsed JSON),
+        // fall back to a JSON.stringify of the parsed DTO which is a close
+        // upper bound on the original size.
+        const rawSize =
+            typeof req?.rawBody === 'string'
+                ? Buffer.byteLength(req.rawBody, 'utf8')
+                : Buffer.byteLength(JSON.stringify(dto ?? {}), 'utf8');
+        if (rawSize > MAX_PAYLOAD_BYTES) {
+            throw new BadRequestException('telemetry payload too large');
+        }
+
+        if (!ALLOWED_EVENT_NAMES.has(dto.event)) {
+            // Belt-and-braces — the DTO `@IsIn` should already reject this,
+            // but the guard makes the contract explicit at the controller
+            // boundary too.
+            throw new BadRequestException(`unknown telemetry event: ${dto.event}`);
+        }
+
+        // Merge envelope + optional per-event passthrough fields. The funnel
+        // sink takes the discriminated union type; we cast through the
+        // generic payload type since the runtime shape is validated above.
+        const payload: ZeroFrictionFunnelPayload = {
+            event: dto.event,
+            funnelStep: dto.funnelStep,
+            timestamp: dto.timestamp,
+            correlationId: dto.correlationId,
+            ...(dto.workId ? { workId: dto.workId } : {}),
+            ...(dto.userId ? { userId: dto.userId } : {}),
+            ...(dto.extra ?? {}),
+        } as ZeroFrictionFunnelPayload;
+
+        this.funnel.emit(payload);
+    }
+}

--- a/apps/api/src/telemetry/telemetry.module.ts
+++ b/apps/api/src/telemetry/telemetry.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ZeroFrictionFunnelService } from '@ever-works/agent/services';
+import { TelemetryController } from './telemetry.controller';
+
+/**
+ * EW-617 G8 — module wiring for the public `/api/telemetry/funnel`
+ * endpoint. Declares its own `ZeroFrictionFunnelService` provider rather
+ * than importing `WorkModule` to keep this module dependency-light. The
+ * service is a stateless logger wrapper, so a duplicate singleton is
+ * harmless. Same pattern as `AuthModule`.
+ */
+@Module({
+    controllers: [TelemetryController],
+    providers: [ZeroFrictionFunnelService],
+})
+export class TelemetryModule {}

--- a/apps/api/src/works/works.controller.ts
+++ b/apps/api/src/works/works.controller.ts
@@ -360,6 +360,11 @@ export class WorksController {
         // 1. Create the Work via the existing pipeline. Provider defaults
         //    (storage/deploy/git) are resolved from the user's
         //    onboardingState inside createWork — no special handling here.
+        //
+        // EW-617 G8: thread the funnel correlationId all the way through so
+        // `WorkLifecycleService.createWork` emits the REPOS_PUSHED event with
+        // the same id and persists it on `work.lastDeployCorrelationId` for
+        // the async DEPLOY_READY poller.
         const createDto: CreateWorkDto = Object.assign(new CreateWorkDto(), {
             slug: dto.slug,
             name: dto.name,
@@ -371,6 +376,7 @@ export class WorksController {
             storageProvider: dto.storageProvider,
             websiteTemplateId: dto.websiteTemplateId,
             readmeConfig: dto.readmeConfig,
+            correlationId: dto.correlationId,
         });
         const created = await this.workLifecycleService.createWork(createDto, user);
         if (!created || created.status !== 'success' || !created.work) {
@@ -406,6 +412,15 @@ export class WorksController {
         // 2. Kick off generation async — the standard generation pipeline
         //    handles persistence + dispatch.  awaitCompletion=false means
         //    we return immediately with the historyId for status polling.
+        //
+        // TODO(EW-617 G8): the downstream generation flow eventually calls
+        // `DeployService.deploy(workId, userId, options)` from a different
+        // entry point (deploy.controller / workflow listener). Threading the
+        // correlationId through `workGenerationService.generateItems` and on
+        // into deploy options is non-trivial and out of scope for this PR.
+        // For now, DEPLOY_STARTED is only emitted when callers explicitly
+        // pass `options.correlationId`. The DEPLOY_READY poller still emits
+        // with `work.lastDeployCorrelationId`, which we persisted above.
         const generatorDto = Object.assign(new CreateItemsGeneratorDto(), {
             name: dto.name,
             prompt: dto.prompt,

--- a/apps/web/src/app/actions/telemetry/funnel.ts
+++ b/apps/web/src/app/actions/telemetry/funnel.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { API_URL } from '@/lib/constants';
+
+/**
+ * EW-617 G8 — client-side funnel event emit, server-action edition.
+ *
+ * Fire-and-forget telemetry: the wizard calls this right before
+ * `quickCreateWorkAction` to land `wizard_finished`, and any other
+ * client-only emit points (landing prompt submit, claim-account UI
+ * click) follow the same pattern. Lives as a server action so the
+ * actual POST to the platform API happens server-side — avoids a CORS
+ * round-trip and keeps API_URL out of the client bundle.
+ *
+ * Errors are swallowed by design. A funnel emit failing must never
+ * break the user flow that triggered it.
+ */
+export async function emitFunnelEventAction(payload: {
+    event: string;
+    funnelStep: number;
+    correlationId: string;
+    timestamp?: string;
+    userId?: string;
+    workId?: string;
+    extra?: Record<string, unknown>;
+}): Promise<void> {
+    try {
+        const body = JSON.stringify({
+            ...payload,
+            timestamp: payload.timestamp || new Date().toISOString(),
+        });
+        // 2s timeout — the funnel sink is a logger, but if the API is
+        // misbehaving we don't want to slow the wizard's "Generate now"
+        // path.
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 2_000);
+        await fetch(`${API_URL}/api/telemetry/funnel`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            signal: controller.signal,
+            // keepalive helps Chromium send the request even if the
+            // wizard immediately navigates away after `quickCreate`.
+            keepalive: true,
+        }).catch(() => {});
+        clearTimeout(timeout);
+    } catch {
+        // Telemetry must never break the user flow.
+    }
+}

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -79,8 +79,15 @@ export function EverWorksOnboardingWizard({
 
     // EW-617 G8 — correlation UUID minted on wizard mount, threaded
     // into telemetry events server-side so ops can trace the full
-    // funnel (landing → wizard → work created → deploy ready).
+    // funnel (landing → wizard → work created → deploy ready). If the
+    // landing page (G1) handed off a `corrId=…` in the URL hash, we
+    // re-use it so the funnel chain is continuous from
+    // `landing_prompt_submit` onwards.
     const correlationId = useMemo(() => {
+        if (typeof window !== 'undefined') {
+            const fromHash = readHashParam(window.location.hash, 'corrId');
+            if (fromHash && /^[A-Za-z0-9_-]{8,64}$/.test(fromHash)) return fromHash;
+        }
         if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
             return crypto.randomUUID();
         }
@@ -140,11 +147,16 @@ export function EverWorksOnboardingWizard({
             flow.jumpTo(createIndex);
         }
 
-        // Strip the prompt from the URL so a reload doesn't re-trigger the
-        // hand-off (and so we don't leak the prompt to analytics referers).
+        // Strip the prompt + corrId from the URL so a reload doesn't
+        // re-trigger the hand-off (and so we don't leak the prompt to
+        // analytics referers). corrId stripping keeps the chain to
+        // `landing_prompt_submit` intact for this session but doesn't
+        // persist it across reloads — that's intentional.
         url.searchParams.delete('prompt');
+        url.searchParams.delete('corrId');
         if (fromHash) {
             url.hash = stripHashParam(url.hash, 'prompt');
+            url.hash = stripHashParam(url.hash, 'corrId');
         }
         window.history.replaceState({}, '', url.toString());
     }, [mounted, flow]);
@@ -463,6 +475,22 @@ function StepBody({
                                   // right before the call. Empty when captcha
                                   // is disabled — server is OK with that.
                                   const captchaToken = await turnstile.getToken();
+                                  // EW-617 G8 — funnel step 3: wizard finished.
+                                  // Fire-and-forget; never blocks the user flow.
+                                  void import('@/app/actions/telemetry/funnel').then(
+                                      ({ emitFunnelEventAction }) =>
+                                          emitFunnelEventAction({
+                                              event: 'zero_friction.wizard_finished',
+                                              funnelStep: 3,
+                                              correlationId,
+                                              extra: {
+                                                  isAnonymous: false,
+                                                  aiChoice: flow.state.ai.choice,
+                                                  storageChoice: flow.state.storage.choice,
+                                                  deployChoice: flow.state.deploy.choice,
+                                              },
+                                          }),
+                                  );
                                   const { quickCreateWorkAction } =
                                       await import('@/app/actions/works/quick-create');
                                   const slug = slugifyPrompt(prompt);

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -208,6 +208,22 @@ export class WorkRepository {
     }
 
     /**
+     * EW-617 G8 — used by `DeployReadyPollerService` to fan out HTTP
+     * health probes against works the platform is still waiting on. The
+     * `take` cap is a safety net for backlog scenarios; the schedule
+     * cron tick will pick up any rows past the limit on the next run.
+     */
+    async findByDeploymentStates(states: string[], take = 200): Promise<Work[]> {
+        if (states.length === 0) {
+            return [];
+        }
+        return this.repository.find({
+            where: { deploymentState: In(states) },
+            take,
+        });
+    }
+
+    /**
      * Conditional UPDATE for the lazy bootstrap of `platformSyncSecretEncrypted`
      * (EW-120 pull transport). Two concurrent deploys can both call
      * `getOrGenerate` and both generate fresh plaintext; this method makes

--- a/packages/agent/src/dto/create-work.dto.ts
+++ b/packages/agent/src/dto/create-work.dto.ts
@@ -145,4 +145,12 @@ export class CreateWorkDto {
     @ValidateNested()
     @Type(() => MarkdownReadmeConfigDto)
     readmeConfig?: MarkdownReadmeConfigDto;
+
+    @ApiPropertyOptional({
+        description:
+            'EW-617 G8 zero-friction funnel correlation id. Minted on the landing form (G1) and threaded through the full funnel so REPOS_PUSHED / DEPLOY_STARTED emits stay joinable with the upstream WORK_CREATED event.',
+    })
+    @IsOptional()
+    @IsString()
+    correlationId?: string;
 }

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -136,6 +136,16 @@ export class Work {
     @TimestampColumn({ nullable: true })
     deploymentStartedAt?: Date;
 
+    /**
+     * EW-617 G8 — last zero-friction funnel correlation id observed for
+     * this work. Set by `WorkLifecycleService.createWork` when the create
+     * DTO carries one, so the async DEPLOY_READY poller can emit with the
+     * same correlationId the rest of the funnel used. Nullable so existing
+     * rows + non-funnel creates keep working unchanged.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    lastDeployCorrelationId?: string | null;
+
     // Repository FIELDS
     @Column('simple-json', { nullable: true })
     lastPullRequest?: { main?: PRUpdate; data?: PRUpdate };

--- a/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
+++ b/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
@@ -1,0 +1,86 @@
+import { DeployReadyPollerService } from '../deploy-ready-poller.service';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
+
+/**
+ * EW-617 G8 — DeployReadyPollerService unit tests. Verifies the happy
+ * path (healthy 200 response → state flipped to READY + funnel event
+ * emitted) and that emit is gated on the persisted correlationId.
+ */
+describe('DeployReadyPollerService.pollOnce', () => {
+    const NOW = new Date('2026-05-15T10:05:00.000Z');
+    const STARTED_AT = new Date('2026-05-15T10:00:00.000Z');
+
+    const buildService = (
+        works: Array<Partial<Record<string, unknown>>>,
+        fetchImpl: typeof fetch,
+    ) => {
+        const workRepository = {
+            findByDeploymentStates: jest.fn().mockResolvedValue(works),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        const funnel = { emit: jest.fn() };
+        const service = new DeployReadyPollerService(workRepository as never, funnel as never);
+        return { service, workRepository, funnel, fetchImpl };
+    };
+
+    it('marks a healthy work as READY and emits deploy_ready funnel event', async () => {
+        const work = {
+            id: 'w-1',
+            slug: 'my-site',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: 'corr-abc123-uuid',
+        };
+        const httpFetch = jest.fn().mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
+        const { service, workRepository, funnel } = buildService([work], httpFetch);
+
+        const summary = await service.pollOnce({
+            fetch: httpFetch,
+            now: () => NOW,
+            domain: 'ever.works',
+        });
+
+        expect(summary).toEqual({ scanned: 1, ready: 1, stillPending: 0, failed: 0 });
+        expect(workRepository.update).toHaveBeenCalledWith('w-1', { deploymentState: 'READY' });
+        expect(funnel.emit).toHaveBeenCalledTimes(1);
+        const payload = funnel.emit.mock.calls[0][0];
+        expect(payload.event).toBe(ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY);
+        expect(payload.funnelStep).toBe(7);
+        expect(payload.correlationId).toBe('corr-abc123-uuid');
+        expect(payload.workId).toBe('w-1');
+        expect(payload.websiteUrl).toBe('https://my-site.ever.works');
+        expect(payload.elapsedMs).toBe(NOW.getTime() - STARTED_AT.getTime());
+    });
+
+    it('flips state to READY but skips emit when lastDeployCorrelationId is absent', async () => {
+        const work = {
+            id: 'w-2',
+            slug: 'other-site',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: null,
+        };
+        const httpFetch = jest.fn().mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
+        const { service, workRepository, funnel } = buildService([work], httpFetch);
+
+        await service.pollOnce({ fetch: httpFetch, now: () => NOW });
+
+        expect(workRepository.update).toHaveBeenCalledWith('w-2', { deploymentState: 'READY' });
+        expect(funnel.emit).not.toHaveBeenCalled();
+    });
+
+    it('leaves the row alone and counts stillPending when the health probe returns non-200', async () => {
+        const work = {
+            id: 'w-3',
+            slug: 'slow-site',
+            deploymentStartedAt: STARTED_AT,
+            lastDeployCorrelationId: 'corr-x',
+        };
+        const httpFetch = jest.fn().mockResolvedValue({ status: 503 }) as unknown as typeof fetch;
+        const { service, workRepository, funnel } = buildService([work], httpFetch);
+
+        const summary = await service.pollOnce({ fetch: httpFetch, now: () => NOW });
+
+        expect(summary).toEqual({ scanned: 1, ready: 0, stillPending: 1, failed: 0 });
+        expect(workRepository.update).not.toHaveBeenCalled();
+        expect(funnel.emit).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -60,6 +60,7 @@ interface MockDeps {
         removeWorkSubdomain: jest.Mock;
         ingressHostFor: jest.Mock;
     };
+    funnel: { emit: jest.Mock };
     eventEmitter: { emit: jest.Mock };
 }
 
@@ -104,6 +105,9 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
         ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
     };
 
+    // EW-617 G8: funnel emit sink — no-op stub by default.
+    const funnel = { emit: jest.fn() };
+
     const service = new WorkLifecycleService(
         workRepo as never,
         userRepo as never,
@@ -118,12 +122,13 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
         quota as never,
         everWorksGit as never,
         everWorksDns as never,
+        funnel as never,
         eventEmitter as never,
     );
 
     return {
         service,
-        deps: { workRepo, userRepo, quota, everWorksGit, everWorksDns, eventEmitter },
+        deps: { workRepo, userRepo, quota, everWorksGit, everWorksDns, funnel, eventEmitter },
     };
 }
 

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -111,6 +111,8 @@ describe('WorkLifecycleService', () => {
             removeWorkSubdomain: jest.fn().mockResolvedValue(undefined),
             ingressHostFor: jest.fn((slug: string) => `${slug}.ever.works`),
         } as never;
+        // EW-617 G8: funnel emit sink — no-op stub.
+        const funnel = { emit: jest.fn() } as never;
 
         service = new WorkLifecycleService(
             workRepository,
@@ -126,6 +128,7 @@ describe('WorkLifecycleService', () => {
             everWorksDeployQuota,
             everWorksGit,
             everWorksDns,
+            funnel,
             eventEmitter as never,
         );
     });

--- a/packages/agent/src/services/deploy-ready-poller.service.ts
+++ b/packages/agent/src/services/deploy-ready-poller.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { WorkRepository } from '@src/database/repositories/work.repository';
+import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
+
+export interface DeployReadyPollerSummary {
+    scanned: number;
+    ready: number;
+    stillPending: number;
+    failed: number;
+}
+
+const READY_STATE = 'READY';
+
+/**
+ * Pending-style states the poller probes for readiness. Mirrors the
+ * states the DeploymentVerifierService transitions through.
+ */
+const PENDING_STATES: readonly string[] = ['pending', 'INITIALIZING', 'QUEUED', 'BUILDING'];
+
+/**
+ * EW-617 G8 — emits the funnel `deploy_ready` event when a freshly
+ * deployed Work's slug-based URL starts responding 200. Backed by a
+ * Trigger.dev schedule (every 2 minutes); see
+ * `packages/tasks/src/tasks/trigger/deploy-ready-poller.task.ts`.
+ *
+ * Strictly best-effort:
+ *  - works without a persisted `lastDeployCorrelationId` get their state
+ *    flipped to READY but no funnel event is emitted (we have nothing to
+ *    correlate with).
+ *  - health-check failures (network errors, non-200 responses) leave the
+ *    row in its current state for the next poll tick.
+ */
+@Injectable()
+export class DeployReadyPollerService {
+    private readonly logger = new Logger(DeployReadyPollerService.name);
+
+    constructor(
+        private readonly workRepository: WorkRepository,
+        private readonly funnel: ZeroFrictionFunnelService,
+    ) {}
+
+    async pollOnce(
+        options: {
+            fetch?: typeof fetch;
+            now?: () => Date;
+            healthTimeoutMs?: number;
+            domain?: string;
+        } = {},
+    ): Promise<DeployReadyPollerSummary> {
+        const httpFetch = options.fetch ?? fetch;
+        const now = options.now ?? (() => new Date());
+        const timeoutMs = options.healthTimeoutMs ?? 5000;
+        const domain = options.domain ?? process.env.EVER_WORKS_DOMAIN ?? 'ever.works';
+
+        const pendingWorks = await this.workRepository.findByDeploymentStates([...PENDING_STATES]);
+        const summary: DeployReadyPollerSummary = {
+            scanned: pendingWorks.length,
+            ready: 0,
+            stillPending: 0,
+            failed: 0,
+        };
+
+        for (const work of pendingWorks) {
+            try {
+                const url = `https://${work.slug}.${domain}/api/healthz`;
+                const ok = await this.probeUrl(httpFetch, url, timeoutMs);
+                if (!ok) {
+                    summary.stillPending += 1;
+                    continue;
+                }
+
+                const startedAt = work.deploymentStartedAt
+                    ? new Date(work.deploymentStartedAt).getTime()
+                    : undefined;
+                const elapsedMs = startedAt ? now().getTime() - startedAt : 0;
+
+                await this.workRepository.update(work.id, { deploymentState: READY_STATE });
+                summary.ready += 1;
+
+                if (work.lastDeployCorrelationId) {
+                    this.funnel.emit({
+                        event: ZERO_FRICTION_FUNNEL_EVENTS.DEPLOY_READY,
+                        funnelStep: 7,
+                        timestamp: now().toISOString(),
+                        correlationId: work.lastDeployCorrelationId,
+                        workId: work.id,
+                        websiteUrl: `https://${work.slug}.${domain}`,
+                        elapsedMs,
+                    });
+                }
+            } catch (cause) {
+                summary.failed += 1;
+                const message = cause instanceof Error ? cause.message : String(cause);
+                this.logger.warn(`deploy-ready-poller failed for work ${work.id}: ${message}`);
+            }
+        }
+
+        return summary;
+    }
+
+    private async probeUrl(
+        httpFetch: typeof fetch,
+        url: string,
+        timeoutMs: number,
+    ): Promise<boolean> {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const res = await httpFetch(url, { method: 'GET', signal: controller.signal });
+            return res.status === 200;
+        } catch {
+            return false;
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+}

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -21,6 +21,7 @@ export * from './state-marker.service';
 export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
 export * from './zero-friction-funnel.service';
+export * from './deploy-ready-poller.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -46,6 +46,8 @@ import {
 } from '@src/ever-works-providers';
 import { config } from '@src/config';
 import type { OnboardingWizardStateV2 } from '@ever-works/contracts/api';
+import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
+import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 
 /**
  * Map a wizard "storage" choice onto the existing `gitProvider` field.
@@ -94,6 +96,7 @@ export class WorkLifecycleService {
         private readonly everWorksDeployQuota: EverWorksDeployQuotaService,
         private readonly everWorksGit: EverWorksGitProvider,
         private readonly everWorksDns: EverWorksDnsService,
+        private readonly funnel: ZeroFrictionFunnelService,
         private readonly eventEmitter: EventEmitter2,
     ) {}
 
@@ -251,6 +254,10 @@ export class WorkLifecycleService {
             websiteTemplateId: selectedWebsiteTemplateId,
             readmeConfig,
             organization,
+            // EW-617 G8 — persist the funnel correlation id so the async
+            // DEPLOY_READY poller can emit with the same id later. Nullable
+            // when the caller is not a zero-friction quick-create.
+            lastDeployCorrelationId: createWorkDto.correlationId ?? null,
         };
 
         // EW-614 — when the user picks "Ever Works Git" AND the feature flag
@@ -327,6 +334,25 @@ export class WorkLifecycleService {
                 WorkCreatedEvent.EVENT_NAME,
                 new WorkCreatedEvent(dir, platformActor),
             );
+
+            // EW-617 G8 — funnel step 5: repos pushed. Only emit when the
+            // caller threaded a correlation id (i.e. this is part of the
+            // zero-friction quick-create funnel). Skipped on error paths
+            // because failure means no repos were actually pushed.
+            if (createWorkDto.correlationId) {
+                const repos: string[] = [];
+                if (everWorksRepo) {
+                    repos.push(everWorksRepo.fullName);
+                }
+                this.funnel.emit({
+                    event: ZERO_FRICTION_FUNNEL_EVENTS.REPOS_PUSHED,
+                    funnelStep: 5,
+                    timestamp: new Date().toISOString(),
+                    correlationId: createWorkDto.correlationId,
+                    workId: dir.id,
+                    repos,
+                });
+            }
 
             return {
                 status: 'success',

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -148,6 +148,7 @@ import { PluginOperationsService } from '../plugins/services/plugin-operations.s
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
 import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
+import { DeployReadyPollerService } from './deploy-ready-poller.service';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
 import { ComparisonGeneratorModule } from '../comparison-generator/comparison-generator.module';
 import { TemplateCatalogModule } from '../template-catalog/template-catalog.module';
@@ -224,6 +225,7 @@ describe('WorkModule', () => {
             EverWorksGitProvider,
             EverWorksDnsService,
             ZeroFrictionFunnelService,
+            DeployReadyPollerService,
         ];
 
         it.each(expectedProviders)('declares %p as a provider', (provider) => {
@@ -301,13 +303,14 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 30-entry shape (27 services + 3 re-exported modules)', () => {
+        it('keeps the exports list at the documented 31-entry shape (28 services + 3 re-exported modules)', () => {
             // Bumped to 28 with the PlatformSyncSecretService resurrection for
             // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
             // Bumped to 29 with AnonymousUserCleanupService for EW-617 G2
             // (nightly cleanup of expired anonymous Users).
             // Bumped to 30 with the EW-617 G8 ZeroFrictionFunnelService.
-            expect(meta('exports')).toHaveLength(30);
+            // Bumped to 31 with the EW-617 G8 DeployReadyPollerService.
+            expect(meta('exports')).toHaveLength(31);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -34,6 +34,7 @@ import { WorksConfigSyncListener } from '@src/works-config/services/works-config
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
 import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
+import { DeployReadyPollerService } from './deploy-ready-poller.service';
 import { ItemHealthService } from './item-health.service';
 import { ItemSourceValidationSchedulerService } from './item-source-validation-scheduler.service';
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
@@ -103,6 +104,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         EverWorksDeployQuotaService,
         PlatformSyncSecretService,
         ZeroFrictionFunnelService,
+        DeployReadyPollerService,
         // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
         // the platform GitHub org (`ever-works-cloud`) using a server-held
         // PAT, so users picking "Ever Works Git" don't need to bring their
@@ -150,6 +152,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigRepositorySyncService,
         PlatformSyncSecretService,
         ZeroFrictionFunnelService,
+        DeployReadyPollerService,
         CommunityPrModule,
         ComparisonGeneratorModule,
         TemplateCatalogModule,

--- a/packages/tasks/src/tasks/trigger/deploy-ready-poller.task.ts
+++ b/packages/tasks/src/tasks/trigger/deploy-ready-poller.task.ts
@@ -1,0 +1,33 @@
+import { schedules } from '@trigger.dev/sdk';
+import { NestFactory } from '@nestjs/core';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { DeployReadyPollerService } from '@ever-works/agent/services';
+import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
+
+/**
+ * EW-617 G8 — polls works currently mid-deploy, flips them to READY once
+ * their slug-based health endpoint responds 200, and emits the
+ * `deploy_ready` funnel event for any work that carries a persisted
+ * `lastDeployCorrelationId`.
+ *
+ * Runs every two minutes. The poller itself is idempotent — works
+ * already in READY are skipped on subsequent ticks because the SELECT
+ * filters on the pending-states only.
+ */
+export const deployReadyPollerTask = schedules.task({
+    id: 'deploy-ready-poller',
+    cron: '*/2 * * * *',
+    run: async () => {
+        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+
+        appContext.useLogger(createTriggerLogger('DeployReadyPoller'));
+
+        try {
+            const poller = appContext.get(DeployReadyPollerService);
+            const summary = await poller.pollOnce();
+            return summary;
+        } finally {
+            await appContext.close();
+        }
+    },
+});

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -1,4 +1,5 @@
 export * from './anonymous-user-cleanup.task';
+export * from './deploy-ready-poller.task';
 export * from './user-research-rerun-dispatcher.task';
 export * from './work-generation.task';
 export * from './work-import.task';


### PR DESCRIPTION
Cascade develop → stage for PR #792 (server-side funnel emits + telemetry endpoint + DEPLOY_READY poller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)