### PR TITLE
test(e2e): expand platform coverage (+70 tests, automated hourly batch)

### DIFF
--- a/apps/web/e2e/conditional-request-headers.spec.ts
+++ b/apps/web/e2e/conditional-request-headers.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Conditional request semantics. The server should:
+ *  - tolerate If-None-Match with any value (304 if matched, full response otherwise)
+ *  - tolerate If-Modified-Since with HTTP-date and edge values
+ *  - never 5xx on malformed conditional headers
+ */
+
+const PUBLIC_PATHS = ['/api/health', '/.well-known/agent.json'];
+
+const IF_NONE_MATCH_VALUES = [
+	'"never-matches"',
+	'W/"weak-tag"',
+	'*',
+	'',
+	'malformed-no-quotes',
+];
+
+const IF_MODIFIED_SINCE_VALUES = [
+	'Wed, 21 Oct 2015 07:28:00 GMT',
+	'Thu, 01 Jan 1970 00:00:00 GMT',
+	'Mon, 31 Dec 2099 23:59:59 GMT',
+	'not-a-date',
+	'',
+];
+
+test.describe('Conditional: If-None-Match tolerance', () => {
+	for (const path of PUBLIC_PATHS) {
+		for (const value of IF_NONE_MATCH_VALUES) {
+			test(`GET ${path} with If-None-Match="${value}"`, async ({ request }) => {
+				const res = await request.get(`${API_BASE}${path}`, {
+					headers: { 'If-None-Match': value },
+				});
+				expect(res.status(), `${path} ifn=${value}`).toBeLessThan(500);
+			});
+		}
+	}
+});
+
+test.describe('Conditional: If-Modified-Since tolerance', () => {
+	for (const path of PUBLIC_PATHS) {
+		for (const value of IF_MODIFIED_SINCE_VALUES) {
+			test(`GET ${path} with If-Modified-Since="${value}"`, async ({ request }) => {
+				const res = await request.get(`${API_BASE}${path}`, {
+					headers: { 'If-Modified-Since': value },
+				});
+				expect(res.status(), `${path} ims=${value}`).toBeLessThan(500);
+			});
+		}
+	}
+});

--- a/apps/web/e2e/conditional-request-headers.spec.ts
+++ b/apps/web/e2e/conditional-request-headers.spec.ts
@@ -10,44 +10,38 @@ import { API_BASE } from './helpers/api';
 
 const PUBLIC_PATHS = ['/api/health', '/.well-known/agent.json'];
 
-const IF_NONE_MATCH_VALUES = [
-	'"never-matches"',
-	'W/"weak-tag"',
-	'*',
-	'',
-	'malformed-no-quotes',
-];
+const IF_NONE_MATCH_VALUES = ['"never-matches"', 'W/"weak-tag"', '*', '', 'malformed-no-quotes'];
 
 const IF_MODIFIED_SINCE_VALUES = [
-	'Wed, 21 Oct 2015 07:28:00 GMT',
-	'Thu, 01 Jan 1970 00:00:00 GMT',
-	'Mon, 31 Dec 2099 23:59:59 GMT',
-	'not-a-date',
-	'',
+    'Wed, 21 Oct 2015 07:28:00 GMT',
+    'Thu, 01 Jan 1970 00:00:00 GMT',
+    'Mon, 31 Dec 2099 23:59:59 GMT',
+    'not-a-date',
+    '',
 ];
 
 test.describe('Conditional: If-None-Match tolerance', () => {
-	for (const path of PUBLIC_PATHS) {
-		for (const value of IF_NONE_MATCH_VALUES) {
-			test(`GET ${path} with If-None-Match="${value}"`, async ({ request }) => {
-				const res = await request.get(`${API_BASE}${path}`, {
-					headers: { 'If-None-Match': value },
-				});
-				expect(res.status(), `${path} ifn=${value}`).toBeLessThan(500);
-			});
-		}
-	}
+    for (const path of PUBLIC_PATHS) {
+        for (const value of IF_NONE_MATCH_VALUES) {
+            test(`GET ${path} with If-None-Match="${value}"`, async ({ request }) => {
+                const res = await request.get(`${API_BASE}${path}`, {
+                    headers: { 'If-None-Match': value },
+                });
+                expect(res.status(), `${path} ifn=${value}`).toBeLessThan(500);
+            });
+        }
+    }
 });
 
 test.describe('Conditional: If-Modified-Since tolerance', () => {
-	for (const path of PUBLIC_PATHS) {
-		for (const value of IF_MODIFIED_SINCE_VALUES) {
-			test(`GET ${path} with If-Modified-Since="${value}"`, async ({ request }) => {
-				const res = await request.get(`${API_BASE}${path}`, {
-					headers: { 'If-Modified-Since': value },
-				});
-				expect(res.status(), `${path} ims=${value}`).toBeLessThan(500);
-			});
-		}
-	}
+    for (const path of PUBLIC_PATHS) {
+        for (const value of IF_MODIFIED_SINCE_VALUES) {
+            test(`GET ${path} with If-Modified-Since="${value}"`, async ({ request }) => {
+                const res = await request.get(`${API_BASE}${path}`, {
+                    headers: { 'If-Modified-Since': value },
+                });
+                expect(res.status(), `${path} ims=${value}`).toBeLessThan(500);
+            });
+        }
+    }
 });

--- a/apps/web/e2e/connection-header-probes.spec.ts
+++ b/apps/web/e2e/connection-header-probes.spec.ts
@@ -11,44 +11,44 @@ import { API_BASE } from './helpers/api';
 const PUBLIC_PATHS = ['/api/health', '/.well-known/agent.json', '/api/version'];
 
 test.describe('Connection / hop-by-hop tolerance', () => {
-	for (const path of PUBLIC_PATHS) {
-		test(`GET ${path} with Connection: close`, async ({ request }) => {
-			const res = await request.get(`${API_BASE}${path}`, {
-				headers: { Connection: 'close' },
-			});
-			expect(res.status(), `${path} conn=close`).toBeLessThan(500);
-		});
+    for (const path of PUBLIC_PATHS) {
+        test(`GET ${path} with Connection: close`, async ({ request }) => {
+            const res = await request.get(`${API_BASE}${path}`, {
+                headers: { Connection: 'close' },
+            });
+            expect(res.status(), `${path} conn=close`).toBeLessThan(500);
+        });
 
-		test(`GET ${path} with Connection: keep-alive`, async ({ request }) => {
-			const res = await request.get(`${API_BASE}${path}`, {
-				headers: { Connection: 'keep-alive' },
-			});
-			expect(res.status(), `${path} conn=keep-alive`).toBeLessThan(500);
-		});
+        test(`GET ${path} with Connection: keep-alive`, async ({ request }) => {
+            const res = await request.get(`${API_BASE}${path}`, {
+                headers: { Connection: 'keep-alive' },
+            });
+            expect(res.status(), `${path} conn=keep-alive`).toBeLessThan(500);
+        });
 
-		test(`GET ${path} with Upgrade: TLS/1.3`, async ({ request }) => {
-			const res = await request.get(`${API_BASE}${path}`, {
-				headers: { Upgrade: 'TLS/1.3' },
-			});
-			expect(res.status(), `${path} upgrade`).toBeLessThan(500);
-		});
+        test(`GET ${path} with Upgrade: TLS/1.3`, async ({ request }) => {
+            const res = await request.get(`${API_BASE}${path}`, {
+                headers: { Upgrade: 'TLS/1.3' },
+            });
+            expect(res.status(), `${path} upgrade`).toBeLessThan(500);
+        });
 
-		test(`GET ${path} with TE: trailers`, async ({ request }) => {
-			const res = await request.get(`${API_BASE}${path}`, {
-				headers: { TE: 'trailers' },
-			});
-			expect(res.status(), `${path} te`).toBeLessThan(500);
-		});
+        test(`GET ${path} with TE: trailers`, async ({ request }) => {
+            const res = await request.get(`${API_BASE}${path}`, {
+                headers: { TE: 'trailers' },
+            });
+            expect(res.status(), `${path} te`).toBeLessThan(500);
+        });
 
-		test(`GET ${path} does not leak X-Powered-By`, async ({ request }) => {
-			const res = await request.get(`${API_BASE}${path}`);
-			const poweredBy = res.headers()['x-powered-by'];
-			// Either absent, or masked to something non-identifying.
-			if (poweredBy) {
-				expect(poweredBy.toLowerCase(), `x-powered-by on ${path}`).not.toMatch(
-					/express|nest|node|nginx/i,
-				);
-			}
-		});
-	}
+        test(`GET ${path} does not leak X-Powered-By`, async ({ request }) => {
+            const res = await request.get(`${API_BASE}${path}`);
+            const poweredBy = res.headers()['x-powered-by'];
+            // Either absent, or masked to something non-identifying.
+            if (poweredBy) {
+                expect(poweredBy.toLowerCase(), `x-powered-by on ${path}`).not.toMatch(
+                    /express|nest|node|nginx/i,
+                );
+            }
+        });
+    }
 });

--- a/apps/web/e2e/connection-header-probes.spec.ts
+++ b/apps/web/e2e/connection-header-probes.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Connection / Upgrade / hop-by-hop header tolerance on public
+ * endpoints. The server should never 5xx when a client sends
+ * unusual hop-by-hop directives, and should never leak the
+ * Server / X-Powered-By framework name (basic hardening).
+ */
+
+const PUBLIC_PATHS = ['/api/health', '/.well-known/agent.json', '/api/version'];
+
+test.describe('Connection / hop-by-hop tolerance', () => {
+	for (const path of PUBLIC_PATHS) {
+		test(`GET ${path} with Connection: close`, async ({ request }) => {
+			const res = await request.get(`${API_BASE}${path}`, {
+				headers: { Connection: 'close' },
+			});
+			expect(res.status(), `${path} conn=close`).toBeLessThan(500);
+		});
+
+		test(`GET ${path} with Connection: keep-alive`, async ({ request }) => {
+			const res = await request.get(`${API_BASE}${path}`, {
+				headers: { Connection: 'keep-alive' },
+			});
+			expect(res.status(), `${path} conn=keep-alive`).toBeLessThan(500);
+		});
+
+		test(`GET ${path} with Upgrade: TLS/1.3`, async ({ request }) => {
+			const res = await request.get(`${API_BASE}${path}`, {
+				headers: { Upgrade: 'TLS/1.3' },
+			});
+			expect(res.status(), `${path} upgrade`).toBeLessThan(500);
+		});
+
+		test(`GET ${path} with TE: trailers`, async ({ request }) => {
+			const res = await request.get(`${API_BASE}${path}`, {
+				headers: { TE: 'trailers' },
+			});
+			expect(res.status(), `${path} te`).toBeLessThan(500);
+		});
+
+		test(`GET ${path} does not leak X-Powered-By`, async ({ request }) => {
+			const res = await request.get(`${API_BASE}${path}`);
+			const poweredBy = res.headers()['x-powered-by'];
+			// Either absent, or masked to something non-identifying.
+			if (poweredBy) {
+				expect(poweredBy.toLowerCase(), `x-powered-by on ${path}`).not.toMatch(
+					/express|nest|node|nginx/i,
+				);
+			}
+		});
+	}
+});

--- a/apps/web/e2e/head-method-parity.spec.ts
+++ b/apps/web/e2e/head-method-parity.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * HEAD method parity with GET. Per RFC 9110 §9.3.2 a HEAD response
+ * MUST contain the same headers as the corresponding GET response,
+ * and MUST NOT contain a body. The server should never 5xx on HEAD
+ * of a public endpoint, even when its handler only declared @Get.
+ */
+
+const TARGETS = [
+	'/api/health',
+	'/api/version',
+	'/api/info',
+	'/.well-known/agent.json',
+];
+
+test.describe('HEAD-GET parity on public endpoints', () => {
+	for (const path of TARGETS) {
+		test(`HEAD ${path} does not 5xx`, async ({ request }) => {
+			const res = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
+			expect(res.status(), `HEAD ${path}`).toBeLessThan(500);
+		});
+
+		test(`HEAD ${path} returns empty body on 200`, async ({ request }) => {
+			const res = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
+			if (res.status() === 200) {
+				const body = await res.body();
+				expect(body.length, `HEAD ${path} body bytes`).toBe(0);
+			}
+		});
+
+		test(`HEAD ${path} shares Content-Type with GET when both 200`, async ({ request }) => {
+			const headRes = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
+			const getRes = await request.get(`${API_BASE}${path}`);
+			if (headRes.status() === 200 && getRes.status() === 200) {
+				const headCt = (headRes.headers()['content-type'] || '').split(';')[0].trim();
+				const getCt = (getRes.headers()['content-type'] || '').split(';')[0].trim();
+				expect(headCt, `HEAD vs GET content-type ${path}`).toBe(getCt);
+			}
+		});
+	}
+});

--- a/apps/web/e2e/head-method-parity.spec.ts
+++ b/apps/web/e2e/head-method-parity.spec.ts
@@ -8,36 +8,31 @@ import { API_BASE } from './helpers/api';
  * of a public endpoint, even when its handler only declared @Get.
  */
 
-const TARGETS = [
-	'/api/health',
-	'/api/version',
-	'/api/info',
-	'/.well-known/agent.json',
-];
+const TARGETS = ['/api/health', '/api/version', '/api/info', '/.well-known/agent.json'];
 
 test.describe('HEAD-GET parity on public endpoints', () => {
-	for (const path of TARGETS) {
-		test(`HEAD ${path} does not 5xx`, async ({ request }) => {
-			const res = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
-			expect(res.status(), `HEAD ${path}`).toBeLessThan(500);
-		});
+    for (const path of TARGETS) {
+        test(`HEAD ${path} does not 5xx`, async ({ request }) => {
+            const res = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
+            expect(res.status(), `HEAD ${path}`).toBeLessThan(500);
+        });
 
-		test(`HEAD ${path} returns empty body on 200`, async ({ request }) => {
-			const res = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
-			if (res.status() === 200) {
-				const body = await res.body();
-				expect(body.length, `HEAD ${path} body bytes`).toBe(0);
-			}
-		});
+        test(`HEAD ${path} returns empty body on 200`, async ({ request }) => {
+            const res = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
+            if (res.status() === 200) {
+                const body = await res.body();
+                expect(body.length, `HEAD ${path} body bytes`).toBe(0);
+            }
+        });
 
-		test(`HEAD ${path} shares Content-Type with GET when both 200`, async ({ request }) => {
-			const headRes = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
-			const getRes = await request.get(`${API_BASE}${path}`);
-			if (headRes.status() === 200 && getRes.status() === 200) {
-				const headCt = (headRes.headers()['content-type'] || '').split(';')[0].trim();
-				const getCt = (getRes.headers()['content-type'] || '').split(';')[0].trim();
-				expect(headCt, `HEAD vs GET content-type ${path}`).toBe(getCt);
-			}
-		});
-	}
+        test(`HEAD ${path} shares Content-Type with GET when both 200`, async ({ request }) => {
+            const headRes = await request.fetch(`${API_BASE}${path}`, { method: 'HEAD' });
+            const getRes = await request.get(`${API_BASE}${path}`);
+            if (headRes.status() === 200 && getRes.status() === 200) {
+                const headCt = (headRes.headers()['content-type'] || '').split(';')[0].trim();
+                const getCt = (getRes.headers()['content-type'] || '').split(';')[0].trim();
+                expect(headCt, `HEAD vs GET content-type ${path}`).toBe(getCt);
+            }
+        });
+    }
 });

--- a/apps/web/e2e/post-body-shape-edges.spec.ts
+++ b/apps/web/e2e/post-body-shape-edges.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Anonymous POST body-shape edge cases against the registration
+ * endpoint. The endpoint should validate input — never 5xx on:
+ *  - empty body
+ *  - wrong Content-Type with JSON-looking body
+ *  - malformed JSON
+ *  - JSON primitives where object expected
+ *  - oversized but well-formed JSON
+ *  - duplicate keys
+ */
+
+const REGISTER = `${API_BASE}/api/auth/register`;
+
+test.describe('Auth register: body shape tolerance', () => {
+	test('POST with empty body returns 4xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: '',
+		});
+		expect(res.status(), 'empty body').toBeLessThan(500);
+		expect(res.status(), 'empty body').toBeGreaterThanOrEqual(400);
+	});
+
+	test('POST with wrong content-type still rejected gracefully', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'text/plain' },
+			data: '{"email":"x@y.z","password":"abc","name":"x"}',
+		});
+		expect(res.status(), 'wrong ct').toBeLessThan(500);
+	});
+
+	test('POST with malformed JSON returns 4xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: '{not valid json',
+		});
+		expect(res.status(), 'malformed json').toBeLessThan(500);
+		expect(res.status(), 'malformed json').toBeGreaterThanOrEqual(400);
+	});
+
+	test('POST with JSON null body returns 4xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: 'null',
+		});
+		expect(res.status(), 'null body').toBeLessThan(500);
+	});
+
+	test('POST with JSON array where object expected returns 4xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: '[]',
+		});
+		expect(res.status(), 'array body').toBeLessThan(500);
+	});
+
+	test('POST with JSON string primitive returns 4xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: '"hello"',
+		});
+		expect(res.status(), 'string primitive').toBeLessThan(500);
+	});
+
+	test('POST with JSON number primitive returns 4xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: '42',
+		});
+		expect(res.status(), 'number primitive').toBeLessThan(500);
+	});
+
+	test('POST with duplicate keys does not 5xx', async ({ request }) => {
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: '{"email":"a@a.com","email":"b@b.com","password":"abc","name":"n"}',
+		});
+		expect(res.status(), 'duplicate keys').toBeLessThan(500);
+	});
+
+	test('POST with large but well-formed JSON does not 5xx', async ({ request }) => {
+		const huge = 'x'.repeat(10_000);
+		const res = await request.post(REGISTER, {
+			headers: { 'Content-Type': 'application/json' },
+			data: JSON.stringify({ email: 'a@a.com', password: 'abc', name: huge }),
+		});
+		expect(res.status(), 'large body').toBeLessThan(500);
+	});
+});

--- a/apps/web/e2e/post-body-shape-edges.spec.ts
+++ b/apps/web/e2e/post-body-shape-edges.spec.ts
@@ -15,78 +15,78 @@ import { API_BASE } from './helpers/api';
 const REGISTER = `${API_BASE}/api/auth/register`;
 
 test.describe('Auth register: body shape tolerance', () => {
-	test('POST with empty body returns 4xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: '',
-		});
-		expect(res.status(), 'empty body').toBeLessThan(500);
-		expect(res.status(), 'empty body').toBeGreaterThanOrEqual(400);
-	});
+    test('POST with empty body returns 4xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: '',
+        });
+        expect(res.status(), 'empty body').toBeLessThan(500);
+        expect(res.status(), 'empty body').toBeGreaterThanOrEqual(400);
+    });
 
-	test('POST with wrong content-type still rejected gracefully', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'text/plain' },
-			data: '{"email":"x@y.z","password":"abc","name":"x"}',
-		});
-		expect(res.status(), 'wrong ct').toBeLessThan(500);
-	});
+    test('POST with wrong content-type still rejected gracefully', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'text/plain' },
+            data: '{"email":"x@y.z","password":"abc","name":"x"}',
+        });
+        expect(res.status(), 'wrong ct').toBeLessThan(500);
+    });
 
-	test('POST with malformed JSON returns 4xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: '{not valid json',
-		});
-		expect(res.status(), 'malformed json').toBeLessThan(500);
-		expect(res.status(), 'malformed json').toBeGreaterThanOrEqual(400);
-	});
+    test('POST with malformed JSON returns 4xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: '{not valid json',
+        });
+        expect(res.status(), 'malformed json').toBeLessThan(500);
+        expect(res.status(), 'malformed json').toBeGreaterThanOrEqual(400);
+    });
 
-	test('POST with JSON null body returns 4xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: 'null',
-		});
-		expect(res.status(), 'null body').toBeLessThan(500);
-	});
+    test('POST with JSON null body returns 4xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: 'null',
+        });
+        expect(res.status(), 'null body').toBeLessThan(500);
+    });
 
-	test('POST with JSON array where object expected returns 4xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: '[]',
-		});
-		expect(res.status(), 'array body').toBeLessThan(500);
-	});
+    test('POST with JSON array where object expected returns 4xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: '[]',
+        });
+        expect(res.status(), 'array body').toBeLessThan(500);
+    });
 
-	test('POST with JSON string primitive returns 4xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: '"hello"',
-		});
-		expect(res.status(), 'string primitive').toBeLessThan(500);
-	});
+    test('POST with JSON string primitive returns 4xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: '"hello"',
+        });
+        expect(res.status(), 'string primitive').toBeLessThan(500);
+    });
 
-	test('POST with JSON number primitive returns 4xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: '42',
-		});
-		expect(res.status(), 'number primitive').toBeLessThan(500);
-	});
+    test('POST with JSON number primitive returns 4xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: '42',
+        });
+        expect(res.status(), 'number primitive').toBeLessThan(500);
+    });
 
-	test('POST with duplicate keys does not 5xx', async ({ request }) => {
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: '{"email":"a@a.com","email":"b@b.com","password":"abc","name":"n"}',
-		});
-		expect(res.status(), 'duplicate keys').toBeLessThan(500);
-	});
+    test('POST with duplicate keys does not 5xx', async ({ request }) => {
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: '{"email":"a@a.com","email":"b@b.com","password":"abc","name":"n"}',
+        });
+        expect(res.status(), 'duplicate keys').toBeLessThan(500);
+    });
 
-	test('POST with large but well-formed JSON does not 5xx', async ({ request }) => {
-		const huge = 'x'.repeat(10_000);
-		const res = await request.post(REGISTER, {
-			headers: { 'Content-Type': 'application/json' },
-			data: JSON.stringify({ email: 'a@a.com', password: 'abc', name: huge }),
-		});
-		expect(res.status(), 'large body').toBeLessThan(500);
-	});
+    test('POST with large but well-formed JSON does not 5xx', async ({ request }) => {
+        const huge = 'x'.repeat(10_000);
+        const res = await request.post(REGISTER, {
+            headers: { 'Content-Type': 'application/json' },
+            data: JSON.stringify({ email: 'a@a.com', password: 'abc', name: huge }),
+        });
+        expect(res.status(), 'large body').toBeLessThan(500);
+    });
 });

--- a/apps/web/e2e/range-request-on-non-bytes.spec.ts
+++ b/apps/web/e2e/range-request-on-non-bytes.spec.ts
@@ -12,24 +12,24 @@ import { API_BASE } from './helpers/api';
 const TARGETS = ['/api/health', '/.well-known/agent.json'];
 
 const RANGE_HEADERS = [
-	'bytes=0-99',
-	'bytes=0-',
-	'bytes=-100',
-	'bytes=1000000000-2000000000',
-	'bytes=0-0',
-	'malformed-range',
-	'',
+    'bytes=0-99',
+    'bytes=0-',
+    'bytes=-100',
+    'bytes=1000000000-2000000000',
+    'bytes=0-0',
+    'malformed-range',
+    '',
 ];
 
 test.describe('Range request tolerance on JSON endpoints', () => {
-	for (const path of TARGETS) {
-		for (const range of RANGE_HEADERS) {
-			test(`GET ${path} with Range="${range}"`, async ({ request }) => {
-				const res = await request.get(`${API_BASE}${path}`, {
-					headers: range ? { Range: range } : {},
-				});
-				expect(res.status(), `${path} range=${range}`).toBeLessThan(500);
-			});
-		}
-	}
+    for (const path of TARGETS) {
+        for (const range of RANGE_HEADERS) {
+            test(`GET ${path} with Range="${range}"`, async ({ request }) => {
+                const res = await request.get(`${API_BASE}${path}`, {
+                    headers: range ? { Range: range } : {},
+                });
+                expect(res.status(), `${path} range=${range}`).toBeLessThan(500);
+            });
+        }
+    }
 });

--- a/apps/web/e2e/range-request-on-non-bytes.spec.ts
+++ b/apps/web/e2e/range-request-on-non-bytes.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * Range request tolerance on endpoints that don't serve bytes. Per
+ * RFC 9110 §14.2 a server that doesn't support range requests should
+ * ignore the Range header and respond as normal. A server that
+ * advertises bytes-range support should respond 206 or 416 on
+ * out-of-range — but never 5xx.
+ */
+
+const TARGETS = ['/api/health', '/.well-known/agent.json'];
+
+const RANGE_HEADERS = [
+	'bytes=0-99',
+	'bytes=0-',
+	'bytes=-100',
+	'bytes=1000000000-2000000000',
+	'bytes=0-0',
+	'malformed-range',
+	'',
+];
+
+test.describe('Range request tolerance on JSON endpoints', () => {
+	for (const path of TARGETS) {
+		for (const range of RANGE_HEADERS) {
+			test(`GET ${path} with Range="${range}"`, async ({ request }) => {
+				const res = await request.get(`${API_BASE}${path}`, {
+					headers: range ? { Range: range } : {},
+				});
+				expect(res.status(), `${path} range=${range}`).toBeLessThan(500);
+			});
+		}
+	}
+});


### PR DESCRIPTION
## Summary

Hourly e2e-expander local batch #2 — HTTP-semantics layer focus. No existing tests modified.

### What's added (5 new spec files, 70 new test cases under apps/web/e2e/)

| File | Tests | Area |
|---|---|---|
| `head-method-parity.spec.ts` | 12 | HEAD method on 4 public endpoints — no 5xx, empty body on 200, Content-Type parity with GET |
| `conditional-request-headers.spec.ts` | 20 | If-None-Match (5 values) + If-Modified-Since (5 values) on 2 public paths |
| `post-body-shape-edges.spec.ts` | 9 | Empty body, wrong CT, malformed JSON, primitives, duplicate keys, large body on POST /api/auth/register |
| `range-request-on-non-bytes.spec.ts` | 14 | Range header tolerance on JSON endpoints |
| `connection-header-probes.spec.ts` | 15 | Connection/Upgrade/TE hop-by-hop tolerance + X-Powered-By non-leak |

### Notes

- All specs follow existing repo conventions (`import { test, expect } from '@playwright/test'`, `API_BASE` from `helpers/api.ts`, no auth state).
- No `.skip` / `.only`. No modification of any existing test or source file.
- Produced by the hourly local `e2e-expander` routine (task id 89). Different focus from prior batch (PR #872 was write-methods + accept negotiation; this batch is HEAD/conditional/body/range/connection).

### Test plan

- [ ] CI green or matches pre-existing failure pattern on develop@HEAD
- [ ] Admin-merge with `--delete-branch` if so

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests to improve API reliability and robustness.
  * Validate handling of conditional request headers and range requests, including malformed values.
  * Probe connection/upgrade and hop-by-hop header tolerance across public endpoints.
  * Verify HEAD/GET parity and consistent Content-Type behavior.
  * Exercise POST body edge cases for authentication endpoints to ensure graceful, non-5xx responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->