### PR TITLE
chore(release): cascade develop -> stage (#825 register/login UX + profile redirect)

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
@@ -85,14 +85,11 @@ export function LoginClient({ availableSocialProviders }: LoginClientProps) {
         setError('');
         setShowResetSuccess(false);
 
-        startTransition(() => {
-            void (async () => {
-                const response = await loginAction(formData.email, formData.password, redirectUrl);
-                if (!response.success) {
-                    setError(response.error || t('errors.invalidCredentials'));
-                    return;
-                }
-            })();
+        startTransition(async () => {
+            const response = await loginAction(formData.email, formData.password, redirectUrl);
+            if (response && !response.success) {
+                setError(response.error || t('errors.invalidCredentials'));
+            }
         });
     };
 

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -44,19 +44,12 @@ export default function RegisterForm({ availableSocialProviders }: RegisterFormP
             return;
         }
 
-        startTransition(() => {
-            void (async () => {
-                const response = await registerAction(
-                    formData.name,
-                    formData.email,
-                    formData.password,
-                );
+        startTransition(async () => {
+            const response = await registerAction(formData.name, formData.email, formData.password);
 
-                if (!response.success) {
-                    setError(response.error || t('errors.generic'));
-                    return;
-                }
-            })();
+            if (response && !response.success) {
+                setError(response.error || t('errors.generic'));
+            }
         });
     };
 

--- a/apps/web/src/app/[locale]/(dashboard)/profile/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from '@/i18n/navigation';
+import { getLocale } from 'next-intl/server';
+import { ROUTES } from '@/lib/constants';
+
+export default async function ProfileRedirect() {
+    redirect({ locale: await getLocale(), href: ROUTES.DASHBOARD_SETTINGS });
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -101,8 +101,8 @@ export const ROUTES = {
     DASHBOARD_SETTINGS_GITHUB_APP: '/settings/github-app',
     // Dynamic plugin settings routes
     DASHBOARD_SETTINGS_PLUGIN_CATEGORY: (category: string) => `/settings/plugins/${category}`,
-    // Profile
-    DASHBOARD_PROFILE: '/profile',
+    // Profile (alias of settings — `/profile` redirects to `/settings`)
+    DASHBOARD_PROFILE: '/settings',
     DASHBOARD_ANALYTICS: '/analytics',
     DASHBOARD_NOTIFICATIONS: '/notifications',
 


### PR DESCRIPTION
## Summary

Cascades #825 (https://github.com/ever-works/ever-works/pull/825) from `develop` to `stage`. The previous `develop` → `stage` → `main` cascade (#818 / #832) already shipped the security-audit + E2E-hardening batch to main as `2e7f0c25`; this PR carries only the #825 delta.

## Included

- **#825** `fix(web): post-register/login double-submit + restore /profile route` — admin-merged to develop at 16:05:44 UTC as `591ff003`.

## CI

- develop E2E (run [26045206284](https://github.com/ever-works/ever-works/actions/runs/26045206284)) — **SUCCESS** in 9m10s on `591ff003`.

## Test plan

- [ ] Required checks green on develop HEAD
- [ ] stage E2E (22.x) passes after merge
- [ ] Stage→main cascade can follow immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)