### PR TITLE
chore(uploads): hoist Test import to file top (Greptile P2 on #896)

### DIFF
--- a/apps/api/src/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/uploads/uploads.controller.spec.ts
@@ -9,6 +9,7 @@ import { BadRequestException, HttpStatus, Logger } from '@nestjs/common';
 import { promises as fs } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { Test } from '@nestjs/testing';
 import { UploadsController } from './uploads.controller';
 import { UploadsService } from './uploads.service';
 import { LocalFsStoragePlugin } from '@ever-works/local-fs-plugin';
@@ -205,8 +206,6 @@ describe('UploadsController', () => {
 // and bypass DI entirely. Bootstrapping a TestingModule with the real
 // providers list is what would have flagged it pre-merge.
 // ============================================================================
-
-import { Test } from '@nestjs/testing';
 
 describe('UploadsService — Nest DI', () => {
     it('resolves with no storage-plugin provider (falls back to factory)', async () => {


### PR DESCRIPTION
Trivial follow-up. Greptile P2 on merged PR #896: `import { Test } from '@nestjs/testing'` was placed mid-file alongside the new DI smoke block. Static imports get hoisted at compile time so it ran, but convention is imports-at-top. Moves it up next to the other imports.

7/7 uploads.controller spec still passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify service instantiation and initialization work correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->