### PR TITLE
test(e2e): close out EW-632 — tighten member-invitation E2E + update spec

### DIFF
--- a/apps/web/e2e/invitation-token-single-use.spec.ts
+++ b/apps/web/e2e/invitation-token-single-use.spec.ts
@@ -2,41 +2,104 @@ import { test, expect } from '@playwright/test';
 import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
 
 /**
- * Invitation token single-use — pass 20. Invitation tokens issued
- * via /api/works/<id>/invitations should be consumable exactly once.
- * Re-accepting a consumed token returns 4xx (not silent dup-member,
- * not 5xx).
+ * Invitation token single-use — pass 20 (re-pinned after EW-632 close-out).
  *
- * We don't have a real token-acceptance flow exposed via API alone
- * (typical UX is email click → accept), so we probe the endpoint
- * surface:
- *  - POST /invitations issues a token-shaped payload
- *  - POST /invitations/<token>/accept twice — second call ≥ 400
+ * Invitations are issued via `POST /api/works/:workId/invitations` and
+ * return a tokenised `claimUrl` ONCE at creation. The token is then
+ * consumed via the public claim flow under `/api/claim/*`:
+ *
+ *   - GET  /api/claim/preview?token=...  (PUBLIC, throttled — does NOT consume)
+ *   - POST /api/claim/accept             (authenticated, consumes)
+ *
+ * Earlier revisions of this spec probed `/api/works/invitations/:token/accept`
+ * defensively and skipped on 404. The real endpoints exist (PR #687,
+ * EW-600) so we now assert rather than skip.
  */
 
+interface InvitationCreatePayload {
+    email: string;
+    role: 'manager' | 'editor' | 'viewer';
+}
+
+/**
+ * Extract the raw token out of a created invitation response.
+ *
+ * The API embeds the token in `claimUrl` (returned ONCE) — we never
+ * see the raw token field directly. Parse it out of the URL.
+ */
+function extractClaimToken(body: unknown): string | null {
+    const claimUrl =
+        (body as { claimUrl?: string })?.claimUrl ??
+        (body as { invitation?: { claimUrl?: string } })?.invitation?.claimUrl ??
+        null;
+    if (!claimUrl) return null;
+    const match = claimUrl.match(/\/claim\/([^/?#]+)/);
+    return match?.[1] ?? null;
+}
+
 test.describe('Invitation tokens — consumed once', () => {
-    test('issuing an invitation returns a token-shaped response', async ({ request }) => {
+    test('issuing an invitation returns a claim URL with a token', async ({ request }) => {
         const owner = await registerUserViaAPI(request);
         const tag = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
         const w = await createWorkViaAPI(request, owner.access_token, {
             name: `invite-${tag}`,
             slug: `invite-${tag}`,
         });
+
+        const payload: InvitationCreatePayload = {
+            email: `invitee-${tag}@test.local`,
+            role: 'editor',
+        };
         const invite = await request.post(`${API_BASE}/api/works/${w.id}/invitations`, {
             headers: authedHeaders(owner.access_token),
-            data: { email: `invitee-${tag}@test.local`, role: 'member' },
+            data: payload,
         });
-        if (invite.status() === 404) test.skip(true, 'no invitations endpoint exposed');
-        expect(invite.status()).toBeLessThan(500);
-        if (!invite.ok()) return;
-        const body = await invite.json().catch(() => null);
-        // Token-shaped: at minimum a string id or token field.
-        const token =
-            body?.token ?? body?.id ?? body?.invitation?.token ?? body?.invitation?.id ?? null;
+
+        // Endpoint exists (EW-600 shipped 2026-05-11), so this MUST succeed
+        // for a fresh owner-on-own-work request.
         expect(
-            typeof token === 'string' && token.length,
-            'no token-shaped field on invitation',
-        ).toBeTruthy();
+            invite.status(),
+            `expected invitation create to succeed, got ${invite.status()}`,
+        ).toBeGreaterThanOrEqual(200);
+        expect(invite.status()).toBeLessThan(300);
+
+        const body = await invite.json();
+        const token = extractClaimToken(body);
+        expect(token, 'no token-shaped field on invitation response').toBeTruthy();
+        expect(token!.length, 'token suspiciously short').toBeGreaterThanOrEqual(32);
+    });
+
+    test('claim preview does NOT consume the token', async ({ request }) => {
+        const owner = await registerUserViaAPI(request);
+        const tag = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+        const w = await createWorkViaAPI(request, owner.access_token, {
+            name: `invite-prev-${tag}`,
+            slug: `invite-prev-${tag}`,
+        });
+
+        const invite = await request.post(`${API_BASE}/api/works/${w.id}/invitations`, {
+            headers: authedHeaders(owner.access_token),
+            data: { email: `invitee-${tag}@test.local`, role: 'editor' },
+        });
+        expect(invite.ok(), `invitation create failed: ${invite.status()}`).toBe(true);
+        const token = extractClaimToken(await invite.json());
+        expect(token).toBeTruthy();
+
+        // Preview is public and idempotent — calling it twice must succeed
+        // both times and report the same role.
+        const preview1 = await request.get(
+            `${API_BASE}/api/claim/preview?token=${encodeURIComponent(token!)}`,
+        );
+        expect(preview1.status(), 'first preview must succeed').toBe(200);
+        const preview1Body = await preview1.json();
+        expect(preview1Body.role).toBe('editor');
+
+        const preview2 = await request.get(
+            `${API_BASE}/api/claim/preview?token=${encodeURIComponent(token!)}`,
+        );
+        expect(preview2.status(), 'second preview must still succeed (preview is read-only)').toBe(
+            200,
+        );
     });
 
     test('accepting an invitation twice returns 4xx on the second call', async ({ request }) => {
@@ -47,32 +110,33 @@ test.describe('Invitation tokens — consumed once', () => {
             name: `invite-2x-${tag}`,
             slug: `invite-2x-${tag}`,
         });
+
         const invite = await request.post(`${API_BASE}/api/works/${w.id}/invitations`, {
             headers: authedHeaders(owner.access_token),
-            data: { email: invitee.email, role: 'member' },
+            data: { email: invitee.email, role: 'editor' },
         });
-        if (!invite.ok()) test.skip(true, `cannot create invitation (${invite.status()})`);
-        const body = await invite.json().catch(() => null);
-        const token = body?.token ?? body?.id ?? body?.invitation?.token ?? body?.invitation?.id;
-        if (!token) test.skip(true, 'no token in invitation response');
-        // Try to accept.
-        const accept1 = await request.post(
-            `${API_BASE}/api/works/invitations/${encodeURIComponent(String(token))}/accept`,
-            { headers: authedHeaders(invitee.access_token) },
-        );
-        if (accept1.status() === 404) {
-            // Endpoint shape differs — try alternative.
-            test.skip(true, 'no accept endpoint at expected path');
-        }
-        if (!accept1.ok()) {
-            // First accept failed — can't test single-use.
-            test.skip(true, `first accept failed (${accept1.status()})`);
-        }
-        const accept2 = await request.post(
-            `${API_BASE}/api/works/invitations/${encodeURIComponent(String(token))}/accept`,
-            { headers: authedHeaders(invitee.access_token) },
-        );
-        // Second accept must be 4xx — token consumed.
+        expect(invite.ok(), `invitation create failed: ${invite.status()}`).toBe(true);
+        const token = extractClaimToken(await invite.json());
+        expect(token, 'no token in invitation response').toBeTruthy();
+
+        // First accept: must succeed (creates a WorkMember row for the
+        // invitee with role=editor).
+        const accept1 = await request.post(`${API_BASE}/api/claim/accept`, {
+            headers: authedHeaders(invitee.access_token),
+            data: { token },
+        });
+        expect(
+            accept1.status(),
+            `first accept must succeed, got ${accept1.status()}`,
+        ).toBeGreaterThanOrEqual(200);
+        expect(accept1.status()).toBeLessThan(300);
+
+        // Second accept with the same token: must fail with a 4xx (token
+        // already consumed; no silent dup-member, no 5xx).
+        const accept2 = await request.post(`${API_BASE}/api/claim/accept`, {
+            headers: authedHeaders(invitee.access_token),
+            data: { token },
+        });
         expect(
             accept2.status(),
             `second accept returned ${accept2.status()} — token may not be single-use`,

--- a/apps/web/e2e/invitation-token-single-use.spec.ts
+++ b/apps/web/e2e/invitation-token-single-use.spec.ts
@@ -92,7 +92,10 @@ test.describe('Invitation tokens — consumed once', () => {
         );
         expect(preview1.status(), 'first preview must succeed').toBe(200);
         const preview1Body = await preview1.json();
-        expect(preview1Body.role).toBe('editor');
+        // Role casing is not pinned by the spec — normalize for comparison
+        // so both lowercase enum strings and uppercase enum names match.
+        // Greptile P1.
+        expect(String(preview1Body.role).toLowerCase()).toBe('editor');
 
         const preview2 = await request.get(
             `${API_BASE}/api/claim/preview?token=${encodeURIComponent(token!)}`,

--- a/apps/web/e2e/member-invitation-happy-path.spec.ts
+++ b/apps/web/e2e/member-invitation-happy-path.spec.ts
@@ -52,7 +52,10 @@ test.describe('Member invitation — full lifecycle', () => {
         );
         expect(preview.status(), `preview failed: ${preview.status()}`).toBe(200);
         const previewBody = await preview.json();
-        expect(previewBody.role).toBe('editor');
+        // Role string casing is not pinned by the spec; normalize for
+        // comparison so both lowercase enum strings ('editor') and
+        // uppercase enum names ('EDITOR') match. Greptile P1.
+        expect(String(previewBody.role).toLowerCase()).toBe('editor');
         expect(previewBody.workName).toContain('mem-lifecycle');
 
         // 3. Invitee accepts. Token is consumed; a WorkMember row is
@@ -65,7 +68,7 @@ test.describe('Member invitation — full lifecycle', () => {
         expect(accept.status()).toBeLessThan(300);
         const acceptBody = await accept.json();
         expect(acceptBody.workId).toBe(w.id);
-        expect(acceptBody.role).toBe('editor');
+        expect(String(acceptBody.role).toLowerCase()).toBe('editor');
 
         // 4. Owner lists members; invitee must now appear with role=editor.
         const list = await request.get(`${API_BASE}/api/works/${w.id}/members`, {
@@ -73,7 +76,13 @@ test.describe('Member invitation — full lifecycle', () => {
         });
         expect(list.status()).toBe(200);
         const listBody = await list.json();
-        const members = listBody?.members ?? [];
+        // Defensive unwrap — matches the idiom used by the peer specs in
+        // this directory so a future API shape change (plain array vs
+        // `{ members: [] }`) doesn't silently surface as "invitee not in
+        // members list". Greptile P2.
+        const members = Array.isArray(listBody)
+            ? listBody
+            : (listBody?.members ?? listBody?.data ?? []);
         const inviteeMember = members.find(
             (m: { userId?: string; user?: { id?: string } }) =>
                 m?.userId === invitee.user.id || m?.user?.id === invitee.user.id,
@@ -98,7 +107,10 @@ test.describe('Member invitation — full lifecycle', () => {
             headers: authedHeaders(owner.access_token),
         });
         const list2Body = await list2.json();
-        const inviteeAfter = (list2Body?.members ?? []).find(
+        const members2 = Array.isArray(list2Body)
+            ? list2Body
+            : (list2Body?.members ?? list2Body?.data ?? []);
+        const inviteeAfter = members2.find(
             (m: { userId?: string; user?: { id?: string } }) =>
                 m?.userId === invitee.user.id || m?.user?.id === invitee.user.id,
         );

--- a/apps/web/e2e/member-invitation-happy-path.spec.ts
+++ b/apps/web/e2e/member-invitation-happy-path.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Member invitation — full happy path (EW-632 close-out coverage).
+ *
+ * Closes the coverage gap implicitly asked for by EW-632 ("E2E coverage
+ * for the full invite → accept → role-change → remove flow"). Other specs
+ * in this dir pin the API contract piecewise; this one drives the entire
+ * collaboration lifecycle end-to-end against the real endpoints:
+ *
+ *   1. Owner POSTs /api/works/:id/invitations           → tokenised invite created
+ *   2. Invitee GETs  /api/claim/preview?token=...       → public, idempotent
+ *   3. Invitee POSTs /api/claim/accept (with token)     → consumes token, creates WorkMember
+ *   4. Owner GETs    /api/works/:id/members             → invitee present with role=editor
+ *   5. Owner PUTs    /api/works/:id/members/:memberId   → editor → viewer demotion
+ *   6. Owner DELETEs /api/works/:id/members/:memberId   → member removed
+ *   7. Demoted invitee GETs work → 403 (no membership anymore)
+ *
+ * Real endpoints all shipped via PR #687 (EW-600). Roles are
+ * owner > manager > editor > viewer (see WorkMemberRole enum).
+ */
+
+test.describe('Member invitation — full lifecycle', () => {
+    test('invite → claim → list → role-change → remove', async ({ request }) => {
+        const owner = await registerUserViaAPI(request);
+        const invitee = await registerUserViaAPI(request);
+        const tag = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+        const w = await createWorkViaAPI(request, owner.access_token, {
+            name: `mem-lifecycle-${tag}`,
+            slug: `mem-lifecycle-${tag}`,
+        });
+
+        // 1. Owner issues the invitation. Returns the raw token ONCE
+        //    via the `claimUrl` field.
+        const create = await request.post(`${API_BASE}/api/works/${w.id}/invitations`, {
+            headers: authedHeaders(owner.access_token),
+            data: { email: invitee.email, role: 'editor' },
+        });
+        expect(create.status(), `invitation create failed: ${create.status()}`).toBe(201);
+        const createBody = await create.json();
+        const claimUrl = createBody?.claimUrl ?? createBody?.invitation?.claimUrl;
+        expect(claimUrl, 'claimUrl must be returned at creation').toBeTruthy();
+        const tokenMatch = String(claimUrl).match(/\/claim\/([^/?#]+)/);
+        const token = tokenMatch?.[1];
+        expect(token, 'no token in claim URL').toBeTruthy();
+
+        // 2. Invitee previews the invitation (PUBLIC; no auth required;
+        //    does NOT consume the token). Verifies role + work name.
+        const preview = await request.get(
+            `${API_BASE}/api/claim/preview?token=${encodeURIComponent(token!)}`,
+        );
+        expect(preview.status(), `preview failed: ${preview.status()}`).toBe(200);
+        const previewBody = await preview.json();
+        expect(previewBody.role).toBe('editor');
+        expect(previewBody.workName).toContain('mem-lifecycle');
+
+        // 3. Invitee accepts. Token is consumed; a WorkMember row is
+        //    created with role=editor.
+        const accept = await request.post(`${API_BASE}/api/claim/accept`, {
+            headers: authedHeaders(invitee.access_token),
+            data: { token },
+        });
+        expect(accept.status(), `accept failed: ${accept.status()}`).toBeGreaterThanOrEqual(200);
+        expect(accept.status()).toBeLessThan(300);
+        const acceptBody = await accept.json();
+        expect(acceptBody.workId).toBe(w.id);
+        expect(acceptBody.role).toBe('editor');
+
+        // 4. Owner lists members; invitee must now appear with role=editor.
+        const list = await request.get(`${API_BASE}/api/works/${w.id}/members`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(list.status()).toBe(200);
+        const listBody = await list.json();
+        const members = listBody?.members ?? [];
+        const inviteeMember = members.find(
+            (m: { userId?: string; user?: { id?: string } }) =>
+                m?.userId === invitee.user.id || m?.user?.id === invitee.user.id,
+        );
+        expect(inviteeMember, `invitee ${invitee.email} not in members list`).toBeTruthy();
+        expect(String(inviteeMember.role).toLowerCase()).toBe('editor');
+
+        // 5. Owner demotes editor → viewer. Members controller uses PUT
+        //    (not PATCH — slight delta from the original EW-632 wording).
+        const memberId = inviteeMember.id ?? inviteeMember.userId ?? invitee.user.id;
+        const demote = await request.put(`${API_BASE}/api/works/${w.id}/members/${memberId}`, {
+            headers: authedHeaders(owner.access_token),
+            data: { role: 'viewer' },
+        });
+        expect(demote.status(), `role update failed: ${demote.status()}`).toBeGreaterThanOrEqual(
+            200,
+        );
+        expect(demote.status()).toBeLessThan(300);
+
+        // Verify the demotion by re-reading the list.
+        const list2 = await request.get(`${API_BASE}/api/works/${w.id}/members`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        const list2Body = await list2.json();
+        const inviteeAfter = (list2Body?.members ?? []).find(
+            (m: { userId?: string; user?: { id?: string } }) =>
+                m?.userId === invitee.user.id || m?.user?.id === invitee.user.id,
+        );
+        expect(inviteeAfter, 'invitee disappeared after role change').toBeTruthy();
+        expect(String(inviteeAfter.role).toLowerCase()).toBe('viewer');
+
+        // 6. Owner removes the member.
+        const remove = await request.delete(`${API_BASE}/api/works/${w.id}/members/${memberId}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(remove.status(), `member removal failed: ${remove.status()}`).toBeGreaterThanOrEqual(
+            200,
+        );
+        expect(remove.status()).toBeLessThan(300);
+
+        // 7. The (now ex-)invitee can no longer read the work's members.
+        const accessAfterRemoval = await request.get(`${API_BASE}/api/works/${w.id}/members`, {
+            headers: authedHeaders(invitee.access_token),
+        });
+        expect(
+            [401, 403, 404],
+            `ex-member must be denied access, got ${accessAfterRemoval.status()}`,
+        ).toContain(accessAfterRemoval.status());
+    });
+});

--- a/apps/web/e2e/multi-user-invitation.spec.ts
+++ b/apps/web/e2e/multi-user-invitation.spec.ts
@@ -26,10 +26,14 @@ test.describe('Multi-user invitations — owner happy path', () => {
             headers: authedHeaders(owner.access_token),
             data: INVITE_PAYLOAD(invitee.email),
         });
-        if ([400, 402, 403, 404, 409].includes(create.status())) {
-            test.skip(true, `invitation flow unavailable in env (${create.status()})`);
-        }
-        expect(create.status()).toBeGreaterThanOrEqual(200);
+        // EW-600 invitation flow is now baseline behaviour — owner POSTing a
+        // well-formed payload to their own work must succeed. The earlier
+        // defensive skip-on-4xx was a holdover from before the endpoint
+        // landed; the test now asserts.
+        expect(
+            create.status(),
+            `expected invitation to be created, got ${create.status()}`,
+        ).toBeGreaterThanOrEqual(200);
         expect(create.status()).toBeLessThan(300);
 
         const list = await request.get(`${API_BASE}/api/works/${w.id}/invitations`, {
@@ -84,7 +88,7 @@ test.describe('Multi-user invitations — members CRUD smoke', () => {
         expect(res.status()).toBeLessThan(500);
     });
 
-    test('owner can read their own membership row (returns OWNER)', async ({ request }) => {
+    test('owner appears in the separate "owner" field, not in "members"', async ({ request }) => {
         const owner = await registerUserViaAPI(request);
         const w = await createWorkViaAPI(request, owner.access_token, {
             name: `member-self-${Date.now().toString(36)}`,
@@ -92,24 +96,25 @@ test.describe('Multi-user invitations — members CRUD smoke', () => {
         const res = await request.get(`${API_BASE}/api/works/${w.id}/members`, {
             headers: authedHeaders(owner.access_token),
         });
-        if (res.status() !== 200) test.skip(true, `members list unavailable (${res.status()})`);
+        // Endpoint is known to exist — owner reading own work must return 200.
+        // Earlier revision skipped here; tightened post EW-632 close-out.
+        expect(res.status(), `expected 200 OK on own /members, got ${res.status()}`).toBe(200);
+
         const body = await res.json();
-        const arr = Array.isArray(body) ? body : (body?.members ?? body?.data ?? []);
-        // Owner should appear in the members list with role=OWNER (or
-        // equivalent). Field naming varies — accept any of role/userRole.
-        const self = arr.find(
+        // FR-2 / FR-10 (docs/specs/features/work-members/spec.md): the owner
+        // is returned in a SEPARATE `owner` field, never folded into the
+        // `members` array. A fresh work has zero collaborator members.
+        expect(body?.owner, 'no owner field in response').toBeTruthy();
+        expect(body.owner.userId ?? body.owner.user?.id ?? body.owner.id).toBe(owner.user.id);
+
+        const members = Array.isArray(body) ? body : (body?.members ?? body?.data ?? []);
+        const ownerInMembersArray = members.find(
             (m: { userId?: string; user?: { id?: string } }) =>
                 m?.userId === owner.user.id || m?.user?.id === owner.user.id,
         );
-        if (!self) test.skip(true, 'owner not in /members list — may use a separate self endpoint');
-        const role = String(self?.role ?? self?.userRole ?? '').toLowerCase();
-        // Owner-level only. "manager" is a distinct lower-privilege role
-        // in the WorkMemberRole enum (owner > manager > editor > viewer);
-        // accepting it here would let a member-promotion regression pass.
-        // Greptile P2 callout.
         expect(
-            role.includes('owner') || role === 'admin',
-            `owner row reported as "${role}" — should be owner/admin`,
-        ).toBe(true);
+            ownerInMembersArray,
+            'owner must NOT appear in members[] — only in the separate owner field',
+        ).toBeFalsy();
     });
 });

--- a/apps/web/e2e/multi-user-invitation.spec.ts
+++ b/apps/web/e2e/multi-user-invitation.spec.ts
@@ -27,14 +27,10 @@ test.describe('Multi-user invitations — owner happy path', () => {
             data: INVITE_PAYLOAD(invitee.email),
         });
         // EW-600 invitation flow is now baseline behaviour — owner POSTing a
-        // well-formed payload to their own work must succeed. The earlier
-        // defensive skip-on-4xx was a holdover from before the endpoint
-        // landed; the test now asserts.
-        expect(
-            create.status(),
-            `expected invitation to be created, got ${create.status()}`,
-        ).toBeGreaterThanOrEqual(200);
-        expect(create.status()).toBeLessThan(300);
+        // well-formed payload to their own work must succeed. Pinned to the
+        // exact 201 the controller returns (matches work-members.spec.ts so
+        // both specs catch any accidental status-code regression). Greptile P2.
+        expect(create.status(), `expected 201 Created, got ${create.status()}`).toBe(201);
 
         const list = await request.get(`${API_BASE}/api/works/${w.id}/invitations`, {
             headers: authedHeaders(owner.access_token),

--- a/apps/web/e2e/work-members.spec.ts
+++ b/apps/web/e2e/work-members.spec.ts
@@ -72,7 +72,7 @@ test.describe('Work invitations — API contract', () => {
         expect(Array.isArray(arr)).toBe(true);
     });
 
-    test('POST /api/works/:id/invitations for own work accepts well-formed body', async ({
+    test('POST /api/works/:id/invitations for own work creates a pending invitation', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -83,10 +83,17 @@ test.describe('Work invitations — API contract', () => {
             headers: authedHeaders(u.access_token),
             data: { email: `invitee-${Date.now()}@test.local`, role: 'editor' },
         });
-        // 200/201 = created; 400 = body schema differs; 409 = duplicate. All "endpoint exists" cases.
-        // Reject 5xx and 401/403 (unexpected).
-        expect(res.status(), `status was ${res.status()}`).toBeLessThan(500);
-        expect([401, 403]).not.toContain(res.status());
+        // EW-600 (PR #687) shipped tokenised invitations — owner POSTing a
+        // well-formed payload to their own work must succeed (201 Created).
+        // Tightened from the original "anything < 500 and not 401/403" guard
+        // now that the endpoint is known to exist.
+        expect(res.status(), `expected 201 Created, got ${res.status()}`).toBe(201);
+        const body = await res.json();
+        expect(body?.id ?? body?.invitation?.id, 'no invitation id in response').toBeTruthy();
+        expect(
+            body?.claimUrl ?? body?.invitation?.claimUrl,
+            'claim URL must be returned ONCE at creation',
+        ).toBeTruthy();
     });
 
     test('DELETE /api/works/:id/invitations/:inv without auth → 401', async ({ request }) => {

--- a/docs/specs/features/work-members/plan.md
+++ b/docs/specs/features/work-members/plan.md
@@ -2,8 +2,15 @@
 
 **Feature ID**: `work-members`
 **Spec**: `./spec.md`
-**Status**: `Done` (Retrospective)
-**Last updated**: 2026-05-01
+**Status**: `Shipped` (Retrospective)
+**Last updated**: 2026-05-21
+
+> **Note (EW-632 close-out).** This plan reflects the original direct-invite
+> flow only. The tokenised-claim flow added by PR #687 (EW-600) is documented
+> in `./spec.md` §5.1 — its architecture differs from the diagram below
+> (token issuance + sha256 hash at rest + public claim preview endpoint +
+> CAS-based status transitions). Treat the spec as authoritative; this plan
+> is left intact as a historical record of phase 1.
 
 ---
 

--- a/docs/specs/features/work-members/spec.md
+++ b/docs/specs/features/work-members/spec.md
@@ -61,7 +61,7 @@ Two invitation flows coexist:
 - **Given** I try to direct-invite an email without an Ever Works
   account, **when** the lookup fails, **then** I get `404`. The
   caller should fall back to the tokenised claim flow (`POST
-  /api/works/:id/invitations`) for off-platform recipients.
+/api/works/:id/invitations`) for off-platform recipients.
 - **Given** I try to assign role `owner` via the direct-invite
   endpoint, **when** the validator checks the role, **then** the
   request is rejected with `400` (use the `owner-claim` invitation
@@ -150,7 +150,7 @@ Recipients consume the token via the public claim endpoints in
 
 - `GET  /api/claim/preview?token=...` — public, throttled (10/min/IP),
   read-only. Returns `{ workName, role, expiresAt,
-  expectedProviderUsername?, sourceUrl? }`.
+expectedProviderUsername?, sourceUrl? }`.
 - `POST /api/claim/accept` — authenticated, throttled. Body:
   `{ token }`. On success creates a `WorkMember` row (member roles)
   or transfers `work.userId` (owner-claim role) via CAS, and marks
@@ -214,14 +214,14 @@ _None on develop._
 - User-facing doc: [`../../../features/work-members.md`](../../../features/work-members.md)
 - API ref: [`../../../api/authentication.md`](../../../api/authentication.md)
 - Implementation:
-  - Controllers: `apps/api/src/works/members.controller.ts`,
-    `apps/api/src/works/invitations.controller.ts`,
-    `apps/api/src/onboarding/claim.controller.ts`
-  - Services: `packages/agent/src/services/work-member.service.ts`,
-    `packages/agent/src/services/work-invitation.service.ts`,
-    `packages/agent/src/services/work-ownership.service.ts`
-  - Entities: `packages/agent/src/entities/work-member.entity.ts`,
-    `packages/agent/src/entities/work-invitation.entity.ts`
+    - Controllers: `apps/api/src/works/members.controller.ts`,
+      `apps/api/src/works/invitations.controller.ts`,
+      `apps/api/src/onboarding/claim.controller.ts`
+    - Services: `packages/agent/src/services/work-member.service.ts`,
+      `packages/agent/src/services/work-invitation.service.ts`,
+      `packages/agent/src/services/work-ownership.service.ts`
+    - Entities: `packages/agent/src/entities/work-member.entity.ts`,
+      `packages/agent/src/entities/work-invitation.entity.ts`
 - E2E specs (`apps/web/e2e/`): `work-members.spec.ts`,
   `multi-user-invitation.spec.ts`,
   `invitation-token-single-use.spec.ts`,

--- a/docs/specs/features/work-members/spec.md
+++ b/docs/specs/features/work-members/spec.md
@@ -1,23 +1,39 @@
 # Feature Specification: Work Members
 
 **Feature ID**: `work-members`
-**Status**: `Retrospective`
+**Status**: `Shipped`
 **Created**: 2026-05-01
-**Last updated**: 2026-05-01
+**Last updated**: 2026-05-21
 **Owner**: Ever Works Team
+
+> **Note (2026-05-21, EW-632 close-out).** This feature shipped in two
+> phases. The original direct-invite flow (this spec, sections 1–5)
+> landed before 2026-05-01. The tokenised-claim flow on top of it
+> shipped via PR #687 / EW-600 on 2026-05-11 — see section 5.1 below.
+> EW-632 was filed by E2E automation that mistook the controllers
+> for stubs; the work was already done.
 
 ---
 
 ## 1. Overview
 
-Work Members lets the work owner invite collaborators with
-role-based access: **Manager** (can invite/remove members and edit
-content), **Editor** (can edit content but not manage members),
-**Viewer** (read-only). Invitations are direct — the invited user must
-already have an Ever Works account, and membership becomes effective
-immediately when the invite endpoint succeeds. The Owner role is
-implicit (the work creator), cannot be reassigned, and never
+Work Members lets a work owner invite collaborators with role-based
+access: **Manager** (can invite/remove members and edit content),
+**Editor** (can edit content but not manage members), **Viewer**
+(read-only). The Owner role is implicit (the work creator) and never
 appears in the members list.
+
+Two invitation flows coexist:
+
+- **Direct invite** (sections 1–5 — original flow): owner POSTs an
+  email + role to `/api/works/:id/members`; the invitee must already
+  have an Ever Works account; membership becomes effective immediately.
+- **Tokenised claim** (section 5.1 — added by EW-600): owner POSTs to
+  `/api/works/:id/invitations`; the API returns a single-use claim
+  URL; the recipient (account-holder or not — they can register on
+  the claim page) consumes the token via `POST /api/claim/accept` to
+  create the membership. The same endpoint also supports
+  `owner-claim` for transferring ownership of imported works.
 
 ## 2. User Scenarios
 
@@ -42,18 +58,20 @@ appears in the members list.
 - **Given** I try to invite the work creator, **when** the
   server checks ownership, **then** the request is rejected with
   `400` ("cannot invite the work owner").
-- **Given** the email I invite doesn't have an Ever Works account,
-  **when** the lookup fails, **then** I get `404` ("no registered
-  user found for that email") — invitations are direct, not pending.
-- **Given** I try to assign role `owner`, **when** the validator
-  checks the role, **then** the request is rejected with `400`
-  (ownership cannot be reassigned).
+- **Given** I try to direct-invite an email without an Ever Works
+  account, **when** the lookup fails, **then** I get `404`. The
+  caller should fall back to the tokenised claim flow (`POST
+  /api/works/:id/invitations`) for off-platform recipients.
+- **Given** I try to assign role `owner` via the direct-invite
+  endpoint, **when** the validator checks the role, **then** the
+  request is rejected with `400` (use the `owner-claim` invitation
+  role for ownership transfer).
 - **Given** the user is already a member, **when** I try to invite
   again, **then** I get `400` ("already a member").
 - **Given** I'm the Owner, **when** I try to leave my own work,
   **then** the request is rejected with `400` ("owner cannot
-  leave"). Ownership is non-transferable; the only way out is to
-  delete the work.
+  leave"). To hand off the work, use the `owner-claim` invitation
+  flow (section 5.1).
 
 ## 3. Functional Requirements
 
@@ -61,11 +79,16 @@ appears in the members list.
   `owner` (implicit), `manager`, `editor`, `viewer`.
 - **FR-2** The Owner role MUST be implicit (set at work
   creation) and MUST NOT appear in the members list.
-- **FR-3** Ownership MUST NOT be transferable.
-- **FR-4** Member invitations MUST require the invitee to already
-  have an Ever Works account; no pending/accept flow.
-- **FR-5** The server MUST send an email notification to the new
-  member with the work name, role, and a link.
+- **FR-3** Ownership MAY be transferred only via the `owner-claim`
+  invitation flow (section 5.1). The direct-invite endpoint MUST
+  reject role `owner`.
+- **FR-4** The direct-invite endpoint MUST require the invitee to
+  already have an Ever Works account; the tokenised-claim endpoint
+  MAY accept arbitrary emails (recipients register at claim time
+  if needed).
+- **FR-5** The server MUST send an email notification on invite:
+  the direct flow sends a "you've been added" notification, the
+  tokenised flow sends a claim-link email with the single-use URL.
 - **FR-6** Manager and Owner roles MUST be allowed to
   invite/remove/update other members.
 - **FR-7** Editor role MUST be allowed to edit content (items,
@@ -79,46 +102,92 @@ appears in the members list.
   separately from the members array.
 - **FR-11** Role updates MUST be effective immediately (cached
   permission checks must invalidate or be short-lived).
+- **FR-12** Tokenised invitations MUST be single-use: a token that
+  has been consumed (status `accepted`) MUST be rejected on
+  subsequent claim attempts with a 4xx. Tokens MUST expire after at
+  most 90 days (default 30); expired tokens MUST be rejected.
 
 ## 4. Non-Functional Requirements
 
 - **Performance**: member endpoints respond in P95 < 200 ms.
 - **Reliability**: race conditions between invite and remove resolve
   deterministically (last writer wins; the API returns the resulting
-  state).
+  state). Tokenised claim acceptance uses CAS-based status
+  transitions so concurrent claim/revoke races resolve to a single
+  winner.
 - **Security & privacy**: every endpoint enforces the role check
-  server-side; UI is the same as a defence in depth.
+  server-side; UI is the same as a defence in depth. Claim tokens
+  are stored as sha256 hashes at rest and compared in constant time.
+  The public `/api/claim/preview` endpoint is throttled per-IP
+  (10/min) to make brute-forcing truncated tokens infeasible.
 - **Observability**: activity-log entries for invite, role change,
-  remove, leave.
+  remove, leave (`MEMBER_INVITED`, `MEMBER_ROLE_CHANGED`,
+  `MEMBER_REMOVED` action types).
 - **Compatibility**: role enum is closed; new roles would require an
   additive enum change.
 
 ## 5. Key Entities & Domain Concepts
 
-| Entity / concept  | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| `WorkMembership`  | Row with `userId`, `workId`, `role`, `invitedBy`, `createdAt` |
-| Owner             | Implicit membership equal to `work.userId`; never in the list |
-| Permission matrix | Action → role mapping (see user-facing doc table)             |
-| Invite            | Synchronous — succeeds or fails, no pending state             |
+| Entity / concept  | Description                                                            |
+| ----------------- | ---------------------------------------------------------------------- |
+| `WorkMember`      | Row in `work_members`: `workId`, `userId`, `role`, `invitedById`, etc. |
+| `WorkInvitation`  | Row in `work_invitations`: tokenised pending invite (see §5.1).        |
+| Owner             | Implicit membership equal to `work.userId`; never in the list.         |
+| Permission matrix | Action → role mapping (see user-facing doc table).                     |
+| Direct invite     | Synchronous — succeeds or fails, no pending state.                     |
+| Tokenised claim   | Asynchronous — pending until consumed via `POST /api/claim/accept`.    |
+
+### 5.1 Tokenised claim flow (EW-600, shipped 2026-05-11)
+
+`POST /api/works/:workId/invitations` issues a `WorkInvitation` with
+a random 32-byte token. The raw token is returned ONCE in the
+response (`claimUrl` field, format `${webAppUrl}/claim/${token}`);
+the server stores only the sha256 hash. Subsequent reads of the
+invitation never expose the token again.
+
+Recipients consume the token via the public claim endpoints in
+`apps/api/src/onboarding/claim.controller.ts`:
+
+- `GET  /api/claim/preview?token=...` — public, throttled (10/min/IP),
+  read-only. Returns `{ workName, role, expiresAt,
+  expectedProviderUsername?, sourceUrl? }`.
+- `POST /api/claim/accept` — authenticated, throttled. Body:
+  `{ token }`. On success creates a `WorkMember` row (member roles)
+  or transfers `work.userId` (owner-claim role) via CAS, and marks
+  the invitation `accepted`.
+
+Invitation roles are `manager | editor | viewer | owner-claim`. The
+`owner-claim` role additionally requires
+`metadata.expectedProviderUsername` (the git host login that must
+match at claim time) and may trigger a follow-up repo transfer via
+the active `IGitProviderPlugin`'s `transferRepository` capability.
 
 ## 6. Out of Scope
 
-- Pending invitations / accept tokens (today: direct).
-- Public link sharing (today: explicit per-user invitations only).
+- Public link sharing without an explicit invitation (today:
+  invitation tokens go to one recipient).
 - Custom roles beyond the four built-ins.
-- Group / org membership (today: per-user only).
-- Ownership transfer.
+- Group / org membership — cross-Work organisations where one org
+  owns multiple Works. Tracked separately: see the EW org-layer
+  follow-up ticket linked from EW-632.
+- SSO group sync.
+- Billing-side seat management.
 
 ## 7. Acceptance Criteria
 
 - [x] Four roles with the documented permission matrix.
 - [x] Owner is implicit and never appears in the members list.
-- [x] Ownership is non-transferable.
-- [x] Invite requires existing Ever Works account.
-- [x] Email notification sent on invite.
+- [x] Direct-invite requires an existing Ever Works account; rejects
+      role `owner`.
+- [x] Tokenised-claim invitations support any email; `owner-claim`
+      role transfers ownership at accept time.
+- [x] Email notification sent on both invite flows.
 - [x] Owner cannot leave own work.
+- [x] Single-use token guarantee: re-accepting a consumed token
+      returns 4xx.
 - [x] Tests cover every cell of the permission matrix.
+- [x] E2E covers the full invite → claim → role-change → remove
+      lifecycle (see `apps/web/e2e/member-invitation-happy-path.spec.ts`).
 
 ## 8. Open Questions
 
@@ -131,9 +200,11 @@ _None on develop._
 - [x] **III**: members are platform-side metadata, not in the data repo
       (membership is about access to platform features, not content).
 - [x] **IV**: invitation email is sent inline; no background job needed.
-- [x] **V**: `work_memberships` table is additive.
-- [x] **VI**: covered by `work-members.service.spec.ts` + e2e.
-- [x] **VII**: no secret leakage; emails are PII but not credentials.
+- [x] **V**: `work_members` and `work_invitations` tables are additive.
+- [x] **VI**: covered by `work-member.service.spec.ts`,
+      `work-invitation.service.spec.ts`, controller specs, and e2e.
+- [x] **VII**: claim tokens are hashed at rest, returned once at
+      creation, compared in constant time; preview endpoint is rate-limited.
 - [x] **VIII**: N/A.
 - [x] **IX**: behaviour-first.
 - [x] **X**: role enum is additive; APIs are stable.
@@ -142,5 +213,18 @@ _None on develop._
 
 - User-facing doc: [`../../../features/work-members.md`](../../../features/work-members.md)
 - API ref: [`../../../api/authentication.md`](../../../api/authentication.md)
-- Implementation: `apps/api/src/works/members/`,
-  `packages/agent/src/services/work-members.service.ts`
+- Implementation:
+  - Controllers: `apps/api/src/works/members.controller.ts`,
+    `apps/api/src/works/invitations.controller.ts`,
+    `apps/api/src/onboarding/claim.controller.ts`
+  - Services: `packages/agent/src/services/work-member.service.ts`,
+    `packages/agent/src/services/work-invitation.service.ts`,
+    `packages/agent/src/services/work-ownership.service.ts`
+  - Entities: `packages/agent/src/entities/work-member.entity.ts`,
+    `packages/agent/src/entities/work-invitation.entity.ts`
+- E2E specs (`apps/web/e2e/`): `work-members.spec.ts`,
+  `multi-user-invitation.spec.ts`,
+  `invitation-token-single-use.spec.ts`,
+  `member-invitation-happy-path.spec.ts`
+- Tracking tickets: EW-632 (close-out), EW-600 (tokenised-claim
+  flow), and the org-layer follow-up filed at EW-632 close.


### PR DESCRIPTION
## Summary

Closes out [EW-632](https://evertech.atlassian.net/browse/EW-632) — the ticket was filed by E2E automation that assumed `members.controller.ts` / `invitations.controller.ts` were stubs. In reality both shipped (PR #687, EW-600) along with the tokenised `/api/claim/*` flow on top. The three E2E specs the ticket referenced exist under different names and already run today, but they were written defensively (skip-on-404, wrong claim URL). The spec doc was also stale.

This PR tightens the existing E2E specs into real assertions, adds a happy-path lifecycle test that the ticket implicitly asked for, and updates the spec doc to reflect what shipped (including EW-600 on top of the original).

## What changed

- **`invitation-token-single-use.spec.ts`** — point at the real claim endpoints (`GET /api/claim/preview`, `POST /api/claim/accept`), replace silent `test.skip()` on 404 with assertions, parse the token out of the returned `claimUrl` (the raw token field is never exposed).
- **`multi-user-invitation.spec.ts`** — remove the broad `[400,402,403,404,409] → skip` guard around invitation create; tighten the owner-self-row test to assert that the owner is returned in the separate `owner` field (per FR-2/FR-10 in the spec) rather than searching for them in `members[]`.
- **`work-members.spec.ts`** — tighten the "POST /invitations accepts well-formed body" test from "anything < 500" to an explicit `201` assertion, and pin that the response includes the `claimUrl`.
- **`member-invitation-happy-path.spec.ts` (new)** — closes the implicit coverage gap from EW-632. Drives the full lifecycle end-to-end: owner invites → invitee previews → invitee accepts → owner lists → owner demotes editor → viewer → owner removes → ex-member is denied.
- **`docs/specs/features/work-members/spec.md`** — status `Retrospective` → `Shipped`; rewritten to reflect the EW-600 tokenised-claim flow on top of the original direct-invite flow; added FR-12 for the single-use token guarantee; fixed implementation paths; moved "Pending invitations" and "Ownership transfer" from Out-of-Scope to Acceptance Criteria.
- **`docs/specs/features/work-members/plan.md`** — status bump + pointer note that `spec.md` §5.1 is authoritative for the tokenised flow.

## Org-layer follow-up (out of scope)

EW-632 also mentioned cross-Work organisations (one org owning multiple Works) as out-of-scope; that's tracked as a separate ticket linked from the EW-632 closeout comment.

## Migration question (raised during closeout)

No `CREATE TABLE` migration exists for `work_members` / `work_invitations`. Per commit 45680773 (May 3) that's deliberate: the team uses TypeORM `synchronize` in prod (`DATABASE_AUTOMIGRATE=true`, `RUN_MIGRATIONS=false`). Not a gap — by design. Flagged in the commit message for future audit clarity.

## Test plan

- [ ] CI green on `develop` checks (`pnpm lint`, `pnpm type-check`, agent + api unit tests).
- [ ] E2E Playwright suite: the 4 touched specs run against a live dev API (no longer skip).
- [ ] Manual: spot-check the new `member-invitation-happy-path.spec.ts` walks the full lifecycle and passes.

[EW-632]: https://evertech.atlassian.net/browse/EW-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tokenized claim invitation flow with single-use tokens; previewing an invite no longer consumes the token.
  * Owner info returned separately from members in membership responses.

* **Behavior Changes**
  * Accepting a token consumes it; repeated accept attempts are rejected.

* **Tests**
  * End-to-end tests added/updated to cover invite creation, preview, acceptance, role changes, listing, and removal.

* **Documentation**
  * Work Members spec and plan updated to document both direct-invite and tokenized-claim flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->