### PR TITLE
feat(templates): tighten AI prompt, strip samples on clone, push SITE_URL + WEBHOOK_SECRET

### DIFF
--- a/apps/api/src/migrations/1779600000000-AddWebhookSecretEncrypted.ts
+++ b/apps/api/src/migrations/1779600000000-AddWebhookSecretEncrypted.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds `works.webhookSecretEncrypted` for the per-Work persistent
+ * `WEBHOOK_SECRET` baked into the deployed minimal-template site at build
+ * time.
+ *
+ * The deployed site's `@ever-works/astro-integration` reads
+ * `process.env.WEBHOOK_SECRET` and registers an authenticated `/api/webhook`
+ * endpoint that verifies incoming GitHub push notifications via
+ * X-Hub-Signature-256. Rotating the secret on every deploy would silently
+ * break verification until the GitHub-side webhook registration was also
+ * updated. Persisting it per-Work — same pattern as `platformSyncSecretEncrypted`
+ * — keeps the secret stable across redeploys unless explicitly rotated via
+ * `WebhookSecretService.rotate()`.
+ *
+ * Forward-only, additive. The column is nullable; existing rows stay NULL
+ * until their next deploy lazily provisions a value via
+ * `WebhookSecretService.getOrGenerate`. No backfill required.
+ */
+export class AddWebhookSecretEncrypted1779600000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasColumn('works', 'webhookSecretEncrypted'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'webhookSecretEncrypted',
+                    type: 'text',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasColumn('works', 'webhookSecretEncrypted')) {
+            await queryRunner.dropColumn('works', 'webhookSecretEncrypted');
+        }
+    }
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
@@ -154,7 +154,10 @@ describe('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + real 
         const platformSyncSecretService = {
             getOrGenerate: jest.fn().mockResolvedValue('platform-sync-secret'),
         };
-        // 9th DI arg added on develop post-EW-616 — Ever Works DNS service.
+        const webhookSecretService = {
+            getOrGenerate: jest.fn().mockResolvedValue('webhook-secret-persisted'),
+        };
+        // 10th DI arg added on develop post-EW-616 — Ever Works DNS service.
         // No deploy path under test reaches it, so a typeless stub is fine.
         const dnsService = {};
         // 10th DI arg — zero-friction funnel telemetry. Stub emit() so
@@ -176,6 +179,7 @@ describe('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + real 
             websiteTemplateResolver as any,
             eventEmitter,
             platformSyncSecretService as any,
+            webhookSecretService as any,
             dnsService as any,
             funnel as any,
         );

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -689,6 +689,62 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         });
     });
 
+    describe('SITE_URL + WEBHOOK_SECRET (Astro minimal-template parity)', () => {
+        it('pushes WEBHOOK_SECRET for every deploy (per-Work random token, like CRON_SECRET)', async () => {
+            const { service, githubPlugin } = buildService({
+                plugin: { id: 'legacy' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+            // Both per-deploy random tokens are present and distinct.
+            expect(byKey.WEBHOOK_SECRET).toBeDefined();
+            expect(byKey.WEBHOOK_SECRET).toMatch(/^[0-9a-f]{64}$/);
+            expect(byKey.CRON_SECRET).toBeDefined();
+            expect(byKey.WEBHOOK_SECRET).not.toBe(byKey.CRON_SECRET);
+        });
+
+        it('derives SITE_URL from settings.ingressHost when applyEverWorksSubdomain set it', async () => {
+            const { service, githubPlugin, dnsService } = buildService({
+                deployProvider: 'ever-works',
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                settings: { kubeconfig: 'apiVersion: v1' },
+            });
+            // Activate the DNS provider so applyEverWorksSubdomain templates
+            // `ingressHost` onto settings.
+            (dnsService.getProvider as jest.Mock).mockReturnValue({});
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+            expect(byKey.SITE_URL).toBe('https://my-site.ever.works');
+        });
+
+        it('does NOT push SITE_URL when ingressHost is unset (non-ever-works providers, or DNS unconfigured)', async () => {
+            const { service, githubPlugin } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml'],
+                    getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+                },
+                settings: { token: 'v1' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+            expect(keys).not.toContain('SITE_URL');
+        });
+    });
+
     describe('default deployProvider fallback (EW-617 G6)', () => {
         // When work.deployProvider is null/empty (e.g. older row pre-migration
         // or anonymous quick-create that hasn't picked a provider yet), the

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -138,6 +138,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             getOrGenerate: jest.fn().mockResolvedValue('hex'.repeat(21) + 'h'), // 64 hex chars
         };
 
+        // Same per-Work-persistent shape as PlatformSyncSecretService.
+        const webhookSecretService = {
+            getOrGenerate: jest.fn().mockResolvedValue('webhook'.repeat(9) + 'a'), // 64 chars
+        };
+
         // EW-617 G5: DNS automation no-ops in tests (no env vars). The
         // dns service still needs to be present so the constructor wires
         // — `getProvider` returns null and `ensureWorkSubdomain` is a
@@ -162,6 +167,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             websiteTemplateResolver as any,
             eventEmitter as any,
             platformSyncSecretService as any,
+            webhookSecretService as any,
             dnsService as any,
             funnel as any,
         );
@@ -176,6 +182,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             githubPlugin,
             eventEmitter,
             platformSyncSecretService,
+            webhookSecretService,
             dnsService,
             funnel,
         };
@@ -690,8 +697,8 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
     });
 
     describe('SITE_URL + WEBHOOK_SECRET (Astro minimal-template parity)', () => {
-        it('pushes WEBHOOK_SECRET for every deploy (per-Work random token, like CRON_SECRET)', async () => {
-            const { service, githubPlugin } = buildService({
+        it('pushes WEBHOOK_SECRET via the persistent per-Work store (not regenerated each deploy)', async () => {
+            const { service, githubPlugin, webhookSecretService } = buildService({
                 plugin: { id: 'legacy' },
             });
 
@@ -699,14 +706,49 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
 
             const { secrets } = captureCalls(githubPlugin);
             const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
-            // Both per-deploy random tokens are present and distinct.
-            expect(byKey.WEBHOOK_SECRET).toBeDefined();
-            expect(byKey.WEBHOOK_SECRET).toMatch(/^[0-9a-f]{64}$/);
+            // Must call into the persistence-aware service, not regenerate ad-hoc.
+            expect(webhookSecretService.getOrGenerate).toHaveBeenCalledWith('work-1');
+            expect(byKey.WEBHOOK_SECRET).toBe('webhook'.repeat(9) + 'a');
+            // Distinct from CRON_SECRET (which IS per-deploy by design).
             expect(byKey.CRON_SECRET).toBeDefined();
             expect(byKey.WEBHOOK_SECRET).not.toBe(byKey.CRON_SECRET);
         });
 
-        it('derives SITE_URL from settings.ingressHost when applyEverWorksSubdomain set it', async () => {
+        it('reuses the SAME WEBHOOK_SECRET across multiple deploys of the same Work (no rotation drift)', async () => {
+            const { service, githubPlugin, webhookSecretService } = buildService({
+                plugin: { id: 'legacy' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+            await service.deploy('work-1', 'user-1', {});
+
+            // Both deploys must have consulted the same persistent store,
+            // producing the same plaintext both times.
+            expect(webhookSecretService.getOrGenerate).toHaveBeenCalledTimes(2);
+            const webhookSecretsPushed = githubPlugin.setActionSecret.mock.calls
+                .map((c: any[]) => c[0])
+                .filter((s: any) => s.key === 'WEBHOOK_SECRET')
+                .map((s: any) => s.value);
+            expect(webhookSecretsPushed).toHaveLength(2);
+            expect(webhookSecretsPushed[0]).toBe(webhookSecretsPushed[1]);
+        });
+
+        it('does NOT block the deploy when webhookSecretService.getOrGenerate throws', async () => {
+            const { service, githubPlugin, webhookSecretService } = buildService({
+                plugin: { id: 'legacy' },
+            });
+            webhookSecretService.getOrGenerate.mockRejectedValueOnce(new Error('encryption key missing'));
+
+            await expect(service.deploy('work-1', 'user-1', {})).resolves.toMatchObject({
+                dispatched: true,
+            });
+            const secretKeys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
+            expect(secretKeys).not.toContain('WEBHOOK_SECRET');
+            // CRON_SECRET still landed — webhook failure is contained.
+            expect(secretKeys).toContain('CRON_SECRET');
+        });
+
+        it('derives SITE_URL from settings.ingressHost when applyEverWorksSubdomain set it, and writes it as a variable not a secret', async () => {
             const { service, githubPlugin, dnsService } = buildService({
                 deployProvider: 'ever-works',
                 plugin: {
@@ -722,9 +764,14 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
 
             await service.deploy('work-1', 'user-1', {});
 
-            const { secrets } = captureCalls(githubPlugin);
-            const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
-            expect(byKey.SITE_URL).toBe('https://my-site.ever.works');
+            const { secrets, variables } = captureCalls(githubPlugin);
+            const varByKey = Object.fromEntries(variables.map((v: any) => [v.key, v.value]));
+            // Public URL: pushed as a variable (visible/overridable in repo
+            // settings UI), not buried as a secret.
+            expect(varByKey.SITE_URL).toBe('https://my-site.ever.works');
+            // Belt-and-suspenders: must NOT also be in secrets.
+            const secretKeys = secrets.map((s: any) => s.key);
+            expect(secretKeys).not.toContain('SITE_URL');
         });
 
         it('does NOT push SITE_URL when ingressHost is unset (non-ever-works providers, or DNS unconfigured)', async () => {
@@ -740,8 +787,9 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
 
             await service.deploy('work-1', 'user-1', {});
 
-            const keys = captureCalls(githubPlugin).secrets.map((s: any) => s.key);
-            expect(keys).not.toContain('SITE_URL');
+            const { secrets, variables } = captureCalls(githubPlugin);
+            expect(secrets.map((s: any) => s.key)).not.toContain('SITE_URL');
+            expect(variables.map((v: any) => v.key)).not.toContain('SITE_URL');
         });
     });
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -198,6 +198,7 @@ export class DeployService {
         await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
+        await this.ensureWebhookSecret(ctx);
 
         const template = await this.websiteTemplateResolver.resolveForWork(work);
         const targetBranch = env.branch ?? template.branch;
@@ -516,6 +517,30 @@ export class DeployService {
             this.setSecret(ctx, 'DEPLOY_TOKEN', deployToken),
         ]);
 
+        // SITE_URL — used by the deployed site for canonical URLs, sitemap.xml,
+        // RSS/Atom self-references, and OpenGraph. Falls back to placeholders
+        // when not set, which is fine for builds but bad for SEO on a live site.
+        //
+        // When `applyEverWorksSubdomain` resolved an `ingressHost` (i.e.
+        // `deployProvider === 'ever-works'` with Cloudflare DNS configured),
+        // SITE_URL is derived from it as `https://${ingressHost}`. For all
+        // other providers we leave SITE_URL unset and rely on the template's
+        // own fallback (the user can override in the Vercel project's env
+        // dashboard, or set SITE_URL in their own GitHub secrets after the
+        // fact).
+        const ingressHost = settings?.ingressHost;
+        if (typeof ingressHost === 'string' && ingressHost.trim().length > 0) {
+            try {
+                await this.setSecret(ctx, 'SITE_URL', `https://${ingressHost.trim()}`);
+            } catch (error: any) {
+                this.logger.error(
+                    `Failed to push SITE_URL secret for work ${work.id} on ${ctx.owner}/${ctx.repo}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+
         // EW-120 dual-mode Activity Feed sync — push the secrets for the
         // active transport only. Disabled mode pushes nothing.
         //
@@ -767,6 +792,31 @@ export class DeployService {
         // Always set a cron secret for new deployments
         const cronSecret = this.generateSecureToken();
         await this.setSecret(ctx, 'CRON_SECRET', cronSecret);
+    }
+
+    /**
+     * Provision a per-Work `WEBHOOK_SECRET` so the deployed site's content-sync
+     * webhook endpoint can verify incoming GitHub push notifications. The
+     * minimal template's `@ever-works/astro-integration` reads this from
+     * `process.env.WEBHOOK_SECRET` at build time and registers a verifying
+     * `/api/webhook` endpoint iff defined; classic template ignores it. Push
+     * unconditionally — harmless on templates that don't consume it, required
+     * on templates that do.
+     *
+     * Failure is logged but not thrown — webhook verification degrades to
+     * "polling-only" rather than blocking the deploy.
+     */
+    private async ensureWebhookSecret(ctx: RepoContext) {
+        try {
+            const webhookSecret = this.generateSecureToken();
+            await this.setSecret(ctx, 'WEBHOOK_SECRET', webhookSecret);
+        } catch (error: any) {
+            this.logger.warn(
+                `Failed to push WEBHOOK_SECRET for ${ctx.owner}/${ctx.repo}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     private generateSecureToken(): string {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -19,7 +19,11 @@ import {
     DeploymentEnvironment,
     DeploymentTriggerSource,
 } from '@ever-works/agent/entities';
-import { PlatformSyncSecretService, ZeroFrictionFunnelService } from '@ever-works/agent/services';
+import {
+    PlatformSyncSecretService,
+    WebhookSecretService,
+    ZeroFrictionFunnelService,
+} from '@ever-works/agent/services';
 import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
 import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import {
@@ -107,6 +111,7 @@ export class DeployService {
         private readonly websiteTemplateResolver: WebsiteTemplateResolverService,
         private readonly eventEmitter: EventEmitter2,
         private readonly platformSyncSecretService: PlatformSyncSecretService,
+        private readonly webhookSecretService: WebhookSecretService,
         private readonly dnsService: EverWorksDnsService,
         private readonly funnel: ZeroFrictionFunnelService,
     ) {}
@@ -198,7 +203,7 @@ export class DeployService {
         await this.setKubernetesGhcrPullSecret(ctx, work, userId);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
-        await this.ensureWebhookSecret(ctx);
+        await this.ensureWebhookSecret(ctx, work);
 
         const template = await this.websiteTemplateResolver.resolveForWork(work);
         const targetBranch = env.branch ?? template.branch;
@@ -521,20 +526,26 @@ export class DeployService {
         // RSS/Atom self-references, and OpenGraph. Falls back to placeholders
         // when not set, which is fine for builds but bad for SEO on a live site.
         //
+        // Pushed as a **GitHub Actions variable** (not a secret) — it is a
+        // public URL with no security sensitivity, and storing it as a variable
+        // makes it visible in the repo's Settings → Actions UI and easily
+        // overridable from the dashboard without a redeploy. Mirrors
+        // DEPLOY_PROVIDER's posture.
+        //
         // When `applyEverWorksSubdomain` resolved an `ingressHost` (i.e.
         // `deployProvider === 'ever-works'` with Cloudflare DNS configured),
         // SITE_URL is derived from it as `https://${ingressHost}`. For all
         // other providers we leave SITE_URL unset and rely on the template's
         // own fallback (the user can override in the Vercel project's env
-        // dashboard, or set SITE_URL in their own GitHub secrets after the
+        // dashboard, or set SITE_URL in the repo's Variables after the
         // fact).
         const ingressHost = settings?.ingressHost;
         if (typeof ingressHost === 'string' && ingressHost.trim().length > 0) {
             try {
-                await this.setSecret(ctx, 'SITE_URL', `https://${ingressHost.trim()}`);
+                await this.setVariable(ctx, 'SITE_URL', `https://${ingressHost.trim()}`);
             } catch (error: any) {
                 this.logger.error(
-                    `Failed to push SITE_URL secret for work ${work.id} on ${ctx.owner}/${ctx.repo}: ${
+                    `Failed to push SITE_URL variable for work ${work.id} on ${ctx.owner}/${ctx.repo}: ${
                         error instanceof Error ? error.message : String(error)
                     }`,
                 );
@@ -795,20 +806,28 @@ export class DeployService {
     }
 
     /**
-     * Provision a per-Work `WEBHOOK_SECRET` so the deployed site's content-sync
-     * webhook endpoint can verify incoming GitHub push notifications. The
-     * minimal template's `@ever-works/astro-integration` reads this from
-     * `process.env.WEBHOOK_SECRET` at build time and registers a verifying
-     * `/api/webhook` endpoint iff defined; classic template ignores it. Push
-     * unconditionally — harmless on templates that don't consume it, required
-     * on templates that do.
+     * Provision the per-Work `WEBHOOK_SECRET` so the deployed site's
+     * content-sync webhook endpoint can verify incoming GitHub push
+     * notifications. The minimal template's `@ever-works/astro-integration`
+     * reads this from `process.env.WEBHOOK_SECRET` at build time and
+     * registers a verifying `/api/webhook` endpoint iff defined; classic
+     * template ignores it. Pushed on every deploy (harmless on templates
+     * that don't consume it, required on templates that do).
+     *
+     * **Persistence**: the secret value is read from (and lazily provisioned
+     * onto) `Work.webhookSecretEncrypted` via `WebhookSecretService` so the
+     * same plaintext is pushed across every deploy of the same Work. Rotating
+     * on every deploy would silently invalidate the GitHub-side webhook
+     * registration — every payload would fail X-Hub-Signature-256 verification
+     * until the workflow re-registered the webhook. The persistence pattern
+     * mirrors `PlatformSyncSecretService` for the EW-120 pull-mode HMAC.
      *
      * Failure is logged but not thrown — webhook verification degrades to
      * "polling-only" rather than blocking the deploy.
      */
-    private async ensureWebhookSecret(ctx: RepoContext) {
+    private async ensureWebhookSecret(ctx: RepoContext, work: Work) {
         try {
-            const webhookSecret = this.generateSecureToken();
+            const webhookSecret = await this.webhookSecretService.getOrGenerate(work.id);
             await this.setSecret(ctx, 'WEBHOOK_SECRET', webhookSecret);
         } catch (error: any) {
             this.logger.warn(

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -358,6 +358,23 @@ export class WorkRepository {
     }
 
     /**
+     * Conditional UPDATE for the lazy bootstrap of `webhookSecretEncrypted`.
+     * Same race-safe semantics as `setPlatformSyncSecretIfNull` — the first
+     * deploy that wins the conditional UPDATE persists its randomly-generated
+     * plaintext; concurrent deploys re-read.
+     */
+    async setWebhookSecretIfNull(workId: string, encrypted: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Work)
+            .set({ webhookSecretEncrypted: encrypted })
+            .where('id = :id', { id: workId })
+            .andWhere('webhookSecretEncrypted IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
      * Update platform-sync observability columns after a pull-transport
      * round-trip. Pass `lastSuccessAt` on success or
      * `{ lastErrorAt, lastErrorMessage }` on failure — partial updates are

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -278,6 +278,17 @@ export class Work {
     @Column({ type: 'text', nullable: true })
     platformSyncSecretEncrypted?: string | null;
 
+    // AES-256-GCM-encrypted per-Work webhook secret used by the deployed
+    // site's `/api/webhook` endpoint (registered by the minimal template's
+    // `@ever-works/astro-integration` when `process.env.WEBHOOK_SECRET` is
+    // set at build time) to verify incoming GitHub push notifications via
+    // X-Hub-Signature-256. Persistent across deploys so a GH-side webhook
+    // registered once stays valid through subsequent redeploys (rotating
+    // would silently break signature verification until the workflow
+    // re-registers the webhook). NULL until the first deploy provisions it.
+    @Column({ type: 'text', nullable: true })
+    webhookSecretEncrypted?: string | null;
+
     // Pull-mode observability — drives the degraded banner UX.
     @TimestampColumn({ nullable: true })
     platformSyncLastSuccessAt?: Date | null;

--- a/packages/agent/src/services/__tests__/webhook-secret.service.spec.ts
+++ b/packages/agent/src/services/__tests__/webhook-secret.service.spec.ts
@@ -1,0 +1,177 @@
+import { randomBytes } from 'crypto';
+import { WebhookSecretService } from '../webhook-secret.service';
+import { WorkRepository } from '../../database/repositories/work.repository';
+import { Work } from '../../entities';
+
+type RepoMock = jest.Mocked<
+    Pick<WorkRepository, 'findById' | 'setWebhookSecretIfNull' | 'update'>
+>;
+
+const VALID_KEY_HEX = randomBytes(32).toString('hex');
+
+function buildRepoMock(): RepoMock {
+    return {
+        findById: jest.fn(),
+        setWebhookSecretIfNull: jest.fn(),
+        update: jest.fn(),
+    } as unknown as RepoMock;
+}
+
+function makeWork(overrides: Partial<Work> = {}): Work {
+    const work = new Work();
+    work.id = 'work-1';
+    work.webhookSecretEncrypted = null;
+    Object.assign(work, overrides);
+    return work;
+}
+
+describe('WebhookSecretService', () => {
+    let repo: RepoMock;
+    let service: WebhookSecretService;
+    const ORIGINAL_ENV_KEY = process.env.PLATFORM_ENCRYPTION_KEY;
+
+    beforeEach(() => {
+        process.env.PLATFORM_ENCRYPTION_KEY = VALID_KEY_HEX;
+        repo = buildRepoMock();
+        service = new WebhookSecretService(repo as unknown as WorkRepository);
+    });
+
+    afterEach(() => {
+        if (ORIGINAL_ENV_KEY === undefined) {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+        } else {
+            process.env.PLATFORM_ENCRYPTION_KEY = ORIGINAL_ENV_KEY;
+        }
+    });
+
+    describe('configuration validation', () => {
+        it('throws when PLATFORM_ENCRYPTION_KEY is missing', async () => {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+            service = new WebhookSecretService(repo as unknown as WorkRepository);
+            repo.findById.mockResolvedValue(makeWork());
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(
+                /PLATFORM_ENCRYPTION_KEY is not set/,
+            );
+        });
+
+        it('throws when PLATFORM_ENCRYPTION_KEY is not hex', async () => {
+            process.env.PLATFORM_ENCRYPTION_KEY = 'not-hex-string!!';
+            service = new WebhookSecretService(repo as unknown as WorkRepository);
+            repo.findById.mockResolvedValue(makeWork());
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(/must be a hex string/);
+        });
+
+        it('throws when key decodes to wrong byte length', async () => {
+            process.env.PLATFORM_ENCRYPTION_KEY = '00112233';
+            service = new WebhookSecretService(repo as unknown as WorkRepository);
+            repo.findById.mockResolvedValue(makeWork());
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(
+                /must decode to 32 bytes/,
+            );
+        });
+    });
+
+    describe('getOrGenerate', () => {
+        it('generates, persists, and returns plaintext when no secret exists', async () => {
+            repo.findById.mockResolvedValueOnce(makeWork({ webhookSecretEncrypted: null }));
+            repo.setWebhookSecretIfNull.mockResolvedValue(true);
+
+            const plaintext = await service.getOrGenerate('work-1');
+
+            expect(plaintext).toMatch(/^[0-9a-f]{64}$/);
+            expect(repo.setWebhookSecretIfNull).toHaveBeenCalledWith(
+                'work-1',
+                expect.any(String),
+            );
+            // Persistence must not leak plaintext — the conditional UPDATE
+            // gets the encrypted envelope, never the raw value.
+            const enc = repo.setWebhookSecretIfNull.mock.calls[0][1];
+            expect(enc).not.toBe(plaintext);
+            expect(enc.length).toBeGreaterThan(0);
+        });
+
+        it('decrypts and returns the existing secret on subsequent calls (no rotation)', async () => {
+            // Round-trip a known plaintext.
+            repo.findById.mockResolvedValueOnce(makeWork());
+            repo.setWebhookSecretIfNull.mockResolvedValue(true);
+            const first = await service.getOrGenerate('work-1');
+            const persistedEnvelope = repo.setWebhookSecretIfNull.mock.calls[0][1];
+
+            // Second call: row now has the encrypted value.
+            repo.findById.mockResolvedValueOnce(
+                makeWork({ webhookSecretEncrypted: persistedEnvelope }),
+            );
+            const second = await service.getOrGenerate('work-1');
+
+            expect(second).toBe(first);
+            // setWebhookSecretIfNull only called once (the first time).
+            expect(repo.setWebhookSecretIfNull).toHaveBeenCalledTimes(1);
+        });
+
+        it('re-reads the persisted value when the conditional UPDATE loses the race', async () => {
+            // First findById sees no secret, the UPDATE returns false
+            // (someone else won), the loser re-reads and decrypts.
+            //
+            // Round-trip a known plaintext into an envelope first so the
+            // re-read can decrypt it back.
+            repo.findById.mockResolvedValueOnce(makeWork());
+            repo.setWebhookSecretIfNull.mockResolvedValueOnce(true);
+            const winningPlaintext = await service.getOrGenerate('work-1');
+            const persistedEnvelope = repo.setWebhookSecretIfNull.mock.calls[0][1];
+
+            // New service instance to clear state; simulate the losing race.
+            service = new WebhookSecretService(repo as unknown as WorkRepository);
+            repo.findById
+                .mockResolvedValueOnce(makeWork({ webhookSecretEncrypted: null }))
+                .mockResolvedValueOnce(
+                    makeWork({ webhookSecretEncrypted: persistedEnvelope }),
+                );
+            repo.setWebhookSecretIfNull.mockResolvedValueOnce(false);
+
+            const result = await service.getOrGenerate('work-1');
+
+            expect(result).toBe(winningPlaintext);
+            expect(repo.findById).toHaveBeenCalledTimes(3); // 1 winner + 1 loser-first + 1 loser-reread
+        });
+
+        it('throws when Work does not exist', async () => {
+            repo.findById.mockResolvedValueOnce(null);
+            await expect(service.getOrGenerate('missing')).rejects.toThrow(/Work not found/);
+        });
+
+        it('throws when the bootstrap race is lost but the value remains absent on re-read', async () => {
+            repo.findById
+                .mockResolvedValueOnce(makeWork())
+                .mockResolvedValueOnce(makeWork({ webhookSecretEncrypted: null }));
+            repo.setWebhookSecretIfNull.mockResolvedValueOnce(false);
+
+            await expect(service.getOrGenerate('work-1')).rejects.toThrow(
+                /bootstrap race lost/,
+            );
+        });
+    });
+
+    describe('rotate', () => {
+        it('writes a fresh secret unconditionally and returns the new plaintext', async () => {
+            repo.findById.mockResolvedValueOnce(makeWork({ webhookSecretEncrypted: 'old-env' }));
+            repo.update.mockResolvedValue(undefined as never);
+
+            const newPlaintext = await service.rotate('work-1');
+
+            expect(newPlaintext).toMatch(/^[0-9a-f]{64}$/);
+            expect(repo.update).toHaveBeenCalledWith(
+                'work-1',
+                expect.objectContaining({ webhookSecretEncrypted: expect.any(String) }),
+            );
+            const enc = (repo.update.mock.calls[0][1] as { webhookSecretEncrypted: string })
+                .webhookSecretEncrypted;
+            expect(enc).not.toBe(newPlaintext);
+            expect(enc).not.toBe('old-env');
+        });
+
+        it('throws when Work does not exist', async () => {
+            repo.findById.mockResolvedValueOnce(null);
+            await expect(service.rotate('missing')).rejects.toThrow(/Work not found/);
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -20,6 +20,7 @@ export * from './webhook-delivery.service';
 export * from './state-marker.service';
 export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
+export * from './webhook-secret.service';
 export * from './zero-friction-funnel.service';
 export * from './deploy-ready-poller.service';
 export * from './category-icon';

--- a/packages/agent/src/services/webhook-secret.service.ts
+++ b/packages/agent/src/services/webhook-secret.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { config } from '../config';
+import { WorkRepository } from '../database/repositories/work.repository';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH_BYTES = 32;
+const IV_LENGTH_BYTES = 12;
+const AUTH_TAG_LENGTH_BYTES = 16;
+const SECRET_LENGTH_BYTES = 32;
+
+/**
+ * Manages the per-Work `WEBHOOK_SECRET` baked into a deployed website's
+ * runtime env by `DeployService.setRequiredSecrets`.
+ *
+ * The minimal template's `@ever-works/astro-integration` reads
+ * `process.env.WEBHOOK_SECRET` at build time and registers an authenticated
+ * `/api/webhook` endpoint that verifies incoming GitHub push notifications
+ * via X-Hub-Signature-256. The classic template ignores the env var.
+ *
+ * **Why persistent**: rotating `WEBHOOK_SECRET` on every deploy would
+ * silently invalidate the GitHub-side webhook registration (which is
+ * configured with the OLD secret) — every incoming payload would fail
+ * verification until the workflow round-tripped the GH Webhooks API to
+ * update the registered secret. Treating it as a stable per-Work value
+ * mirrors how `PlatformSyncSecretService` handles the EW-120 pull-mode
+ * HMAC secret: lazily provisioned on first deploy, encrypted-at-rest with
+ * `PLATFORM_ENCRYPTION_KEY`, and only regenerated when explicitly rotated.
+ *
+ * Bootstrap is lazy: `getOrGenerate` is called by `DeployService` on every
+ * deploy. First deploy generates and persists; subsequent deploys read the
+ * existing value back. Concurrent deploys are race-safe via the conditional
+ * UPDATE in `WorkRepository.setWebhookSecretIfNull` — losers re-read.
+ *
+ * Rotation: `rotate()` writes a fresh secret unconditionally. The deployed
+ * site only learns the new value at the next deploy; admin UX should warn
+ * the operator that BOTH a redeploy AND a GitHub-side webhook-secret
+ * update are required.
+ */
+@Injectable()
+export class WebhookSecretService {
+    private readonly logger = new Logger(WebhookSecretService.name);
+    private cachedKey: Buffer | null = null;
+
+    constructor(private readonly workRepository: WorkRepository) {}
+
+    /**
+     * Lazily provision the per-Work webhook secret. Returns the plaintext hex.
+     *
+     * Concurrency: two simultaneous calls for the same Work both generate a
+     * fresh value, but only one wins the conditional UPDATE; the loser
+     * re-reads and returns the persisted value.
+     */
+    async getOrGenerate(workId: string): Promise<string> {
+        const existing = await this.workRepository.findById(workId);
+        if (!existing) {
+            throw new Error(`Work not found: ${workId}`);
+        }
+        if (existing.webhookSecretEncrypted) {
+            return this.decrypt(existing.webhookSecretEncrypted);
+        }
+        const plaintext = randomBytes(SECRET_LENGTH_BYTES).toString('hex');
+        const encrypted = this.encrypt(plaintext);
+        const won = await this.workRepository.setWebhookSecretIfNull(workId, encrypted);
+        if (won) {
+            return plaintext;
+        }
+        // Lost the race — another deploy generated it first. Read back.
+        const reread = await this.workRepository.findById(workId);
+        if (!reread?.webhookSecretEncrypted) {
+            throw new Error(
+                `Webhook secret bootstrap race lost but no value found for work ${workId}`,
+            );
+        }
+        return this.decrypt(reread.webhookSecretEncrypted);
+    }
+
+    /**
+     * Rotate the per-Work webhook secret unconditionally. Returns the new
+     * plaintext. The next deploy carries the new value to the site's
+     * runtime env; until the operator also updates the GitHub-side webhook
+     * registration with the new secret, incoming payloads will fail
+     * X-Hub-Signature-256 verification. Admin UX must call this out.
+     */
+    async rotate(workId: string): Promise<string> {
+        const existing = await this.workRepository.findById(workId);
+        if (!existing) {
+            throw new Error(`Work not found: ${workId}`);
+        }
+        const plaintext = randomBytes(SECRET_LENGTH_BYTES).toString('hex');
+        const encrypted = this.encrypt(plaintext);
+        await this.workRepository.update(workId, { webhookSecretEncrypted: encrypted });
+        this.logger.log(
+            `Rotated webhook secret for work ${workId} — redeploy AND GitHub-side webhook update required`,
+        );
+        return plaintext;
+    }
+
+    private getKey(): Buffer {
+        if (this.cachedKey) {
+            return this.cachedKey;
+        }
+        const hex = config.platformSync.getEncryptionKey();
+        if (!hex) {
+            throw new Error(
+                'PLATFORM_ENCRYPTION_KEY is not set. Required for encrypting per-Work webhook_secret.',
+            );
+        }
+        if (!/^[0-9a-fA-F]+$/.test(hex)) {
+            throw new Error('PLATFORM_ENCRYPTION_KEY must be a hex string.');
+        }
+        const key = Buffer.from(hex, 'hex');
+        if (key.length !== KEY_LENGTH_BYTES) {
+            throw new Error(
+                `PLATFORM_ENCRYPTION_KEY must decode to ${KEY_LENGTH_BYTES} bytes (got ${key.length}).`,
+            );
+        }
+        this.cachedKey = key;
+        return key;
+    }
+
+    private encrypt(plaintext: string): string {
+        const key = this.getKey();
+        const iv = randomBytes(IV_LENGTH_BYTES);
+        const cipher = createCipheriv(ALGORITHM, key, iv);
+        const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+        const authTag = cipher.getAuthTag();
+        return Buffer.concat([iv, authTag, ciphertext]).toString('base64');
+    }
+
+    private decrypt(envelope: string): string {
+        const key = this.getKey();
+        const buf = Buffer.from(envelope, 'base64');
+        if (buf.length < IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES + 1) {
+            throw new Error('webhook_secret envelope is malformed (too short).');
+        }
+        const iv = buf.subarray(0, IV_LENGTH_BYTES);
+        const authTag = buf.subarray(IV_LENGTH_BYTES, IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES);
+        const ciphertext = buf.subarray(IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES);
+        const decipher = createDecipheriv(ALGORITHM, key, iv);
+        decipher.setAuthTag(authTag);
+        try {
+            return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+        } catch (err) {
+            this.logger.error('Failed to decrypt webhook_secret', err);
+            throw new Error('webhook_secret decryption failed (auth tag mismatch).');
+        }
+    }
+}

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -147,6 +147,7 @@ import { WorksConfigWriterService } from '@src/works-config/services/works-confi
 import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
 import { SettingsSchemaValidatorService } from '../plugins/services/settings-schema-validator.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { WebhookSecretService } from './webhook-secret.service';
 import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { DeployReadyPollerService } from './deploy-ready-poller.service';
 import { CommunityPrModule } from '../community-pr/community-pr.module';
@@ -222,6 +223,7 @@ describe('WorkModule', () => {
             SettingsSchemaValidatorService,
             EverWorksDeployQuotaService,
             PlatformSyncSecretService,
+            WebhookSecretService,
             EverWorksGitProvider,
             EverWorksDnsService,
             ZeroFrictionFunnelService,
@@ -303,14 +305,16 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 31-entry shape (28 services + 3 re-exported modules)', () => {
+        it('keeps the exports list at the documented 32-entry shape (29 services + 3 re-exported modules)', () => {
             // Bumped to 28 with the PlatformSyncSecretService resurrection for
             // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
             // Bumped to 29 with AnonymousUserCleanupService for EW-617 G2
             // (nightly cleanup of expired anonymous Users).
             // Bumped to 30 with the EW-617 G8 ZeroFrictionFunnelService.
             // Bumped to 31 with the EW-617 G8 DeployReadyPollerService.
-            expect(meta('exports')).toHaveLength(31);
+            // Bumped to 32 with WebhookSecretService for per-Work persistent
+            // WEBHOOK_SECRET (mirrors PlatformSyncSecretService pattern).
+            expect(meta('exports')).toHaveLength(32);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -33,6 +33,7 @@ import { WorksConfigService } from '@src/works-config/services/works-config.serv
 import { WorksConfigSyncListener } from '@src/works-config/services/works-config-sync.listener';
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
+import { WebhookSecretService } from './webhook-secret.service';
 import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { DeployReadyPollerService } from './deploy-ready-poller.service';
 import { ItemHealthService } from './item-health.service';
@@ -103,6 +104,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         SettingsSchemaValidatorService,
         EverWorksDeployQuotaService,
         PlatformSyncSecretService,
+        WebhookSecretService,
         ZeroFrictionFunnelService,
         DeployReadyPollerService,
         // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
@@ -151,6 +153,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigProjectionService,
         WorksConfigRepositorySyncService,
         PlatformSyncSecretService,
+        WebhookSecretService,
         ZeroFrictionFunnelService,
         DeployReadyPollerService,
         CommunityPrModule,

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -354,6 +354,121 @@ describe('TemplateCustomizationService.createAndStart', () => {
     });
 });
 
+describe('TemplateCustomizationService.createAndStart — provision strip', () => {
+    // The strip removes reference samples / docs / e2e from the base template
+    // clone before pushing the fork to the user's GitHub org. We mount a real
+    // temp dir as the "base clone" and seed the same layout the upstream
+    // minimal template ships, then assert the strip removed the right things
+    // and the unrelated paths survived.
+    const fsPromises = jest.requireActual('node:fs/promises') as typeof import('node:fs/promises');
+    const pathMod = jest.requireActual('node:path') as typeof import('node:path');
+    const osMod = jest.requireActual('node:os') as typeof import('node:os');
+
+    async function seedFakeMinimalClone(): Promise<string> {
+        const root = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'tpl-strip-test-'));
+        // Reference samples + docs + e2e — should all be stripped.
+        const samples = [
+            'apps/sample-basic',
+            'apps/sample-events',
+            'apps/sample-git',
+            'apps/sample-jobs',
+            'apps/sample-real-estate',
+            'apps/docs',
+            'apps/web-e2e',
+        ];
+        for (const rel of samples) {
+            const abs = pathMod.join(root, rel);
+            await fsPromises.mkdir(abs, { recursive: true });
+            await fsPromises.writeFile(pathMod.join(abs, 'placeholder.txt'), 'x', 'utf8');
+        }
+        // apps/web — the only thing that SHOULD survive — plus packages/ui.
+        await fsPromises.mkdir(pathMod.join(root, 'apps/web/src'), { recursive: true });
+        await fsPromises.writeFile(
+            pathMod.join(root, 'apps/web/package.json'),
+            '{"name":"@ever-works/web-minimal"}',
+            'utf8',
+        );
+        await fsPromises.mkdir(pathMod.join(root, 'packages/ui/src'), { recursive: true });
+        await fsPromises.writeFile(
+            pathMod.join(root, 'packages/ui/package.json'),
+            '{"name":"@ever-works/ui"}',
+            'utf8',
+        );
+        return root;
+    }
+
+    it('strips apps/sample-*, apps/docs, apps/web-e2e from the cloned minimal base and commits the removal', async () => {
+        const { service, mocks } = makeService();
+        const tempBaseDir = await seedFakeMinimalClone();
+        mocks.gitFacade.cloneOrPull.mockResolvedValue(tempBaseDir);
+        jest.spyOn(service, 'execute').mockResolvedValue(undefined);
+
+        try {
+            await service.createAndStart('user-1', baseInput);
+
+            // All strip paths must be gone.
+            for (const stripped of [
+                'apps/sample-basic',
+                'apps/sample-events',
+                'apps/sample-git',
+                'apps/sample-jobs',
+                'apps/sample-real-estate',
+                'apps/docs',
+                'apps/web-e2e',
+            ]) {
+                await expect(
+                    fsPromises.access(pathMod.join(tempBaseDir, stripped)),
+                ).rejects.toThrow();
+            }
+
+            // apps/web and packages/ui must survive.
+            await expect(
+                fsPromises.access(pathMod.join(tempBaseDir, 'apps/web/package.json')),
+            ).resolves.toBeUndefined();
+            await expect(
+                fsPromises.access(pathMod.join(tempBaseDir, 'packages/ui/package.json')),
+            ).resolves.toBeUndefined();
+
+            // The strip must have committed (so the user's repo history reflects
+            // the slim-down rather than a silent delta vs. upstream).
+            expect(mocks.gitFacade.addAll).toHaveBeenCalledWith('github', tempBaseDir);
+            expect(mocks.gitFacade.commit).toHaveBeenCalledWith(
+                'github',
+                tempBaseDir,
+                expect.stringMatching(/remove reference samples/),
+                expect.any(Object),
+            );
+        } finally {
+            await fsPromises.rm(tempBaseDir, { recursive: true, force: true });
+        }
+    });
+
+    it('skips the strip commit entirely when no strip paths exist on disk', async () => {
+        const { service, mocks } = makeService();
+        // Seed a minimal-template clone that has only apps/web — none of the
+        // strip paths exist. The strip helper should silently no-op and the
+        // gitFacade.addAll/commit calls (for the strip phase) should not
+        // fire because `removed.length === 0`.
+        const tempBaseDir = await fsPromises.mkdtemp(
+            pathMod.join(osMod.tmpdir(), 'tpl-strip-empty-'),
+        );
+        try {
+            await fsPromises.mkdir(pathMod.join(tempBaseDir, 'apps/web/src'), {
+                recursive: true,
+            });
+            mocks.gitFacade.cloneOrPull.mockResolvedValue(tempBaseDir);
+            jest.spyOn(service, 'execute').mockResolvedValue(undefined);
+
+            await service.createAndStart('user-1', baseInput);
+
+            expect(mocks.gitFacade.addAll).not.toHaveBeenCalled();
+            expect(mocks.gitFacade.commit).not.toHaveBeenCalled();
+        } finally {
+            await fsPromises.rm(tempBaseDir, { recursive: true, force: true });
+        }
+    });
+});
+
 describe('TemplateCustomizationService.execute', () => {
     function seedRunning(mocks: Mocks) {
         mocks.customizationRepository.findById.mockResolvedValue({

--- a/packages/agent/src/template-catalog/customization-prompts/minimal-template.prompt.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/minimal-template.prompt.ts
@@ -13,20 +13,16 @@ Apply the user's UI request to this repository. Treat the request as a styling b
 
 \`\`\`
 apps/
-  web/                 ← PRIMARY canonical app. Default target for every request.
-  sample-basic/        ← niche sample (generic directory)
-  sample-events/       ← niche sample (events vertical)
-  sample-jobs/         ← niche sample (jobs vertical)
-  sample-real-estate/  ← niche sample (real-estate vertical)
-  sample-git/          ← niche sample (git-tools vertical)
-  ...                  ← other niche samples; same internal layout as apps/web
-  docs/                ← Docusaurus docs site — DO NOT modify
-  web-e2e/             ← Playwright tests — DO NOT modify
+  web/                 ← ONLY edit target. This is the directory site that gets deployed.
+                        Every UI change MUST land inside apps/web/. Nothing outside it
+                        ever reaches the deployed site (Vercel project rootDirectory
+                        is hard-pinned to apps/web, and the Dockerfile only COPYs
+                        apps/web for k8s deploys).
 
-  apps/<app>/src/
+  apps/web/src/
     styles/global.css      ← Tailwind v4 \`@theme\` tokens (--color-brand-*) + headless component styling via [data-component=...] / [data-part=...] selectors. PRIMARY styling lever.
     layouts/BaseLayout.astro ← page chrome (header, footer, nav, theme toggle). SECONDARY lever for layout-level tweaks.
-    components/            ← app-local Astro/React wrappers (BreadcrumbNav, ItemBrowser)
+    components/            ← app-local Astro/Preact wrappers (if present)
     pages/                 ← Astro file-based routes (index, item/[slug], category/[slug], tag/[slug], collection/[slug], comparison/[slug], 404, rss/atom/robots feeds). Edit visible markup/classes only.
     lib/                   ← content loaders + plugin config — do NOT modify
     env.d.ts, tsconfig.json, astro.config.ts, package.json ← do NOT modify
@@ -35,19 +31,17 @@ packages/
   ui/                  ← shared component library imported as @ever-works/ui/astro/* and @ever-works/ui/preact/*. DO NOT modify — overrides happen via the per-app global.css selectors.
   core/, adapters/, astro-integration/, plugin-*/, eslint-config/ ← runtime/build infrastructure — DO NOT modify
 
-.content/              ← markdown items/categories/tags (only present in some samples) — DO NOT modify
+.content/              ← markdown items/categories/tags (cloned at build time from the user's data repo) — DO NOT modify
 .deploy/, .github/, Dockerfile, .env.example ← infrastructure — DO NOT modify
 \`\`\`
 
 # Where to make edits
 
-1. **Theme tokens** — change \`apps/<app>/src/styles/global.css\` inside the \`@theme { ... }\` block. The \`--color-brand-*\` ramp is the canonical brand palette; replace its 11 stops to re-skin the whole site.
+1. **Theme tokens** — change \`apps/web/src/styles/global.css\` inside the \`@theme { ... }\` block. The \`--color-brand-*\` ramp is the canonical brand palette; replace its 11 stops to re-skin the whole site.
 2. **Component styling** — components from \`@ever-works/ui\` emit \`data-component\` / \`data-part\` attributes. Restyle them by editing the matching \`[data-component="..."] [data-part="..."]\` rules in the same \`global.css\`. Do NOT edit the source under \`packages/ui/\`.
-3. **Layout chrome** — adjust classes / structure in \`apps/<app>/src/layouts/BaseLayout.astro\` and the local Astro pages under \`apps/<app>/src/pages/\`.
-4. **Target app — pick exactly one.**
-   - Default: \`apps/web/\`. Edit only files inside \`apps/web/\`.
-   - If the user explicitly names a niche ("make the events theme purple", "for the jobs site …"), use the matching \`apps/sample-<niche>/\` instead.
-   - Do NOT fan changes out across multiple \`apps/sample-*/\` directories. One run = one app. The niche samples are independent variants the user opts into by name.
+3. **Layout chrome** — adjust classes / structure in \`apps/web/src/layouts/BaseLayout.astro\` and the local Astro pages under \`apps/web/src/pages/\`.
+
+**Target app is fixed.** Always edit \`apps/web/\` and only \`apps/web/\`. Do NOT touch any other \`apps/*\` directory. If you find stray \`apps/sample-*\`, \`apps/docs\`, or \`apps/web-e2e\` directories in the workspace, ignore them entirely — they are leftover reference samples that the platform normally strips from user-cloned forks and that never reach the deployed site. Any edits there would be lost.
 
 # Rules
 
@@ -60,6 +54,7 @@ packages/
 7. **No new files unless strictly needed for styling** (e.g. a new \`styles/<theme-name>.css\` imported by \`global.css\` is fine; a new component is not).
 8. **Accessibility:** keep color contrast ≥ AA in both light and dark mode. The site uses \`[data-theme="dark"]\` via the \`ThemeToggle\` component — verify dark-mode variants stay readable.
 9. **No commits, no PRs.** Just edit files in place — the orchestrator handles commit + push.
+10. **At least one visible-styling file MUST change.** A successful run must touch at least one of \`apps/web/src/styles/global.css\`, \`apps/web/src/layouts/BaseLayout.astro\`, or a file under \`apps/web/src/pages/\` or \`apps/web/src/components/\`. If the user's brief can't be satisfied without going elsewhere, prefer adding new selectors to \`global.css\` over reaching outside \`apps/web/\`.
 
 The user's customization request follows below.
 `;

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -7,6 +7,8 @@ import {
     Optional,
 } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { TemplateRepository } from '@src/database/repositories/template.repository';
 import { TemplateCustomizationRepository } from '@src/database/repositories/template-customization.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
@@ -34,6 +36,30 @@ import { inferFrameworkFromRepository } from './utils/framework-inference';
 const GIT_PROVIDER_ID = 'github';
 const REPO_NAME_MAX = 90;
 const SUFFIX_LEN = 6;
+
+/**
+ * Paths inside a freshly cloned base template that should be stripped before
+ * pushing the per-template fork to the user's GitHub org. These directories
+ * exist in-tree for the source template's own developers (reference samples,
+ * docs site, e2e tests) but they never reach a deployed Work — Vercel pins
+ * `rootDirectory: apps/web` and the Dockerfile only COPYs `apps/web/`. Carrying
+ * them into every user-cloned fork would bloat repo size, slow `pnpm install`,
+ * waste CI minutes building things that never ship, and confuse users who open
+ * "their" repo expecting one app.
+ *
+ * Only paths inside the template clone are stripped. Workspace package
+ * directories under `packages/` are intentionally preserved — `apps/web/`
+ * depends on them.
+ */
+const PROVISION_STRIP_PATHS: readonly string[] = [
+    'apps/sample-basic',
+    'apps/sample-events',
+    'apps/sample-git',
+    'apps/sample-jobs',
+    'apps/sample-real-estate',
+    'apps/docs',
+    'apps/web-e2e',
+];
 
 export interface CreateAndStartCustomizationInput {
     baseTemplateId: string;
@@ -372,6 +398,27 @@ export class TemplateCustomizationService {
             gitOptions,
         );
 
+        // Strip reference samples / docs / e2e from the per-template fork
+        // before pushing. See PROVISION_STRIP_PATHS for the why. The strip
+        // is committed (when anything was removed) so the user's repo
+        // history reflects the deliberate slim-down rather than a silent
+        // delta vs. the upstream template.
+        const stripped = await this.stripProvisionedDir(baseDir, baseConfig);
+        if (stripped.length > 0) {
+            await this.gitFacade.addAll(GIT_PROVIDER_ID, baseDir);
+            await this.gitFacade.commit(
+                GIT_PROVIDER_ID,
+                baseDir,
+                `chore(template): remove reference samples for per-Work fork\n\n` +
+                    `These directories live in the upstream template for its own\n` +
+                    `developers (reference samples, docs site, e2e tests) and are\n` +
+                    `not part of a deployed Work site. Stripped to keep the fork\n` +
+                    `lean and avoid confusing the deploying user.\n\n` +
+                    stripped.map((p) => `- ${p}`).join('\n'),
+                committer,
+            );
+        }
+
         const personal = await this.gitFacade.getUser(gitOptions);
         const isOrg = personal.login.toLowerCase() !== targetOwner.toLowerCase();
 
@@ -403,6 +450,56 @@ export class TemplateCustomizationService {
             branch: created.defaultBranch || baseConfig.branch,
             repositoryUrl,
         };
+    }
+
+    /**
+     * Remove `PROVISION_STRIP_PATHS` directories from a freshly cloned base
+     * template. Returns the list of paths actually removed (relative to the
+     * workspace) so the caller can record them in a commit message — when
+     * the base template doesn't ship some of these (e.g. classic has no
+     * `apps/sample-*`), they're silently skipped.
+     *
+     * Strip is only applied to the `minimal` template today; the classic
+     * template has none of these paths and the helper short-circuits.
+     */
+    private async stripProvisionedDir(
+        workspaceDir: string,
+        baseConfig: WebsiteTemplateConfig,
+    ): Promise<string[]> {
+        if (baseConfig.id !== 'minimal') {
+            return [];
+        }
+        const removed: string[] = [];
+        for (const relPath of PROVISION_STRIP_PATHS) {
+            const absPath = path.join(workspaceDir, relPath);
+            const existed = await fs
+                .access(absPath)
+                .then(() => true)
+                .catch(() => false);
+            if (!existed) {
+                // Not every base template ships every strip path; just
+                // skip silently.
+                continue;
+            }
+            try {
+                await fs.rm(absPath, { recursive: true, force: true });
+                removed.push(relPath);
+            } catch (error) {
+                // Don't block the provision on a strip failure. The repo
+                // will still work; it'll just be heavier than ideal.
+                this.logger.warn(
+                    `Failed to strip ${relPath} from ${workspaceDir}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+        if (removed.length > 0) {
+            this.logger.log(
+                `Stripped ${removed.length} reference path(s) from ${baseConfig.id} fork: ${removed.join(', ')}`,
+            );
+        }
+        return removed;
     }
 
     private async resolveTargetOwner(userId: string, override?: string): Promise<string> {

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -469,7 +469,10 @@ export class TemplateCustomizationService {
         if (baseConfig.id !== 'minimal') {
             return [];
         }
-        const removed: string[] = [];
+        // `let` because `removed` is built up via push() through the loop —
+        // the binding is conceptually mutable. Repo convention prefers `let`
+        // for mutated locals over `const`.
+        let removed: string[] = [];
         for (const relPath of PROVISION_STRIP_PATHS) {
             const absPath = path.join(workspaceDir, relPath);
             const existed = await fs


### PR DESCRIPTION
## Summary

Three coordinated platform-side fixes so the **Generate Custom Template with AI** flow produces a fork that actually deploys correctly when paired with the workflows added in [ever-works/directory-web-minimal-template#6](https://github.com/ever-works/directory-web-minimal-template/pull/6).

### G2 — Tighten \`MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT\`
The old prompt listed all 5 \`apps/sample-*\` + \`apps/docs\` + \`apps/web-e2e\` as candidate edit targets. But the Vercel project's \`rootDirectory\` is hard-pinned to \`apps/web\` and the Dockerfile only \`COPY\`s \`apps/web/\` — anything the AI edited outside \`apps/web/\` silently never reached the deployed site. **Footgun:** user prompts like *"make my events directory purple"* would land commits in \`apps/sample-events\` and the deployed site would look unchanged.

New prompt makes \`apps/web/\` the ONLY allowed edit target, marks stray samples as "ignore if present (will be removed by build pipeline)", and adds rule #10 requiring at least one visible-styling file under \`apps/web/src/\` to change.

### G6 — Strip reference samples in \`provisionFromBase\`
After cloning the minimal base into the user's workspace, remove \`apps/sample-*\` / \`apps/docs\` / \`apps/web-e2e\` before pushing to the user's GH org. Saves repo size, \`pnpm install\` time, and CI minutes for the user's fork. The strip is committed (so the diff is honest history rather than a silent delta vs. upstream), and only fires for \`baseTemplateId='minimal'\` — classic ships none of these.

### G4 — Push \`SITE_URL\` + \`WEBHOOK_SECRET\` from \`DeployService.setRequiredSecrets\`
- **\`SITE_URL\`** — derived from \`settings.ingressHost\` when \`applyEverWorksSubdomain\` already templated it (\`deployProvider='ever-works'\` + Cloudflare DNS configured). Drives the deployed site's sitemap.xml / RSS / OG / canonical URLs. Skipped for non-ever-works providers so the template's own fallback or the user's Vercel-dashboard override stays in charge.
- **\`WEBHOOK_SECRET\`** — generated per-deploy (mirrors \`CRON_SECRET\` shape). Minimal template's \`@ever-works/astro-integration\` reads it at build time and registers a verifying \`/api/webhook\` endpoint iff defined; classic ignores it. Harmless on templates that don't consume it; required on templates that do.

## Test plan

- [x] \`pnpm install --frozen-lockfile\` (platform)
- [x] \`turbo build --filter=@ever-works/agent\` — 0 TS issues
- [x] \`pnpm jest --testPathPattern='deploy.service'\` — 37/37 pass (3 new for SITE_URL + WEBHOOK_SECRET)
- [x] \`pnpm jest --testPathPattern='template-customization'\` — 16/16 pass (2 new for strip behavior using real temp dirs)
- [x] \`pnpm jest --testPathPattern='template'\` — 73/73 across 8 suites pass
- [x] Existing customization-prompt pin assertions (UI-only, no functional changes, no commits, @theme, global.css, \`data-component\`, packages/ui off-limits) all still hold
- [ ] E2E: customize a template through the dashboard, verify the resulting tpl-... repo has no samples and the deploy lands with WEBHOOK_SECRET / SITE_URL set (manual — needs the minimal-template companion PR merged first)

## Companion PR

- [ever-works/directory-web-minimal-template#6](https://github.com/ever-works/directory-web-minimal-template/pull/6) — adds \`deploy_vercel.yaml\` + \`deploy_prod.yaml\` so this customized fork has workflows for the platform to dispatch against.

Order of merge: minimal-template #6 first, then this PR. Either order works; both ship value on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now automatically provision a unique webhook secret for enhanced verification.
  * Site URL is automatically configured from DNS settings when available.
  * Template provisioning now cleanly removes reference and sample directories, keeping only essential app files.

* **Tests**
  * Added comprehensive test coverage for template provisioning and cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->