### PR TITLE
fix(ci): bump E2E AUTH_SECRET to 32+ chars (unblocks H-14 hardening)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,7 +119,13 @@ jobs:
           # API
           DATABASE_TYPE: sqlite
           DATABASE_IN_MEMORY: 'true'
-          AUTH_SECRET: ever-works-e2e-ci-secret
+          # H-14 (PR #816) raised the floor on COOKIE_SECRET / AUTH_SECRET
+          # to 32 characters of high-entropy material and removed the silent
+          # short-secret padding. The previous 24-char value broke cookie
+          # encryption in the web's `setAuthCookies` → registration succeeded
+          # but no session cookie was set → every subsequent request 401'd.
+          # Padded to 51 chars (CI-only, obviously fake — do not reuse).
+          AUTH_SECRET: ever-works-e2e-ci-secret-padding-to-meet-32min-fake
           NODE_ENV: development
           # C-07 PR-B: `autoMigrate()` now defaults to OFF everywhere except
           # `NODE_ENV=test`. E2E boots a real dev-mode API with in-memory


### PR DESCRIPTION
## Root cause

PR #816 (H-14 batch) hardened \`apps/web/src/lib/auth/crypto.ts\`:

\`\`\`ts
if (secret.length < 32) {
    throw new Error('COOKIE_SECRET / AUTH_SECRET must be at least 32 characters …');
}
\`\`\`

The E2E workflow was still passing \`AUTH_SECRET: ever-works-e2e-ci-secret\` (24 chars). The API side registered the user just fine (\`Activity logged: [user_signup] Account created\`), but the web's server-action \`setAuthCookies\` couldn't encrypt the cookie:

\`\`\`
Encryption error: Error: COOKIE_SECRET / AUTH_SECRET must be at least 32 characters …
    at getPassword (src/lib/auth/crypto.ts:18:15)
    at encrypt (src/lib/auth/crypto.ts:31:23)
    at setAuthAccessCookie (src/lib/auth/cookies.ts:35:41)
    at async setAuthCookies (src/lib/auth/cookies.ts:62:5)
    at async register (src/app/actions/auth.ts:109:9)
\`\`\`

No session cookie → every subsequent test request returns 401 → Playwright \`authenticate-setup\` waits 120 s for the redirect that never happens → cascade of "status was 401" failures.

This is **exactly** the failure mode that motivated PR #824 (api.log dump). The dump from run [26037975971](https://github.com/ever-works/ever-works/actions/runs/26037975971) made the root cause obvious.

## Fix

Bump \`AUTH_SECRET\` to a 51-character CI-only value. Added a leading comment that points at H-14 / PR #816 so future regressions don't reintroduce a short secret.

## Why this only surfaces now

- The H-14 commit landed in \`develop\` as part of #816 (merged earlier today).
- The workflow change wasn't re-run with this hardening until #823 / #824 retriggered E2E.
- The two prior E2E reruns (cancelled / failed in 20 m) both hit the timeout via the same root cause, but the api.log dump only existed after #824 merged at 13:54:33 UTC.

## Test plan

- [ ] E2E (22.x) on develop passes after merge
- [ ] PR #818 (develop→stage cascade) goes green and can be admin-merged
- [ ] Web \`crypto.unit.spec.ts\` still passes (it asserts on this exact ≥32 rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication cookie encryption issues in end-to-end tests that were causing 401 errors following successful registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->