### PR TITLE
fix(ci): set NODE_ENV=test for publish-cli test:cli steps

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -78,6 +78,16 @@ jobs:
 
       - name: Test Internal CLI build
         working-directory: apps/internal-cli
+        # NODE_ENV=test signals this is a test-context bootstrap (the CLI uses
+        # in-memory sqlite here, not a real database). C-07 PR-B made
+        # `autoMigrate()` default-off everywhere except NODE_ENV=test — without
+        # this env, `synchronize` doesn't run and the eager NestJS bootstrap
+        # hits "no such table: subscription_plans". Equivalent to setting
+        # DATABASE_AUTOMIGRATE=true explicitly; NODE_ENV=test is the standard
+        # test-context signal already used by the unit-test suite. Same fix
+        # as ci.yml (commit 1d7eb1d4).
+        env:
+          NODE_ENV: test
         run: pnpm test:cli
 
       - name: Build External CLI
@@ -89,6 +99,9 @@ jobs:
 
       - name: Test External CLI build
         working-directory: apps/cli
+        # See note above on the Internal CLI step — same C-07 PR-B implication.
+        env:
+          NODE_ENV: test
         run: pnpm test:cli
 
       - name: Upload Internal CLI artifact


### PR DESCRIPTION
## Summary

- Add `NODE_ENV: test` env to the `Test Internal CLI build` and `Test External CLI build` steps in `.github/workflows/publish-cli.yml`
- Same fix already applied to `ci.yml` in commit 1d7eb1d4 — `publish-cli.yml` was missed in that PR
- Unblocks the failing [`Build and Publish CLIs`](https://github.com/ever-works/ever-works/actions/runs/26231216256/job/77191853283) workflow on `main`

## Root cause

C-07 PR-B (#816) flipped `autoMigrate()` to default-off everywhere except `NODE_ENV=test`. The `pnpm test:cli` smoke step boots the built CLI artifact under in-memory sqlite for a `--help` invocation. Without `NODE_ENV=test`, TypeORM `synchronize` does not run, and the eager NestJS bootstrap (`SubscriptionService.onModuleInit` → `seedPlans()`) queries `subscription_plans` against an empty schema and crashes with:

```
SqliteError: no such table: subscription_plans
```

The workflow has failed on every push to `main` since 2026-05-18 (8 consecutive failures: 2e7f0c25 → 2782cbca).

## Test plan

- [ ] CI run on this PR succeeds at the `Test Internal CLI build` and `Test External CLI build` steps
- [ ] After merge to `develop` → `stage` → `main`, the `Build and Publish CLIs` workflow on the next push to `main` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI test configuration to ensure consistent behavior and improved reliability across test environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->