### PR TITLE
fix(mail): export MailService so BudgetsModule can inject it (EW-602 follow-up, unblocks rollouts)

### DIFF
--- a/apps/api/src/mail/mail.module.ts
+++ b/apps/api/src/mail/mail.module.ts
@@ -56,5 +56,15 @@ import { MailerService } from './providers/mailer.service';
         MailerService,
         FakerMailerService,
     ],
+    // EW-602 follow-up: `BudgetAlertHandler` (in BudgetsModule) injects
+    // `MailService` to send threshold-crossed emails. Without an
+    // `exports` list, MailService is module-private and Nest fails at
+    // boot with `Nest can't resolve dependencies of the
+    // BudgetAlertHandler ... MailService at index [2] is available in
+    // the BudgetsModule module`. Exporting both the public surface
+    // (MailService) and the underlying transport wrapper (MailerService)
+    // lets downstream modules consume them; internal providers
+    // (RESEND_CLIENT, FakerMailerService) stay private as intended.
+    exports: [MailService, MailerService],
 })
 export class MailModule {}


### PR DESCRIPTION
## Problem
New pods on **both stage and prod** have been crashing on boot since EW-602 shipped (commit \`81231022\`, ~24h ago). Old pods keep serving traffic so the platform is up, but every subsequent deploy is wedged.

\`\`\`
Nest can't resolve dependencies of the BudgetAlertHandler
(UserRepository, NotificationService, ?, AnalyticsService).
Please make sure that the argument MailService at index [2] is
available in the BudgetsModule module.
\`\`\`

## Root cause
\`BudgetsModule\` imports \`MailModule\` and \`BudgetAlertHandler\` injects \`MailService\` — but \`MailModule\` had no \`exports:\` list, so \`MailService\` was module-private. Nest correctly refused to wire it through the import boundary.

## Fix
Add \`exports: [MailService, MailerService]\` to \`MailModule\`. Internal providers (\`RESEND_CLIENT\`, \`FakerMailerService\`) stay private as intended.

## Why now
Audit of the EW-617 rollout state revealed two old pods serving + one new pod stuck in \`CrashLoopBackOff\` on both stage and prod. The runtime improvements from PR #800 (PostHog funnel forwarding + DEPLOY_STARTED corrId fallback) have been merged but are not actually live because of this wedge.

## Test plan
- [ ] After admin-merge + cascade: \`kubectl rollout status deploy/ever-works-api-stage\` finishes, all replicas \`Ready=True\`
- [ ] After stage rollout: synthetic funnel event lands in PostHog (PR #800's analytics binding actually runs)
- [ ] No regression in existing mail flow (verification emails, budget alerts, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced service module organization to improve code accessibility and maintainability across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->