### PR TITLE
chore(release): cascade stage -> main (#825 register/login UX + profile redirect)

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/login-client.tsx
@@ -85,14 +85,11 @@ export function LoginClient({ availableSocialProviders }: LoginClientProps) {
         setError('');
         setShowResetSuccess(false);
 
-        startTransition(() => {
-            void (async () => {
-                const response = await loginAction(formData.email, formData.password, redirectUrl);
-                if (!response.success) {
-                    setError(response.error || t('errors.invalidCredentials'));
-                    return;
-                }
-            })();
+        startTransition(async () => {
+            const response = await loginAction(formData.email, formData.password, redirectUrl);
+            if (response && !response.success) {
+                setError(response.error || t('errors.invalidCredentials'));
+            }
         });
     };
 

--- a/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/register-form.tsx
@@ -44,19 +44,12 @@ export default function RegisterForm({ availableSocialProviders }: RegisterFormP
             return;
         }
 
-        startTransition(() => {
-            void (async () => {
-                const response = await registerAction(
-                    formData.name,
-                    formData.email,
-                    formData.password,
-                );
+        startTransition(async () => {
+            const response = await registerAction(formData.name, formData.email, formData.password);
 
-                if (!response.success) {
-                    setError(response.error || t('errors.generic'));
-                    return;
-                }
-            })();
+            if (response && !response.success) {
+                setError(response.error || t('errors.generic'));
+            }
         });
     };
 

--- a/apps/web/src/app/[locale]/(dashboard)/profile/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from '@/i18n/navigation';
+import { getLocale } from 'next-intl/server';
+import { ROUTES } from '@/lib/constants';
+
+export default async function ProfileRedirect() {
+    redirect({ locale: await getLocale(), href: ROUTES.DASHBOARD_SETTINGS });
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -101,8 +101,8 @@ export const ROUTES = {
     DASHBOARD_SETTINGS_GITHUB_APP: '/settings/github-app',
     // Dynamic plugin settings routes
     DASHBOARD_SETTINGS_PLUGIN_CATEGORY: (category: string) => `/settings/plugins/${category}`,
-    // Profile
-    DASHBOARD_PROFILE: '/profile',
+    // Profile (alias of settings — `/profile` redirects to `/settings`)
+    DASHBOARD_PROFILE: '/settings',
     DASHBOARD_ANALYTICS: '/analytics',
     DASHBOARD_NOTIFICATIONS: '/notifications',
 


### PR DESCRIPTION
## Summary

Cascades #825 (https://github.com/ever-works/ever-works/pull/825) from `stage` to `main`. Final leg of the develop→stage→main chain.

## Included

- **#825** `fix(web): post-register/login double-submit + restore /profile route` — landed on stage via #833 at 16:22:15 UTC as `f46efad7`.

## CI

- develop E2E (run [26045206284](https://github.com/ever-works/ever-works/actions/runs/26045206284)) — SUCCESS in 9m10s on `591ff003`.
- stage E2E (run [26046052464](https://github.com/ever-works/ever-works/actions/runs/26046052464)) — SUCCESS in 9m6s on `f46efad7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)