### PR TITLE
fix(webhooks): mark orphaned deliveries failed (EW-634 P1 follow-up)

### DIFF
--- a/packages/agent/src/services/__tests__/webhook-subscription-delivery.service.spec.ts
+++ b/packages/agent/src/services/__tests__/webhook-subscription-delivery.service.spec.ts
@@ -63,8 +63,12 @@ function setup(opts: { sub?: SubRow; deliverResult: DeliveryResult; initialFailu
 describe('WebhookSubscriptionDeliveryService.dispatch', () => {
     afterEach(() => delete process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES);
 
-    it('returns subscription_not_found when the row is missing', async () => {
-        const { svc, subscriptionsRepo } = setup({
+    it('returns subscription_not_found AND marks the orphaned delivery row failed', async () => {
+        // Codex P1 follow-up: previously the dispatcher bailed without
+        // touching the pre-allocated `webhook_deliveries` row, which left
+        // it forever-pending. Now we always record a terminal attempt
+        // when the producer supplied a deliveryId.
+        const { svc, subscriptionsRepo, deliveriesRepo } = setup({
             deliverResult: { ok: true, outcome: 'success', deliveryId: 'd' },
         });
         subscriptionsRepo.findById.mockResolvedValueOnce(null);
@@ -77,9 +81,33 @@ describe('WebhookSubscriptionDeliveryService.dispatch', () => {
         expect(out.result.outcome).toBe('client_error');
         expect(out.result.error).toBe('subscription_not_found');
         expect(out.shouldRetry).toBe(false);
+        expect(deliveriesRepo.recordAttempt).toHaveBeenCalledWith(
+            'd-1',
+            expect.objectContaining({
+                status: 'failed',
+                lastOutcome: 'subscription_not_found',
+                lastError: 'subscription_not_found',
+            }),
+        );
     });
 
-    it('skips dispatch when subscription is paused', async () => {
+    it('does NOT touch the deliveries repo when subscription_not_found AND no deliveryId was supplied', async () => {
+        const { svc, subscriptionsRepo, deliveriesRepo } = setup({
+            deliverResult: { ok: true, outcome: 'success', deliveryId: 'd' },
+        });
+        subscriptionsRepo.findById.mockResolvedValueOnce(null);
+        const out = await svc.dispatch({
+            subscriptionId: 'missing',
+            event: 'x',
+            payload: {},
+        });
+        expect(out.result.outcome).toBe('client_error');
+        expect(deliveriesRepo.recordAttempt).not.toHaveBeenCalled();
+    });
+
+    it('skips dispatch when subscription is paused AND marks the orphaned delivery row failed', async () => {
+        // Same Codex P1 fix as above — pause-during-flight should not
+        // leave the pre-allocated row in `pending`.
         const { svc, deliveryService, deliveriesRepo } = setup({
             sub: makeSub({ status: 'paused' }),
             deliverResult: { ok: true, outcome: 'success', deliveryId: 'd' },
@@ -93,7 +121,14 @@ describe('WebhookSubscriptionDeliveryService.dispatch', () => {
         expect(out.result.outcome).toBe('client_error');
         expect(out.result.error).toBe('subscription_paused');
         expect(deliveryService.deliver).not.toHaveBeenCalled();
-        expect(deliveriesRepo.recordAttempt).not.toHaveBeenCalled();
+        expect(deliveriesRepo.recordAttempt).toHaveBeenCalledWith(
+            'd-1',
+            expect.objectContaining({
+                status: 'failed',
+                lastOutcome: 'subscription_paused',
+                lastError: 'subscription_paused',
+            }),
+        );
     });
 
     it('marks success + resets the counter on 2xx', async () => {

--- a/packages/agent/src/services/webhook-subscription-delivery.service.ts
+++ b/packages/agent/src/services/webhook-subscription-delivery.service.ts
@@ -90,6 +90,17 @@ export class WebhookSubscriptionDeliveryService {
     async dispatch(input: DispatchWebhookInput): Promise<DispatchedWebhookResult> {
         const sub = await this.subscriptions.findById(input.subscriptionId);
         if (!sub) {
+            // Codex P1 follow-up to EW-634 / PR #886: the producer-side
+            // dispatcher inserted a `webhook_deliveries` row with
+            // `status='pending'` before calling us. If we bail without
+            // recording a terminal attempt, the row sits forever-pending
+            // and the deliveries API misreports it as still in flight.
+            // Happens in races where the subscription is deleted between
+            // enqueue and dispatch (or redelivery against a removed sub).
+            await this.recordTerminalSkip(input, {
+                outcome: 'subscription_not_found',
+                error: 'subscription_not_found',
+            });
             return {
                 result: {
                     ok: false,
@@ -107,6 +118,14 @@ export class WebhookSubscriptionDeliveryService {
             this.logger.log(
                 `webhook.dispatch_skipped sub=${sub.id} status=${sub.status} event=${input.event}`,
             );
+            // Same Codex P1 fix — if the producer pre-allocated a delivery
+            // row, record a terminal `failed` attempt so it doesn't sit
+            // in `pending` after the subscription got paused or
+            // dead-lettered between enqueue and dispatch.
+            await this.recordTerminalSkip(input, {
+                outcome: `subscription_${sub.status}`,
+                error: `subscription_${sub.status}`,
+            });
             return {
                 result: {
                     ok: false,
@@ -249,5 +268,31 @@ export class WebhookSubscriptionDeliveryService {
             shouldRetry: retryable && !shouldDeadLetter,
             consecutiveFailures: failures,
         };
+    }
+
+    /**
+     * Mark a pre-allocated `webhook_deliveries` row as terminally failed
+     * when we never actually POST anything (subscription missing / paused /
+     * dead-lettered between enqueue and dispatch). No-op if the producer
+     * didn't pre-allocate a row.
+     */
+    private async recordTerminalSkip(
+        input: DispatchWebhookInput,
+        info: { outcome: string; error: string },
+    ): Promise<void> {
+        if (!input.deliveryId) return;
+        await this.deliveries
+            .recordAttempt(input.deliveryId, {
+                status: 'failed',
+                lastOutcome: info.outcome,
+                lastError: info.error,
+                triggerRunId: input.triggerRunId ?? null,
+            })
+            .catch((err) =>
+                this.logger.error(
+                    `webhook.delivery_record_failed delivery=${input.deliveryId} reason=${(err as Error).message}`,
+                    err as Error,
+                ),
+            );
     }
 }


### PR DESCRIPTION
## Summary

Codex P1 follow-up to [EW-634](https://evertech.atlassian.net/browse/EW-634) /
[#886](https://github.com/ever-works/ever-works/pull/886).

`WebhookSubscriptionDeliveryService.dispatch` previously bailed early
without recording any attempt when the subscription was missing or
non-active, leaving the producer-allocated `webhook_deliveries` row
in `status='pending'` forever. The deliveries API would misreport
those rows as still queued — they're actually terminally undeliverable.

Now both early-return branches record a terminal `failed` attempt
(with `lastOutcome='subscription_not_found'` or
`lastOutcome='subscription_<status>'`) when the producer supplied a
deliveryId. No-op when no deliveryId is present, so synchronous
in-process callers that don't pre-allocate rows are unaffected.

## Test plan

- [x] Existing "skips dispatch when subscription is paused" assertion
      flipped from "recordAttempt not called" to expect a `failed`
      attempt with the new outcome label.
- [x] Same shape applied to the "subscription_not_found" case.
- [x] New spec for the no-deliveryId path so in-process callers
      don't regress.
- [x] 54 webhook tests pass (was 53).

Original Codex thread: https://github.com/ever-works/ever-works/pull/886#discussion_r3280285650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-634]: https://evertech.atlassian.net/browse/EW-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook deliveries now properly record terminal failure states when subscriptions are unavailable or paused, ensuring accurate delivery status tracking.

* **Tests**
  * Enhanced test coverage for webhook delivery failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->