### PR TITLE
fix(agent): update regression guards broken by EW-634 (P0 — develop CI red)

### DIFF
--- a/packages/agent/src/database/database.module.spec.ts
+++ b/packages/agent/src/database/database.module.spec.ts
@@ -30,6 +30,7 @@ import { TemplateRepository } from './repositories/template.repository';
 import { TemplateCustomizationRepository } from './repositories/template-customization.repository';
 import { UserTemplatePreferenceRepository } from './repositories/user-template-preference.repository';
 import { WebhookSubscriptionRepository } from './repositories/webhook-subscription.repository';
+import { WebhookDeliveryRepository } from './repositories/webhook-delivery.repository';
 
 /**
  * `DatabaseModule` is a wire-format-stable contract: every NestJS feature
@@ -85,6 +86,7 @@ describe('DatabaseModule decorator metadata', () => {
         UserRepository,
         UserSubscriptionRepository,
         UserTemplatePreferenceRepository,
+        WebhookDeliveryRepository,
         WebhookSubscriptionRepository,
         WorkAdvancedPromptsRepository,
         WorkBudgetAlertStateRepository,
@@ -106,10 +108,12 @@ describe('DatabaseModule decorator metadata', () => {
             }
         });
 
-        it('declares EXACTLY 29 providers (regression guard against silent additions)', () => {
+        it('declares EXACTLY 30 providers (regression guard against silent additions)', () => {
+            // Bumped from 29 → 30 in the EW-634 follow-up that landed
+            // `WebhookDeliveryRepository` for the new `webhook_deliveries` table.
             const providers = getMeta('providers');
             expect(providers.length).toBe(REPOSITORY_PROVIDERS.length);
-            expect(providers.length).toBe(29);
+            expect(providers.length).toBe(30);
         });
 
         it('every provider is a class constructor (function with prototype) — pinned so a future `useClass`/`useFactory` swap is deliberate', () => {
@@ -149,12 +153,13 @@ describe('DatabaseModule decorator metadata', () => {
             }
         });
 
-        it('exports EXACTLY 30 symbols — TypeOrmModule + 29 repositories (regression guard)', () => {
+        it('exports EXACTLY 31 symbols — TypeOrmModule + 30 repositories (regression guard)', () => {
             // Pinned so a future "stop exporting WorkRepository" tweak (which
-            // would orphan every consumer) breaks loudly.
+            // would orphan every consumer) breaks loudly. Bumped 30 → 31
+            // in the EW-634 follow-up that added `WebhookDeliveryRepository`.
             const exports = getMeta('exports');
             expect(exports.length).toBe(REPOSITORY_PROVIDERS.length + 1);
-            expect(exports.length).toBe(30);
+            expect(exports.length).toBe(31);
         });
 
         it('exports list is exactly the providers list + TypeOrmModule (no provider held back from consumers)', () => {

--- a/packages/agent/src/tasks/tasks.spec.ts
+++ b/packages/agent/src/tasks/tasks.spec.ts
@@ -307,6 +307,7 @@ describe('agent/tasks submodule', () => {
             expect(runtimeKeys).toEqual(
                 [
                     'TEMPLATE_CUSTOMIZATION_DISPATCHER',
+                    'WEBHOOK_DELIVERY_DISPATCHER',
                     'WORK_GENERATION_DISPATCHER',
                     'WORK_GENERATION_MODE',
                     'WORK_IMPORT_DISPATCHER',


### PR DESCRIPTION
## Summary

**P0 — develop CI has been red since the EW-634 merge.** Two intentional
allow-list regression guards weren't bumped in [#886](https://github.com/ever-works/ever-works/pull/886):

1. `packages/agent/src/tasks/tasks.spec.ts` — pins the runtime symbols
   exported from `@ever-works/agent/tasks`. Adding
   `WEBHOOK_DELIVERY_DISPATCHER` requires extending the allow-list.

2. `packages/agent/src/database/database.module.spec.ts` — pins the
   exact provider count (29 → 30) and exports count (30 → 31). Adding
   `WebhookDeliveryRepository` requires bumping both numbers and
   adding the import + entry to `REPOSITORY_PROVIDERS`.

Both guards exist on purpose ("update this allow-list deliberately" /
"silently appending a provider would break the regression-guard test")
— they caught the omission, just one merge late.

## Test plan

- [x] `packages/agent/src/tasks/tasks.spec.ts` passes (20 tests, was failing 1).
- [x] `packages/agent/src/database/database.module.spec.ts` passes
      (20 tests, was failing 2).
- [x] Both specs verified locally before push.

Failed CI run (sha=665cba20): https://github.com/ever-works/ever-works/actions/runs/26219088177

🤖 Generated with [Claude Code](https://claude.com/claude-code)