### PR TITLE
fix(auth): fail boot when AUTH_SECRET < 32 chars (H-14 follow-up)

### DIFF
--- a/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
@@ -78,11 +78,13 @@ describe('createAuthRuntimeInstance', () => {
     const ORIGINAL_ENV = { ...process.env };
 
     beforeEach(() => {
-        // Reset env to a known baseline. AUTH_SECRET is required by config.auth.secret().
+        // Reset env to a known baseline. AUTH_SECRET is required by
+        // config.auth.secret() AND must satisfy the H-14 minimum length
+        // (32 chars) — use a deterministic 32-byte value.
         for (const key of [...SOCIAL_ENV_KEYS, ...RUNTIME_ENV_KEYS]) {
             delete process.env[key];
         }
-        process.env.AUTH_SECRET = 'test-secret';
+        process.env.AUTH_SECRET = 'a'.repeat(32);
 
         betterAuthMock.mockClear();
         betterAuthMock.mockReturnValue({ __betterAuthInstance: true });
@@ -233,11 +235,12 @@ describe('createAuthRuntimeInstance', () => {
 
     describe('secret', () => {
         it('reads from `config.auth.secret()` (delegates to AUTH_SECRET env var)', () => {
-            process.env.AUTH_SECRET = 'sup3r-secret';
+            const strong = 'b'.repeat(48);
+            process.env.AUTH_SECRET = strong;
 
             createAuthRuntimeInstance(makeDataSource('postgres', { master: {} }) as any);
 
-            expect(getCapturedOptions().secret).toBe('sup3r-secret');
+            expect(getCapturedOptions().secret).toBe(strong);
         });
 
         it('lets the `config.auth.secret()` AUTH_SECRET-required error propagate', () => {
@@ -246,6 +249,16 @@ describe('createAuthRuntimeInstance', () => {
             expect(() =>
                 createAuthRuntimeInstance(makeDataSource('postgres', { master: {} }) as any),
             ).toThrow('AUTH_SECRET environment variable is required');
+        });
+
+        // H-14: surface a too-short AUTH_SECRET at construction time instead
+        // of mid-OAuth-callback (see 2026-05-18 incident).
+        it('lets the `config.auth.secret()` AUTH_SECRET-min-length error propagate', () => {
+            process.env.AUTH_SECRET = 'short';
+
+            expect(() =>
+                createAuthRuntimeInstance(makeDataSource('postgres', { master: {} }) as any),
+            ).toThrow(/at least 32 characters/);
         });
     });
 

--- a/apps/api/src/config/constants.spec.ts
+++ b/apps/api/src/config/constants.spec.ts
@@ -90,20 +90,35 @@ describe('config/constants', () => {
     });
 
     describe('config.auth.secret', () => {
+        const STRONG_SECRET = 'a'.repeat(32);
+
         it('throws when AUTH_SECRET is missing', () => {
             expect(() => config.auth.secret()).toThrow(
                 'AUTH_SECRET environment variable is required',
             );
         });
 
-        it('returns the AUTH_SECRET value when set', () => {
-            process.env.AUTH_SECRET = 's3cret';
-            expect(config.auth.secret()).toBe('s3cret');
+        it('returns the AUTH_SECRET value when set with sufficient length', () => {
+            process.env.AUTH_SECRET = STRONG_SECRET;
+            expect(config.auth.secret()).toBe(STRONG_SECRET);
         });
 
         it('throws on empty string (falsy)', () => {
             process.env.AUTH_SECRET = '';
             expect(() => config.auth.secret()).toThrow();
+        });
+
+        // H-14: keep the API in lockstep with apps/web/src/lib/auth/crypto.ts —
+        // a sub-32-char secret silently breaks every OAuth callback when the
+        // web tier tries to seal cookies (see 2026-05-18 incident).
+        it('throws when AUTH_SECRET is shorter than 32 characters', () => {
+            process.env.AUTH_SECRET = 'a'.repeat(31);
+            expect(() => config.auth.secret()).toThrow(/at least 32 characters/);
+        });
+
+        it('accepts exactly 32 characters', () => {
+            process.env.AUTH_SECRET = STRONG_SECRET;
+            expect(config.auth.secret()).toBe(STRONG_SECRET);
         });
     });
 

--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -32,10 +32,25 @@ export const config = {
     },
 
     auth: {
+        // H-14 (companion to apps/web/src/lib/auth/crypto.ts): the web tier
+        // refuses to seal the auth cookie when AUTH_SECRET is shorter than
+        // 32 characters, because the previous "pad short secrets with a
+        // constant" path produced a predictable key. The API consumes the
+        // same env var for JWT signing, so anchor both tiers on the same
+        // minimum here and surface the misconfiguration at first call —
+        // which `main.ts` triggers eagerly at boot — instead of mid-flow
+        // during an OAuth callback (see 2026-05-18 incident).
         secret: () => {
             const secret = process.env.AUTH_SECRET;
             if (!secret) {
                 throw new Error('AUTH_SECRET environment variable is required');
+            }
+            if (secret.length < 32) {
+                throw new Error(
+                    'AUTH_SECRET must be at least 32 characters of high-entropy material ' +
+                        '(e.g. `openssl rand -base64 48`). The web tier refuses to seal cookies ' +
+                        'with a shorter secret, so logins silently break in the OAuth callback.',
+                );
             }
             return secret;
         },

--- a/apps/api/src/integrations/github-app/github-app-onboarding.service.spec.ts
+++ b/apps/api/src/integrations/github-app/github-app-onboarding.service.spec.ts
@@ -6,7 +6,9 @@ jest.mock('@ever-works/agent/entities', () => ({}));
 
 describe('GitHubAppOnboardingService', () => {
     beforeAll(() => {
-        process.env.AUTH_SECRET = 'test-auth-secret';
+        // H-14: config.auth.secret() now enforces a 32-char minimum, so
+        // use a 32+ byte fixture instead of the historic 15-char one.
+        process.env.AUTH_SECRET = 'test-auth-secret-test-auth-secret';
     });
 
     const createService = () => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,10 +10,20 @@ import { IncomingMessage, ServerResponse } from 'http';
 import * as path from 'path';
 import { json, urlencoded } from 'express';
 import { assertProductionCorsConfig } from './cors-validation';
+import { config as appConfig } from './config/constants';
 
 async function bootstrap() {
     // Load environment variables from .env file
     configDotenv({ path: path.resolve(process.cwd(), '.env') });
+
+    // H-14: fail fast on a misconfigured AUTH_SECRET (missing or shorter
+    // than 32 chars). The web tier's `setAuthAccessCookie` will refuse to
+    // seal cookies with a short secret, so without this check the API
+    // boots clean and the misconfiguration only surfaces mid-OAuth-callback
+    // as an opaque "Authentication Error" (see 2026-05-18 incident).
+    // Aliased to `appConfig` because `bootstrap()` also declares a local
+    // `const config` for Swagger.
+    appConfig.auth.secret();
 
     // Initialize Sentry and PostHog
     initSentry();

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,0 +1,29 @@
+// Next.js boot hook. Runs once per worker before any request is served,
+// in both the Node.js and Edge runtimes.
+//
+// H-14: surface an undersized AUTH_SECRET (`COOKIE_SECRET` or `AUTH_SECRET`)
+// at boot instead of mid-OAuth-callback. `apps/web/src/lib/auth/crypto.ts`
+// fails closed when the secret is shorter than 32 chars (after H-14 removed
+// the constant-padding fallback), so a short secret used to silently break
+// every social login the first time `setAuthAccessCookie` ran — the
+// 2026-05-18 incident. Failing the boot makes the misconfiguration loud
+// and stops the rollout instead.
+
+export async function register() {
+    if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+    const secret = process.env.COOKIE_SECRET || process.env.AUTH_SECRET;
+    if (!secret) {
+        throw new Error(
+            'COOKIE_SECRET or AUTH_SECRET environment variable is required for cookie encryption.',
+        );
+    }
+    if (secret.length < 32) {
+        throw new Error(
+            'COOKIE_SECRET / AUTH_SECRET must be at least 32 characters of high-entropy material ' +
+                '(e.g. `openssl rand -base64 48`). The previous behavior of padding short secrets ' +
+                'with a fixed string has been removed because it produced a predictable encryption ' +
+                'key, and the OAuth callback handler now fails closed if the secret is too short.',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the H-14 hardening + the 2026-05-18 OAuth outage.

`apps/web/src/lib/auth/crypto.ts` already fails closed when `AUTH_SECRET` is shorter than 32 chars (after H-14 removed the constant-padding fallback), but the API + web booted clean with a short secret and the misconfiguration only surfaced **mid-OAuth-callback** as `Authentication Error`. That's exactly the symptom that landed in prod yesterday after a rotation left `AUTH_SECRET` at 16 chars on the live k8s deployments. Customers couldn't log in with Google / GitHub / Facebook / LinkedIn until the secret was rotated to a 64-char value.

This PR adds **boot-time validation on both tiers** so a sub-32-char secret kills the rollout instead of silently degrading the OAuth callback.

- `apps/api/src/config/constants.ts` — `config.auth.secret()` now rejects a sub-32-char value with a message that points at `openssl rand -base64 48`.
- `apps/api/src/main.ts` — call `appConfig.auth.secret()` eagerly during bootstrap so the API refuses to start on a short secret instead of waiting for the first lazy getter. (Renamed the import to `appConfig` because `bootstrap()` already declares a local `const config` for Swagger; without the alias the eager call would trip a TDZ ReferenceError.)
- `apps/web/src/instrumentation.ts` — new Next.js boot hook that mirrors the same check on the web side. Picks `COOKIE_SECRET || AUTH_SECRET` to match what `apps/web/src/lib/constants.ts` already does, and runs only in the `nodejs` runtime so the Edge runtime isn't asked to load `process.env` early.

## What this is **not**

This is **not** the rotation itself. The live k8s `AUTH_SECRET` + `JWT_SECRET` have already been rotated to 64-char values (via `gh secret set` + `kubectl set env` against `ever-works-{web,api}{,-dev,-stage}`), and Google OAuth state-mint + email login + password-reset all verified end-to-end against `api.ever.works`. This PR is the durable codification so the same misconfig can't slip through a future deploy.

## Test plan

- [x] `apps/api/src/config/constants.spec.ts` — new tests cover missing / empty / 31-char / 32-char / 48-char paths
- [x] `apps/api/src/auth/providers/auth-runtime.instance.spec.ts` — assertion that the min-length error propagates through `createAuthRuntimeInstance`; baseline fixtures bumped from `'test-secret'` / `'sup3r-secret'` to 32-byte values
- [x] `apps/web/src/lib/auth/crypto.unit.spec.ts` — existing 31-char / 32-char / 64-char round-trip tests already cover the encrypt-time check; unchanged
- [x] `pnpm test -- src/config/constants.spec.ts` ✅ 51 passed
- [x] `pnpm test -- --testPathPattern='auth-runtime.instance.spec'` ✅ 59 passed
- [x] `pnpm test -- crypto.unit auth.unit` (web) ✅ 83 passed
- [ ] CI runs (Codex / CodeRabbit / Sonar / Snyk to chime in)
- [ ] Stage smoke (`Sign in with Google` lands on dashboard, not `/auth/error`)
- [ ] Prod smoke after `develop → stage → main` cascade

## Related

- Incident: `knowledge/incidents/2026-05-18-platform-oauth-state-mismatch.md`
- Runbook: `knowledge/runbooks/EVER_WORKS_DB_MIGRATIONS.md`
- Original H-14 commit: see `crypto.ts:13-23`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum 32-character authentication secret and fail-fast validation at application startup to prevent later OAuth/runtime failures.
  * Startup validation extended to both API and web runtimes so misconfiguration is detected earlier.

* **Tests**
  * Updated tests to assert the stronger secret length rules and to use deterministic long-secret fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->