### PR TITLE
fix(compose,test): address bot findings on PR #837

### DIFF
--- a/apps/web/e2e/oauth-state.spec.ts
+++ b/apps/web/e2e/oauth-state.spec.ts
@@ -59,7 +59,6 @@ for (const providerId of PROVIDERS) {
             const res = await request.get(`${API_BASE}/api/oauth/${providerId}/url`);
             if (await isProviderUnconfigured(res)) {
                 test.skip(true, `${providerId} OAuth client id/secret not configured; skipping`);
-                return;
             }
             expect(res.status(), `status was ${res.status()}`).toBe(200);
 
@@ -87,7 +86,6 @@ for (const providerId of PROVIDERS) {
             const b = await request.get(`${API_BASE}/api/oauth/${providerId}/url`);
             if ((await isProviderUnconfigured(a)) || (await isProviderUnconfigured(b))) {
                 test.skip(true, `${providerId} OAuth client id/secret not configured; skipping`);
-                return;
             }
             expect(a.status(), `first call status was ${a.status()}`).toBe(200);
             expect(b.status(), `second call status was ${b.status()}`).toBe(200);

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -36,7 +36,13 @@ services:
         container_name: ever-works-web
         restart: unless-stopped
         env_file: .env.demo.compose
+        # PORT is a container-role value: web listens on 3000, API on 3100,
+        # MCP on 3200. Pin it inline so the env_file's API-targeted `PORT`
+        # value (3100) doesn't bleed into the web container — otherwise
+        # the Next standalone server binds to 3100 inside the container
+        # while `ports: 3000:3000` publishes 3000, breaking the demo URL.
         environment:
+            PORT: 3000
             API_URL: http://ever-works-api:3100
         depends_on:
             - ever-works-api


### PR DESCRIPTION
## Summary

Two findings from the AI review on PR #837 (develop→stage cascade for the OAuth state fix). Both shipped to develop so they automatically flow through the cascade.

### Codex P1 — `docker-compose.demo.yml`

`ever-works-web` inherits `PORT=3100` (API-targeted) from `.env.demo.compose` via `env_file`. Without an inline override, the Next standalone server binds to **3100 inside the container** while `ports: 3000:3000` publishes 3000 on the host — so the documented quick-start URL `http://localhost:3000` never serves the web app.

Fix: add `PORT: 3000` inline under the web service's `environment:`, matching the comment + pattern already used in `docker-compose.yml` and `docker-compose.build.yml`.

> Technically out of scope for the OAuth state fix; included per operator direction to clean up everything that surfaces in review.

### Greptile P2 — `apps/web/e2e/oauth-state.spec.ts`

`test.skip(true, …)` inside a running test body throws an internal exception to abort the test — so the `return` on the following line is dead code. Two occurrences (one per test in the suite). Dropped both.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, PR #837 (develop→stage cascade) auto-picks up these commits — re-check that CI on #837 stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)