### PR TITLE
test(e2e): expand platform coverage (+102 tests, automated hourly batch)

### DIFF
--- a/apps/web/e2e/accept-content-negotiation.spec.ts
+++ b/apps/web/e2e/accept-content-negotiation.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Content-negotiation tolerance on public JSON endpoints. The server
+ * should never 5xx on unusual Accept headers — it should either honour
+ * the requested type, fall back to its default, or return 406.
+ */
+
+const PUBLIC_JSON_PATHS = ['/api/health', '/api/version', '/api/info'];
+
+const UNUSUAL_ACCEPTS = [
+	'application/xml',
+	'text/html',
+	'text/plain',
+	'*/*',
+	'application/json, text/plain; q=0.9',
+	'image/png',
+	'application/octet-stream',
+];
+
+test.describe('Public API: Accept-header negotiation', () => {
+	for (const path of PUBLIC_JSON_PATHS) {
+		for (const accept of UNUSUAL_ACCEPTS) {
+			test(`GET ${path} with Accept: ${accept}`, async ({ request }) => {
+				const res = await request.get(`${API_BASE}${path}`, {
+					headers: { Accept: accept },
+				});
+				expect(res.status(), `${path} accept=${accept}`).toBeLessThan(500);
+			});
+		}
+	}
+});

--- a/apps/web/e2e/accept-content-negotiation.spec.ts
+++ b/apps/web/e2e/accept-content-negotiation.spec.ts
@@ -10,24 +10,24 @@ import { API_BASE } from './helpers/api';
 const PUBLIC_JSON_PATHS = ['/api/health', '/api/version', '/api/info'];
 
 const UNUSUAL_ACCEPTS = [
-	'application/xml',
-	'text/html',
-	'text/plain',
-	'*/*',
-	'application/json, text/plain; q=0.9',
-	'image/png',
-	'application/octet-stream',
+    'application/xml',
+    'text/html',
+    'text/plain',
+    '*/*',
+    'application/json, text/plain; q=0.9',
+    'image/png',
+    'application/octet-stream',
 ];
 
 test.describe('Public API: Accept-header negotiation', () => {
-	for (const path of PUBLIC_JSON_PATHS) {
-		for (const accept of UNUSUAL_ACCEPTS) {
-			test(`GET ${path} with Accept: ${accept}`, async ({ request }) => {
-				const res = await request.get(`${API_BASE}${path}`, {
-					headers: { Accept: accept },
-				});
-				expect(res.status(), `${path} accept=${accept}`).toBeLessThan(500);
-			});
-		}
-	}
+    for (const path of PUBLIC_JSON_PATHS) {
+        for (const accept of UNUSUAL_ACCEPTS) {
+            test(`GET ${path} with Accept: ${accept}`, async ({ request }) => {
+                const res = await request.get(`${API_BASE}${path}`, {
+                    headers: { Accept: accept },
+                });
+                expect(res.status(), `${path} accept=${accept}`).toBeLessThan(500);
+            });
+        }
+    }
 });

--- a/apps/web/e2e/accept-language-fallback.spec.ts
+++ b/apps/web/e2e/accept-language-fallback.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Accept-Language tolerance on public pages — when a browser sends a
+ * locale that the platform doesn't ship, the page must still render
+ * (fallback locale) and never 5xx. Combined with the en-locale
+ * default, this is a common source of subtle middleware regressions.
+ */
+
+const UNSUPPORTED_OR_EDGE_LOCALES = [
+	'xx',
+	'qq-QQ',
+	'klingon',
+	'',
+	'*',
+	'en;q=0',
+	'en;q=invalid',
+	'fr-CA, en;q=0.9, de;q=0.8',
+	'zz, ',
+	'en-US, en;q=0.9, fr;q=0.8, de;q=0.7, it;q=0.6, pt;q=0.5, ru;q=0.4',
+];
+
+test.describe('Accept-Language tolerance', () => {
+	for (const lang of UNSUPPORTED_OR_EDGE_LOCALES) {
+		test(`home page renders with Accept-Language="${lang}"`, async ({ browser }) => {
+			const context = await browser.newContext({
+				locale: 'en-US',
+				extraHTTPHeaders: { 'Accept-Language': lang },
+			});
+			const page = await context.newPage();
+			try {
+				const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+				expect(response, `lang=${lang}`).not.toBeNull();
+				expect(response!.status(), `status for lang=${lang}`).toBeLessThan(500);
+				await expect(page.locator('body')).toBeVisible();
+			} finally {
+				await context.close();
+			}
+		});
+	}
+});

--- a/apps/web/e2e/accept-language-fallback.spec.ts
+++ b/apps/web/e2e/accept-language-fallback.spec.ts
@@ -8,34 +8,34 @@ import { test, expect } from '@playwright/test';
  */
 
 const UNSUPPORTED_OR_EDGE_LOCALES = [
-	'xx',
-	'qq-QQ',
-	'klingon',
-	'',
-	'*',
-	'en;q=0',
-	'en;q=invalid',
-	'fr-CA, en;q=0.9, de;q=0.8',
-	'zz, ',
-	'en-US, en;q=0.9, fr;q=0.8, de;q=0.7, it;q=0.6, pt;q=0.5, ru;q=0.4',
+    'xx',
+    'qq-QQ',
+    'klingon',
+    '',
+    '*',
+    'en;q=0',
+    'en;q=invalid',
+    'fr-CA, en;q=0.9, de;q=0.8',
+    'zz, ',
+    'en-US, en;q=0.9, fr;q=0.8, de;q=0.7, it;q=0.6, pt;q=0.5, ru;q=0.4',
 ];
 
 test.describe('Accept-Language tolerance', () => {
-	for (const lang of UNSUPPORTED_OR_EDGE_LOCALES) {
-		test(`home page renders with Accept-Language="${lang}"`, async ({ browser }) => {
-			const context = await browser.newContext({
-				locale: 'en-US',
-				extraHTTPHeaders: { 'Accept-Language': lang },
-			});
-			const page = await context.newPage();
-			try {
-				const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
-				expect(response, `lang=${lang}`).not.toBeNull();
-				expect(response!.status(), `status for lang=${lang}`).toBeLessThan(500);
-				await expect(page.locator('body')).toBeVisible();
-			} finally {
-				await context.close();
-			}
-		});
-	}
+    for (const lang of UNSUPPORTED_OR_EDGE_LOCALES) {
+        test(`home page renders with Accept-Language="${lang}"`, async ({ browser }) => {
+            const context = await browser.newContext({
+                locale: 'en-US',
+                extraHTTPHeaders: { 'Accept-Language': lang },
+            });
+            const page = await context.newPage();
+            try {
+                const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+                expect(response, `lang=${lang}`).not.toBeNull();
+                expect(response!.status(), `status for lang=${lang}`).toBeLessThan(500);
+                await expect(page.locator('body')).toBeVisible();
+            } finally {
+                await context.close();
+            }
+        });
+    }
 });

--- a/apps/web/e2e/content-encoding-negotiation.spec.ts
+++ b/apps/web/e2e/content-encoding-negotiation.spec.ts
@@ -14,32 +14,32 @@ import { API_BASE } from './helpers/api';
 const PUBLIC_PATHS = ['/api/health', '/.well-known/agent.json'];
 
 const ENCODINGS = [
-	'gzip',
-	'br',
-	'deflate',
-	'gzip, br, deflate',
-	'identity',
-	'*',
-	'zstd',
-	'br;q=1.0, gzip;q=0.8, *;q=0.1',
-	'invalid-encoding',
-	'',
+    'gzip',
+    'br',
+    'deflate',
+    'gzip, br, deflate',
+    'identity',
+    '*',
+    'zstd',
+    'br;q=1.0, gzip;q=0.8, *;q=0.1',
+    'invalid-encoding',
+    '',
 ];
 
 test.describe('Public API: Accept-Encoding negotiation', () => {
-	for (const path of PUBLIC_PATHS) {
-		for (const encoding of ENCODINGS) {
-			test(`GET ${path} with Accept-Encoding="${encoding}"`, async ({ request }) => {
-				const res = await request.get(`${API_BASE}${path}`, {
-					headers: { 'Accept-Encoding': encoding },
-				});
-				expect(res.status(), `${path} encoding=${encoding}`).toBeLessThan(500);
-				const sentEncoding = res.headers()['content-encoding'];
-				if (sentEncoding) {
-					// If server sets Content-Encoding it must be a known token (lowercase, no semicolon parameters).
-					expect(sentEncoding).toMatch(/^[a-z0-9*-]+$/i);
-				}
-			});
-		}
-	}
+    for (const path of PUBLIC_PATHS) {
+        for (const encoding of ENCODINGS) {
+            test(`GET ${path} with Accept-Encoding="${encoding}"`, async ({ request }) => {
+                const res = await request.get(`${API_BASE}${path}`, {
+                    headers: { 'Accept-Encoding': encoding },
+                });
+                expect(res.status(), `${path} encoding=${encoding}`).toBeLessThan(500);
+                const sentEncoding = res.headers()['content-encoding'];
+                if (sentEncoding) {
+                    // If server sets Content-Encoding it must be a known token (lowercase, no semicolon parameters).
+                    expect(sentEncoding).toMatch(/^[a-z0-9*-]+$/i);
+                }
+            });
+        }
+    }
 });

--- a/apps/web/e2e/content-encoding-negotiation.spec.ts
+++ b/apps/web/e2e/content-encoding-negotiation.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Content-encoding negotiation. The server should:
+ *  - never 5xx on unusual Accept-Encoding values
+ *  - either honour the requested encoding or omit Content-Encoding
+ *  - never claim an encoding it doesn't actually use
+ *
+ * Targets are small public JSON endpoints — payload is too small to
+ * trigger encoding on some setups, but the request should still succeed.
+ */
+
+const PUBLIC_PATHS = ['/api/health', '/.well-known/agent.json'];
+
+const ENCODINGS = [
+	'gzip',
+	'br',
+	'deflate',
+	'gzip, br, deflate',
+	'identity',
+	'*',
+	'zstd',
+	'br;q=1.0, gzip;q=0.8, *;q=0.1',
+	'invalid-encoding',
+	'',
+];
+
+test.describe('Public API: Accept-Encoding negotiation', () => {
+	for (const path of PUBLIC_PATHS) {
+		for (const encoding of ENCODINGS) {
+			test(`GET ${path} with Accept-Encoding="${encoding}"`, async ({ request }) => {
+				const res = await request.get(`${API_BASE}${path}`, {
+					headers: { 'Accept-Encoding': encoding },
+				});
+				expect(res.status(), `${path} encoding=${encoding}`).toBeLessThan(500);
+				const sentEncoding = res.headers()['content-encoding'];
+				if (sentEncoding) {
+					// If server sets Content-Encoding it must be a known token (lowercase, no semicolon parameters).
+					expect(sentEncoding).toMatch(/^[a-z0-9*-]+$/i);
+				}
+			});
+		}
+	}
+});

--- a/apps/web/e2e/http-write-methods-on-public-api.spec.ts
+++ b/apps/web/e2e/http-write-methods-on-public-api.spec.ts
@@ -9,24 +9,24 @@ import { API_BASE } from './helpers/api';
  */
 
 const READ_ONLY_PUBLIC_PATHS = [
-	'/api/health',
-	'/api/version',
-	'/api/info',
-	'/api/works',
-	'/api/auth/providers',
-	'/.well-known/agent.json',
+    '/api/health',
+    '/api/version',
+    '/api/info',
+    '/api/works',
+    '/api/auth/providers',
+    '/.well-known/agent.json',
 ];
 
 const NON_GET_METHODS: Array<'PUT' | 'PATCH' | 'DELETE'> = ['PUT', 'PATCH', 'DELETE'];
 
 test.describe('Public API: write-method rejection shape', () => {
-	for (const path of READ_ONLY_PUBLIC_PATHS) {
-		for (const method of NON_GET_METHODS) {
-			test(`${method} ${path} returns 4xx, not 5xx`, async ({ request }) => {
-				const res = await request.fetch(`${API_BASE}${path}`, { method });
-				expect(res.status(), `${method} ${path}`).toBeLessThan(500);
-				expect(res.status(), `${method} ${path}`).toBeGreaterThanOrEqual(400);
-			});
-		}
-	}
+    for (const path of READ_ONLY_PUBLIC_PATHS) {
+        for (const method of NON_GET_METHODS) {
+            test(`${method} ${path} returns 4xx, not 5xx`, async ({ request }) => {
+                const res = await request.fetch(`${API_BASE}${path}`, { method });
+                expect(res.status(), `${method} ${path}`).toBeLessThan(500);
+                expect(res.status(), `${method} ${path}`).toBeGreaterThanOrEqual(400);
+            });
+        }
+    }
 });

--- a/apps/web/e2e/http-write-methods-on-public-api.spec.ts
+++ b/apps/web/e2e/http-write-methods-on-public-api.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Write-method probes against read-only public API endpoints. Anonymous
+ * PUT/PATCH/DELETE on a read-only resource should respond with a 4xx
+ * (typically 401, 403, 404, or 405) — never 5xx. A 5xx would mean an
+ * unhandled exception in the framework's method-rejection path.
+ */
+
+const READ_ONLY_PUBLIC_PATHS = [
+	'/api/health',
+	'/api/version',
+	'/api/info',
+	'/api/works',
+	'/api/auth/providers',
+	'/.well-known/agent.json',
+];
+
+const NON_GET_METHODS: Array<'PUT' | 'PATCH' | 'DELETE'> = ['PUT', 'PATCH', 'DELETE'];
+
+test.describe('Public API: write-method rejection shape', () => {
+	for (const path of READ_ONLY_PUBLIC_PATHS) {
+		for (const method of NON_GET_METHODS) {
+			test(`${method} ${path} returns 4xx, not 5xx`, async ({ request }) => {
+				const res = await request.fetch(`${API_BASE}${path}`, { method });
+				expect(res.status(), `${method} ${path}`).toBeLessThan(500);
+				expect(res.status(), `${method} ${path}`).toBeGreaterThanOrEqual(400);
+			});
+		}
+	}
+});

--- a/apps/web/e2e/uncommon-http-methods.spec.ts
+++ b/apps/web/e2e/uncommon-http-methods.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Uncommon / non-standard HTTP methods against public endpoints. The
+ * server should reject with a 4xx (typically 405 Method Not Allowed)
+ * — never 5xx, and never silently echo (TRACE leaks request data and
+ * should be disabled).
+ */
+
+const TARGETS = ['/', '/api/health', '/api/works', '/.well-known/agent.json'];
+
+// Methods that should be rejected on a typical app server.
+const UNCOMMON_METHODS = [
+	'TRACE',
+	'CONNECT',
+	'PROPFIND',
+	'MKCOL',
+	'COPY',
+	'MOVE',
+	'LOCK',
+	'UNLOCK',
+];
+
+test.describe('Public endpoints: uncommon HTTP methods', () => {
+	for (const path of TARGETS) {
+		for (const method of UNCOMMON_METHODS) {
+			test(`${method} ${path} rejected without 5xx`, async ({ request }) => {
+				const res = await request.fetch(`${API_BASE}${path}`, { method });
+				expect(res.status(), `${method} ${path}`).toBeLessThan(500);
+			});
+		}
+	}
+});
+
+test.describe('Public endpoints: TRACE should not echo request data', () => {
+	test('TRACE / does not echo a custom request header in the body', async ({ request }) => {
+		const res = await request.fetch(`${API_BASE}/`, {
+			method: 'TRACE',
+			headers: { 'X-Leak-Probe': 'should-not-be-echoed' },
+		});
+		// 405/501/403/400/404 all fine. If the server actually answered with 200, that's bad — TRACE should be disabled.
+		expect(res.status()).toBeLessThan(500);
+		if (res.status() === 200) {
+			const body = await res.text();
+			expect(body).not.toContain('should-not-be-echoed');
+		}
+	});
+});

--- a/apps/web/e2e/uncommon-http-methods.spec.ts
+++ b/apps/web/e2e/uncommon-http-methods.spec.ts
@@ -12,38 +12,38 @@ const TARGETS = ['/', '/api/health', '/api/works', '/.well-known/agent.json'];
 
 // Methods that should be rejected on a typical app server.
 const UNCOMMON_METHODS = [
-	'TRACE',
-	'CONNECT',
-	'PROPFIND',
-	'MKCOL',
-	'COPY',
-	'MOVE',
-	'LOCK',
-	'UNLOCK',
+    'TRACE',
+    'CONNECT',
+    'PROPFIND',
+    'MKCOL',
+    'COPY',
+    'MOVE',
+    'LOCK',
+    'UNLOCK',
 ];
 
 test.describe('Public endpoints: uncommon HTTP methods', () => {
-	for (const path of TARGETS) {
-		for (const method of UNCOMMON_METHODS) {
-			test(`${method} ${path} rejected without 5xx`, async ({ request }) => {
-				const res = await request.fetch(`${API_BASE}${path}`, { method });
-				expect(res.status(), `${method} ${path}`).toBeLessThan(500);
-			});
-		}
-	}
+    for (const path of TARGETS) {
+        for (const method of UNCOMMON_METHODS) {
+            test(`${method} ${path} rejected without 5xx`, async ({ request }) => {
+                const res = await request.fetch(`${API_BASE}${path}`, { method });
+                expect(res.status(), `${method} ${path}`).toBeLessThan(500);
+            });
+        }
+    }
 });
 
 test.describe('Public endpoints: TRACE should not echo request data', () => {
-	test('TRACE / does not echo a custom request header in the body', async ({ request }) => {
-		const res = await request.fetch(`${API_BASE}/`, {
-			method: 'TRACE',
-			headers: { 'X-Leak-Probe': 'should-not-be-echoed' },
-		});
-		// 405/501/403/400/404 all fine. If the server actually answered with 200, that's bad — TRACE should be disabled.
-		expect(res.status()).toBeLessThan(500);
-		if (res.status() === 200) {
-			const body = await res.text();
-			expect(body).not.toContain('should-not-be-echoed');
-		}
-	});
+    test('TRACE / does not echo a custom request header in the body', async ({ request }) => {
+        const res = await request.fetch(`${API_BASE}/`, {
+            method: 'TRACE',
+            headers: { 'X-Leak-Probe': 'should-not-be-echoed' },
+        });
+        // 405/501/403/400/404 all fine. If the server actually answered with 200, that's bad — TRACE should be disabled.
+        expect(res.status()).toBeLessThan(500);
+        if (res.status() === 200) {
+            const body = await res.text();
+            expect(body).not.toContain('should-not-be-echoed');
+        }
+    });
 });


### PR DESCRIPTION
## Summary

Hourly e2e-expander local batch — pure HTTP-level coverage addition. No existing tests modified.

### What's added (5 new spec files, 102 new test cases under apps/web/e2e/)

| File | Tests | Area |
|---|---|---|
| `http-write-methods-on-public-api.spec.ts` | 18 | PUT/PATCH/DELETE on 6 read-only paths (`/api/health`, `/api/version`, `/api/info`, `/api/works`, `/api/auth/providers`, `/.well-known/agent.json`) return 4xx not 5xx |
| `accept-content-negotiation.spec.ts` | 21 | 7 unusual Accept headers (xml, html, plain, octet-stream, png, */* with q-values) on 3 JSON endpoints |
| `uncommon-http-methods.spec.ts` | 33 | TRACE/CONNECT/PROPFIND/MKCOL/COPY/MOVE/LOCK/UNLOCK rejection on 4 endpoints + explicit TRACE-does-not-echo guard |
| `accept-language-fallback.spec.ts` | 10 | Home renders with unsupported/edge Accept-Language values (`xx`, `klingon`, malformed q-values, very long lang lists) |
| `content-encoding-negotiation.spec.ts` | 20 | gzip/br/deflate/zstd/invalid Accept-Encoding tolerated on 2 public paths |

### Notes

- All specs follow existing repo conventions: `import { test, expect } from '@playwright/test'`, `API_BASE` from `helpers/api.ts`, pure-HTTP probes via `request.fetch/get`, no auth state required.
- No `.skip` / `.only`. No modification of any existing test or non-test source.
- Produced by the hourly local `e2e-expander` routine (task id 89) running in a worktree under `C:/Coding/Worktrees/`.

### Test plan

- [ ] CI green or matches pre-existing failure pattern on develop@HEAD
- [ ] Admin-merge with `--delete-branch` if so

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added E2E coverage validating content negotiation on public JSON endpoints
  * Added tests ensuring graceful handling of unusual Accept-Language headers on the home page
  * Added tests for robustness of Content-Encoding handling and header validation
  * Added tests verifying anonymous write methods are properly rejected (4xx)
  * Added tests covering uncommon/non-standard HTTP methods and TRACE behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->