### PR TITLE
fix(security): L-05 propagate isAnonymous through bearer-auth path

### DIFF
--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -357,6 +357,15 @@ export class AuthProviderService extends AuthProvider {
             provider: user.registrationProvider || 'local',
             emailVerified: user.emailVerified,
             isActive: user.isActive !== false,
+            // L-05: propagate `isAnonymous` so controller-level guards
+            // (e.g. claim-account is anonymous-only) can see it on `req.user`.
+            // Without this, the post-bearer-auth user object lacks
+            // `isAnonymous` and the L-05 check rejects legitimate anon-claim
+            // attempts with 403 — surfaced by zero-friction E2E run
+            // 26039862248. Better Auth's session.user shape may not include
+            // the custom column, hence the defensive cast + `=== true`.
+            isAnonymous:
+                (user as AuthRuntimeUser & { isAnonymous?: boolean }).isAnonymous === true,
             avatar: user.image || null,
             iat: Math.floor(Date.now() / 1000),
             iss: 'auth-runtime',
@@ -372,6 +381,8 @@ export class AuthProviderService extends AuthProvider {
             provider: user.registrationProvider || 'local',
             emailVerified: user.emailVerified,
             isActive: user.isActive !== false,
+            // L-05: propagate `isAnonymous` — see `mapAuthenticatedUser`.
+            isAnonymous: user.isAnonymous === true,
             avatar: user.avatar || null,
             iat: Math.floor(Date.now() / 1000),
             iss: 'auth-runtime',

--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -364,8 +364,7 @@ export class AuthProviderService extends AuthProvider {
             // attempts with 403 — surfaced by zero-friction E2E run
             // 26039862248. Better Auth's session.user shape may not include
             // the custom column, hence the defensive cast + `=== true`.
-            isAnonymous:
-                (user as AuthRuntimeUser & { isAnonymous?: boolean }).isAnonymous === true,
+            isAnonymous: (user as AuthRuntimeUser & { isAnonymous?: boolean }).isAnonymous === true,
             avatar: user.image || null,
             iat: Math.floor(Date.now() / 1000),
             iss: 'auth-runtime',

--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -383,17 +383,39 @@ export class AuthProviderService extends AuthProvider {
         return this.dataSource.getRepository(AuthSession);
     }
 
-    // H-01 (sessions): lookup is now keyed on sha256(submitted token). Raw
+    // H-01 (sessions): primary lookup is sha256(submitted token). Raw
     // bearer is hashed by the caller (`getBearerToken` → `hashSessionToken`)
     // before it touches the DB.
+    //
+    // Fallback path: Better Auth's signInEmail / signUpEmail / OAuth flows
+    // create sessions through Better Auth's own adapter, which writes the
+    // raw token to the legacy `token` column WITHOUT populating `tokenHash`.
+    // Those sessions wouldn't match the tokenHash lookup, so every
+    // bearer-authenticated request from a freshly-issued session would 401.
+    // When tokenHash lookup misses, fall back to plain-token lookup, then
+    // migrate the row in place: write `tokenHash = sha256(token)` and null
+    // out the plaintext `token` column. Over time every session converges
+    // to the H-01 invariant (hash-only) on first use.
     private async findSessionRecord(token: string) {
-        return this.getSessionRepository().findOne({
-            where: { tokenHash: hashSessionToken(token) },
-        });
+        const tokenHash = hashSessionToken(token);
+        let session = await this.getSessionRepository().findOne({ where: { tokenHash } });
+        if (session) return session;
+
+        session = await this.getSessionRepository().findOne({ where: { token } });
+        if (session) {
+            await this.getSessionRepository().update(session.id, { token: null, tokenHash });
+            session.token = null;
+            session.tokenHash = tokenHash;
+        }
+        return session;
     }
 
     private async deleteSessionRecord(token: string) {
-        await this.getSessionRepository().delete({ tokenHash: hashSessionToken(token) });
+        const tokenHash = hashSessionToken(token);
+        // Same dual-path as `findSessionRecord` — sessions created via Better
+        // Auth's adapter live under the plaintext column until first use.
+        await this.getSessionRepository().delete({ tokenHash });
+        await this.getSessionRepository().delete({ token });
     }
 
     // H-04 + H-01 (sessions): bind sessions to the requesting client at


### PR DESCRIPTION
L-05 added a controller-level guard `if (req.user?.isAnonymous !== true) throw Forbidden` on /auth/claim, but the bearer-auth user-mapping didn't include `isAnonymous` in its output. So `req.user.isAnonymous` was always undefined post-bearer-auth, and even legitimate anonymous users got 403'd when claiming.

Caught by E2E run [#26039862248](https://github.com/ever-works/ever-works/actions/runs/26039862248): `POST /api/auth/claim flips an anon user into a registered one` returned 403 instead of 200.

Fix: both `mapAuthenticatedUser` and `mapAuthenticatedUserFromUser` propagate `isAnonymous`. 54 existing auth-provider tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where anonymous users were not consistently identified during authentication. Anonymous status is now preserved across all sign-in methods, preventing misclassification and ensuring downstream checks and features that rely on anonymous/user status behave correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->