### PR TITLE
fix(agent): use portable simple-json for WebhookDelivery.payload (EW-634 P0)

### DIFF
--- a/packages/agent/src/entities/webhook-delivery.entity.ts
+++ b/packages/agent/src/entities/webhook-delivery.entity.ts
@@ -52,8 +52,18 @@ export class WebhookDelivery {
      *
      * x-secret-adjacent: payloads may carry user-scoped business data; the
      * deliveries list endpoint redacts the body before returning it.
+     *
+     * Column type is `simple-json` (portable across Postgres + SQLite)
+     * rather than `jsonb` (Postgres-only). The migration creates the
+     * physical column as `jsonb` on Postgres production; TypeORM's
+     * `simple-json` driver reads/writes JSON via JSON.stringify/parse
+     * which works equally well against a `jsonb` (prod) or `text`
+     * (test/SQLite synchronize) column. Using `jsonb` here would break
+     * the better-sqlite3 test path with
+     * `DataTypeNotSupportedError: Data type "jsonb" ... is not supported
+     * by "better-sqlite3" database.` (caught on CI for PR #888).
      */
-    @Column({ type: 'jsonb' })
+    @Column({ type: 'simple-json' })
     payload: Record<string, unknown>;
 
     @Column({ type: 'varchar', length: 32, default: 'pending' })


### PR DESCRIPTION
## Summary

**P0 — currently blocking #887 and #888.** Real bug from [#886](https://github.com/ever-works/ever-works/pull/886), not a regression guard.

`WebhookDelivery.payload` was declared `@Column({ type: 'jsonb' })` —
Postgres-only. The better-sqlite3 test path doesn't know that type,
so `synchronize: true` blew up at schema-create time with:

```
DataTypeNotSupportedError: Data type "jsonb" in "WebhookDelivery.payload"
is not supported by "better-sqlite3" database.
```

Caught on the Internal CLI test job in #888's CI run.

Switch to `simple-json`, the established codebase pattern (15+ other
entities use it: activity-log, conversation, notification, template,
user, …). TypeORM maps `simple-json` to `text` on SQLite and
serializes JSON via `JSON.stringify` / `JSON.parse`.

**Production unchanged:** the migration created the column as `jsonb`
and that column stays. TypeORM's `simple-json` driver writes
JSON-as-string through the Postgres driver, which writes happily
into a `jsonb` column (and reads back identically). No data-loss
risk.

## Test plan

- [x] `webhook-*` + `database.config.spec` pass locally (89 tests).
- [x] Internal CLI's `DataTypeNotSupportedError` reproduced and verified
      cleared by this change.

Failed CI run: https://github.com/ever-works/ever-works/actions/runs/26224181365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database payload handling for enhanced compatibility across different database systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->