### PR TITLE
fix(webhooks): persist Trigger.dev run id on deliveries (EW-634 P2 follow-up)

### DIFF
--- a/apps/api/src/webhooks/webhook-event-dispatcher.service.ts
+++ b/apps/api/src/webhooks/webhook-event-dispatcher.service.ts
@@ -230,7 +230,22 @@ export class WebhookEventDispatcherService {
     private async enqueue(payload: WebhookDeliveryPayload): Promise<string | null> {
         if (this.remoteDispatcher) {
             const runId = await this.remoteDispatcher.dispatchWebhookDelivery(payload);
-            if (runId) return runId;
+            if (runId) {
+                // EW-634 Codex P2 follow-up: persist the Trigger run id
+                // on the pending delivery row immediately so the
+                // deliveries API can correlate row → Trigger run even
+                // before the first attempt finishes. Best-effort —
+                // failure here doesn't change the dispatch outcome.
+                await this.deliveries
+                    .markEnqueued(payload.deliveryId, runId)
+                    .catch((err) =>
+                        this.logger.error(
+                            `webhook.mark_enqueued_failed delivery=${payload.deliveryId} reason=${(err as Error).message}`,
+                            err as Error,
+                        ),
+                    );
+                return runId;
+            }
         }
         // In-process fallback. Fire-and-forget — the orchestrator records
         // its own delivery row updates. We do NOT await here when invoked

--- a/packages/agent/src/database/repositories/__tests__/webhook-delivery.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/webhook-delivery.repository.spec.ts
@@ -1,0 +1,93 @@
+import type { Repository } from 'typeorm';
+import { WebhookDeliveryRepository } from '../webhook-delivery.repository';
+import { WebhookDelivery } from '../../../entities';
+
+type Mocked = jest.Mocked<
+    Pick<
+        Repository<WebhookDelivery>,
+        'create' | 'save' | 'find' | 'update' | 'increment' | 'findOne' | 'delete'
+    >
+>;
+
+describe('WebhookDeliveryRepository', () => {
+    let repository: Mocked;
+    let service: WebhookDeliveryRepository;
+
+    beforeEach(() => {
+        repository = {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            update: jest.fn(),
+            increment: jest.fn(),
+            findOne: jest.fn(),
+            delete: jest.fn(),
+        };
+        service = new WebhookDeliveryRepository(
+            repository as unknown as Repository<WebhookDelivery>,
+        );
+    });
+
+    describe('markEnqueued', () => {
+        it('stamps the Trigger.dev run id on the pending row WITHOUT touching attempts', async () => {
+            await service.markEnqueued('d-1', 'run_abc123');
+            expect(repository.update).toHaveBeenCalledWith('d-1', {
+                triggerRunId: 'run_abc123',
+            });
+            // Crucially: no increment call. attempts stays at whatever
+            // createPending set it to (0).
+            expect(repository.increment).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('recordAttempt', () => {
+        it('bumps the attempts counter and writes the outcome fields', async () => {
+            await service.recordAttempt('d-1', {
+                status: 'delivered',
+                lastResponseStatus: 200,
+                lastOutcome: 'success',
+                durationMs: 42,
+                triggerRunId: 'run_abc',
+            });
+            expect(repository.increment).toHaveBeenCalledWith({ id: 'd-1' }, 'attempts', 1);
+            expect(repository.update).toHaveBeenCalledWith(
+                'd-1',
+                expect.objectContaining({
+                    status: 'delivered',
+                    lastResponseStatus: 200,
+                    lastOutcome: 'success',
+                    durationMs: 42,
+                    triggerRunId: 'run_abc',
+                }),
+            );
+        });
+
+        it('preserves an existing triggerRunId when the attempt does NOT supply one', async () => {
+            // EW-634 Codex P2 fix: previously the update set
+            // `triggerRunId: attempt.triggerRunId ?? null`, which clobbered
+            // the value the producer-side `markEnqueued` had stamped on
+            // the pending row. Now the update only writes triggerRunId
+            // when the attempt actually supplied one.
+            await service.recordAttempt('d-1', {
+                status: 'retrying',
+                lastResponseStatus: 503,
+                lastOutcome: 'server_error',
+            });
+            const update = (repository.update.mock.calls[0]?.[1] ?? {}) as Record<string, unknown>;
+            expect('triggerRunId' in update).toBe(false);
+        });
+
+        it('also preserves the existing run id when triggerRunId is explicitly null', async () => {
+            // In-process orchestrator callers pass `triggerRunId: null`
+            // (no Trigger.dev context to draw from). Must NOT clobber.
+            await service.recordAttempt('d-1', {
+                status: 'delivered',
+                lastResponseStatus: 200,
+                lastOutcome: 'success',
+                triggerRunId: null,
+            });
+            const update = (repository.update.mock.calls[0]?.[1] ?? {}) as Record<string, unknown>;
+            expect('triggerRunId' in update).toBe(false);
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/webhook-delivery.repository.ts
+++ b/packages/agent/src/database/repositories/webhook-delivery.repository.ts
@@ -40,15 +40,40 @@ export class WebhookDeliveryRepository {
 
     async recordAttempt(id: string, attempt: RecordAttemptInput): Promise<void> {
         await this.repository.increment({ id }, 'attempts', 1);
-        await this.repository.update(id, {
+        // EW-634 Codex P2 follow-up: previously we always overwrote
+        // `triggerRunId` with the value (or null) from the attempt
+        // payload. The producer-side `markEnqueued` writes the run id
+        // BEFORE the orchestrator runs, and the in-process orchestrator
+        // doesn't have the run id in scope — so blindly overwriting
+        // would null it out on the very next recordAttempt call.
+        // Build the update set explicitly so we leave `triggerRunId`
+        // alone when the attempt didn't supply one.
+        const updates: Partial<WebhookDelivery> & { lastAttemptAt: Date } = {
             status: attempt.status,
             lastResponseStatus: attempt.lastResponseStatus ?? null,
             lastOutcome: attempt.lastOutcome ?? null,
             lastError: attempt.lastError ?? null,
             durationMs: attempt.durationMs ?? null,
-            triggerRunId: attempt.triggerRunId ?? null,
             lastAttemptAt: new Date(),
-        });
+        };
+        if (attempt.triggerRunId != null) {
+            updates.triggerRunId = attempt.triggerRunId;
+        }
+        await this.repository.update(id, updates);
+    }
+
+    /**
+     * Stamp the Trigger.dev run id on a pending row at enqueue time.
+     * Called by the producer-side dispatcher right after
+     * `dispatchWebhookDelivery` returns a non-null run id, so the
+     * deliveries API can correlate a row back to its Trigger.dev run
+     * even before the first attempt completes.
+     *
+     * Distinct from {@link recordAttempt} so we don't bump the
+     * `attempts` counter (no attempt has actually run yet).
+     */
+    async markEnqueued(id: string, triggerRunId: string): Promise<void> {
+        await this.repository.update(id, { triggerRunId });
     }
 
     async findById(id: string): Promise<WebhookDelivery | null> {

--- a/packages/tasks/src/tasks/trigger/webhook-delivery.task.ts
+++ b/packages/tasks/src/tasks/trigger/webhook-delivery.task.ts
@@ -49,17 +49,23 @@ export const webhookDeliveryTask = task<'webhook-delivery', WebhookDeliveryPaylo
         factor: 6,
         randomize: true,
     },
-    run: async (payload: WebhookDeliveryPayload) => {
+    run: async (payload: WebhookDeliveryPayload, { ctx }) => {
         const appContext = await NestFactory.createApplicationContext(TriggerWebhookDeliveryModule);
         appContext.useLogger(createTriggerLogger('WebhookDelivery'));
 
         try {
             const orchestrator = appContext.get(WebhookSubscriptionDeliveryService);
+            // EW-634 Codex P2 follow-up: pass the Trigger run id through
+            // to the orchestrator so the `webhook_deliveries.triggerRunId`
+            // column stays populated across attempts. The producer side
+            // stamps it via `markEnqueued` at enqueue time; this keeps
+            // it correct on each retry's recordAttempt update too.
             const outcome = await orchestrator.dispatch({
                 deliveryId: payload.deliveryId,
                 subscriptionId: payload.subscriptionId,
                 event: payload.eventName,
                 payload: payload.payload,
+                triggerRunId: ctx?.run?.id ?? null,
             });
 
             if (outcome.shouldRetry) {


### PR DESCRIPTION
## Summary

Codex P2 follow-up to [EW-634](https://evertech.atlassian.net/browse/EW-634) /
[#886](https://github.com/ever-works/ever-works/pull/886).

The Trigger.dev run id was fetched by `TriggerService.dispatchWebhookDelivery`
and returned to the caller, but never persisted to
`webhook_deliveries.triggerRunId`. So the field exposed by
`GET /api/webhooks/deliveries` stayed null for every Trigger-dispatched
delivery — losing run-to-delivery traceability for debugging and audit.

Three changes:

1. **Producer-side stamp at enqueue time.** `WebhookEventDispatcherService.enqueue`
   now calls a new `WebhookDeliveryRepository.markEnqueued(id, runId)`
   immediately after `dispatchWebhookDelivery` returns. `markEnqueued`
   is distinct from `recordAttempt` so the `attempts` counter isn't
   bumped (no attempt has actually run yet).

2. **`recordAttempt` stops clobbering.** Previously the update wrote
   `triggerRunId: attempt.triggerRunId ?? null`, blowing away the
   stamped value on every retry — especially harmful for the
   in-process orchestrator which doesn't carry a Trigger run id at
   all. Now the update only writes `triggerRunId` when the attempt
   explicitly supplies a non-null value.

3. **Worker plumbs `ctx.run.id` through.** The Trigger.dev
   `webhook-delivery.task` extracts `ctx.run.id` and passes it as
   `triggerRunId` to `orchestrator.dispatch`, so the value is
   reinforced on every attempt.

## Test plan

- [x] New `webhook-delivery.repository.spec.ts` (4 tests):
      `markEnqueued` doesn't bump attempts; `recordAttempt` does;
      `recordAttempt` preserves `triggerRunId` when undefined; same
      when explicitly null.
- [x] 57 webhook tests pass (was 53).
- [x] `pnpm turbo build` clean (zero TS issues) across
      `@ever-works/agent`, `@ever-works/trigger-tasks`, `ever-works-api`.

Original Codex thread: https://github.com/ever-works/ever-works/pull/886#discussion_r3280285662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-634]: https://evertech.atlassian.net/browse/EW-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook deliveries now capture and maintain tracking information for associated run identifiers to improve observability.

* **Bug Fixes**
  * Fixed an issue where run identifier data could be overwritten during subsequent delivery attempts.

* **Tests**
  * Added test coverage for webhook delivery persistence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->