### PR TITLE
fix(db): runtime migrations glob is .js-only — Node ESM/CJS race on .ts

### DIFF
--- a/docs/specs/architecture/database.md
+++ b/docs/specs/architecture/database.md
@@ -200,13 +200,23 @@ synchronize: false,                  // never auto-derive schema (DANGEROUS)
 migrationsRun: true,                 // run pending migrations on startup
 migrations: [                        // resolved relative to process.cwd()
   '${cwd}/dist/migrations/*.js',     // Docker / prod
-  '${cwd}/src/migrations/*.ts',      // pnpm dev:api inside apps/api
   '${cwd}/apps/api/dist/migrations/*.js',
-  '${cwd}/apps/api/src/migrations/*.ts',
 ],
 migrationsTableName: 'migrations',
 migrationsTransactionMode: 'all',    // all pending migrations in ONE shared transaction (atomic batch)
 ```
+
+**`.js` only, intentionally.** TypeORM 0.3.x's
+`DirectoryExportedClassesLoader` loads matched files via
+`Promise.all(import(file))`. On Node ≥ 22, importing several `.ts`
+files concurrently trips Node's "Unexpected module status 0" internal
+assertion (a known race between `require()` and dynamic `import()` on
+the same module). The runtime config sticks to compiled `.js` only;
+the CLI path in `apps/api/typeorm.config.ts` still globs `.ts` and
+runs under `ts-node` (synchronous loader, no race). For local dev,
+`pnpm build --filter ever-works-api` populates
+`apps/api/dist/migrations/` so the API picks up pending migrations
+on next boot.
 
 `synchronize: true` is **only** allowed in `NODE_ENV=test` for fast
 e2e suite startup (`DATABASE_AUTOMIGRATE=true` is the explicit opt-in

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -112,34 +112,40 @@ export const ENTITIES = [
 ];
 
 /**
- * Resolve TypeORM migration globs that work in both dev (TS source) and
- * Docker / k8s (compiled JS). TypeORM accepts an array of globs and
- * silently ignores any that don't match files, so listing all known
- * layouts is safe and idempotent.
+ * Resolve TypeORM migration globs for the runtime path. TypeORM accepts
+ * an array of globs and silently ignores any that don't match files, so
+ * listing the candidate layouts is safe and idempotent.
  *
- * Paths are absolute and use forward slashes (TypeORM's glob loader is
- * cross-platform but a few internals trip on backslashes on Windows).
+ * **Only `.js` patterns**, intentionally. TypeORM 0.3.x's
+ * `DirectoryExportedClassesLoader` loads matched files via
+ * `Promise.all(import(file))`. On Node ≥ 22, requiring `.ts` files (even
+ * after Nest+SWC transpilation) goes through the ESM loader and
+ * `Promise.all`-importing several at once trips Node's internal
+ * "Unexpected module status 0" assertion (a known race between
+ * `require()` and dynamic `import()` on the same module). Compiled JS
+ * doesn't hit this path. The manual `pnpm typeorm migration:generate /
+ * migration:run` commands keep their own `'.ts'` glob in
+ * `apps/api/typeorm.config.ts` and run under `ts-node`, which loads
+ * synchronously and is unaffected.
+ *
+ * Paths are absolute and use forward slashes (TypeORM's underlying glob
+ * engine — `globby` / `fast-glob` — handles forward-slash absolute paths
+ * correctly on Windows too).
  *
  *   - Docker / prod:        `/app/dist/migrations/*.js` (cwd = /app)
  *   - Local API workspace:  `apps/api/dist/migrations/*.js` (from repo root)
- *   - Local API workspace:  `apps/api/src/migrations/*.ts` (ts-node / SWC)
- *   - From apps/api cwd:    `src/migrations/*.ts` and `dist/migrations/*.js`
+ *   - From apps/api cwd:    `dist/migrations/*.js`
  *
- * Windows note: `process.cwd()` returns `C:\…` on Windows; the `.replace`
- * below normalises to forward slashes. TypeORM's underlying glob engine
- * (`globby` / `fast-glob`) treats forward-slash absolute paths on Windows
- * correctly, so `C:/Users/…/migrations/*.ts` resolves. If a Windows dev
- * ever sees zero migrations loaded despite running `pnpm dev:api`, check
- * `databaseConfig().migrations` and confirm the cwd path.
+ * For local dev: run `pnpm build --filter ever-works-api` (or `pnpm dev`
+ * which builds before watching) to populate `apps/api/dist/migrations/`,
+ * then the API will pick up pending migrations on next boot. Authoring
+ * a new migration still goes through `pnpm typeorm migration:generate`
+ * (which produces `.ts` next to the existing ones) — the build step
+ * compiles it to `.js` automatically.
  */
 function resolveMigrationGlobs(): string[] {
     const cwd = process.cwd().replace(/\\/g, '/');
-    return [
-        `${cwd}/dist/migrations/*.js`,
-        `${cwd}/src/migrations/*.ts`,
-        `${cwd}/apps/api/dist/migrations/*.js`,
-        `${cwd}/apps/api/src/migrations/*.ts`,
-    ];
+    return [`${cwd}/dist/migrations/*.js`, `${cwd}/apps/api/dist/migrations/*.js`];
 }
 
 export const databaseConfig = registerAs('database', (): DatabaseConfig => {


### PR DESCRIPTION
## Summary

Follow-up to PR #840 — E2E run [26059014536](https://github.com/ever-works/ever-works/actions/runs/26059014536) caught a Node-level race between TypeORM's parallel migration loader and Node 22's ESM↔CJS interop on `.ts` files:

```
Error [ERR_INTERNAL_ASSERTION]: Unexpected module status 0.
Cannot require() ES Module
…/apps/api/src/migrations/1779500000000-DropLegacyAuthSessionTokenIndexH01.ts
because it is not yet fully loaded. This may be caused by a race
condition if the module is simultaneously dynamically import()-ed
via Promise.all().
```

TypeORM 0.3.x's `DirectoryExportedClassesLoader` loads matched files via `Promise.all(import(file))`. On Node ≥ 22, importing several `.ts` files concurrently trips Node's internal "Unexpected module status 0" assertion (a known race between `require()` and dynamic `import()` on the same module).

## Fix

Drop the two `.ts` globs from the runtime config in `packages/agent/src/database/database.config.ts`. Compiled `.js` doesn't hit the race. The manual `pnpm typeorm migration:generate / migration:run` commands keep their own `'.ts'` glob in `apps/api/typeorm.config.ts` and run under ts-node, which loads synchronously.

## Effect

- Runtime config: `.js` only. Boot loads from `${cwd}/dist/migrations/*.js` or `${cwd}/apps/api/dist/migrations/*.js`.
- Dev workflow updated in jsdoc: after `pnpm typeorm migration:generate`, run `pnpm build --filter ever-works-api` so the new `.ts` migration is compiled to `.js` and picked up on next boot.
- Docs updated: `docs/specs/architecture/database.md` §6.3 explains the race + the dev workflow.
- All 35 `database.config.spec.ts` tests pass locally.

## Test plan

- [ ] CI E2E green (the failure that prompted this fix).
- [ ] Stage smoke after develop→stage cascade.
- [ ] Main smoke after stage→main cascade — OAuth login on `app.ever.works` should finally work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)