### PR TITLE
fix(db): gate migrationsRun on !synchronize (TypeORM order trap)

### DIFF
--- a/docs/specs/architecture/database.md
+++ b/docs/specs/architecture/database.md
@@ -233,6 +233,16 @@ silently left prod with no migration runner for several deploys:
   migrations from the `migrations` array). Default `true` outside
   test. **Stays on in prod** so every API pod boot self-heals.
 
+**Mutual exclusion (TypeORM order trap).** When `synchronize: true`
+is on, the runtime config forces `migrationsRun: false` regardless of
+`RUN_MIGRATIONS`. The reason: `DataSource.initialize()` runs migrations
+**before** synchronize, so any ALTER-style migration would hit an
+empty schema and fail. Synchronize bootstraps the full schema from
+entities; migrations are only meaningful in environments with real
+persisted data (prod / stage). This mutual exclusion is what makes
+the E2E suite work (`DATABASE_AUTOMIGRATE=true` for fast empty-DB
+bootstrap, migrations skipped automatically).
+
 ### 6.4 Schema-change workflow (the rule for AI agents and humans)
 
 Every TypeORM entity / schema change MUST ship with a migration in

--- a/packages/agent/src/database/database.config.spec.ts
+++ b/packages/agent/src/database/database.config.spec.ts
@@ -315,9 +315,10 @@ describe('database.config', () => {
                 }
             });
 
-            it('migrationsRun=true when runMigrations()=true and appType=api', () => {
+            it('migrationsRun=true when runMigrations()=true and appType=api and autoMigrate()=false (prod-shape)', () => {
                 cfgMock.getAppType.mockReturnValue('api');
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false);
                 const result = (databaseConfig as any)();
                 expect(result.migrationsRun).toBe(true);
             });
@@ -325,6 +326,7 @@ describe('database.config', () => {
             it('migrationsRun=false when runMigrations()=false (kill switch wins)', () => {
                 cfgMock.getAppType.mockReturnValue('api');
                 cfgMock.database.runMigrations.mockReturnValue(false);
+                cfgMock.database.autoMigrate.mockReturnValue(false);
                 const result = (databaseConfig as any)();
                 expect(result.migrationsRun).toBe(false);
             });
@@ -332,7 +334,21 @@ describe('database.config', () => {
             it('migrationsRun=false for CLI even when runMigrations()=true (CLI uses synchronize)', () => {
                 cfgMock.getAppType.mockReturnValue('cli');
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false);
                 const result = (databaseConfig as any)();
+                expect(result.migrationsRun).toBe(false);
+            });
+
+            it('migrationsRun=false when synchronize is ON (mutual exclusion — TypeORM order trap)', () => {
+                // TypeORM `DataSource.initialize()` runs migrationsRun BEFORE
+                // synchronize. With synchronize=true the schema is built from
+                // entities, so any ALTER-style migration would fail against
+                // an empty DB first. The test/E2E env needs synchronize-only.
+                cfgMock.getAppType.mockReturnValue('api');
+                cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(true);
+                const result = (databaseConfig as any)();
+                expect(result.synchronize).toBe(true);
                 expect(result.migrationsRun).toBe(false);
             });
 
@@ -340,6 +356,7 @@ describe('database.config', () => {
                 cfgMock.database.getType.mockReturnValue('postgres');
                 cfgMock.database.getHost.mockReturnValue('db.example.com');
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false); // prod-shape
                 const result = (databaseConfig as any)();
                 expect(result.type).toBe('postgres');
                 expect(result.migrationsRun).toBe(true);
@@ -351,19 +368,21 @@ describe('database.config', () => {
                 cfgMock.database.getUrl.mockReturnValue('postgres://u:p@h:5432/d');
                 parseMock.mockReturnValue({ database: 'd' } as any);
                 cfgMock.database.runMigrations.mockReturnValue(true);
+                cfgMock.database.autoMigrate.mockReturnValue(false); // prod-shape
                 const result = (databaseConfig as any)();
                 expect(result.url).toBe('postgres://u:p@h:5432/d');
                 expect(result.migrationsRun).toBe(true);
                 expect(Array.isArray(result.migrations)).toBe(true);
             });
 
-            it('migrations + migrationsRun flow through SQLite branch', () => {
+            it('migrations array is always present in SQLite branch (E2E shape: synchronize on, migrationsRun off)', () => {
                 cfgMock.database.getType.mockReturnValue('better-sqlite3');
                 cfgMock.getEnvironment.mockReturnValue('test');
+                // autoMigrate=true by default in resetMocks, simulating E2E.
                 const result = (databaseConfig as any)();
                 expect(result.type).toBe('better-sqlite3');
-                // appType=api in resetMocks; runMigrations=true; migrationsRun=true.
-                expect(result.migrationsRun).toBe(true);
+                expect(result.synchronize).toBe(true);
+                expect(result.migrationsRun).toBe(false); // gated off by autoMigrate
                 expect(Array.isArray(result.migrations)).toBe(true);
             });
         });

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -153,10 +153,19 @@ export const databaseConfig = registerAs('database', (): DatabaseConfig => {
     const appType = config.getAppType() || 'api';
     let dbType = config.database.getType();
 
-    // `migrationsRun` is gated on the API app type — CLI uses synchronize
-    // for its local SQLite (`DatabaseInitService` does that), so it has no
-    // use for the migrations table.
-    const migrationsRun = appType === 'api' && config.database.runMigrations();
+    // `migrationsRun` is gated on:
+    //   - API app type only — CLI uses synchronize for its local SQLite
+    //     (`DatabaseInitService` does that), so it has no use for the
+    //     migrations table.
+    //   - `!autoMigrate()` — when synchronize is ON (test / E2E), TypeORM's
+    //     `DataSource.initialize()` runs `migrationsRun` BEFORE
+    //     `synchronize`, so any ALTER-style migration would fail against
+    //     the still-empty schema. Synchronize bootstraps the full schema
+    //     from entities and the migrations table catches up implicitly;
+    //     migrations are only needed in environments with real persisted
+    //     data (prod/stage).
+    const migrationsRun =
+        appType === 'api' && config.database.runMigrations() && !config.database.autoMigrate();
 
     const baseConfig: any = {
         entities: ENTITIES,


### PR DESCRIPTION
## Summary

Follow-up to PR #842 — E2E run [26060289174](https://github.com/ever-works/ever-works/actions/runs/26060289174) caught a second real bug after the `.ts` glob fix landed: TypeORM `DataSource.initialize()` runs `migrationsRun` BEFORE `synchronize`. So even when E2E correctly sets `DATABASE_AUTOMIGRATE=true` for the empty-DB bootstrap, migrations execute first and the first ALTER fails:

```
Migration "AddActivityLogIngestEventId1778677529777" failed,
error: Table "activity_log" does not exist.
```

## Fix

Make the two flags mutually exclusive in `database.config.ts`:

```ts
const migrationsRun =
    appType === 'api' &&
    config.database.runMigrations() &&
    !config.database.autoMigrate();
```

The semantics:
- `synchronize: true` (no persisted data — test / E2E) → migrations skipped automatically. Schema bootstraps from entities.
- `synchronize: false` (real DB — prod / stage) → migrations apply deltas.

There's no realistic use case for both at once, and the order trap above is exactly the kind of footgun this gate prevents.

## Test coverage

- New test `migrationsRun=false when synchronize is ON (mutual exclusion — TypeORM order trap)` explicitly pins the behaviour.
- Pre-existing dbType-branch tests adjusted: prod-shape ones now pass `autoMigrate=false`, the SQLite branch test rewritten to encode the E2E shape (synchronize on, migrationsRun off automatic).
- All 36 db config tests pass locally.

## Docs

`docs/specs/architecture/database.md` §6.3 adds the "Mutual exclusion (TypeORM order trap)" paragraph.

## Test plan

- [ ] CI green on develop after merge (lint-and-test).
- [ ] E2E green on the next develop→stage cascade attempt.
- [ ] Stage smoke after merge — first API pod boot should apply migrations and Google/GitHub sign-in should work on `stage.app.ever.works`.
- [ ] Main cascade after stage validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)