### PR TITLE
ci: dump API + Web logs when Playwright fails

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -100,6 +100,19 @@ jobs:
           echo "Web ready."
 
           echo "::group::Running Playwright e2e suite"
+          # Trap to dump API + Web stdout on Playwright failure — without this
+          # we can only see the test-runner's view (e.g. `Expected: 200,
+          # Received: 401`) and not why the API was rejecting. The dev-server
+          # stdout is the authoritative source for NestJS exceptions and
+          # Better Auth's request-flow logging.
+          trap '{
+            echo "::group::API log (last 200 lines)"
+            tail -n 200 /tmp/api.log || true
+            echo "::endgroup::"
+            echo "::group::Web log (last 200 lines)"
+            tail -n 200 /tmp/web.log || true
+            echo "::endgroup::"
+          }' EXIT
           pnpm exec playwright test
           echo "::endgroup::"
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,6 +114,12 @@ jobs:
           # before Playwright fires. Set this explicitly instead of flipping
           # NODE_ENV (which would change other dev-vs-test branches).
           DATABASE_AUTOMIGRATE: 'true'
+          # H-07: Better Auth now requires email verification before sign-in.
+          # The E2E suite registers users via API and immediately logs in;
+          # without disabling the check here, every login returns 403
+          # EMAIL_NOT_VERIFIED. Production still enforces the check (default
+          # `true`); `false` is opt-in for test contexts only.
+          REQUIRE_EMAIL_VERIFICATION: 'false'
           # Web
           API_URL: http://localhost:3100
           NEXT_PUBLIC_API_URL: http://localhost:3100/api

--- a/apps/api/src/auth/providers/auth-runtime.instance.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.ts
@@ -166,8 +166,12 @@ export function createAuthRuntimeInstance(dataSource: DataSource) {
             // email and immediately gains an authenticated session. Existing
             // unverified users will be prompted to verify on next login
             // (the platform currently has very few users, all internal).
+            // Env-overridable for E2E + local-dev: `REQUIRE_EMAIL_VERIFICATION=false`
+            // turns off the check so test flows can register + login in one go.
+            // Default stays `true` so production deploys can't accidentally
+            // disable the check by omission.
             autoSignIn: true,
-            requireEmailVerification: true,
+            requireEmailVerification: process.env.REQUIRE_EMAIL_VERIFICATION !== 'false',
             minPasswordLength: 8,
             password: {
                 // L-07: cost is read on each call so operators can raise it

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -425,6 +425,15 @@ export class AuthService {
 
     async validateEmailVerificationToken(token: string) {
         // H-01: lookup by sha256(submitted). DB stores hashes only.
+        // Guard non-string/empty input so a missing `?token=` query param
+        // returns 200 + `valid: false` instead of 500ing inside
+        // `createHash().update(undefined)`. The E2E `api-public-contract`
+        // suite hits these endpoints without a token to verify the public
+        // contract; without the guard, NestJS surfaces the TypeError as a
+        // 500 and the spec fails (`expect(res.status()).toBeLessThan(500)`).
+        if (typeof token !== 'string' || token.length === 0) {
+            return { valid: false, message: 'Invalid verification token' };
+        }
         const tokenHash = hashToken(token);
         const user = await this.userRepository.findOne({
             where: { emailVerificationToken: tokenHash },
@@ -448,6 +457,11 @@ export class AuthService {
 
     async validatePasswordResetToken(token: string) {
         // H-01: lookup by sha256(submitted). DB stores hashes only.
+        // Guard non-string/empty input — see validateEmailVerificationToken
+        // for the rationale.
+        if (typeof token !== 'string' || token.length === 0) {
+            return { valid: false, message: 'Invalid reset token' };
+        }
         const tokenHash = hashToken(token);
         const user = await this.userRepository.findOne({
             where: { passwordResetToken: tokenHash },


### PR DESCRIPTION
E2E run [#26035849349](https://github.com/ever-works/ever-works/actions/runs/26035849349) failed with `Received: 401` on POST /api/auth/login but the NestJS exception is invisible because dev-server stdout goes to /tmp/api.log which is only tailed on startup failure. Add EXIT trap to dump last 200 lines of api.log + web.log into the Actions log on test failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for email verification and password reset flows to prevent server errors when invalid tokens are provided.

* **Chores**
  * Enhanced test environment diagnostics with automatic server log capture during failures.
  * Made email verification requirement configurable for testing environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->