### PR TITLE
Merge develop into stage — DB migrations auto-run on API startup (cascade #840)

### DIFF
--- a/.deploy/docker/api/Dockerfile
+++ b/.deploy/docker/api/Dockerfile
@@ -49,7 +49,11 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV APP_TYPE=api
 ENV PORT=3100
-ENV RUN_MIGRATIONS=false
+# RUN_MIGRATIONS gates whether the API self-applies pending TypeORM
+# migrations on startup. Default `true` so deployments self-heal after a
+# schema change — set to `false` only for diagnostic / debug pods that
+# should not touch the schema.
+ENV RUN_MIGRATIONS=true
 
 COPY --from=installer --chown=node:node /app/deploy/dist ./dist
 COPY --from=installer --chown=node:node /app/deploy/node_modules ./node_modules

--- a/.deploy/docker/api/entrypoint.sh
+++ b/.deploy/docker/api/entrypoint.sh
@@ -20,9 +20,11 @@ echo "==> Starting Ever Works API..."
 #      via `maxUnavailable: 0`.
 #
 # If you ever need to run migrations WITHOUT starting the API (e.g. for a
-# one-shot k8s Job in a more cautious rollout), use the TypeORM CLI:
-#   node /app/dist/migrations-cli.js  # NOT YET WIRED — placeholder
-# or shell into a pod and run `pnpm typeorm migration:run` via apps/api.
+# one-shot k8s Job in a more cautious rollout), shell into a checkout of
+# the repo and run `pnpm typeorm migration:run -d typeorm.config.ts` from
+# `apps/api/`. There is intentionally NO pre-baked migration-only CLI in
+# the production image — keeping the same code path (TypeORM via the API)
+# for every environment avoids drift.
 
 echo "==> Starting API server (migrations run in-process via TypeORM migrationsRun)..."
 exec node /app/dist/main

--- a/.deploy/docker/api/entrypoint.sh
+++ b/.deploy/docker/api/entrypoint.sh
@@ -3,45 +3,26 @@ set -e
 
 echo "==> Starting Ever Works API..."
 
-# Run migrations if enabled
-if [ "$RUN_MIGRATIONS" = "true" ]; then
-    echo "==> Running database migrations..."
+# Migrations:
+#
+# The TypeORM DataSource in the agent's `database.config.ts` is configured
+# with `migrationsRun: true` (gated on RUN_MIGRATIONS env, default `true`
+# outside `NODE_ENV=test`). So the API self-applies pending migrations on
+# every startup — no out-of-process step needed in the common case.
+#
+# This entrypoint still honours `RUN_MIGRATIONS` as a kill switch for
+# diagnostic pods (`RUN_MIGRATIONS=false ...`) but does NOT run a separate
+# `runMigrations()` call. Two reasons to keep the API as the sole runner:
+#   1. Single code path means dev (pnpm dev:api), CI, Docker, and k8s all
+#      apply migrations the same way.
+#   2. If migrations fail, the API crashes loudly with the same exit
+#      semantics on every platform; k8s will keep the prior pod serving
+#      via `maxUnavailable: 0`.
+#
+# If you ever need to run migrations WITHOUT starting the API (e.g. for a
+# one-shot k8s Job in a more cautious rollout), use the TypeORM CLI:
+#   node /app/dist/migrations-cli.js  # NOT YET WIRED — placeholder
+# or shell into a pod and run `pnpm typeorm migration:run` via apps/api.
 
-    # Wait for database to be ready (if using PostgreSQL/MySQL)
-    if [ "$DATABASE_TYPE" = "postgres" ] || [ "$DATABASE_TYPE" = "mysql" ]; then
-        echo "==> Waiting for database to be ready..."
-        sleep 5
-    fi
-
-    # Run migrations using compiled TypeORM config
-    node -e "
-        require('reflect-metadata');
-        const { DataSource } = require('typeorm');
-        const { databaseConfig } = require('@ever-works/agent/database');
-
-        const config = databaseConfig();
-        const dataSource = new DataSource({
-            ...config,
-            migrations: [__dirname + '/dist/migrations/*.js'],
-            migrationsTableName: 'migrations',
-        });
-
-        dataSource.initialize()
-            .then(async () => {
-                console.log('==> Running pending migrations...');
-                const migrations = await dataSource.runMigrations();
-                console.log('==> Migrations completed:', migrations.length, 'migration(s) executed');
-                await dataSource.destroy();
-                process.exit(0);
-            })
-            .catch((err) => {
-                console.error('==> Migration failed:', err);
-                process.exit(1);
-            });
-    "
-
-    echo "==> Migrations completed successfully"
-fi
-
-echo "==> Starting API server..."
+echo "==> Starting API server (migrations run in-process via TypeORM migrationsRun)..."
 exec node /app/dist/main

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,22 +1,27 @@
-# Force LF line endings on files that must run as scripts inside Linux
-# containers regardless of host OS. Without this, a Windows checkout
-# converts the files to CRLF on disk and `COPY` bakes those CRLF endings
-# into the image — Linux then tries to run `#!/bin/sh\r` as the
-# interpreter and reports "exec: no such file or directory".
+# Force LF line endings on files where CRLF causes real defects:
 #
-# Catches:
-#   - Container entrypoints (e.g. .deploy/docker/api/entrypoint.sh)
-#   - Any *.sh dropped into an image via Dockerfile COPY
-#   - Dockerfiles themselves (no shebang, but `\r` in RUN lines breaks busybox)
+#   1. Files baked into a Linux container via Dockerfile COPY —
+#      shell-script shebangs like `#!/bin/sh\r` make the kernel
+#      report "exec: no such file or directory", and `\r` in
+#      Dockerfile RUN lines breaks busybox.
 #
-# `text=auto` keeps source files using each developer's local convention
-# for normal text files (Windows devs still get CRLF for *.ts etc.); the
-# patterns below are the surgical exceptions.
+#   2. Files checked by Prettier `pnpm format:check` — Prettier 3
+#      defaults to `endOfLine: lf`, so any CRLF on a Windows
+#      working tree shows as a false-positive formatting failure.
+#      `git ls-files --eol` shows these are stored LF in the index
+#      already; the problem is purely Windows working-tree
+#      conversion via `core.autocrlf=true`. CI is Linux + LF, so
+#      this is a Windows-only paper cut — a fresh clone reports
+#      thousands of files as "needing reformatting" when nothing
+#      is actually wrong with them.
+#
+# `text=auto` keeps the default of "git decides per-file using its
+# heuristics"; the explicit patterns below are surgical overrides.
 
 * text=auto
 
-# Shell scripts MUST be LF — they're run inside Linux containers / on
-# Linux/macOS hosts and the shebang line breaks with CRLF.
+# Shell scripts MUST be LF — they're run inside Linux containers /
+# on Linux/macOS hosts and the shebang line breaks with CRLF.
 *.sh        text eol=lf
 *.bash      text eol=lf
 
@@ -26,12 +31,27 @@ Dockerfile  text eol=lf
 *.dockerfile text eol=lf
 
 # YAML used by Docker Compose and Kubernetes is parsed by Go YAML
-# libraries that accept either, but keeping it LF avoids needless diff
-# noise when someone on Linux re-saves a file edited on Windows.
+# libraries that accept either, but keeping it LF avoids needless
+# diff noise when someone on Linux re-saves a file edited on Windows.
 *.yml       text eol=lf
 *.yaml      text eol=lf
 
-# PowerShell scripts stay CRLF — that's the Windows native convention
-# and Windows PowerShell tolerates either, but PS 5.1 occasionally
-# gets confused by LF-only here-strings.
+# Files in the `pnpm format:check` glob — Prettier 3 defaults to
+# `endOfLine: lf` and rejects CRLF.  Without these rules, Windows
+# devs running `pnpm format:check` locally hit thousands of false-
+# positive "needs reformatting" warnings purely from autocrlf
+# conversion (3360 files on the develop tip as of 2026-05-18,
+# breakdown: 1966 .ts, 905 .md, 320 .tsx, 161 .json, 7 .css, 1 other).
+# CI is Linux + LF and passes, so the local results mislead.  Force
+# LF in the working tree on every OS to make local match CI.
+*.ts        text eol=lf
+*.tsx       text eol=lf
+*.jsx       text eol=lf
+*.json      text eol=lf
+*.md        text eol=lf
+*.css       text eol=lf
+
+# PowerShell scripts stay CRLF — that's the Windows native
+# convention and Windows PowerShell tolerates either, but PS 5.1
+# occasionally gets confused by LF-only here-strings.
 *.ps1       text eol=crlf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,23 @@ pnpm type-check         # TypeScript check all packages
 pnpm format             # Prettier format all files
 
 # Database migrations (from apps/api/)
-pnpm typeorm migration:generate -d typeorm.config.ts
+#
+# Schema is owned by TypeORM migrations under `apps/api/src/migrations/`.
+# The API self-applies pending migrations on every startup via TypeORM's
+# `migrationsRun: true` (gated by RUN_MIGRATIONS env, default `true`
+# outside NODE_ENV=test) — `pnpm dev:api`, Docker, and k8s share the
+# same self-healing path. Manual commands below are only needed when
+# AUTHORING a new migration; nothing has to be run manually on deploy.
+#
+# RULE: every TypeORM entity / schema change MUST ship with a migration
+# in the SAME PR. See `docs/specs/architecture/database-migrations.md`.
+#
+# Generate a migration from current entity diff vs current DB schema:
+pnpm typeorm migration:generate -d typeorm.config.ts src/migrations/<NameOfMigration>
+# Run pending migrations explicitly (rare — API does this on boot):
 pnpm typeorm migration:run -d typeorm.config.ts
+# Revert the most recent migration (DESTRUCTIVE — coordinate with operator):
+pnpm typeorm migration:revert -d typeorm.config.ts
 
 # Trigger.dev deployment
 pnpm deploy:trigger

--- a/apps/web/e2e/oauth-state.spec.ts
+++ b/apps/web/e2e/oauth-state.spec.ts
@@ -59,7 +59,6 @@ for (const providerId of PROVIDERS) {
             const res = await request.get(`${API_BASE}/api/oauth/${providerId}/url`);
             if (await isProviderUnconfigured(res)) {
                 test.skip(true, `${providerId} OAuth client id/secret not configured; skipping`);
-                return;
             }
             expect(res.status(), `status was ${res.status()}`).toBe(200);
 
@@ -87,7 +86,6 @@ for (const providerId of PROVIDERS) {
             const b = await request.get(`${API_BASE}/api/oauth/${providerId}/url`);
             if ((await isProviderUnconfigured(a)) || (await isProviderUnconfigured(b))) {
                 test.skip(true, `${providerId} OAuth client id/secret not configured; skipping`);
-                return;
             }
             expect(a.status(), `first call status was ${a.status()}`).toBe(200);
             expect(b.status(), `second call status was ${b.status()}`).toBe(200);

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -36,7 +36,13 @@ services:
         container_name: ever-works-web
         restart: unless-stopped
         env_file: .env.demo.compose
+        # PORT is a container-role value: web listens on 3000, API on 3100,
+        # MCP on 3200. Pin it inline so the env_file's API-targeted `PORT`
+        # value (3100) doesn't bleed into the web container — otherwise
+        # the Next standalone server binds to 3100 inside the container
+        # while `ports: 3000:3000` publishes 3000, breaking the demo URL.
         environment:
+            PORT: 3000
             API_URL: http://ever-works-api:3100
         depends_on:
             - ever-works-api

--- a/docs/specs/architecture/database.md
+++ b/docs/specs/architecture/database.md
@@ -233,6 +233,16 @@ silently left prod with no migration runner for several deploys:
   migrations from the `migrations` array). Default `true` outside
   test. **Stays on in prod** so every API pod boot self-heals.
 
+**Mutual exclusion (TypeORM order trap).** When `synchronize: true`
+is on, the runtime config forces `migrationsRun: false` regardless of
+`RUN_MIGRATIONS`. The reason: `DataSource.initialize()` runs migrations
+**before** synchronize, so any ALTER-style migration would hit an
+empty schema and fail. Synchronize bootstraps the full schema from
+entities; migrations are only meaningful in environments with real
+persisted data (prod / stage). This mutual exclusion is what makes
+the E2E suite work (`DATABASE_AUTOMIGRATE=true` for fast empty-DB
+bootstrap, migrations skipped automatically).
+
 ### 6.4 Schema-change workflow (the rule for AI agents and humans)
 
 Every TypeORM entity / schema change MUST ship with a migration in

--- a/docs/specs/architecture/database.md
+++ b/docs/specs/architecture/database.md
@@ -205,7 +205,7 @@ migrations: [                        // resolved relative to process.cwd()
   '${cwd}/apps/api/src/migrations/*.ts',
 ],
 migrationsTableName: 'migrations',
-migrationsTransactionMode: 'all',    // one tx per migration
+migrationsTransactionMode: 'all',    // all pending migrations in ONE shared transaction (atomic batch)
 ```
 
 `synchronize: true` is **only** allowed in `NODE_ENV=test` for fast

--- a/docs/specs/architecture/database.md
+++ b/docs/specs/architecture/database.md
@@ -200,13 +200,23 @@ synchronize: false,                  // never auto-derive schema (DANGEROUS)
 migrationsRun: true,                 // run pending migrations on startup
 migrations: [                        // resolved relative to process.cwd()
   '${cwd}/dist/migrations/*.js',     // Docker / prod
-  '${cwd}/src/migrations/*.ts',      // pnpm dev:api inside apps/api
   '${cwd}/apps/api/dist/migrations/*.js',
-  '${cwd}/apps/api/src/migrations/*.ts',
 ],
 migrationsTableName: 'migrations',
 migrationsTransactionMode: 'all',    // all pending migrations in ONE shared transaction (atomic batch)
 ```
+
+**`.js` only, intentionally.** TypeORM 0.3.x's
+`DirectoryExportedClassesLoader` loads matched files via
+`Promise.all(import(file))`. On Node ≥ 22, importing several `.ts`
+files concurrently trips Node's "Unexpected module status 0" internal
+assertion (a known race between `require()` and dynamic `import()` on
+the same module). The runtime config sticks to compiled `.js` only;
+the CLI path in `apps/api/typeorm.config.ts` still globs `.ts` and
+runs under `ts-node` (synchronous loader, no race). For local dev,
+`pnpm build --filter ever-works-api` populates
+`apps/api/dist/migrations/` so the API picks up pending migrations
+on next boot.
 
 `synchronize: true` is **only** allowed in `NODE_ENV=test` for fast
 e2e suite startup (`DATABASE_AUTOMIGRATE=true` is the explicit opt-in

--- a/docs/specs/architecture/database.md
+++ b/docs/specs/architecture/database.md
@@ -195,26 +195,74 @@ Per Constitution Principle V, the platform is **forward-only**:
 ### 6.3 Synchronize disabled in production
 
 ```ts
-// database.config.ts (production branch)
-synchronize: false,
-migrationsRun: true,        // run migrations on startup
-migrations: ['dist/migrations/*.js'],
+// database.config.ts (every branch — postgres, sqlite, URL-style)
+synchronize: false,                  // never auto-derive schema (DANGEROUS)
+migrationsRun: true,                 // run pending migrations on startup
+migrations: [                        // resolved relative to process.cwd()
+  '${cwd}/dist/migrations/*.js',     // Docker / prod
+  '${cwd}/src/migrations/*.ts',      // pnpm dev:api inside apps/api
+  '${cwd}/apps/api/dist/migrations/*.js',
+  '${cwd}/apps/api/src/migrations/*.ts',
+],
+migrationsTableName: 'migrations',
+migrationsTransactionMode: 'all',    // one tx per migration
 ```
 
 `synchronize: true` is **only** allowed in `NODE_ENV=test` for fast
-e2e suite startup. Production catches a misconfigured `synchronize`
-at boot via `DatabaseInitService`.
+e2e suite startup (`DATABASE_AUTOMIGRATE=true` is the explicit opt-in
+flag).
 
-### 6.4 Generate + run
+Two distinct env flags control two distinct things — do not conflate
+them. The 2026-05-17 audit batch (C-07) historically did, which
+silently left prod with no migration runner for several deploys:
+
+- **`DATABASE_AUTOMIGRATE`** → TypeORM `synchronize` (auto-derive
+  schema from entities). Default `false` outside test. **Must stay
+  off in prod** — that was the point of C-07.
+- **`RUN_MIGRATIONS`** → TypeORM `migrationsRun` (apply pending
+  migrations from the `migrations` array). Default `true` outside
+  test. **Stays on in prod** so every API pod boot self-heals.
+
+### 6.4 Schema-change workflow (the rule for AI agents and humans)
+
+Every TypeORM entity / schema change MUST ship with a migration in
+the **same PR**. The flow:
+
+1. Edit the entity under `packages/agent/src/entities/` (add column,
+   change type, add index, …).
+2. From `apps/api/`, generate the migration from the entity diff:
+    ```bash
+    pnpm typeorm migration:generate -d typeorm.config.ts \
+        src/migrations/<DescriptiveName>
+    ```
+    This produces `apps/api/src/migrations/<unix-millis>-<Name>.ts`.
+3. **Review the generated SQL** — TypeORM's diff is best-effort and
+   sometimes proposes destructive changes (DROP / ALTER TYPE). For
+   destructive changes, follow the two-phase pattern in §6.2.
+4. Include the migration file in the PR alongside the entity change.
+   CI's `pnpm test` exercises the migration against a fresh test DB
+   (catches syntax + ordering bugs).
+5. On merge to `develop` → `stage` → `main`, every new API pod boot
+   self-applies the migration via `migrationsRun: true`. No manual
+   `kubectl exec`, no operator step.
+
+**Never** push an entity change without its migration. The next
+deploy will silently 500 on any query that touches the missing
+column. (This is exactly how the 2026-05-18 OAuth login outage
+happened — H-17 added two columns, the audit batch correctly
+generated the migration but the runner had been disabled by C-07's
+flag misnaming.)
+
+### 6.5 Generate + run
 
 ```bash
 # Generate a new migration from current entity diffs (run from apps/api/)
 pnpm typeorm migration:generate -d typeorm.config.ts src/migrations/<name>
 
-# Apply pending migrations
+# Apply pending migrations explicitly (rare — API does this on boot)
 pnpm typeorm migration:run -d typeorm.config.ts
 
-# Revert the most recent migration (dev / staging only)
+# Revert the most recent migration (DESTRUCTIVE — coordinate with operator)
 pnpm typeorm migration:revert -d typeorm.config.ts
 ```
 

--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -256,6 +256,56 @@ describe('agent/config', () => {
             });
         });
 
+        // `runMigrations` controls actual migration execution (TypeORM
+        // `migrationsRun`). It is INTENTIONALLY a different flag from
+        // `autoMigrate` (which controls the dangerous `synchronize`) — these
+        // two flags must not be conflated in either env or code.
+        describe('runMigrations (default-on everywhere except NODE_ENV=test)', () => {
+            it('defaults to true when RUN_MIGRATIONS is unset and NODE_ENV is unset', () => {
+                expect(config.database.runMigrations()).toBe(true);
+            });
+
+            it("returns false when NODE_ENV='test' and RUN_MIGRATIONS is unset", () => {
+                process.env.NODE_ENV = 'test';
+                expect(config.database.runMigrations()).toBe(false);
+            });
+
+            it("returns true when RUN_MIGRATIONS='true' (explicit opt-in)", () => {
+                process.env.RUN_MIGRATIONS = 'true';
+                expect(config.database.runMigrations()).toBe(true);
+            });
+
+            it("returns false when RUN_MIGRATIONS='false' (explicit opt-out)", () => {
+                process.env.RUN_MIGRATIONS = 'false';
+                expect(config.database.runMigrations()).toBe(false);
+            });
+
+            it("returns true when NODE_ENV='test' but RUN_MIGRATIONS='true' (explicit override beats test env)", () => {
+                process.env.NODE_ENV = 'test';
+                process.env.RUN_MIGRATIONS = 'true';
+                expect(config.database.runMigrations()).toBe(true);
+            });
+
+            it("returns false when NODE_ENV='production' but RUN_MIGRATIONS='false' (kill switch wins)", () => {
+                process.env.NODE_ENV = 'production';
+                process.env.RUN_MIGRATIONS = 'false';
+                expect(config.database.runMigrations()).toBe(false);
+            });
+
+            it("treats non-'true'/'false' values as unset (falls through to NODE_ENV default)", () => {
+                process.env.NODE_ENV = 'production';
+                for (const value of ['1', '0', 'yes', 'TRUE']) {
+                    process.env.RUN_MIGRATIONS = value;
+                    expect(config.database.runMigrations()).toBe(true);
+                }
+                process.env.NODE_ENV = 'test';
+                for (const value of ['1', '0', 'yes', 'TRUE']) {
+                    process.env.RUN_MIGRATIONS = value;
+                    expect(config.database.runMigrations()).toBe(false);
+                }
+            });
+        });
+
         describe('loggingEnabled / sslMode / getInMemory (strict "true" gates)', () => {
             it.each([
                 ['DATABASE_LOGGING', 'loggingEnabled'],

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -62,9 +62,33 @@ export const config = {
             // forgets to set the flag still doesn't run TypeORM `synchronize`
             // against production. Opt back in by setting
             // DATABASE_AUTOMIGRATE=true explicitly.
+            //
+            // IMPORTANT: this controls TypeORM `synchronize` — auto-derive
+            // schema from entities, DANGEROUS in prod. It is NOT the same
+            // as "run pending migrations on startup"; that's
+            // `runMigrations()` below. The two flags serve two different
+            // purposes and must not be conflated.
             if (process.env.DATABASE_AUTOMIGRATE === 'true') return true;
             if (process.env.DATABASE_AUTOMIGRATE === 'false') return false;
             return process.env.NODE_ENV === 'test';
+        },
+        runMigrations() {
+            // Whether to run pending TypeORM migrations on API startup.
+            // Default `true` everywhere except `NODE_ENV=test` (the test
+            // suite owns its own schema bootstrap via `synchronize`).
+            //
+            // This is the SAFE auto-apply path — TypeORM consults the
+            // `migrations` table and applies anything new in order, one
+            // transaction per migration. Idempotent across replicas (the
+            // adapter takes a row-level lock on the table). Distinct from
+            // `autoMigrate()` (which controls the dangerous `synchronize`
+            // flag); these two flags should never be conflated.
+            //
+            // Opt out with RUN_MIGRATIONS=false (e.g. one-off debugging
+            // pods that should not touch schema).
+            if (process.env.RUN_MIGRATIONS === 'true') return true;
+            if (process.env.RUN_MIGRATIONS === 'false') return false;
+            return process.env.NODE_ENV !== 'test';
         },
         loggingEnabled() {
             return process.env.DATABASE_LOGGING === 'true';

--- a/packages/agent/src/database/database.config.spec.ts
+++ b/packages/agent/src/database/database.config.spec.ts
@@ -315,9 +315,10 @@ describe('database.config', () => {
                 }
             });
 
-            it('migrationsRun=true when runMigrations()=true and appType=api', () => {
+            it('migrationsRun=true when runMigrations()=true and appType=api and autoMigrate()=false (prod-shape)', () => {
                 cfgMock.getAppType.mockReturnValue('api');
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false);
                 const result = (databaseConfig as any)();
                 expect(result.migrationsRun).toBe(true);
             });
@@ -325,6 +326,7 @@ describe('database.config', () => {
             it('migrationsRun=false when runMigrations()=false (kill switch wins)', () => {
                 cfgMock.getAppType.mockReturnValue('api');
                 cfgMock.database.runMigrations.mockReturnValue(false);
+                cfgMock.database.autoMigrate.mockReturnValue(false);
                 const result = (databaseConfig as any)();
                 expect(result.migrationsRun).toBe(false);
             });
@@ -332,7 +334,21 @@ describe('database.config', () => {
             it('migrationsRun=false for CLI even when runMigrations()=true (CLI uses synchronize)', () => {
                 cfgMock.getAppType.mockReturnValue('cli');
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false);
                 const result = (databaseConfig as any)();
+                expect(result.migrationsRun).toBe(false);
+            });
+
+            it('migrationsRun=false when synchronize is ON (mutual exclusion — TypeORM order trap)', () => {
+                // TypeORM `DataSource.initialize()` runs migrationsRun BEFORE
+                // synchronize. With synchronize=true the schema is built from
+                // entities, so any ALTER-style migration would fail against
+                // an empty DB first. The test/E2E env needs synchronize-only.
+                cfgMock.getAppType.mockReturnValue('api');
+                cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(true);
+                const result = (databaseConfig as any)();
+                expect(result.synchronize).toBe(true);
                 expect(result.migrationsRun).toBe(false);
             });
 
@@ -340,6 +356,7 @@ describe('database.config', () => {
                 cfgMock.database.getType.mockReturnValue('postgres');
                 cfgMock.database.getHost.mockReturnValue('db.example.com');
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false); // prod-shape
                 const result = (databaseConfig as any)();
                 expect(result.type).toBe('postgres');
                 expect(result.migrationsRun).toBe(true);
@@ -351,19 +368,21 @@ describe('database.config', () => {
                 cfgMock.database.getUrl.mockReturnValue('postgres://u:p@h:5432/d');
                 parseMock.mockReturnValue({ database: 'd' } as any);
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false); // prod-shape
                 const result = (databaseConfig as any)();
                 expect(result.url).toBe('postgres://u:p@h:5432/d');
                 expect(result.migrationsRun).toBe(true);
                 expect(Array.isArray(result.migrations)).toBe(true);
             });
 
-            it('migrations + migrationsRun flow through SQLite branch', () => {
+            it('migrations array is always present in SQLite branch (E2E shape: synchronize on, migrationsRun off)', () => {
                 cfgMock.database.getType.mockReturnValue('better-sqlite3');
                 cfgMock.getEnvironment.mockReturnValue('test');
+                // autoMigrate=true by default in resetMocks, simulating E2E.
                 const result = (databaseConfig as any)();
                 expect(result.type).toBe('better-sqlite3');
-                // appType=api in resetMocks; runMigrations=true; migrationsRun=true.
-                expect(result.migrationsRun).toBe(true);
+                expect(result.synchronize).toBe(true);
+                expect(result.migrationsRun).toBe(false); // gated off by autoMigrate
                 expect(Array.isArray(result.migrations)).toBe(true);
             });
         });

--- a/packages/agent/src/database/database.config.spec.ts
+++ b/packages/agent/src/database/database.config.spec.ts
@@ -60,6 +60,7 @@ jest.mock('@src/config', () => {
         getHost: jest.fn(() => undefined as string | undefined),
         getPort: jest.fn(() => undefined as string | undefined),
         autoMigrate: jest.fn(() => true),
+        runMigrations: jest.fn(() => true),
         loggingEnabled: jest.fn(() => false),
         sslMode: jest.fn(() => false),
         databaseCaCert: jest.fn(() => undefined as string | undefined),
@@ -108,6 +109,7 @@ const cfgMock = config as unknown as {
         getHost: jest.Mock;
         getPort: jest.Mock;
         autoMigrate: jest.Mock;
+        runMigrations: jest.Mock;
         loggingEnabled: jest.Mock;
         sslMode: jest.Mock;
         databaseCaCert: jest.Mock;
@@ -130,6 +132,7 @@ function resetMocks() {
     cfgMock.database.getHost.mockReturnValue(undefined);
     cfgMock.database.getPort.mockReturnValue(undefined);
     cfgMock.database.autoMigrate.mockReturnValue(true);
+    cfgMock.database.runMigrations.mockReturnValue(true);
     cfgMock.database.loggingEnabled.mockReturnValue(false);
     cfgMock.database.sslMode.mockReturnValue(false);
     cfgMock.database.databaseCaCert.mockReturnValue(undefined);
@@ -294,6 +297,75 @@ describe('database.config', () => {
             cfgMock.getEnvironment.mockReturnValue('test');
             const result = (databaseConfig as any)();
             expect(result.logging).toBe(true);
+        });
+
+        // TypeORM migrations contract — distinct from `synchronize`. The
+        // runtime config must always carry a migrations glob + table name,
+        // and `migrationsRun` must reflect `runMigrations()` for API apps.
+        describe('migrations wiring (runMigrations + migrations array)', () => {
+            it('always exposes a non-empty `migrations` glob array + table name', () => {
+                const result = (databaseConfig as any)();
+                expect(Array.isArray(result.migrations)).toBe(true);
+                expect(result.migrations.length).toBeGreaterThan(0);
+                expect(result.migrationsTableName).toBe('migrations');
+                expect(result.migrationsTransactionMode).toBe('all');
+                // Every glob is absolute (TypeORM does not normalize cwd-relative globs).
+                for (const glob of result.migrations as string[]) {
+                    expect(glob).toMatch(/^([A-Za-z]:)?\//);
+                }
+            });
+
+            it('migrationsRun=true when runMigrations()=true and appType=api', () => {
+                cfgMock.getAppType.mockReturnValue('api');
+                cfgMock.database.runMigrations.mockReturnValue(true);
+                const result = (databaseConfig as any)();
+                expect(result.migrationsRun).toBe(true);
+            });
+
+            it('migrationsRun=false when runMigrations()=false (kill switch wins)', () => {
+                cfgMock.getAppType.mockReturnValue('api');
+                cfgMock.database.runMigrations.mockReturnValue(false);
+                const result = (databaseConfig as any)();
+                expect(result.migrationsRun).toBe(false);
+            });
+
+            it('migrationsRun=false for CLI even when runMigrations()=true (CLI uses synchronize)', () => {
+                cfgMock.getAppType.mockReturnValue('cli');
+                cfgMock.database.runMigrations.mockReturnValue(true);
+                const result = (databaseConfig as any)();
+                expect(result.migrationsRun).toBe(false);
+            });
+
+            it('migrations + migrationsRun flow through every dbType branch (postgres)', () => {
+                cfgMock.database.getType.mockReturnValue('postgres');
+                cfgMock.database.getHost.mockReturnValue('db.example.com');
+                cfgMock.database.runMigrations.mockReturnValue(true);
+                const result = (databaseConfig as any)();
+                expect(result.type).toBe('postgres');
+                expect(result.migrationsRun).toBe(true);
+                expect(Array.isArray(result.migrations)).toBe(true);
+            });
+
+            it('migrations + migrationsRun flow through DATABASE_URL branch', () => {
+                cfgMock.database.getType.mockReturnValue('postgres');
+                cfgMock.database.getUrl.mockReturnValue('postgres://u:p@h:5432/d');
+                parseMock.mockReturnValue({ database: 'd' } as any);
+                cfgMock.database.runMigrations.mockReturnValue(true);
+                const result = (databaseConfig as any)();
+                expect(result.url).toBe('postgres://u:p@h:5432/d');
+                expect(result.migrationsRun).toBe(true);
+                expect(Array.isArray(result.migrations)).toBe(true);
+            });
+
+            it('migrations + migrationsRun flow through SQLite branch', () => {
+                cfgMock.database.getType.mockReturnValue('better-sqlite3');
+                cfgMock.getEnvironment.mockReturnValue('test');
+                const result = (databaseConfig as any)();
+                expect(result.type).toBe('better-sqlite3');
+                // appType=api in resetMocks; runMigrations=true; migrationsRun=true.
+                expect(result.migrationsRun).toBe(true);
+                expect(Array.isArray(result.migrations)).toBe(true);
+            });
         });
     });
 

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -111,15 +111,48 @@ export const ENTITIES = [
     UserSyncConfig,
 ];
 
+/**
+ * Resolve TypeORM migration globs that work in both dev (TS source) and
+ * Docker / k8s (compiled JS). TypeORM accepts an array of globs and
+ * silently ignores any that don't match files, so listing all known
+ * layouts is safe and idempotent.
+ *
+ * Paths are absolute and use forward slashes (TypeORM's glob loader is
+ * cross-platform but a few internals trip on backslashes on Windows).
+ *
+ *   - Docker / prod:        `/app/dist/migrations/*.js` (cwd = /app)
+ *   - Local API workspace:  `apps/api/dist/migrations/*.js` (from repo root)
+ *   - Local API workspace:  `apps/api/src/migrations/*.ts` (ts-node / SWC)
+ *   - From apps/api cwd:    `src/migrations/*.ts` and `dist/migrations/*.js`
+ */
+function resolveMigrationGlobs(): string[] {
+    const cwd = process.cwd().replace(/\\/g, '/');
+    return [
+        `${cwd}/dist/migrations/*.js`,
+        `${cwd}/src/migrations/*.ts`,
+        `${cwd}/apps/api/dist/migrations/*.js`,
+        `${cwd}/apps/api/src/migrations/*.ts`,
+    ];
+}
+
 export const databaseConfig = registerAs('database', (): DatabaseConfig => {
     const environment = config.getEnvironment() || 'development';
     const appType = config.getAppType() || 'api';
     let dbType = config.database.getType();
 
+    // `migrationsRun` is gated on the API app type — CLI uses synchronize
+    // for its local SQLite (`DatabaseInitService` does that), so it has no
+    // use for the migrations table.
+    const migrationsRun = appType === 'api' && config.database.runMigrations();
+
     const baseConfig: any = {
         entities: ENTITIES,
         synchronize: config.database.autoMigrate(),
         logging: config.database.loggingEnabled(),
+        migrations: resolveMigrationGlobs(),
+        migrationsRun,
+        migrationsTableName: 'migrations',
+        migrationsTransactionMode: 'all' as const,
     };
 
     if (config.database.sslMode()) {

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -112,34 +112,40 @@ export const ENTITIES = [
 ];
 
 /**
- * Resolve TypeORM migration globs that work in both dev (TS source) and
- * Docker / k8s (compiled JS). TypeORM accepts an array of globs and
- * silently ignores any that don't match files, so listing all known
- * layouts is safe and idempotent.
+ * Resolve TypeORM migration globs for the runtime path. TypeORM accepts
+ * an array of globs and silently ignores any that don't match files, so
+ * listing the candidate layouts is safe and idempotent.
  *
- * Paths are absolute and use forward slashes (TypeORM's glob loader is
- * cross-platform but a few internals trip on backslashes on Windows).
+ * **Only `.js` patterns**, intentionally. TypeORM 0.3.x's
+ * `DirectoryExportedClassesLoader` loads matched files via
+ * `Promise.all(import(file))`. On Node ≥ 22, requiring `.ts` files (even
+ * after Nest+SWC transpilation) goes through the ESM loader and
+ * `Promise.all`-importing several at once trips Node's internal
+ * "Unexpected module status 0" assertion (a known race between
+ * `require()` and dynamic `import()` on the same module). Compiled JS
+ * doesn't hit this path. The manual `pnpm typeorm migration:generate /
+ * migration:run` commands keep their own `'.ts'` glob in
+ * `apps/api/typeorm.config.ts` and run under `ts-node`, which loads
+ * synchronously and is unaffected.
+ *
+ * Paths are absolute and use forward slashes (TypeORM's underlying glob
+ * engine — `globby` / `fast-glob` — handles forward-slash absolute paths
+ * correctly on Windows too).
  *
  *   - Docker / prod:        `/app/dist/migrations/*.js` (cwd = /app)
  *   - Local API workspace:  `apps/api/dist/migrations/*.js` (from repo root)
- *   - Local API workspace:  `apps/api/src/migrations/*.ts` (ts-node / SWC)
- *   - From apps/api cwd:    `src/migrations/*.ts` and `dist/migrations/*.js`
+ *   - From apps/api cwd:    `dist/migrations/*.js`
  *
- * Windows note: `process.cwd()` returns `C:\…` on Windows; the `.replace`
- * below normalises to forward slashes. TypeORM's underlying glob engine
- * (`globby` / `fast-glob`) treats forward-slash absolute paths on Windows
- * correctly, so `C:/Users/…/migrations/*.ts` resolves. If a Windows dev
- * ever sees zero migrations loaded despite running `pnpm dev:api`, check
- * `databaseConfig().migrations` and confirm the cwd path.
+ * For local dev: run `pnpm build --filter ever-works-api` (or `pnpm dev`
+ * which builds before watching) to populate `apps/api/dist/migrations/`,
+ * then the API will pick up pending migrations on next boot. Authoring
+ * a new migration still goes through `pnpm typeorm migration:generate`
+ * (which produces `.ts` next to the existing ones) — the build step
+ * compiles it to `.js` automatically.
  */
 function resolveMigrationGlobs(): string[] {
     const cwd = process.cwd().replace(/\\/g, '/');
-    return [
-        `${cwd}/dist/migrations/*.js`,
-        `${cwd}/src/migrations/*.ts`,
-        `${cwd}/apps/api/dist/migrations/*.js`,
-        `${cwd}/apps/api/src/migrations/*.ts`,
-    ];
+    return [`${cwd}/dist/migrations/*.js`, `${cwd}/apps/api/dist/migrations/*.js`];
 }
 
 export const databaseConfig = registerAs('database', (): DatabaseConfig => {

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -153,10 +153,19 @@ export const databaseConfig = registerAs('database', (): DatabaseConfig => {
     const appType = config.getAppType() || 'api';
     let dbType = config.database.getType();
 
-    // `migrationsRun` is gated on the API app type — CLI uses synchronize
-    // for its local SQLite (`DatabaseInitService` does that), so it has no
-    // use for the migrations table.
-    const migrationsRun = appType === 'api' && config.database.runMigrations();
+    // `migrationsRun` is gated on:
+    //   - API app type only — CLI uses synchronize for its local SQLite
+    //     (`DatabaseInitService` does that), so it has no use for the
+    //     migrations table.
+    //   - `!autoMigrate()` — when synchronize is ON (test / E2E), TypeORM's
+    //     `DataSource.initialize()` runs `migrationsRun` BEFORE
+    //     `synchronize`, so any ALTER-style migration would fail against
+    //     the still-empty schema. Synchronize bootstraps the full schema
+    //     from entities and the migrations table catches up implicitly;
+    //     migrations are only needed in environments with real persisted
+    //     data (prod/stage).
+    const migrationsRun =
+        appType === 'api' && config.database.runMigrations() && !config.database.autoMigrate();
 
     const baseConfig: any = {
         entities: ENTITIES,

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -124,6 +124,13 @@ export const ENTITIES = [
  *   - Local API workspace:  `apps/api/dist/migrations/*.js` (from repo root)
  *   - Local API workspace:  `apps/api/src/migrations/*.ts` (ts-node / SWC)
  *   - From apps/api cwd:    `src/migrations/*.ts` and `dist/migrations/*.js`
+ *
+ * Windows note: `process.cwd()` returns `C:\…` on Windows; the `.replace`
+ * below normalises to forward slashes. TypeORM's underlying glob engine
+ * (`globby` / `fast-glob`) treats forward-slash absolute paths on Windows
+ * correctly, so `C:/Users/…/migrations/*.ts` resolves. If a Windows dev
+ * ever sees zero migrations loaded despite running `pnpm dev:api`, check
+ * `databaseConfig().migrations` and confirm the cwd path.
  */
 function resolveMigrationGlobs(): string[] {
     const cwd = process.cwd().replace(/\\/g, '/');
@@ -152,6 +159,11 @@ export const databaseConfig = registerAs('database', (): DatabaseConfig => {
         migrations: resolveMigrationGlobs(),
         migrationsRun,
         migrationsTableName: 'migrations',
+        // `'all'` = all pending migrations in ONE shared transaction. If
+        // migration N fails, migrations 1..N-1 are rolled back too and the
+        // whole batch is retried on the next boot. Use `'each'` if you ever
+        // need partial-progress semantics; we want atomic-batch behaviour so
+        // a half-applied schema can't escape between pod restarts.
         migrationsTransactionMode: 'all' as const,
     };
 


### PR DESCRIPTION
## Summary

Cascading PR #840 (DB migrations auto-run on API startup) from develop → stage on the way to production. This is the actual fix that unblocks Google/GitHub sign-in on `app.ever.works` — the OAuth state PR (#836) deployed correctly but the auth flow then died on `column User.failedLoginAttempts does not exist` because the pending H-01/H-17 migrations had never been applied to the prod DB.

## Commits in this cascade

- `4852b477` fix(db): run pending TypeORM migrations on API startup (self-healing deploys)
- `2145d2ea` fix(db): address Greptile P2 findings on PR #840 (transactionMode comment, entrypoint placeholder, Windows glob note)

## Effect

- API self-applies pending migrations on every pod boot via TypeORM `migrationsRun: true` (default `true` outside `NODE_ENV=test`).
- `DATABASE_AUTOMIGRATE` (TypeORM `synchronize`) stays default-off — still serves its post-audit purpose.
- Two flags, two concepts — `docs/specs/architecture/database.md` §6.3 spells out the distinction.
- New `Workspace/AGENTS.md` NN #16 mandates entity-change + migration in same PR; runbook at `Workspace/knowledge/runbooks/EVER_WORKS_DB_MIGRATIONS.md`.

## Test plan

- [ ] CI green on stage post-merge.
- [ ] First API pod boot on stage shows migration queries in logs.
- [ ] `stage.app.ever.works` sign in with Google → land authenticated.
- [ ] Cascade stage → main only after stage validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)