### PR TITLE
fix(web): post-register/login double-submit + restore /profile route

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
@@ -85,14 +85,11 @@ export function LoginClient({ availableSocialProviders }: LoginClientProps) {
         setError('');
         setShowResetSuccess(false);
 
-        startTransition(() => {
-            void (async () => {
-                const response = await loginAction(formData.email, formData.password, redirectUrl);
-                if (!response.success) {
-                    setError(response.error || t('errors.invalidCredentials'));
-                    return;
-                }
-            })();
+        startTransition(async () => {
+            const response = await loginAction(formData.email, formData.password, redirectUrl);
+            if (response && !response.success) {
+                setError(response.error || t('errors.invalidCredentials'));
+            }
         });
     };
 

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -44,19 +44,16 @@ export default function RegisterForm({ availableSocialProviders }: RegisterFormP
             return;
         }
 
-        startTransition(() => {
-            void (async () => {
-                const response = await registerAction(
-                    formData.name,
-                    formData.email,
-                    formData.password,
-                );
+        startTransition(async () => {
+            const response = await registerAction(
+                formData.name,
+                formData.email,
+                formData.password,
+            );
 
-                if (!response.success) {
-                    setError(response.error || t('errors.generic'));
-                    return;
-                }
-            })();
+            if (response && !response.success) {
+                setError(response.error || t('errors.generic'));
+            }
         });
     };
 

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -45,11 +45,7 @@ export default function RegisterForm({ availableSocialProviders }: RegisterFormP
         }
 
         startTransition(async () => {
-            const response = await registerAction(
-                formData.name,
-                formData.email,
-                formData.password,
-            );
+            const response = await registerAction(formData.name, formData.email, formData.password);
 
             if (response && !response.success) {
                 setError(response.error || t('errors.generic'));

--- a/apps/web/src/app/[locale]/(dashboard)/profile/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from '@/i18n/navigation';
+import { getLocale } from 'next-intl/server';
+import { ROUTES } from '@/lib/constants';
+
+export default async function ProfileRedirect() {
+    redirect({ locale: await getLocale(), href: ROUTES.DASHBOARD_SETTINGS });
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -101,8 +101,8 @@ export const ROUTES = {
     DASHBOARD_SETTINGS_GITHUB_APP: '/settings/github-app',
     // Dynamic plugin settings routes
     DASHBOARD_SETTINGS_PLUGIN_CATEGORY: (category: string) => `/settings/plugins/${category}`,
-    // Profile
-    DASHBOARD_PROFILE: '/profile',
+    // Profile (alias of settings — `/profile` redirects to `/settings`)
+    DASHBOARD_PROFILE: '/settings',
     DASHBOARD_ANALYTICS: '/analytics',
     DASHBOARD_NOTIFICATIONS: '/notifications',
 


### PR DESCRIPTION
## Summary

Two related auth-UX fixes surfaced while smoke-testing the production register flow on https://app.ever.works/en/register.

### 1. Register/Login: button re-enables mid-flight (double-submit race)

`apps/web/src/app/[locale]/(auth)/register/register-form.tsx` and `…/login/login-client.tsx` both pass a **synchronous** callback to `startTransition` that fires an async IIFE and returns void:

```ts
startTransition(() => {
    void (async () => { await registerAction(...) })();   // ❌
});
```

Because the transition callback resolves immediately, `isPending` flips back to `false` *before the server action returns*. The submit button re-enables while the network call is still in flight, so a user can click again and trigger a second `register` / `login` call (and on the register side that means a second account-creation attempt + a second `setAuthCookies` round-trip).

Fix: pass the async function directly to `startTransition` — React 19 keeps `isPending` true until the returned Promise resolves.

```ts
startTransition(async () => {
    const response = await registerAction(...);          // ✅
    if (response && !response.success) setError(...);
});
```

### 2. `/[locale]/profile` returns 404

`DASHBOARD_PROFILE: '/profile'` is exported from `lib/constants.ts`, but no page file exists under `app/[locale]/(dashboard)/profile/`. Anyone hitting `/en/profile` (stale email, old bookmark, manual URL) gets a hard 404 even though their session is valid. The actual profile UI lives at `/[locale]/(dashboard)/settings/page.tsx`.

Fix:
- Add a server-side redirect page at `/[locale]/(dashboard)/profile/page.tsx` → `ROUTES.DASHBOARD_SETTINGS`.
- Point `DASHBOARD_PROFILE` at `/settings` so future internal links land directly with no extra hop.

## Files

- `apps/web/src/app/[locale]/(auth)/register/register-form.tsx`
- `apps/web/src/app/[locale]/(auth)/login/login-client.tsx`
- `apps/web/src/app/[locale]/(dashboard)/profile/page.tsx` *(new — 6 lines, server redirect)*
- `apps/web/src/lib/constants.ts`

## Test plan

- [ ] CI green (lint, type-check, unit, E2E)
- [ ] Manual: register a fresh account on a preview deploy → submit button stays disabled and labeled "Submitting…" for the full duration of the network round-trip; clicking it again is a no-op
- [ ] Manual: same check on `/en/login`
- [ ] Manual: visit `/en/profile` while authenticated → 302 to `/en/settings`, profile form renders
- [ ] Manual: visit `/en/profile` while unauthenticated → middleware redirects to `/en/login` (no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Profile page now redirects to dashboard settings, consolidating user account settings management into a unified interface
  
* **Refactor**
  * Enhanced async handling in login and registration form submissions to improve application responsiveness and reliability while maintaining existing error handling behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->