### PR TITLE
fix(security): guard empty token in validate-{email,reset}-token (H-01 regression)

### DIFF
--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -425,6 +425,15 @@ export class AuthService {
 
     async validateEmailVerificationToken(token: string) {
         // H-01: lookup by sha256(submitted). DB stores hashes only.
+        // Guard non-string/empty input so a missing `?token=` query param
+        // returns 200 + `valid: false` instead of 500ing inside
+        // `createHash().update(undefined)`. The E2E `api-public-contract`
+        // suite hits these endpoints without a token to verify the public
+        // contract; without the guard, NestJS surfaces the TypeError as a
+        // 500 and the spec fails (`expect(res.status()).toBeLessThan(500)`).
+        if (typeof token !== 'string' || token.length === 0) {
+            return { valid: false, message: 'Invalid verification token' };
+        }
         const tokenHash = hashToken(token);
         const user = await this.userRepository.findOne({
             where: { emailVerificationToken: tokenHash },
@@ -448,6 +457,11 @@ export class AuthService {
 
     async validatePasswordResetToken(token: string) {
         // H-01: lookup by sha256(submitted). DB stores hashes only.
+        // Guard non-string/empty input — see validateEmailVerificationToken
+        // for the rationale.
+        if (typeof token !== 'string' || token.length === 0) {
+            return { valid: false, message: 'Invalid reset token' };
+        }
         const tokenHash = hashToken(token);
         const user = await this.userRepository.findOne({
             where: { passwordResetToken: tokenHash },


### PR DESCRIPTION
E2E api-public-contract suite hits both endpoints without `?token=` to verify the public contract returns 4xx (not 5xx). H-01 introduced `hashToken(token)` at the top of both validators, and `createHash().update(undefined)` throws `TypeError` → 500 → spec fails. Guard non-string/empty input and early-return the same negative envelope.

Root cause: E2E run [#26032394563](https://github.com/ever-works/ever-works/actions/runs/26032394563).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email verification and password reset processes to provide clearer error messages when invalid tokens are submitted, preventing processing errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->