### PR TITLE
test(e2e): coverage pass 14 — service boundary + observability + transport

### DIFF
--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -380,18 +380,34 @@ Realtime + i18n + browser hygiene. **+10 new spec files.**
 
 Routing — `playwright.config.ts` testIgnore + testMatch now also exclude `referrer-policy-redirects`, `static-asset-fingerprint`, `feature-detect-storage`, and `iframe-sandbox` from the storageState project so their unauth UI assertions hit fresh contexts.
 
-## Pass 14 — queued
+## Pass 14 — this PR (`chore/e2e-coverage-pass-14`)
 
-- [ ] `service-isolation.spec.ts` — cross-module boundary: trigger endpoint A, verify side-effects don't leak to module B (e.g. work-deploy doesn't trigger notification subscription)
-- [ ] `metrics-endpoint.spec.ts` — `/api/metrics` (Prometheus format) returns `# HELP` + `# TYPE` lines + at least one `http_requests_total` series
-- [ ] `graphql-introspection.spec.ts` — if a GraphQL endpoint is exposed, introspection is disabled in production (returns 4xx for `__schema` query)
-- [ ] `connection-pool-leak.spec.ts` — 50 sequential authenticated requests don't exhaust the DB pool (no 503/504)
-- [ ] `idempotency-keys.spec.ts` — POST with `Idempotency-Key` header returns same response on retry (or skip if not wired)
-- [ ] `content-security-violations.spec.ts` — CSP `report-to` / `report-uri` endpoint accepts violation reports without 5xx
-- [ ] `secure-cookies-on-https.spec.ts` — when behind https, session cookies carry `Secure` attribute
-- [ ] `password-history.spec.ts` — `update-password` rejects reusing the last 3 passwords (if policy is configured)
-- [ ] `api-version-header.spec.ts` — `/api/health` carries `X-API-Version` (or similar) for client compatibility checks
-- [ ] `signed-url-expiry.spec.ts` — pre-signed upload URLs (if exposed) expire within 1 hour and 4xx after expiry
+Service boundary + observability + transport security. **+10 new spec
+files.**
+
+- [x] `service-isolation.spec.ts` — work-create doesn't regress /api/notifications shape, /api/health hits don't consume auth throttler bucket, profile id/email byte-stable across unrelated module writes
+- [x] `metrics-endpoint.spec.ts` — `/api/metrics` returns text/plain (not JSON) when exposed, carries `# HELP` + `# TYPE` directives + one canonical Prometheus series
+- [x] `graphql-introspection.spec.ts` — `/graphql` / `/api/graphql` either 404, reject introspection 4xx, return GraphQL errors, or empty schema — never a populated `__schema.types` array in production
+- [x] `connection-pool-leak.spec.ts` — 50 sequential authed /profile hits maintain ≥48/50 success rate, 20 parallel /api/health bursts ≤1 5xx
+- [x] `idempotency-keys.spec.ts` — POST /api/works with same `Idempotency-Key` retry stays < 500, empty key not 5xx
+- [x] `content-security-violations.spec.ts` — one of `/api/csp-report` / `/api/reports/csp` / `/api/security/csp-violations` accepts application/csp-report POST without 5xx; CSP report-to/report-uri presence soft-warns
+- [x] `secure-cookies-on-https.spec.ts` — auth cookies carry HttpOnly, carry Secure on https, carry SameSite=Lax/Strict/None — skip http for Secure
+- [x] `password-history.spec.ts` — rotating BACK to original password is either 4xx (history enforced) or informational (policy off); update-password without current_password rejected 4xx
+- [x] `api-version-header.spec.ts` — `/api/health` exposes a version via X-API-Version/X-Version/body version field that looks semver/sha/date-shaped; stable across calls
+- [x] `signed-url-expiry.spec.ts` — when a signed-URL endpoint exists, the URL carries `Expires=` / `X-Amz-Expires=` / `?exp=` / `?expires_in=` / `token=` / `signature=` marker; unauth GET on upload-url path is auth-gated 401/403/404
+
+## Pass 15 — queued
+
+- [ ] `db-readonly-replica.spec.ts` — if a read replica is configured, read-only endpoints (`/api/works`, `/api/notifications`) hit it; write endpoints don't
+- [ ] `feature-flag-runtime-toggle.spec.ts` — flipping a flag at runtime (via admin endpoint if exposed) reflects in next request without server restart
+- [ ] `webhook-redelivery.spec.ts` — failed webhook delivery is retried; backoff envelope shape probed
+- [ ] `multi-tenant-data-leak.spec.ts` — listing endpoints with `?owner=` / `?tenant=` / `?org_id=` query params never leak rows owned by another tenant
+- [ ] `oauth-pkce.spec.ts` — OAuth authorize URL carries `code_challenge` + `code_challenge_method=S256` (PKCE)
+- [ ] `audit-tamper-resistance.spec.ts` — manipulated activity-log entries don't pass integrity check (HMAC/signature if implemented)
+- [ ] `backup-restore-noop.spec.ts` — health check exposes last-backup timestamp; backup health probe < 500
+- [ ] `cloud-sdk-headers.spec.ts` — User-Agent allowlist; outbound HTTP from server carries a recognised UA
+- [ ] `webhook-secret-rotation.spec.ts` — rotating a webhook secret invalidates the old secret signature
+- [ ] `request-id-tracing.spec.ts` — `X-Request-ID` header echoes on response; uniquely generated when not provided
 
 ## Pass 15+ — long-tail / hardening
 

--- a/apps/web/e2e/api-version-header.spec.ts
+++ b/apps/web/e2e/api-version-header.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * API version header — pass 14. Best-practice REST APIs surface a
+ * version in headers so clients can negotiate compatibility. Common
+ * shapes: `X-API-Version`, `X-Version`, `API-Version`, or a `Server`
+ * suffix carrying the app version.
+ *
+ * We probe /api/health and assert that EITHER a recognised version
+ * header is present OR the body's JSON carries a `version` field.
+ * If neither, the platform is silent on versioning — that's an
+ * informational skip (clients can't pin compat).
+ */
+
+const VERSION_HEADERS = [
+    'x-api-version',
+    'x-version',
+    'api-version',
+    'x-app-version',
+    'x-platform-version',
+];
+
+test.describe('Versioning — /api/health surfaces a platform version', () => {
+    test('/api/health response carries a version somewhere (header or body)', async ({
+        request,
+    }) => {
+        const res = await request.get(`${API_BASE}/api/health`);
+        expect(res.status()).toBeLessThan(500);
+        const headerVersion = VERSION_HEADERS.map((h) => res.headers()[h]).filter(Boolean)[0];
+        let bodyVersion: string | undefined;
+        try {
+            const body = await res.json();
+            bodyVersion =
+                body?.version ??
+                body?.app?.version ??
+                body?.info?.version ??
+                body?.platform?.version;
+        } catch {
+            // Not JSON — ignore.
+        }
+        if (!headerVersion && !bodyVersion) {
+            test.info().annotations.push({
+                type: 'informational',
+                description:
+                    "no version header or body field on /api/health — clients can't pin compat",
+            });
+            test.skip(true, 'no version info exposed');
+        }
+        const version = headerVersion || bodyVersion!;
+        // Version should look like a semver-ish or git-ish string.
+        // Accept: 1.2.3, v1.2.3, 1.2.3-rc.4, sha-shaped (8+ hex), or
+        // a YYYY-MM-DD date.
+        const semverShape = /^v?\d+\.\d+(?:\.\d+)?(?:-[\w.-]+)?$/.test(version);
+        const shaShape = /^[a-f0-9]{8,40}$/.test(version);
+        const dateShape = /^\d{4}-\d{2}-\d{2}$/.test(version);
+        expect(
+            semverShape || shaShape || dateShape,
+            `version doesn't match semver/sha/date: "${version}"`,
+        ).toBe(true);
+    });
+
+    test('Version header (if present) is stable across calls', async ({ request }) => {
+        const a = await request.get(`${API_BASE}/api/health`);
+        const b = await request.get(`${API_BASE}/api/health`);
+        const aVer = VERSION_HEADERS.map((h) => a.headers()[h]).filter(Boolean)[0];
+        const bVer = VERSION_HEADERS.map((h) => b.headers()[h]).filter(Boolean)[0];
+        if (!aVer || !bVer) {
+            test.skip(true, 'no version header to compare');
+        }
+        expect(aVer, 'version header drifted between consecutive calls').toBe(bVer);
+    });
+});

--- a/apps/web/e2e/connection-pool-leak.spec.ts
+++ b/apps/web/e2e/connection-pool-leak.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Connection pool leak — pass 14. A common backend bug is forgetting
+ * to release a DB connection back to the pool. After N requests the
+ * pool is exhausted and the API starts returning 503/504/timeouts.
+ *
+ * We hammer a handful of authenticated endpoints sequentially and
+ * verify the success rate stays high. We're not measuring latency —
+ * just that nothing 5xxs from pool starvation.
+ */
+
+test.describe('Connection pool — 50 sequential requests do not exhaust DB', () => {
+    test('50 GETs against /api/auth/profile stay < 500 with high success rate', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        let ok = 0;
+        let bad = 0;
+        for (let i = 0; i < 50; i++) {
+            const res = await request.get(`${API_BASE}/api/auth/profile`, {
+                headers: authedHeaders(u.access_token),
+            });
+            const status = res.status();
+            if (status >= 500) {
+                bad++;
+            } else {
+                ok++;
+            }
+        }
+        // ≥ 96% (48/50) should succeed without a 5xx. The remaining
+        // small budget accounts for transient retries — not pool
+        // exhaustion patterns.
+        expect(ok, `${bad}/50 requests returned 5xx — pool may be leaking`).toBeGreaterThanOrEqual(
+            48,
+        );
+    });
+
+    test("parallel bursts against /api/health don't accumulate 5xx", async ({ request }) => {
+        const promises: Promise<number>[] = [];
+        for (let i = 0; i < 20; i++) {
+            promises.push(request.get(`${API_BASE}/api/health`).then((r) => r.status()));
+        }
+        const statuses = await Promise.all(promises);
+        const fivexx = statuses.filter((s) => s >= 500).length;
+        expect(
+            fivexx,
+            `${fivexx}/20 parallel /api/health requests 5xx — likely pool issue`,
+        ).toBeLessThanOrEqual(1);
+    });
+});

--- a/apps/web/e2e/content-security-violations.spec.ts
+++ b/apps/web/e2e/content-security-violations.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * CSP violation reporting — pass 14. A modern CSP carries a
+ * `report-to` or `report-uri` directive pointing at an endpoint that
+ * accepts violation reports. The endpoint should:
+ * - exist (status < 500 when posting a valid CSP report)
+ * - accept `application/csp-report` AND `application/reports+json`
+ * - NOT require auth (browsers can't auth)
+ *
+ * We probe a few candidate paths. If none exists, skip.
+ */
+
+const REPORT_PATHS = ['/api/csp-report', '/api/reports/csp', '/api/security/csp-violations'];
+
+const SAMPLE_REPORT = {
+    'csp-report': {
+        'document-uri': 'http://localhost:3000/en/login',
+        referrer: '',
+        'violated-directive': "script-src 'self'",
+        'effective-directive': 'script-src',
+        'original-policy': "default-src 'self'",
+        disposition: 'enforce',
+        blocked: 'https://evil.example.com/x.js',
+        'status-code': 0,
+    },
+};
+
+test.describe('CSP — violation report endpoint accepts reports', () => {
+    test('one of the candidate paths exists and accepts a CSP report payload', async ({
+        request,
+    }) => {
+        let accepted = false;
+        let probedStatuses: string[] = [];
+        for (const p of REPORT_PATHS) {
+            const res = await request.post(`${API_BASE}${p}`, {
+                headers: { 'Content-Type': 'application/csp-report' },
+                data: SAMPLE_REPORT,
+            });
+            probedStatuses.push(`${p}=${res.status()}`);
+            if (res.status() < 500 && res.status() !== 404) {
+                accepted = true;
+                break;
+            }
+        }
+        if (!accepted) {
+            test.skip(true, `no CSP reporting endpoint configured: ${probedStatuses.join(', ')}`);
+        }
+        expect(accepted).toBe(true);
+    });
+
+    test('CSP header on /en/login references a report directive (or N/A)', async ({
+        page,
+        baseURL,
+    }) => {
+        const res = await page.request.get(`${baseURL || 'http://localhost:3000'}/en/login`);
+        const csp =
+            res.headers()['content-security-policy'] ||
+            res.headers()['content-security-policy-report-only'] ||
+            '';
+        if (!csp) {
+            test.skip(true, 'no CSP header on /en/login — covered in csp-strict.spec.ts');
+        }
+        const hasReporter = /report-to|report-uri/i.test(csp);
+        // If the platform sets a CSP, having a reporting directive is
+        // best-practice (so violations are visible). Soft-warn only.
+        if (!hasReporter) {
+            test.info().annotations.push({
+                type: 'warning',
+                description: `CSP on /en/login has no report-to/report-uri — violations are invisible`,
+            });
+        }
+    });
+});

--- a/apps/web/e2e/graphql-introspection.spec.ts
+++ b/apps/web/e2e/graphql-introspection.spec.ts
@@ -22,13 +22,28 @@ test.describe('GraphQL — introspection disabled in production', () => {
             const probe = await request.post(`${API_BASE}${p}`, {
                 data: { query: '{__typename}' },
             });
-            if (probe.status() !== 404) {
+            // Greptile P2: a bare non-404 isn't proof the path is
+            // GraphQL — a REST endpoint that 401s would also pass.
+            // Require either a 200 JSON response that round-trips a
+            // `data.__typename` / `errors` field, OR a 400/422 that
+            // carries a `errors[]` array (GraphQL servers commonly
+            // return this on malformed queries). Anything else is
+            // shape-mismatched and we skip rather than mis-assert.
+            if (probe.status() === 404) continue;
+            const ct = probe.headers()['content-type'] || '';
+            if (!ct.includes('json')) continue;
+            const body = await probe.json().catch(() => null);
+            if (!body) continue;
+            const looksLikeGraphQL =
+                typeof body?.data?.__typename === 'string' ||
+                (Array.isArray(body?.errors) && body.errors.length > 0);
+            if (looksLikeGraphQL) {
                 foundPath = p;
                 break;
             }
         }
         if (!foundPath) {
-            test.skip(true, 'no GraphQL endpoint exposed in this env');
+            test.skip(true, 'no GraphQL endpoint with GraphQL-shaped response in this env');
         }
         const res = await request.post(`${API_BASE}${foundPath}`, {
             data: { query: INTROSPECTION_QUERY },

--- a/apps/web/e2e/graphql-introspection.spec.ts
+++ b/apps/web/e2e/graphql-introspection.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * GraphQL introspection — pass 14. If a GraphQL endpoint exists,
+ * production posture demands that `__schema` introspection is
+ * disabled. An exposed schema gives attackers a complete API map
+ * including mutations, types, and field names.
+ *
+ * We probe the common `/graphql` and `/api/graphql` paths. If neither
+ * exists, skip (no GraphQL surface to test). If one does, the
+ * introspection query must NOT return a full schema object.
+ */
+
+const GQL_PATHS = ['/graphql', '/api/graphql', '/api/v1/graphql'];
+const INTROSPECTION_QUERY = '{__schema{types{name}}}';
+
+test.describe('GraphQL — introspection disabled in production', () => {
+    test('introspection query is blocked or rejected', async ({ request }) => {
+        let foundPath: string | null = null;
+        for (const p of GQL_PATHS) {
+            const probe = await request.post(`${API_BASE}${p}`, {
+                data: { query: '{__typename}' },
+            });
+            if (probe.status() !== 404) {
+                foundPath = p;
+                break;
+            }
+        }
+        if (!foundPath) {
+            test.skip(true, 'no GraphQL endpoint exposed in this env');
+        }
+        const res = await request.post(`${API_BASE}${foundPath}`, {
+            data: { query: INTROSPECTION_QUERY },
+        });
+        // The query must NOT return a populated schema. Acceptable:
+        //   - 4xx rejecting the query
+        //   - 200 with `errors` field signaling introspection disabled
+        //   - 200 with `data.__schema = null`
+        if (res.status() >= 400 && res.status() < 500) {
+            // Rejected — good.
+            return;
+        }
+        const body = await res.json();
+        if (body?.errors && body.errors.length > 0) {
+            // Server returned a GraphQL error — likely "introspection
+            // disabled". This is the expected production posture.
+            return;
+        }
+        const types = body?.data?.__schema?.types;
+        expect(
+            Array.isArray(types) && types.length > 0,
+            `GraphQL introspection leaked ${types?.length ?? 0} types in production`,
+        ).toBe(false);
+    });
+});

--- a/apps/web/e2e/idempotency-keys.spec.ts
+++ b/apps/web/e2e/idempotency-keys.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Idempotency keys — pass 14. POST requests that mutate state are
+ * meant to be idempotent when carrying an `Idempotency-Key` header.
+ * The platform may or may not implement this — when it does, a retry
+ * with the same key returns the same response (and doesn't create a
+ * duplicate).
+ *
+ * We try creating a work twice with the same Idempotency-Key. If the
+ * platform honors it, we get one resource (status 200/201) on the
+ * first call and a 200 / 201 / 409 on the second. If the platform
+ * ignores the header, we may get two distinct rows — that's a
+ * not-yet-implemented signal, not a crash.
+ */
+
+test.describe('Idempotency — repeated POST with same key', () => {
+    test('POST /api/works with Idempotency-Key returns coherent response on retry', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const key = `idem-${Date.now().toString(36)}`;
+        const payload = {
+            name: `idem-${Date.now().toString(36)}`,
+            slug: `idem-${Date.now().toString(36)}`,
+        };
+        const first = await request.post(`${API_BASE}/api/works`, {
+            headers: { ...authedHeaders(u.access_token), 'Idempotency-Key': key },
+            data: payload,
+        });
+        // First call must succeed if we're going to assert anything.
+        if (!first.ok()) {
+            test.skip(true, `first POST failed (${first.status()}) — can't test idempotency`);
+        }
+        const second = await request.post(`${API_BASE}/api/works`, {
+            headers: { ...authedHeaders(u.access_token), 'Idempotency-Key': key },
+            data: payload,
+        });
+        // Second call must NOT crash. Acceptable statuses:
+        // - 200/201 (idempotent replay returning the same resource)
+        // - 409 (conflict — slug duplicate, also coherent)
+        // - 422 (validation rejecting duplicate slug)
+        // - 4xx generally — the server rejected the duplicate cleanly
+        expect(second.status(), `idempotent retry crashed with ${second.status()}`).toBeLessThan(
+            500,
+        );
+    });
+
+    test('Idempotency-Key without value does not crash the API', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.post(`${API_BASE}/api/works`, {
+            headers: { ...authedHeaders(u.access_token), 'Idempotency-Key': '' },
+            data: {
+                name: `idem-empty-${Date.now().toString(36)}`,
+                slug: `idem-empty-${Date.now().toString(36)}`,
+            },
+        });
+        // Empty key should either be rejected (4xx) or ignored (success).
+        // It should NEVER cause a 5xx.
+        expect(res.status()).toBeLessThan(500);
+    });
+});

--- a/apps/web/e2e/metrics-endpoint.spec.ts
+++ b/apps/web/e2e/metrics-endpoint.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Metrics endpoint — pass 14. Prometheus-style `/metrics` is the
+ * standard observability surface. If exposed, it should:
+ * - return text/plain (NOT application/json)
+ * - carry `# HELP` and `# TYPE` directive lines
+ * - expose at least one well-known series (http_requests_total,
+ *   process_cpu_seconds_total, nodejs_version_info)
+ * - NOT require auth (most scrapers can't auth, but it should be
+ *   network-restricted at the cluster level)
+ *
+ * If `/api/metrics` returns 404, the endpoint isn't wired here — skip.
+ */
+
+const METRIC_PATHS = ['/api/metrics', '/metrics'];
+
+test.describe('Metrics — Prometheus-format /metrics endpoint', () => {
+    test('one of the candidate paths returns Prometheus-shaped text', async ({ request }) => {
+        let body = '';
+        let foundPath: string | null = null;
+        for (const p of METRIC_PATHS) {
+            const res = await request.get(`${API_BASE}${p}`);
+            if (res.status() === 200) {
+                const ct = res.headers()['content-type'] || '';
+                if (/text\/plain|application\/openmetrics-text/.test(ct)) {
+                    body = await res.text();
+                    foundPath = p;
+                    break;
+                }
+            }
+        }
+        if (!foundPath) {
+            test.skip(true, 'no /metrics-shaped endpoint exposed in this env');
+        }
+        // Prometheus exposition format always carries `# HELP` and
+        // `# TYPE` directive lines for each series.
+        expect(body, 'no # HELP directive').toMatch(/^# HELP /m);
+        expect(body, 'no # TYPE directive').toMatch(/^# TYPE /m);
+        // At least one of the canonical series should be present.
+        const canonical =
+            /(?:http_requests_total|process_cpu_seconds_total|nodejs_version_info|process_start_time_seconds)/.test(
+                body,
+            );
+        expect(canonical, 'no canonical Prometheus series found').toBe(true);
+    });
+
+    test('/api/metrics is not exposed as JSON', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/metrics`);
+        if (res.status() === 404) {
+            test.skip(true, '/api/metrics not exposed');
+        }
+        const ct = res.headers()['content-type'] || '';
+        // JSON metrics endpoint = misconfig — Prometheus scrapers can't
+        // parse it. Allow text/plain or openmetrics-text only.
+        expect(/application\/json/.test(ct), `/api/metrics returned JSON: ${ct}`).toBe(false);
+    });
+});

--- a/apps/web/e2e/password-history.spec.ts
+++ b/apps/web/e2e/password-history.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Password history — pass 14. If the platform enforces a password
+ * history (NIST SP 800-63B encourages it for high-security accounts),
+ * `update-password` should reject re-using the just-rotated password.
+ *
+ * We register a user with password P0, rotate to P1, then try
+ * rotating BACK to P0. If history is enforced, the second rotation is
+ * 4xx. If not enforced, both rotations succeed — that's an
+ * informational skip, not a fail (the policy may be intentional).
+ */
+
+const STRONG_BASE = 'Hist0r1cal#Pass';
+
+test.describe('Password history — recent passwords cannot be reused', () => {
+    test('rotating back to the original password is rejected (or policy is informational)', async ({
+        request,
+    }) => {
+        const p0 = `${STRONG_BASE}-A${Date.now().toString(36)}`;
+        const p1 = `${STRONG_BASE}-B${Date.now().toString(36)}`;
+        const u = await registerUserViaAPI(request, { password: p0 });
+        // Rotate to P1.
+        const r1 = await request.post(`${API_BASE}/api/auth/update-password`, {
+            headers: authedHeaders(u.access_token),
+            data: { current_password: p0, new_password: p1, currentPassword: p0, newPassword: p1 },
+        });
+        if (!r1.ok()) {
+            test.skip(true, `first rotation failed (${r1.status()}) — endpoint may differ`);
+        }
+        // Now try rotating BACK to P0.
+        const r2 = await request.post(`${API_BASE}/api/auth/update-password`, {
+            headers: authedHeaders(u.access_token),
+            data: { current_password: p1, new_password: p0, currentPassword: p1, newPassword: p0 },
+        });
+        if (r2.ok()) {
+            // Platform does not enforce password history — informational
+            // skip (policy may be intentional for now).
+            test.info().annotations.push({
+                type: 'informational',
+                description: 'password history not enforced — rotating back to original succeeded',
+            });
+            return;
+        }
+        expect(
+            r2.status(),
+            `re-using previous password: status ${r2.status()}`,
+        ).toBeGreaterThanOrEqual(400);
+        expect(r2.status()).toBeLessThan(500);
+    });
+
+    test('update-password without current_password is rejected', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.post(`${API_BASE}/api/auth/update-password`, {
+            headers: authedHeaders(u.access_token),
+            data: { new_password: 'Brand1New#Pass', newPassword: 'Brand1New#Pass' },
+        });
+        // No current password = silent acceptance would let a stolen
+        // session change the password without re-auth. Must be 4xx.
+        expect(res.status()).toBeGreaterThanOrEqual(400);
+        expect(res.status()).toBeLessThan(500);
+    });
+});

--- a/apps/web/e2e/password-history.spec.ts
+++ b/apps/web/e2e/password-history.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { API_BASE, authedHeaders, loginViaAPI, registerUserViaAPI } from './helpers/api';
 
 /**
  * Password history — pass 14. If the platform enforces a password
@@ -21,18 +21,25 @@ test.describe('Password history — recent passwords cannot be reused', () => {
         const p0 = `${STRONG_BASE}-A${Date.now().toString(36)}`;
         const p1 = `${STRONG_BASE}-B${Date.now().toString(36)}`;
         const u = await registerUserViaAPI(request, { password: p0 });
-        // Rotate to P1.
+        // Codex P2: global ValidationPipe uses forbidNonWhitelisted, so
+        // snake_case duplicates get the request rejected with 400 before
+        // the password-change logic runs. Stick to the DTO field names.
         const r1 = await request.post(`${API_BASE}/api/auth/update-password`, {
             headers: authedHeaders(u.access_token),
-            data: { current_password: p0, new_password: p1, currentPassword: p0, newPassword: p1 },
+            data: { currentPassword: p0, newPassword: p1 },
         });
         if (!r1.ok()) {
             test.skip(true, `first rotation failed (${r1.status()}) — endpoint may differ`);
         }
-        // Now try rotating BACK to P0.
+        // Greptile P1: many JWT setups invalidate the pre-rotation token
+        // after password change. Using `u.access_token` for the second
+        // rotation would 401 from token revocation, not history policy.
+        // Re-login with P1 to get a fresh token before the second
+        // rotation, so a 4xx unambiguously means history enforcement.
+        const refresh = await loginViaAPI(request, { email: u.email, password: p1 });
         const r2 = await request.post(`${API_BASE}/api/auth/update-password`, {
-            headers: authedHeaders(u.access_token),
-            data: { current_password: p1, new_password: p0, currentPassword: p1, newPassword: p0 },
+            headers: authedHeaders(refresh.access_token),
+            data: { currentPassword: p1, newPassword: p0 },
         });
         if (r2.ok()) {
             // Platform does not enforce password history — informational
@@ -50,11 +57,11 @@ test.describe('Password history — recent passwords cannot be reused', () => {
         expect(r2.status()).toBeLessThan(500);
     });
 
-    test('update-password without current_password is rejected', async ({ request }) => {
+    test('update-password without currentPassword is rejected', async ({ request }) => {
         const u = await registerUserViaAPI(request);
         const res = await request.post(`${API_BASE}/api/auth/update-password`, {
             headers: authedHeaders(u.access_token),
-            data: { new_password: 'Brand1New#Pass', newPassword: 'Brand1New#Pass' },
+            data: { newPassword: 'Brand1New#Pass' },
         });
         // No current password = silent acceptance would let a stolen
         // session change the password without re-auth. Must be 4xx.

--- a/apps/web/e2e/secure-cookies-on-https.spec.ts
+++ b/apps/web/e2e/secure-cookies-on-https.spec.ts
@@ -84,10 +84,16 @@ test.describe('Cookies — Secure + HttpOnly attributes', () => {
             test.skip(true, 'no auth cookies set');
         }
         for (const c of authCookies) {
-            // SameSite=None without Secure is invalid; SameSite=Lax /
-            // Strict / explicit Secure-paired None all acceptable.
-            const hasSameSite = /SameSite=(Lax|Strict|None)/i.test(c.value);
-            expect(hasSameSite, `auth cookie missing SameSite: ${c.value.slice(0, 80)}`).toBe(true);
+            // Greptile P2: SameSite=None without Secure is invalid —
+            // RFC 6265bis says browsers must downgrade to Lax or reject
+            // it. Require either SameSite=Lax/Strict, OR
+            // SameSite=None + Secure as the only acceptable combos.
+            const laxOrStrict = /SameSite=(Lax|Strict)/i.test(c.value);
+            const noneWithSecure = /SameSite=None/i.test(c.value) && /Secure/i.test(c.value);
+            expect(
+                laxOrStrict || noneWithSecure,
+                `auth cookie has unsafe SameSite/Secure combo: ${c.value.slice(0, 120)}`,
+            ).toBe(true);
         }
     });
 });

--- a/apps/web/e2e/secure-cookies-on-https.spec.ts
+++ b/apps/web/e2e/secure-cookies-on-https.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, makeTestUser } from './helpers/api';
+
+/**
+ * Secure-cookies on HTTPS — pass 14. Session / auth cookies set by
+ * the platform must carry `Secure` (only sent over HTTPS) and
+ * `HttpOnly` (no JS access) when running behind https. Over plain
+ * http we skip, since `Secure` would prevent the cookie from being
+ * sent at all in dev.
+ */
+
+test.describe('Cookies — Secure + HttpOnly attributes', () => {
+    test('login response sets HttpOnly on auth cookies', async ({ request }) => {
+        const u = makeTestUser('cookie');
+        // Register so login has something to authenticate against.
+        const reg = await request.post(`${API_BASE}/api/auth/register`, {
+            data: { username: u.name, email: u.email, password: u.password },
+        });
+        if (!reg.ok()) test.skip(true, `register failed (${reg.status()})`);
+        const res = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: u.email, password: u.password },
+        });
+        const setCookies = res.headersArray().filter((h) => h.name.toLowerCase() === 'set-cookie');
+        if (setCookies.length === 0) {
+            test.skip(true, 'login does not set cookies — token-only auth');
+        }
+        // For every Set-Cookie that looks like a session/auth cookie,
+        // HttpOnly should be set.
+        const authCookies = setCookies.filter((c) =>
+            /(?:session|auth|token|refresh|access)/i.test(c.value),
+        );
+        if (authCookies.length === 0) {
+            test.skip(true, 'no auth-shaped cookies set by login');
+        }
+        for (const c of authCookies) {
+            expect(
+                /HttpOnly/i.test(c.value),
+                `auth cookie missing HttpOnly: ${c.value.slice(0, 80)}`,
+            ).toBe(true);
+        }
+    });
+
+    test('over HTTPS, auth cookies carry Secure attribute', async ({ request }) => {
+        if (!API_BASE.startsWith('https://')) {
+            test.skip(true, 'API_BASE is http — Secure attribute would block cookies in dev');
+        }
+        const u = makeTestUser('cookie-https');
+        const reg = await request.post(`${API_BASE}/api/auth/register`, {
+            data: { username: u.name, email: u.email, password: u.password },
+        });
+        if (!reg.ok()) test.skip(true, `register failed (${reg.status()})`);
+        const res = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: u.email, password: u.password },
+        });
+        const setCookies = res.headersArray().filter((h) => h.name.toLowerCase() === 'set-cookie');
+        const authCookies = setCookies.filter((c) =>
+            /(?:session|auth|token|refresh|access)/i.test(c.value),
+        );
+        if (authCookies.length === 0) {
+            test.skip(true, 'no auth-shaped cookies on this env');
+        }
+        for (const c of authCookies) {
+            expect(
+                /Secure/i.test(c.value),
+                `auth cookie missing Secure on https: ${c.value.slice(0, 80)}`,
+            ).toBe(true);
+        }
+    });
+
+    test('SameSite is set to Lax or Strict (CSRF defense)', async ({ request }) => {
+        const u = makeTestUser('cookie-samesite');
+        const reg = await request.post(`${API_BASE}/api/auth/register`, {
+            data: { username: u.name, email: u.email, password: u.password },
+        });
+        if (!reg.ok()) test.skip(true, `register failed (${reg.status()})`);
+        const res = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: u.email, password: u.password },
+        });
+        const setCookies = res.headersArray().filter((h) => h.name.toLowerCase() === 'set-cookie');
+        const authCookies = setCookies.filter((c) =>
+            /(?:session|auth|token|refresh|access)/i.test(c.value),
+        );
+        if (authCookies.length === 0) {
+            test.skip(true, 'no auth cookies set');
+        }
+        for (const c of authCookies) {
+            // SameSite=None without Secure is invalid; SameSite=Lax /
+            // Strict / explicit Secure-paired None all acceptable.
+            const hasSameSite = /SameSite=(Lax|Strict|None)/i.test(c.value);
+            expect(hasSameSite, `auth cookie missing SameSite: ${c.value.slice(0, 80)}`).toBe(true);
+        }
+    });
+});

--- a/apps/web/e2e/service-isolation.spec.ts
+++ b/apps/web/e2e/service-isolation.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Service isolation — pass 14. Modules should not bleed side-effects
+ * into unrelated modules. Creating a work shouldn't auto-subscribe the
+ * user to notifications, deploying a work shouldn't crash activity
+ * logging, and so on.
+ *
+ * We probe a few cross-module boundaries by exercising one endpoint
+ * and asserting an unrelated module endpoint still returns its
+ * baseline shape.
+ */
+
+test.describe('Service isolation — work CRUD does not bleed into unrelated modules', () => {
+    test('creating a work leaves /api/notifications shape stable', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const before = await request.get(`${API_BASE}/api/notifications`, {
+            headers: authedHeaders(u.access_token),
+        });
+        const beforeStatus = before.status();
+        await createWorkViaAPI(request, u.access_token, {
+            name: `isolation-${Date.now().toString(36)}`,
+            slug: `isolation-${Date.now().toString(36)}`,
+        });
+        const after = await request.get(`${API_BASE}/api/notifications`, {
+            headers: authedHeaders(u.access_token),
+        });
+        // The status family (200 / 204 / 401 etc.) must NOT regress
+        // after creating a work — a 200 turning into a 5xx would mean
+        // we accidentally introduced a hard dependency.
+        expect(
+            after.status(),
+            `notifications status regressed after work creation: ${beforeStatus} → ${after.status()}`,
+        ).toBeLessThan(500);
+        // Both responses must agree on whether auth is required.
+        expect(Math.floor(after.status() / 100)).toBe(Math.floor(beforeStatus / 100));
+    });
+
+    test('hitting /api/health does not consume rate-limit budget for /api/auth/login', async ({
+        request,
+    }) => {
+        for (let i = 0; i < 5; i++) {
+            const res = await request.get(`${API_BASE}/api/health`);
+            expect(res.status()).toBeLessThan(500);
+        }
+        // After 5 health hits, login should still be reachable — health
+        // must be excluded from the auth throttler bucket.
+        const login = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: `nonexistent-${Date.now()}@test.local`, password: 'Wrong123!' },
+        });
+        // 401/422 OK, 429 means health hits leaked into the auth bucket.
+        expect(login.status(), 'health hits leaked into auth throttler').not.toBe(429);
+    });
+});
+
+test.describe('Service isolation — write in module A leaves module B unchanged', () => {
+    test('creating a work does not mutate /api/account/profile counters', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const profileBefore = await request.get(`${API_BASE}/api/auth/profile`, {
+            headers: authedHeaders(u.access_token),
+        });
+        if (!profileBefore.ok()) {
+            test.skip(true, `profile endpoint not exposed (${profileBefore.status()})`);
+        }
+        const before = await profileBefore.json();
+        await createWorkViaAPI(request, u.access_token, {
+            name: `isolation-prof-${Date.now().toString(36)}`,
+            slug: `isolation-prof-${Date.now().toString(36)}`,
+        });
+        const profileAfter = await request.get(`${API_BASE}/api/auth/profile`, {
+            headers: authedHeaders(u.access_token),
+        });
+        const after = await profileAfter.json();
+        // The user.id and email must be byte-stable across an
+        // unrelated module write — drift here means the profile is
+        // accidentally being modified by work creation.
+        expect(after?.user?.id ?? after?.id).toBe(before?.user?.id ?? before?.id);
+        expect(after?.user?.email ?? after?.email).toBe(before?.user?.email ?? before?.email);
+    });
+});

--- a/apps/web/e2e/signed-url-expiry.spec.ts
+++ b/apps/web/e2e/signed-url-expiry.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Signed URL expiry — pass 14. Pre-signed upload / download URLs
+ * must carry an explicit expiry — they're effectively bearer tokens
+ * for the duration they're valid. Industry default: 1 hour or less.
+ *
+ * We probe a handful of candidate endpoints that might issue signed
+ * URLs (image upload, export, deploy artifact). For each that returns
+ * a URL, we verify the URL string carries SOMETHING that looks like
+ * an expiry parameter (`Expires=`, `X-Amz-Expires=`, `?exp=`, etc.).
+ */
+
+const SIGNED_URL_CANDIDATES = [
+    '/api/works/__WORK_ID__/upload-url',
+    '/api/works/__WORK_ID__/screenshot/signed-url',
+    '/api/account/export-url',
+    '/api/activity-log/export?download=1',
+];
+
+const EXPIRY_MARKERS = [
+    /[?&]Expires=\d+/,
+    /[?&]X-Amz-Expires=\d+/,
+    /[?&]exp=\d+/,
+    /[?&]expires_in=\d+/,
+    /[?&]token=[A-Za-z0-9_-]{16,}/,
+    /[?&]signature=[A-Za-z0-9%_-]{16,}/,
+];
+
+test.describe('Signed URLs — issued URLs carry an expiry parameter', () => {
+    test('one of the candidate endpoints returns a URL with an expiry marker', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const w = await createWorkViaAPI(request, u.access_token, {
+            name: `signed-${Date.now().toString(36)}`,
+            slug: `signed-${Date.now().toString(36)}`,
+        });
+        let foundUrl: string | null = null;
+        for (const c of SIGNED_URL_CANDIDATES) {
+            const path = c.replace('__WORK_ID__', w.id);
+            const res = await request.get(`${API_BASE}${path}`, {
+                headers: authedHeaders(u.access_token),
+            });
+            if (!res.ok()) continue;
+            const ct = res.headers()['content-type'] || '';
+            if (!ct.includes('json')) continue;
+            const body = await res.json().catch(() => ({}));
+            const candidate =
+                body?.url ??
+                body?.signed_url ??
+                body?.signedUrl ??
+                body?.upload_url ??
+                body?.uploadUrl;
+            if (typeof candidate === 'string' && candidate.startsWith('http')) {
+                foundUrl = candidate;
+                break;
+            }
+        }
+        if (!foundUrl) {
+            test.skip(true, 'no signed-URL endpoint exposes a URL in this env');
+        }
+        const hasExpiry = EXPIRY_MARKERS.some((re) => re.test(foundUrl!));
+        expect(
+            hasExpiry,
+            `signed URL has no expiry/signature marker: ${foundUrl!.slice(0, 200)}`,
+        ).toBe(true);
+    });
+
+    test("GET against a stranger's upload-url path is auth-gated", async ({ request }) => {
+        // No token — unauthenticated probe.
+        const res = await request.get(`${API_BASE}/api/works/fake-id/upload-url`);
+        if (res.status() === 404) {
+            test.skip(true, 'upload-url endpoint not exposed');
+        }
+        expect(res.status(), 'upload-url should require auth').toBeGreaterThanOrEqual(400);
+        expect(res.status()).toBeLessThan(500);
+        expect([401, 403, 404]).toContain(res.status());
+    });
+});


### PR DESCRIPTION
## Summary

Pass 14 of the rolling E2E coverage campaign. **+10 new spec files** under `apps/web/e2e/` exercising cross-module service boundaries, observability surfaces, and transport-security posture.

## Specs added

- `service-isolation.spec.ts` — cross-module side-effect probes (work-create vs notifications, health vs auth throttler, profile byte-stability)
- `metrics-endpoint.spec.ts` — Prometheus-shape `/metrics` (text/plain, `# HELP` / `# TYPE` directives, canonical series)
- `graphql-introspection.spec.ts` — production posture: `__schema` query rejected, errors, or empty types
- `connection-pool-leak.spec.ts` — 50 sequential authed hits + 20-burst `/health` stay 5xx-clean
- `idempotency-keys.spec.ts` — same-key retry < 500, empty key not 5xx
- `content-security-violations.spec.ts` — CSP report endpoint accepts `/csp-report` POST without 5xx
- `secure-cookies-on-https.spec.ts` — HttpOnly + Secure-on-https + SameSite enforcement
- `password-history.spec.ts` — rotating back to previous password 4xx (or informational skip if policy off); update-password without current rejected
- `api-version-header.spec.ts` — `/api/health` surfaces semver/sha/date-shaped version via header or body; stable across calls
- `signed-url-expiry.spec.ts` — issued signed URLs carry expiry/signature marker; unauth probe 401/403/404

## COVERAGE.md

All 10 Pass-14 rows flip to `[x]`; new `Pass 15 — queued` section adds 10 long-tail items (db-readonly-replica, feature-flag-runtime-toggle, webhook-redelivery, multi-tenant-data-leak, oauth-pkce, audit-tamper-resistance, backup-restore-noop, cloud-sdk-headers, webhook-secret-rotation, request-id-tracing).

## Test plan

- [ ] CI E2E suite runs all new specs
- [ ] CodeRabbit / Greptile / Codex review clean
- [ ] No regressions on existing passes 1–13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added 10 new end-to-end test specs covering API health/version checks, connection-pool stability, CSP reporting, secure cookie attributes, GraphQL introspection hardening, idempotency behavior, metrics endpoint exposure, password-history enforcement, signed-URL expiry, and service isolation boundaries.
* **Chores**
  * Updated E2E coverage tracker: marked Pass 14 complete and queued Pass 15.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->