### PR TITLE
fix(auth): propagate isAnonymous through AuthenticatedUser map (unblocks claim flow E2E)

### DIFF
--- a/apps/api/src/auth/providers/auth-provider.service.spec.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.spec.ts
@@ -240,6 +240,56 @@ describe('AuthProviderService', () => {
                 service.authenticate(new Headers({ authorization: 'Bearer t' })),
             ).rejects.toThrow(new UnauthorizedException('User not found'));
         });
+
+        // EW-617 G3: zero-friction-flow e2e calls POST /api/auth/claim via the
+        // bearer token returned by POST /api/auth/anonymous. The claim controller
+        // throws Forbidden unless `req.user.isAnonymous === true`, so the field
+        // must round-trip from the DB row through mapAuthenticatedUserFromUser.
+        it('propagates isAnonymous=true from the User row', async () => {
+            const { service, sessionRepository, userRepository } = createService();
+            sessionRepository.findOne.mockResolvedValue({
+                token: 't',
+                userId: 'u-anon',
+                expiresAt: new Date(Date.now() + 1000),
+            });
+            userRepository.findById.mockResolvedValue({
+                id: 'u-anon',
+                email: null,
+                username: 'anon-abc',
+                registrationProvider: 'anonymous',
+                emailVerified: false,
+                isActive: true,
+                avatar: null,
+                isAnonymous: true,
+            });
+
+            const result = await service.authenticate(new Headers({ authorization: 'Bearer t' }));
+
+            expect(result?.isAnonymous).toBe(true);
+        });
+
+        it('returns isAnonymous=false for a regular User row', async () => {
+            const { service, sessionRepository, userRepository } = createService();
+            sessionRepository.findOne.mockResolvedValue({
+                token: 't',
+                userId: 'u-real',
+                expiresAt: new Date(Date.now() + 1000),
+            });
+            userRepository.findById.mockResolvedValue({
+                id: 'u-real',
+                email: 'a@b.co',
+                username: 'alice',
+                registrationProvider: 'local',
+                emailVerified: true,
+                isActive: true,
+                avatar: null,
+                isAnonymous: false,
+            });
+
+            const result = await service.authenticate(new Headers({ authorization: 'Bearer t' }));
+
+            expect(result?.isAnonymous).toBe(false);
+        });
     });
 
     describe('authenticate — Better Auth cookie path', () => {

--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -363,11 +363,10 @@ export class AuthProviderService extends AuthProvider {
             aud: 'ever-works-users',
             // EW-617 G3: propagate isAnonymous so `/api/auth/claim`'s
             // controller-level anonymous-only guard can read it from
-            // `req.user`. Better Auth's session.user does carry the column
-            // through the TypeORM adapter even though it's not declared on
-            // the trimmed AuthRuntimeUser shape.
-            isAnonymous:
-                (user as AuthRuntimeUser & { isAnonymous?: boolean }).isAnonymous === true,
+            // `req.user`. Better Auth's session.user carries the column
+            // through the TypeORM adapter even though it's not declared
+            // on the trimmed AuthRuntimeUser shape.
+            isAnonymous: (user as { isAnonymous?: boolean }).isAnonymous === true,
         };
     }
 

--- a/apps/api/src/auth/providers/auth-provider.service.ts
+++ b/apps/api/src/auth/providers/auth-provider.service.ts
@@ -361,6 +361,13 @@ export class AuthProviderService extends AuthProvider {
             iat: Math.floor(Date.now() / 1000),
             iss: 'auth-runtime',
             aud: 'ever-works-users',
+            // EW-617 G3: propagate isAnonymous so `/api/auth/claim`'s
+            // controller-level anonymous-only guard can read it from
+            // `req.user`. Better Auth's session.user does carry the column
+            // through the TypeORM adapter even though it's not declared on
+            // the trimmed AuthRuntimeUser shape.
+            isAnonymous:
+                (user as AuthRuntimeUser & { isAnonymous?: boolean }).isAnonymous === true,
         };
     }
 
@@ -376,6 +383,11 @@ export class AuthProviderService extends AuthProvider {
             iat: Math.floor(Date.now() / 1000),
             iss: 'auth-runtime',
             aud: 'ever-works-users',
+            // EW-617 G3: propagate isAnonymous from the DB row. This is the
+            // bearer-token code path (POST /api/auth/anonymous returns an
+            // opaque token; the zero-friction-flow e2e test then bearer-auths
+            // POST /api/auth/claim, which throws 403 unless req.user.isAnonymous === true).
+            isAnonymous: user.isAnonymous === true,
         };
     }
 


### PR DESCRIPTION
## Root cause

After PR #827 fixed the AUTH_SECRET hardening regression, develop E2E narrowed to a single failing test:

\`\`\`
[chromium] › e2e/zero-friction-flow.spec.ts:220:9 › EW-617 zero-friction flow — API contract › POST /api/auth/claim flips an anon user into a registered one
    Expected: 200
    Received: 403
\`\`\`

(334 passed, 10 skipped, 1 failed — from run [26039862248](https://github.com/ever-works/ever-works/actions/runs/26039862248).)

The \`claim\` controller is gated at \`auth.controller.ts:235\`:

\`\`\`ts
if (req.user?.isAnonymous !== true) {
    throw new ForbiddenException('claim is only valid for anonymous (zero-friction) accounts');
}
\`\`\`

\`req.user\` is populated by \`AuthSessionGuard\` → \`AuthProviderService.authenticate()\` → \`mapAuthenticatedUserFromUser(user)\` or \`mapAuthenticatedUser(...)\`. Both map methods built the \`AuthenticatedUser\` shape but **dropped the \`isAnonymous\` column entirely** — so the controller guard always tripped, even for sessions minted by \`POST /api/auth/anonymous\` (the exact entrypoint of the zero-friction flow).

## Fix

Include \`isAnonymous\` in both map methods:
- \`mapAuthenticatedUserFromUser\` reads from \`User.isAnonymous\` (the entity column).
- \`mapAuthenticatedUser\` pulls from Better Auth's \`session.user\` row. The TypeORM adapter does return the column at runtime; the trimmed \`AuthRuntimeUser\` type just didn't declare it (hence the local cast).

Added two unit tests covering the bearer-token path (true + false cases) so a future refactor of the mapper trips Jest before it trips the e2e.

## Test plan

- [ ] CI lint-and-test passes (new spec cases run under \`apps/api/jest\`)
- [ ] develop E2E (after merge) goes 335/335 — only the claim test was blocking
- [ ] PR #818 (develop→stage cascade) becomes mergeable

## Sibling PRs in flight

- #816 H-14 secret hardening
- #818 develop→stage cascade
- #820 DATABASE_AUTOMIGRATE
- #823 H-07 email-verify env-override
- #824 E2E log dump
- #827 E2E AUTH_SECRET 32+ chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication system to properly propagate the anonymous user flag in both bearer-token and database user authentication flows, ensuring anonymous user status is correctly recognized throughout the system.

* **Tests**
  * Added test coverage for anonymous user status handling in authentication scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->