### PR TITLE
fix(ci): set DATABASE_AUTOMIGRATE=true for E2E (C-07 PR-B regression)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,12 @@ jobs:
           DATABASE_IN_MEMORY: 'true'
           AUTH_SECRET: ever-works-e2e-ci-secret
           NODE_ENV: development
+          # C-07 PR-B: `autoMigrate()` now defaults to OFF everywhere except
+          # `NODE_ENV=test`. E2E boots a real dev-mode API with in-memory
+          # sqlite, so the tables must be created via TypeORM `synchronize`
+          # before Playwright fires. Set this explicitly instead of flipping
+          # NODE_ENV (which would change other dev-vs-test branches).
+          DATABASE_AUTOMIGRATE: 'true'
           # Web
           API_URL: http://localhost:3100
           NEXT_PUBLIC_API_URL: http://localhost:3100/api


### PR DESCRIPTION
After #816 flipped `autoMigrate()` to default-off everywhere except `NODE_ENV=test`, the E2E workflow (which uses `NODE_ENV=development` + in-memory sqlite) boots the API without running TypeORM `synchronize` → first DB query trips `no such table: subscription_plans` → Playwright fails.

Set `DATABASE_AUTOMIGRATE='true'` explicitly in the E2E env block. Targeted fix; doesn't touch `NODE_ENV` to avoid changing other dev-vs-test branches.

Same pattern as the test:cli fix in `ci.yml` from commit 1d7eb1d4.

Failed E2E run: https://github.com/ever-works/ever-works/actions/runs/26029991334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end testing workflow configuration to ensure proper database initialization for test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->