### PR TITLE
fix(api,storage): address 3 Codex P1/P2 findings on PR #890 (EW-637 follow-up)

### DIFF
--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -14,6 +14,7 @@ import { UploadsService } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
 import type { PluginContext } from '@ever-works/plugin';
 import type { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
+import type { AuthProvider } from '../auth/providers/auth-provider.abstract';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 
 const stubContext = (id: string): PluginContext => {
@@ -117,7 +118,14 @@ describe('UploadsController', () => {
                 throw new Error('AnonymousAuthService stub: not expected in these tests');
             },
         } as unknown as AnonymousAuthService;
-        controller = new UploadsController(service, anonStub);
+        // AuthProvider is consumed by `tryAuthenticate` on the @Public()
+        // upload routes (Codex P2 follow-up). These auth-required tests
+        // never hit that path, so we hand it a stub that returns null
+        // (treated as "no session present" by the controller).
+        const authProviderStub = {
+            authenticate: async () => null,
+        } as unknown as AuthProvider;
+        controller = new UploadsController(service, anonStub, authProviderStub);
     });
 
     afterEach(async () => {

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -7,6 +7,7 @@ import {
     Headers,
     HttpCode,
     HttpStatus,
+    Inject,
     NotImplementedException,
     Param,
     Post,
@@ -22,6 +23,9 @@ import { CurrentUser } from '../auth/decorators/user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
+import { AUTH_PROVIDER } from '../auth/providers/auth-provider.constants';
+import { AuthProvider } from '../auth/providers/auth-provider.abstract';
+import { toHeaders } from '../auth/providers/request-headers';
 import { UploadsService } from './uploads.service';
 import { PresignUploadDto } from './dto/presign-upload.dto';
 
@@ -50,6 +54,14 @@ export class UploadsController {
     constructor(
         private readonly uploads: UploadsService,
         private readonly anonymousAuthService: AnonymousAuthService,
+        // Codex P2 finding on PR #890: `AuthSessionGuard` returns early
+        // when `@Public()` is set without populating `request.user`, so
+        // the old `req.user?.userId` check below was dead code and every
+        // authenticated caller hitting /anonymous or /presign got
+        // re-anon-minted. We resolve the bearer ourselves via the same
+        // provider the guard would have called, so an authenticated
+        // session is honored on public-by-default upload routes.
+        @Inject(AUTH_PROVIDER) private readonly authProvider: AuthProvider,
     ) {}
 
     /**
@@ -284,10 +296,19 @@ export class UploadsController {
         anonAccessToken: string | undefined;
         anonymousExpiresAt: string | null | undefined;
     }> {
-        const existing = req.user?.userId;
+        // Codex P2 finding on PR #890: `@Public()` routes never have
+        // `req.user` populated (the guard short-circuits before it
+        // gets to bearer parsing), so the old `req.user?.userId`
+        // check was dead and every authenticated caller hitting
+        // /anonymous or /presign was getting re-anon-minted. Resolve
+        // the bearer here directly — same `authProvider.authenticate`
+        // path the guard would have taken. We swallow the error case:
+        // an unauthenticated request shouldn't fail the upload, it
+        // should fall through to the anon-mint branch.
+        const existing = await this.tryAuthenticate(req);
         if (existing) {
             return {
-                userId: existing,
+                userId: existing.userId,
                 anonAccessToken: undefined,
                 anonymousExpiresAt: undefined,
             };
@@ -312,5 +333,22 @@ export class UploadsController {
             anonAccessToken: anon.access_token,
             anonymousExpiresAt: anon.user.anonymousExpiresAt ?? null,
         };
+    }
+
+    /**
+     * Best-effort bearer resolution for `@Public()` upload routes.
+     * Returns the authenticated user when a valid session token is
+     * present, otherwise `null`. Never throws — an invalid/missing
+     * token falls through to anon-mint instead of 401-ing a route
+     * that's documented as accepting anonymous traffic.
+     */
+    private async tryAuthenticate(req: AnonRequest): Promise<AuthenticatedUser | null> {
+        const auth = req.headers?.authorization;
+        if (!auth) return null;
+        try {
+            return await this.authProvider.authenticate(toHeaders(req.headers || {}));
+        } catch {
+            return null;
+        }
     }
 }

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -268,5 +268,85 @@ describe('UploadsService', () => {
             const { buffer } = await service.readFile(otherUser, r.filename);
             expect(buffer.equals(TINY_PNG)).toBe(true);
         });
+
+        // Codex P1 follow-up to PR #890: prove that readFile asks the active
+        // backend to derive its own canonical key instead of hardcoding the
+        // legacy `<ownerId>/<filename>` shape. Without deriveKey, S3-prefixed
+        // backends would 404 every read for a file they successfully wrote.
+        it('uses backend.deriveKey() when present, not the legacy <user>/<file> shape', async () => {
+            const calls: { put: string[]; get: string[]; derive: Array<[string, string]> } = {
+                put: [],
+                get: [],
+                derive: [],
+            };
+            const fakeBackend = {
+                providerName: 'fake-prefixed',
+                async putObject(input: { ownerId?: string; filename: string; buffer: Buffer }) {
+                    // Mirrors the AWS S3 plugin: prefix every key with `uploads/`.
+                    const key = `uploads/${input.ownerId}/${input.filename}`;
+                    calls.put.push(key);
+                    return { key, url: 's3://ignored-by-service' };
+                },
+                async getObject(key: string) {
+                    calls.get.push(key);
+                    // Only the prefixed shape exists on this backend.
+                    if (!key.startsWith('uploads/')) {
+                        throw new Error('not found');
+                    }
+                    return { buffer: TINY_PNG, mimeType: 'image/png' };
+                },
+                async deleteObject() {},
+                async isAvailable() {
+                    return true;
+                },
+                deriveKey(ownerId: string, filename: string) {
+                    calls.derive.push([ownerId, filename]);
+                    return `uploads/${ownerId}/${filename}`;
+                },
+            };
+            const svc = new UploadsService(fakeBackend as never);
+            const r = await svc.saveImage(userId, fakeFile({}));
+
+            // Codex P1 #2: response URL is the API-routed path regardless of
+            // what the backend's putObject returned. Private buckets and
+            // owner-gated reads depend on this.
+            expect(r.url).toBe(`/api/uploads/${userId}/${r.filename}`);
+            expect(r.url).not.toContain('s3://');
+
+            // Round-trip the read; without deriveKey() the service would
+            // hand `<user>/<file>` to getObject and the backend would 404.
+            const { buffer } = await svc.readFile(userId, r.filename);
+            expect(buffer.equals(TINY_PNG)).toBe(true);
+            expect(calls.derive).toEqual([[userId, r.filename]]);
+            expect(calls.get).toEqual([`uploads/${userId}/${r.filename}`]);
+        });
+
+        // Codex P1 #1 fallback path: a backend without deriveKey (older
+        // third-party plugins, ad-hoc test doubles) keeps working via the
+        // legacy `<ownerId>/<filename>` shape. local-fs uses exactly that
+        // key, so removing its deriveKey override should not change reads.
+        it('falls back to <user>/<file> when backend does not implement deriveKey', async () => {
+            const lastSeenKey: string[] = [];
+            const backendNoDerive = {
+                providerName: 'fake-bare',
+                async putObject(input: { ownerId?: string; filename: string }) {
+                    const key = `${input.ownerId}/${input.filename}`;
+                    return { key, url: '/api/uploads/whatever' };
+                },
+                async getObject(key: string) {
+                    lastSeenKey.push(key);
+                    return { buffer: TINY_PNG, mimeType: 'image/png' };
+                },
+                async deleteObject() {},
+                async isAvailable() {
+                    return true;
+                },
+                // intentionally NO deriveKey
+            };
+            const svc = new UploadsService(backendNoDerive as never);
+            const r = await svc.saveImage(userId, fakeFile({}));
+            await svc.readFile(userId, r.filename);
+            expect(lastSeenKey).toEqual([`${userId}/${r.filename}`]);
+        });
     });
 });

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -168,7 +168,7 @@ export class UploadsService {
         const filename = `${hash}.${sniffed.ext}`;
 
         const backend = await this.getBackend();
-        const { key, url } = await backend.putObject({
+        const { key } = await backend.putObject({
             buffer: file.buffer,
             filename,
             mimeType: sniffed.mime,
@@ -176,19 +176,20 @@ export class UploadsService {
             ownerId: userId,
         });
 
+        // Codex P1 finding on PR #890: returning the plugin's backend-native
+        // URL (S3 / MinIO / raw.githubusercontent.com) directly broke two
+        // invariants — (a) private buckets / private repos respond with
+        // 401/404 because the URL isn't signed, and (b) it sidesteps the
+        // owner-gated `UploadsController.serve` check that is the
+        // documented access model. Always return the API-routed URL;
+        // the controller reads through `backend.getObject(deriveKey(...))`
+        // to do the actual fetch. Operators who want a CDN / public-bucket
+        // direct URL can still introspect the active plugin themselves.
         return {
             // `id` historically was the sha256 (object segment of the key).
             // Keep that shape for existing callers.
             id: hash,
-            // Resolve `url` to the platform-served route. Plugins return a
-            // backend-native URL (S3 / raw.githubusercontent / local route);
-            // for the legacy callers that expect `/api/uploads/<owner>/<file>`,
-            // we synthesize that path regardless of the backend so existing
-            // clients keep working. The plugin's URL is exposed via the
-            // backend factory for callers that want direct CDN access.
-            url: url.startsWith('http')
-                ? url
-                : `/api/uploads/${encodeURIComponent(userId)}/${filename}`,
+            url: `/api/uploads/${encodeURIComponent(userId)}/${filename}`,
             filename,
             size: file.size,
             mimeType: sniffed.mime,
@@ -213,13 +214,17 @@ export class UploadsService {
         this.assertValidFilename(filename);
         const backend = await this.getBackend();
 
-        // Reconstruct the storage key from the legacy <userId>/<filename>
-        // path shape. For local-fs and the S3-family plugins this is the
-        // exact key; github-storage embeds its own path-prefix and
-        // therefore is NOT compatible with the legacy /:userId/:filename
-        // route. Operators using github-storage should route reads through
-        // the plugin-native URL returned by saveImage.
-        const key = `${userId}/${filename}`;
+        // Codex P1 finding on PR #890: don't hardcode the storage key
+        // shape — each backend layers its own path prefix on top of
+        // `<ownerId>/<filename>` (`uploads/...` for S3/MinIO/GitHub;
+        // bare `<ownerId>/<filename>` for local-fs). Ask the plugin to
+        // reconstruct its own canonical key from the URL segments. If
+        // the plugin doesn't implement `deriveKey` (older third-party
+        // backends, in-test mocks), fall back to the legacy shape so
+        // existing local-fs setups keep working unchanged.
+        const key = backend.deriveKey
+            ? backend.deriveKey(userId, filename)
+            : `${userId}/${filename}`;
 
         let result: { buffer: Buffer; mimeType: string };
         try {

--- a/packages/plugin/src/contracts/capabilities/storage.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/storage.interface.ts
@@ -112,6 +112,23 @@ export interface IStoragePlugin extends IPlugin {
 	 */
 	presignPut?(input: StoragePresignInput): Promise<StoragePresignResult>;
 
+	/**
+	 * Reconstruct the plugin's canonical storage key from the legacy
+	 * `/api/uploads/:ownerId/:filename` URL shape. Each backend layers
+	 * its own path prefix on top of `<ownerId>/<filename>` (`uploads/...`
+	 * for S3/MinIO/GitHub; bare `<ownerId>/<filename>` for local-fs), so
+	 * the API's read route cannot guess the right key without asking the
+	 * plugin. Returns the exact key the plugin would have written for
+	 * `putObject({ ownerId, filename })`.
+	 *
+	 * Plugins that follow the bare `<ownerId>/<filename>` convention
+	 * (local-fs) can leave this unset — the uploads service falls back
+	 * to that shape — but any backend with a prefix MUST implement it,
+	 * otherwise owner-gated reads will 404 for files it successfully
+	 * wrote (Codex P1 finding on PR #890).
+	 */
+	deriveKey?(ownerId: string, filename: string): string;
+
 	/** Whether the backend is healthy / configured. Used by the
 	 *  uploads service at startup to fail loudly when the operator
 	 *  selected an unconfigured backend. */

--- a/packages/plugins/aws-s3/src/aws-s3.plugin.ts
+++ b/packages/plugins/aws-s3/src/aws-s3.plugin.ts
@@ -185,6 +185,20 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 		}
 	}
 
+	/**
+	 * S3 keys (and MinIO via inheritance) follow `uploads/<ownerId>/<filename>` —
+	 * see `buildKey`. The API's owner-gated read route hands us the
+	 * `<ownerId>/<filename>` segment from the URL; we re-prepend `uploads/`
+	 * so the GetObject call hits the right key.
+	 *
+	 * Without this method, `UploadsService.readFile` would fall back to
+	 * the legacy bare `<ownerId>/<filename>` shape and 404 every S3
+	 * read (Codex P1 finding on PR #890).
+	 */
+	deriveKey(ownerId: string, filename: string): string {
+		return `uploads/${ownerId}/${filename}`;
+	}
+
 	async onLoad(context: PluginContext): Promise<void> {
 		this.context = context;
 		context.logger.log('AWS S3 storage plugin loaded');

--- a/packages/plugins/github-storage/src/github-storage.plugin.ts
+++ b/packages/plugins/github-storage/src/github-storage.plugin.ts
@@ -197,6 +197,20 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		}
 	}
 
+	/**
+	 * GitHub-storage keys are `<pathPrefix>/<ownerId>/<filename>`. The
+	 * pathPrefix is config-controlled (default `uploads`), so even the
+	 * "bare" case still differs from the legacy `<ownerId>/<filename>`
+	 * shape used by local-fs. Implementing this lets the owner-gated
+	 * read route reach the right path on the GitHub Contents API
+	 * regardless of how the operator configured the prefix
+	 * (Codex P1 finding on PR #890).
+	 */
+	deriveKey(ownerId: string, filename: string): string {
+		const cfg = this.config();
+		return `${cfg.pathPrefix}/${ownerId}/${filename}`;
+	}
+
 	async onLoad(context: PluginContext): Promise<void> {
 		this.context = context;
 		context.logger.log('GitHub storage plugin loaded');

--- a/packages/plugins/local-fs/src/local-fs.plugin.ts
+++ b/packages/plugins/local-fs/src/local-fs.plugin.ts
@@ -131,6 +131,16 @@ export class LocalFsStoragePlugin implements IPlugin, IStoragePlugin {
 		return true;
 	}
 
+	/**
+	 * Local-fs keys are bare `<ownerId>/<filename>` with no path prefix —
+	 * the legacy default. Implementing this explicitly (instead of leaving
+	 * the interface fallback to do it) makes the contract obvious and
+	 * keeps the read path symmetric with the prefixed backends.
+	 */
+	deriveKey(ownerId: string, filename: string): string {
+		return `${ownerId}/${filename}`;
+	}
+
 	// ============================================================================
 	// IPlugin lifecycle
 	// ============================================================================


### PR DESCRIPTION
## Summary

Follow-up to the merged Storage Plugins PR ([#890](https://github.com/ever-works/ever-works/pull/890)). Codex flagged three real bugs that surface the moment an operator switches off the default \`local-fs\` backend; the PR was reviewed by Greptile-only and landed without them being addressed. This PR closes them in a separate branch off \`develop\` per the operator's pre-merge AI-bot-review NN.

### What was wrong

**P1 — \`UploadsService.readFile\` hardcoded the storage key.**
The legacy \`\${userId}/\${filename}\` shape matches local-fs by accident, but every other backend layers a prefix on top: S3/MinIO use \`uploads/<owner>/<file>\`, GitHub-storage uses \`<pathPrefix>/<owner>/<file>\`. With the legacy key the owner-gated GET route 404s every read for files those backends successfully wrote.
[(Codex comment)](https://github.com/ever-works/ever-works/pull/890#discussion_r-codex-readfile)

**P1 — \`saveImage\` returned the plugin's backend-native URL directly** (\`https://bucket.s3.region.amazonaws.com/...\`, \`https://endpoint/bucket/...\`) whenever it started with \`http\`. That breaks the documented access model: private buckets/repos respond 401/404 because the URL isn't signed, and the URL sidesteps the owner-gated \`UploadsController.serve\` check.
[(Codex comment)](https://github.com/ever-works/ever-works/pull/890#discussion_r-codex-url)

**P2 — \`/anonymous\` and \`/presign\` always minted a new anon user even when a valid bearer was supplied.** Both routes are \`@Public()\`, \`AuthSessionGuard\` short-circuits before populating \`req.user\`, and the \"honor existing session\" branch in \`resolveActingUser\` was dead code. Authenticated callers got re-anon-minted (extra \`anonAccessToken\`, wrong attribution).
[(Codex comment)](https://github.com/ever-works/ever-works/pull/890#discussion_r-codex-anon)

### How it's fixed

- **\`IStoragePlugin\` gets an optional \`deriveKey(ownerId, filename)\` method**; each plugin returns its own canonical key shape. \`uploads.service.ts:readFile\` calls \`backend.deriveKey?.(...)\` with a fallback to the legacy shape so older third-party plugins keep working.
- **\`saveImage\` always returns \`/api/uploads/<userId>/<filename>\`** regardless of what the plugin's \`putObject\` returned. \`getObject(deriveKey(...))\` is the one path that fetches bytes.
- **\`UploadsController\` injects \`AuthProvider\` directly** and calls a new \`tryAuthenticate()\` helper that resolves the bearer non-throwingly. Missing/invalid → falls through to anon-mint as documented. Valid → session honored.

### Tests

- \`uploads.service.spec.ts\` — 2 new cases (mock prefixed backend exercises both P1s end-to-end; mock without \`deriveKey\` proves the fallback path).
- \`uploads.controller.spec.ts\` — constructor signature updated, AuthProvider stub.
- Full uploads suite: **25/25 passing**.

No migrations. No env changes. Local-fs deployments (the only backend currently in prod) see no behavior change: local-fs's canonical key IS the legacy shape.

## Pre-existing notes

- Unrelated \`apps/mcp/src/guards/api-key.guard.ts\` has 2 ESLint unused-assertion errors on develop, but CI only runs \`format:check\`, not \`lint\`, so this is silent tech debt — outside this PR's scope.

## Test plan

- [ ] CI green
- [ ] Manual smoke once merged: POST /api/uploads with a real session token, GET back via the returned URL on local-fs (should still 200)
- [ ] When S3 / MinIO / github-storage gets exercised in a follow-up, the deriveKey path is what makes those reads work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Public upload endpoints now respect existing authenticated sessions via bearer token authentication instead of creating new anonymous sessions.
  * Storage backends can now define custom key formats for file reads.

* **Improvements**
  * Upload responses now consistently return API-routed URLs across all storage backends.
  * File reads support both custom-keyed and legacy key formats with automatic fallback.
  * Enhanced compatibility with storage backends using custom key prefixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->