### PR TITLE
fix(agent): add WebhookDelivery entity mock to database.config.spec (P0 — unblocks #887/#888)

### DIFF
--- a/packages/agent/src/database/database.config.spec.ts
+++ b/packages/agent/src/database/database.config.spec.ts
@@ -35,6 +35,13 @@ jest.mock('../entities', () => ({
     TemplateCustomization: class TemplateCustomization {},
     UserTemplatePreference: class UserTemplatePreference {},
     WebhookSubscription: class WebhookSubscription {},
+    // EW-634 follow-up: `WebhookDelivery` was added to the real entities
+    // barrel + `ENTITIES` array in PR #886. Without an explicit mock
+    // here the parent `jest.mock('../entities', ...)` above shadows
+    // the real barrel and `database.config.ts` resolves the import
+    // to `undefined`, breaking the "every entry is a function"
+    // assertion below.
+    WebhookDelivery: class WebhookDelivery {},
     WorkProposal: class WorkProposal {},
     // Work Agent control-plane entities (introduced in #868). Without
     // these mocks the database.config import resolves them to undefined


### PR DESCRIPTION
## Summary

**P0 — blocking the rebased CI on [#887](https://github.com/ever-works/ever-works/pull/887) and [#888](https://github.com/ever-works/ever-works/pull/888).**

The third regression guard I missed in [EW-634](https://evertech.atlassian.net/browse/EW-634) /
[#886](https://github.com/ever-works/ever-works/pull/886). `database.config.spec.ts` mocks the
`../entities` barrel with stub classes (to avoid loading TypeORM under
Jest, which hits a known `path-scurry` init bug). Every entity
referenced from `database.config.ts`'s `ENTITIES` array needs an
explicit mock entry; without one, the import resolves to `undefined`
and the "every entry is a function" assertion fails.

#886 added `WebhookDelivery` to the real entities barrel + the
`ENTITIES` array but never updated this mock. This PR adds the missing
`WebhookDelivery: class WebhookDelivery {}` line.

Same class of fix as #889 (which bumped the tasks-barrel + DatabaseModule
regression guards). Worth a follow-up cleanup ticket to consolidate the
three allow-list specs into one driven by a single source of truth.

## Test plan

- [x] `database/database.config.spec.ts` passes locally (36 tests, was failing 1).

Failed CI run on #888: https://github.com/ever-works/ever-works/actions/runs/26223749458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-634]: https://evertech.atlassian.net/browse/EW-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ