### PR TITLE
fix(templates): scope code-edit provider list to current user

### DIFF
--- a/apps/api/src/template-catalog/dto/list-templates.dto.ts
+++ b/apps/api/src/template-catalog/dto/list-templates.dto.ts
@@ -179,3 +179,24 @@ export class CustomizeTemplateFromBaseDto {
     @MaxLength(500)
     description?: string;
 }
+
+export class IterateCustomTemplateDto {
+    @ApiProperty({ description: 'New customization prompt for the agent.' })
+    @IsString()
+    @MinLength(3)
+    @MaxLength(4000)
+    prompt: string;
+
+    @ApiProperty({ description: 'Code-edit plugin id (claude-code, codex, gemini, opencode).' })
+    @IsString()
+    @MinLength(1)
+    providerId: string;
+
+    @ApiPropertyOptional({
+        description:
+            'AI provider plugin id, required when the chosen code-edit plugin declares "ai-provider" in selectableProviderCategories.',
+    })
+    @IsOptional()
+    @IsString()
+    aiProviderId?: string;
+}

--- a/apps/api/src/template-catalog/dto/list-templates.dto.ts
+++ b/apps/api/src/template-catalog/dto/list-templates.dto.ts
@@ -160,6 +160,14 @@ export class CustomizeTemplateFromBaseDto {
     @MinLength(1)
     providerId: string;
 
+    @ApiPropertyOptional({
+        description:
+            'AI provider plugin id, required when the chosen code-edit plugin declares "ai-provider" in selectableProviderCategories (e.g. opencode).',
+    })
+    @IsOptional()
+    @IsString()
+    aiProviderId?: string;
+
     @ApiPropertyOptional({ description: 'GitHub login (personal or org). Defaults to user.' })
     @IsOptional()
     @IsString()

--- a/apps/api/src/template-catalog/template-catalog.controller.spec.ts
+++ b/apps/api/src/template-catalog/template-catalog.controller.spec.ts
@@ -35,6 +35,7 @@ describe('TemplateCatalogController', () => {
         getByIdForUser: jest.Mock;
         listForTemplate: jest.Mock;
         listProviders: jest.Mock;
+        listAiProviders: jest.Mock;
     };
     let activityLogService: { log: jest.Mock };
 
@@ -49,6 +50,7 @@ describe('TemplateCatalogController', () => {
             getByIdForUser: jest.fn(),
             listForTemplate: jest.fn(),
             listProviders: jest.fn().mockResolvedValue([]),
+            listAiProviders: jest.fn().mockResolvedValue([]),
         };
         activityLogService = {
             log: jest.fn().mockResolvedValue(undefined),
@@ -157,6 +159,22 @@ describe('TemplateCatalogController', () => {
         expect(result).toEqual({
             status: 'success',
             providers: [{ id: 'claude-code', name: 'Claude Code', enabled: true }],
+        });
+    });
+
+    it('scopes customization AI providers to the current user', async () => {
+        templateCustomizationService.listAiProviders.mockResolvedValue([
+            { id: 'openai', name: 'OpenAI', enabled: true },
+        ]);
+
+        const result = await controller.listCustomizationAiProviders({
+            userId: 'user-1',
+        } as any);
+
+        expect(templateCustomizationService.listAiProviders).toHaveBeenCalledWith('user-1');
+        expect(result).toEqual({
+            status: 'success',
+            providers: [{ id: 'openai', name: 'OpenAI', enabled: true }],
         });
     });
 });

--- a/apps/api/src/template-catalog/template-catalog.controller.spec.ts
+++ b/apps/api/src/template-catalog/template-catalog.controller.spec.ts
@@ -48,7 +48,7 @@ describe('TemplateCatalogController', () => {
             createAndStart: jest.fn(),
             getByIdForUser: jest.fn(),
             listForTemplate: jest.fn(),
-            listProviders: jest.fn().mockReturnValue([]),
+            listProviders: jest.fn().mockResolvedValue([]),
         };
         activityLogService = {
             log: jest.fn().mockResolvedValue(undefined),
@@ -141,6 +141,22 @@ describe('TemplateCatalogController', () => {
             kind: 'website',
             defaultTemplateId: 'classic',
             templates: [{ id: 'classic', name: 'Classic' }],
+        });
+    });
+
+    it('scopes customization providers to the current user', async () => {
+        templateCustomizationService.listProviders.mockResolvedValue([
+            { id: 'claude-code', name: 'Claude Code', enabled: true },
+        ]);
+
+        const result = await controller.listCustomizationProviders({
+            userId: 'user-1',
+        } as any);
+
+        expect(templateCustomizationService.listProviders).toHaveBeenCalledWith('user-1');
+        expect(result).toEqual({
+            status: 'success',
+            providers: [{ id: 'claude-code', name: 'Claude Code', enabled: true }],
         });
     });
 });

--- a/apps/api/src/template-catalog/template-catalog.controller.ts
+++ b/apps/api/src/template-catalog/template-catalog.controller.ts
@@ -244,8 +244,9 @@ export class TemplateCatalogController {
         summary: 'List installed code-edit providers usable for template customization',
     })
     @ApiResponse({ status: 200, description: 'Providers' })
-    async listCustomizationProviders() {
-        return { status: 'success', providers: this.templateCustomizationService.listProviders() };
+    async listCustomizationProviders(@CurrentUser() auth: AuthenticatedUser) {
+        const providers = await this.templateCustomizationService.listProviders(auth.userId);
+        return { status: 'success', providers };
     }
 
     @Post('templates/custom-from-base')

--- a/apps/api/src/template-catalog/template-catalog.controller.ts
+++ b/apps/api/src/template-catalog/template-catalog.controller.ts
@@ -23,6 +23,7 @@ import {
     ArchiveCustomTemplateDto,
     CustomizeTemplateFromBaseDto,
     ForkTemplateDto,
+    IterateCustomTemplateDto,
     ListTemplatesQueryDto,
     RefreshTemplatesDto,
     SetDefaultTemplateDto,
@@ -298,6 +299,48 @@ export class TemplateCatalogController {
                 repositoryName: result.template.repositoryName,
                 repositoryUrl: result.template.repositoryUrl,
             },
+            customization: this.serializeCustomization(result.customization),
+        };
+    }
+
+    @Post('templates/custom/:templateId/customize')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Re-run agent customization on an existing custom template',
+        description:
+            'Submits a new customization run with a fresh prompt against the same custom template (same repo).',
+    })
+    @ApiResponse({ status: 200, description: 'Customization scheduled' })
+    async iterateCustomTemplate(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('templateId') templateId: string,
+        @Body() body: IterateCustomTemplateDto,
+    ) {
+        const result = await this.templateCustomizationService.runOnExistingTemplate(
+            auth.userId,
+            templateId,
+            body,
+        );
+
+        this.activityLogService
+            .log({
+                userId: auth.userId,
+                actionType: ActivityActionType.TEMPLATE_ADDED,
+                action: 'template.customized',
+                status: ActivityStatus.IN_PROGRESS,
+                summary: `Re-customize template ${result.template.name}`,
+                metadata: {
+                    templateId: result.template.id,
+                    customizationId: result.customization.id,
+                    providerId: body.providerId,
+                    aiProviderId: body.aiProviderId,
+                },
+            })
+            .catch(() => {});
+
+        return {
+            status: 'success',
+            customizationId: result.customization.id,
             customization: this.serializeCustomization(result.customization),
         };
     }

--- a/apps/api/src/template-catalog/template-catalog.controller.ts
+++ b/apps/api/src/template-catalog/template-catalog.controller.ts
@@ -249,6 +249,18 @@ export class TemplateCatalogController {
         return { status: 'success', providers };
     }
 
+    @Get('templates/customization-ai-providers')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary:
+            'List installed AI providers, used when a chosen code-edit plugin declares ai-provider in selectableProviderCategories',
+    })
+    @ApiResponse({ status: 200, description: 'AI providers' })
+    async listCustomizationAiProviders(@CurrentUser() auth: AuthenticatedUser) {
+        const providers = await this.templateCustomizationService.listAiProviders(auth.userId);
+        return { status: 'success', providers };
+    }
+
     @Post('templates/custom-from-base')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Create a new custom template from a base + agent UI customization' })
@@ -271,6 +283,7 @@ export class TemplateCatalogController {
                     baseTemplateId: body.baseTemplateId,
                     customizationId: result.customization.id,
                     providerId: body.providerId,
+                    aiProviderId: body.aiProviderId,
                 },
             })
             .catch(() => {});

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -98,8 +98,9 @@ describe('TriggerInternalController', () => {
             templateCustomizationRepository,
             userTemplatePreferenceRepository,
             userRepository,
-            undefined,
-            undefined,
+            undefined, // dataSyncDispatcher
+            undefined, // deployReadyPoller
+            undefined, // workProposalsApiService
         );
         c.onModuleInit();
         return c;

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -75,7 +75,9 @@ describe('TriggerInternalController', () => {
     let workPluginRepository: any;
     let authAccountRepository: any;
     let templateRepository: any;
+    let templateCustomizationRepository: any;
     let userTemplatePreferenceRepository: any;
+    let userRepository: any;
     let controller: TriggerInternalController;
 
     const buildController = () => {
@@ -93,7 +95,10 @@ describe('TriggerInternalController', () => {
             workPluginRepository,
             authAccountRepository,
             templateRepository,
+            templateCustomizationRepository,
             userTemplatePreferenceRepository,
+            userRepository,
+            undefined,
             undefined,
         );
         c.onModuleInit();

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -21,7 +21,9 @@ import {
     WorkRepository,
     AuthAccountRepository,
     TemplateRepository,
+    TemplateCustomizationRepository,
     UserTemplatePreferenceRepository,
+    UserRepository,
 } from '@ever-works/agent/database';
 import { Work, User } from '@ever-works/agent/entities';
 import { CACHE_MANAGER, Cache } from '@ever-works/agent/cache';
@@ -62,7 +64,9 @@ export class TriggerInternalController implements OnModuleInit {
         private readonly workPluginRepository: WorkPluginRepository,
         private readonly authAccountRepository: AuthAccountRepository,
         private readonly templateRepository: TemplateRepository,
+        private readonly templateCustomizationRepository: TemplateCustomizationRepository,
         private readonly userTemplatePreferenceRepository: UserTemplatePreferenceRepository,
+        private readonly userRepository: UserRepository,
         // EW-628 G7 — dispatcher fanned out from the data-repo-sync cron.
         private readonly dataSyncDispatcher: DataSyncDispatcherService,
         @Optional()
@@ -80,7 +84,9 @@ export class TriggerInternalController implements OnModuleInit {
             NotificationService: this.notificationService,
             WorkRepository: this.workRepository,
             TemplateRepository: this.templateRepository,
+            TemplateCustomizationRepository: this.templateCustomizationRepository,
             UserTemplatePreferenceRepository: this.userTemplatePreferenceRepository,
+            UserRepository: this.userRepository,
             CacheManager: this.cacheManager,
             WorkScheduleDispatcherService: this.scheduleDispatcher,
             WorkScheduleService: this.workScheduleService,

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -31,6 +31,7 @@ import { WorkOperationsService } from '@ever-works/agent/work-operations';
 import { WorkContextResponse } from '@ever-works/agent/tasks';
 import { SkipThrottle } from '@nestjs/throttler';
 import {
+    DeployReadyPollerService,
     WorkOwnershipService,
     WorkScheduleDispatcherService,
     WorkScheduleService,
@@ -69,6 +70,8 @@ export class TriggerInternalController implements OnModuleInit {
         private readonly userRepository: UserRepository,
         // EW-628 G7 — dispatcher fanned out from the data-repo-sync cron.
         private readonly dataSyncDispatcher: DataSyncDispatcherService,
+        // EW-617 G8 — exposed for the deploy-ready-poller cron task.
+        private readonly deployReadyPoller: DeployReadyPollerService,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -92,6 +95,8 @@ export class TriggerInternalController implements OnModuleInit {
             WorkScheduleService: this.workScheduleService,
             // EW-628 G7 — exposed for the data-repo-sync dispatcher cron.
             DataSyncDispatcherService: this.dataSyncDispatcher,
+            // EW-617 G8 — exposed for the deploy-ready-poller cron task.
+            DeployReadyPollerService: this.deployReadyPoller,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3274,6 +3274,8 @@
                 "fork": "Fork",
                 "edit": "Edit",
                 "archive": "Archive",
+                "customizeAgain": "Customize again",
+                "viewStatus": "View customization status",
                 "catalogOnly": "Catalog item",
                 "openRepository": "Open repository",
                 "previewAlt": "{name} preview",
@@ -3281,7 +3283,15 @@
                 "branch": "Branch: {branch}",
                 "syncBranches": "{count} sync branches",
                 "betaBranch": "Beta: {branch}",
-                "noDescription": "No description yet."
+                "noDescription": "No description yet.",
+                "status": {
+                    "pending": "Queued",
+                    "forking": "Forking",
+                    "customizing": "Customizing",
+                    "pushing": "Pushing",
+                    "succeeded": "Customized",
+                    "failed": "Last run failed"
+                }
             },
             "dialog": {
                 "title": "Add custom template",
@@ -3360,7 +3370,13 @@
             },
             "customizeDialog": {
                 "title": "Create a custom template with AI",
+                "titleIterate": "Customize {name} again",
+                "titleStatus": "Customization status — {name}",
                 "description": "We duplicate a base template into a new repo in your GitHub account, then run your chosen AI agent against it to apply UI-only changes. Functionality stays untouched.",
+                "descriptionIterate": "Run another round of agent edits on the same repository. A new commit is pushed each time.",
+                "descriptionStatus": "Live status of the latest customization run for this template.",
+                "templateLabel": "Template",
+                "templateIterateHelp": "Re-running on this existing custom template's repository.",
                 "nameLabel": "Template name",
                 "namePlaceholder": "e.g. Dark Purple Theme",
                 "nameHelp": "Shown in your catalog and used to name the new GitHub repo.",
@@ -3376,8 +3392,10 @@
                 "organizationTarget": "Organization ({login})",
                 "promptLabel": "Describe the UI you want",
                 "promptPlaceholder": "Example: switch to a dark theme with subtle purple accents, rounded corners, and a more modern serif headline font.",
+                "promptIteratePlaceholder": "Example: increase the sidebar contrast and switch the headline font to Inter.",
                 "promptHelp": "Be specific about styling. New features are out of scope — UI only.",
                 "submit": "Create custom template",
+                "submitIterate": "Run customization",
                 "retry": "Retry",
                 "cancel": "Cancel",
                 "done": "Done",
@@ -3406,7 +3424,8 @@
                     "noProviders": "No code-edit agent plugins are installed or enabled. Install one from the plugin catalog (e.g. claude-code, codex, gemini, opencode).",
                     "noAiProviders": "{plugin} requires an AI provider, but none are installed or enabled. Install one (e.g. openai, anthropic, google) from the plugin catalog.",
                     "noTargets": "Connect a GitHub account to choose a destination.",
-                    "browsePlugins": "Browse plugin catalog"
+                    "browsePlugins": "Browse plugin catalog",
+                    "noRuns": "No customization runs yet for this template."
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3366,7 +3366,9 @@
                 "refreshFailed": "Failed to refresh templates.",
                 "defaultUpdated": "Default template updated.",
                 "defaultFailed": "Failed to update default template.",
-                "customizeFailed": "Failed to start template customization."
+                "customizeFailed": "Failed to start template customization.",
+                "customizationSucceeded": "Template customization completed.",
+                "customizationFailed": "Template customization failed."
             },
             "customizeDialog": {
                 "title": "Create a custom template with AI",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3368,6 +3368,8 @@
                 "baseHelp": "Only bases marked AI-customizable are listed.",
                 "providerLabel": "Code-edit agent",
                 "providerHelp": "Pick one of your installed code-edit plugins. The default is preselected.",
+                "aiProviderLabel": "AI provider",
+                "aiProviderHelp": "{plugin} runs against an external LLM — pick which one to use.",
                 "targetLabel": "GitHub destination",
                 "targetHelp": "Where to create the new repo. Personal account or an org you belong to.",
                 "personalTarget": "Personal account ({login})",
@@ -3398,9 +3400,11 @@
                     "nameRequired": "Template name is required.",
                     "baseRequired": "Choose a base template.",
                     "providerRequired": "Choose a code-edit agent.",
+                    "aiProviderRequired": "Choose an AI provider for the selected agent.",
                     "promptTooShort": "Describe the changes in at least a few words.",
                     "noCustomizableBases": "No customizable base templates are available.",
                     "noProviders": "No code-edit agent plugins are installed or enabled. Install one from the plugin catalog (e.g. claude-code, codex, gemini, opencode).",
+                    "noAiProviders": "{plugin} requires an AI provider, but none are installed or enabled. Install one (e.g. openai, anthropic, google) from the plugin catalog.",
                     "noTargets": "Connect a GitHub account to choose a destination.",
                     "browsePlugins": "Browse plugin catalog"
                 }

--- a/apps/web/src/app/[locale]/(dashboard)/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/templates/page.tsx
@@ -10,26 +10,31 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function TemplatesPage() {
-    const [templatesData, gitUserResult, organizationsResult, providersResult] = await Promise.all([
-        templatesAPI.list('website').catch(() => ({
-            status: 'success' as const,
-            kind: 'website' as const,
-            defaultTemplateId: null,
-            templates: [],
-        })),
-        gitProvidersAPI.getUser('github').catch(() => ({
-            success: false,
-            user: null,
-        })),
-        gitProvidersAPI.getOrganizations('github').catch(() => ({
-            success: false,
-            organizations: [],
-        })),
-        templatesAPI.listCustomizationProviders().catch(() => ({
-            status: 'success' as const,
-            providers: [],
-        })),
-    ]);
+    const [templatesData, gitUserResult, organizationsResult, providersResult, aiProvidersResult] =
+        await Promise.all([
+            templatesAPI.list('website').catch(() => ({
+                status: 'success' as const,
+                kind: 'website' as const,
+                defaultTemplateId: null,
+                templates: [],
+            })),
+            gitProvidersAPI.getUser('github').catch(() => ({
+                success: false,
+                user: null,
+            })),
+            gitProvidersAPI.getOrganizations('github').catch(() => ({
+                success: false,
+                organizations: [],
+            })),
+            templatesAPI.listCustomizationProviders().catch(() => ({
+                status: 'success' as const,
+                providers: [],
+            })),
+            templatesAPI.listCustomizationAiProviders().catch(() => ({
+                status: 'success' as const,
+                providers: [],
+            })),
+        ]);
 
     const forkTargets = [
         ...(gitUserResult.success && gitUserResult.user
@@ -56,6 +61,7 @@ export default async function TemplatesPage() {
                 defaultTemplateId={templatesData.defaultTemplateId}
                 forkTargets={forkTargets}
                 customizationProviders={providersResult.providers ?? []}
+                customizationAiProviders={aiProvidersResult.providers ?? []}
             />
         </div>
     );

--- a/apps/web/src/app/actions/dashboard/templates.ts
+++ b/apps/web/src/app/actions/dashboard/templates.ts
@@ -254,6 +254,40 @@ export async function customizeTemplateFromBase(input: {
     }
 }
 
+export async function iterateCustomTemplate(
+    templateId: string,
+    input: { prompt: string; providerId: string; aiProviderId?: string },
+) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const t = await getTranslations('dashboard.templates');
+
+    try {
+        const response = await templatesAPI.iterateCustom(templateId, input);
+        revalidatePath(ROUTES.DASHBOARD_TEMPLATES);
+        return {
+            success: response.status === 'success',
+            customizationId: response.customizationId ?? null,
+            customization: response.customization ?? null,
+            error:
+                response.status === 'error'
+                    ? getResponseMessage(response) || t('messages.customizeFailed')
+                    : null,
+        };
+    } catch (error) {
+        console.error('Iterate custom template error:', error);
+        return {
+            success: false,
+            customizationId: null,
+            customization: null,
+            error: error instanceof Error ? error.message : t('messages.customizeFailed'),
+        };
+    }
+}
+
 export async function listCustomizationProviders() {
     const user = await getAuthFromCookie();
     if (!user) {

--- a/apps/web/src/app/actions/dashboard/templates.ts
+++ b/apps/web/src/app/actions/dashboard/templates.ts
@@ -219,6 +219,7 @@ export async function customizeTemplateFromBase(input: {
     name: string;
     prompt: string;
     providerId: string;
+    aiProviderId?: string;
     targetOwner?: string;
     description?: string;
 }) {
@@ -268,6 +269,29 @@ export async function listCustomizationProviders() {
         };
     } catch (error) {
         console.error('List customization providers error:', error);
+        return {
+            success: false,
+            providers: [],
+            error: error instanceof Error ? error.message : 'unknown',
+        };
+    }
+}
+
+export async function listCustomizationAiProviders() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await templatesAPI.listCustomizationAiProviders();
+        return {
+            success: response.status === 'success',
+            providers: response.providers ?? [],
+            error: response.status === 'error' ? getResponseMessage(response) : null,
+        };
+    } catch (error) {
+        console.error('List customization AI providers error:', error);
         return {
             success: false,
             providers: [],

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Sparkles, Loader2, ExternalLink } from 'lucide-react';
@@ -113,6 +113,18 @@ export function CreateCustomTemplateDialog({
             setPendingCustomization(null);
         }
     }, [pendingCustomization, targetTemplate?.latestCustomization?.id]);
+
+    // Seed the prompt with the prior run on iterate-mode open. Only fires
+    // on the false→true transition so polling updates don't overwrite
+    // whatever the user is typing mid-session.
+    const prevOpenRef = useRef(false);
+    useEffect(() => {
+        if (open && !prevOpenRef.current && mode === 'iterate') {
+            const seed = targetTemplate?.latestCustomization?.prompt ?? '';
+            if (seed) setPrompt(seed);
+        }
+        prevOpenRef.current = open;
+    }, [open, mode, targetTemplate?.latestCustomization?.prompt]);
 
     const reset = useCallback(() => {
         setName('');

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -101,6 +101,10 @@ export function CreateCustomTemplateDialog({
     const [pendingCustomization, setPendingCustomization] = useState<TemplateCustomization | null>(
         null,
     );
+    // Id of the run this dialog instance kicked off. Lets us distinguish
+    // "you just submitted and it finished" (show Done, hide submit) from
+    // "this template has a prior succeeded run" (keep submit available).
+    const [sessionRunId, setSessionRunId] = useState<string | null>(null);
 
     const customization: TemplateCustomization | TemplateCustomizationSummary | null =
         targetTemplate?.latestCustomization ?? pendingCustomization;
@@ -130,6 +134,7 @@ export function CreateCustomTemplateDialog({
         setName('');
         setPrompt('');
         setPendingCustomization(null);
+        setSessionRunId(null);
         setBaseTemplateId(customizableBases[0]?.id ?? '');
         setProviderId(defaultProviderId);
         setAiProviderId(defaultAiProviderId);
@@ -170,6 +175,7 @@ export function CreateCustomTemplateDialog({
                         return;
                     }
                     setPendingCustomization(result.customization);
+                    setSessionRunId(result.customization.id);
                     onCustomizationStarted?.({ customization: result.customization });
                     toast.message(t('toast.started'));
                 })();
@@ -196,6 +202,7 @@ export function CreateCustomTemplateDialog({
                     return;
                 }
                 setPendingCustomization(result.customization);
+                setSessionRunId(result.customization.id);
                 onCustomizationStarted?.({
                     customization: result.customization,
                     template: result.template ?? undefined,
@@ -208,6 +215,8 @@ export function CreateCustomTemplateDialog({
     const running = customization && !TERMINAL_STATUSES.includes(customization.status);
     const succeeded = customization?.status === 'succeeded';
     const failed = customization?.status === 'failed';
+    const isSessionRun = !!customization && customization.id === sessionRunId;
+    const sessionRunSucceeded = isSessionRun && succeeded;
     const disabled = submitting || !!running;
     const missingAiProvider = requiresAiProvider && enabledAiProviders.length === 0;
     const noPrereqs =
@@ -389,7 +398,7 @@ export function CreateCustomTemplateDialog({
                             helperText={t('promptHelp')}
                         />
 
-                        {customization && (
+                        {customization && (isSessionRun || !!running || failed) && (
                             <StatusBox failed={failed} succeeded={succeeded} running={!!running}>
                                 <span className="font-medium">
                                     {t(`status.${customization.status}`)}
@@ -397,7 +406,9 @@ export function CreateCustomTemplateDialog({
                                 {failed && customization.errorMessage && (
                                     <p className="mt-2 text-xs">{customization.errorMessage}</p>
                                 )}
-                                {succeeded && <p className="mt-2 text-xs">{t('successHelp')}</p>}
+                                {sessionRunSucceeded && (
+                                    <p className="mt-2 text-xs">{t('successHelp')}</p>
+                                )}
                             </StatusBox>
                         )}
                     </div>
@@ -409,14 +420,14 @@ export function CreateCustomTemplateDialog({
                         onClick={() => handleClose(false)}
                         disabled={submitting}
                     >
-                        {succeeded ? t('done') : t('cancel')}
+                        {sessionRunSucceeded ? t('done') : t('cancel')}
                     </Button>
-                    {mode !== 'status' && !succeeded && !noPrereqs && (
+                    {mode !== 'status' && !sessionRunSucceeded && !noPrereqs && (
                         <Button onClick={handleSubmit} loading={disabled} disabled={!!running}>
-                            {customization
-                                ? t('retry')
-                                : mode === 'iterate'
-                                  ? t('submitIterate')
+                            {mode === 'iterate'
+                                ? t('submitIterate')
+                                : failed
+                                  ? t('retry')
                                   : t('submit')}
                         </Button>
                     )}

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -17,7 +17,6 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select } from '@/components/ui/select';
 import { ProviderChoiceButton } from '@/components/works/detail/plugins/ProviderChoiceButton';
-import { ChatProviderSelector } from '@/components/ai/ChatProviderSelector';
 import {
     Dialog,
     DialogClose,
@@ -232,35 +231,35 @@ export function CreateCustomTemplateDialog({
                             helperText={t('nameHelp')}
                         />
 
-                        <Field label={t('baseLabel')} hint={t('baseHelp')}>
-                            <Select
-                                value={baseTemplateId}
-                                onValueChange={setBaseTemplateId}
-                                disabled={disabled}
-                            >
-                                {customizableBases.map((base) => (
-                                    <option key={base.id} value={base.id}>
-                                        {base.name}
-                                    </option>
-                                ))}
-                            </Select>
-                        </Field>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <Field label={t('baseLabel')} hint={t('baseHelp')}>
+                                <Select
+                                    value={baseTemplateId}
+                                    onValueChange={setBaseTemplateId}
+                                    disabled={disabled}
+                                >
+                                    {customizableBases.map((base) => (
+                                        <option key={base.id} value={base.id}>
+                                            {base.name}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </Field>
 
-                        <Field label={t('providerLabel')} hint={t('providerHelp')}>
-                            <ChatProviderSelector
-                                providers={providers.map((p) => ({
-                                    id: p.id,
-                                    name: p.providerName || p.name,
-                                    description: p.description ?? undefined,
-                                    configured: p.enabled,
-                                    isDefault: p.isDefault,
-                                    icon: p.icon,
-                                }))}
-                                selectedProvider={providerId}
-                                isStreaming={disabled}
-                                onSelect={setProviderId}
-                            />
-                        </Field>
+                            <Field label={t('providerLabel')} hint={t('providerHelp')}>
+                                <Select
+                                    value={providerId}
+                                    onValueChange={setProviderId}
+                                    disabled={disabled}
+                                >
+                                    {providers.map((p) => (
+                                        <option key={p.id} value={p.id}>
+                                            {p.providerName || p.name}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </Field>
+                        </div>
 
                         {requiresAiProvider && (
                             <Field

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -16,8 +16,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select } from '@/components/ui/select';
-import { Tooltip } from '@/components/ui/tooltip';
 import { ProviderChoiceButton } from '@/components/works/detail/plugins/ProviderChoiceButton';
+import { ChatProviderSelector } from '@/components/ai/ChatProviderSelector';
 import {
     Dialog,
     DialogClose,
@@ -61,7 +61,6 @@ export function CreateCustomTemplateDialog({
     onSucceeded,
 }: CreateCustomTemplateDialogProps) {
     const t = useTranslations('dashboard.templates.customizeDialog');
-    const tGen = useTranslations('dashboard.workDetail.generator');
     const enabledProviders = useMemo(() => providers.filter((p) => p.enabled), [providers]);
     const enabledAiProviders = useMemo(() => aiProviders.filter((p) => p.enabled), [aiProviders]);
     // Prefer the plugin that declares 'code-edit' in defaultForCapabilities;
@@ -248,35 +247,19 @@ export function CreateCustomTemplateDialog({
                         </Field>
 
                         <Field label={t('providerLabel')} hint={t('providerHelp')}>
-                            <div className="flex flex-wrap gap-1.5">
-                                {providers.map((provider) => {
-                                    const isActive = providerId === provider.id;
-                                    const notConfigured = !provider.enabled;
-                                    const button = (
-                                        <ProviderChoiceButton
-                                            name={provider.providerName || provider.name}
-                                            icon={provider.icon}
-                                            isActive={isActive}
-                                            disabled={disabled}
-                                            notConfigured={notConfigured}
-                                            notConfiguredLabel={tGen('notConfigured')}
-                                            onSelect={() => {
-                                                if (!notConfigured) setProviderId(provider.id);
-                                            }}
-                                        />
-                                    );
-                                    return notConfigured ? (
-                                        <Tooltip
-                                            key={provider.id}
-                                            content={tGen('notConfiguredTooltip')}
-                                        >
-                                            {button}
-                                        </Tooltip>
-                                    ) : (
-                                        <span key={provider.id}>{button}</span>
-                                    );
-                                })}
-                            </div>
+                            <ChatProviderSelector
+                                providers={providers.map((p) => ({
+                                    id: p.id,
+                                    name: p.providerName || p.name,
+                                    description: p.description ?? undefined,
+                                    configured: p.enabled,
+                                    isDefault: p.isDefault,
+                                    icon: p.icon,
+                                }))}
+                                selectedProvider={providerId}
+                                isStreaming={disabled}
+                                onSelect={setProviderId}
+                            />
                         </Field>
 
                         {requiresAiProvider && (

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Sparkles, Loader2, ExternalLink } from 'lucide-react';
@@ -29,12 +29,21 @@ import {
 } from '@/components/ui/dialog';
 import {
     customizeTemplateFromBase,
-    getTemplateCustomization,
     iterateCustomTemplate,
 } from '@/app/actions/dashboard/templates';
 
-const POLL_INTERVAL_MS = 4000;
 const TERMINAL_STATUSES: TemplateCustomization['status'][] = ['succeeded', 'failed'];
+
+export interface CustomizationStartedArgs {
+    customization: TemplateCustomization;
+    template?: {
+        id: string;
+        name: string;
+        repositoryOwner: string;
+        repositoryName: string;
+        repositoryUrl: string | null;
+    };
+}
 
 interface ForkTarget {
     login: string;
@@ -51,10 +60,9 @@ interface CreateCustomTemplateDialogProps {
     providers: CustomizationProvider[];
     aiProviders: CustomizationAiProvider[];
     forkTargets: ForkTarget[];
-    onSucceeded?: () => void;
     mode?: CustomizeDialogMode;
     targetTemplate?: TemplateCatalogItem | null;
-    initialCustomization?: TemplateCustomization | TemplateCustomizationSummary | null;
+    onCustomizationStarted?: (args: CustomizationStartedArgs) => void;
 }
 
 export function CreateCustomTemplateDialog({
@@ -64,10 +72,9 @@ export function CreateCustomTemplateDialog({
     providers,
     aiProviders,
     forkTargets,
-    onSucceeded,
     mode = 'new',
     targetTemplate = null,
-    initialCustomization = null,
+    onCustomizationStarted,
 }: CreateCustomTemplateDialogProps) {
     const t = useTranslations('dashboard.templates.customizeDialog');
     const enabledProviders = useMemo(() => providers.filter((p) => p.enabled), [providers]);
@@ -88,59 +95,34 @@ export function CreateCustomTemplateDialog({
     const [name, setName] = useState('');
     const [prompt, setPrompt] = useState('');
     const [submitting, startSubmitting] = useTransition();
-    const [customization, setCustomization] = useState<
-        TemplateCustomization | TemplateCustomizationSummary | null
-    >(initialCustomization);
-    const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Local customization snapshot covers the gap between submit success
+    // and the parent picking up the new latestCustomization. After that,
+    // the page-level poller is the source of truth via `targetTemplate`.
+    const [pendingCustomization, setPendingCustomization] = useState<TemplateCustomization | null>(
+        null,
+    );
 
-    const stopPolling = useCallback(() => {
-        if (pollTimer.current) {
-            clearTimeout(pollTimer.current);
-            pollTimer.current = null;
-        }
-    }, []);
-
-    useEffect(() => () => stopPolling(), [stopPolling]);
-
-    // Sync the polled customization when the dialog opens with a fresh
-    // `initialCustomization` (e.g. user clicked another card while the
-    // dialog was still mounted).
-    useEffect(() => {
-        if (open) setCustomization(initialCustomization);
-    }, [open, initialCustomization]);
+    const customization: TemplateCustomization | TemplateCustomizationSummary | null =
+        targetTemplate?.latestCustomization ?? pendingCustomization;
 
     useEffect(() => {
-        if (!open) {
-            stopPolling();
-            return;
+        if (
+            pendingCustomization &&
+            targetTemplate?.latestCustomization?.id === pendingCustomization.id
+        ) {
+            setPendingCustomization(null);
         }
-        if (!customization || TERMINAL_STATUSES.includes(customization.status)) return;
-
-        pollTimer.current = setTimeout(async () => {
-            const result = await getTemplateCustomization(customization.id);
-            if (!result.success || !result.customization) return;
-            setCustomization(result.customization);
-            if (result.customization.status === 'succeeded') {
-                toast.success(t('toast.success'));
-                onSucceeded?.();
-            } else if (result.customization.status === 'failed') {
-                toast.error(result.customization.errorMessage || t('toast.failed'));
-            }
-        }, POLL_INTERVAL_MS);
-
-        return () => stopPolling();
-    }, [open, customization, stopPolling, t, onSucceeded]);
+    }, [pendingCustomization, targetTemplate?.latestCustomization?.id]);
 
     const reset = useCallback(() => {
-        stopPolling();
         setName('');
         setPrompt('');
-        setCustomization(null);
+        setPendingCustomization(null);
         setBaseTemplateId(customizableBases[0]?.id ?? '');
         setProviderId(defaultProviderId);
         setAiProviderId(defaultAiProviderId);
         setTargetOwner(forkTargets[0]?.login ?? '');
-    }, [stopPolling, customizableBases, defaultProviderId, defaultAiProviderId, forkTargets]);
+    }, [customizableBases, defaultProviderId, defaultAiProviderId, forkTargets]);
 
     const handleClose = (nextOpen: boolean) => {
         if (!nextOpen) reset();
@@ -175,7 +157,8 @@ export function CreateCustomTemplateDialog({
                         toast.error(result.error || t('toast.startFailed'));
                         return;
                     }
-                    setCustomization(result.customization);
+                    setPendingCustomization(result.customization);
+                    onCustomizationStarted?.({ customization: result.customization });
                     toast.message(t('toast.started'));
                 })();
             });
@@ -200,7 +183,11 @@ export function CreateCustomTemplateDialog({
                     toast.error(result.error || t('toast.startFailed'));
                     return;
                 }
-                setCustomization(result.customization);
+                setPendingCustomization(result.customization);
+                onCustomizationStarted?.({
+                    customization: result.customization,
+                    template: result.template ?? undefined,
+                });
                 toast.message(t('toast.started'));
             })();
         });

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -11,6 +11,7 @@ import type {
     CustomizationProvider,
     TemplateCatalogItem,
     TemplateCustomization,
+    TemplateCustomizationSummary,
 } from '@/lib/api/templates';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -29,6 +30,7 @@ import {
 import {
     customizeTemplateFromBase,
     getTemplateCustomization,
+    iterateCustomTemplate,
 } from '@/app/actions/dashboard/templates';
 
 const POLL_INTERVAL_MS = 4000;
@@ -40,6 +42,8 @@ interface ForkTarget {
     kind: 'personal' | 'organization';
 }
 
+export type CustomizeDialogMode = 'new' | 'iterate' | 'status';
+
 interface CreateCustomTemplateDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
@@ -48,6 +52,9 @@ interface CreateCustomTemplateDialogProps {
     aiProviders: CustomizationAiProvider[];
     forkTargets: ForkTarget[];
     onSucceeded?: () => void;
+    mode?: CustomizeDialogMode;
+    targetTemplate?: TemplateCatalogItem | null;
+    initialCustomization?: TemplateCustomization | TemplateCustomizationSummary | null;
 }
 
 export function CreateCustomTemplateDialog({
@@ -58,12 +65,13 @@ export function CreateCustomTemplateDialog({
     aiProviders,
     forkTargets,
     onSucceeded,
+    mode = 'new',
+    targetTemplate = null,
+    initialCustomization = null,
 }: CreateCustomTemplateDialogProps) {
     const t = useTranslations('dashboard.templates.customizeDialog');
     const enabledProviders = useMemo(() => providers.filter((p) => p.enabled), [providers]);
     const enabledAiProviders = useMemo(() => aiProviders.filter((p) => p.enabled), [aiProviders]);
-    // Prefer the plugin that declares 'code-edit' in defaultForCapabilities;
-    // fall back to first enabled if none does.
     const defaultProviderId = useMemo(
         () => enabledProviders.find((p) => p.isDefault)?.id ?? enabledProviders[0]?.id ?? '',
         [enabledProviders],
@@ -80,7 +88,9 @@ export function CreateCustomTemplateDialog({
     const [name, setName] = useState('');
     const [prompt, setPrompt] = useState('');
     const [submitting, startSubmitting] = useTransition();
-    const [customization, setCustomization] = useState<TemplateCustomization | null>(null);
+    const [customization, setCustomization] = useState<
+        TemplateCustomization | TemplateCustomizationSummary | null
+    >(initialCustomization);
     const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const stopPolling = useCallback(() => {
@@ -91,6 +101,13 @@ export function CreateCustomTemplateDialog({
     }, []);
 
     useEffect(() => () => stopPolling(), [stopPolling]);
+
+    // Sync the polled customization when the dialog opens with a fresh
+    // `initialCustomization` (e.g. user clicked another card while the
+    // dialog was still mounted).
+    useEffect(() => {
+        if (open) setCustomization(initialCustomization);
+    }, [open, initialCustomization]);
 
     useEffect(() => {
         if (!open) {
@@ -114,7 +131,7 @@ export function CreateCustomTemplateDialog({
         return () => stopPolling();
     }, [open, customization, stopPolling, t, onSucceeded]);
 
-    const reset = () => {
+    const reset = useCallback(() => {
         stopPolling();
         setName('');
         setPrompt('');
@@ -123,7 +140,7 @@ export function CreateCustomTemplateDialog({
         setProviderId(defaultProviderId);
         setAiProviderId(defaultAiProviderId);
         setTargetOwner(forkTargets[0]?.login ?? '');
-    };
+    }, [stopPolling, customizableBases, defaultProviderId, defaultAiProviderId, forkTargets]);
 
     const handleClose = (nextOpen: boolean) => {
         if (!nextOpen) reset();
@@ -138,15 +155,36 @@ export function CreateCustomTemplateDialog({
         selectedProvider?.selectableProviderCategories?.includes('ai-provider') ?? false;
 
     const handleSubmit = () => {
-        const trimmedName = name.trim();
         const trimmedPrompt = prompt.trim();
-        if (!trimmedName) return toast.error(t('messages.nameRequired'));
         if (trimmedPrompt.length < 3) return toast.error(t('messages.promptTooShort'));
-        if (!baseTemplateId) return toast.error(t('messages.baseRequired'));
         if (!providerId) return toast.error(t('messages.providerRequired'));
         if (requiresAiProvider && !aiProviderId) {
             return toast.error(t('messages.aiProviderRequired'));
         }
+
+        if (mode === 'iterate') {
+            if (!targetTemplate?.id) return;
+            startSubmitting(() => {
+                void (async () => {
+                    const result = await iterateCustomTemplate(targetTemplate.id, {
+                        prompt: trimmedPrompt,
+                        providerId,
+                        aiProviderId: requiresAiProvider ? aiProviderId : undefined,
+                    });
+                    if (!result.success || !result.customization) {
+                        toast.error(result.error || t('toast.startFailed'));
+                        return;
+                    }
+                    setCustomization(result.customization);
+                    toast.message(t('toast.started'));
+                })();
+            });
+            return;
+        }
+
+        const trimmedName = name.trim();
+        if (!trimmedName) return toast.error(t('messages.nameRequired'));
+        if (!baseTemplateId) return toast.error(t('messages.baseRequired'));
 
         startSubmitting(() => {
             void (async () => {
@@ -174,10 +212,23 @@ export function CreateCustomTemplateDialog({
     const disabled = submitting || !!running;
     const missingAiProvider = requiresAiProvider && enabledAiProviders.length === 0;
     const noPrereqs =
-        customizableBases.length === 0 ||
-        enabledProviders.length === 0 ||
-        forkTargets.length === 0 ||
-        missingAiProvider;
+        mode === 'new'
+            ? customizableBases.length === 0 ||
+              enabledProviders.length === 0 ||
+              forkTargets.length === 0 ||
+              missingAiProvider
+            : mode === 'iterate'
+              ? enabledProviders.length === 0 || missingAiProvider
+              : false;
+
+    const titleKey =
+        mode === 'iterate' ? 'titleIterate' : mode === 'status' ? 'titleStatus' : 'title';
+    const descriptionKey =
+        mode === 'iterate'
+            ? 'descriptionIterate'
+            : mode === 'status'
+              ? 'descriptionStatus'
+              : 'description';
 
     return (
         <Dialog open={open} onOpenChange={handleClose}>
@@ -186,15 +237,17 @@ export function CreateCustomTemplateDialog({
                 <DialogHeader>
                     <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark flex items-center gap-2">
                         <Sparkles className="h-4 w-4 text-primary" />
-                        {t('title')}
+                        {t(titleKey, { name: targetTemplate?.name ?? '' })}
                     </DialogTitle>
-                    <DialogDescription>{t('description')}</DialogDescription>
+                    <DialogDescription>
+                        {t(descriptionKey, { name: targetTemplate?.name ?? '' })}
+                    </DialogDescription>
                 </DialogHeader>
 
                 {noPrereqs ? (
                     <div className="space-y-3 rounded-lg border border-dashed border-border bg-surface px-4 py-6 text-sm text-text-secondary dark:border-border-dark dark:bg-white/4 dark:text-text-secondary-dark">
                         <ul className="space-y-2">
-                            {customizableBases.length === 0 && (
+                            {mode === 'new' && customizableBases.length === 0 && (
                                 <li>• {t('messages.noCustomizableBases')}</li>
                             )}
                             {enabledProviders.length === 0 && (
@@ -208,7 +261,9 @@ export function CreateCustomTemplateDialog({
                                     })}
                                 </li>
                             )}
-                            {forkTargets.length === 0 && <li>• {t('messages.noTargets')}</li>}
+                            {mode === 'new' && forkTargets.length === 0 && (
+                                <li>• {t('messages.noTargets')}</li>
+                            )}
                         </ul>
                         {(enabledProviders.length === 0 || missingAiProvider) && (
                             <Link
@@ -220,31 +275,49 @@ export function CreateCustomTemplateDialog({
                             </Link>
                         )}
                     </div>
+                ) : mode === 'status' ? (
+                    <CustomizationStatusPanel
+                        t={t}
+                        customization={customization}
+                        running={!!running}
+                        succeeded={succeeded}
+                        failed={failed}
+                    />
                 ) : (
                     <div className="space-y-4">
-                        <Input
-                            label={t('nameLabel')}
-                            placeholder={t('namePlaceholder')}
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            disabled={disabled}
-                            helperText={t('nameHelp')}
-                        />
+                        {mode === 'new' && (
+                            <Input
+                                label={t('nameLabel')}
+                                placeholder={t('namePlaceholder')}
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                disabled={disabled}
+                                helperText={t('nameHelp')}
+                            />
+                        )}
 
                         <div className="grid gap-4 md:grid-cols-2">
-                            <Field label={t('baseLabel')} hint={t('baseHelp')}>
-                                <Select
-                                    value={baseTemplateId}
-                                    onValueChange={setBaseTemplateId}
-                                    disabled={disabled}
-                                >
-                                    {customizableBases.map((base) => (
-                                        <option key={base.id} value={base.id}>
-                                            {base.name}
-                                        </option>
-                                    ))}
-                                </Select>
-                            </Field>
+                            {mode === 'new' ? (
+                                <Field label={t('baseLabel')} hint={t('baseHelp')}>
+                                    <Select
+                                        value={baseTemplateId}
+                                        onValueChange={setBaseTemplateId}
+                                        disabled={disabled}
+                                    >
+                                        {customizableBases.map((base) => (
+                                            <option key={base.id} value={base.id}>
+                                                {base.name}
+                                            </option>
+                                        ))}
+                                    </Select>
+                                </Field>
+                            ) : (
+                                <Field label={t('templateLabel')} hint={t('templateIterateHelp')}>
+                                    <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text dark:border-border-dark dark:bg-white/4 dark:text-text-dark">
+                                        {targetTemplate?.name ?? '—'}
+                                    </div>
+                                </Field>
+                            )}
 
                             <Field label={t('providerLabel')} hint={t('providerHelp')}>
                                 <Select
@@ -283,25 +356,33 @@ export function CreateCustomTemplateDialog({
                             </Field>
                         )}
 
-                        <Field label={t('targetLabel')} hint={t('targetHelp')}>
-                            <Select
-                                value={targetOwner}
-                                onValueChange={setTargetOwner}
-                                disabled={disabled || forkTargets.length === 0}
-                            >
-                                {forkTargets.map((target) => (
-                                    <option key={target.login} value={target.login}>
-                                        {target.kind === 'personal'
-                                            ? t('personalTarget', { login: target.login })
-                                            : t('organizationTarget', { login: target.login })}
-                                    </option>
-                                ))}
-                            </Select>
-                        </Field>
+                        {mode === 'new' && (
+                            <Field label={t('targetLabel')} hint={t('targetHelp')}>
+                                <Select
+                                    value={targetOwner}
+                                    onValueChange={setTargetOwner}
+                                    disabled={disabled || forkTargets.length === 0}
+                                >
+                                    {forkTargets.map((target) => (
+                                        <option key={target.login} value={target.login}>
+                                            {target.kind === 'personal'
+                                                ? t('personalTarget', { login: target.login })
+                                                : t('organizationTarget', {
+                                                      login: target.login,
+                                                  })}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </Field>
+                        )}
 
                         <Textarea
                             label={t('promptLabel')}
-                            placeholder={t('promptPlaceholder')}
+                            placeholder={
+                                mode === 'iterate'
+                                    ? t('promptIteratePlaceholder')
+                                    : t('promptPlaceholder')
+                            }
                             rows={6}
                             value={prompt}
                             onChange={(e) => setPrompt(e.target.value)}
@@ -331,14 +412,49 @@ export function CreateCustomTemplateDialog({
                     >
                         {succeeded ? t('done') : t('cancel')}
                     </Button>
-                    {!succeeded && !noPrereqs && (
+                    {mode !== 'status' && !succeeded && !noPrereqs && (
                         <Button onClick={handleSubmit} loading={disabled} disabled={!!running}>
-                            {customization ? t('retry') : t('submit')}
+                            {customization
+                                ? t('retry')
+                                : mode === 'iterate'
+                                  ? t('submitIterate')
+                                  : t('submit')}
                         </Button>
                     )}
                 </DialogFooter>
             </DialogContent>
         </Dialog>
+    );
+}
+
+function CustomizationStatusPanel({
+    t,
+    customization,
+    running,
+    succeeded,
+    failed,
+}: {
+    t: ReturnType<typeof useTranslations>;
+    customization: TemplateCustomization | TemplateCustomizationSummary | null;
+    running: boolean;
+    succeeded: boolean;
+    failed: boolean;
+}) {
+    if (!customization) {
+        return (
+            <div className="rounded-lg border border-dashed border-border bg-surface px-4 py-6 text-sm text-text-secondary dark:border-border-dark dark:bg-white/4 dark:text-text-secondary-dark">
+                {t('messages.noRuns')}
+            </div>
+        );
+    }
+    return (
+        <StatusBox failed={failed} succeeded={succeeded} running={running}>
+            <span className="font-medium">{t(`status.${customization.status}`)}</span>
+            {failed && customization.errorMessage && (
+                <p className="mt-2 text-xs">{customization.errorMessage}</p>
+            )}
+            {succeeded && <p className="mt-2 text-xs">{t('successHelp')}</p>}
+        </StatusBox>
     );
 }
 

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -120,15 +120,26 @@ export function CreateCustomTemplateDialog({
 
     // Seed the prompt with the prior run on iterate-mode open. Only fires
     // on the false→true transition so polling updates don't overwrite
-    // whatever the user is typing mid-session.
+    // whatever the user is typing mid-session. Prefer the most-recent
+    // run's prompt; fall back to the last-known-good prompt persisted on
+    // template.metadata so prefill works even when the customization
+    // summary doesn't carry it.
     const prevOpenRef = useRef(false);
     useEffect(() => {
         if (open && !prevOpenRef.current && mode === 'iterate') {
-            const seed = targetTemplate?.latestCustomization?.prompt ?? '';
+            const seed =
+                targetTemplate?.latestCustomization?.prompt ||
+                targetTemplate?.lastCustomizationPrompt ||
+                '';
             if (seed) setPrompt(seed);
         }
         prevOpenRef.current = open;
-    }, [open, mode, targetTemplate?.latestCustomization?.prompt]);
+    }, [
+        open,
+        mode,
+        targetTemplate?.latestCustomization?.prompt,
+        targetTemplate?.lastCustomizationPrompt,
+    ]);
 
     const reset = useCallback(() => {
         setName('');

--- a/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
+++ b/apps/web/src/components/templates/CreateCustomTemplateDialog.tsx
@@ -7,6 +7,7 @@ import { Sparkles, Loader2, ExternalLink } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import type {
+    CustomizationAiProvider,
     CustomizationProvider,
     TemplateCatalogItem,
     TemplateCustomization,
@@ -45,6 +46,7 @@ interface CreateCustomTemplateDialogProps {
     onOpenChange: (open: boolean) => void;
     customizableBases: TemplateCatalogItem[];
     providers: CustomizationProvider[];
+    aiProviders: CustomizationAiProvider[];
     forkTargets: ForkTarget[];
     onSucceeded?: () => void;
 }
@@ -54,21 +56,28 @@ export function CreateCustomTemplateDialog({
     onOpenChange,
     customizableBases,
     providers,
+    aiProviders,
     forkTargets,
     onSucceeded,
 }: CreateCustomTemplateDialogProps) {
     const t = useTranslations('dashboard.templates.customizeDialog');
     const tGen = useTranslations('dashboard.workDetail.generator');
     const enabledProviders = useMemo(() => providers.filter((p) => p.enabled), [providers]);
+    const enabledAiProviders = useMemo(() => aiProviders.filter((p) => p.enabled), [aiProviders]);
     // Prefer the plugin that declares 'code-edit' in defaultForCapabilities;
     // fall back to first enabled if none does.
     const defaultProviderId = useMemo(
         () => enabledProviders.find((p) => p.isDefault)?.id ?? enabledProviders[0]?.id ?? '',
         [enabledProviders],
     );
+    const defaultAiProviderId = useMemo(
+        () => enabledAiProviders.find((p) => p.isDefault)?.id ?? enabledAiProviders[0]?.id ?? '',
+        [enabledAiProviders],
+    );
 
     const [baseTemplateId, setBaseTemplateId] = useState<string>(customizableBases[0]?.id ?? '');
     const [providerId, setProviderId] = useState<string>(defaultProviderId);
+    const [aiProviderId, setAiProviderId] = useState<string>(defaultAiProviderId);
     const [targetOwner, setTargetOwner] = useState<string>(forkTargets[0]?.login ?? '');
     const [name, setName] = useState('');
     const [prompt, setPrompt] = useState('');
@@ -114,6 +123,7 @@ export function CreateCustomTemplateDialog({
         setCustomization(null);
         setBaseTemplateId(customizableBases[0]?.id ?? '');
         setProviderId(defaultProviderId);
+        setAiProviderId(defaultAiProviderId);
         setTargetOwner(forkTargets[0]?.login ?? '');
     };
 
@@ -122,6 +132,13 @@ export function CreateCustomTemplateDialog({
         onOpenChange(nextOpen);
     };
 
+    const selectedProvider = useMemo(
+        () => providers.find((p) => p.id === providerId) ?? null,
+        [providers, providerId],
+    );
+    const requiresAiProvider =
+        selectedProvider?.selectableProviderCategories?.includes('ai-provider') ?? false;
+
     const handleSubmit = () => {
         const trimmedName = name.trim();
         const trimmedPrompt = prompt.trim();
@@ -129,6 +146,9 @@ export function CreateCustomTemplateDialog({
         if (trimmedPrompt.length < 3) return toast.error(t('messages.promptTooShort'));
         if (!baseTemplateId) return toast.error(t('messages.baseRequired'));
         if (!providerId) return toast.error(t('messages.providerRequired'));
+        if (requiresAiProvider && !aiProviderId) {
+            return toast.error(t('messages.aiProviderRequired'));
+        }
 
         startSubmitting(() => {
             void (async () => {
@@ -137,6 +157,7 @@ export function CreateCustomTemplateDialog({
                     name: trimmedName,
                     prompt: trimmedPrompt,
                     providerId,
+                    aiProviderId: requiresAiProvider ? aiProviderId : undefined,
                     targetOwner: targetOwner || undefined,
                 });
                 if (!result.success || !result.customization) {
@@ -153,8 +174,12 @@ export function CreateCustomTemplateDialog({
     const succeeded = customization?.status === 'succeeded';
     const failed = customization?.status === 'failed';
     const disabled = submitting || !!running;
+    const missingAiProvider = requiresAiProvider && enabledAiProviders.length === 0;
     const noPrereqs =
-        customizableBases.length === 0 || enabledProviders.length === 0 || forkTargets.length === 0;
+        customizableBases.length === 0 ||
+        enabledProviders.length === 0 ||
+        forkTargets.length === 0 ||
+        missingAiProvider;
 
     return (
         <Dialog open={open} onOpenChange={handleClose}>
@@ -177,9 +202,17 @@ export function CreateCustomTemplateDialog({
                             {enabledProviders.length === 0 && (
                                 <li>• {t('messages.noProviders')}</li>
                             )}
+                            {missingAiProvider && (
+                                <li>
+                                    •{' '}
+                                    {t('messages.noAiProviders', {
+                                        plugin: selectedProvider?.name ?? '',
+                                    })}
+                                </li>
+                            )}
                             {forkTargets.length === 0 && <li>• {t('messages.noTargets')}</li>}
                         </ul>
-                        {enabledProviders.length === 0 && (
+                        {(enabledProviders.length === 0 || missingAiProvider) && (
                             <Link
                                 href={ROUTES.DASHBOARD_PLUGINS}
                                 className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
@@ -245,6 +278,28 @@ export function CreateCustomTemplateDialog({
                                 })}
                             </div>
                         </Field>
+
+                        {requiresAiProvider && (
+                            <Field
+                                label={t('aiProviderLabel')}
+                                hint={t('aiProviderHelp', {
+                                    plugin: selectedProvider?.name ?? '',
+                                })}
+                            >
+                                <div className="flex flex-wrap gap-1.5">
+                                    {enabledAiProviders.map((provider) => (
+                                        <ProviderChoiceButton
+                                            key={provider.id}
+                                            name={provider.providerName || provider.name}
+                                            icon={provider.icon}
+                                            isActive={aiProviderId === provider.id}
+                                            disabled={disabled}
+                                            onSelect={() => setAiProviderId(provider.id)}
+                                        />
+                                    ))}
+                                </div>
+                            </Field>
+                        )}
 
                         <Field label={t('targetLabel')} hint={t('targetHelp')}>
                             <Select

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useTransition } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { parseGitHubRepositoryUrl } from '@ever-works/contracts';
@@ -48,14 +48,40 @@ import {
     addCustomTemplate,
     archiveCustomTemplate,
     forkTemplate,
+    getTemplateCustomization,
     refreshTemplates,
     setDefaultTemplate,
     updateCustomTemplate,
 } from '@/app/actions/dashboard/templates';
 import { cn } from '@/lib/utils/cn';
-import { CreateCustomTemplateDialog, type CustomizeDialogMode } from './CreateCustomTemplateDialog';
+import {
+    CreateCustomTemplateDialog,
+    type CustomizationStartedArgs,
+    type CustomizeDialogMode,
+} from './CreateCustomTemplateDialog';
 
 const TERMINAL_CUSTOMIZATION_STATUSES: TemplateCustomizationStatus[] = ['succeeded', 'failed'];
+const CUSTOMIZATION_POLL_INTERVAL_MS = 5_000;
+
+function toCustomizationSummary(c: {
+    id: string;
+    status: TemplateCustomizationStatus;
+    errorMessage?: string | null;
+    startedAt?: string | null;
+    completedAt?: string | null;
+    createdAt: string;
+    updatedAt: string;
+}): TemplateCustomizationSummary {
+    return {
+        id: c.id,
+        status: c.status,
+        errorMessage: c.errorMessage ?? null,
+        startedAt: c.startedAt ?? null,
+        completedAt: c.completedAt ?? null,
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+    };
+}
 
 type FilterMode = 'all' | 'built_in' | 'custom';
 
@@ -386,31 +412,156 @@ export function TemplatesCatalog({
     const [isRefreshingTemplates, startRefreshingTemplates] = useTransition();
     const [customizeDialogOpen, setCustomizeDialogOpen] = useState(false);
     const [customizeMode, setCustomizeMode] = useState<CustomizeDialogMode>('new');
-    const [customizeTargetTemplate, setCustomizeTargetTemplate] =
-        useState<TemplateCatalogItem | null>(null);
-    const [customizeInitialCustomization, setCustomizeInitialCustomization] =
-        useState<TemplateCustomizationSummary | null>(null);
+    const [customizeTargetId, setCustomizeTargetId] = useState<string | null>(null);
+
+    // Always resolve the target from current templates state so the dialog
+    // sees status updates pushed by the page-level poller below.
+    const customizeTargetTemplate = useMemo(
+        () => (customizeTargetId ? (templates.find((t) => t.id === customizeTargetId) ?? null) : null),
+        [customizeTargetId, templates],
+    );
 
     const openCustomizeNew = () => {
         setCustomizeMode('new');
-        setCustomizeTargetTemplate(null);
-        setCustomizeInitialCustomization(null);
+        setCustomizeTargetId(null);
         setCustomizeDialogOpen(true);
     };
 
     const openCustomizeIterate = (template: TemplateCatalogItem) => {
         setCustomizeMode('iterate');
-        setCustomizeTargetTemplate(template);
-        setCustomizeInitialCustomization(null);
+        setCustomizeTargetId(template.id);
         setCustomizeDialogOpen(true);
     };
 
     const openCustomizeStatus = (template: TemplateCatalogItem) => {
         if (!template.latestCustomization) return;
         setCustomizeMode('status');
-        setCustomizeTargetTemplate(template);
-        setCustomizeInitialCustomization(template.latestCustomization);
+        setCustomizeTargetId(template.id);
         setCustomizeDialogOpen(true);
+    };
+
+    const inFlightIdsKey = useMemo(
+        () =>
+            templates
+                .filter(
+                    (t) =>
+                        t.latestCustomization &&
+                        !TERMINAL_CUSTOMIZATION_STATUSES.includes(
+                            t.latestCustomization.status,
+                        ),
+                )
+                .map((t) => t.latestCustomization!.id)
+                .sort()
+                .join(','),
+        [templates],
+    );
+
+    // One shared interval polls every in-flight customization. Mirrors the
+    // WorkLayoutClient pattern (apps/web/src/components/works/detail/WorkLayoutClient.tsx).
+    const previousStatusesRef = useRef<Record<string, TemplateCustomizationStatus>>({});
+
+    useEffect(() => {
+        if (!inFlightIdsKey) return;
+        const ids = inFlightIdsKey.split(',');
+        let cancelled = false;
+
+        const tick = async () => {
+            const results = await Promise.allSettled(
+                ids.map((id) => getTemplateCustomization(id)),
+            );
+            if (cancelled) return;
+
+            const updates = new Map<string, TemplateCustomizationSummary>();
+            const transitions: TemplateCustomizationSummary[] = [];
+            const prev = previousStatusesRef.current;
+
+            for (const r of results) {
+                if (r.status !== 'fulfilled') continue;
+                const c = r.value.customization;
+                if (!r.value.success || !c) continue;
+                const summary = toCustomizationSummary(c);
+                updates.set(summary.id, summary);
+                if (
+                    prev[summary.id] &&
+                    prev[summary.id] !== summary.status &&
+                    TERMINAL_CUSTOMIZATION_STATUSES.includes(summary.status)
+                ) {
+                    transitions.push(summary);
+                }
+                previousStatusesRef.current[summary.id] = summary.status;
+            }
+
+            if (updates.size > 0) {
+                setTemplates((current) =>
+                    current.map((tpl) => {
+                        if (!tpl.latestCustomization) return tpl;
+                        const next = updates.get(tpl.latestCustomization.id);
+                        return next ? { ...tpl, latestCustomization: next } : tpl;
+                    }),
+                );
+            }
+
+            for (const transition of transitions) {
+                if (transition.status === 'succeeded') {
+                    toast.success(t('messages.customizationSucceeded'));
+                } else if (transition.status === 'failed') {
+                    toast.error(transition.errorMessage || t('messages.customizationFailed'));
+                }
+            }
+
+            if (transitions.length > 0) {
+                // Pick up the new `lastCustomizedAt` and any template fields
+                // refreshed by the agent run.
+                const refreshed = await refreshTemplates({ kind });
+                if (!cancelled && refreshed.success) {
+                    setTemplates(refreshed.templates.sort(compareTemplates));
+                    setCurrentDefaultTemplateId(refreshed.defaultTemplateId);
+                }
+            }
+        };
+
+        void tick();
+        const interval = window.setInterval(tick, CUSTOMIZATION_POLL_INTERVAL_MS);
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+        };
+    }, [inFlightIdsKey, kind, t]);
+
+    const handleCustomizationStarted = ({ customization, template }: CustomizationStartedArgs) => {
+        const summary = toCustomizationSummary(customization);
+
+        if (template) {
+            // New customization → new template. Refresh once to pull the
+            // fully-shaped TemplateCatalogItem; then the polling effect
+            // takes over.
+            setCustomizeTargetId(template.id);
+            void (async () => {
+                const refreshed = await refreshTemplates({ kind });
+                if (refreshed.success) {
+                    setTemplates(
+                        refreshed.templates
+                            .map((tpl) =>
+                                tpl.id === template.id
+                                    ? { ...tpl, latestCustomization: summary }
+                                    : tpl,
+                            )
+                            .sort(compareTemplates),
+                    );
+                    setCurrentDefaultTemplateId(refreshed.defaultTemplateId);
+                }
+            })();
+            return;
+        }
+
+        // Iterate against an existing template → update in place.
+        setTemplates((current) =>
+            current.map((tpl) =>
+                tpl.id === customization.templateId
+                    ? { ...tpl, latestCustomization: summary }
+                    : tpl,
+            ),
+        );
     };
 
     const customizableBases = useMemo(
@@ -1050,16 +1201,7 @@ export function TemplatesCatalog({
                 forkTargets={forkTargets}
                 mode={customizeMode}
                 targetTemplate={customizeTargetTemplate}
-                initialCustomization={customizeInitialCustomization}
-                onSucceeded={() => {
-                    void (async () => {
-                        const refreshed = await refreshTemplates({ kind });
-                        if (refreshed.success) {
-                            setTemplates(refreshed.templates.sort(compareTemplates));
-                            setCurrentDefaultTemplateId(refreshed.defaultTemplateId);
-                        }
-                    })();
-                }}
+                onCustomizationStarted={handleCustomizationStarted}
             />
 
             <Dialog

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -416,10 +416,11 @@ export function TemplatesCatalog({
 
     // Always resolve the target from current templates state so the dialog
     // sees status updates pushed by the page-level poller below.
-    const customizeTargetTemplate = useMemo(
-        () => (customizeTargetId ? (templates.find((t) => t.id === customizeTargetId) ?? null) : null),
-        [customizeTargetId, templates],
-    );
+    const customizeTargetTemplate = useMemo(() => {
+        return customizeTargetId
+            ? (templates.find((t) => t.id === customizeTargetId) ?? null)
+            : null;
+    }, [customizeTargetId, templates]);
 
     const openCustomizeNew = () => {
         setCustomizeMode('new');
@@ -446,9 +447,7 @@ export function TemplatesCatalog({
                 .filter(
                     (t) =>
                         t.latestCustomization &&
-                        !TERMINAL_CUSTOMIZATION_STATUSES.includes(
-                            t.latestCustomization.status,
-                        ),
+                        !TERMINAL_CUSTOMIZATION_STATUSES.includes(t.latestCustomization.status),
                 )
                 .map((t) => t.latestCustomization!.id)
                 .sort()
@@ -466,9 +465,7 @@ export function TemplatesCatalog({
         let cancelled = false;
 
         const tick = async () => {
-            const results = await Promise.allSettled(
-                ids.map((id) => getTemplateCustomization(id)),
-            );
+            const results = await Promise.allSettled(ids.map((id) => getTemplateCustomization(id)));
             if (cancelled) return;
 
             const updates = new Map<string, TemplateCustomizationSummary>();

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -18,7 +18,12 @@ import {
     Star,
     Sparkles,
 } from 'lucide-react';
-import type { CustomizationProvider, TemplateCatalogItem, TemplateKind } from '@/lib/api/templates';
+import type {
+    CustomizationAiProvider,
+    CustomizationProvider,
+    TemplateCatalogItem,
+    TemplateKind,
+} from '@/lib/api/templates';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
@@ -52,6 +57,7 @@ interface TemplatesCatalogProps {
     defaultTemplateId: string | null;
     forkTargets: ForkTarget[];
     customizationProviders: CustomizationProvider[];
+    customizationAiProviders: CustomizationAiProvider[];
 }
 
 interface ForkTarget {
@@ -283,6 +289,7 @@ export function TemplatesCatalog({
     defaultTemplateId,
     forkTargets,
     customizationProviders,
+    customizationAiProviders,
 }: TemplatesCatalogProps) {
     const t = useTranslations('dashboard.templates');
     const [templates, setTemplates] = useState(initialTemplates);
@@ -939,6 +946,7 @@ export function TemplatesCatalog({
                 onOpenChange={setCustomizeDialogOpen}
                 customizableBases={customizableBases}
                 providers={customizationProviders}
+                aiProviders={customizationAiProviders}
                 forkTargets={forkTargets}
                 onSucceeded={() => {
                     void (async () => {

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -17,11 +17,17 @@ import {
     Trash2,
     Star,
     Sparkles,
+    Loader2,
+    AlertCircle,
+    CheckCircle2,
+    Wand2,
 } from 'lucide-react';
 import type {
     CustomizationAiProvider,
     CustomizationProvider,
     TemplateCatalogItem,
+    TemplateCustomizationStatus,
+    TemplateCustomizationSummary,
     TemplateKind,
 } from '@/lib/api/templates';
 import { Button } from '@/components/ui/button';
@@ -47,7 +53,9 @@ import {
     updateCustomTemplate,
 } from '@/app/actions/dashboard/templates';
 import { cn } from '@/lib/utils/cn';
-import { CreateCustomTemplateDialog } from './CreateCustomTemplateDialog';
+import { CreateCustomTemplateDialog, type CustomizeDialogMode } from './CreateCustomTemplateDialog';
+
+const TERMINAL_CUSTOMIZATION_STATUSES: TemplateCustomizationStatus[] = ['succeeded', 'failed'];
 
 type FilterMode = 'all' | 'built_in' | 'custom';
 
@@ -112,6 +120,49 @@ function getTemplatePreviewUrl(template: TemplateCatalogItem): string | null {
     return `https://opengraph.githubassets.com/${cacheKey}/${owner}/${repository}`;
 }
 
+function CustomizationStatusChip({
+    summary,
+    onClick,
+}: {
+    summary: TemplateCustomizationSummary;
+    onClick?: () => void;
+}) {
+    const t = useTranslations('dashboard.templates');
+    const isTerminal = TERMINAL_CUSTOMIZATION_STATUSES.includes(summary.status);
+    const succeeded = summary.status === 'succeeded';
+    const failed = summary.status === 'failed';
+    const tone = failed
+        ? 'bg-destructive/15 text-destructive border border-destructive/30'
+        : succeeded
+          ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border border-emerald-500/30'
+          : 'bg-amber-500/15 text-amber-700 dark:text-amber-300 border border-amber-500/30';
+    const Icon = failed ? AlertCircle : succeeded ? CheckCircle2 : Loader2;
+
+    const chip = (
+        <span
+            className={cn(
+                'inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-medium backdrop-blur-sm',
+                tone,
+            )}
+        >
+            <Icon className={cn('w-2.5 h-2.5', !isTerminal && 'animate-spin')} />
+            {t(`card.status.${summary.status}`)}
+        </span>
+    );
+
+    if (isTerminal || !onClick) return chip;
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="inline-flex"
+            title={t('card.viewStatus')}
+        >
+            {chip}
+        </button>
+    );
+}
+
 function TemplateCard({
     template,
     isDefault,
@@ -119,6 +170,8 @@ function TemplateCard({
     onFork,
     onEdit,
     onArchive,
+    onCustomizeAgain,
+    onViewStatus,
     loading,
     forkLoading,
     archiveLoading,
@@ -129,6 +182,8 @@ function TemplateCard({
     onFork: (template: TemplateCatalogItem) => void;
     onEdit: (template: TemplateCatalogItem) => void;
     onArchive: (template: TemplateCatalogItem) => void;
+    onCustomizeAgain: (template: TemplateCatalogItem) => void;
+    onViewStatus: (template: TemplateCatalogItem) => void;
     loading: boolean;
     forkLoading: boolean;
     archiveLoading: boolean;
@@ -171,6 +226,14 @@ function TemplateCard({
                         <Star className="w-2.5 h-2.5 fill-current" />
                         {t('card.default')}
                     </span>
+                )}
+                {template.latestCustomization && (
+                    <div className="absolute top-2 left-2">
+                        <CustomizationStatusChip
+                            summary={template.latestCustomization}
+                            onClick={() => onViewStatus(template)}
+                        />
+                    </div>
                 )}
             </div>
 
@@ -243,6 +306,18 @@ function TemplateCard({
                             </Button>
                         ) : (
                             <>
+                                {template.customizable && (
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        disabled={loading || archiveLoading}
+                                        onClick={() => onCustomizeAgain(template)}
+                                        title={t('card.customizeAgain')}
+                                        className="text-xs"
+                                    >
+                                        <Wand2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                )}
                                 <Button
                                     variant="ghost"
                                     size="sm"
@@ -310,6 +385,33 @@ export function TemplatesCatalog({
     const [isArchivingTemplate, startArchivingTemplate] = useTransition();
     const [isRefreshingTemplates, startRefreshingTemplates] = useTransition();
     const [customizeDialogOpen, setCustomizeDialogOpen] = useState(false);
+    const [customizeMode, setCustomizeMode] = useState<CustomizeDialogMode>('new');
+    const [customizeTargetTemplate, setCustomizeTargetTemplate] =
+        useState<TemplateCatalogItem | null>(null);
+    const [customizeInitialCustomization, setCustomizeInitialCustomization] =
+        useState<TemplateCustomizationSummary | null>(null);
+
+    const openCustomizeNew = () => {
+        setCustomizeMode('new');
+        setCustomizeTargetTemplate(null);
+        setCustomizeInitialCustomization(null);
+        setCustomizeDialogOpen(true);
+    };
+
+    const openCustomizeIterate = (template: TemplateCatalogItem) => {
+        setCustomizeMode('iterate');
+        setCustomizeTargetTemplate(template);
+        setCustomizeInitialCustomization(null);
+        setCustomizeDialogOpen(true);
+    };
+
+    const openCustomizeStatus = (template: TemplateCatalogItem) => {
+        if (!template.latestCustomization) return;
+        setCustomizeMode('status');
+        setCustomizeTargetTemplate(template);
+        setCustomizeInitialCustomization(template.latestCustomization);
+        setCustomizeDialogOpen(true);
+    };
 
     const customizableBases = useMemo(
         () =>
@@ -602,11 +704,7 @@ export function TemplatesCatalog({
                             <RefreshCw className="h-4 w-4" />
                         </Button>
                         {customizableBases.length > 0 && (
-                            <Button
-                                size="sm"
-                                variant="secondary"
-                                onClick={() => setCustomizeDialogOpen(true)}
-                            >
+                            <Button size="sm" variant="secondary" onClick={openCustomizeNew}>
                                 <Sparkles className="h-4 w-4" />
                                 {t('actions.customizeTemplate')}
                             </Button>
@@ -705,6 +803,8 @@ export function TemplatesCatalog({
                             onArchive={(selectedTemplate) =>
                                 setArchiveDialogTemplate(selectedTemplate)
                             }
+                            onCustomizeAgain={openCustomizeIterate}
+                            onViewStatus={openCustomizeStatus}
                             loading={isSavingDefault}
                             forkLoading={
                                 isForkingTemplate && forkDialogTemplate?.id === template.id
@@ -948,6 +1048,9 @@ export function TemplatesCatalog({
                 providers={customizationProviders}
                 aiProviders={customizationAiProviders}
                 forkTargets={forkTargets}
+                mode={customizeMode}
+                targetTemplate={customizeTargetTemplate}
+                initialCustomization={customizeInitialCustomization}
                 onSucceeded={() => {
                     void (async () => {
                         const refreshed = await refreshTemplates({ kind });

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -66,6 +66,7 @@ const CUSTOMIZATION_POLL_INTERVAL_MS = 5_000;
 function toCustomizationSummary(c: {
     id: string;
     status: TemplateCustomizationStatus;
+    prompt: string;
     errorMessage?: string | null;
     startedAt?: string | null;
     completedAt?: string | null;
@@ -75,6 +76,7 @@ function toCustomizationSummary(c: {
     return {
         id: c.id,
         status: c.status,
+        prompt: c.prompt,
         errorMessage: c.errorMessage ?? null,
         startedAt: c.startedAt ?? null,
         completedAt: c.completedAt ?? null,

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -34,6 +34,7 @@ export interface TemplateCatalogItem {
 export interface TemplateCustomizationSummary {
     id: string;
     status: TemplateCustomizationStatus;
+    prompt: string;
     errorMessage: string | null;
     startedAt: string | null;
     completedAt: string | null;

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -28,6 +28,7 @@ export interface TemplateCatalogItem {
     customizable?: boolean;
     baseTemplateId?: string | null;
     lastCustomizedAt?: string | null;
+    lastCustomizationPrompt?: string | null;
     latestCustomization?: TemplateCustomizationSummary | null;
 }
 

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -121,10 +121,27 @@ export interface CustomizationProvider {
     providerName?: string;
     enabled: boolean;
     isDefault?: boolean;
+    // Mirrors the plugin manifest declaration. The dialog renders a conditional
+    // AI provider picker when this includes 'ai-provider' (e.g. opencode).
+    selectableProviderCategories?: readonly string[];
 }
 
 export type ListCustomizationProvidersResponse = APIResponse<{
     providers: CustomizationProvider[];
+}>;
+
+export interface CustomizationAiProvider {
+    id: string;
+    name: string;
+    description?: string | null;
+    icon?: PluginIcon;
+    providerName?: string;
+    enabled: boolean;
+    isDefault?: boolean;
+}
+
+export type ListCustomizationAiProvidersResponse = APIResponse<{
+    providers: CustomizationAiProvider[];
 }>;
 
 export const templatesAPI = {
@@ -211,6 +228,7 @@ export const templatesAPI = {
         name: string;
         prompt: string;
         providerId: string;
+        aiProviderId?: string;
         targetOwner?: string;
         description?: string;
     }) => {
@@ -231,6 +249,12 @@ export const templatesAPI = {
     listCustomizationProviders: async () => {
         return serverFetch<ListCustomizationProvidersResponse>(
             '/templates/customization-providers',
+        );
+    },
+
+    listCustomizationAiProviders: async () => {
+        return serverFetch<ListCustomizationAiProvidersResponse>(
+            '/templates/customization-ai-providers',
         );
     },
 };

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -28,6 +28,17 @@ export interface TemplateCatalogItem {
     customizable?: boolean;
     baseTemplateId?: string | null;
     lastCustomizedAt?: string | null;
+    latestCustomization?: TemplateCustomizationSummary | null;
+}
+
+export interface TemplateCustomizationSummary {
+    id: string;
+    status: TemplateCustomizationStatus;
+    errorMessage: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export type TemplateCustomizationStatus =
@@ -110,6 +121,11 @@ export type CustomizeTemplateFromBaseResponse = APIResponse<{
 }>;
 
 export type GetTemplateCustomizationResponse = APIResponse<{
+    customization: TemplateCustomization;
+}>;
+
+export type IterateCustomTemplateResponse = APIResponse<{
+    customizationId: string;
     customization: TemplateCustomization;
 }>;
 
@@ -234,6 +250,18 @@ export const templatesAPI = {
     }) => {
         return serverMutation<CustomizeTemplateFromBaseResponse>({
             endpoint: '/templates/custom-from-base',
+            data,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    iterateCustom: async (
+        templateId: string,
+        data: { prompt: string; providerId: string; aiProviderId?: string },
+    ) => {
+        return serverMutation<IterateCustomTemplateResponse>({
+            endpoint: `/templates/custom/${templateId}/customize`,
             data,
             method: 'POST',
             wrapInData: false,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"prettier": "^3.7.4",
 		"prettier-eslint-cli": "^8.0.1",
 		"prettier-plugin-tailwindcss": "^0.5.14",
-		"turbo": "^2.9.12"
+		"turbo": "^2.9.14"
 	},
 	"engines": {
 		"node": ">=22",

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -23,6 +23,7 @@ export * from './repositories/github-app-installation-repository.repository';
 export * from './repositories/github-app-user-link.repository';
 export * from './repositories/onboarding-request.repository';
 export * from './repositories/template.repository';
+export * from './repositories/template-customization.repository';
 export * from './repositories/user-template-preference.repository';
 export * from './repositories/webhook-subscription.repository';
 export * from './database-init.service';

--- a/packages/agent/src/database/repositories/template-customization.repository.ts
+++ b/packages/agent/src/database/repositories/template-customization.repository.ts
@@ -23,6 +23,7 @@ export type UpdateTemplateCustomizationPatch = Partial<
         | 'commitSha'
         | 'errorMessage'
         | 'providerId'
+        | 'triggerRunId'
         | 'startedAt'
         | 'completedAt'
     >

--- a/packages/agent/src/database/repositories/template-customization.repository.ts
+++ b/packages/agent/src/database/repositories/template-customization.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import {
     TemplateCustomization,
     TemplateCustomizationStatus,
@@ -75,5 +75,22 @@ export class TemplateCustomizationRepository {
             order: { createdAt: 'DESC' },
             take: limit,
         });
+    }
+
+    async findLatestForTemplates(
+        templateIds: readonly string[],
+        userId: string,
+    ): Promise<Map<string, TemplateCustomization>> {
+        const result = new Map<string, TemplateCustomization>();
+        if (templateIds.length === 0) return result;
+
+        const rows = await this.repository.find({
+            where: { templateId: In(templateIds as string[]), userId },
+            order: { createdAt: 'DESC' },
+        });
+        for (const row of rows) {
+            if (!result.has(row.templateId)) result.set(row.templateId, row);
+        }
+        return result;
     }
 }

--- a/packages/agent/src/database/repositories/template-customization.repository.ts
+++ b/packages/agent/src/database/repositories/template-customization.repository.ts
@@ -11,6 +11,7 @@ export type CreateTemplateCustomizationInput = Pick<
     'templateId' | 'userId' | 'baseTemplateId' | 'prompt'
 > & {
     providerId?: string | null;
+    aiProviderId?: string | null;
     status?: TemplateCustomizationStatus;
 };
 
@@ -41,6 +42,7 @@ export class TemplateCustomizationRepository {
             baseTemplateId: input.baseTemplateId,
             prompt: input.prompt,
             providerId: input.providerId ?? null,
+            aiProviderId: input.aiProviderId ?? null,
             status: input.status ?? TemplateCustomizationStatus.PENDING,
         });
         return this.repository.save(entity);

--- a/packages/agent/src/entities/template-customization.entity.ts
+++ b/packages/agent/src/entities/template-customization.entity.ts
@@ -57,6 +57,9 @@ export class TemplateCustomization {
     @Column({ type: 'varchar', length: 80, nullable: true })
     aiProviderId?: string | null;
 
+    @Column({ type: 'varchar', length: 80, nullable: true })
+    triggerRunId?: string | null;
+
     @Column({ type: 'varchar', length: 255, nullable: true })
     branch?: string | null;
 

--- a/packages/agent/src/entities/template-customization.entity.ts
+++ b/packages/agent/src/entities/template-customization.entity.ts
@@ -54,6 +54,9 @@ export class TemplateCustomization {
     @Column({ type: 'varchar', length: 80, nullable: true })
     providerId?: string | null;
 
+    @Column({ type: 'varchar', length: 80, nullable: true })
+    aiProviderId?: string | null;
+
     @Column({ type: 'varchar', length: 255, nullable: true })
     branch?: string | null;
 

--- a/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CodeEditFacadeService } from '../code-edit.facade';
+import { ProviderNotFoundError, NoProviderError } from '../base.facade';
 import {
     PluginRegistryService,
     type RegisteredPlugin,
@@ -20,7 +21,7 @@ describe('CodeEditFacadeService', () => {
             category: 'pipeline',
             capabilities: ['code-edit'],
             configurationMode: 'hybrid',
-            executeCodeEdit: jest.fn(),
+            executeCodeEdit: jest.fn().mockResolvedValue({ success: true }),
             onLoad: jest.fn(),
             onUnload: jest.fn(),
         }) as unknown as ICodeEditPlugin;
@@ -81,16 +82,6 @@ describe('CodeEditFacadeService', () => {
             const providers = await service.listProviders('user-1');
 
             expect(providers.map((p) => p.id)).toEqual(['claude-code']);
-            expect(registry.isPluginEnabledForScope).toHaveBeenCalledWith(
-                'claude-code',
-                undefined,
-                'user-1',
-            );
-            expect(registry.isPluginEnabledForScope).toHaveBeenCalledWith(
-                'gemini',
-                undefined,
-                'user-1',
-            );
         });
 
         it('skips plugins that are registered but not loaded', async () => {
@@ -122,42 +113,46 @@ describe('CodeEditFacadeService', () => {
             await expect(service.listProviders('user-1')).resolves.toEqual([]);
         });
 
-        it('marks defaultForCapabilities plugin as isDefault', async () => {
+        it('marks defaultForCapabilities plugin as isDefault and sorts it first', async () => {
             registry.getByCapability.mockReturnValue([
-                createRegistered('claude-code', { defaultForCapabilities: ['code-edit'] }),
                 createRegistered('codex'),
+                createRegistered('claude-code', { defaultForCapabilities: ['code-edit'] }),
             ]);
             registry.isPluginEnabledForScope.mockResolvedValue(true);
 
             const providers = await service.listProviders('user-1');
 
-            expect(providers.find((p) => p.id === 'claude-code')?.isDefault).toBe(true);
-            expect(providers.find((p) => p.id === 'codex')?.isDefault).toBe(false);
+            expect(providers[0].id).toBe('claude-code');
+            expect(providers[0].isDefault).toBe(true);
+            expect(providers[1].isDefault).toBe(false);
         });
     });
 
-    describe('resolveProvider', () => {
-        it('throws when the user has not enabled the requested plugin', async () => {
+    describe('execute (resolution via BaseFacadeService.resolvePlugin)', () => {
+        it('throws ProviderNotFoundError when the user has not enabled the requested plugin', async () => {
             const registered = createRegistered('gemini');
             registry.get.mockReturnValue(registered);
             registry.isPluginEnabledForScope.mockResolvedValue(false);
 
             await expect(
-                service.resolveProvider({ userId: 'user-1', providerId: 'gemini' }),
-            ).rejects.toThrow(/not enabled for this user/);
+                service.execute(
+                    { workspaceDir: '/tmp/x', prompt: 'p' },
+                    { userId: 'user-1', providerId: 'gemini' },
+                ),
+            ).rejects.toBeInstanceOf(ProviderNotFoundError);
         });
 
-        it('returns the plugin when the user has it enabled', async () => {
+        it('runs the plugin when the user has it enabled', async () => {
             const registered = createRegistered('claude-code');
             registry.get.mockReturnValue(registered);
             registry.isPluginEnabledForScope.mockResolvedValue(true);
 
-            const plugin = await service.resolveProvider({
-                userId: 'user-1',
-                providerId: 'claude-code',
-            });
+            await service.execute(
+                { workspaceDir: '/tmp/x', prompt: 'p' },
+                { userId: 'user-1', providerId: 'claude-code' },
+            );
 
-            expect(plugin.id).toBe('claude-code');
+            expect((registered.plugin as ICodeEditPlugin).executeCodeEdit).toHaveBeenCalled();
         });
 
         it('falls back to the first user-enabled plugin when no providerId is given', async () => {
@@ -166,18 +161,18 @@ describe('CodeEditFacadeService', () => {
             registry.get.mockReturnValue(registered);
             registry.isPluginEnabledForScope.mockResolvedValue(true);
 
-            const plugin = await service.resolveProvider({ userId: 'user-1' });
+            await service.execute({ workspaceDir: '/tmp/x', prompt: 'p' }, { userId: 'user-1' });
 
-            expect(plugin.id).toBe('codex');
+            expect((registered.plugin as ICodeEditPlugin).executeCodeEdit).toHaveBeenCalled();
         });
 
-        it('throws when the user has no providers enabled and none was requested', async () => {
+        it('throws NoProviderError when the user has no providers enabled and none was requested', async () => {
             registry.getByCapability.mockReturnValue([createRegistered('codex')]);
             registry.isPluginEnabledForScope.mockResolvedValue(false);
 
-            await expect(service.resolveProvider({ userId: 'user-1' })).rejects.toThrow(
-                /No code-edit provider available/,
-            );
+            await expect(
+                service.execute({ workspaceDir: '/tmp/x', prompt: 'p' }, { userId: 'user-1' }),
+            ).rejects.toBeInstanceOf(NoProviderError);
         });
     });
 });

--- a/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
@@ -71,6 +71,51 @@ describe('CodeEditFacadeService', () => {
         registry = module.get(PluginRegistryService);
     });
 
+    describe('isProviderAvailable', () => {
+        it('returns false when the plugin id is unknown', async () => {
+            registry.get.mockReturnValue(undefined);
+            await expect(service.isProviderAvailable('nope', 'user-1')).resolves.toBe(false);
+            expect(registry.isPluginEnabledForScope).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the plugin is registered but not loaded', async () => {
+            registry.get.mockReturnValue(createRegistered('codex', {}, 'error'));
+            await expect(service.isProviderAvailable('codex', 'user-1')).resolves.toBe(false);
+            expect(registry.isPluginEnabledForScope).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the plugin does not declare the code-edit capability', async () => {
+            registry.get.mockReturnValue(createRegistered('helper', { capabilities: ['search'] }));
+            await expect(service.isProviderAvailable('helper', 'user-1')).resolves.toBe(false);
+            expect(registry.isPluginEnabledForScope).not.toHaveBeenCalled();
+        });
+
+        it('returns false for supplementary plugins even when the user has them enabled', async () => {
+            registry.get.mockReturnValue(createRegistered('helper', { supplementary: true }));
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+            await expect(service.isProviderAvailable('helper', 'user-1')).resolves.toBe(false);
+            expect(registry.isPluginEnabledForScope).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the user has the plugin disabled', async () => {
+            registry.get.mockReturnValue(createRegistered('claude-code'));
+            registry.isPluginEnabledForScope.mockResolvedValue(false);
+            await expect(service.isProviderAvailable('claude-code', 'user-1')).resolves.toBe(false);
+        });
+
+        it('returns true when loaded, code-edit-capable, not supplementary, and user-enabled', async () => {
+            registry.get.mockReturnValue(createRegistered('claude-code'));
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+            await expect(service.isProviderAvailable('claude-code', 'user-1')).resolves.toBe(true);
+            expect(registry.isPluginEnabledForScope).toHaveBeenCalledTimes(1);
+            expect(registry.isPluginEnabledForScope).toHaveBeenCalledWith(
+                'claude-code',
+                undefined,
+                'user-1',
+            );
+        });
+    });
+
     describe('listProviders', () => {
         it('returns only plugins the user has enabled', async () => {
             registry.getByCapability.mockReturnValue([

--- a/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
@@ -174,5 +174,18 @@ describe('CodeEditFacadeService', () => {
                 service.execute({ workspaceDir: '/tmp/x', prompt: 'p' }, { userId: 'user-1' }),
             ).rejects.toBeInstanceOf(NoProviderError);
         });
+
+        it('rejects supplementary plugins even if a caller posts their id directly', async () => {
+            const registered = createRegistered('helper', { supplementary: true });
+            registry.get.mockReturnValue(registered);
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+
+            await expect(
+                service.execute(
+                    { workspaceDir: '/tmp/x', prompt: 'p' },
+                    { userId: 'user-1', providerId: 'helper' },
+                ),
+            ).rejects.toBeInstanceOf(ProviderNotFoundError);
+        });
     });
 });

--- a/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/code-edit.facade.spec.ts
@@ -1,0 +1,183 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CodeEditFacadeService } from '../code-edit.facade';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { AiFacadeService } from '../ai.facade';
+import type { ICodeEditPlugin, PluginManifest } from '@ever-works/plugin';
+
+describe('CodeEditFacadeService', () => {
+    let service: CodeEditFacadeService;
+    let registry: jest.Mocked<PluginRegistryService>;
+
+    const createCodeEditPlugin = (id: string): ICodeEditPlugin =>
+        ({
+            id,
+            name: id,
+            version: '1.0.0',
+            category: 'pipeline',
+            capabilities: ['code-edit'],
+            configurationMode: 'hybrid',
+            executeCodeEdit: jest.fn(),
+            onLoad: jest.fn(),
+            onUnload: jest.fn(),
+        }) as unknown as ICodeEditPlugin;
+
+    const createRegistered = (
+        id: string,
+        manifest: Partial<PluginManifest> = {},
+        state: RegisteredPlugin['state'] = 'loaded',
+    ): RegisteredPlugin => ({
+        plugin: createCodeEditPlugin(id),
+        manifest: {
+            id,
+            name: id,
+            version: '1.0.0',
+            description: 'Test code-edit plugin',
+            category: 'pipeline',
+            capabilities: ['code-edit'],
+            ...manifest,
+        } as PluginManifest,
+        state,
+        builtIn: false,
+        stateHistory: [],
+        registeredAt: Date.now(),
+    });
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CodeEditFacadeService,
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        get: jest.fn(),
+                        getByCapability: jest.fn().mockReturnValue([]),
+                        isPluginEnabledForScope: jest.fn().mockResolvedValue(false),
+                    },
+                },
+                {
+                    provide: PluginSettingsService,
+                    useValue: { getSettings: jest.fn().mockResolvedValue({}) },
+                },
+                { provide: AiFacadeService, useValue: {} },
+            ],
+        }).compile();
+
+        service = module.get(CodeEditFacadeService);
+        registry = module.get(PluginRegistryService);
+    });
+
+    describe('listProviders', () => {
+        it('returns only plugins the user has enabled', async () => {
+            registry.getByCapability.mockReturnValue([
+                createRegistered('claude-code'),
+                createRegistered('gemini'),
+            ]);
+            registry.isPluginEnabledForScope.mockImplementation(async (id) => id === 'claude-code');
+
+            const providers = await service.listProviders('user-1');
+
+            expect(providers.map((p) => p.id)).toEqual(['claude-code']);
+            expect(registry.isPluginEnabledForScope).toHaveBeenCalledWith(
+                'claude-code',
+                undefined,
+                'user-1',
+            );
+            expect(registry.isPluginEnabledForScope).toHaveBeenCalledWith(
+                'gemini',
+                undefined,
+                'user-1',
+            );
+        });
+
+        it('skips plugins that are registered but not loaded', async () => {
+            registry.getByCapability.mockReturnValue([
+                createRegistered('claude-code', {}, 'error'),
+                createRegistered('codex'),
+            ]);
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+
+            const providers = await service.listProviders('user-1');
+
+            expect(providers.map((p) => p.id)).toEqual(['codex']);
+        });
+
+        it('skips supplementary plugins', async () => {
+            registry.getByCapability.mockReturnValue([
+                createRegistered('claude-code'),
+                createRegistered('helper', { supplementary: true }),
+            ]);
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+
+            const providers = await service.listProviders('user-1');
+
+            expect(providers.map((p) => p.id)).toEqual(['claude-code']);
+        });
+
+        it('returns an empty list when no code-edit plugins are registered', async () => {
+            registry.getByCapability.mockReturnValue([]);
+            await expect(service.listProviders('user-1')).resolves.toEqual([]);
+        });
+
+        it('marks defaultForCapabilities plugin as isDefault', async () => {
+            registry.getByCapability.mockReturnValue([
+                createRegistered('claude-code', { defaultForCapabilities: ['code-edit'] }),
+                createRegistered('codex'),
+            ]);
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+
+            const providers = await service.listProviders('user-1');
+
+            expect(providers.find((p) => p.id === 'claude-code')?.isDefault).toBe(true);
+            expect(providers.find((p) => p.id === 'codex')?.isDefault).toBe(false);
+        });
+    });
+
+    describe('resolveProvider', () => {
+        it('throws when the user has not enabled the requested plugin', async () => {
+            const registered = createRegistered('gemini');
+            registry.get.mockReturnValue(registered);
+            registry.isPluginEnabledForScope.mockResolvedValue(false);
+
+            await expect(
+                service.resolveProvider({ userId: 'user-1', providerId: 'gemini' }),
+            ).rejects.toThrow(/not enabled for this user/);
+        });
+
+        it('returns the plugin when the user has it enabled', async () => {
+            const registered = createRegistered('claude-code');
+            registry.get.mockReturnValue(registered);
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+
+            const plugin = await service.resolveProvider({
+                userId: 'user-1',
+                providerId: 'claude-code',
+            });
+
+            expect(plugin.id).toBe('claude-code');
+        });
+
+        it('falls back to the first user-enabled plugin when no providerId is given', async () => {
+            const registered = createRegistered('codex');
+            registry.getByCapability.mockReturnValue([registered]);
+            registry.get.mockReturnValue(registered);
+            registry.isPluginEnabledForScope.mockResolvedValue(true);
+
+            const plugin = await service.resolveProvider({ userId: 'user-1' });
+
+            expect(plugin.id).toBe('codex');
+        });
+
+        it('throws when the user has no providers enabled and none was requested', async () => {
+            registry.getByCapability.mockReturnValue([createRegistered('codex')]);
+            registry.isPluginEnabledForScope.mockResolvedValue(false);
+
+            await expect(service.resolveProvider({ userId: 'user-1' })).rejects.toThrow(
+                /No code-edit provider available/,
+            );
+        });
+    });
+});

--- a/packages/agent/src/facades/base.facade.ts
+++ b/packages/agent/src/facades/base.facade.ts
@@ -5,7 +5,7 @@ import {
 } from '../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
-import type { IPlugin, FacadeOptions } from '@ever-works/plugin';
+import type { IPlugin, FacadeOptions, PluginIcon } from '@ever-works/plugin';
 
 // Common error classes for all facades
 export class FacadeError extends Error {
@@ -37,6 +37,17 @@ export class ProviderNotFoundError extends FacadeError {
 export interface DefaultProviderInfo {
     id: string;
     name: string;
+}
+
+export interface UserProviderInfo {
+    id: string;
+    name: string;
+    description?: string;
+    icon?: PluginIcon;
+    providerName?: string;
+    enabled: boolean;
+    isDefault: boolean;
+    selectableProviderCategories: readonly string[];
 }
 
 /**
@@ -77,6 +88,29 @@ export abstract class BaseFacadeService {
             name: this.getProviderName(p.plugin),
             enabled: p.state === 'loaded',
         }));
+    }
+
+    // User-scoped listing for picker UIs (Code-edit dialog, AI provider picker,
+    // etc.). Mirrors the filter sequence used by the generator form-schema
+    // service: by-capability + loaded + not supplementary + enabled-for-user,
+    // with defaultForCapabilities sorted first.
+    async getAvailableProvidersForUser(
+        userId: string,
+        workId?: string,
+    ): Promise<UserProviderInfo[]> {
+        const enabled = await this.getEnabledPlugins(workId as string, userId);
+        return enabled
+            .filter((p) => !p.manifest.supplementary)
+            .map((p) => ({
+                id: p.plugin.id,
+                name: p.manifest.name ?? p.plugin.id,
+                description: p.manifest.description,
+                icon: p.manifest.icon,
+                providerName: this.getProviderName(p.plugin),
+                enabled: true,
+                isDefault: p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) ?? false,
+                selectableProviderCategories: p.manifest.selectableProviderCategories ?? [],
+            }));
     }
 
     async getDefaultProvider(

--- a/packages/agent/src/facades/code-edit.facade.ts
+++ b/packages/agent/src/facades/code-edit.facade.ts
@@ -39,16 +39,33 @@ export class CodeEditFacadeService {
         private readonly aiFacade: AiFacadeService,
     ) {}
 
-    listProviders(): CodeEditProviderInfo[] {
-        return this.registry.getByCapability(this.CAPABILITY).map((p) => ({
-            id: p.plugin.id,
-            name: p.manifest.name ?? p.plugin.id,
-            description: p.manifest.description,
-            icon: p.manifest.icon,
-            providerName: (p.plugin as ICodeEditPlugin).providerName,
-            enabled: p.state === 'loaded',
-            isDefault: p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) || false,
-        }));
+    async listProviders(userId: string): Promise<CodeEditProviderInfo[]> {
+        const candidates = this.registry
+            .getByCapability(this.CAPABILITY)
+            .filter((p) => p.state === 'loaded' && !p.manifest.supplementary);
+
+        const results = await Promise.all(
+            candidates.map(async (p): Promise<CodeEditProviderInfo | null> => {
+                const enabled = await this.registry.isPluginEnabledForScope(
+                    p.plugin.id,
+                    undefined,
+                    userId,
+                );
+                if (!enabled) return null;
+                return {
+                    id: p.plugin.id,
+                    name: p.manifest.name ?? p.plugin.id,
+                    description: p.manifest.description,
+                    icon: p.manifest.icon,
+                    providerName: (p.plugin as ICodeEditPlugin).providerName,
+                    enabled: true,
+                    isDefault:
+                        p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) || false,
+                };
+            }),
+        );
+
+        return results.filter((p): p is CodeEditProviderInfo => p !== null);
     }
 
     async resolveProvider(opts: CodeEditFacadeOptions): Promise<ICodeEditPlugin> {
@@ -62,24 +79,33 @@ export class CodeEditFacadeService {
                     `Provider ${opts.providerId} does not implement the code-edit capability`,
                 );
             }
+            const enabled = await this.registry.isPluginEnabledForScope(
+                opts.providerId,
+                undefined,
+                opts.userId,
+            );
+            if (!enabled) {
+                throw new Error(
+                    `Code-edit provider "${opts.providerId}" is not enabled for this user`,
+                );
+            }
             return registered.plugin;
         }
 
-        const loaded = this.registry
-            .getByCapability(this.CAPABILITY)
-            .filter((p) => p.state === 'loaded');
-        if (loaded.length === 0) {
+        const available = await this.listProviders(opts.userId);
+        const first = available[0];
+        if (!first) {
             throw new Error(
-                'No code-edit provider available — install claude-code, codex, gemini, or opencode',
+                'No code-edit provider available — install one from the plugin catalog',
             );
         }
-        const plugin = loaded[0].plugin;
-        if (!isCodeEditPlugin(plugin)) {
+        const registered = this.registry.get(first.id);
+        if (!registered || !isCodeEditPlugin(registered.plugin)) {
             throw new Error(
-                `Default plugin ${plugin.id} does not implement the code-edit capability`,
+                `Default plugin ${first.id} does not implement the code-edit capability`,
             );
         }
-        return plugin;
+        return registered.plugin;
     }
 
     async execute(

--- a/packages/agent/src/facades/code-edit.facade.ts
+++ b/packages/agent/src/facades/code-edit.facade.ts
@@ -17,6 +17,9 @@ export interface CodeEditFacadeOptions {
     userId: string;
     workId?: string;
     providerId?: string;
+    // Forwarded to plugins that proxy to an AI provider (e.g. opencode). Plugins
+    // that bring their own model (claude-code, codex, gemini) ignore this.
+    aiProviderId?: string;
 }
 
 export interface CodeEditProviderInfo {
@@ -26,7 +29,8 @@ export interface CodeEditProviderInfo {
     icon?: PluginIcon;
     providerName?: string;
     enabled: boolean;
-    isDefault?: boolean;
+    isDefault: boolean;
+    selectableProviderCategories: readonly string[];
 }
 
 @Injectable()
@@ -48,6 +52,14 @@ export class CodeEditFacadeService extends BaseFacadeService {
         userId: string,
         workId?: string,
     ): Promise<boolean> {
+        return (await this.getProviderForUser(providerId, userId, workId)) !== null;
+    }
+
+    async getProviderForUser(
+        providerId: string,
+        userId: string,
+        workId?: string,
+    ): Promise<CodeEditProviderInfo | null> {
         const registered = this.registry.get(providerId);
         if (
             !registered ||
@@ -55,24 +67,25 @@ export class CodeEditFacadeService extends BaseFacadeService {
             !registered.manifest.capabilities.includes(this.CAPABILITY) ||
             registered.manifest.supplementary
         ) {
-            return false;
+            return null;
         }
-        return this.registry.isPluginEnabledForScope(providerId, workId, userId);
+        const enabled = await this.registry.isPluginEnabledForScope(providerId, workId, userId);
+        if (!enabled) return null;
+        return {
+            id: registered.plugin.id,
+            name: registered.manifest.name ?? registered.plugin.id,
+            description: registered.manifest.description,
+            icon: registered.manifest.icon,
+            providerName: this.getProviderName(registered.plugin),
+            enabled: true,
+            isDefault:
+                registered.manifest.defaultForCapabilities?.includes(this.CAPABILITY) ?? false,
+            selectableProviderCategories: registered.manifest.selectableProviderCategories ?? [],
+        };
     }
 
-    async listProviders(userId: string, workId?: string): Promise<CodeEditProviderInfo[]> {
-        const enabled = await this.getEnabledPlugins(workId as string, userId);
-        return enabled
-            .filter((p) => !p.manifest.supplementary)
-            .map((p) => ({
-                id: p.plugin.id,
-                name: p.manifest.name ?? p.plugin.id,
-                description: p.manifest.description,
-                icon: p.manifest.icon,
-                providerName: (p.plugin as ICodeEditPlugin).providerName,
-                enabled: true,
-                isDefault: p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) || false,
-            }));
+    listProviders(userId: string, workId?: string): Promise<CodeEditProviderInfo[]> {
+        return this.getAvailableProvidersForUser(userId, workId);
     }
 
     async execute(
@@ -105,6 +118,7 @@ export class CodeEditFacadeService extends BaseFacadeService {
                 aiFacade: this.aiFacade,
                 userId: opts.userId,
                 workId: opts.workId,
+                aiProviderId: opts.aiProviderId,
             },
         });
     }

--- a/packages/agent/src/facades/code-edit.facade.ts
+++ b/packages/agent/src/facades/code-edit.facade.ts
@@ -11,7 +11,7 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
 import { AiFacadeService } from './ai.facade';
-import { BaseFacadeService } from './base.facade';
+import { BaseFacadeService, ProviderNotFoundError } from './base.facade';
 
 export interface CodeEditFacadeOptions {
     userId: string;
@@ -68,6 +68,9 @@ export class CodeEditFacadeService extends BaseFacadeService {
             opts.userId,
             opts.workId,
         );
+        if (this.registry.get(plugin.id)?.manifest.supplementary) {
+            throw new ProviderNotFoundError(plugin.id, this.CAPABILITY);
+        }
         const settings = await this.pluginSettings.getSettings(plugin.id, {
             userId: opts.userId,
             workId: opts.workId,

--- a/packages/agent/src/facades/code-edit.facade.ts
+++ b/packages/agent/src/facades/code-edit.facade.ts
@@ -1,7 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import {
     PLUGIN_CAPABILITIES,
-    isCodeEditPlugin,
     type ICodeEditPlugin,
     type CodeEditRequest,
     type CodeEditOptions,
@@ -10,7 +9,9 @@ import {
 } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
+import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
 import { AiFacadeService } from './ai.facade';
+import { BaseFacadeService } from './base.facade';
 
 export interface CodeEditFacadeOptions {
     userId: string;
@@ -29,83 +30,32 @@ export interface CodeEditProviderInfo {
 }
 
 @Injectable()
-export class CodeEditFacadeService {
-    private readonly logger = new Logger(CodeEditFacadeService.name);
-    private readonly CAPABILITY = PLUGIN_CAPABILITIES.CODE_EDIT;
+export class CodeEditFacadeService extends BaseFacadeService {
+    protected readonly logger = new Logger(CodeEditFacadeService.name);
+    protected readonly CAPABILITY = PLUGIN_CAPABILITIES.CODE_EDIT;
 
     constructor(
-        private readonly registry: PluginRegistryService,
+        registry: PluginRegistryService,
         private readonly pluginSettings: PluginSettingsService,
         private readonly aiFacade: AiFacadeService,
-    ) {}
-
-    async listProviders(userId: string): Promise<CodeEditProviderInfo[]> {
-        const candidates = this.registry
-            .getByCapability(this.CAPABILITY)
-            .filter((p) => p.state === 'loaded' && !p.manifest.supplementary);
-
-        const results = await Promise.all(
-            candidates.map(async (p): Promise<CodeEditProviderInfo | null> => {
-                const enabled = await this.registry.isPluginEnabledForScope(
-                    p.plugin.id,
-                    undefined,
-                    userId,
-                );
-                if (!enabled) return null;
-                return {
-                    id: p.plugin.id,
-                    name: p.manifest.name ?? p.plugin.id,
-                    description: p.manifest.description,
-                    icon: p.manifest.icon,
-                    providerName: (p.plugin as ICodeEditPlugin).providerName,
-                    enabled: true,
-                    isDefault:
-                        p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) || false,
-                };
-            }),
-        );
-
-        return results.filter((p): p is CodeEditProviderInfo => p !== null);
+        @Optional() workPluginRepository?: WorkPluginRepository,
+    ) {
+        super(registry, pluginSettings, workPluginRepository);
     }
 
-    async resolveProvider(opts: CodeEditFacadeOptions): Promise<ICodeEditPlugin> {
-        if (opts.providerId) {
-            const registered = this.registry.get(opts.providerId);
-            if (!registered || registered.state !== 'loaded') {
-                throw new Error(`Code-edit provider not loaded: ${opts.providerId}`);
-            }
-            if (!isCodeEditPlugin(registered.plugin)) {
-                throw new Error(
-                    `Provider ${opts.providerId} does not implement the code-edit capability`,
-                );
-            }
-            const enabled = await this.registry.isPluginEnabledForScope(
-                opts.providerId,
-                undefined,
-                opts.userId,
-            );
-            if (!enabled) {
-                throw new Error(
-                    `Code-edit provider "${opts.providerId}" is not enabled for this user`,
-                );
-            }
-            return registered.plugin;
-        }
-
-        const available = await this.listProviders(opts.userId);
-        const first = available[0];
-        if (!first) {
-            throw new Error(
-                'No code-edit provider available — install one from the plugin catalog',
-            );
-        }
-        const registered = this.registry.get(first.id);
-        if (!registered || !isCodeEditPlugin(registered.plugin)) {
-            throw new Error(
-                `Default plugin ${first.id} does not implement the code-edit capability`,
-            );
-        }
-        return registered.plugin;
+    async listProviders(userId: string, workId?: string): Promise<CodeEditProviderInfo[]> {
+        const enabled = await this.getEnabledPlugins(workId as string, userId);
+        return enabled
+            .filter((p) => !p.manifest.supplementary)
+            .map((p) => ({
+                id: p.plugin.id,
+                name: p.manifest.name ?? p.plugin.id,
+                description: p.manifest.description,
+                icon: p.manifest.icon,
+                providerName: (p.plugin as ICodeEditPlugin).providerName,
+                enabled: true,
+                isDefault: p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) || false,
+            }));
     }
 
     async execute(
@@ -113,7 +63,11 @@ export class CodeEditFacadeService {
         opts: CodeEditFacadeOptions,
         options?: Omit<CodeEditOptions, 'execContext'>,
     ): Promise<CodeEditResult> {
-        const plugin = await this.resolveProvider(opts);
+        const plugin = await this.resolvePlugin<ICodeEditPlugin>(
+            opts.providerId,
+            opts.userId,
+            opts.workId,
+        );
         const settings = await this.pluginSettings.getSettings(plugin.id, {
             userId: opts.userId,
             workId: opts.workId,
@@ -124,8 +78,6 @@ export class CodeEditFacadeService {
             `Running code-edit via ${plugin.id} for user=${opts.userId} workspace=${request.workspaceDir}`,
         );
 
-        // aiFacade is forwarded so plugins that proxy to an AI provider (e.g.
-        // opencode) can resolve provider/model via the user's AI settings.
         return plugin.executeCodeEdit(request, {
             ...options,
             execContext: {

--- a/packages/agent/src/facades/code-edit.facade.ts
+++ b/packages/agent/src/facades/code-edit.facade.ts
@@ -43,6 +43,23 @@ export class CodeEditFacadeService extends BaseFacadeService {
         super(registry, pluginSettings, workPluginRepository);
     }
 
+    async isProviderAvailable(
+        providerId: string,
+        userId: string,
+        workId?: string,
+    ): Promise<boolean> {
+        const registered = this.registry.get(providerId);
+        if (
+            !registered ||
+            registered.state !== 'loaded' ||
+            !registered.manifest.capabilities.includes(this.CAPABILITY) ||
+            registered.manifest.supplementary
+        ) {
+            return false;
+        }
+        return this.registry.isPluginEnabledForScope(providerId, workId, userId);
+    }
+
     async listProviders(userId: string, workId?: string): Promise<CodeEditProviderInfo[]> {
         const enabled = await this.getEnabledPlugins(workId as string, userId);
         return enabled

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -22,6 +22,7 @@ export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
 export * from './zero-friction-funnel.service';
 export * from './deploy-ready-poller.service';
+export * from './category-icon';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/tasks/index.ts
+++ b/packages/agent/src/tasks/index.ts
@@ -2,3 +2,5 @@ export * from './work-generation.types';
 export * from './work-generation-dispatcher';
 export * from './work-import.types';
 export * from './work-import-dispatcher';
+export * from './template-customization.types';
+export * from './template-customization-dispatcher';

--- a/packages/agent/src/tasks/tasks.spec.ts
+++ b/packages/agent/src/tasks/tasks.spec.ts
@@ -306,6 +306,7 @@ describe('agent/tasks submodule', () => {
             const runtimeKeys = Object.keys(tasksBarrel).sort();
             expect(runtimeKeys).toEqual(
                 [
+                    'TEMPLATE_CUSTOMIZATION_DISPATCHER',
                     'WORK_GENERATION_DISPATCHER',
                     'WORK_GENERATION_MODE',
                     'WORK_IMPORT_DISPATCHER',

--- a/packages/agent/src/tasks/template-customization-dispatcher.ts
+++ b/packages/agent/src/tasks/template-customization-dispatcher.ts
@@ -1,0 +1,7 @@
+import { TemplateCustomizationPayload } from './template-customization.types';
+
+export interface TemplateCustomizationDispatcher {
+    dispatchTemplateCustomization(payload: TemplateCustomizationPayload): Promise<string | null>;
+}
+
+export const TEMPLATE_CUSTOMIZATION_DISPATCHER = Symbol('TEMPLATE_CUSTOMIZATION_DISPATCHER');

--- a/packages/agent/src/tasks/template-customization.types.ts
+++ b/packages/agent/src/tasks/template-customization.types.ts
@@ -1,0 +1,3 @@
+export type TemplateCustomizationPayload = {
+    customizationId: string;
+};

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -63,8 +63,10 @@ interface Mocks {
     codeEditFacade: {
         listProviders: AnyMock;
         isProviderAvailable: AnyMock;
+        getProviderForUser: AnyMock;
         execute: AnyMock;
     };
+    aiFacade: { getAvailableProvidersForUser: AnyMock };
 }
 
 function makeService(): { service: TemplateCustomizationService; mocks: Mocks } {
@@ -112,15 +114,31 @@ function makeService(): { service: TemplateCustomizationService; mocks: Mocks } 
             push: jest.fn().mockResolvedValue(undefined),
         },
         codeEditFacade: {
-            listProviders: jest
-                .fn()
-                .mockResolvedValue([{ id: 'claude-code', name: 'Claude Code', enabled: true }]),
+            listProviders: jest.fn().mockResolvedValue([
+                {
+                    id: 'claude-code',
+                    name: 'Claude Code',
+                    enabled: true,
+                    isDefault: true,
+                    selectableProviderCategories: [],
+                },
+            ]),
             isProviderAvailable: jest.fn().mockResolvedValue(true),
+            getProviderForUser: jest.fn().mockResolvedValue({
+                id: 'claude-code',
+                name: 'Claude Code',
+                enabled: true,
+                isDefault: true,
+                selectableProviderCategories: [],
+            }),
             execute: jest.fn().mockResolvedValue({
                 success: true,
                 summary: 'Applied UI changes',
                 filesChanged: [{ path: 'src/styles/theme.css', status: 'modified' }],
             }),
+        },
+        aiFacade: {
+            getAvailableProvidersForUser: jest.fn().mockResolvedValue([]),
         },
     };
     const service = new TemplateCustomizationService(
@@ -129,6 +147,7 @@ function makeService(): { service: TemplateCustomizationService; mocks: Mocks } 
         mocks.userRepository as any,
         mocks.gitFacade as any,
         mocks.codeEditFacade as any,
+        mocks.aiFacade as any,
     );
     return { service, mocks };
 }
@@ -170,11 +189,11 @@ describe('TemplateCustomizationService.createAndStart', () => {
 
     it('rejects when the selected provider is not enabled for this user', async () => {
         const { service, mocks } = makeService();
-        mocks.codeEditFacade.isProviderAvailable.mockResolvedValue(false);
+        mocks.codeEditFacade.getProviderForUser.mockResolvedValue(null);
         await expect(service.createAndStart('user-1', baseInput)).rejects.toThrow(
             BadRequestException,
         );
-        expect(mocks.codeEditFacade.isProviderAvailable).toHaveBeenCalledWith(
+        expect(mocks.codeEditFacade.getProviderForUser).toHaveBeenCalledWith(
             'claude-code',
             'user-1',
         );
@@ -182,9 +201,69 @@ describe('TemplateCustomizationService.createAndStart', () => {
 
     it('rejects when the user has no code-edit providers enabled', async () => {
         const { service, mocks } = makeService();
-        mocks.codeEditFacade.isProviderAvailable.mockResolvedValue(false);
+        mocks.codeEditFacade.getProviderForUser.mockResolvedValue(null);
         await expect(service.createAndStart('user-1', baseInput)).rejects.toThrow(
             BadRequestException,
+        );
+    });
+
+    it('rejects when the chosen code-edit plugin requires ai-provider but none was supplied', async () => {
+        const { service, mocks } = makeService();
+        mocks.codeEditFacade.getProviderForUser.mockResolvedValue({
+            id: 'opencode',
+            name: 'OpenCode',
+            enabled: true,
+            isDefault: false,
+            selectableProviderCategories: ['ai-provider'],
+        });
+        await expect(
+            service.createAndStart('user-1', { ...baseInput, providerId: 'opencode' }),
+        ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when the supplied ai-provider is not enabled for this user', async () => {
+        const { service, mocks } = makeService();
+        mocks.codeEditFacade.getProviderForUser.mockResolvedValue({
+            id: 'opencode',
+            name: 'OpenCode',
+            enabled: true,
+            isDefault: false,
+            selectableProviderCategories: ['ai-provider'],
+        });
+        mocks.aiFacade.getAvailableProvidersForUser.mockResolvedValue([
+            { id: 'openai', name: 'OpenAI', enabled: true },
+        ]);
+        await expect(
+            service.createAndStart('user-1', {
+                ...baseInput,
+                providerId: 'opencode',
+                aiProviderId: 'anthropic',
+            }),
+        ).rejects.toThrow(BadRequestException);
+    });
+
+    it('persists ai-provider id when the chosen code-edit plugin requires it', async () => {
+        const { service, mocks } = makeService();
+        mocks.codeEditFacade.getProviderForUser.mockResolvedValue({
+            id: 'opencode',
+            name: 'OpenCode',
+            enabled: true,
+            isDefault: false,
+            selectableProviderCategories: ['ai-provider'],
+        });
+        mocks.aiFacade.getAvailableProvidersForUser.mockResolvedValue([
+            { id: 'openai', name: 'OpenAI', enabled: true },
+        ]);
+        jest.spyOn(service, 'execute').mockResolvedValue(undefined);
+
+        await service.createAndStart('user-1', {
+            ...baseInput,
+            providerId: 'opencode',
+            aiProviderId: 'openai',
+        });
+
+        expect(mocks.customizationRepository.create).toHaveBeenCalledWith(
+            expect.objectContaining({ providerId: 'opencode', aiProviderId: 'openai' }),
         );
     });
 
@@ -228,6 +307,7 @@ describe('TemplateCustomizationService.createAndStart', () => {
             baseTemplateId: 'minimal',
             prompt: baseInput.prompt,
             providerId: 'claude-code',
+            aiProviderId: null,
         });
         expect(result.customization.id).toBe('cust-1');
 

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -108,10 +108,9 @@ function makeService(): { service: TemplateCustomizationService; mocks: Mocks } 
             push: jest.fn().mockResolvedValue(undefined),
         },
         codeEditFacade: {
-            listProviders: jest.fn().mockReturnValue([
-                { id: 'claude-code', name: 'Claude Code', enabled: true },
-                { id: 'codex', name: 'Codex', enabled: false },
-            ]),
+            listProviders: jest
+                .fn()
+                .mockResolvedValue([{ id: 'claude-code', name: 'Claude Code', enabled: true }]),
             execute: jest.fn().mockResolvedValue({
                 success: true,
                 summary: 'Applied UI changes',
@@ -164,19 +163,19 @@ describe('TemplateCustomizationService.createAndStart', () => {
         ).rejects.toThrow(NotFoundException);
     });
 
-    it('rejects when the selected provider is not installed/enabled', async () => {
+    it('rejects when the selected provider is not enabled for this user', async () => {
         const { service, mocks } = makeService();
-        mocks.codeEditFacade.listProviders.mockReturnValue([
-            { id: 'codex', name: 'Codex', enabled: false },
+        mocks.codeEditFacade.listProviders.mockResolvedValue([
+            { id: 'codex', name: 'Codex', enabled: true },
         ]);
         await expect(service.createAndStart('user-1', baseInput)).rejects.toThrow(
             BadRequestException,
         );
     });
 
-    it('rejects when no code-edit providers are installed at all', async () => {
+    it('rejects when the user has no code-edit providers enabled', async () => {
         const { service, mocks } = makeService();
-        mocks.codeEditFacade.listProviders.mockReturnValue([]);
+        mocks.codeEditFacade.listProviders.mockResolvedValue([]);
         await expect(service.createAndStart('user-1', baseInput)).rejects.toThrow(
             BadRequestException,
         );

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -67,6 +67,7 @@ interface Mocks {
         execute: AnyMock;
     };
     aiFacade: { getAvailableProvidersForUser: AnyMock };
+    dispatcher: { dispatchTemplateCustomization: AnyMock };
 }
 
 function makeService(): { service: TemplateCustomizationService; mocks: Mocks } {
@@ -140,6 +141,9 @@ function makeService(): { service: TemplateCustomizationService; mocks: Mocks } 
         aiFacade: {
             getAvailableProvidersForUser: jest.fn().mockResolvedValue([]),
         },
+        dispatcher: {
+            dispatchTemplateCustomization: jest.fn().mockResolvedValue(null),
+        },
     };
     const service = new TemplateCustomizationService(
         mocks.templateRepository as any,
@@ -148,6 +152,7 @@ function makeService(): { service: TemplateCustomizationService; mocks: Mocks } 
         mocks.gitFacade as any,
         mocks.codeEditFacade as any,
         mocks.aiFacade as any,
+        mocks.dispatcher as any,
     );
     return { service, mocks };
 }
@@ -240,6 +245,39 @@ describe('TemplateCustomizationService.createAndStart', () => {
                 aiProviderId: 'anthropic',
             }),
         ).rejects.toThrow(BadRequestException);
+    });
+
+    it('dispatches to Trigger.dev when a dispatcher is bound and stores the run id', async () => {
+        const { service, mocks } = makeService();
+        mocks.dispatcher.dispatchTemplateCustomization.mockResolvedValue('run-tpl-1');
+        const executeSpy = jest.spyOn(service, 'execute').mockResolvedValue(undefined);
+
+        const result = await service.createAndStart('user-1', baseInput);
+
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+        });
+        expect(mocks.customizationRepository.updateById).toHaveBeenCalledWith(
+            result.customization.id,
+            { triggerRunId: 'run-tpl-1' },
+        );
+        await new Promise((r) => setImmediate(r));
+        expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to in-process execution when the dispatcher returns null', async () => {
+        const { service, mocks } = makeService();
+        mocks.dispatcher.dispatchTemplateCustomization.mockResolvedValue(null);
+        const executeSpy = jest.spyOn(service, 'execute').mockResolvedValue(undefined);
+
+        const result = await service.createAndStart('user-1', baseInput);
+
+        await new Promise((r) => setImmediate(r));
+        expect(executeSpy).toHaveBeenCalledWith(result.customization.id);
+        expect(mocks.customizationRepository.updateById).not.toHaveBeenCalledWith(
+            result.customization.id,
+            expect.objectContaining({ triggerRunId: expect.anything() }),
+        );
     });
 
     it('persists ai-provider id when the chosen code-edit plugin requires it', async () => {

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -60,7 +60,11 @@ interface Mocks {
         commit: AnyMock;
         push: AnyMock;
     };
-    codeEditFacade: { listProviders: AnyMock; execute: AnyMock };
+    codeEditFacade: {
+        listProviders: AnyMock;
+        isProviderAvailable: AnyMock;
+        execute: AnyMock;
+    };
 }
 
 function makeService(): { service: TemplateCustomizationService; mocks: Mocks } {
@@ -111,6 +115,7 @@ function makeService(): { service: TemplateCustomizationService; mocks: Mocks } 
             listProviders: jest
                 .fn()
                 .mockResolvedValue([{ id: 'claude-code', name: 'Claude Code', enabled: true }]),
+            isProviderAvailable: jest.fn().mockResolvedValue(true),
             execute: jest.fn().mockResolvedValue({
                 success: true,
                 summary: 'Applied UI changes',
@@ -165,17 +170,19 @@ describe('TemplateCustomizationService.createAndStart', () => {
 
     it('rejects when the selected provider is not enabled for this user', async () => {
         const { service, mocks } = makeService();
-        mocks.codeEditFacade.listProviders.mockResolvedValue([
-            { id: 'codex', name: 'Codex', enabled: true },
-        ]);
+        mocks.codeEditFacade.isProviderAvailable.mockResolvedValue(false);
         await expect(service.createAndStart('user-1', baseInput)).rejects.toThrow(
             BadRequestException,
+        );
+        expect(mocks.codeEditFacade.isProviderAvailable).toHaveBeenCalledWith(
+            'claude-code',
+            'user-1',
         );
     });
 
     it('rejects when the user has no code-edit providers enabled', async () => {
         const { service, mocks } = makeService();
-        mocks.codeEditFacade.listProviders.mockResolvedValue([]);
+        mocks.codeEditFacade.isProviderAvailable.mockResolvedValue(false);
         await expect(service.createAndStart('user-1', baseInput)).rejects.toThrow(
             BadRequestException,
         );

--- a/packages/agent/src/template-catalog/customization-prompts/__tests__/index.spec.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/__tests__/index.spec.ts
@@ -25,19 +25,32 @@ describe('customization prompt registry', () => {
     });
 
     describe('minimal-template prompt', () => {
+        // These assertions pin load-bearing fragments of the prompt: if any of
+        // them silently drop, the agent may break the user's fork. Updating a
+        // matcher here should be a deliberate change.
         it('forbids functional / config changes so the user’s site stays mergeable upstream', () => {
-            // These guardrails are load-bearing: if any of them silently drop
-            // from the prompt the agent may break the user's fork. Pinned so
-            // a future prompt-edit is a deliberate change.
             expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/UI/i);
-            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/Do NOT change functionality/i);
-            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/Do NOT modify content data/i);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/No functional changes/i);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/No content edits/i);
             expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/package\.json/);
             expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/astro\.config/);
         });
 
         it('reminds the agent it must not commit or push', () => {
             expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/No commits, no PRs/i);
+        });
+
+        it('points the agent at the canonical styling levers (global.css, BaseLayout, @theme)', () => {
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/styles\/global\.css/);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/@theme/);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/--color-brand-/);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/BaseLayout\.astro/);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/data-component/);
+        });
+
+        it('marks shared workspace packages and content as off-limits', () => {
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/packages\/ui\//);
+            expect(MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT).toMatch(/\.content\//);
         });
     });
 });

--- a/packages/agent/src/template-catalog/customization-prompts/minimal-template.prompt.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/minimal-template.prompt.ts
@@ -13,14 +13,15 @@ Apply the user's UI request to this repository. Treat the request as a styling b
 
 \`\`\`
 apps/
-  sample-basic/        ← default minimal site; treat as the canonical target unless the user names a niche
-  sample-events/       ← events vertical
-  sample-jobs/         ← jobs vertical
-  sample-real-estate/  ← real-estate vertical
-  sample-git/          ← git-tools vertical
-  ...                  ← other niche samples; same internal layout as sample-basic
-  docs/                ← Docusaurus docs site — do NOT modify
-  web-e2e/             ← Playwright tests — do NOT modify
+  web/                 ← PRIMARY canonical app. Default target for every request.
+  sample-basic/        ← niche sample (generic directory)
+  sample-events/       ← niche sample (events vertical)
+  sample-jobs/         ← niche sample (jobs vertical)
+  sample-real-estate/  ← niche sample (real-estate vertical)
+  sample-git/          ← niche sample (git-tools vertical)
+  ...                  ← other niche samples; same internal layout as apps/web
+  docs/                ← Docusaurus docs site — DO NOT modify
+  web-e2e/             ← Playwright tests — DO NOT modify
 
   apps/<app>/src/
     styles/global.css      ← Tailwind v4 \`@theme\` tokens (--color-brand-*) + headless component styling via [data-component=...] / [data-part=...] selectors. PRIMARY styling lever.
@@ -43,7 +44,10 @@ packages/
 1. **Theme tokens** — change \`apps/<app>/src/styles/global.css\` inside the \`@theme { ... }\` block. The \`--color-brand-*\` ramp is the canonical brand palette; replace its 11 stops to re-skin the whole site.
 2. **Component styling** — components from \`@ever-works/ui\` emit \`data-component\` / \`data-part\` attributes. Restyle them by editing the matching \`[data-component="..."] [data-part="..."]\` rules in the same \`global.css\`. Do NOT edit the source under \`packages/ui/\`.
 3. **Layout chrome** — adjust classes / structure in \`apps/<app>/src/layouts/BaseLayout.astro\` and the local Astro pages under \`apps/<app>/src/pages/\`.
-4. **Per-app vs. all apps** — if the request names a niche ("make the events theme purple"), restrict edits to \`apps/sample-<niche>/\`. Otherwise default to \`apps/sample-basic/\` and apply the SAME change to every other \`apps/sample-*/global.css\` so all samples stay visually consistent.
+4. **Target app — pick exactly one.**
+   - Default: \`apps/web/\`. Edit only files inside \`apps/web/\`.
+   - If the user explicitly names a niche ("make the events theme purple", "for the jobs site …"), use the matching \`apps/sample-<niche>/\` instead.
+   - Do NOT fan changes out across multiple \`apps/sample-*/\` directories. One run = one app. The niche samples are independent variants the user opts into by name.
 
 # Rules
 

--- a/packages/agent/src/template-catalog/customization-prompts/minimal-template.prompt.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/minimal-template.prompt.ts
@@ -3,28 +3,59 @@
 // CSS, Tailwind/utility classes, layout, copy tone, color tokens, etc.
 // The user's request is appended to this prompt at runtime.
 
-export const MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT = `You are customizing a fork of \`directory-web-minimal-template\` — a small Astro-based directory site.
+export const MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT = `You are customizing a fork of \`directory-web-minimal-template\` — an Astro-based directory site (pnpm + Turborepo monorepo).
 
 # Goal
 
 Apply the user's UI request to this repository. Treat the request as a styling brief, not a feature request.
 
+# Repository map
+
+\`\`\`
+apps/
+  sample-basic/        ← default minimal site; treat as the canonical target unless the user names a niche
+  sample-events/       ← events vertical
+  sample-jobs/         ← jobs vertical
+  sample-real-estate/  ← real-estate vertical
+  sample-git/          ← git-tools vertical
+  ...                  ← other niche samples; same internal layout as sample-basic
+  docs/                ← Docusaurus docs site — do NOT modify
+  web-e2e/             ← Playwright tests — do NOT modify
+
+  apps/<app>/src/
+    styles/global.css      ← Tailwind v4 \`@theme\` tokens (--color-brand-*) + headless component styling via [data-component=...] / [data-part=...] selectors. PRIMARY styling lever.
+    layouts/BaseLayout.astro ← page chrome (header, footer, nav, theme toggle). SECONDARY lever for layout-level tweaks.
+    components/            ← app-local Astro/React wrappers (BreadcrumbNav, ItemBrowser)
+    pages/                 ← Astro file-based routes (index, item/[slug], category/[slug], tag/[slug], collection/[slug], comparison/[slug], 404, rss/atom/robots feeds). Edit visible markup/classes only.
+    lib/                   ← content loaders + plugin config — do NOT modify
+    env.d.ts, tsconfig.json, astro.config.ts, package.json ← do NOT modify
+
+packages/
+  ui/                  ← shared component library imported as @ever-works/ui/astro/* and @ever-works/ui/preact/*. DO NOT modify — overrides happen via the per-app global.css selectors.
+  core/, adapters/, astro-integration/, plugin-*/, eslint-config/ ← runtime/build infrastructure — DO NOT modify
+
+.content/              ← markdown items/categories/tags (only present in some samples) — DO NOT modify
+.deploy/, .github/, Dockerfile, .env.example ← infrastructure — DO NOT modify
+\`\`\`
+
+# Where to make edits
+
+1. **Theme tokens** — change \`apps/<app>/src/styles/global.css\` inside the \`@theme { ... }\` block. The \`--color-brand-*\` ramp is the canonical brand palette; replace its 11 stops to re-skin the whole site.
+2. **Component styling** — components from \`@ever-works/ui\` emit \`data-component\` / \`data-part\` attributes. Restyle them by editing the matching \`[data-component="..."] [data-part="..."]\` rules in the same \`global.css\`. Do NOT edit the source under \`packages/ui/\`.
+3. **Layout chrome** — adjust classes / structure in \`apps/<app>/src/layouts/BaseLayout.astro\` and the local Astro pages under \`apps/<app>/src/pages/\`.
+4. **Per-app vs. all apps** — if the request names a niche ("make the events theme purple"), restrict edits to \`apps/sample-<niche>/\`. Otherwise default to \`apps/sample-basic/\` and apply the SAME change to every other \`apps/sample-*/global.css\` so all samples stay visually consistent.
+
 # Rules
 
-1. **UI / presentation only.** Edit CSS files, Tailwind/utility classes inside JSX/Astro components, theme tokens (CSS variables), color palettes, spacing, fonts, layout containers, and visible copy/tone.
-2. **Do NOT change functionality.** Do not add or remove pages, routes, components, props, data fetching, build configuration, dependencies, or environment variables. Do not modify \`package.json\` (except styling deps like a Google Font import if explicitly requested), \`astro.config.*\`, \`tsconfig.json\`, or anything under \`scripts/\` or \`.github/\`.
-3. **Do NOT modify content data.** \`content/\`, \`data/\`, items, categories, tags — leave untouched. The site's content comes from the deploying user; you only restyle the chrome.
-4. **Preserve all imports, exports, and component signatures.** A future merge from upstream must continue to work.
-5. **Keep diffs small.** Touch only what the user asked for. If the request is vague ("make it modern"), make conservative, cohesive choices and stop.
-6. **No new files unless strictly needed for styling** (e.g. a new \`styles/theme.css\` is fine; a new component is not).
-7. **Accessibility:** keep color contrast ≥ AA. Don't remove \`alt\`, \`aria-*\`, or \`role\` attributes.
-8. **No commits, no PRs.** Just edit files in place. The orchestrator will commit and push.
-
-# Working notes
-
-- Tailwind classes are the primary styling lever. Prefer changing classes over adding new CSS.
-- Theme tokens (if present in \`src/styles/\` or \`tailwind.config.*\`) are the second lever — change them once instead of per-component.
-- If you change a token, verify the change makes sense in dark mode too (if dark mode is wired up).
+1. **UI / presentation only.** Edit CSS, Tailwind classes, theme tokens, layout containers, fonts, spacing, visible copy/tone.
+2. **No functional changes.** Do not add/remove pages, routes, components, props, data fetching, dependencies, env vars, or build config. Do not modify \`package.json\`, \`astro.config.*\`, \`tsconfig.json\`, \`Dockerfile\`, \`.deploy/\`, \`.github/\`, \`scripts/\`.
+3. **No content edits.** Leave \`.content/\`, items, categories, tags, collections untouched — the deploying user owns the content.
+4. **No upstream package edits.** \`packages/ui/\`, \`packages/core/\`, \`packages/adapters/\`, \`packages/plugin-*/\` and other workspace packages are shared upstream — restyle via the per-app \`global.css\` selectors instead.
+5. **Preserve imports, exports, component signatures, \`data-component\`/\`data-part\`/\`aria-*\`/\`role\` attributes.** A future merge from upstream must keep working.
+6. **Small diffs.** Touch only what the user asked for. If the request is vague ("make it modern"), make conservative cohesive choices and stop.
+7. **No new files unless strictly needed for styling** (e.g. a new \`styles/<theme-name>.css\` imported by \`global.css\` is fine; a new component is not).
+8. **Accessibility:** keep color contrast ≥ AA in both light and dark mode. The site uses \`[data-theme="dark"]\` via the \`ThemeToggle\` component — verify dark-mode variants stay readable.
+9. **No commits, no PRs.** Just edit files in place — the orchestrator handles commit + push.
 
 The user's customization request follows below.
 `;

--- a/packages/agent/src/template-catalog/template-catalog.service.spec.ts
+++ b/packages/agent/src/template-catalog/template-catalog.service.spec.ts
@@ -3,6 +3,7 @@ import { TemplateCatalogService } from './template-catalog.service';
 
 describe('TemplateCatalogService', () => {
     let templateRepository: any;
+    let customizationRepository: any;
     let userTemplatePreferenceRepository: any;
     let workRepository: any;
     let gitFacade: any;
@@ -21,6 +22,9 @@ describe('TemplateCatalogService', () => {
             findById: jest.fn(),
             upsert: jest.fn(),
             updateById: jest.fn(),
+        };
+        customizationRepository = {
+            findLatestForTemplates: jest.fn().mockResolvedValue(new Map()),
         };
         userTemplatePreferenceRepository = {
             findByUserAndKind: jest.fn(),
@@ -44,6 +48,7 @@ describe('TemplateCatalogService', () => {
 
         service = new TemplateCatalogService(
             templateRepository,
+            customizationRepository,
             userTemplatePreferenceRepository,
             workRepository,
             gitFacade,

--- a/packages/agent/src/template-catalog/template-catalog.service.ts
+++ b/packages/agent/src/template-catalog/template-catalog.service.ts
@@ -56,6 +56,9 @@ export interface TemplateCatalogItem {
     baseTemplateId?: string | null;
     // ISO timestamp of the last successful agent customization, if any.
     lastCustomizedAt?: string | null;
+    // Prompt of the last successful agent customization, if any. Lets the
+    // UI pre-fill the "Customize again" textarea without an extra fetch.
+    lastCustomizationPrompt?: string | null;
     // Latest customization run for this template (most recent by createdAt),
     // surfaced so the UI can render a status chip without an extra fetch.
     latestCustomization?: TemplateCustomizationSummary | null;
@@ -785,6 +788,7 @@ export class TemplateCatalogService implements OnModuleInit {
     ): TemplateCatalogItem {
         const baseTemplateId = this.resolveBaseTemplateId(template);
         const lastCustomizedAtRaw = template.metadata?.lastCustomizedAt;
+        const lastCustomizationPromptRaw = template.metadata?.lastCustomizationPrompt;
         return {
             id: template.id,
             kind: template.kind,
@@ -806,6 +810,8 @@ export class TemplateCatalogService implements OnModuleInit {
             customizable: this.isCustomizable(template.sourceType, baseTemplateId, template.id),
             baseTemplateId,
             lastCustomizedAt: typeof lastCustomizedAtRaw === 'string' ? lastCustomizedAtRaw : null,
+            lastCustomizationPrompt:
+                typeof lastCustomizationPromptRaw === 'string' ? lastCustomizationPromptRaw : null,
             latestCustomization: latestCustomization
                 ? this.toCustomizationSummary(latestCustomization)
                 : null,

--- a/packages/agent/src/template-catalog/template-catalog.service.ts
+++ b/packages/agent/src/template-catalog/template-catalog.service.ts
@@ -64,6 +64,7 @@ export interface TemplateCatalogItem {
 export interface TemplateCustomizationSummary {
     id: string;
     status: TemplateCustomizationStatus;
+    prompt: string;
     errorMessage: string | null;
     startedAt: string | null;
     completedAt: string | null;
@@ -815,6 +816,7 @@ export class TemplateCatalogService implements OnModuleInit {
         return {
             id: c.id,
             status: c.status,
+            prompt: c.prompt,
             errorMessage: c.errorMessage ?? null,
             startedAt: c.startedAt ? c.startedAt.toISOString() : null,
             completedAt: c.completedAt ? c.completedAt.toISOString() : null,

--- a/packages/agent/src/template-catalog/template-catalog.service.ts
+++ b/packages/agent/src/template-catalog/template-catalog.service.ts
@@ -47,12 +47,12 @@ export interface TemplateCatalogItem {
     isDefault: boolean;
     ownerUserId?: string | null;
     // Built-in: true when the WebsiteTemplateConfig marks it `customizable: true`
-    // AND a customization prompt is registered. Custom forks: true when their
-    // metadata.forkedFromTemplateId resolves to a customizable built-in.
+    // AND a customization prompt is registered. Custom templates: true when
+    // their metadata links them to a customizable built-in via
+    // `forkedFromTemplateId` (fork flow) or `baseTemplateId` (AI flow).
     customizable: boolean;
-    // For custom forks created via the agent flow, the built-in template id
-    // they were forked from. Lets the UI re-run a customization without
-    // making the user pick a base again.
+    // The built-in template id this custom template descends from. Lets the
+    // UI re-run a customization without making the user pick a base again.
     baseTemplateId?: string | null;
     // ISO timestamp of the last successful agent customization, if any.
     lastCustomizedAt?: string | null;
@@ -831,8 +831,13 @@ export class TemplateCatalogService implements OnModuleInit {
         if (template.sourceType === 'built_in') {
             return template.id;
         }
+        // Forked-from-base templates use `forkedFromTemplateId`; templates
+        // created via the AI customization flow use `baseTemplateId`. Both
+        // mark the template as customizable.
         const forkedFrom = template.metadata?.forkedFromTemplateId;
-        return typeof forkedFrom === 'string' ? forkedFrom : null;
+        if (typeof forkedFrom === 'string') return forkedFrom;
+        const baseTemplateId = template.metadata?.baseTemplateId;
+        return typeof baseTemplateId === 'string' ? baseTemplateId : null;
     }
 
     private isCustomizable(

--- a/packages/agent/src/template-catalog/template-catalog.service.ts
+++ b/packages/agent/src/template-catalog/template-catalog.service.ts
@@ -7,9 +7,14 @@ import {
     OnModuleInit,
 } from '@nestjs/common';
 import { TemplateRepository } from '@src/database/repositories/template.repository';
+import { TemplateCustomizationRepository } from '@src/database/repositories/template-customization.repository';
 import { UserTemplatePreferenceRepository } from '@src/database/repositories/user-template-preference.repository';
 import { WorkRepository } from '@src/database/repositories/work.repository';
 import { GitFacadeService } from '@src/facades/git.facade';
+import {
+    TemplateCustomization,
+    TemplateCustomizationStatus,
+} from '@src/entities/template-customization.entity';
 import {
     findWebsiteTemplateConfig,
     getDefaultWebsiteTemplateId,
@@ -51,6 +56,19 @@ export interface TemplateCatalogItem {
     baseTemplateId?: string | null;
     // ISO timestamp of the last successful agent customization, if any.
     lastCustomizedAt?: string | null;
+    // Latest customization run for this template (most recent by createdAt),
+    // surfaced so the UI can render a status chip without an extra fetch.
+    latestCustomization?: TemplateCustomizationSummary | null;
+}
+
+export interface TemplateCustomizationSummary {
+    id: string;
+    status: TemplateCustomizationStatus;
+    errorMessage: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface ForkTemplateResult {
@@ -72,6 +90,7 @@ export class TemplateCatalogService implements OnModuleInit {
 
     constructor(
         private readonly templateRepository: TemplateRepository,
+        private readonly customizationRepository: TemplateCustomizationRepository,
         private readonly userTemplatePreferenceRepository: UserTemplatePreferenceRepository,
         private readonly workRepository: WorkRepository,
         private readonly gitFacade: GitFacadeService,
@@ -136,9 +155,16 @@ export class TemplateCatalogService implements OnModuleInit {
             this.getDefaultTemplateIdForUser(kind, userId),
         ]);
 
+        const latestByTemplate = await this.customizationRepository.findLatestForTemplates(
+            templates.map((t) => t.id),
+            userId,
+        );
+
         return {
             defaultTemplateId,
-            templates: templates.map((template) => this.toCatalogItem(template, defaultTemplateId)),
+            templates: templates.map((template) =>
+                this.toCatalogItem(template, defaultTemplateId, latestByTemplate.get(template.id)),
+            ),
         };
     }
 
@@ -754,6 +780,7 @@ export class TemplateCatalogService implements OnModuleInit {
             ownerUserId?: string | null;
         },
         defaultTemplateId: string | null,
+        latestCustomization?: TemplateCustomization,
     ): TemplateCatalogItem {
         const baseTemplateId = this.resolveBaseTemplateId(template);
         const lastCustomizedAtRaw = template.metadata?.lastCustomizedAt;
@@ -778,6 +805,21 @@ export class TemplateCatalogService implements OnModuleInit {
             customizable: this.isCustomizable(template.sourceType, baseTemplateId, template.id),
             baseTemplateId,
             lastCustomizedAt: typeof lastCustomizedAtRaw === 'string' ? lastCustomizedAtRaw : null,
+            latestCustomization: latestCustomization
+                ? this.toCustomizationSummary(latestCustomization)
+                : null,
+        };
+    }
+
+    private toCustomizationSummary(c: TemplateCustomization): TemplateCustomizationSummary {
+        return {
+            id: c.id,
+            status: c.status,
+            errorMessage: c.errorMessage ?? null,
+            startedAt: c.startedAt ? c.startedAt.toISOString() : null,
+            completedAt: c.completedAt ? c.completedAt.toISOString() : null,
+            createdAt: c.createdAt.toISOString(),
+            updatedAt: c.updatedAt.toISOString(),
         };
     }
 

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -309,9 +309,8 @@ export class TemplateCustomizationService {
     }
 
     private async assertProviderAvailable(providerId: string, userId: string): Promise<void> {
-        const available = await this.codeEditFacade.listProviders(userId);
-        const match = available.find((p) => p.id === providerId);
-        if (!match) {
+        const available = await this.codeEditFacade.isProviderAvailable(providerId, userId);
+        if (!available) {
             throw new BadRequestException({
                 status: 'error',
                 message: `Code-edit provider "${providerId}" is not installed or not enabled for this account.`,

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+    BadRequestException,
+    Inject,
+    Injectable,
+    Logger,
+    NotFoundException,
+    Optional,
+} from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import { TemplateRepository } from '@src/database/repositories/template.repository';
 import { TemplateCustomizationRepository } from '@src/database/repositories/template-customization.repository';
@@ -7,6 +14,10 @@ import { GitFacadeService, type GitFacadeOptions } from '@src/facades/git.facade
 import type { GitCommitter } from '@ever-works/plugin';
 import { CodeEditFacadeService, type CodeEditProviderInfo } from '@src/facades/code-edit.facade';
 import { AiFacadeService } from '@src/facades/ai.facade';
+import {
+    TEMPLATE_CUSTOMIZATION_DISPATCHER,
+    type TemplateCustomizationDispatcher,
+} from '@src/tasks';
 import {
     findWebsiteTemplateConfig,
     type WebsiteTemplateConfig,
@@ -55,6 +66,9 @@ export class TemplateCustomizationService {
         private readonly gitFacade: GitFacadeService,
         private readonly codeEditFacade: CodeEditFacadeService,
         private readonly aiFacade: AiFacadeService,
+        @Optional()
+        @Inject(TEMPLATE_CUSTOMIZATION_DISPATCHER)
+        private readonly dispatcher?: TemplateCustomizationDispatcher,
     ) {}
 
     async createAndStart(
@@ -136,9 +150,29 @@ export class TemplateCustomizationService {
             aiProviderId,
         });
 
-        void this.runAsync(customization.id);
+        await this.start(customization.id);
 
         return { customization, template };
+    }
+
+    private async start(customizationId: string): Promise<void> {
+        const dispatchedId = this.dispatcher
+            ? await this.dispatcher.dispatchTemplateCustomization({ customizationId })
+            : null;
+
+        if (dispatchedId) {
+            await this.customizationRepository.updateById(customizationId, {
+                triggerRunId: dispatchedId,
+            });
+            return;
+        }
+
+        if (this.dispatcher) {
+            this.logger.warn(
+                `Trigger dispatch failed, falling back to in-process customization for ${customizationId}`,
+            );
+        }
+        void this.runAsync(customizationId);
     }
 
     getByIdForUser(id: string, userId: string): Promise<TemplateCustomization | null> {

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -6,6 +6,7 @@ import { UserRepository } from '@src/database/repositories/user.repository';
 import { GitFacadeService, type GitFacadeOptions } from '@src/facades/git.facade';
 import type { GitCommitter } from '@ever-works/plugin';
 import { CodeEditFacadeService, type CodeEditProviderInfo } from '@src/facades/code-edit.facade';
+import { AiFacadeService } from '@src/facades/ai.facade';
 import {
     findWebsiteTemplateConfig,
     type WebsiteTemplateConfig,
@@ -28,6 +29,7 @@ export interface CreateAndStartCustomizationInput {
     name: string;
     prompt: string;
     providerId: string;
+    aiProviderId?: string;
     targetOwner?: string;
     description?: string;
 }
@@ -52,6 +54,7 @@ export class TemplateCustomizationService {
         private readonly userRepository: UserRepository,
         private readonly gitFacade: GitFacadeService,
         private readonly codeEditFacade: CodeEditFacadeService,
+        private readonly aiFacade: AiFacadeService,
     ) {}
 
     async createAndStart(
@@ -79,7 +82,12 @@ export class TemplateCustomizationService {
         }
 
         const baseConfig = this.resolveCustomizableBase(input.baseTemplateId);
-        await this.assertProviderAvailable(providerId, userId);
+        const codeEditProvider = await this.assertProviderAvailable(providerId, userId);
+        const aiProviderId = await this.resolveAiProviderRequirement(
+            codeEditProvider,
+            input.aiProviderId?.trim(),
+            userId,
+        );
         const user = await this.userRepository.findById(userId);
         if (!user) {
             throw new NotFoundException({ status: 'error', message: 'User not found.' });
@@ -125,6 +133,7 @@ export class TemplateCustomizationService {
             baseTemplateId: baseConfig.id,
             prompt,
             providerId,
+            aiProviderId,
         });
 
         void this.runAsync(customization.id);
@@ -142,6 +151,10 @@ export class TemplateCustomizationService {
 
     listProviders(userId: string): Promise<CodeEditProviderInfo[]> {
         return this.codeEditFacade.listProviders(userId);
+    }
+
+    listAiProviders(userId: string) {
+        return this.aiFacade.getAvailableProvidersForUser(userId);
     }
 
     /** Exposed for direct invocation by background tasks / tests. */
@@ -188,7 +201,11 @@ export class TemplateCustomizationService {
 
             const edit = await this.codeEditFacade.execute(
                 { workspaceDir, prompt: composedPrompt },
-                { userId: record.userId, providerId: record.providerId ?? undefined },
+                {
+                    userId: record.userId,
+                    providerId: record.providerId ?? undefined,
+                    aiProviderId: record.aiProviderId ?? undefined,
+                },
                 { onLogLine: (s, line) => this.logger.debug(`[tpl-customize:${s}] ${line}`) },
             );
 
@@ -308,14 +325,42 @@ export class TemplateCustomizationService {
         };
     }
 
-    private async assertProviderAvailable(providerId: string, userId: string): Promise<void> {
-        const available = await this.codeEditFacade.isProviderAvailable(providerId, userId);
-        if (!available) {
+    private async assertProviderAvailable(
+        providerId: string,
+        userId: string,
+    ): Promise<CodeEditProviderInfo> {
+        const match = await this.codeEditFacade.getProviderForUser(providerId, userId);
+        if (!match) {
             throw new BadRequestException({
                 status: 'error',
                 message: `Code-edit provider "${providerId}" is not installed or not enabled for this account.`,
             });
         }
+        return match;
+    }
+
+    private async resolveAiProviderRequirement(
+        codeEditProvider: CodeEditProviderInfo,
+        candidateAiProviderId: string | undefined,
+        userId: string,
+    ): Promise<string | null> {
+        if (!codeEditProvider.selectableProviderCategories.includes('ai-provider')) {
+            return null;
+        }
+        if (!candidateAiProviderId) {
+            throw new BadRequestException({
+                status: 'error',
+                message: `${codeEditProvider.name} requires you to pick an AI provider.`,
+            });
+        }
+        const available = await this.aiFacade.getAvailableProvidersForUser(userId);
+        if (!available.some((p) => p.id === candidateAiProviderId)) {
+            throw new BadRequestException({
+                status: 'error',
+                message: `AI provider "${candidateAiProviderId}" is not installed or not enabled for this account.`,
+            });
+        }
+        return candidateAiProviderId;
     }
 
     private resolveCustomizableBase(id: string): WebsiteTemplateConfig {

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -50,6 +50,12 @@ export interface CreateAndStartCustomizationResult {
     template: Template;
 }
 
+export interface IterateCustomizationInput {
+    prompt: string;
+    providerId: string;
+    aiProviderId?: string;
+}
+
 /**
  * Provision a brand-new repo for each customization (clone base → push to new
  * repo → run agent → push). NOT a GitHub fork — fork API is 1-per-account,
@@ -145,6 +151,65 @@ export class TemplateCustomizationService {
             templateId: template.id,
             userId,
             baseTemplateId: baseConfig.id,
+            prompt,
+            providerId,
+            aiProviderId,
+        });
+
+        await this.start(customization.id);
+
+        return { customization, template };
+    }
+
+    async runOnExistingTemplate(
+        userId: string,
+        templateId: string,
+        input: IterateCustomizationInput,
+    ): Promise<CreateAndStartCustomizationResult> {
+        const prompt = input.prompt?.trim();
+        const providerId = input.providerId?.trim();
+
+        if (!prompt) {
+            throw new BadRequestException({ status: 'error', message: 'Prompt is required.' });
+        }
+        if (!providerId) {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'Select an installed code-edit provider before continuing.',
+            });
+        }
+
+        const template = await this.templateRepository.findById(templateId);
+        if (!template || template.ownerUserId !== userId || template.sourceType !== 'custom') {
+            throw new NotFoundException({
+                status: 'error',
+                message: 'Custom template not found.',
+            });
+        }
+
+        const baseTemplateId =
+            typeof template.metadata?.baseTemplateId === 'string'
+                ? template.metadata.baseTemplateId
+                : null;
+        if (!baseTemplateId) {
+            throw new BadRequestException({
+                status: 'error',
+                message: 'Template is not linked to a customizable base.',
+            });
+        }
+        this.resolveCustomizableBase(baseTemplateId);
+
+        const codeEditProvider = await this.assertProviderAvailable(providerId, userId);
+        const aiProviderId = await this.resolveAiProviderRequirement(
+            codeEditProvider,
+            input.aiProviderId?.trim(),
+            userId,
+        );
+
+        const customization = await this.customizationRepository.create({
+            templateId: template.id,
+            userId,
+            baseTemplateId,
             prompt,
             providerId,
             aiProviderId,

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -79,7 +79,7 @@ export class TemplateCustomizationService {
         }
 
         const baseConfig = this.resolveCustomizableBase(input.baseTemplateId);
-        await this.assertProviderAvailable(providerId);
+        await this.assertProviderAvailable(providerId, userId);
         const user = await this.userRepository.findById(userId);
         if (!user) {
             throw new NotFoundException({ status: 'error', message: 'User not found.' });
@@ -140,8 +140,8 @@ export class TemplateCustomizationService {
         return this.customizationRepository.listForTemplate(templateId, userId);
     }
 
-    listProviders(): CodeEditProviderInfo[] {
-        return this.codeEditFacade.listProviders();
+    listProviders(userId: string): Promise<CodeEditProviderInfo[]> {
+        return this.codeEditFacade.listProviders(userId);
     }
 
     /** Exposed for direct invocation by background tasks / tests. */
@@ -308,13 +308,13 @@ export class TemplateCustomizationService {
         };
     }
 
-    private async assertProviderAvailable(providerId: string): Promise<void> {
-        const available = this.codeEditFacade.listProviders();
+    private async assertProviderAvailable(providerId: string, userId: string): Promise<void> {
+        const available = await this.codeEditFacade.listProviders(userId);
         const match = available.find((p) => p.id === providerId);
-        if (!match || !match.enabled) {
+        if (!match) {
             throw new BadRequestException({
                 status: 'error',
-                message: `Code-edit provider "${providerId}" is not installed or not enabled.`,
+                message: `Code-edit provider "${providerId}" is not installed or not enabled for this account.`,
             });
         }
     }

--- a/packages/plugins/opencode/src/opencode.plugin.ts
+++ b/packages/plugins/opencode/src/opencode.plugin.ts
@@ -957,6 +957,7 @@ export class OpenCodePlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 			aiFacade?: IAiFacade;
 			userId?: string;
 			workId?: string;
+			aiProviderId?: string;
 		};
 		const settings = execContext.settings ?? {};
 		const aiFacade = execContext.aiFacade;
@@ -967,7 +968,11 @@ export class OpenCodePlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 			return failedCodeEditResult(startTime, 'OpenCode requires an AI facade (no aiFacade in execContext).');
 		}
 
-		const facadeOptions: FacadeOptions = { userId, workId };
+		const facadeOptions: FacadeOptions = {
+			userId,
+			workId,
+			providerOverride: execContext.aiProviderId
+		};
 		const { providerConfig, modelName } = await this.resolveAiProvider(
 			{ aiFacade } as unknown as NonNullable<PipelineExecutionOptions['execContext']>,
 			facadeOptions

--- a/packages/tasks/src/__tests__/trigger.service.spec.ts
+++ b/packages/tasks/src/__tests__/trigger.service.spec.ts
@@ -5,6 +5,7 @@ const {
     runsCancelMock,
     workGenTriggerMock,
     workImportTriggerMock,
+    templateCustomizationTriggerMock,
     triggerConfig,
     subscriptionsConfig,
 } = vi.hoisted(() => {
@@ -13,6 +14,7 @@ const {
         runsCancelMock: vi.fn(),
         workGenTriggerMock: vi.fn(),
         workImportTriggerMock: vi.fn(),
+        templateCustomizationTriggerMock: vi.fn(),
         triggerConfig: {
             shouldUseTrigger: vi.fn(),
             getSecretKey: vi.fn(),
@@ -43,6 +45,7 @@ vi.mock('@ever-works/agent/config', () => ({
 vi.mock('@ever-works/agent/tasks', () => ({
     WORK_GENERATION_DISPATCHER: Symbol('WORK_GENERATION_DISPATCHER'),
     WORK_IMPORT_DISPATCHER: Symbol('WORK_IMPORT_DISPATCHER'),
+    TEMPLATE_CUSTOMIZATION_DISPATCHER: Symbol('TEMPLATE_CUSTOMIZATION_DISPATCHER'),
 }));
 
 vi.mock('../tasks/trigger/work-generation.task', () => ({
@@ -50,6 +53,9 @@ vi.mock('../tasks/trigger/work-generation.task', () => ({
 }));
 vi.mock('../tasks/trigger/work-import.task', () => ({
     workImportTask: { trigger: workImportTriggerMock },
+}));
+vi.mock('../tasks/trigger/template-customization.task', () => ({
+    templateCustomizationTask: { trigger: templateCustomizationTriggerMock },
 }));
 
 import { TriggerService } from '../trigger/trigger.service';
@@ -231,6 +237,36 @@ describe('TriggerService', () => {
                 sourceType: 'github',
             } as any);
 
+            expect(out).toBeNull();
+        });
+    });
+
+    describe('dispatchTemplateCustomization', () => {
+        it('returns null when trigger is disabled', async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            const out = await service.dispatchTemplateCustomization({ customizationId: 'c1' });
+            expect(out).toBeNull();
+            expect(templateCustomizationTriggerMock).not.toHaveBeenCalled();
+        });
+
+        it('returns the run id and tags the customization id', async () => {
+            templateCustomizationTriggerMock.mockResolvedValue({ id: 'run-tpl-1' });
+
+            const out = await service.dispatchTemplateCustomization({ customizationId: 'c1' });
+
+            expect(out).toBe('run-tpl-1');
+            expect(templateCustomizationTriggerMock).toHaveBeenCalledWith(
+                { customizationId: 'c1' },
+                expect.objectContaining({
+                    tags: ['template-customization', 'c1'],
+                    machine: 'small-1x',
+                }),
+            );
+        });
+
+        it('returns null when the SDK throws', async () => {
+            templateCustomizationTriggerMock.mockRejectedValue(new Error('boom'));
+            const out = await service.dispatchTemplateCustomization({ customizationId: 'c1' });
             expect(out).toBeNull();
         });
     });

--- a/packages/tasks/src/tasks/trigger/data-repo-sync-dispatcher.task.ts
+++ b/packages/tasks/src/tasks/trigger/data-repo-sync-dispatcher.task.ts
@@ -50,7 +50,16 @@ export const dataRepoSyncDispatcherTask = schedules.task({
     run: async () => {
         const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
         appContext.useLogger(createTriggerLogger('DataRepoSyncDispatcher'));
-        const logger = appContext.get('NestFactoryStaticLogger', { strict: false }) ?? console;
+        // `appContext.get('NestFactoryStaticLogger', { strict: false })` still
+        // throws under Nest 11 when the provider isn't registered, so the
+        // `?? console` fallback never fires. Guard explicitly.
+        let logger: { log?: (m: string) => void } = console;
+        try {
+            const fromCtx = appContext.get('NestFactoryStaticLogger', { strict: false });
+            if (fromCtx) logger = fromCtx as typeof logger;
+        } catch {
+            // Fall back to console — already the default.
+        }
 
         try {
             const dispatcher = appContext.get<DataSyncDispatcher>(DATA_SYNC_DISPATCHER_SERVICE);

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -2,6 +2,7 @@ export * from './anonymous-user-cleanup.task';
 export * from './data-repo-sync-dispatcher.task';
 export * from './deploy-ready-poller.task';
 export * from './user-research-rerun-dispatcher.task';
+export * from './template-customization.task';
 export * from './work-generation.task';
 export * from './work-import.task';
 export * from './work-onboarding.task';

--- a/packages/tasks/src/tasks/trigger/template-customization.task.ts
+++ b/packages/tasks/src/tasks/trigger/template-customization.task.ts
@@ -1,0 +1,21 @@
+import { task } from '@trigger.dev/sdk';
+import { TemplateCustomizationPayload } from '@ever-works/agent/tasks';
+import { TemplateCustomizationService } from '@ever-works/agent/template-catalog';
+import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+
+export const templateCustomizationTask = task<
+    'template-customization',
+    TemplateCustomizationPayload
+>({
+    id: 'template-customization',
+    maxDuration: 3600, // 1 hour — UI-only edits should finish in minutes
+    run: async (payload) => {
+        return withWorkerContext('TemplateCustomization', async (appContext) => {
+            await appContext.get(TriggerPluginHydratorService).initialize();
+            const service = appContext.get(TemplateCustomizationService);
+            await service.execute(payload.customizationId);
+            return { status: 'completed', customizationId: payload.customizationId };
+        });
+    },
+});

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -1,6 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { TriggerService } from './trigger.service';
-import { WORK_GENERATION_DISPATCHER, WORK_IMPORT_DISPATCHER } from '@ever-works/agent/tasks';
+import {
+    WORK_GENERATION_DISPATCHER,
+    WORK_IMPORT_DISPATCHER,
+    TEMPLATE_CUSTOMIZATION_DISPATCHER,
+} from '@ever-works/agent/tasks';
 
 @Global()
 @Module({
@@ -14,7 +18,16 @@ import { WORK_GENERATION_DISPATCHER, WORK_IMPORT_DISPATCHER } from '@ever-works/
             provide: WORK_IMPORT_DISPATCHER,
             useExisting: TriggerService,
         },
+        {
+            provide: TEMPLATE_CUSTOMIZATION_DISPATCHER,
+            useExisting: TriggerService,
+        },
     ],
-    exports: [TriggerService, WORK_GENERATION_DISPATCHER, WORK_IMPORT_DISPATCHER],
+    exports: [
+        TriggerService,
+        WORK_GENERATION_DISPATCHER,
+        WORK_IMPORT_DISPATCHER,
+        TEMPLATE_CUSTOMIZATION_DISPATCHER,
+    ],
 })
 export class TriggerModule {}

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -6,12 +6,17 @@ import {
     WorkGenerationDispatcher,
     WorkImportPayload,
     WorkImportDispatcher,
+    TemplateCustomizationPayload,
+    TemplateCustomizationDispatcher,
 } from '@ever-works/agent/tasks';
 import { workGenerationTask } from '../tasks/trigger/work-generation.task';
 import { workImportTask } from '../tasks/trigger/work-import.task';
+import { templateCustomizationTask } from '../tasks/trigger/template-customization.task';
 
 @Injectable()
-export class TriggerService implements WorkGenerationDispatcher, WorkImportDispatcher {
+export class TriggerService
+    implements WorkGenerationDispatcher, WorkImportDispatcher, TemplateCustomizationDispatcher
+{
     private readonly logger = new Logger(TriggerService.name);
     private configured = false;
 
@@ -101,6 +106,26 @@ export class TriggerService implements WorkGenerationDispatcher, WorkImportDispa
             return handle.id;
         } catch (error) {
             this.logger.error('Failed to dispatch work-import task', error as Error);
+            return null;
+        }
+    }
+
+    async dispatchTemplateCustomization(
+        payload: TemplateCustomizationPayload,
+    ): Promise<string | null> {
+        if (!this.ensureConfigured()) {
+            return null;
+        }
+
+        try {
+            const handle = await templateCustomizationTask.trigger(payload, {
+                tags: ['template-customization', payload.customizationId],
+                machine: this.machine() as any,
+            });
+
+            return handle.id;
+        } catch (error) {
+            this.logger.error('Failed to dispatch template-customization task', error as Error);
             return null;
         }
     }

--- a/packages/tasks/src/trigger/worker/modules/trigger-facades.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-facades.module.ts
@@ -7,6 +7,7 @@ import {
     DataSourceFacadeService,
     GitFacadeService,
     PromptFacadeService,
+    CodeEditFacadeService,
 } from '@ever-works/agent/facades';
 import {
     AuthAccountRepository,
@@ -25,6 +26,7 @@ const FACADES = [
     DataSourceFacadeService,
     GitFacadeService,
     PromptFacadeService,
+    CodeEditFacadeService,
 ];
 
 /**

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -1,5 +1,9 @@
 import { Module } from '@nestjs/common';
-import { WorkScheduleDispatcherService, WorkScheduleService } from '@ever-works/agent/services';
+import {
+    DeployReadyPollerService,
+    WorkScheduleDispatcherService,
+    WorkScheduleService,
+} from '@ever-works/agent/services';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
 
@@ -34,12 +38,19 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'DataSyncDispatcherService'),
             inject: [TriggerInternalApiClient],
         },
+        {
+            provide: DeployReadyPollerService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'DeployReadyPollerService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
         WorkScheduleDispatcherService,
         WorkScheduleService,
         DATA_SYNC_DISPATCHER_SERVICE,
+        DeployReadyPollerService,
     ],
 })
 export class TriggerInternalModule {}

--- a/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { WorkOperationsService } from '@ever-works/agent/work-operations';
 import {
     TemplateRepository,
+    TemplateCustomizationRepository,
+    UserRepository,
     UserTemplatePreferenceRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
@@ -15,6 +17,7 @@ import {
 } from '@ever-works/agent/generators';
 import { SourceRepoAnalyzerService, ImportExecutorService } from '@ever-works/agent/import';
 import { WorksConfigService, WorksConfigWriterService } from '@ever-works/agent/works-config';
+import { TemplateCustomizationService } from '@ever-works/agent/template-catalog';
 import { TriggerPluginsModule } from './trigger-plugins.module';
 import { TriggerFacadesModule } from './trigger-facades.module';
 import { TriggerPipelineModule } from './trigger-pipeline.module';
@@ -64,6 +67,18 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
                 createRemoteProxy(apiClient, 'UserTemplatePreferenceRepository'),
             inject: [TriggerInternalApiClient],
         },
+        {
+            provide: TemplateCustomizationRepository,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'TemplateCustomizationRepository'),
+            inject: [TriggerInternalApiClient],
+        },
+        {
+            provide: UserRepository,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'UserRepository'),
+            inject: [TriggerInternalApiClient],
+        },
         DataGeneratorService,
         MarkdownGeneratorService,
         WebsiteGeneratorService,
@@ -75,7 +90,13 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
         ImportExecutorService,
         TriggerGenerationOrchestrator,
         TriggerImportOrchestrator,
+        TemplateCustomizationService,
     ],
-    exports: [TriggerGenerationOrchestrator, TriggerImportOrchestrator, TriggerInternalModule],
+    exports: [
+        TriggerGenerationOrchestrator,
+        TriggerImportOrchestrator,
+        TemplateCustomizationService,
+        TriggerInternalModule,
+    ],
 })
 export class TriggerWorkerModule {}

--- a/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
@@ -18,6 +18,7 @@ import {
 import { SourceRepoAnalyzerService, ImportExecutorService } from '@ever-works/agent/import';
 import { WorksConfigService, WorksConfigWriterService } from '@ever-works/agent/works-config';
 import { TemplateCustomizationService } from '@ever-works/agent/template-catalog';
+import { CategoryIconService } from '@ever-works/agent/services';
 import { TriggerPluginsModule } from './trigger-plugins.module';
 import { TriggerFacadesModule } from './trigger-facades.module';
 import { TriggerPipelineModule } from './trigger-pipeline.module';
@@ -79,6 +80,10 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
                 createRemoteProxy(apiClient, 'UserRepository'),
             inject: [TriggerInternalApiClient],
         },
+        // DataGeneratorService consumes CategoryIconService for icon enrichment (EW-357).
+        // CACHE_MANAGER is provided globally via TriggerRemoteCacheModule; AiFacadeService
+        // comes from TriggerFacadesModule — both deps reachable in worker scope.
+        CategoryIconService,
         DataGeneratorService,
         MarkdownGeneratorService,
         WebsiteGeneratorService,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.5.14
         version: 0.5.14(prettier@3.8.1)
       turbo:
-        specifier: ^2.9.12
-        version: 2.9.12
+        specifier: ^2.9.14
+        version: 2.9.14
 
   apps/api:
     dependencies:
@@ -8103,33 +8103,33 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/darwin-64@2.9.12':
-    resolution: {integrity: sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g==}
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.12':
-    resolution: {integrity: sha512-RUkAE404z/J8NsyrUosMcBaXT6M4bRFxTQrmkDQBLQVXaC8Jl0e9bMvYDSX0GW7Ffm2m3j9y7RXgR1foeUAM9w==}
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.12':
-    resolution: {integrity: sha512-InIUtH7cw/vqXNX1Gr7QgWfmw3ct08pV5CpfdEOR48z2u2rzdmpIuk00B/Q2xCb0PMWtKgiMQynfuphmEuUyTQ==}
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.12':
-    resolution: {integrity: sha512-lC6nD//Xh67fmJM0LKaLsg74Wry0aYrgMklpiNgCbUaMdPIOqj0A00iri3NU7Lb7pZHx8ViisgpeDKlpSgFUCA==}
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.12':
-    resolution: {integrity: sha512-conYri8VUl72JOdYnLDPYwzqbPcY5ECoHmo9FWoKznemhaAIilj4maHqs9Uar0aKfNoZIULniy+6iWaLtLO34A==}
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.12':
-    resolution: {integrity: sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ==}
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
     cpu: [arm64]
     os: [win32]
 
@@ -17230,8 +17230,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.9.12:
-    resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
   turndown@7.2.2:
@@ -25446,22 +25446,22 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/darwin-64@2.9.12':
+  '@turbo/darwin-64@2.9.14':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.12':
+  '@turbo/darwin-arm64@2.9.14':
     optional: true
 
-  '@turbo/linux-64@2.9.12':
+  '@turbo/linux-64@2.9.14':
     optional: true
 
-  '@turbo/linux-arm64@2.9.12':
+  '@turbo/linux-arm64@2.9.14':
     optional: true
 
-  '@turbo/windows-64@2.9.12':
+  '@turbo/windows-64@2.9.14':
     optional: true
 
-  '@turbo/windows-arm64@2.9.12':
+  '@turbo/windows-arm64@2.9.14':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -29091,7 +29091,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -29128,7 +29128,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -29142,7 +29142,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -37031,14 +37031,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.9.12:
+  turbo@2.9.14:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.12
-      '@turbo/darwin-arm64': 2.9.12
-      '@turbo/linux-64': 2.9.12
-      '@turbo/linux-arm64': 2.9.12
-      '@turbo/windows-64': 2.9.12
-      '@turbo/windows-arm64': 2.9.12
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   turndown@7.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

The Code-edit agent picker introduced in EW-550 (#747) listed every plugin loaded in the process, including ones the user had not installed or had explicitly disabled (e.g. Gemini and Claude Code Generator showing up for accounts that never enabled them).

This aligns the list with the canonical pattern used by the generator form-schema service — \`PluginRegistryService.isPluginEnabledForScope\` — so it reflects per-user enablement, not process-wide load state.

## Changes

- \`CodeEditFacadeService.listProviders(userId)\` filters by \`state === 'loaded'\`, skips \`supplementary\` plugins, then asks the registry whether each plugin is enabled for the user. Disabled plugins are dropped from the response entirely instead of being returned with \`enabled: false\`.
- \`resolveProvider\` re-checks enablement when a \`providerId\` is supplied to prevent bypass via direct POST.
- \`TemplateCustomizationService.listProviders\` and \`assertProviderAvailable\` thread \`userId\` through.
- Controller \`GET /templates/customization-providers\` passes the authenticated user.
- New unit suite for \`CodeEditFacadeService\` covers user-scoped filter, supplementary skip, default detection, and the resolve bypass guard. Existing customization service tests updated to async mocks.

## Test plan

- [x] \`packages/agent\` Jest: \`code-edit | template-customization\` (18 tests)
- [x] \`packages/agent\` Jest: \`facades | template-catalog\` (372 tests, no regressions)
- [x] \`apps/api\` Jest: \`template-catalog\` (31 tests, incl. new controller assertion that \`listProviders\` is called with \`auth.userId\`)
- [x] Agent package build: \`tsc -p tsconfig.types.json\` clean
- [ ] Manual: in an account with no code-edit plugins enabled, open Templates → Create with AI — only enabled plugins appear in the chip row; submission with a disabled plugin id returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider availability and validation are now scoped to each user account; clearer account-scoped error when a provider is unavailable.

* **Refactor**
  * Provider listing, availability checks, and execution now respect user (and optional workspace) scope; API endpoint uses the authenticated user context.

* **New Features**
  * Expanded, repo-specific template customization guidance and tighter rules for safe UI-only edits.

* **Tests**
  * Added and expanded tests for user-scoped provider listing, availability, resolution, execution, and prompt behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->