### PR TITLE
fix(security): H-01 bearer auth — fall back to plain-token lookup for Better Auth sessions

### DIFF
--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -383,17 +383,39 @@ export class AuthProviderService extends AuthProvider {
         return this.dataSource.getRepository(AuthSession);
     }
 
-    // H-01 (sessions): lookup is now keyed on sha256(submitted token). Raw
+    // H-01 (sessions): primary lookup is sha256(submitted token). Raw
     // bearer is hashed by the caller (`getBearerToken` → `hashSessionToken`)
     // before it touches the DB.
+    //
+    // Fallback path: Better Auth's signInEmail / signUpEmail / OAuth flows
+    // create sessions through Better Auth's own adapter, which writes the
+    // raw token to the legacy `token` column WITHOUT populating `tokenHash`.
+    // Those sessions wouldn't match the tokenHash lookup, so every
+    // bearer-authenticated request from a freshly-issued session would 401.
+    // When tokenHash lookup misses, fall back to plain-token lookup, then
+    // migrate the row in place: write `tokenHash = sha256(token)` and null
+    // out the plaintext `token` column. Over time every session converges
+    // to the H-01 invariant (hash-only) on first use.
     private async findSessionRecord(token: string) {
-        return this.getSessionRepository().findOne({
-            where: { tokenHash: hashSessionToken(token) },
-        });
+        const tokenHash = hashSessionToken(token);
+        let session = await this.getSessionRepository().findOne({ where: { tokenHash } });
+        if (session) return session;
+
+        session = await this.getSessionRepository().findOne({ where: { token } });
+        if (session) {
+            await this.getSessionRepository().update(session.id, { token: null, tokenHash });
+            session.token = null;
+            session.tokenHash = tokenHash;
+        }
+        return session;
     }
 
     private async deleteSessionRecord(token: string) {
-        await this.getSessionRepository().delete({ tokenHash: hashSessionToken(token) });
+        const tokenHash = hashSessionToken(token);
+        // Same dual-path as `findSessionRecord` — sessions created via Better
+        // Auth's adapter live under the plaintext column until first use.
+        await this.getSessionRepository().delete({ tokenHash });
+        await this.getSessionRepository().delete({ token });
     }
 
     // H-04 + H-01 (sessions): bind sessions to the requesting client at


### PR DESCRIPTION
**Root cause** (caught by E2E run [#26037975971](https://github.com/ever-works/ever-works/actions/runs/26037975971), surfaced by [#824](https://github.com/ever-works/ever-works/pull/824)'s api.log dump):

H-01 assumed our `createSessionRecord` is the only path that writes `auth_session` rows. In practice, Better Auth's `signInEmail` / `signUpEmail` / OAuth flows create sessions through Better Auth's adapter, which writes the raw token to the legacy `token` column WITHOUT populating `tokenHash`. Our `findSessionRecord` looks up by `tokenHash` only → returns null → every bearer-authenticated request from a freshly-issued session 401s.

The api.log dump showed:

```
[user_signup] Account created (user: 58c69162-…)   ← register OK (Better Auth signUpEmail)
[user_login] Signed in (user: 58c69162-…)         ← login OK (returns token)
[POST /api/works] 401                              ← bearer lookup fails
```

**Fix:** `findSessionRecord` tries the hash lookup first (normal path); if it misses, falls back to plain-token lookup and **migrates the row in place** — write `tokenHash = sha256(token)`, null out `token`. Over time every session converges to the H-01 invariant (hash-only) on first use.

Same fallback in `deleteSessionRecord` so logout works for Better Auth sessions too.

54 existing auth-provider tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session authentication to gracefully handle and migrate legacy session data during login, improving compatibility and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->