### PR TITLE
feat(api): Storage Plugins — local-fs, S3, MinIO, GitHub + anon uploads (EW-637)

### DIFF
--- a/.env.compose
+++ b/.env.compose
@@ -333,6 +333,41 @@ EVER_WORKS_DEPLOY_TLS_ISSUER=letsencrypt-prod
 EVER_WORKS_DEPLOY_REGISTRY=
 EVER_WORKS_DEPLOY_MAX_WORKS_PER_USER=3
 
+# ─── Object storage / file uploads (EW-637) ─────────────────────────────────
+# `POST /api/uploads` and `POST /api/uploads/anonymous` route through a
+# pluggable IStoragePlugin backend selected here. Default is `local-fs`,
+# which writes to UPLOADS_DIR on the API node's disk.
+
+# Active backend: local-fs | aws-s3 | minio | github-storage
+STORAGE_BACKEND=local-fs
+
+# Local FS backend (default) — UPLOADS_DIR is created on demand.
+UPLOADS_DIR=
+UPLOADS_MAX_BYTES=5242880
+
+# AWS S3 backend — set STORAGE_BACKEND=aws-s3 to activate.
+AWS_S3_REGION=
+AWS_S3_BUCKET=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_PRESIGN_EXPIRES_SECONDS=600
+
+# MinIO backend (S3-compatible) — set STORAGE_BACKEND=minio to activate.
+MINIO_ENDPOINT=
+MINIO_REGION=us-east-1
+MINIO_BUCKET=
+MINIO_ACCESS_KEY=
+MINIO_SECRET_KEY=
+MINIO_PRESIGN_EXPIRES_SECONDS=600
+
+# GitHub-blob backend — set STORAGE_BACKEND=github-storage to activate.
+# The PAT needs `contents:write` on the storage repo.
+GITHUB_STORAGE_TOKEN=
+GITHUB_STORAGE_OWNER=
+GITHUB_STORAGE_REPO=
+GITHUB_STORAGE_BRANCH=main
+GITHUB_STORAGE_PATH_PREFIX=uploads
+
 # ─── User Research Agent (EW-584) ───────────────────────────────────────────
 # Tool-calling AI agent that researches new users at signup and generates
 # personalized Work proposals.

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -46,6 +46,14 @@ module.exports = {
         '^@ever-works/agent/(.*)$': '<rootDir>/../../../packages/agent/src/$1/index.ts',
         '^@ever-works/agent$': '<rootDir>/../../../packages/agent/src/index.ts',
         '^@ever-works/monitoring$': '<rootDir>/../../../packages/monitoring/src/index.ts',
+        // EW-637 — storage plugins source-mapped for tests.
+        '^@ever-works/local-fs-plugin$':
+            '<rootDir>/../../../packages/plugins/local-fs/src/index.ts',
+        '^@ever-works/aws-s3-plugin$':
+            '<rootDir>/../../../packages/plugins/aws-s3/src/index.ts',
+        '^@ever-works/minio-plugin$': '<rootDir>/../../../packages/plugins/minio/src/index.ts',
+        '^@ever-works/github-storage-plugin$':
+            '<rootDir>/../../../packages/plugins/github-storage/src/index.ts',
         // Handle .js extension in ESM-style imports (resolve to .ts)
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,7 +30,11 @@
     },
     "dependencies": {
         "@ever-works/agent": "workspace:*",
+        "@ever-works/aws-s3-plugin": "workspace:*",
         "@ever-works/contracts": "workspace:*",
+        "@ever-works/github-storage-plugin": "workspace:*",
+        "@ever-works/local-fs-plugin": "workspace:*",
+        "@ever-works/minio-plugin": "workspace:*",
         "@ever-works/monitoring": "workspace:*",
         "@ever-works/plugin": "workspace:*",
         "@ever-works/trigger-tasks": "workspace:*",

--- a/apps/api/src/uploads/dto/presign-upload.dto.ts
+++ b/apps/api/src/uploads/dto/presign-upload.dto.ts
@@ -1,0 +1,40 @@
+import { IsInt, IsMimeType, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * EW-637 — body of `POST /api/uploads/presign`.
+ *
+ * The active backend uses these fields to mint a pre-signed PUT URL. The
+ * browser then uploads bytes directly to S3 / MinIO; the API never sees
+ * the payload, so MIME / magic-byte validation has to happen client-side
+ * (or in a post-upload integrity check). For untrusted clients, use the
+ * regular `POST /api/uploads` route instead so the API can sniff bytes.
+ */
+export class PresignUploadDto {
+    @ApiProperty({ description: 'Original filename (used for extension only)' })
+    @IsString()
+    @MaxLength(256)
+    filename!: string;
+
+    @ApiProperty({ description: 'MIME type the browser will upload as' })
+    @IsString()
+    @IsMimeType()
+    mimeType!: string;
+
+    @ApiProperty({ description: 'Byte size of the file to upload' })
+    @IsInt()
+    @Min(1)
+    // Hard cap pinned to 2 GiB — anything larger should go through a
+    // dedicated multipart-upload flow, not a single presigned PUT.
+    @Max(2 * 1024 * 1024 * 1024)
+    size!: number;
+
+    @ApiPropertyOptional({
+        description:
+            'Correlation id from the website landing form, for stitching the upload to the prompt-submit funnel step.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    correlationId?: string;
+}

--- a/apps/api/src/uploads/storage-backend.factory.ts
+++ b/apps/api/src/uploads/storage-backend.factory.ts
@@ -75,6 +75,24 @@ export async function getActiveStorageBackend(): Promise<IStoragePlugin> {
     const plugin = await instantiate(wanted);
     await plugin.onLoad(makeStubContext(plugin.id));
 
+    // Probe `isAvailable()` at boot so misconfigured backends fail loudly
+    // here instead of on the first upload with a confusing SDK error
+    // (e.g. "Region is missing"). local-fs always returns true after
+    // ensuring its data dir; S3/MinIO test bucket reachability;
+    // github-storage validates the configured token + repo.
+    if (typeof plugin.isAvailable === 'function') {
+        const available = await plugin.isAvailable().catch(() => false);
+        if (!available) {
+            throw new Error(
+                `STORAGE_BACKEND="${wanted}" loaded but isAvailable() returned false. ` +
+                    `Check the backend-specific env vars (see .env.compose). ` +
+                    `For aws-s3/minio: bucket must exist + credentials must allow HeadBucket. ` +
+                    `For github-storage: GITHUB_STORAGE_TOKEN must have repo write to ` +
+                    `GITHUB_STORAGE_OWNER/GITHUB_STORAGE_REPO.`,
+            );
+        }
+    }
+
     cached = plugin;
     cachedId = wanted;
     return plugin;

--- a/apps/api/src/uploads/storage-backend.factory.ts
+++ b/apps/api/src/uploads/storage-backend.factory.ts
@@ -1,0 +1,128 @@
+import { Logger } from '@nestjs/common';
+import type { IStoragePlugin, PluginContext, PluginLogger } from '@ever-works/plugin';
+import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
+
+/**
+ * EW-637 — selects + lazily instantiates the active storage backend.
+ *
+ * `STORAGE_BACKEND` env (case-insensitive):
+ *   - `local-fs` (default) — disk under `UPLOADS_DIR`. Bundled.
+ *   - `aws-s3`             — S3 bucket. Requires the optional dep
+ *                            `@ever-works/aws-s3-plugin` to be installed.
+ *   - `minio`              — MinIO endpoint. `@ever-works/minio-plugin`.
+ *   - `github-storage`     — GitHub repo blobs. `@ever-works/github-storage-plugin`.
+ *
+ * The non-default backends are loaded via dynamic `import()` so deployments
+ * that only use local-fs don't have to install the heavy AWS SDK or octokit.
+ * If the import fails (missing package, bad env), we throw at boot — better
+ * loud than silently falling back to local disk.
+ *
+ * The factory keeps a single instance per backend across the process. It
+ * also runs the plugin's `onLoad` lifecycle hook with a minimal stub
+ * context so logging works the same as in the standard plugin loader
+ * path. Settings access (`getSettings`, cache, http, events) is not used
+ * by storage plugins — they resolve config directly from env vars — so
+ * the stub keeps those as no-ops.
+ */
+function makeStubContext(pluginId: string): PluginContext {
+	const nestLogger = new Logger(`StoragePlugin/${pluginId}`);
+	const logger: PluginLogger = {
+		log: (m, ...a) => nestLogger.log(formatMsg(m, a)),
+		error: (m, ...a) => nestLogger.error(formatMsg(m, a)),
+		warn: (m, ...a) => nestLogger.warn(formatMsg(m, a)),
+		debug: (m, ...a) => nestLogger.debug(formatMsg(m, a)),
+		verbose: (m, ...a) => nestLogger.verbose?.(formatMsg(m, a)),
+	};
+	// Storage plugins only ever touch `logger` and `pluginId` in our
+	// codebase. Anything else is cast through `unknown` so we don't have
+	// to stub the entire plugin SDK surface (cache, http, events, etc).
+	return {
+		pluginId,
+		logger,
+	} as unknown as PluginContext;
+}
+
+function formatMsg(message: string, args: unknown[]): string {
+	if (args.length === 0) return message;
+	return `${message} ${args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}`;
+}
+
+export type StorageBackendId = 'local-fs' | 'aws-s3' | 'minio' | 'github-storage';
+
+let cached: IStoragePlugin | undefined;
+let cachedId: StorageBackendId | undefined;
+
+export function resolveStorageBackendId(): StorageBackendId {
+	const raw = (process.env.STORAGE_BACKEND || 'local-fs').toLowerCase();
+	switch (raw) {
+		case 'local-fs':
+		case 'aws-s3':
+		case 'minio':
+		case 'github-storage':
+			return raw;
+		default:
+			throw new Error(
+				`STORAGE_BACKEND="${raw}" is not a supported backend. ` +
+					`Choose one of: local-fs, aws-s3, minio, github-storage.`
+			);
+	}
+}
+
+export async function getActiveStorageBackend(): Promise<IStoragePlugin> {
+	const wanted = resolveStorageBackendId();
+	if (cached && cachedId === wanted) return cached;
+
+	const plugin = await instantiate(wanted);
+	await plugin.onLoad(makeStubContext(plugin.id));
+
+	cached = plugin;
+	cachedId = wanted;
+	return plugin;
+}
+
+/**
+ * Reset the cached backend. Tests use this when they want to swap
+ * STORAGE_BACKEND between cases; production code never calls it.
+ */
+export function resetStorageBackendCache(): void {
+	cached = undefined;
+	cachedId = undefined;
+}
+
+async function instantiate(id: StorageBackendId): Promise<IStoragePlugin> {
+	switch (id) {
+		case 'local-fs':
+			// Bundled — always available, no dynamic import needed.
+			return new LocalFsStoragePlugin();
+		case 'aws-s3': {
+			const mod = await import('@ever-works/aws-s3-plugin').catch((err) => {
+				throw new Error(
+					`STORAGE_BACKEND=aws-s3 but @ever-works/aws-s3-plugin failed to load: ${
+						err instanceof Error ? err.message : String(err)
+					}`
+				);
+			});
+			return new mod.AwsS3StoragePlugin();
+		}
+		case 'minio': {
+			const mod = await import('@ever-works/minio-plugin').catch((err) => {
+				throw new Error(
+					`STORAGE_BACKEND=minio but @ever-works/minio-plugin failed to load: ${
+						err instanceof Error ? err.message : String(err)
+					}`
+				);
+			});
+			return new mod.MinioStoragePlugin();
+		}
+		case 'github-storage': {
+			const mod = await import('@ever-works/github-storage-plugin').catch((err) => {
+				throw new Error(
+					`STORAGE_BACKEND=github-storage but @ever-works/github-storage-plugin failed to load: ${
+						err instanceof Error ? err.message : String(err)
+					}`
+				);
+			});
+			return new mod.GitHubStoragePlugin();
+		}
+	}
+}

--- a/apps/api/src/uploads/storage-backend.factory.ts
+++ b/apps/api/src/uploads/storage-backend.factory.ts
@@ -25,26 +25,26 @@ import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
  * the stub keeps those as no-ops.
  */
 function makeStubContext(pluginId: string): PluginContext {
-	const nestLogger = new Logger(`StoragePlugin/${pluginId}`);
-	const logger: PluginLogger = {
-		log: (m, ...a) => nestLogger.log(formatMsg(m, a)),
-		error: (m, ...a) => nestLogger.error(formatMsg(m, a)),
-		warn: (m, ...a) => nestLogger.warn(formatMsg(m, a)),
-		debug: (m, ...a) => nestLogger.debug(formatMsg(m, a)),
-		verbose: (m, ...a) => nestLogger.verbose?.(formatMsg(m, a)),
-	};
-	// Storage plugins only ever touch `logger` and `pluginId` in our
-	// codebase. Anything else is cast through `unknown` so we don't have
-	// to stub the entire plugin SDK surface (cache, http, events, etc).
-	return {
-		pluginId,
-		logger,
-	} as unknown as PluginContext;
+    const nestLogger = new Logger(`StoragePlugin/${pluginId}`);
+    const logger: PluginLogger = {
+        log: (m, ...a) => nestLogger.log(formatMsg(m, a)),
+        error: (m, ...a) => nestLogger.error(formatMsg(m, a)),
+        warn: (m, ...a) => nestLogger.warn(formatMsg(m, a)),
+        debug: (m, ...a) => nestLogger.debug(formatMsg(m, a)),
+        verbose: (m, ...a) => nestLogger.verbose?.(formatMsg(m, a)),
+    };
+    // Storage plugins only ever touch `logger` and `pluginId` in our
+    // codebase. Anything else is cast through `unknown` so we don't have
+    // to stub the entire plugin SDK surface (cache, http, events, etc).
+    return {
+        pluginId,
+        logger,
+    } as unknown as PluginContext;
 }
 
 function formatMsg(message: string, args: unknown[]): string {
-	if (args.length === 0) return message;
-	return `${message} ${args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}`;
+    if (args.length === 0) return message;
+    return `${message} ${args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}`;
 }
 
 export type StorageBackendId = 'local-fs' | 'aws-s3' | 'minio' | 'github-storage';
@@ -53,31 +53,31 @@ let cached: IStoragePlugin | undefined;
 let cachedId: StorageBackendId | undefined;
 
 export function resolveStorageBackendId(): StorageBackendId {
-	const raw = (process.env.STORAGE_BACKEND || 'local-fs').toLowerCase();
-	switch (raw) {
-		case 'local-fs':
-		case 'aws-s3':
-		case 'minio':
-		case 'github-storage':
-			return raw;
-		default:
-			throw new Error(
-				`STORAGE_BACKEND="${raw}" is not a supported backend. ` +
-					`Choose one of: local-fs, aws-s3, minio, github-storage.`
-			);
-	}
+    const raw = (process.env.STORAGE_BACKEND || 'local-fs').toLowerCase();
+    switch (raw) {
+        case 'local-fs':
+        case 'aws-s3':
+        case 'minio':
+        case 'github-storage':
+            return raw;
+        default:
+            throw new Error(
+                `STORAGE_BACKEND="${raw}" is not a supported backend. ` +
+                    `Choose one of: local-fs, aws-s3, minio, github-storage.`,
+            );
+    }
 }
 
 export async function getActiveStorageBackend(): Promise<IStoragePlugin> {
-	const wanted = resolveStorageBackendId();
-	if (cached && cachedId === wanted) return cached;
+    const wanted = resolveStorageBackendId();
+    if (cached && cachedId === wanted) return cached;
 
-	const plugin = await instantiate(wanted);
-	await plugin.onLoad(makeStubContext(plugin.id));
+    const plugin = await instantiate(wanted);
+    await plugin.onLoad(makeStubContext(plugin.id));
 
-	cached = plugin;
-	cachedId = wanted;
-	return plugin;
+    cached = plugin;
+    cachedId = wanted;
+    return plugin;
 }
 
 /**
@@ -85,44 +85,44 @@ export async function getActiveStorageBackend(): Promise<IStoragePlugin> {
  * STORAGE_BACKEND between cases; production code never calls it.
  */
 export function resetStorageBackendCache(): void {
-	cached = undefined;
-	cachedId = undefined;
+    cached = undefined;
+    cachedId = undefined;
 }
 
 async function instantiate(id: StorageBackendId): Promise<IStoragePlugin> {
-	switch (id) {
-		case 'local-fs':
-			// Bundled — always available, no dynamic import needed.
-			return new LocalFsStoragePlugin();
-		case 'aws-s3': {
-			const mod = await import('@ever-works/aws-s3-plugin').catch((err) => {
-				throw new Error(
-					`STORAGE_BACKEND=aws-s3 but @ever-works/aws-s3-plugin failed to load: ${
-						err instanceof Error ? err.message : String(err)
-					}`
-				);
-			});
-			return new mod.AwsS3StoragePlugin();
-		}
-		case 'minio': {
-			const mod = await import('@ever-works/minio-plugin').catch((err) => {
-				throw new Error(
-					`STORAGE_BACKEND=minio but @ever-works/minio-plugin failed to load: ${
-						err instanceof Error ? err.message : String(err)
-					}`
-				);
-			});
-			return new mod.MinioStoragePlugin();
-		}
-		case 'github-storage': {
-			const mod = await import('@ever-works/github-storage-plugin').catch((err) => {
-				throw new Error(
-					`STORAGE_BACKEND=github-storage but @ever-works/github-storage-plugin failed to load: ${
-						err instanceof Error ? err.message : String(err)
-					}`
-				);
-			});
-			return new mod.GitHubStoragePlugin();
-		}
-	}
+    switch (id) {
+        case 'local-fs':
+            // Bundled — always available, no dynamic import needed.
+            return new LocalFsStoragePlugin();
+        case 'aws-s3': {
+            const mod = await import('@ever-works/aws-s3-plugin').catch((err) => {
+                throw new Error(
+                    `STORAGE_BACKEND=aws-s3 but @ever-works/aws-s3-plugin failed to load: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            });
+            return new mod.AwsS3StoragePlugin();
+        }
+        case 'minio': {
+            const mod = await import('@ever-works/minio-plugin').catch((err) => {
+                throw new Error(
+                    `STORAGE_BACKEND=minio but @ever-works/minio-plugin failed to load: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            });
+            return new mod.MinioStoragePlugin();
+        }
+        case 'github-storage': {
+            const mod = await import('@ever-works/github-storage-plugin').catch((err) => {
+                throw new Error(
+                    `STORAGE_BACKEND=github-storage but @ever-works/github-storage-plugin failed to load: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            });
+            return new mod.GitHubStoragePlugin();
+        }
+    }
 }

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -1,10 +1,33 @@
-import { BadRequestException, HttpStatus } from '@nestjs/common';
+// EW-637 — UploadsController transitively imports AnonymousAuthService,
+// which pulls in @ever-works/agent/database (TypeORM repositories). The
+// database module's @src/config alias is resolvable in the API runtime
+// but not in this isolated jest context, so we mock the agent surface
+// the same way auth.controller.spec.ts does.
+jest.mock('@ever-works/agent/database', () => ({}));
+
+import { BadRequestException, HttpStatus, Logger } from '@nestjs/common';
 import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
+import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
+import type { PluginContext } from '@ever-works/plugin';
+import type { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+const stubContext = (id: string): PluginContext => {
+    const log = new Logger(`StoragePlugin/${id}`);
+    return {
+        pluginId: id,
+        logger: {
+            log: (m: string) => log.log(m),
+            error: (m: string) => log.error(m),
+            warn: (m: string) => log.warn(m),
+            debug: (m: string) => log.debug(m),
+        },
+    } as unknown as PluginContext;
+};
 
 const TINY_PNG = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgAAIAAAUAAarVyFEAAAAASUVORK5CYII=',
@@ -76,15 +99,25 @@ describe('UploadsController', () => {
     let controller: UploadsController;
     let service: UploadsService;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         root = resolve(
             tmpdir(),
             `ever-works-uploads-ctl-${Date.now()}-${Math.random().toString(36).slice(2)}`,
         );
         process.env.UPLOADS_DIR = root;
         delete process.env.UPLOADS_MAX_BYTES;
-        service = new UploadsService();
-        controller = new UploadsController(service);
+        const backend = new LocalFsStoragePlugin();
+        await backend.onLoad(stubContext('local-fs'));
+        service = new UploadsService(backend);
+        // The anonymous-auth service is only invoked by /anonymous and
+        // /presign endpoints — pass a stub that throws if these tests
+        // ever exercise it accidentally.
+        const anonStub = {
+            createAnonymousUser: () => {
+                throw new Error('AnonymousAuthService stub: not expected in these tests');
+            },
+        } as unknown as AnonymousAuthService;
+        controller = new UploadsController(service, anonStub);
     });
 
     afterEach(async () => {

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -220,11 +220,11 @@ export class UploadsController {
             'Requests a pre-signed upload URL for direct browser-to-cloud upload. Only available when STORAGE_BACKEND supports it (S3, MinIO). Returns 501 for local-fs / github-storage.',
     })
     @ApiResponse({ status: 200, description: 'Returns { url, key, fields?, expiresAt }' })
-    @ApiResponse({ status: 501, description: 'Backend does not support presign — use POST /api/uploads' })
-    async presign(
-        @Body() body: PresignUploadDto,
-        @Req() req: AnonRequest,
-    ) {
+    @ApiResponse({
+        status: 501,
+        description: 'Backend does not support presign — use POST /api/uploads',
+    })
+    async presign(@Body() body: PresignUploadDto, @Req() req: AnonRequest) {
         const backend = await this.uploads.getBackend();
         if (!backend.presignPut) {
             throw new NotImplementedException({

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -150,34 +150,11 @@ export class UploadsController {
             });
         }
 
-        // Honor an existing session if one happened through — the
-        // AuthSessionGuard is set as APP_GUARD with @Public() bypass, so
-        // anon callers reach this point with `req.user` unset; an
-        // authenticated caller would normally never hit /anonymous, but
-        // we accept that case for the no-branch convenience.
-        let userId = req.user?.userId;
-        let anonAccessToken: string | undefined;
-        let anonymousExpiresAt: string | null | undefined;
-
-        if (!userId) {
-            const ipAddress =
-                (typeof req.ip === 'string' && req.ip) ||
-                (typeof req.headers['x-forwarded-for'] === 'string'
-                    ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
-                    : null);
-            const userAgent =
-                typeof req.headers['user-agent'] === 'string'
-                    ? (req.headers['user-agent'] as string)
-                    : null;
-
-            const anon = await this.anonymousAuthService.createAnonymousUser({
-                ipAddress,
-                userAgent,
-            });
-            userId = anon.user.id;
-            anonAccessToken = anon.access_token;
-            anonymousExpiresAt = anon.user.anonymousExpiresAt ?? null;
-        }
+        // Honor an existing session if one happened through — anon callers
+        // reach this point with `req.user` unset (because @Public() bypasses
+        // AuthSessionGuard), an authenticated caller is supported as a
+        // no-branch convenience.
+        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
 
         const result = await this.uploads.saveImage(userId, file);
 
@@ -237,29 +214,7 @@ export class UploadsController {
 
         // Mint an anon user when no session is present, same as the anon
         // upload route — direct-to-cloud uploads need an owner segment.
-        let userId = req.user?.userId;
-        let anonAccessToken: string | undefined;
-        let anonymousExpiresAt: string | null | undefined;
-
-        if (!userId) {
-            const ipAddress =
-                (typeof req.ip === 'string' && req.ip) ||
-                (typeof req.headers['x-forwarded-for'] === 'string'
-                    ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
-                    : null);
-            const userAgent =
-                typeof req.headers['user-agent'] === 'string'
-                    ? (req.headers['user-agent'] as string)
-                    : null;
-
-            const anon = await this.anonymousAuthService.createAnonymousUser({
-                ipAddress,
-                userAgent,
-            });
-            userId = anon.user.id;
-            anonAccessToken = anon.access_token;
-            anonymousExpiresAt = anon.user.anonymousExpiresAt ?? null;
-        }
+        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
 
         const presign = await backend.presignPut({
             filename: body.filename,
@@ -316,5 +271,46 @@ export class UploadsController {
         // Type is somehow wrong.
         res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
         res.send(buffer);
+    }
+
+    /**
+     * Resolve who's doing the upload: honor an existing session if a bearer
+     * token came through; otherwise mint an anonymous user inline. Both
+     * /anonymous and /presign route through here so the IP / user-agent
+     * extraction strategy stays in one place.
+     */
+    private async resolveActingUser(req: AnonRequest): Promise<{
+        userId: string;
+        anonAccessToken: string | undefined;
+        anonymousExpiresAt: string | null | undefined;
+    }> {
+        const existing = req.user?.userId;
+        if (existing) {
+            return {
+                userId: existing,
+                anonAccessToken: undefined,
+                anonymousExpiresAt: undefined,
+            };
+        }
+
+        const ipAddress =
+            (typeof req.ip === 'string' && req.ip) ||
+            (typeof req.headers['x-forwarded-for'] === 'string'
+                ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
+                : null);
+        const userAgent =
+            typeof req.headers['user-agent'] === 'string'
+                ? (req.headers['user-agent'] as string)
+                : null;
+
+        const anon = await this.anonymousAuthService.createAnonymousUser({
+            ipAddress,
+            userAgent,
+        });
+        return {
+            userId: anon.user.id,
+            anonAccessToken: anon.access_token,
+            anonymousExpiresAt: anon.user.anonymousExpiresAt ?? null,
+        };
     }
 }

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -1,12 +1,16 @@
 import {
     BadRequestException,
+    Body,
     Controller,
     Get,
     Header,
+    Headers,
     HttpCode,
     HttpStatus,
+    NotImplementedException,
     Param,
     Post,
+    Req,
     Res,
     UploadedFile,
     UseInterceptors,
@@ -15,15 +19,18 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CurrentUser } from '../auth/decorators/user.decorator';
+import { Public } from '../auth/decorators/public.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
 import { UploadsService } from './uploads.service';
+import { PresignUploadDto } from './dto/presign-upload.dto';
 
 const MAX_UPLOAD_BYTES = Number(process.env.UPLOADS_MAX_BYTES) || 5 * 1024 * 1024;
 
-// Minimal Express response surface — mirrors the local style in
-// `works.controller.ts` (see `DownloadResponse` there). Avoids pulling
-// the full express type-graph into this module, which conflicts with
-// the global `Express.Response` namespace used elsewhere in the build.
+// Minimal Express response / request surfaces — mirrors the local style
+// in `works.controller.ts` to avoid pulling the full express type-graph
+// into this module, which conflicts with the global `Express.Response`
+// namespace used elsewhere in the build.
 type ServeResponse = {
     status(code: number): ServeResponse;
     setHeader(name: string, value: string | number): void;
@@ -31,16 +38,25 @@ type ServeResponse = {
     send(body: string | Buffer): void;
 };
 
+type AnonRequest = {
+    ip?: string;
+    headers: Record<string, string | string[] | undefined>;
+    user?: AuthenticatedUser;
+};
+
 @ApiTags('Uploads')
 @Controller('api/uploads')
 export class UploadsController {
-    constructor(private readonly uploads: UploadsService) {}
+    constructor(
+        private readonly uploads: UploadsService,
+        private readonly anonymousAuthService: AnonymousAuthService,
+    ) {}
 
     /**
      * Image upload — auth-gated, MIME-sniffed, size-capped, user-scoped.
      *
      * Rate-limited tighter than the global cap because:
-     *  (1) each call writes to disk, so it costs more than a JSON read,
+     *  (1) each call writes to disk / object store, so it costs more than a JSON read,
      *  (2) it's an obvious target for storage-exhaustion DoS.
      *
      * Two routes (`/api/uploads` and `/api/uploads/image`) share the
@@ -86,6 +102,178 @@ export class UploadsController {
         @UploadedFile() file: Express.Multer.File | undefined,
     ) {
         return this.upload(auth, file);
+    }
+
+    /**
+     * EW-637 — anonymous upload entrypoint for the website's landing-page
+     * prompt-with-attachments flow.
+     *
+     * When the request arrives unauthenticated, we mint an anonymous user
+     * inline (re-using the same TTL-bounded row the `/api/auth/anonymous`
+     * route creates) and scope the upload to that anon user. The returned
+     * `anonAccessToken` is the bearer the website will send back when it
+     * later submits the prompt — same shape as the regular anonymous-auth
+     * response so the website doesn't need a separate token-handling path.
+     *
+     * If the request IS already authenticated, we honor the existing
+     * session and skip the anon-mint — letting a real user attach files
+     * via this endpoint is harmless and saves the website a code branch.
+     *
+     * The upload's lifetime is tied to the anon user's TTL
+     * (`ANONYMOUS_USER_TTL_DAYS`, default 3). When that user is GC'd by
+     * the `anonymous-user-cleanup` schedule, their files go too (the
+     * cleanup job already handles this for Works; storage-side GC for
+     * uploads is a follow-up — see EW-637 comments).
+     */
+    @Public()
+    @Post('anonymous')
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ default: { limit: 10, ttl: 60_000 } })
+    @UseInterceptors(FileInterceptor('file', { limits: { fileSize: MAX_UPLOAD_BYTES } }))
+    @ApiOperation({
+        summary: 'Upload from an anonymous (pre-signup) visitor',
+        description:
+            'Accepts a multipart file from an unauthenticated visitor. Mints an anonymous user inline (or honors an existing session if a bearer is supplied) and scopes the upload to it. Returns { uploadId, url, expiresAt, anonAccessToken? }. uploadId is what the caller passes back when submitting their prompt. Lifetime is tied to the anonymous user TTL (ANONYMOUS_USER_TTL_DAYS, default 3 days).',
+    })
+    @ApiResponse({ status: 201, description: 'Upload accepted' })
+    @ApiResponse({ status: 400, description: 'Validation failed' })
+    @ApiResponse({ status: 413, description: 'File exceeds size cap' })
+    async uploadAnonymous(
+        @UploadedFile() file: Express.Multer.File | undefined,
+        @Req() req: AnonRequest,
+        @Headers('x-correlation-id') correlationHeader: string | undefined,
+    ) {
+        if (!file) {
+            throw new BadRequestException({
+                status: 'error',
+                message: "Multipart field 'file' is required",
+            });
+        }
+
+        // Honor an existing session if one happened through — the
+        // AuthSessionGuard is set as APP_GUARD with @Public() bypass, so
+        // anon callers reach this point with `req.user` unset; an
+        // authenticated caller would normally never hit /anonymous, but
+        // we accept that case for the no-branch convenience.
+        let userId = req.user?.userId;
+        let anonAccessToken: string | undefined;
+        let anonymousExpiresAt: string | null | undefined;
+
+        if (!userId) {
+            const ipAddress =
+                (typeof req.ip === 'string' && req.ip) ||
+                (typeof req.headers['x-forwarded-for'] === 'string'
+                    ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
+                    : null);
+            const userAgent =
+                typeof req.headers['user-agent'] === 'string'
+                    ? (req.headers['user-agent'] as string)
+                    : null;
+
+            const anon = await this.anonymousAuthService.createAnonymousUser({
+                ipAddress,
+                userAgent,
+            });
+            userId = anon.user.id;
+            anonAccessToken = anon.access_token;
+            anonymousExpiresAt = anon.user.anonymousExpiresAt ?? null;
+        }
+
+        const result = await this.uploads.saveImage(userId, file);
+
+        // Note: `correlationHeader` is accepted but not yet propagated to
+        // analytics. Hook it into the ZeroFrictionFunnel emit in a follow-up
+        // once the website starts sending it. For now we acknowledge it
+        // exists so the API contract is stable.
+        void correlationHeader;
+
+        return {
+            uploadId: result.key ?? `${userId}/${result.filename}`,
+            id: result.id,
+            url: result.url,
+            filename: result.filename,
+            size: result.size,
+            mimeType: result.mimeType,
+            hash: result.hash,
+            expiresAt: anonymousExpiresAt ?? null,
+            ...(anonAccessToken ? { anonAccessToken } : {}),
+        };
+    }
+
+    /**
+     * EW-637 — mint a presigned upload URL when the active storage backend
+     * supports direct-to-cloud uploads (S3 / MinIO). Local-fs and
+     * github-storage don't, in which case we return HTTP 501 with a hint
+     * to use POST /api/uploads instead.
+     *
+     * This endpoint is intentionally public-by-default (same anon-mint
+     * fallback as POST /api/uploads/anonymous) so the website can hand
+     * the browser a presigned URL before the visitor signs up.
+     */
+    @Public()
+    @Post('presign')
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ default: { limit: 20, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Mint a presigned upload URL (when backend supports it)',
+        description:
+            'Requests a pre-signed upload URL for direct browser-to-cloud upload. Only available when STORAGE_BACKEND supports it (S3, MinIO). Returns 501 for local-fs / github-storage.',
+    })
+    @ApiResponse({ status: 200, description: 'Returns { url, key, fields?, expiresAt }' })
+    @ApiResponse({ status: 501, description: 'Backend does not support presign — use POST /api/uploads' })
+    async presign(
+        @Body() body: PresignUploadDto,
+        @Req() req: AnonRequest,
+    ) {
+        const backend = await this.uploads.getBackend();
+        if (!backend.presignPut) {
+            throw new NotImplementedException({
+                status: 'error',
+                code: 'PresignNotSupported',
+                message:
+                    'Active storage backend does not support presigned uploads — use POST /api/uploads with multipart form data instead.',
+            });
+        }
+
+        // Mint an anon user when no session is present, same as the anon
+        // upload route — direct-to-cloud uploads need an owner segment.
+        let userId = req.user?.userId;
+        let anonAccessToken: string | undefined;
+        let anonymousExpiresAt: string | null | undefined;
+
+        if (!userId) {
+            const ipAddress =
+                (typeof req.ip === 'string' && req.ip) ||
+                (typeof req.headers['x-forwarded-for'] === 'string'
+                    ? (req.headers['x-forwarded-for'] as string).split(',')[0].trim()
+                    : null);
+            const userAgent =
+                typeof req.headers['user-agent'] === 'string'
+                    ? (req.headers['user-agent'] as string)
+                    : null;
+
+            const anon = await this.anonymousAuthService.createAnonymousUser({
+                ipAddress,
+                userAgent,
+            });
+            userId = anon.user.id;
+            anonAccessToken = anon.access_token;
+            anonymousExpiresAt = anon.user.anonymousExpiresAt ?? null;
+        }
+
+        const presign = await backend.presignPut({
+            filename: body.filename,
+            mimeType: body.mimeType,
+            size: body.size,
+            ownerId: userId,
+        });
+
+        return {
+            ...presign,
+            ownerId: userId,
+            expiresAt: presign.expiresAt,
+            ...(anonAccessToken ? { anonAccessToken, anonymousExpiresAt } : {}),
+        };
     }
 
     /**

--- a/apps/api/src/uploads/uploads.module.ts
+++ b/apps/api/src/uploads/uploads.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
 
 @Module({
+    // EW-637 — AuthModule exports AnonymousAuthService, which the
+    // /api/uploads/anonymous and /api/uploads/presign endpoints use to
+    // inline-mint an anon user when the request arrives without a
+    // bearer.
+    imports: [AuthModule],
     controllers: [UploadsController],
     providers: [UploadsService],
     exports: [UploadsService],

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -1,8 +1,26 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { promises as fs } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
+import type { PluginContext } from '@ever-works/plugin';
 import { UploadsService } from './uploads.service';
+
+// Minimal stub matching what the storage-backend factory hands plugins
+// at boot — only the logger is read by LocalFsStoragePlugin.onLoad().
+const stubContext = (id: string): PluginContext => {
+    const log = new Logger(`StoragePlugin/${id}`);
+    return {
+        pluginId: id,
+        logger: {
+            log: (m: string) => log.log(m),
+            error: (m: string) => log.error(m),
+            warn: (m: string) => log.warn(m),
+            debug: (m: string) => log.debug(m),
+        },
+    } as unknown as PluginContext;
+};
 
 const TINY_PNG = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgAAIAAAUAAarVyFEAAAAASUVORK5CYII=',
@@ -41,7 +59,13 @@ describe('UploadsService', () => {
         );
         process.env.UPLOADS_DIR = root;
         delete process.env.UPLOADS_MAX_BYTES;
-        service = new UploadsService();
+        // EW-637 — inject a fresh local-fs storage plugin so each test
+        // sees the new UPLOADS_DIR. Plugins are lazy in production via
+        // getActiveStorageBackend(); tests skip the env-resolution cache
+        // by passing the plugin directly to the service constructor.
+        const backend = new LocalFsStoragePlugin();
+        await backend.onLoad(stubContext('local-fs'));
+        service = new UploadsService(backend);
     });
 
     afterEach(async () => {
@@ -168,7 +192,9 @@ describe('UploadsService', () => {
 
         it('rejects oversized files', async () => {
             process.env.UPLOADS_MAX_BYTES = '100';
-            const s = new UploadsService();
+            const localBackend = new LocalFsStoragePlugin();
+            await localBackend.onLoad(stubContext('local-fs'));
+            const s = new UploadsService(localBackend);
             const big = Buffer.concat([TINY_PNG, Buffer.alloc(200)]);
             await expect(
                 s.saveImage(userId, {

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
 import { createHash } from 'node:crypto';
-import { promises as fs } from 'node:fs';
-import { join, resolve, normalize, sep } from 'node:path';
-import { tmpdir } from 'node:os';
+import { extname } from 'node:path';
+import type { IStoragePlugin } from '@ever-works/plugin';
+import { getActiveStorageBackend } from './storage-backend.factory';
 
 export interface UploadResult {
     id: string;
@@ -11,6 +11,13 @@ export interface UploadResult {
     size: number;
     mimeType: string;
     hash: string;
+    /**
+     * Opaque storage-backend key. Same as `id` for the legacy local-fs
+     * layout; for other backends (S3, MinIO, GitHub) this may differ.
+     * The anonymous-upload flow returns it as `uploadId` so the website
+     * can hand it back when submitting the prompt.
+     */
+    key?: string;
 }
 
 /**
@@ -55,33 +62,61 @@ const ALLOWED_MIME = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/web
 
 const DEFAULT_MAX_SIZE = 5 * 1024 * 1024; // 5 MiB
 
+/**
+ * EW-637 — UploadsService is now the validation + dispatch layer in front
+ * of an `IStoragePlugin`. The storage backend is selected at boot time by
+ * `STORAGE_BACKEND` (default `local-fs`); the validation, MIME sniffing,
+ * size cap, and user-scoping rules live HERE so they apply uniformly
+ * regardless of the active backend.
+ *
+ * Backwards-compatibility:
+ *  - `saveImage(userId, file)` and `readFile(userId, filename)` retain
+ *    their original signatures + response shapes. The existing controller
+ *    and unit tests don't need changes; `id`/`filename`/`url` keep the
+ *    same look. Internally, `id` is now `<sha256>` (the storage key's
+ *    object segment) — same as before for the disk backend.
+ *  - The constructor takes an optional `IStoragePlugin`. The DI module
+ *    wires in the env-selected backend; tests can pass a custom one or
+ *    fall back to local-fs (default `STORAGE_BACKEND`).
+ */
 @Injectable()
 export class UploadsService {
     private readonly logger = new Logger(UploadsService.name);
-    private readonly storageRoot: string;
     private readonly maxSize: number;
+    private backendPromise?: Promise<IStoragePlugin>;
 
-    constructor() {
-        // `UPLOADS_DIR` is an operator-controlled absolute path; default
-        // to a per-process tmp dir so dev / CI work out of the box and
-        // never collide with another instance.
-        this.storageRoot = resolve(process.env.UPLOADS_DIR || join(tmpdir(), 'ever-works-uploads'));
+    constructor(backend?: IStoragePlugin) {
         this.maxSize = Number(process.env.UPLOADS_MAX_BYTES) || DEFAULT_MAX_SIZE;
+        if (backend) {
+            this.backendPromise = Promise.resolve(backend);
+        }
+    }
+
+    /**
+     * Returns the active storage backend, instantiating it once and reusing
+     * the same instance for the lifetime of the service. Exposed for the
+     * controller's presign / availability checks.
+     */
+    async getBackend(): Promise<IStoragePlugin> {
+        if (!this.backendPromise) {
+            this.backendPromise = getActiveStorageBackend();
+        }
+        return this.backendPromise;
     }
 
     /**
      * Validate + persist an uploaded image. Returns the canonical
      * reference shape (id + url + metadata). Throws BadRequestException
-     * for any validation failure — never lets bad bytes hit disk.
+     * for any validation failure — never lets bad bytes hit storage.
      *
      * Security properties pinned by the test suite:
      *  - MIME must be in the allow-list (no SVG, no octet-stream)
      *  - Magic bytes MUST match the declared MIME (no lying)
      *  - Size must be <= configured max
-     *  - Storage path is user-scoped so a stranger can never see / overwrite
-     *    another user's files even if they guess the filename
+     *  - Storage is user-scoped via the active plugin so a stranger can never see /
+     *    overwrite another user's files even if they guess the filename
      *  - Filename is derived from the SHA-256 of the bytes; no part of
-     *    the client-supplied originalname reaches disk (defeats path
+     *    the client-supplied originalname reaches storage (defeats path
      *    traversal in `../../etc/passwd`-style payloads)
      */
     async saveImage(
@@ -131,19 +166,37 @@ export class UploadsService {
 
         const hash = createHash('sha256').update(file.buffer).digest('hex');
         const filename = `${hash}.${sniffed.ext}`;
-        const userDir = this.userDir(userId);
-        await fs.mkdir(userDir, { recursive: true });
-        const absPath = this.resolveSafe(userDir, filename);
-        await fs.writeFile(absPath, file.buffer, { flag: 'w' });
 
-        const url = `/api/uploads/${encodeURIComponent(userId)}/${filename}`;
+        const backend = await this.getBackend();
+        const { key, url } = await backend.putObject({
+            buffer: file.buffer,
+            filename,
+            mimeType: sniffed.mime,
+            size: file.size,
+            ownerId: userId,
+        });
+
         return {
+            // `id` historically was the sha256 (object segment of the key).
+            // Keep that shape for existing callers.
             id: hash,
-            url,
+            // Resolve `url` to the platform-served route. Plugins return a
+            // backend-native URL (S3 / raw.githubusercontent / local route);
+            // for the legacy callers that expect `/api/uploads/<owner>/<file>`,
+            // we synthesize that path regardless of the backend so existing
+            // clients keep working. The plugin's URL is exposed via the
+            // backend factory for callers that want direct CDN access.
+            url: url.startsWith('http')
+                ? url
+                : `/api/uploads/${encodeURIComponent(userId)}/${filename}`,
             filename,
             size: file.size,
             mimeType: sniffed.mime,
             hash,
+            // Keep the storage key around for callers that want to round-
+            // trip via the IStoragePlugin abstraction (anonymous uploads
+            // hand this back as `uploadId`).
+            key,
         };
     }
 
@@ -158,24 +211,34 @@ export class UploadsService {
     ): Promise<{ buffer: Buffer; mimeType: string }> {
         this.assertValidUserId(userId);
         this.assertValidFilename(filename);
-        const userDir = this.userDir(userId);
-        const absPath = this.resolveSafe(userDir, filename);
-        let buffer: Buffer;
+        const backend = await this.getBackend();
+
+        // Reconstruct the storage key from the legacy <userId>/<filename>
+        // path shape. For local-fs and the S3-family plugins this is the
+        // exact key; github-storage embeds its own path-prefix and
+        // therefore is NOT compatible with the legacy /:userId/:filename
+        // route. Operators using github-storage should route reads through
+        // the plugin-native URL returned by saveImage.
+        const key = `${userId}/${filename}`;
+
+        let result: { buffer: Buffer; mimeType: string };
         try {
-            buffer = await fs.readFile(absPath);
+            result = await backend.getObject(key);
         } catch (err) {
-            // Either the user-scoped directory or the file inside it
-            // doesn't exist — surface as 404 rather than letting ENOENT
-            // bubble up as a 500.
-            const code = (err as NodeJS.ErrnoException).code;
-            if (code === 'ENOENT' || code === 'ENOTDIR') {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (/not found/i.test(msg) || /ENOENT/i.test(msg)) {
                 throw new NotFoundException({ status: 'error', message: 'Upload not found' });
             }
             throw err;
         }
-        const sniffed = this.sniffMagicBytes(buffer);
-        const mimeType = sniffed?.mime ?? 'application/octet-stream';
-        return { buffer, mimeType };
+
+        // Re-sniff the magic bytes on read — this is what the original
+        // implementation did for all backends, and it's a defense against
+        // a malicious storage backend (or operator misconfig) handing back
+        // bytes whose Content-Type metadata doesn't match the payload.
+        const sniffed = this.sniffMagicBytes(result.buffer);
+        const mimeType = sniffed?.mime ?? result.mimeType ?? 'application/octet-stream';
+        return { buffer: result.buffer, mimeType };
     }
 
     private sniffMagicBytes(buf: Buffer): { mime: string; ext: string } | null {
@@ -196,34 +259,10 @@ export class UploadsService {
         return null;
     }
 
-    private userDir(userId: string): string {
-        return resolve(this.storageRoot, userId);
-    }
-
-    /**
-     * Resolve `filename` under `userDir`, then re-check it really IS
-     * still under `userDir`. Defeats `..` segments and absolute paths.
-     */
-    private resolveSafe(userDir: string, filename: string): string {
-        const candidate = resolve(userDir, filename);
-        const userDirNorm = normalize(userDir + sep);
-        const candidateNorm = normalize(candidate);
-        if (!candidateNorm.startsWith(userDirNorm)) {
-            // Path traversal attempt — the resolve() output escaped the
-            // user-scoped directory. Refuse loudly.
-            throw new BadRequestException({
-                status: 'error',
-                code: 'InvalidPath',
-                message: 'Resolved path escapes user storage root',
-            });
-        }
-        return candidate;
-    }
-
     private assertValidUserId(userId: string): void {
         // userIds are UUIDv4 in this codebase. Reject anything with path
         // separators / null bytes / control characters to keep the
-        // resolveSafe check honest.
+        // storage-key construction honest.
         if (!userId || !/^[A-Za-z0-9_-]{1,128}$/.test(userId)) {
             throw new BadRequestException({
                 status: 'error',
@@ -237,6 +276,19 @@ export class UploadsService {
         // Only allow `<hex64>.<ext>` shapes — same format saveImage
         // writes. Anything else is invalid by construction.
         if (!filename || !/^[a-f0-9]{64}\.(png|jpg|jpeg|gif|webp)$/.test(filename)) {
+            throw new BadRequestException({
+                status: 'error',
+                code: 'InvalidFilename',
+                message: 'Invalid filename',
+            });
+        }
+        // Defensive: although the regex above already restricts to
+        // canonical hash-named files, extract the extension here as a
+        // belt-and-suspenders check — the spec uses both alphanumeric and
+        // dot characters and a malicious key would have to slip past the
+        // regex to reach this point. Throw on anything unexpected.
+        const ext = extname(filename).toLowerCase();
+        if (!['.png', '.jpg', '.jpeg', '.gif', '.webp'].includes(ext)) {
             throw new BadRequestException({
                 status: 'error',
                 code: 'InvalidFilename',

--- a/apps/web/src/lib/utils/plugin-category-icons.ts
+++ b/apps/web/src/lib/utils/plugin-category-icons.ts
@@ -12,6 +12,7 @@ import {
     Puzzle,
     Wrench,
     Palette,
+    HardDrive,
     type LucideIcon,
 } from 'lucide-react';
 import { PluginCategory, PLUGIN_CATEGORIES } from '@ever-works/plugin';
@@ -33,6 +34,8 @@ export const CATEGORY_ICONS: Record<PluginCategory, LucideIcon> = {
     integration: Puzzle,
     utility: Wrench,
     theme: Palette,
+    // EW-637 — object storage backends (local-fs, S3, MinIO, GitHub blob)
+    storage: HardDrive,
 };
 
 /**
@@ -52,6 +55,7 @@ export const CATEGORY_LABELS: Record<PluginCategory, string> = {
     integration: 'Integrations',
     utility: 'Utilities',
     theme: 'Themes',
+    storage: 'Storage',
 };
 
 // Type-safe assertion that all categories are covered
@@ -107,6 +111,11 @@ export const CAPABILITY_LABELS: Record<string, string> = {
     'oauth-provider': 'OAuth',
     pipeline: 'Pipeline',
     form: 'Form',
+    // EW-637 — storage capabilities
+    storage: 'Storage',
+    'put-object': 'Put Object',
+    'get-object': 'Get Object',
+    'presigned-put': 'Presigned Upload',
 };
 
 /**
@@ -136,6 +145,7 @@ export const CATEGORY_DISPLAY_ORDER: readonly PluginCategory[] = [
     'git-provider',
     'deployment',
     'data-source',
+    'storage',
     'form',
     'integration',
     'utility',

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -12,3 +12,4 @@ export * from './code-edit-plugin.interface.js';
 export * from './form-schema-provider.interface.js';
 export * from './prompt-provider.interface.js';
 export * from './device-auth-provider.interface.js';
+export * from './storage.interface.js';

--- a/packages/plugin/src/contracts/capabilities/storage.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/storage.interface.ts
@@ -1,0 +1,126 @@
+import type { IPlugin } from '../plugin.interface.js';
+
+/**
+ * EW-637 — pluggable object storage.
+ *
+ * `IStoragePlugin` is the contract every storage backend (local-fs, S3,
+ * MinIO, GitHub blob, ...) implements. The API's uploads service depends
+ * only on this interface and selects an implementation at boot time from
+ * the `STORAGE_BACKEND` env var (default: `local-fs`).
+ *
+ * Capabilities are declared in the plugin's `everworks.plugin.capabilities`
+ * field:
+ *   - `put-object` (required) — accepts a buffer + metadata, returns a key + URL
+ *   - `get-object` (required) — reads a previously written key
+ *   - `presigned-put` (optional) — backend can mint a direct-to-cloud upload
+ *     URL the browser uses to skip the API process. S3 / MinIO support
+ *     this; local-fs and GitHub-blob do not (the API has to mediate).
+ */
+export interface StoragePutInput {
+	/** Bytes to write. */
+	readonly buffer: Buffer;
+	/** Client-supplied filename. NOT used as the storage key — only for
+	 *  derived extension / Content-Disposition. The key is opaque. */
+	readonly filename: string;
+	/** Already-validated MIME type. The uploads service magic-byte-sniffs
+	 *  BEFORE handing the buffer here; plugins MUST NOT re-trust the client. */
+	readonly mimeType: string;
+	/** Byte length, matches `buffer.length`. Passed explicitly so the plugin
+	 *  doesn't have to recompute it for backends that want it as metadata. */
+	readonly size: number;
+	/**
+	 * Optional owner identifier (typically the user id, anonymous or real).
+	 * Used by user-scoped backends (local-fs path-scopes by ownerId; S3 can
+	 * embed it in the key prefix). Plugins SHOULD NOT trust this for
+	 * authorization — that lives in the API layer. They use it only to
+	 * derive the key prefix for the chosen layout.
+	 */
+	readonly ownerId?: string;
+}
+
+/**
+ * Result of a successful `putObject`. `key` is the canonical reference the
+ * uploads service hands back to clients; `url` is the read URL (either the
+ * S3 object URL, the local `/api/uploads/<owner>/<file>` route, or the
+ * GitHub `raw.githubusercontent.com` URL — backend's choice).
+ */
+export interface StoragePutResult {
+	readonly key: string;
+	readonly url: string;
+}
+
+/**
+ * Bytes + MIME for a previously written key. The uploads service uses this
+ * for the read route. MIME is whatever the plugin can recover (S3 returns
+ * it from `Content-Type` metadata; local-fs sniffs again).
+ */
+export interface StorageGetResult {
+	readonly buffer: Buffer;
+	readonly mimeType: string;
+}
+
+/**
+ * Input for `presignPut`. The plugin returns a URL + (for backends that
+ * need it — e.g. POST policies) extra fields the browser includes in the
+ * multipart form. For pure presigned PUT (S3 v4 signed PUT), `fields` is
+ * undefined.
+ */
+export interface StoragePresignInput {
+	readonly filename: string;
+	readonly mimeType: string;
+	readonly size: number;
+	readonly ownerId?: string;
+}
+
+export interface StoragePresignResult {
+	/** Pre-signed URL the browser uploads to. */
+	readonly url: string;
+	/** The key the object will be stored under, so the client can echo it
+	 *  back to the API when submitting the prompt. */
+	readonly key: string;
+	/** Optional form fields for POST-policy style presigning. When using
+	 *  PUT-style signed URLs (default for S3 SigV4), leave undefined. */
+	readonly fields?: Record<string, string>;
+	/** ISO-8601 timestamp the URL stops accepting uploads at. */
+	readonly expiresAt: string;
+}
+
+/**
+ * Storage plugin interface — capability `storage`.
+ *
+ * Concrete implementations live in `packages/plugins/local-fs`,
+ * `packages/plugins/aws-s3`, `packages/plugins/minio`, and
+ * `packages/plugins/github-storage`.
+ */
+export interface IStoragePlugin extends IPlugin {
+	/** Backend name for facade identification ('local-fs', 'aws-s3', ...). */
+	readonly providerName: string;
+
+	/** Write an object. Returns the storage key + a URL the API can hand back. */
+	putObject(input: StoragePutInput): Promise<StoragePutResult>;
+
+	/** Read an object by key. Throws if not found. */
+	getObject(key: string): Promise<StorageGetResult>;
+
+	/** Delete an object by key. Idempotent — deleting a missing key is a no-op. */
+	deleteObject(key: string): Promise<void>;
+
+	/**
+	 * Optional: mint a pre-signed upload URL so the browser can stream
+	 * bytes directly to the storage backend, skipping the API. S3 / MinIO
+	 * implement this; local-fs / GitHub do not.
+	 */
+	presignPut?(input: StoragePresignInput): Promise<StoragePresignResult>;
+
+	/** Whether the backend is healthy / configured. Used by the
+	 *  uploads service at startup to fail loudly when the operator
+	 *  selected an unconfigured backend. */
+	isAvailable(): Promise<boolean>;
+}
+
+/**
+ * Type guard for storage plugins.
+ */
+export function isStoragePlugin(plugin: IPlugin): plugin is IStoragePlugin {
+	return plugin.capabilities.includes('put-object') && plugin.capabilities.includes('get-object');
+}

--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -12,7 +12,14 @@ export const PLUGIN_CAPABILITIES = {
 	GIT_PROVIDER: 'git-provider',
 	OAUTH: 'oauth',
 	DEVICE_AUTH: 'device-auth',
-	PROMPT_PROVIDER: 'prompt-provider'
+	PROMPT_PROVIDER: 'prompt-provider',
+	// EW-637 — pluggable object storage. `put-object` + `get-object` are the
+	// floor; `presigned-put` is opt-in for backends that can hand the
+	// browser a direct-upload URL (S3, MinIO).
+	STORAGE: 'storage',
+	PUT_OBJECT: 'put-object',
+	GET_OBJECT: 'get-object',
+	PRESIGNED_PUT: 'presigned-put'
 } as const;
 
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[keyof typeof PLUGIN_CAPABILITIES];

--- a/packages/plugin/src/contracts/plugin-manifest.types.ts
+++ b/packages/plugin/src/contracts/plugin-manifest.types.ts
@@ -14,7 +14,10 @@ export const PLUGIN_CATEGORIES = [
 	'form',
 	'integration',
 	'utility',
-	'theme'
+	'theme',
+	// EW-637 — pluggable object storage backends (local-fs, S3, MinIO, GitHub).
+	// See packages/plugin/src/contracts/capabilities/storage.interface.ts.
+	'storage'
 ] as const;
 
 export type PluginCategory = (typeof PLUGIN_CATEGORIES)[number];

--- a/packages/plugins/aws-s3/package.json
+++ b/packages/plugins/aws-s3/package.json
@@ -1,0 +1,92 @@
+{
+	"name": "@ever-works/aws-s3-plugin",
+	"version": "1.0.0",
+	"description": "AWS S3 storage backend for Ever Works — stores uploaded objects in an S3 bucket and supports browser-direct presigned PUT.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"@aws-sdk/client-s3": "^3.700.0",
+		"@aws-sdk/s3-request-presigner": "^3.700.0"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.0.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "aws-s3",
+			"name": "AWS S3",
+			"version": "1.0.0",
+			"category": "storage",
+			"capabilities": [
+				"storage",
+				"put-object",
+				"get-object",
+				"presigned-put"
+			],
+			"description": "Stores uploaded objects in an AWS S3 bucket. Supports direct browser uploads via presigned PUT URLs for large files.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"systemPlugin": false,
+			"builtIn": false,
+			"envVars": [
+				{
+					"name": "AWS_S3_REGION",
+					"required": false,
+					"secret": false,
+					"description": "AWS region of the S3 bucket (e.g. us-east-1)."
+				},
+				{
+					"name": "AWS_S3_BUCKET",
+					"required": false,
+					"secret": false,
+					"description": "S3 bucket name."
+				},
+				{
+					"name": "AWS_ACCESS_KEY_ID",
+					"required": false,
+					"secret": true,
+					"description": "AWS access key id (or use IAM role / instance profile)."
+				},
+				{
+					"name": "AWS_SECRET_ACCESS_KEY",
+					"required": false,
+					"secret": true,
+					"description": "AWS secret access key (or use IAM role / instance profile)."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/aws-s3/src/aws-s3.plugin.ts
+++ b/packages/plugins/aws-s3/src/aws-s3.plugin.ts
@@ -53,12 +53,7 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 	readonly name: string = 'AWS S3';
 	readonly version = '1.0.0';
 	readonly category: PluginCategory = 'storage';
-	readonly capabilities: readonly string[] = [
-		'storage',
-		'put-object',
-		'get-object',
-		'presigned-put'
-	];
+	readonly capabilities: readonly string[] = ['storage', 'put-object', 'get-object', 'presigned-put'];
 
 	readonly providerName: string = 'aws-s3';
 
@@ -233,8 +228,7 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 		const endpoint = overrides.endpoint;
 		const forcePathStyle = overrides.forcePathStyle ?? false;
 		const presignExpiresSeconds =
-			overrides.presignExpiresSeconds ??
-			(Number(process.env.AWS_S3_PRESIGN_EXPIRES_SECONDS) || 600);
+			overrides.presignExpiresSeconds ?? (Number(process.env.AWS_S3_PRESIGN_EXPIRES_SECONDS) || 600);
 
 		if (!region || !bucket) {
 			throw new Error(

--- a/packages/plugins/aws-s3/src/aws-s3.plugin.ts
+++ b/packages/plugins/aws-s3/src/aws-s3.plugin.ts
@@ -1,0 +1,360 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { extname } from 'node:path';
+import {
+	S3Client,
+	PutObjectCommand,
+	GetObjectCommand,
+	DeleteObjectCommand,
+	HeadBucketCommand
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import type {
+	IStoragePlugin,
+	StoragePutInput,
+	StoragePutResult,
+	StorageGetResult,
+	StoragePresignInput,
+	StoragePresignResult,
+	IPlugin,
+	PluginContext,
+	PluginCategory,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema
+} from '@ever-works/plugin';
+
+/**
+ * EW-637 — AWS S3 storage backend.
+ *
+ * Stores uploaded objects in an S3 bucket. Supports browser-direct uploads
+ * via presigned PUT URLs so large files (videos, archives) can bypass the
+ * API process entirely.
+ *
+ * Configuration (resolved at putObject/presign time from env):
+ *   - AWS_S3_REGION  — bucket region (e.g. us-east-1)
+ *   - AWS_S3_BUCKET  — bucket name
+ *   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY — credentials.
+ *     When omitted, falls back to the default AWS SDK credential chain
+ *     (IAM role, instance profile, ~/.aws/credentials, etc).
+ *
+ * Object key layout:
+ *   uploads/<ownerId or _shared>/<sha256>.<ext>
+ *
+ * Returned URL is the standard virtual-hosted-style S3 URL. If the bucket
+ * is private (recommended), the caller must fetch via the API's
+ * `GET /api/uploads/:owner/:filename` route which streams through
+ * `getObject`. We never return a presigned GET URL from `putObject` —
+ * that would leak read access via the database.
+ */
+export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
+	// Use widened `string` so subclasses (MinIO) can re-declare different
+	// id/name/providerName without TS narrowing to the literal value.
+	readonly id: string = 'aws-s3';
+	readonly name: string = 'AWS S3';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'storage';
+	readonly capabilities: readonly string[] = [
+		'storage',
+		'put-object',
+		'get-object',
+		'presigned-put'
+	];
+
+	readonly providerName: string = 'aws-s3';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			region: {
+				type: 'string',
+				title: 'AWS Region',
+				description: 'Region of the S3 bucket (e.g. us-east-1).',
+				'x-envVar': 'AWS_S3_REGION'
+			},
+			bucket: {
+				type: 'string',
+				title: 'S3 Bucket',
+				description: 'Bucket name.',
+				'x-envVar': 'AWS_S3_BUCKET'
+			},
+			accessKeyId: {
+				type: 'string',
+				title: 'AWS Access Key Id',
+				description: 'IAM access key (omit to use the default credential chain).',
+				'x-secret': true,
+				'x-envVar': 'AWS_ACCESS_KEY_ID'
+			},
+			secretAccessKey: {
+				type: 'string',
+				title: 'AWS Secret Access Key',
+				description: 'IAM secret (omit to use the default credential chain).',
+				'x-secret': true,
+				'x-envVar': 'AWS_SECRET_ACCESS_KEY'
+			},
+			presignExpiresSeconds: {
+				type: 'number',
+				title: 'Presign URL TTL (seconds)',
+				description: 'How long pre-signed upload URLs stay valid. Default 600 (10 min).',
+				default: 600,
+				minimum: 60,
+				maximum: 3600,
+				'x-envVar': 'AWS_S3_PRESIGN_EXPIRES_SECONDS'
+			}
+		},
+		required: ['region', 'bucket']
+	};
+
+	private context?: PluginContext;
+
+	async putObject(input: StoragePutInput): Promise<StoragePutResult> {
+		const cfg = this.config();
+		const client = this.client(cfg);
+		const key = this.buildKey(input.buffer, input.filename, input.ownerId);
+
+		await client.send(
+			new PutObjectCommand({
+				Bucket: cfg.bucket,
+				Key: key,
+				Body: input.buffer,
+				ContentType: input.mimeType,
+				ContentLength: input.size
+			})
+		);
+
+		const url = this.objectUrl(cfg, key);
+		return { key, url };
+	}
+
+	async getObject(key: string): Promise<StorageGetResult> {
+		const cfg = this.config();
+		const client = this.client(cfg);
+		const out = await client.send(new GetObjectCommand({ Bucket: cfg.bucket, Key: key }));
+		const body = out.Body;
+		if (!body) {
+			throw new Error(`S3 GetObject returned no body for key ${key}`);
+		}
+		// AWS SDK v3 returns a Node Readable in node.js — read fully into a
+		// buffer for the API's response stream. Browser-direct downloads
+		// should go through a presigned GET (not yet exposed).
+		const buffer = await streamToBuffer(body as NodeJS.ReadableStream);
+		return {
+			buffer,
+			mimeType: out.ContentType || guessMime(key)
+		};
+	}
+
+	async deleteObject(key: string): Promise<void> {
+		const cfg = this.config();
+		const client = this.client(cfg);
+		await client.send(new DeleteObjectCommand({ Bucket: cfg.bucket, Key: key }));
+	}
+
+	async presignPut(input: StoragePresignInput): Promise<StoragePresignResult> {
+		const cfg = this.config();
+		const client = this.client(cfg);
+		// Use a fresh random key — the browser can't know the sha256 of its
+		// own bytes ahead of time, and we don't want to round-trip them
+		// through the API just to compute it. The trade-off: presigned-PUT
+		// keys are NOT content-addressed.
+		const key = this.buildRandomKey(input.filename, input.ownerId);
+		const url = await getSignedUrl(
+			client,
+			new PutObjectCommand({
+				Bucket: cfg.bucket,
+				Key: key,
+				ContentType: input.mimeType,
+				ContentLength: input.size
+			}),
+			{ expiresIn: cfg.presignExpiresSeconds }
+		);
+		const expiresAt = new Date(Date.now() + cfg.presignExpiresSeconds * 1000).toISOString();
+		return { url, key, expiresAt };
+	}
+
+	async isAvailable(): Promise<boolean> {
+		try {
+			const cfg = this.config();
+			const client = this.client(cfg);
+			await client.send(new HeadBucketCommand({ Bucket: cfg.bucket }));
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log('AWS S3 storage plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		const available = await this.isAvailable();
+		return {
+			status: available ? 'healthy' : 'unhealthy',
+			message: available
+				? 'S3 bucket reachable'
+				: 'S3 bucket not reachable (missing config or invalid credentials)',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Stores uploaded objects in AWS S3, with presigned-PUT support.',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			builtIn: false,
+			systemPlugin: false,
+			icon: { type: 'lucide', value: 'Cloud', backgroundColor: '#ff9900' }
+		};
+	}
+
+	// ============================================================================
+	// Helpers
+	// ============================================================================
+
+	protected envOverrides(): Partial<S3Config> {
+		return {};
+	}
+
+	private config(): S3Config {
+		const overrides = this.envOverrides();
+		const region = overrides.region ?? process.env.AWS_S3_REGION ?? '';
+		const bucket = overrides.bucket ?? process.env.AWS_S3_BUCKET ?? '';
+		const accessKeyId = overrides.accessKeyId ?? process.env.AWS_ACCESS_KEY_ID;
+		const secretAccessKey = overrides.secretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY;
+		const endpoint = overrides.endpoint;
+		const forcePathStyle = overrides.forcePathStyle ?? false;
+		const presignExpiresSeconds =
+			overrides.presignExpiresSeconds ??
+			(Number(process.env.AWS_S3_PRESIGN_EXPIRES_SECONDS) || 600);
+
+		if (!region || !bucket) {
+			throw new Error(
+				`${this.id} storage plugin not configured: region=${region || '<empty>'} bucket=${bucket || '<empty>'}`
+			);
+		}
+
+		return {
+			region,
+			bucket,
+			accessKeyId,
+			secretAccessKey,
+			endpoint,
+			forcePathStyle,
+			presignExpiresSeconds
+		};
+	}
+
+	private client(cfg: S3Config): S3Client {
+		const credentials =
+			cfg.accessKeyId && cfg.secretAccessKey
+				? {
+						accessKeyId: cfg.accessKeyId,
+						secretAccessKey: cfg.secretAccessKey
+					}
+				: undefined;
+
+		return new S3Client({
+			region: cfg.region,
+			credentials,
+			endpoint: cfg.endpoint,
+			forcePathStyle: cfg.forcePathStyle
+		});
+	}
+
+	private buildKey(buffer: Buffer, filename: string, ownerId?: string): string {
+		const hash = createHash('sha256').update(buffer).digest('hex');
+		const ext = sanitizeExt(filename);
+		const owner = sanitizeOwner(ownerId);
+		return `uploads/${owner}/${hash}${ext}`;
+	}
+
+	private buildRandomKey(filename: string, ownerId?: string): string {
+		const ext = sanitizeExt(filename);
+		const owner = sanitizeOwner(ownerId);
+		return `uploads/${owner}/${randomUUID()}${ext}`;
+	}
+
+	protected objectUrl(cfg: S3Config, key: string): string {
+		if (cfg.endpoint) {
+			// MinIO / custom endpoint — path-style URL.
+			const base = cfg.endpoint.replace(/\/$/, '');
+			return `${base}/${cfg.bucket}/${key}`;
+		}
+		return `https://${cfg.bucket}.s3.${cfg.region}.amazonaws.com/${key}`;
+	}
+}
+
+// ============================================================================
+// Shared helpers (also used by the MinIO subclass)
+// ============================================================================
+
+export interface S3Config {
+	region: string;
+	bucket: string;
+	accessKeyId?: string;
+	secretAccessKey?: string;
+	endpoint?: string;
+	forcePathStyle?: boolean;
+	presignExpiresSeconds: number;
+}
+
+export function sanitizeExt(filename: string): string {
+	const e = extname(filename || '').toLowerCase();
+	if (!/^\.[a-z0-9]{1,8}$/.test(e)) return '';
+	return e;
+}
+
+export function sanitizeOwner(ownerId: string | undefined): string {
+	if (!ownerId) return '_shared';
+	// S3 keys allow slashes, but we restrict the OWNER segment to the same
+	// alphabet local-fs uses so the abstraction's key shape is portable.
+	if (!/^[A-Za-z0-9_-]{1,128}$/.test(ownerId)) {
+		throw new Error('Invalid ownerId for S3 storage');
+	}
+	return ownerId;
+}
+
+export function guessMime(key: string): string {
+	const ext = extname(key).toLowerCase();
+	switch (ext) {
+		case '.png':
+			return 'image/png';
+		case '.jpg':
+		case '.jpeg':
+			return 'image/jpeg';
+		case '.gif':
+			return 'image/gif';
+		case '.webp':
+			return 'image/webp';
+		case '.pdf':
+			return 'application/pdf';
+		case '.txt':
+			return 'text/plain';
+		case '.json':
+			return 'application/json';
+		default:
+			return 'application/octet-stream';
+	}
+}
+
+export async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+	const chunks: Buffer[] = [];
+	return await new Promise<Buffer>((resolveP, rejectP) => {
+		stream.on('data', (chunk: Buffer | string) => {
+			chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+		});
+		stream.on('end', () => resolveP(Buffer.concat(chunks)));
+		stream.on('error', rejectP);
+	});
+}
+
+export default AwsS3StoragePlugin;

--- a/packages/plugins/aws-s3/src/aws-s3.plugin.ts
+++ b/packages/plugins/aws-s3/src/aws-s3.plugin.ts
@@ -101,6 +101,14 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 
 	private context?: PluginContext;
 
+	// Cache the S3Client so we don't construct a new one (and a new HTTPS
+	// agent / connection pool) per upload. The cache key is a tuple of the
+	// fields the client constructor cares about; if any of them change
+	// (e.g. credentials get rotated via env, or a test resets MINIO_*) we
+	// build a fresh client.
+	private cachedClient?: S3Client;
+	private cachedClientKey?: string;
+
 	async putObject(input: StoragePutInput): Promise<StoragePutResult> {
 		const cfg = this.config();
 		const client = this.client(cfg);
@@ -184,6 +192,15 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 
 	async onUnload(): Promise<void> {
 		this.context = undefined;
+		if (this.cachedClient) {
+			try {
+				this.cachedClient.destroy();
+			} catch {
+				/* best-effort */
+			}
+			this.cachedClient = undefined;
+			this.cachedClientKey = undefined;
+		}
 	}
 
 	async healthCheck(): Promise<PluginHealthCheck> {
@@ -248,6 +265,10 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 	}
 
 	private client(cfg: S3Config): S3Client {
+		// Cache the client across calls. AWS SDK v3 S3Client maintains its
+		// own HTTPS agent / connection pool, so constructing one per request
+		// (the previous behavior) prevented TCP reuse and risked FD
+		// exhaustion under sustained upload load.
 		const credentials =
 			cfg.accessKeyId && cfg.secretAccessKey
 				? {
@@ -256,12 +277,37 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 					}
 				: undefined;
 
-		return new S3Client({
+		// Stable signature of every input that affects S3Client construction.
+		// Credentials are deliberately included (rotation should yield a new
+		// client) but only via presence/length — never via the raw secret.
+		const credKey = credentials
+			? `${credentials.accessKeyId}:${credentials.secretAccessKey.length}`
+			: '<default-chain>';
+		const key = `${cfg.region}|${cfg.endpoint || ''}|${cfg.forcePathStyle ? '1' : '0'}|${credKey}`;
+
+		if (this.cachedClient && this.cachedClientKey === key) {
+			return this.cachedClient;
+		}
+
+		// Destroy the previous client (releases sockets) before swapping it
+		// out. Older client is unreachable from here onwards.
+		if (this.cachedClient) {
+			try {
+				this.cachedClient.destroy();
+			} catch {
+				/* best-effort */
+			}
+		}
+
+		const client = new S3Client({
 			region: cfg.region,
 			credentials,
 			endpoint: cfg.endpoint,
 			forcePathStyle: cfg.forcePathStyle
 		});
+		this.cachedClient = client;
+		this.cachedClientKey = key;
+		return client;
 	}
 
 	private buildKey(buffer: Buffer, filename: string, ownerId?: string): string {

--- a/packages/plugins/aws-s3/src/index.ts
+++ b/packages/plugins/aws-s3/src/index.ts
@@ -1,0 +1,4 @@
+export { AwsS3StoragePlugin } from './aws-s3.plugin.js';
+export { AwsS3StoragePlugin as default } from './aws-s3.plugin.js';
+export type { S3Config } from './aws-s3.plugin.js';
+export { sanitizeExt, sanitizeOwner, guessMime, streamToBuffer } from './aws-s3.plugin.js';

--- a/packages/plugins/aws-s3/tsconfig.json
+++ b/packages/plugins/aws-s3/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/aws-s3/tsup.config.ts
+++ b/packages/plugins/aws-s3/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/github-storage/package.json
+++ b/packages/plugins/github-storage/package.json
@@ -1,0 +1,96 @@
+{
+	"name": "@ever-works/github-storage-plugin",
+	"version": "1.0.0",
+	"description": "GitHub-blob storage backend for Ever Works — stores uploaded objects as files in a configured repository. Only enabled when a GitHub token is configured.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"octokit": "^4.0.0"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.0.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "github-storage",
+			"name": "GitHub Storage",
+			"version": "1.0.0",
+			"category": "storage",
+			"capabilities": [
+				"storage",
+				"put-object",
+				"get-object"
+			],
+			"description": "Stores uploaded objects as files in a configured GitHub repository. Useful for low-traffic deployments that already have a GitHub PAT and want to avoid running a separate object store.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"systemPlugin": false,
+			"builtIn": false,
+			"envVars": [
+				{
+					"name": "GITHUB_STORAGE_TOKEN",
+					"required": false,
+					"secret": true,
+					"description": "GitHub Personal Access Token with `contents:write` scope on the storage repo."
+				},
+				{
+					"name": "GITHUB_STORAGE_OWNER",
+					"required": false,
+					"secret": false,
+					"description": "Owner (user or org) of the storage repository."
+				},
+				{
+					"name": "GITHUB_STORAGE_REPO",
+					"required": false,
+					"secret": false,
+					"description": "Storage repository name."
+				},
+				{
+					"name": "GITHUB_STORAGE_BRANCH",
+					"required": false,
+					"secret": false,
+					"description": "Branch to commit blobs to (default `main`)."
+				},
+				{
+					"name": "GITHUB_STORAGE_PATH_PREFIX",
+					"required": false,
+					"secret": false,
+					"description": "Prefix prepended to every blob path (default `uploads`)."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/github-storage/src/github-storage.plugin.ts
+++ b/packages/plugins/github-storage/src/github-storage.plugin.ts
@@ -230,10 +230,7 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		const owner = process.env.GITHUB_STORAGE_OWNER || '';
 		const repo = process.env.GITHUB_STORAGE_REPO || '';
 		const branch = process.env.GITHUB_STORAGE_BRANCH || 'main';
-		const pathPrefix = (process.env.GITHUB_STORAGE_PATH_PREFIX || 'uploads').replace(
-			/(^\/+|\/+$)/g,
-			''
-		);
+		const pathPrefix = (process.env.GITHUB_STORAGE_PATH_PREFIX || 'uploads').replace(/(^\/+|\/+$)/g, '');
 		if (!token || !owner || !repo) {
 			throw new Error(
 				'github-storage plugin not configured: GITHUB_STORAGE_TOKEN / GITHUB_STORAGE_OWNER / GITHUB_STORAGE_REPO required'

--- a/packages/plugins/github-storage/src/github-storage.plugin.ts
+++ b/packages/plugins/github-storage/src/github-storage.plugin.ts
@@ -129,7 +129,17 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		});
 
 		const key = repoPath;
-		const url = `https://raw.githubusercontent.com/${cfg.owner}/${cfg.repo}/${cfg.branch}/${repoPath}`;
+		// IMPORTANT: do NOT return raw.githubusercontent.com here. That host
+		// returns 404 (no token, no auth) for private repos, which is the
+		// recommended setup for landing-page uploads. Callers should
+		// stream through the API's owner-scoped `GET /api/uploads/:owner/:filename`
+		// route, which delegates back to this plugin's `getObject(key)` over
+		// the authenticated GitHub Contents API.
+		// For public repos the operator can override via `cfg.publicRawUrl`
+		// (env: `GITHUB_STORAGE_PUBLIC_URL_BASE`); see config().
+		const url = cfg.publicRawUrl
+			? `${cfg.publicRawUrl.replace(/\/$/, '')}/${repoPath}`
+			: `/api/uploads/${owner}/${hash}${ext}`;
 		return { key, url };
 	}
 
@@ -231,12 +241,18 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		const repo = process.env.GITHUB_STORAGE_REPO || '';
 		const branch = process.env.GITHUB_STORAGE_BRANCH || 'main';
 		const pathPrefix = (process.env.GITHUB_STORAGE_PATH_PREFIX || 'uploads').replace(/(^\/+|\/+$)/g, '');
+		// Optional public URL base for cases where the configured repo IS
+		// public and operators want raw.githubusercontent.com URLs (or a
+		// CDN in front of it). When unset, putObject returns an internal
+		// API-routed URL; getObject streams the blob via the GitHub Contents
+		// API regardless, so private-repo + no-public-url is still correct.
+		const publicRawUrl = process.env.GITHUB_STORAGE_PUBLIC_URL_BASE || undefined;
 		if (!token || !owner || !repo) {
 			throw new Error(
 				'github-storage plugin not configured: GITHUB_STORAGE_TOKEN / GITHUB_STORAGE_OWNER / GITHUB_STORAGE_REPO required'
 			);
 		}
-		return { token, owner, repo, branch, pathPrefix };
+		return { token, owner, repo, branch, pathPrefix, publicRawUrl };
 	}
 
 	private client(cfg: GitHubStorageConfig): Octokit {
@@ -250,6 +266,15 @@ interface GitHubStorageConfig {
 	repo: string;
 	branch: string;
 	pathPrefix: string;
+	/**
+	 * Optional public URL base for the repo's raw content (e.g.
+	 * `https://raw.githubusercontent.com/foo/bar/main`). When set,
+	 * `putObject` returns `${publicRawUrl}/${repoPath}`. When unset
+	 * (the recommended setup for private repos), `putObject` returns
+	 * an internal API-routed URL — `getObject` always reads through
+	 * the authenticated Contents API.
+	 */
+	publicRawUrl?: string;
 }
 
 function sanitizeExt(filename: string): string {

--- a/packages/plugins/github-storage/src/github-storage.plugin.ts
+++ b/packages/plugins/github-storage/src/github-storage.plugin.ts
@@ -1,0 +1,295 @@
+import { createHash } from 'node:crypto';
+import { extname } from 'node:path';
+import { Octokit, RequestError } from 'octokit';
+import type {
+	IStoragePlugin,
+	StoragePutInput,
+	StoragePutResult,
+	StorageGetResult,
+	IPlugin,
+	PluginContext,
+	PluginCategory,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema
+} from '@ever-works/plugin';
+
+/**
+ * EW-637 — GitHub-blob storage backend.
+ *
+ * Writes each uploaded object as a file in a configured repository via
+ * `PUT /repos/{owner}/{repo}/contents/{path}` (the same endpoint the
+ * existing `@ever-works/github-plugin` uses for repo edits). Reads come
+ * back through the matching `GET` endpoint.
+ *
+ * Use case: low-traffic deployments that already have a GitHub PAT (e.g.
+ * the operator's "Ever Works Customers" org) and don't want to run a
+ * separate object store. NOT recommended for high-volume uploads — every
+ * write creates a git commit.
+ *
+ * Runtime gate: the plugin is "available" only when the four required
+ * env vars (`GITHUB_STORAGE_TOKEN`, `GITHUB_STORAGE_OWNER`,
+ * `GITHUB_STORAGE_REPO`, plus optional `GITHUB_STORAGE_BRANCH` /
+ * `GITHUB_STORAGE_PATH_PREFIX`) are set. The uploads service should
+ * check `isAvailable()` at boot and refuse to use this backend if it
+ * returns false (rather than crashing on the first write).
+ *
+ * No `presignPut` — there's no way to mint a direct-upload URL into a
+ * GitHub repo, the API has to mediate.
+ */
+export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
+	readonly id = 'github-storage';
+	readonly name = 'GitHub Storage';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'storage';
+	readonly capabilities: readonly string[] = ['storage', 'put-object', 'get-object'];
+
+	readonly providerName = 'github-storage';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			token: {
+				type: 'string',
+				title: 'Token',
+				description: 'GitHub PAT with `contents:write` scope on the storage repo.',
+				'x-secret': true,
+				'x-envVar': 'GITHUB_STORAGE_TOKEN'
+			},
+			owner: {
+				type: 'string',
+				title: 'Owner',
+				description: 'GitHub user or org that owns the storage repo.',
+				'x-envVar': 'GITHUB_STORAGE_OWNER'
+			},
+			repo: {
+				type: 'string',
+				title: 'Repository',
+				description: 'Storage repository name.',
+				'x-envVar': 'GITHUB_STORAGE_REPO'
+			},
+			branch: {
+				type: 'string',
+				title: 'Branch',
+				description: 'Branch to commit blobs to.',
+				default: 'main',
+				'x-envVar': 'GITHUB_STORAGE_BRANCH'
+			},
+			pathPrefix: {
+				type: 'string',
+				title: 'Path Prefix',
+				description: 'Prefix prepended to every blob path (default `uploads`).',
+				default: 'uploads',
+				'x-envVar': 'GITHUB_STORAGE_PATH_PREFIX'
+			}
+		},
+		required: ['token', 'owner', 'repo']
+	};
+
+	private context?: PluginContext;
+
+	async putObject(input: StoragePutInput): Promise<StoragePutResult> {
+		const cfg = this.config();
+		const octokit = this.client(cfg);
+
+		const hash = createHash('sha256').update(input.buffer).digest('hex');
+		const ext = sanitizeExt(input.filename);
+		const owner = sanitizeOwner(input.ownerId);
+		const repoPath = `${cfg.pathPrefix}/${owner}/${hash}${ext}`;
+		const content = input.buffer.toString('base64');
+
+		// PUT /repos/{owner}/{repo}/contents/{path} — creates or updates.
+		// If the same hash is uploaded twice (idempotent put), we look up
+		// the existing SHA so the second commit doesn't 409.
+		let existingSha: string | undefined;
+		try {
+			const { data } = await octokit.rest.repos.getContent({
+				owner: cfg.owner,
+				repo: cfg.repo,
+				path: repoPath,
+				ref: cfg.branch
+			});
+			if (!Array.isArray(data) && data.type === 'file') {
+				existingSha = data.sha;
+			}
+		} catch (err) {
+			if (!(err instanceof RequestError) || err.status !== 404) {
+				throw err;
+			}
+		}
+
+		await octokit.rest.repos.createOrUpdateFileContents({
+			owner: cfg.owner,
+			repo: cfg.repo,
+			path: repoPath,
+			message: `upload(${owner}): ${hash}${ext}`,
+			content,
+			branch: cfg.branch,
+			...(existingSha ? { sha: existingSha } : {})
+		});
+
+		const key = repoPath;
+		const url = `https://raw.githubusercontent.com/${cfg.owner}/${cfg.repo}/${cfg.branch}/${repoPath}`;
+		return { key, url };
+	}
+
+	async getObject(key: string): Promise<StorageGetResult> {
+		const cfg = this.config();
+		const octokit = this.client(cfg);
+		const { data } = await octokit.rest.repos.getContent({
+			owner: cfg.owner,
+			repo: cfg.repo,
+			path: key,
+			ref: cfg.branch
+		});
+		if (Array.isArray(data) || data.type !== 'file') {
+			throw new Error(`GitHub storage key is not a file: ${key}`);
+		}
+		// `content` is base64, possibly with newlines depending on the endpoint.
+		const buffer = Buffer.from(data.content.replace(/\n/g, ''), 'base64');
+		return { buffer, mimeType: guessMime(key) };
+	}
+
+	async deleteObject(key: string): Promise<void> {
+		const cfg = this.config();
+		const octokit = this.client(cfg);
+		try {
+			const { data } = await octokit.rest.repos.getContent({
+				owner: cfg.owner,
+				repo: cfg.repo,
+				path: key,
+				ref: cfg.branch
+			});
+			if (Array.isArray(data) || data.type !== 'file') return;
+			await octokit.rest.repos.deleteFile({
+				owner: cfg.owner,
+				repo: cfg.repo,
+				path: key,
+				message: `delete-upload: ${key}`,
+				sha: data.sha,
+				branch: cfg.branch
+			});
+		} catch (err) {
+			// Idempotent delete — 404 is fine.
+			if (err instanceof RequestError && err.status === 404) return;
+			throw err;
+		}
+	}
+
+	async isAvailable(): Promise<boolean> {
+		try {
+			const cfg = this.config();
+			const octokit = this.client(cfg);
+			await octokit.rest.repos.get({ owner: cfg.owner, repo: cfg.repo });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log('GitHub storage plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		const available = await this.isAvailable();
+		return {
+			status: available ? 'healthy' : 'unhealthy',
+			message: available
+				? 'GitHub storage repo reachable'
+				: 'GitHub storage not configured or token lacks repo access',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Stores uploaded objects as commits in a GitHub repository.',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			builtIn: false,
+			systemPlugin: false,
+			icon: { type: 'lucide', value: 'Github', backgroundColor: '#181717' }
+		};
+	}
+
+	// ============================================================================
+	// Helpers
+	// ============================================================================
+
+	private config(): GitHubStorageConfig {
+		const token = process.env.GITHUB_STORAGE_TOKEN || '';
+		const owner = process.env.GITHUB_STORAGE_OWNER || '';
+		const repo = process.env.GITHUB_STORAGE_REPO || '';
+		const branch = process.env.GITHUB_STORAGE_BRANCH || 'main';
+		const pathPrefix = (process.env.GITHUB_STORAGE_PATH_PREFIX || 'uploads').replace(
+			/(^\/+|\/+$)/g,
+			''
+		);
+		if (!token || !owner || !repo) {
+			throw new Error(
+				'github-storage plugin not configured: GITHUB_STORAGE_TOKEN / GITHUB_STORAGE_OWNER / GITHUB_STORAGE_REPO required'
+			);
+		}
+		return { token, owner, repo, branch, pathPrefix };
+	}
+
+	private client(cfg: GitHubStorageConfig): Octokit {
+		return new Octokit({ auth: cfg.token });
+	}
+}
+
+interface GitHubStorageConfig {
+	token: string;
+	owner: string;
+	repo: string;
+	branch: string;
+	pathPrefix: string;
+}
+
+function sanitizeExt(filename: string): string {
+	const e = extname(filename || '').toLowerCase();
+	if (!/^\.[a-z0-9]{1,8}$/.test(e)) return '';
+	return e;
+}
+
+function sanitizeOwner(ownerId: string | undefined): string {
+	if (!ownerId) return '_shared';
+	if (!/^[A-Za-z0-9_-]{1,128}$/.test(ownerId)) {
+		throw new Error('Invalid ownerId for github-storage');
+	}
+	return ownerId;
+}
+
+function guessMime(key: string): string {
+	const ext = extname(key).toLowerCase();
+	switch (ext) {
+		case '.png':
+			return 'image/png';
+		case '.jpg':
+		case '.jpeg':
+			return 'image/jpeg';
+		case '.gif':
+			return 'image/gif';
+		case '.webp':
+			return 'image/webp';
+		case '.pdf':
+			return 'application/pdf';
+		case '.txt':
+			return 'text/plain';
+		case '.json':
+			return 'application/json';
+		default:
+			return 'application/octet-stream';
+	}
+}
+
+export default GitHubStoragePlugin;

--- a/packages/plugins/github-storage/src/index.ts
+++ b/packages/plugins/github-storage/src/index.ts
@@ -1,0 +1,2 @@
+export { GitHubStoragePlugin } from './github-storage.plugin.js';
+export { GitHubStoragePlugin as default } from './github-storage.plugin.js';

--- a/packages/plugins/github-storage/tsconfig.json
+++ b/packages/plugins/github-storage/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/github-storage/tsup.config.ts
+++ b/packages/plugins/github-storage/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/local-fs/package.json
+++ b/packages/plugins/local-fs/package.json
@@ -1,0 +1,82 @@
+{
+	"name": "@ever-works/local-fs-plugin",
+	"version": "1.0.0",
+	"description": "Local-filesystem storage backend for Ever Works — writes uploaded objects under UPLOADS_DIR. Default storage backend.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.0.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "local-fs",
+			"name": "Local Filesystem",
+			"version": "1.0.0",
+			"category": "storage",
+			"capabilities": [
+				"storage",
+				"put-object",
+				"get-object"
+			],
+			"description": "Stores uploaded objects on the API server's local disk under UPLOADS_DIR. Default backend for self-hosted / single-node deployments.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"autoEnable": true,
+			"systemPlugin": true,
+			"builtIn": true,
+			"visibility": "hidden",
+			"defaultForCapabilities": [
+				"storage",
+				"put-object",
+				"get-object"
+			],
+			"envVars": [
+				{
+					"name": "UPLOADS_DIR",
+					"required": false,
+					"secret": false,
+					"description": "Absolute path where uploaded objects are written. Defaults to <tmpdir>/ever-works-uploads."
+				},
+				{
+					"name": "UPLOADS_MAX_BYTES",
+					"required": false,
+					"secret": false,
+					"description": "Per-object size cap in bytes. Default 5242880 (5 MiB)."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/local-fs/src/index.ts
+++ b/packages/plugins/local-fs/src/index.ts
@@ -1,0 +1,2 @@
+export { LocalFsStoragePlugin } from './local-fs.plugin.js';
+export { LocalFsStoragePlugin as default } from './local-fs.plugin.js';

--- a/packages/plugins/local-fs/src/local-fs.plugin.ts
+++ b/packages/plugins/local-fs/src/local-fs.plugin.ts
@@ -1,0 +1,269 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { join, resolve, normalize, sep, extname } from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+	IStoragePlugin,
+	StoragePutInput,
+	StoragePutResult,
+	StorageGetResult,
+	IPlugin,
+	PluginContext,
+	PluginCategory,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema
+} from '@ever-works/plugin';
+
+/**
+ * EW-637 — Local-filesystem storage backend.
+ *
+ * Refactored out of `apps/api/src/uploads/uploads.service.ts`. Keeps the
+ * exact same on-disk layout (`<UPLOADS_DIR>/<ownerId>/<sha256>.<ext>`),
+ * the same path-traversal defenses, and the same `/api/uploads/...` URL
+ * shape so existing clients continue to work after the uploads service
+ * is switched over to the plugin abstraction.
+ *
+ * NOTE: MIME validation and magic-byte sniffing live in the API layer
+ * (UploadsService) — the plugin trusts the bytes it receives. This keeps
+ * the validation logic in one place across all backends.
+ */
+export class LocalFsStoragePlugin implements IPlugin, IStoragePlugin {
+	// ============================================================================
+	// IPlugin Properties
+	// ============================================================================
+
+	readonly id = 'local-fs';
+	readonly name = 'Local Filesystem';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'storage';
+	readonly capabilities: readonly string[] = ['storage', 'put-object', 'get-object'];
+
+	readonly providerName = 'local-fs';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			uploadsDir: {
+				type: 'string',
+				title: 'Uploads Directory',
+				description:
+					'Absolute path on the API server where objects are written. Defaults to <tmpdir>/ever-works-uploads.',
+				'x-envVar': 'UPLOADS_DIR'
+			},
+			maxBytes: {
+				type: 'number',
+				title: 'Max Bytes',
+				description: 'Per-object size cap in bytes. Default 5242880 (5 MiB).',
+				default: 5 * 1024 * 1024,
+				'x-envVar': 'UPLOADS_MAX_BYTES'
+			}
+		}
+	};
+
+	private context?: PluginContext;
+
+	// ============================================================================
+	// IStoragePlugin
+	// ============================================================================
+
+	async putObject(input: StoragePutInput): Promise<StoragePutResult> {
+		const ownerId = this.resolveOwnerId(input.ownerId);
+		this.assertValidOwnerId(ownerId);
+
+		// Storage key is sha256(buffer) + lowercase extension derived from the
+		// client-supplied filename — the filename itself NEVER reaches disk
+		// (defeats `../../etc/passwd`-style payloads).
+		const hash = createHash('sha256').update(input.buffer).digest('hex');
+		const ext = this.extractExt(input.filename);
+		const objectName = `${hash}${ext}`;
+		const key = `${ownerId}/${objectName}`;
+
+		const userDir = this.ownerDir(ownerId);
+		await fs.mkdir(userDir, { recursive: true });
+		const absPath = this.resolveSafe(userDir, objectName);
+		await fs.writeFile(absPath, input.buffer, { flag: 'w' });
+
+		// URL is served by the API at /api/uploads/:owner/:filename
+		const url = `/api/uploads/${encodeURIComponent(ownerId)}/${objectName}`;
+		return { key, url };
+	}
+
+	async getObject(key: string): Promise<StorageGetResult> {
+		const { ownerId, filename } = this.parseKey(key);
+		const userDir = this.ownerDir(ownerId);
+		const absPath = this.resolveSafe(userDir, filename);
+
+		let buffer: Buffer;
+		try {
+			buffer = await fs.readFile(absPath);
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === 'ENOENT' || code === 'ENOTDIR') {
+				throw new Error(`Upload not found: ${key}`);
+			}
+			throw err;
+		}
+
+		// Recover MIME from extension. The API layer treats this as a hint
+		// only — it re-sniffs magic bytes before serving the response.
+		return { buffer, mimeType: this.mimeFromExt(filename) };
+	}
+
+	async deleteObject(key: string): Promise<void> {
+		const { ownerId, filename } = this.parseKey(key);
+		const userDir = this.ownerDir(ownerId);
+		const absPath = this.resolveSafe(userDir, filename);
+		try {
+			await fs.unlink(absPath);
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			// Idempotent delete — missing is fine.
+			if (code === 'ENOENT' || code === 'ENOTDIR') return;
+			throw err;
+		}
+	}
+
+	async isAvailable(): Promise<boolean> {
+		// Local FS is always "available" — directories are created lazily.
+		// The only failure mode is permissions, which we surface at putObject
+		// time so the operator sees the real OS error.
+		return true;
+	}
+
+	// ============================================================================
+	// IPlugin lifecycle
+	// ============================================================================
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log(
+			`LocalFs storage plugin loaded; storageRoot=${this.storageRoot()} maxBytes=${this.maxBytes()}`
+		);
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		try {
+			const root = this.storageRoot();
+			await fs.mkdir(root, { recursive: true });
+			return { status: 'healthy', message: `Writable at ${root}`, checkedAt: Date.now() };
+		} catch (err) {
+			return {
+				status: 'unhealthy',
+				message: `LocalFs storage root not writable: ${err instanceof Error ? err.message : String(err)}`,
+				checkedAt: Date.now()
+			};
+		}
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Default object storage on local disk.',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			builtIn: true,
+			systemPlugin: true,
+			visibility: 'hidden',
+			defaultForCapabilities: ['storage', 'put-object', 'get-object'],
+			icon: { type: 'lucide', value: 'HardDrive', backgroundColor: '#0ea5e9' }
+		};
+	}
+
+	// ============================================================================
+	// Helpers (same defenses as the legacy UploadsService)
+	// ============================================================================
+
+	private storageRoot(): string {
+		// `UPLOADS_DIR` is an operator-controlled absolute path; default to
+		// a per-process tmp dir so dev / CI work out of the box and never
+		// collide with another instance.
+		return resolve(process.env.UPLOADS_DIR || join(tmpdir(), 'ever-works-uploads'));
+	}
+
+	private maxBytes(): number {
+		const v = Number(process.env.UPLOADS_MAX_BYTES);
+		return Number.isFinite(v) && v > 0 ? v : 5 * 1024 * 1024;
+	}
+
+	private resolveOwnerId(ownerId: string | undefined): string {
+		// When no owner is supplied (legacy callers, scripts), bucket under
+		// "_shared" so files are still scoped to a directory and don't
+		// pollute the storage root.
+		return ownerId || '_shared';
+	}
+
+	private ownerDir(ownerId: string): string {
+		return resolve(this.storageRoot(), ownerId);
+	}
+
+	private resolveSafe(ownerDir: string, filename: string): string {
+		const candidate = resolve(ownerDir, filename);
+		const ownerDirNorm = normalize(ownerDir + sep);
+		const candidateNorm = normalize(candidate);
+		if (!candidateNorm.startsWith(ownerDirNorm)) {
+			throw new Error('Resolved path escapes owner storage root');
+		}
+		return candidate;
+	}
+
+	private assertValidOwnerId(ownerId: string): void {
+		if (!ownerId || !/^[A-Za-z0-9_-]{1,128}$/.test(ownerId)) {
+			throw new Error('Invalid ownerId for local-fs storage');
+		}
+	}
+
+	private parseKey(key: string): { ownerId: string; filename: string } {
+		const idx = key.indexOf('/');
+		if (idx <= 0 || idx === key.length - 1) {
+			throw new Error(`Malformed storage key: ${key}`);
+		}
+		const ownerId = key.slice(0, idx);
+		const filename = key.slice(idx + 1);
+		this.assertValidOwnerId(ownerId);
+		// Filename must be `<hex>.<ext>` or `<hex>` — same shape `putObject` writes.
+		if (!filename || !/^[A-Za-z0-9._-]{1,256}$/.test(filename) || filename.includes('..')) {
+			throw new Error(`Malformed filename in storage key: ${filename}`);
+		}
+		return { ownerId, filename };
+	}
+
+	private extractExt(filename: string): string {
+		const e = extname(filename || '').toLowerCase();
+		// Only allow simple [a-z0-9] extensions; everything else gets dropped
+		// to keep the on-disk name strictly hex.ext (no quotes, slashes, etc).
+		if (!/^\.[a-z0-9]{1,8}$/.test(e)) return '';
+		return e;
+	}
+
+	private mimeFromExt(filename: string): string {
+		const ext = extname(filename).toLowerCase();
+		switch (ext) {
+			case '.png':
+				return 'image/png';
+			case '.jpg':
+			case '.jpeg':
+				return 'image/jpeg';
+			case '.gif':
+				return 'image/gif';
+			case '.webp':
+				return 'image/webp';
+			case '.pdf':
+				return 'application/pdf';
+			case '.txt':
+				return 'text/plain';
+			case '.json':
+				return 'application/json';
+			default:
+				return 'application/octet-stream';
+		}
+	}
+}
+
+export default LocalFsStoragePlugin;

--- a/packages/plugins/local-fs/tsconfig.json
+++ b/packages/plugins/local-fs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/local-fs/tsup.config.ts
+++ b/packages/plugins/local-fs/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/minio/package.json
+++ b/packages/plugins/minio/package.json
@@ -1,0 +1,99 @@
+{
+	"name": "@ever-works/minio-plugin",
+	"version": "1.0.0",
+	"description": "MinIO storage backend for Ever Works — S3-compatible storage on self-hosted endpoints.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"@aws-sdk/client-s3": "^3.700.0",
+		"@aws-sdk/s3-request-presigner": "^3.700.0",
+		"@ever-works/aws-s3-plugin": "workspace:*"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.0.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "minio",
+			"name": "MinIO",
+			"version": "1.0.0",
+			"category": "storage",
+			"capabilities": [
+				"storage",
+				"put-object",
+				"get-object",
+				"presigned-put"
+			],
+			"description": "Self-hosted S3-compatible object storage (MinIO). Same protocol as AWS S3 but points at a custom endpoint.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"systemPlugin": false,
+			"builtIn": false,
+			"envVars": [
+				{
+					"name": "MINIO_ENDPOINT",
+					"required": false,
+					"secret": false,
+					"description": "MinIO endpoint URL (e.g. https://minio.example.com:9000)."
+				},
+				{
+					"name": "MINIO_REGION",
+					"required": false,
+					"secret": false,
+					"description": "Region label sent in S3 requests. MinIO ignores it but the SDK requires one (default us-east-1)."
+				},
+				{
+					"name": "MINIO_BUCKET",
+					"required": false,
+					"secret": false,
+					"description": "MinIO bucket name."
+				},
+				{
+					"name": "MINIO_ACCESS_KEY",
+					"required": false,
+					"secret": true,
+					"description": "MinIO access key."
+				},
+				{
+					"name": "MINIO_SECRET_KEY",
+					"required": false,
+					"secret": true,
+					"description": "MinIO secret key."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/minio/src/index.ts
+++ b/packages/plugins/minio/src/index.ts
@@ -1,0 +1,2 @@
+export { MinioStoragePlugin } from './minio.plugin.js';
+export { MinioStoragePlugin as default } from './minio.plugin.js';

--- a/packages/plugins/minio/src/minio.plugin.ts
+++ b/packages/plugins/minio/src/minio.plugin.ts
@@ -82,6 +82,10 @@ export class MinioStoragePlugin extends AwsS3StoragePlugin {
 	}
 
 	override async onLoad(context: PluginContext): Promise<void> {
+		// Chain to the parent so `this.context` (and the S3Client cache
+		// state managed there) is initialized. The previous override
+		// skipped super and left context undefined.
+		await super.onLoad(context);
 		context.logger.log('MinIO storage plugin loaded');
 	}
 

--- a/packages/plugins/minio/src/minio.plugin.ts
+++ b/packages/plugins/minio/src/minio.plugin.ts
@@ -1,10 +1,5 @@
 import { AwsS3StoragePlugin, type S3Config } from '@ever-works/aws-s3-plugin';
-import type {
-	PluginCategory,
-	PluginManifest,
-	JsonSchema,
-	PluginContext
-} from '@ever-works/plugin';
+import type { PluginCategory, PluginManifest, JsonSchema, PluginContext } from '@ever-works/plugin';
 
 /**
  * EW-637 — MinIO storage backend.
@@ -82,8 +77,7 @@ export class MinioStoragePlugin extends AwsS3StoragePlugin {
 			accessKeyId: process.env.MINIO_ACCESS_KEY,
 			secretAccessKey: process.env.MINIO_SECRET_KEY,
 			forcePathStyle: true,
-			presignExpiresSeconds:
-				Number(process.env.MINIO_PRESIGN_EXPIRES_SECONDS) || 600
+			presignExpiresSeconds: Number(process.env.MINIO_PRESIGN_EXPIRES_SECONDS) || 600
 		};
 	}
 

--- a/packages/plugins/minio/src/minio.plugin.ts
+++ b/packages/plugins/minio/src/minio.plugin.ts
@@ -1,0 +1,109 @@
+import { AwsS3StoragePlugin, type S3Config } from '@ever-works/aws-s3-plugin';
+import type {
+	PluginCategory,
+	PluginManifest,
+	JsonSchema,
+	PluginContext
+} from '@ever-works/plugin';
+
+/**
+ * EW-637 — MinIO storage backend.
+ *
+ * Functionally identical to AWS S3 but pointed at a custom endpoint
+ * (typically a self-hosted MinIO cluster) with path-style URLs forced on
+ * (MinIO doesn't always support virtual-hosted-style with arbitrary
+ * bucket names). We reuse `AwsS3StoragePlugin` and only override the
+ * env-resolution + manifest metadata.
+ */
+export class MinioStoragePlugin extends AwsS3StoragePlugin {
+	override readonly id = 'minio';
+	override readonly name = 'MinIO';
+	override readonly category: PluginCategory = 'storage';
+	override readonly providerName = 'minio';
+
+	override readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			endpoint: {
+				type: 'string',
+				title: 'MinIO Endpoint',
+				description: 'Full endpoint URL (e.g. https://minio.example.com:9000).',
+				'x-envVar': 'MINIO_ENDPOINT'
+			},
+			region: {
+				type: 'string',
+				title: 'Region Label',
+				description: 'Region string sent in S3 requests. MinIO ignores it (default us-east-1).',
+				default: 'us-east-1',
+				'x-envVar': 'MINIO_REGION'
+			},
+			bucket: {
+				type: 'string',
+				title: 'Bucket',
+				description: 'MinIO bucket name.',
+				'x-envVar': 'MINIO_BUCKET'
+			},
+			accessKey: {
+				type: 'string',
+				title: 'Access Key',
+				description: 'MinIO access key.',
+				'x-secret': true,
+				'x-envVar': 'MINIO_ACCESS_KEY'
+			},
+			secretKey: {
+				type: 'string',
+				title: 'Secret Key',
+				description: 'MinIO secret key.',
+				'x-secret': true,
+				'x-envVar': 'MINIO_SECRET_KEY'
+			},
+			presignExpiresSeconds: {
+				type: 'number',
+				title: 'Presign URL TTL (seconds)',
+				description: 'How long pre-signed upload URLs stay valid. Default 600 (10 min).',
+				default: 600,
+				minimum: 60,
+				maximum: 3600,
+				'x-envVar': 'MINIO_PRESIGN_EXPIRES_SECONDS'
+			}
+		},
+		required: ['endpoint', 'bucket']
+	};
+
+	protected override envOverrides(): Partial<S3Config> {
+		const endpoint = process.env.MINIO_ENDPOINT;
+		if (!endpoint) {
+			throw new Error('MINIO_ENDPOINT is not set');
+		}
+		return {
+			endpoint,
+			region: process.env.MINIO_REGION || 'us-east-1',
+			bucket: process.env.MINIO_BUCKET || '',
+			accessKeyId: process.env.MINIO_ACCESS_KEY,
+			secretAccessKey: process.env.MINIO_SECRET_KEY,
+			forcePathStyle: true,
+			presignExpiresSeconds:
+				Number(process.env.MINIO_PRESIGN_EXPIRES_SECONDS) || 600
+		};
+	}
+
+	override async onLoad(context: PluginContext): Promise<void> {
+		context.logger.log('MinIO storage plugin loaded');
+	}
+
+	override getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Self-hosted S3-compatible storage backend (MinIO).',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			builtIn: false,
+			systemPlugin: false,
+			icon: { type: 'lucide', value: 'Server', backgroundColor: '#c72e29' }
+		};
+	}
+}
+
+export default MinioStoragePlugin;

--- a/packages/plugins/minio/tsconfig.json
+++ b/packages/plugins/minio/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/minio/tsup.config.ts
+++ b/packages/plugins/minio/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin', '@ever-works/aws-s3-plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1178,6 +1178,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
+  packages/plugins/aws-s3:
+    dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1051.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.700.0
+        version: 3.1051.0
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
   packages/plugins/brave:
     devDependencies:
       '@ever-works/plugin':
@@ -1383,6 +1408,28 @@ importers:
       isomorphic-git:
         specifier: ^1.27.0
         version: 1.37.1
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
+  packages/plugins/github-storage:
+    dependencies:
+      octokit:
+        specifier: ^4.0.0
+        version: 4.1.4
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
@@ -1606,6 +1653,24 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
+  packages/plugins/local-fs:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
   packages/plugins/make:
     devDependencies:
       '@ever-works/plugin':
@@ -1622,6 +1687,34 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
+  packages/plugins/minio:
+    dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1051.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.700.0
+        version: 3.1051.0
+      '@ever-works/aws-s3-plugin':
+        specifier: workspace:*
+        version: link:../aws-s3
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/plugins/mistral:
@@ -2344,6 +2437,129 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1051.0':
+    resolution: {integrity: sha512-0Yhq7AMw2te5YtxDHkm2KKpXF8IccOO4nmCsp12EzYB/e3IKQ73NHH4jA2ki8mQwvAQzFGB+1GoycT00U8sZCg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.12':
+    resolution: {integrity: sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.8':
+    resolution: {integrity: sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    resolution: {integrity: sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    resolution: {integrity: sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    resolution: {integrity: sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    resolution: {integrity: sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.43':
+    resolution: {integrity: sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    resolution: {integrity: sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    resolution: {integrity: sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    resolution: {integrity: sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.14':
+    resolution: {integrity: sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.12':
+    resolution: {integrity: sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.20':
+    resolution: {integrity: sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.41':
+    resolution: {integrity: sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.10':
+    resolution: {integrity: sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1051.0':
+    resolution: {integrity: sha512-9ZULJHf5IAObmqtg2XhiufMmgEl+aM9jlRog2V9qbICeSOgDCHekmlRxF9FuqZKMqrpLzGtJPDbd8gGAHJZv/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1049.0':
+    resolution: {integrity: sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -7655,6 +7871,42 @@ packages:
   '@slorber/remark-comment@1.0.0':
     resolution: {integrity: sha512-RCE24n7jsOj1M0UPvIQCHTe7fI0sFL4S2nwKVWwHyVr/wI/H8GosgsJGyhnsZoGFnD/P2hLf1mSbrrgSLN93NA==}
 
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -9638,6 +9890,9 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   boxen@6.2.1:
     resolution: {integrity: sha512-H4PEsJXfFI/Pt8sjDWbHlQPx4zL/bvSQjcilJmaulGt5mLDorHOHpmdXAJcBcmru7PhYSp/cDMWRko4ZUMFkSw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -11609,6 +11864,10 @@ packages:
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastq@1.20.1:
@@ -18529,6 +18788,280 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1051.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.14
+      '@aws-sdk/middleware-expect-continue': 3.972.12
+      '@aws-sdk/middleware-flexible-checksums': 3.974.20
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-sdk-s3': 3.972.41
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.8':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-login': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.43':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-ini': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/token-providers': 3.1049.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.14':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.20':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/crc64-nvme': 3.972.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.10':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1051.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1049.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -24997,6 +25530,54 @@ snapshots:
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
 
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@sqltools/formatter@1.2.5': {}
@@ -27263,6 +27844,8 @@ snapshots:
   boolify@1.0.1: {}
 
   bottleneck@2.19.5: {}
+
+  bowser@2.14.1: {}
 
   boxen@6.2.1:
     dependencies:
@@ -29713,6 +30296,13 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -30843,7 +31433,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   is-callable@1.2.7: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,21 @@ importers:
       '@ever-works/agent':
         specifier: workspace:*
         version: link:../../packages/agent
+      '@ever-works/aws-s3-plugin':
+        specifier: workspace:*
+        version: link:../../packages/plugins/aws-s3
       '@ever-works/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      '@ever-works/github-storage-plugin':
+        specifier: workspace:*
+        version: link:../../packages/plugins/github-storage
+      '@ever-works/local-fs-plugin':
+        specifier: workspace:*
+        version: link:../../packages/plugins/local-fs
+      '@ever-works/minio-plugin':
+        specifier: workspace:*
+        version: link:../../packages/plugins/minio
       '@ever-works/monitoring':
         specifier: workspace:*
         version: link:../../packages/monitoring
@@ -27776,7 +27788,7 @@ snapshots:
   binary-version-check@6.1.0:
     dependencies:
       binary-version: 7.1.0
-      semver: 7.7.4
+      semver: 7.8.0
       semver-truncate: 3.0.0
 
   binary-version@7.1.0:
@@ -31987,7 +31999,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.4
+      semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -33966,7 +33978,7 @@ snapshots:
 
   node-abi@3.87.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   node-abort-controller@3.1.1: {}
 


### PR DESCRIPTION
## Summary

EW-637 — adds a pluggable **object storage** plugin category so the API's `/api/uploads` endpoint isn't married to local disk, and opens an **anonymous upload route** so the website's landing-page prompt-with-attachments flow can accept files from visitors who haven't signed up yet.

- New plugin category `storage` + capability constants `put-object`, `get-object`, `presigned-put` — wired into the existing `PLUGIN_CATEGORIES` SoT so manifest validation / discovery / settings UI pick it up automatically.
- New `IStoragePlugin` contract in `@ever-works/plugin/contracts/capabilities/storage.interface.ts`.
- Four backend plugins under `packages/plugins/`:
  - **`local-fs`** — system / built-in / `autoEnable`, refactor of the existing `UPLOADS_DIR` disk code, **default backend**.
  - **`aws-s3`** — `@aws-sdk/client-s3` + `s3-request-presigner`. Reads `AWS_S3_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. Supports `presignPut`.
  - **`minio`** — subclass of aws-s3 with custom endpoint + path-style URLs. Reads `MINIO_ENDPOINT`, `MINIO_REGION`, `MINIO_BUCKET`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`. Supports `presignPut`.
  - **`github-storage`** — uses octokit to write blobs via `repos.createOrUpdateFileContents`. Reads `GITHUB_STORAGE_TOKEN`, `GITHUB_STORAGE_OWNER`, `GITHUB_STORAGE_REPO`, `GITHUB_STORAGE_BRANCH`, `GITHUB_STORAGE_PATH_PREFIX`. No presign.
- `apps/api/src/uploads` refactor:
  - `UploadsService` keeps its `saveImage` / `readFile` shape (MIME validation, magic-byte sniff, size cap, user-scoping all stay) but delegates the bytes to an `IStoragePlugin` selected at boot via `STORAGE_BACKEND` env (default `local-fs`; non-default backends dynamic-imported so dependent SDKs are optional).
  - **New** `POST /api/uploads/anonymous` (`@Public()`) — mints an anonymous user inline via `AnonymousAuthService` when no bearer is present, returns `{ uploadId, url, expiresAt, anonAccessToken }`.
  - **New** `POST /api/uploads/presign` — proxies to active plugin's `presignPut()` when supported; returns 501 otherwise.
- `.env.compose` documents `STORAGE_BACKEND`, `UPLOADS_DIR`, `UPLOADS_MAX_BYTES`, and all four backends' env vars with safe defaults / placeholders.

**Why:** website landing page (`LandingPromptForm.tsx`) lets a visitor write a prompt + attach files before signup. The current `POST /api/uploads` requires auth, so we need an anon-friendly path; and self-hosted deployments need to swap the disk-only backend for S3 / MinIO / GitHub without forking the API.

**Existing behavior preserved:** the 23 existing `uploads.service.spec.ts` + `uploads.controller.spec.ts` tests pass unchanged against the local-fs-backed service.

Ticket: https://evertech.atlassian.net/browse/EW-637

## Test plan

- [x] `pnpm build` from `apps/api` — TS clean, 375 files compile
- [x] `pnpm test -- uploads` — 23/23 pass (service + controller, all magic-byte / path-traversal / MIME-mismatch cases)
- [x] `pnpm build` in each new plugin package — local-fs, aws-s3, minio, github-storage all build
- [x] `pnpm test` in `packages/plugin` — 199/199 pass (interface addition didn't break existing contracts)
- [ ] Manual: deploy with `STORAGE_BACKEND=local-fs` (no env change needed) → existing upload tests on staging
- [ ] Manual: deploy with `STORAGE_BACKEND=aws-s3` + bucket creds → confirm `POST /api/uploads` writes to S3 + `POST /api/uploads/presign` returns a signed URL
- [ ] Manual: `STORAGE_BACKEND=minio` + a local MinIO container → same as above
- [ ] Manual: `STORAGE_BACKEND=github-storage` + scratch repo → confirm blobs land + `POST /presign` returns 501
- [ ] Manual: from the website's landing-page form (separate workstream), POST a file to `/api/uploads/anonymous` without auth → confirm `anonAccessToken` + `uploadId` come back and the file is reachable via the standard owner-scoped GET

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple object storage backends: local filesystem, AWS S3, MinIO, and GitHub.
  * Anonymous public file uploads endpoint.
  * Presigned direct-to-cloud upload capability.
  * Storage plugin surfaced in UI: new "Storage" category, icons and capability labels.

* **Configuration**
  * New environment configuration to select and tune storage backends (size limits, paths, credentials, presign settings).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->