### PR TITLE
fix(docs): prettier-format docker-compose.md to unblock CI

### DIFF
--- a/docs/devops/docker-compose.md
+++ b/docs/devops/docker-compose.md
@@ -9,13 +9,13 @@ sidebar_position: 9
 
 Ever Works ships five layered Compose files at the repository root, so you can pick the right stack for what you're doing:
 
-| File                         | Purpose                                                                 | Use when                                                          |
-| ---------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `docker-compose.demo.yml`    | Minimal SQLite showcase, pre-built images. No infra deps.               | First-time evaluator, "clone and run" to kick the tires.          |
-| `docker-compose.infra.yml`   | PostgreSQL + Redis only. No application services.                       | Running the platform apps locally with `pnpm dev` against real deps. |
-| `docker-compose.yml`         | Full platform from pre-built GHCR images + bundled Postgres/Redis.      | Production-shaped self-host, no local Docker build.               |
-| `docker-compose.build.yml`   | Same as above, but builds api/web/mcp/docs from source.                 | Hacking on the apps, or building your own registry images.        |
-| `docker-compose.trigger.yml` | Optional self-hosted Trigger.dev (profile-gated, off by default).       | Local Trigger.dev webapp for background jobs.                     |
+| File                         | Purpose                                                            | Use when                                                             |
+| ---------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `docker-compose.demo.yml`    | Minimal SQLite showcase, pre-built images. No infra deps.          | First-time evaluator, "clone and run" to kick the tires.             |
+| `docker-compose.infra.yml`   | PostgreSQL + Redis only. No application services.                  | Running the platform apps locally with `pnpm dev` against real deps. |
+| `docker-compose.yml`         | Full platform from pre-built GHCR images + bundled Postgres/Redis. | Production-shaped self-host, no local Docker build.                  |
+| `docker-compose.build.yml`   | Same as above, but builds api/web/mcp/docs from source.            | Hacking on the apps, or building your own registry images.           |
+| `docker-compose.trigger.yml` | Optional self-hosted Trigger.dev (profile-gated, off by default).  | Local Trigger.dev webapp for background jobs.                        |
 
 The infra file is `include:`d by both `docker-compose.yml` and `docker-compose.build.yml`, so Postgres and Redis come up automatically with either flavour.
 
@@ -88,19 +88,19 @@ For a full production self-host (workers on separate machines, ClickHouse, objec
 
 ### `ever-works-api`
 
-NestJS REST API. Listens on `3100`. Reads `.env.compose` for all backing-service config — the compose file only hardcodes the container's *role* (`APP_TYPE=api`, `PORT=3100`), so every DB / Redis / Trigger.dev knob below can be overridden by editing `.env.compose` (or shelling out an env var before `docker compose up`) without touching the compose YAML.
+NestJS REST API. Listens on `3100`. Reads `.env.compose` for all backing-service config — the compose file only hardcodes the container's _role_ (`APP_TYPE=api`, `PORT=3100`), so every DB / Redis / Trigger.dev knob below can be overridden by editing `.env.compose` (or shelling out an env var before `docker compose up`) without touching the compose YAML.
 
-| Env var               | Default in `.env.compose`            | Notes                                                                    |
-| --------------------- | ------------------------------------ | ------------------------------------------------------------------------ |
-| `DATABASE_TYPE`       | `postgres`                           | Demo path overrides to `sqlite` via `.env.demo.compose`.                 |
-| `DATABASE_HOST`       | `ever-works-db`                      | Compose service name. Point at a managed Postgres FQDN to swap.          |
-| `DATABASE_PORT`       | `5432`                               |                                                                          |
-| `DATABASE_USERNAME`   | `postgres`                           |                                                                          |
-| `DATABASE_PASSWORD`   | `ever_works_password`                | **Replace before any non-local use.**                                    |
-| `DATABASE_NAME`       | `ever_works`                         |                                                                          |
-| `THROTTLER_REDIS_URL` | `redis://ever-works-redis:6379`      | Used by the distributed rate limiter (`apps/api`).                       |
-| `REDIS_URL`           | `redis://ever-works-redis:6379`      | Used by BullMQ queues in `@ever-works/agent`.                            |
-| `RUN_MIGRATIONS`      | `true`                               | Set to `false` if you run migrations out-of-band.                        |
+| Env var               | Default in `.env.compose`       | Notes                                                           |
+| --------------------- | ------------------------------- | --------------------------------------------------------------- |
+| `DATABASE_TYPE`       | `postgres`                      | Demo path overrides to `sqlite` via `.env.demo.compose`.        |
+| `DATABASE_HOST`       | `ever-works-db`                 | Compose service name. Point at a managed Postgres FQDN to swap. |
+| `DATABASE_PORT`       | `5432`                          |                                                                 |
+| `DATABASE_USERNAME`   | `postgres`                      |                                                                 |
+| `DATABASE_PASSWORD`   | `ever_works_password`           | **Replace before any non-local use.**                           |
+| `DATABASE_NAME`       | `ever_works`                    |                                                                 |
+| `THROTTLER_REDIS_URL` | `redis://ever-works-redis:6379` | Used by the distributed rate limiter (`apps/api`).              |
+| `REDIS_URL`           | `redis://ever-works-redis:6379` | Used by BullMQ queues in `@ever-works/agent`.                   |
+| `RUN_MIGRATIONS`      | `true`                          | Set to `false` if you run migrations out-of-band.               |
 
 ### `ever-works-web`
 
@@ -156,22 +156,22 @@ When the `trigger` profile is active, three more containers join `ever-works-net
 
 ## Volumes
 
-| Volume                    | Mount                                      | File                          |
-| ------------------------- | ------------------------------------------ | ----------------------------- |
-| `postgres_data`           | `/var/lib/postgresql/data/`                | infra                         |
-| `redis_data`              | `/data`                                    | infra                         |
-| `api_data`                | `/app/apps/api/data` (SQLite)              | demo                          |
-| `trigger_postgres_data`   | `/var/lib/postgresql/data/`                | trigger (profile)             |
-| `trigger_redis_data`      | `/data`                                    | trigger (profile)             |
+| Volume                  | Mount                         | File              |
+| ----------------------- | ----------------------------- | ----------------- |
+| `postgres_data`         | `/var/lib/postgresql/data/`   | infra             |
+| `redis_data`            | `/data`                       | infra             |
+| `api_data`              | `/app/apps/api/data` (SQLite) | demo              |
+| `trigger_postgres_data` | `/var/lib/postgresql/data/`   | trigger (profile) |
+| `trigger_redis_data`    | `/data`                       | trigger (profile) |
 
 Named volumes survive `docker compose down`. Wipe them with `docker compose down -v`.
 
 ## Environment files
 
-| File                  | Paired compose file                                   | Defaults to              |
-| --------------------- | ----------------------------------------------------- | ------------------------ |
-| `.env.compose`        | `docker-compose.yml`, `docker-compose.build.yml`      | Postgres + Redis         |
-| `.env.demo.compose`   | `docker-compose.demo.yml`                             | SQLite, no Redis         |
+| File                | Paired compose file                              | Defaults to      |
+| ------------------- | ------------------------------------------------ | ---------------- |
+| `.env.compose`      | `docker-compose.yml`, `docker-compose.build.yml` | Postgres + Redis |
+| `.env.demo.compose` | `docker-compose.demo.yml`                        | SQLite, no Redis |
 
 Both files are committed with placeholder secrets — replace them before any non-local use. Compose loads variables with this priority (highest first):
 
@@ -226,11 +226,11 @@ docker compose down -v
 
 ## Troubleshooting
 
-| Symptom                                       | Likely cause                                                | Fix                                                                                        |
-| --------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Web shows "Unable to connect to API"          | API still starting up                                       | `docker compose logs -f ever-works-api`. Healthcheck on `ever-works-db` may still be amber. |
-| API exits with `ECONNREFUSED 127.0.0.1:6379`  | Stale `REDIS_URL` pointing at localhost                     | Confirm `REDIS_URL=redis://ever-works-redis:6379` in the running container's env.          |
-| Port already in use                           | Another local service on 3000/3100/5432/6379                | Remap the host side: `'3001:3000'` in the compose file, or stop the conflicting process.   |
-| `pg_isready` healthcheck never goes green     | Custom `DATABASE_USERNAME` not matched in healthcheck cmd   | The healthcheck uses `$POSTGRES_USER`/`$POSTGRES_DB` — both come from the env, so make sure your overrides are consistent. |
-| Trigger.dev webapp 500s on first login        | Placeholder `TRIGGER_ENCRYPTION_KEY` still 32 ASCII chars   | Regenerate: `openssl rand -hex 32` and bounce the webapp container.                        |
-| `RUN_MIGRATIONS=true` with SQLite fails       | Migration script targets Postgres/MySQL                     | Set `RUN_MIGRATIONS=false` in `.env.demo.compose` (already the default there).             |
+| Symptom                                      | Likely cause                                              | Fix                                                                                                                        |
+| -------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Web shows "Unable to connect to API"         | API still starting up                                     | `docker compose logs -f ever-works-api`. Healthcheck on `ever-works-db` may still be amber.                                |
+| API exits with `ECONNREFUSED 127.0.0.1:6379` | Stale `REDIS_URL` pointing at localhost                   | Confirm `REDIS_URL=redis://ever-works-redis:6379` in the running container's env.                                          |
+| Port already in use                          | Another local service on 3000/3100/5432/6379              | Remap the host side: `'3001:3000'` in the compose file, or stop the conflicting process.                                   |
+| `pg_isready` healthcheck never goes green    | Custom `DATABASE_USERNAME` not matched in healthcheck cmd | The healthcheck uses `$POSTGRES_USER`/`$POSTGRES_DB` — both come from the env, so make sure your overrides are consistent. |
+| Trigger.dev webapp 500s on first login       | Placeholder `TRIGGER_ENCRYPTION_KEY` still 32 ASCII chars | Regenerate: `openssl rand -hex 32` and bounce the webapp container.                                                        |
+| `RUN_MIGRATIONS=true` with SQLite fails      | Migration script targets Postgres/MySQL                   | Set `RUN_MIGRATIONS=false` in `.env.demo.compose` (already the default there).                                             |


### PR DESCRIPTION
## Summary

[`docs/devops/docker-compose.md`](https://github.com/ever-works/ever-works/blob/develop/docs/devops/docker-compose.md) (landed in #819) wasn't formatted per `pnpm format:check`. Post-merge develop CI ([run 26051737178](https://github.com/ever-works/ever-works/actions/runs/26051737178)) failed on it:

\`\`\`
[warn] docs/devops/docker-compose.md
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
ELIFECYCLE  Command failed with exit code 1.
\`\`\`

Ran \`pnpm prettier --write docs/devops/docker-compose.md\` against the root \`package.json#prettier\` config (which is what Prettier resolves for files outside the per-package \`.prettierrc\` scopes). Diff is whitespace-only: table-column widths re-aligned + \`*role*\` → \`_role_\` (Prettier 3 normalises markdown emphasis to underscores).

## Aside on the \`pnpm audit\` failure mentioned on #819

The PR description noted a parallel \`pnpm audit\` failure for transitive deps (\`@docusaurus/babel\`, \`langsmith\`, \`systeminformation\`, \`fast-xml-builder\`). On investigation it was transient — the npm advisory API returned 8 highs on #819's CI run at 17:30 UTC, then 0 highs on develop's post-merge run minutes later, and 0 highs again locally now. The root \`package.json\` already has overrides for all four packages. Nothing actionable for this PR.

## Test plan

- [x] \`pnpm prettier --check docs/devops/docker-compose.md\` — local pass.
- [ ] \`lint-and-test (22.x)\` CI check passes on this PR.
- [ ] Develop CI passes again after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Compose setup guides with improved formatting and consistency across reference tables, including file purpose matrices, API environment specifications, volume mounts, and troubleshooting guidance for enhanced readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->