### PR TITLE
chore(github-storage): remove dead GITHUB_STORAGE_PUBLIC_URL_BASE config

### DIFF
--- a/packages/plugins/github-storage/src/github-storage.plugin.ts
+++ b/packages/plugins/github-storage/src/github-storage.plugin.ts
@@ -129,17 +129,13 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		});
 
 		const key = repoPath;
-		// IMPORTANT: do NOT return raw.githubusercontent.com here. That host
-		// returns 404 (no token, no auth) for private repos, which is the
-		// recommended setup for landing-page uploads. Callers should
-		// stream through the API's owner-scoped `GET /api/uploads/:owner/:filename`
-		// route, which delegates back to this plugin's `getObject(key)` over
-		// the authenticated GitHub Contents API.
-		// For public repos the operator can override via `cfg.publicRawUrl`
-		// (env: `GITHUB_STORAGE_PUBLIC_URL_BASE`); see config().
-		const url = cfg.publicRawUrl
-			? `${cfg.publicRawUrl.replace(/\/$/, '')}/${repoPath}`
-			: `/api/uploads/${owner}/${hash}${ext}`;
+		// Always return the owner-gated API route. `UploadsService.saveImage`
+		// rewrites this to the same shape anyway (Codex P1 fix in PR #894),
+		// so the plugin no longer tries to hand back a public CDN URL.
+		// Public-repo operators who want raw URLs can read the storage key
+		// off the upload response and build their own URL — there is no
+		// internal consumer for the old `publicRawUrl` path.
+		const url = `/api/uploads/${owner}/${hash}${ext}`;
 		return { key, url };
 	}
 
@@ -255,18 +251,12 @@ export class GitHubStoragePlugin implements IPlugin, IStoragePlugin {
 		const repo = process.env.GITHUB_STORAGE_REPO || '';
 		const branch = process.env.GITHUB_STORAGE_BRANCH || 'main';
 		const pathPrefix = (process.env.GITHUB_STORAGE_PATH_PREFIX || 'uploads').replace(/(^\/+|\/+$)/g, '');
-		// Optional public URL base for cases where the configured repo IS
-		// public and operators want raw.githubusercontent.com URLs (or a
-		// CDN in front of it). When unset, putObject returns an internal
-		// API-routed URL; getObject streams the blob via the GitHub Contents
-		// API regardless, so private-repo + no-public-url is still correct.
-		const publicRawUrl = process.env.GITHUB_STORAGE_PUBLIC_URL_BASE || undefined;
 		if (!token || !owner || !repo) {
 			throw new Error(
 				'github-storage plugin not configured: GITHUB_STORAGE_TOKEN / GITHUB_STORAGE_OWNER / GITHUB_STORAGE_REPO required'
 			);
 		}
-		return { token, owner, repo, branch, pathPrefix, publicRawUrl };
+		return { token, owner, repo, branch, pathPrefix };
 	}
 
 	private client(cfg: GitHubStorageConfig): Octokit {
@@ -280,15 +270,6 @@ interface GitHubStorageConfig {
 	repo: string;
 	branch: string;
 	pathPrefix: string;
-	/**
-	 * Optional public URL base for the repo's raw content (e.g.
-	 * `https://raw.githubusercontent.com/foo/bar/main`). When set,
-	 * `putObject` returns `${publicRawUrl}/${repoPath}`. When unset
-	 * (the recommended setup for private repos), `putObject` returns
-	 * an internal API-routed URL — `getObject` always reads through
-	 * the authenticated Contents API.
-	 */
-	publicRawUrl?: string;
 }
 
 function sanitizeExt(filename: string): string {


### PR DESCRIPTION
## Summary

After PR #894's Codex P1 fix, `UploadsService.saveImage` always rewrites the response URL to the owner-gated `/api/uploads/<owner>/<file>` shape regardless of what the plugin returns. The github-storage plugin's `publicRawUrl` branch became dead config — operators who set `GITHUB_STORAGE_PUBLIC_URL_BASE` got the same API URL as everyone else.

This PR removes:
- The env-var read in `config()`
- The `publicRawUrl` field on `GitHubStorageConfig`
- The ternary in `putObject` that used it

The plugin now unconditionally returns the API route. No env vars to set, no behaviour change for any operator.

## Forward note

If we ever want public-bucket-style URLs again (e.g. for a deliberately public uploads bucket), the right place is `UploadsService`, not the plugin. The plugin should keep returning its canonical key; the service decides policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
