### PR TITLE
chore(stage): cascade develop → stage (uploads DI hotfix + Codex follow-ups)

### DIFF
--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -14,6 +14,7 @@ import { UploadsService } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
 import type { PluginContext } from '@ever-works/plugin';
 import type { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
+import type { AuthProvider } from '../auth/providers/auth-provider.abstract';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 
 const stubContext = (id: string): PluginContext => {
@@ -117,7 +118,14 @@ describe('UploadsController', () => {
                 throw new Error('AnonymousAuthService stub: not expected in these tests');
             },
         } as unknown as AnonymousAuthService;
-        controller = new UploadsController(service, anonStub);
+        // AuthProvider is consumed by `tryAuthenticate` on the @Public()
+        // upload routes (Codex P2 follow-up). These auth-required tests
+        // never hit that path, so we hand it a stub that returns null
+        // (treated as "no session present" by the controller).
+        const authProviderStub = {
+            authenticate: async () => null,
+        } as unknown as AuthProvider;
+        controller = new UploadsController(service, anonStub, authProviderStub);
     });
 
     afterEach(async () => {

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -195,3 +195,29 @@ describe('UploadsController', () => {
         });
     });
 });
+
+// ============================================================================
+// NestJS DI smoke test — guard against the EW-637 regression where
+// `UploadsService(backend?: IStoragePlugin)` lacked `@Optional()`. At
+// runtime `IStoragePlugin` is an erased TS interface, so Nest has no
+// token to resolve and the API boot dies with `UnknownDependenciesException`.
+// The agent unit tests above don't catch this — they `new UploadsService(...)`
+// and bypass DI entirely. Bootstrapping a TestingModule with the real
+// providers list is what would have flagged it pre-merge.
+// ============================================================================
+
+import { Test } from '@nestjs/testing';
+
+describe('UploadsService — Nest DI', () => {
+    it('resolves with no storage-plugin provider (falls back to factory)', async () => {
+        // No IStoragePlugin / no factory binding here — the service should
+        // accept that and lazily resolve on first call via the env-driven
+        // backend factory (which we DO NOT exercise in this test).
+        const moduleRef = await Test.createTestingModule({
+            providers: [UploadsService],
+        }).compile();
+        const svc = moduleRef.get(UploadsService);
+        expect(svc).toBeInstanceOf(UploadsService);
+        await moduleRef.close();
+    });
+});

--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -9,6 +9,7 @@ import { BadRequestException, HttpStatus, Logger } from '@nestjs/common';
 import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { Test } from '@nestjs/testing';
 import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
@@ -205,8 +206,6 @@ describe('UploadsController', () => {
 // and bypass DI entirely. Bootstrapping a TestingModule with the real
 // providers list is what would have flagged it pre-merge.
 // ============================================================================
-
-import { Test } from '@nestjs/testing';
 
 describe('UploadsService — Nest DI', () => {
     it('resolves with no storage-plugin provider (falls back to factory)', async () => {

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -7,6 +7,7 @@ import {
     Headers,
     HttpCode,
     HttpStatus,
+    Inject,
     NotImplementedException,
     Param,
     Post,
@@ -22,6 +23,9 @@ import { CurrentUser } from '../auth/decorators/user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import { AnonymousAuthService } from '../auth/services/anonymous-auth.service';
+import { AUTH_PROVIDER } from '../auth/providers/auth-provider.constants';
+import { AuthProvider } from '../auth/providers/auth-provider.abstract';
+import { toHeaders } from '../auth/providers/request-headers';
 import { UploadsService } from './uploads.service';
 import { PresignUploadDto } from './dto/presign-upload.dto';
 
@@ -50,6 +54,14 @@ export class UploadsController {
     constructor(
         private readonly uploads: UploadsService,
         private readonly anonymousAuthService: AnonymousAuthService,
+        // Codex P2 finding on PR #890: `AuthSessionGuard` returns early
+        // when `@Public()` is set without populating `request.user`, so
+        // the old `req.user?.userId` check below was dead code and every
+        // authenticated caller hitting /anonymous or /presign got
+        // re-anon-minted. We resolve the bearer ourselves via the same
+        // provider the guard would have called, so an authenticated
+        // session is honored on public-by-default upload routes.
+        @Inject(AUTH_PROVIDER) private readonly authProvider: AuthProvider,
     ) {}
 
     /**
@@ -284,10 +296,19 @@ export class UploadsController {
         anonAccessToken: string | undefined;
         anonymousExpiresAt: string | null | undefined;
     }> {
-        const existing = req.user?.userId;
+        // Codex P2 finding on PR #890: `@Public()` routes never have
+        // `req.user` populated (the guard short-circuits before it
+        // gets to bearer parsing), so the old `req.user?.userId`
+        // check was dead and every authenticated caller hitting
+        // /anonymous or /presign was getting re-anon-minted. Resolve
+        // the bearer here directly — same `authProvider.authenticate`
+        // path the guard would have taken. We swallow the error case:
+        // an unauthenticated request shouldn't fail the upload, it
+        // should fall through to the anon-mint branch.
+        const existing = await this.tryAuthenticate(req);
         if (existing) {
             return {
-                userId: existing,
+                userId: existing.userId,
                 anonAccessToken: undefined,
                 anonymousExpiresAt: undefined,
             };
@@ -312,5 +333,22 @@ export class UploadsController {
             anonAccessToken: anon.access_token,
             anonymousExpiresAt: anon.user.anonymousExpiresAt ?? null,
         };
+    }
+
+    /**
+     * Best-effort bearer resolution for `@Public()` upload routes.
+     * Returns the authenticated user when a valid session token is
+     * present, otherwise `null`. Never throws — an invalid/missing
+     * token falls through to anon-mint instead of 401-ing a route
+     * that's documented as accepting anonymous traffic.
+     */
+    private async tryAuthenticate(req: AnonRequest): Promise<AuthenticatedUser | null> {
+        const auth = req.headers?.authorization;
+        if (!auth) return null;
+        try {
+            return await this.authProvider.authenticate(toHeaders(req.headers || {}));
+        } catch {
+            return null;
+        }
     }
 }

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -268,5 +268,85 @@ describe('UploadsService', () => {
             const { buffer } = await service.readFile(otherUser, r.filename);
             expect(buffer.equals(TINY_PNG)).toBe(true);
         });
+
+        // Codex P1 follow-up to PR #890: prove that readFile asks the active
+        // backend to derive its own canonical key instead of hardcoding the
+        // legacy `<ownerId>/<filename>` shape. Without deriveKey, S3-prefixed
+        // backends would 404 every read for a file they successfully wrote.
+        it('uses backend.deriveKey() when present, not the legacy <user>/<file> shape', async () => {
+            const calls: { put: string[]; get: string[]; derive: Array<[string, string]> } = {
+                put: [],
+                get: [],
+                derive: [],
+            };
+            const fakeBackend = {
+                providerName: 'fake-prefixed',
+                async putObject(input: { ownerId?: string; filename: string; buffer: Buffer }) {
+                    // Mirrors the AWS S3 plugin: prefix every key with `uploads/`.
+                    const key = `uploads/${input.ownerId}/${input.filename}`;
+                    calls.put.push(key);
+                    return { key, url: 's3://ignored-by-service' };
+                },
+                async getObject(key: string) {
+                    calls.get.push(key);
+                    // Only the prefixed shape exists on this backend.
+                    if (!key.startsWith('uploads/')) {
+                        throw new Error('not found');
+                    }
+                    return { buffer: TINY_PNG, mimeType: 'image/png' };
+                },
+                async deleteObject() {},
+                async isAvailable() {
+                    return true;
+                },
+                deriveKey(ownerId: string, filename: string) {
+                    calls.derive.push([ownerId, filename]);
+                    return `uploads/${ownerId}/${filename}`;
+                },
+            };
+            const svc = new UploadsService(fakeBackend as never);
+            const r = await svc.saveImage(userId, fakeFile({}));
+
+            // Codex P1 #2: response URL is the API-routed path regardless of
+            // what the backend's putObject returned. Private buckets and
+            // owner-gated reads depend on this.
+            expect(r.url).toBe(`/api/uploads/${userId}/${r.filename}`);
+            expect(r.url).not.toContain('s3://');
+
+            // Round-trip the read; without deriveKey() the service would
+            // hand `<user>/<file>` to getObject and the backend would 404.
+            const { buffer } = await svc.readFile(userId, r.filename);
+            expect(buffer.equals(TINY_PNG)).toBe(true);
+            expect(calls.derive).toEqual([[userId, r.filename]]);
+            expect(calls.get).toEqual([`uploads/${userId}/${r.filename}`]);
+        });
+
+        // Codex P1 #1 fallback path: a backend without deriveKey (older
+        // third-party plugins, ad-hoc test doubles) keeps working via the
+        // legacy `<ownerId>/<filename>` shape. local-fs uses exactly that
+        // key, so removing its deriveKey override should not change reads.
+        it('falls back to <user>/<file> when backend does not implement deriveKey', async () => {
+            const lastSeenKey: string[] = [];
+            const backendNoDerive = {
+                providerName: 'fake-bare',
+                async putObject(input: { ownerId?: string; filename: string }) {
+                    const key = `${input.ownerId}/${input.filename}`;
+                    return { key, url: '/api/uploads/whatever' };
+                },
+                async getObject(key: string) {
+                    lastSeenKey.push(key);
+                    return { buffer: TINY_PNG, mimeType: 'image/png' };
+                },
+                async deleteObject() {},
+                async isAvailable() {
+                    return true;
+                },
+                // intentionally NO deriveKey
+            };
+            const svc = new UploadsService(backendNoDerive as never);
+            const r = await svc.saveImage(userId, fakeFile({}));
+            await svc.readFile(userId, r.filename);
+            expect(lastSeenKey).toEqual([`${userId}/${r.filename}`]);
+        });
     });
 });

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -168,7 +168,7 @@ export class UploadsService {
         const filename = `${hash}.${sniffed.ext}`;
 
         const backend = await this.getBackend();
-        const { key, url } = await backend.putObject({
+        const { key } = await backend.putObject({
             buffer: file.buffer,
             filename,
             mimeType: sniffed.mime,
@@ -176,19 +176,20 @@ export class UploadsService {
             ownerId: userId,
         });
 
+        // Codex P1 finding on PR #890: returning the plugin's backend-native
+        // URL (S3 / MinIO / raw.githubusercontent.com) directly broke two
+        // invariants — (a) private buckets / private repos respond with
+        // 401/404 because the URL isn't signed, and (b) it sidesteps the
+        // owner-gated `UploadsController.serve` check that is the
+        // documented access model. Always return the API-routed URL;
+        // the controller reads through `backend.getObject(deriveKey(...))`
+        // to do the actual fetch. Operators who want a CDN / public-bucket
+        // direct URL can still introspect the active plugin themselves.
         return {
             // `id` historically was the sha256 (object segment of the key).
             // Keep that shape for existing callers.
             id: hash,
-            // Resolve `url` to the platform-served route. Plugins return a
-            // backend-native URL (S3 / raw.githubusercontent / local route);
-            // for the legacy callers that expect `/api/uploads/<owner>/<file>`,
-            // we synthesize that path regardless of the backend so existing
-            // clients keep working. The plugin's URL is exposed via the
-            // backend factory for callers that want direct CDN access.
-            url: url.startsWith('http')
-                ? url
-                : `/api/uploads/${encodeURIComponent(userId)}/${filename}`,
+            url: `/api/uploads/${encodeURIComponent(userId)}/${filename}`,
             filename,
             size: file.size,
             mimeType: sniffed.mime,
@@ -213,13 +214,17 @@ export class UploadsService {
         this.assertValidFilename(filename);
         const backend = await this.getBackend();
 
-        // Reconstruct the storage key from the legacy <userId>/<filename>
-        // path shape. For local-fs and the S3-family plugins this is the
-        // exact key; github-storage embeds its own path-prefix and
-        // therefore is NOT compatible with the legacy /:userId/:filename
-        // route. Operators using github-storage should route reads through
-        // the plugin-native URL returned by saveImage.
-        const key = `${userId}/${filename}`;
+        // Codex P1 finding on PR #890: don't hardcode the storage key
+        // shape — each backend layers its own path prefix on top of
+        // `<ownerId>/<filename>` (`uploads/...` for S3/MinIO/GitHub;
+        // bare `<ownerId>/<filename>` for local-fs). Ask the plugin to
+        // reconstruct its own canonical key from the URL segments. If
+        // the plugin doesn't implement `deriveKey` (older third-party
+        // backends, in-test mocks), fall back to the legacy shape so
+        // existing local-fs setups keep working unchanged.
+        const key = backend.deriveKey
+            ? backend.deriveKey(userId, filename)
+            : `${userId}/${filename}`;
 
         let result: { buffer: Buffer; mimeType: string };
         try {

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+    Injectable,
+    Logger,
+    BadRequestException,
+    NotFoundException,
+    Optional,
+} from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { extname } from 'node:path';
 import type { IStoragePlugin } from '@ever-works/plugin';
@@ -85,7 +91,17 @@ export class UploadsService {
     private readonly maxSize: number;
     private backendPromise?: Promise<IStoragePlugin>;
 
-    constructor(backend?: IStoragePlugin) {
+    // EW-637 follow-up — `@Optional()` is REQUIRED here. `IStoragePlugin`
+    // is a TypeScript interface (erased at runtime), so Nest can't tell
+    // there's no provider it should try to resolve at index 0. Without
+    // `@Optional()`, every API boot dies with `UnknownDependenciesException:
+    // Nest can't resolve dependencies of the UploadsService (?)` — the
+    // agent unit tests pass (they instantiate directly with `new
+    // UploadsService(backend)`), but E2E / production boots crash. With
+    // `@Optional()` Nest passes `undefined` when no provider matches and
+    // the service falls back to `getActiveStorageBackend()` lazily on
+    // the first call. Tests still inject the backend via the constructor.
+    constructor(@Optional() backend?: IStoragePlugin) {
         this.maxSize = Number(process.env.UPLOADS_MAX_BYTES) || DEFAULT_MAX_SIZE;
         if (backend) {
             this.backendPromise = Promise.resolve(backend);

--- a/packages/plugin/src/contracts/capabilities/storage.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/storage.interface.ts
@@ -112,6 +112,23 @@ export interface IStoragePlugin extends IPlugin {
 	 */
 	presignPut?(input: StoragePresignInput): Promise<StoragePresignResult>;
 
+	/**
+	 * Reconstruct the plugin's canonical storage key from the legacy
+	 * `/api/uploads/:ownerId/:filename` URL shape. Each backend layers
+	 * its own path prefix on top of `<ownerId>/<filename>` (`uploads/...`
+	 * for S3/MinIO/GitHub; bare `<ownerId>/<filename>` for local-fs), so
+	 * the API's read route cannot guess the right key without asking the
+	 * plugin. Returns the exact key the plugin would have written for
+	 * `putObject({ ownerId, filename })`.
+	 *
+	 * Plugins that follow the bare `<ownerId>/<filename>` convention
+	 * (local-fs) can leave this unset — the uploads service falls back
+	 * to that shape — but any backend with a prefix MUST implement it,
+	 * otherwise owner-gated reads will 404 for files it successfully
+	 * wrote (Codex P1 finding on PR #890).
+	 */
+	deriveKey?(ownerId: string, filename: string): string;
+
 	/** Whether the backend is healthy / configured. Used by the
 	 *  uploads service at startup to fail loudly when the operator
 	 *  selected an unconfigured backend. */

--- a/packages/plugins/aws-s3/src/aws-s3.plugin.ts
+++ b/packages/plugins/aws-s3/src/aws-s3.plugin.ts
@@ -185,6 +185,20 @@ export class AwsS3StoragePlugin implements IPlugin, IStoragePlugin {
 		}
 	}
 
+	/**
+	 * S3 keys (and MinIO via inheritance) follow `uploads/<ownerId>/<filename>` —
+	 * see `buildKey`. The API's owner-gated read route hands us the
+	 * `<ownerId>/<filename>` segment from the URL; we re-prepend `uploads/`
+	 * so the GetObject call hits the right key.
+	 *
+	 * Without this method, `UploadsService.readFile` would fall back to
+	 * the legacy bare `<ownerId>/<filename>` shape and 404 every S3
+	 * read (Codex P1 finding on PR #890).
+	 */
+	deriveKey(ownerId: string, filename: string): string {
+		return `uploads/${ownerId}/${filename}`;
+	}
+
 	async onLoad(context: PluginContext): Promise<void> {
 		this.context = context;
 		context.logger.log('AWS S3 storage plugin loaded');

--- a/packages/plugins/github-storage/src/github-storage.plugin.ts
+++ b/packages/plugins/github-storage/src/github-storage.plugin.ts
@@ -197,6 +197,20 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		}
 	}
 
+	/**
+	 * GitHub-storage keys are `<pathPrefix>/<ownerId>/<filename>`. The
+	 * pathPrefix is config-controlled (default `uploads`), so even the
+	 * "bare" case still differs from the legacy `<ownerId>/<filename>`
+	 * shape used by local-fs. Implementing this lets the owner-gated
+	 * read route reach the right path on the GitHub Contents API
+	 * regardless of how the operator configured the prefix
+	 * (Codex P1 finding on PR #890).
+	 */
+	deriveKey(ownerId: string, filename: string): string {
+		const cfg = this.config();
+		return `${cfg.pathPrefix}/${ownerId}/${filename}`;
+	}
+
 	async onLoad(context: PluginContext): Promise<void> {
 		this.context = context;
 		context.logger.log('GitHub storage plugin loaded');

--- a/packages/plugins/local-fs/src/local-fs.plugin.ts
+++ b/packages/plugins/local-fs/src/local-fs.plugin.ts
@@ -131,6 +131,16 @@ export class LocalFsStoragePlugin implements IPlugin, IStoragePlugin {
 		return true;
 	}
 
+	/**
+	 * Local-fs keys are bare `<ownerId>/<filename>` with no path prefix —
+	 * the legacy default. Implementing this explicitly (instead of leaving
+	 * the interface fallback to do it) makes the contract obvious and
+	 * keeps the read path symmetric with the prefixed backends.
+	 */
+	deriveKey(ownerId: string, filename: string): string {
+		return `${ownerId}/${filename}`;
+	}
+
 	// ============================================================================
 	// IPlugin lifecycle
 	// ============================================================================


### PR DESCRIPTION
## Summary

Second cascade in this batch. Brings to stage:

- **fix(api,uploads): @Optional() on UploadsService backend param (#896)** — unblocks API boot. Pre-existing PR #890 regression that lint-and-test missed (agent tests bypass DI) but stage E2E caught when PR #895 ran. Now guarded by a TestingModule smoke test inside lint-and-test.
- **fix(api,storage): 3 Codex P1/P2 findings on PR #890 (#894)** — \`deriveKey\` on plugins so non-local-fs reads don't 404, always-API-routed response URL, optional auth on @Public() upload routes.

## Test plan

- [ ] Stage CI green (lint-and-test + E2E + Docker builds)
- [ ] PR #895 (stage → main) auto-rebases and goes green after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)