### PR TITLE
chore(ci): only cancel-in-progress on PR pushes for K8s E2E

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -30,8 +30,15 @@ permissions:
   contents: read
 
 concurrency:
+  # Only cancel-in-progress on PR pushes (where rapid iteration is the
+  # whole point). On main/stage/develop, the workflow can take 5+ minutes
+  # to spin up the kind cluster — if a second push lands while the first
+  # is still in setup, cancelling it shows "FAILURE" after 2-3 seconds in
+  # the PR check rollup, which is indistinguishable from a real test
+  # failure unless you click into the logs. Let branch-push runs finish
+  # so their result is a real signal.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e:


### PR DESCRIPTION
Scope `cancel-in-progress` to `pull_request` events only on the K8s Plugin E2E workflow.

**Background:** The workflow takes 5+ minutes to provision the kind cluster. When two commits land in quick succession on `develop` / `stage` / `main` (e.g. during a cascade), the first run gets cancelled mid-provision and shows as `FAILURE` after 2-3 seconds. We hit this 4-5 times in yesterday's cascade — every time, someone had to click into the logs to confirm it was just a concurrency cancel rather than a real regression.

**Fix:** `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. PR iteration still cancels the previous run (which is the whole point of the original config). Branch-push runs are allowed to finish — their conclusion is then a real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
