### PR TITLE
feat(kb): service layer + DTOs + repositories + unit tests (EW-640 / 2 of N)

### DIFF
--- a/packages/agent/src/database/repositories/work-knowledge-citation.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-citation.repository.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkKnowledgeCitation } from '../../entities/work-knowledge-citation.entity';
+import { KbCitationConsumerType } from '../../entities/kb-types';
+
+@Injectable()
+export class WorkKnowledgeCitationRepository {
+    constructor(
+        @InjectRepository(WorkKnowledgeCitation)
+        private readonly repository: Repository<WorkKnowledgeCitation>,
+    ) {}
+
+    /**
+     * Append-only. Returns the inserted row.
+     */
+    async record(data: {
+        workId: string;
+        documentId: string;
+        consumerType: KbCitationConsumerType;
+        consumerId: string;
+        chunkRange?: { start: number; end: number } | null;
+        relevanceScore?: number | null;
+    }): Promise<WorkKnowledgeCitation> {
+        const entity = this.repository.create({
+            workId: data.workId,
+            documentId: data.documentId,
+            consumerType: data.consumerType,
+            consumerId: data.consumerId,
+            chunkRange: data.chunkRange ?? null,
+            relevanceScore: data.relevanceScore ?? null,
+        });
+        return this.repository.save(entity);
+    }
+
+    async listForDocument(documentId: string, limit = 100): Promise<WorkKnowledgeCitation[]> {
+        return this.repository.find({
+            where: { documentId },
+            order: { createdAt: 'DESC' },
+            take: limit,
+        });
+    }
+
+    async listForConsumer(
+        consumerType: KbCitationConsumerType,
+        consumerId: string,
+    ): Promise<WorkKnowledgeCitation[]> {
+        return this.repository.find({
+            where: { consumerType, consumerId },
+            order: { createdAt: 'ASC' },
+        });
+    }
+}

--- a/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
@@ -1,0 +1,211 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, IsNull, Like, Not, Repository } from 'typeorm';
+import { WorkKnowledgeDocument } from '../../entities/work-knowledge-document.entity';
+import {
+    KB_ORG_INHERITABLE_CLASSES,
+    KbDocumentClass,
+    KbDocumentSource,
+    KbDocumentStatus,
+    KbLockMode,
+} from '../../entities/kb-types';
+
+export interface KbDocumentListOptions {
+    workId?: string;
+    organizationId?: string;
+    classes?: KbDocumentClass[];
+    statuses?: KbDocumentStatus[];
+    tag?: string;
+    locked?: boolean;
+    language?: string;
+    source?: KbDocumentSource;
+    q?: string;
+    limit?: number;
+    offset?: number;
+}
+
+/**
+ * Repository for WorkKnowledgeDocument.
+ *
+ * Encapsulates the queries that need either a Work-scope or an
+ * organization-scope filter; the spec's `workId XOR organizationId`
+ * CHECK constraint means there's no "list documents for either" query
+ * we'd want to expose at this layer.
+ *
+ * Lexical search (`q`) is implemented as a portable `LIKE` against
+ * title + description in v1. Postgres FTS via a generated `tsvector`
+ * column is the Phase 2 upgrade; we delay it because it requires a
+ * separate migration + driver branch.
+ */
+@Injectable()
+export class WorkKnowledgeDocumentRepository {
+    constructor(
+        @InjectRepository(WorkKnowledgeDocument)
+        private readonly repository: Repository<WorkKnowledgeDocument>,
+    ) {}
+
+    async findById(workId: string, docId: string): Promise<WorkKnowledgeDocument | null> {
+        return this.repository.findOne({ where: { id: docId, workId } });
+    }
+
+    async findByPath(workId: string, path: string): Promise<WorkKnowledgeDocument | null> {
+        return this.repository.findOne({ where: { workId, path } });
+    }
+
+    async findOrgById(
+        organizationId: string,
+        docId: string,
+    ): Promise<WorkKnowledgeDocument | null> {
+        return this.repository.findOne({
+            where: { id: docId, organizationId, workId: IsNull() },
+        });
+    }
+
+    async list(
+        opts: KbDocumentListOptions,
+    ): Promise<{ items: WorkKnowledgeDocument[]; total: number }> {
+        const qb = this.repository.createQueryBuilder('doc');
+
+        if (opts.workId) {
+            qb.andWhere('doc.workId = :workId', { workId: opts.workId });
+        }
+
+        if (opts.organizationId) {
+            qb.andWhere('doc.organizationId = :orgId', { orgId: opts.organizationId });
+            qb.andWhere('doc.workId IS NULL');
+        }
+
+        if (opts.classes && opts.classes.length > 0) {
+            qb.andWhere('doc.kb_document_class IN (:...classes)', { classes: opts.classes });
+        }
+
+        if (opts.statuses && opts.statuses.length > 0) {
+            qb.andWhere('doc.status IN (:...statuses)', { statuses: opts.statuses });
+        }
+
+        if (opts.locked !== undefined) {
+            qb.andWhere('doc.locked = :locked', { locked: opts.locked });
+        }
+
+        if (opts.language) {
+            qb.andWhere('doc.language = :language', { language: opts.language });
+        }
+
+        if (opts.source) {
+            qb.andWhere('doc.source = :source', { source: opts.source });
+        }
+
+        if (opts.q) {
+            qb.andWhere('(doc.title LIKE :q OR doc.description LIKE :q)', {
+                q: `%${opts.q}%`,
+            });
+        }
+
+        qb.orderBy('doc.updatedAt', 'DESC');
+
+        const total = await qb.getCount();
+
+        if (opts.limit !== undefined) {
+            qb.take(opts.limit);
+        }
+        if (opts.offset !== undefined) {
+            qb.skip(opts.offset);
+        }
+
+        const items = await qb.getMany();
+
+        return { items, total };
+    }
+
+    async listInheritableForOrg(
+        organizationId: string,
+        classes?: KbDocumentClass[],
+    ): Promise<WorkKnowledgeDocument[]> {
+        const inheritableClasses = (classes ?? [...KB_ORG_INHERITABLE_CLASSES]).filter((c) =>
+            (KB_ORG_INHERITABLE_CLASSES as ReadonlyArray<KbDocumentClass>).includes(c),
+        );
+
+        if (inheritableClasses.length === 0) {
+            return [];
+        }
+
+        return this.repository.find({
+            where: {
+                organizationId,
+                workId: IsNull(),
+                kbDocumentClass: In(inheritableClasses),
+                status: 'active' as KbDocumentStatus,
+            },
+            order: { path: 'ASC' },
+        });
+    }
+
+    async listWorkOverridesForClasses(
+        workId: string,
+        classes: KbDocumentClass[],
+    ): Promise<WorkKnowledgeDocument[]> {
+        if (classes.length === 0) {
+            return [];
+        }
+
+        return this.repository.find({
+            where: {
+                workId,
+                kbDocumentClass: In(classes),
+                status: 'active' as KbDocumentStatus,
+            },
+            order: { path: 'ASC' },
+        });
+    }
+
+    /**
+     * Path-collision check used to suffix on conflict (see service).
+     */
+    async pathExists(workId: string, path: string, excludeId?: string): Promise<boolean> {
+        const where = excludeId ? { workId, path, id: Not(excludeId) } : { workId, path };
+        const count = await this.repository.count({ where });
+        return count > 0;
+    }
+
+    async create(data: Partial<WorkKnowledgeDocument>): Promise<WorkKnowledgeDocument> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    async update(
+        docId: string,
+        patch: Partial<WorkKnowledgeDocument>,
+    ): Promise<WorkKnowledgeDocument | null> {
+        await this.repository.update({ id: docId }, patch);
+        return this.repository.findOne({ where: { id: docId } });
+    }
+
+    async delete(docId: string): Promise<boolean> {
+        const result = await this.repository.delete({ id: docId });
+        return (result.affected ?? 0) > 0;
+    }
+
+    async setLock(
+        docId: string,
+        locked: boolean,
+        lockMode: KbLockMode | null,
+    ): Promise<WorkKnowledgeDocument | null> {
+        await this.repository.update({ id: docId }, { locked, lockMode });
+        return this.repository.findOne({ where: { id: docId } });
+    }
+
+    /** Lookup using either Work id+slug-path or org id+path. */
+    async findByWorkOrPath(
+        workId: string,
+        idOrPath: string,
+    ): Promise<WorkKnowledgeDocument | null> {
+        // Heuristic: a path contains '/' or ends with '.md'; an id is a UUID.
+        if (idOrPath.includes('/') || idOrPath.endsWith('.md')) {
+            return this.findByPath(workId, idOrPath);
+        }
+        return this.findById(workId, idOrPath);
+    }
+}
+
+/** Convenience re-export of search helper used by the service. */
+export { Like };

--- a/packages/agent/src/database/repositories/work-knowledge-tag.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-tag.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkKnowledgeTag } from '../../entities/work-knowledge-tag.entity';
+
+@Injectable()
+export class WorkKnowledgeTagRepository {
+    constructor(
+        @InjectRepository(WorkKnowledgeTag)
+        private readonly repository: Repository<WorkKnowledgeTag>,
+    ) {}
+
+    async list(workId: string): Promise<WorkKnowledgeTag[]> {
+        return this.repository.find({ where: { workId }, order: { slug: 'ASC' } });
+    }
+
+    async findBySlug(workId: string, slug: string): Promise<WorkKnowledgeTag | null> {
+        return this.repository.findOne({ where: { workId, slug } });
+    }
+
+    async findById(workId: string, tagId: string): Promise<WorkKnowledgeTag | null> {
+        return this.repository.findOne({ where: { workId, id: tagId } });
+    }
+
+    async create(data: Partial<WorkKnowledgeTag>): Promise<WorkKnowledgeTag> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    /**
+     * Create-on-first-use: if the slug already exists for this Work,
+     * return the existing row instead of throwing. Used by the
+     * inline-tag-create-from-autocomplete flow.
+     */
+    async upsertBySlug(workId: string, slug: string, name: string): Promise<WorkKnowledgeTag> {
+        const existing = await this.findBySlug(workId, slug);
+        if (existing) {
+            return existing;
+        }
+        return this.create({ workId, slug, name });
+    }
+
+    async update(
+        tagId: string,
+        patch: Partial<WorkKnowledgeTag>,
+    ): Promise<WorkKnowledgeTag | null> {
+        await this.repository.update({ id: tagId }, patch);
+        return this.repository.findOne({ where: { id: tagId } });
+    }
+
+    async delete(tagId: string): Promise<boolean> {
+        const result = await this.repository.delete({ id: tagId });
+        return (result.affected ?? 0) > 0;
+    }
+}

--- a/packages/agent/src/database/repositories/work-knowledge-upload.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-upload.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkKnowledgeUpload } from '../../entities/work-knowledge-upload.entity';
+import { KbUploadExtractionStatus } from '../../entities/kb-types';
+
+@Injectable()
+export class WorkKnowledgeUploadRepository {
+    constructor(
+        @InjectRepository(WorkKnowledgeUpload)
+        private readonly repository: Repository<WorkKnowledgeUpload>,
+    ) {}
+
+    async findById(workId: string, uploadId: string): Promise<WorkKnowledgeUpload | null> {
+        return this.repository.findOne({ where: { id: uploadId, workId } });
+    }
+
+    async findBySha256(workId: string, sha256: string): Promise<WorkKnowledgeUpload | null> {
+        return this.repository.findOne({ where: { workId, sha256 } });
+    }
+
+    async list(workId: string, status?: KbUploadExtractionStatus): Promise<WorkKnowledgeUpload[]> {
+        return this.repository.find({
+            where: status ? { workId, extractionStatus: status } : { workId },
+            order: { createdAt: 'DESC' },
+        });
+    }
+
+    async create(data: Partial<WorkKnowledgeUpload>): Promise<WorkKnowledgeUpload> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    async update(
+        uploadId: string,
+        patch: Partial<WorkKnowledgeUpload>,
+    ): Promise<WorkKnowledgeUpload | null> {
+        await this.repository.update({ id: uploadId }, patch);
+        return this.repository.findOne({ where: { id: uploadId } });
+    }
+
+    async delete(uploadId: string): Promise<boolean> {
+        const result = await this.repository.delete({ id: uploadId });
+        return (result.affected ?? 0) > 0;
+    }
+}

--- a/packages/agent/src/dto/kb.dto.ts
+++ b/packages/agent/src/dto/kb.dto.ts
@@ -1,0 +1,210 @@
+import { Type } from 'class-transformer';
+import {
+    ArrayMaxSize,
+    IsArray,
+    IsBoolean,
+    IsIn,
+    IsInt,
+    IsOptional,
+    IsString,
+    IsUUID,
+    Length,
+    MaxLength,
+    Min,
+} from 'class-validator';
+import {
+    KB_DOCUMENT_CLASSES,
+    KB_DOCUMENT_STATUSES,
+    KB_LOCK_MODES,
+    KbDocumentClass,
+    KbDocumentStatus,
+    KbLockMode,
+} from '@ever-works/contracts';
+
+/** Max body size per spec D9 — 1 MB Markdown. */
+const KB_BODY_MAX_BYTES = 1_048_576;
+const KB_TITLE_MAX = 255;
+const KB_PATH_MAX = 512;
+const KB_DESCRIPTION_MAX = 2000;
+const KB_TAGS_MAX = 32;
+const KB_TAG_SLUG_MAX = 64;
+
+export class CreateKbDocumentDto {
+    @IsString()
+    @Length(1, KB_PATH_MAX)
+    path: string;
+
+    @IsString()
+    @Length(1, KB_TITLE_MAX)
+    title: string;
+
+    @IsIn(KB_DOCUMENT_CLASSES as unknown as readonly string[])
+    class: KbDocumentClass;
+
+    @IsString()
+    @MaxLength(KB_BODY_MAX_BYTES)
+    body: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(KB_DESCRIPTION_MAX)
+    description?: string | null;
+
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(KB_TAGS_MAX)
+    @IsString({ each: true })
+    @MaxLength(KB_TAG_SLUG_MAX, { each: true })
+    tags?: string[];
+
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(KB_TAGS_MAX)
+    @IsString({ each: true })
+    @MaxLength(KB_TAG_SLUG_MAX, { each: true })
+    categories?: string[];
+
+    @IsOptional()
+    @IsString()
+    @Length(2, 8)
+    language?: string;
+
+    @IsOptional()
+    @IsIn(KB_DOCUMENT_STATUSES as unknown as readonly string[])
+    status?: KbDocumentStatus;
+}
+
+export class UpdateKbDocumentDto {
+    @IsOptional()
+    @IsString()
+    @Length(1, KB_TITLE_MAX)
+    title?: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(KB_DESCRIPTION_MAX)
+    description?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(KB_BODY_MAX_BYTES)
+    body?: string;
+
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(KB_TAGS_MAX)
+    @IsString({ each: true })
+    @MaxLength(KB_TAG_SLUG_MAX, { each: true })
+    tags?: string[];
+
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(KB_TAGS_MAX)
+    @IsString({ each: true })
+    @MaxLength(KB_TAG_SLUG_MAX, { each: true })
+    categories?: string[];
+
+    @IsOptional()
+    @IsString()
+    @Length(2, 8)
+    language?: string;
+
+    @IsOptional()
+    @IsIn(KB_DOCUMENT_STATUSES as unknown as readonly string[])
+    status?: KbDocumentStatus;
+}
+
+export class LockKbDocumentDto {
+    @IsIn(KB_LOCK_MODES as unknown as readonly string[])
+    mode: KbLockMode;
+}
+
+export class KbDocumentQueryDto {
+    @IsOptional()
+    @IsIn(KB_DOCUMENT_CLASSES as unknown as readonly string[])
+    class?: KbDocumentClass;
+
+    @IsOptional()
+    @IsIn(KB_DOCUMENT_STATUSES as unknown as readonly string[])
+    status?: KbDocumentStatus;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(KB_TAG_SLUG_MAX)
+    tag?: string;
+
+    @IsOptional()
+    @IsBoolean()
+    @Type(() => Boolean)
+    locked?: boolean;
+
+    @IsOptional()
+    @IsString()
+    @Length(2, 8)
+    language?: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    q?: string;
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Type(() => Number)
+    limit?: number;
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Type(() => Number)
+    offset?: number;
+}
+
+export class CreateKbTagDto {
+    @IsString()
+    @Length(1, KB_TAG_SLUG_MAX)
+    slug: string;
+
+    @IsString()
+    @Length(1, 128)
+    name: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(16)
+    color?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(500)
+    description?: string | null;
+}
+
+export class UpdateKbTagDto {
+    @IsOptional()
+    @IsString()
+    @Length(1, 128)
+    name?: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(16)
+    color?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(500)
+    description?: string | null;
+}
+
+export class RestoreKbDocumentDto {
+    @IsString()
+    @Length(7, 40)
+    commitSha: string;
+}
+
+export class OrgKbDocumentScopeDto {
+    @IsUUID()
+    organizationId: string;
+}

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -1,0 +1,375 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { KnowledgeBaseService } from '../knowledge-base.service';
+import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
+import { WorkKnowledgeUploadRepository } from '../../database/repositories/work-knowledge-upload.repository';
+import { WorkKnowledgeTagRepository } from '../../database/repositories/work-knowledge-tag.repository';
+import { WorkKnowledgeCitationRepository } from '../../database/repositories/work-knowledge-citation.repository';
+import { WorkOwnershipService } from '../work-ownership.service';
+import { WorkKnowledgeDocument } from '../../entities/work-knowledge-document.entity';
+import {
+    KbDocumentClass,
+    KbDocumentSource,
+    KbDocumentStatus,
+    KbLockMode,
+} from '../../entities/kb-types';
+
+const WORK_ID = '00000000-0000-0000-0000-000000000001';
+const ORG_ID = '00000000-0000-0000-0000-0000000000aa';
+const USER_ID = '00000000-0000-0000-0000-000000000002';
+
+function buildDocument(overrides: Partial<WorkKnowledgeDocument> = {}): WorkKnowledgeDocument {
+    return {
+        id: '00000000-0000-0000-0000-000000000010',
+        workId: WORK_ID,
+        organizationId: null,
+        path: 'brand/voice.md',
+        slug: 'voice',
+        title: 'Brand voice',
+        description: null,
+        kbDocumentClass: 'brand' as KbDocumentClass,
+        tags: null,
+        categories: null,
+        status: 'active' as KbDocumentStatus,
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: 0,
+        tokenCount: 0,
+        source: 'user' as KbDocumentSource,
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: USER_ID,
+        updatedById: USER_ID,
+        lastIndexedAt: null,
+        lastCommitSha: null,
+        metadata: null,
+        createdAt: new Date('2026-05-21T12:00:00Z'),
+        updatedAt: new Date('2026-05-21T12:00:00Z'),
+        ...overrides,
+    } as WorkKnowledgeDocument;
+}
+
+describe('KnowledgeBaseService', () => {
+    let service: KnowledgeBaseService;
+    let docRepo: jest.Mocked<WorkKnowledgeDocumentRepository>;
+    let tagRepo: jest.Mocked<WorkKnowledgeTagRepository>;
+    let ownership: jest.Mocked<WorkOwnershipService>;
+
+    beforeEach(async () => {
+        const docRepoMock: Partial<jest.Mocked<WorkKnowledgeDocumentRepository>> = {
+            findById: jest.fn(),
+            findByPath: jest.fn(),
+            findOrgById: jest.fn(),
+            findByWorkOrPath: jest.fn(),
+            list: jest.fn(),
+            listInheritableForOrg: jest.fn(),
+            listWorkOverridesForClasses: jest.fn(),
+            pathExists: jest.fn().mockResolvedValue(false),
+            create: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn().mockResolvedValue(true),
+            setLock: jest.fn(),
+        };
+
+        const tagRepoMock: Partial<jest.Mocked<WorkKnowledgeTagRepository>> = {
+            list: jest.fn().mockResolvedValue([]),
+            findBySlug: jest.fn(),
+            findById: jest.fn(),
+            create: jest.fn(),
+            upsertBySlug: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+        };
+
+        const ownershipMock: Partial<jest.Mocked<WorkOwnershipService>> = {
+            ensureCanView: jest.fn().mockResolvedValue({ role: 'editor' } as any),
+            ensureCanEdit: jest.fn().mockResolvedValue({ role: 'editor' } as any),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                KnowledgeBaseService,
+                { provide: WorkKnowledgeDocumentRepository, useValue: docRepoMock },
+                { provide: WorkKnowledgeUploadRepository, useValue: {} },
+                { provide: WorkKnowledgeTagRepository, useValue: tagRepoMock },
+                {
+                    provide: WorkKnowledgeCitationRepository,
+                    useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                },
+                { provide: WorkOwnershipService, useValue: ownershipMock },
+            ],
+        }).compile();
+
+        service = module.get(KnowledgeBaseService);
+        docRepo = module.get(WorkKnowledgeDocumentRepository);
+        tagRepo = module.get(WorkKnowledgeTagRepository);
+        ownership = module.get(WorkOwnershipService);
+    });
+
+    describe('listDocuments', () => {
+        it('returns mapped DTOs for the caller', async () => {
+            docRepo.list.mockResolvedValue({ items: [buildDocument()], total: 1 });
+
+            const result = await service.listDocuments(WORK_ID, USER_ID);
+
+            expect(ownership.ensureCanView).toHaveBeenCalledWith(WORK_ID, USER_ID);
+            expect(result.total).toBe(1);
+            expect(result.items[0]).toMatchObject({
+                id: expect.any(String),
+                path: 'brand/voice.md',
+                class: 'brand',
+            });
+        });
+
+        it('forwards filters to the repository', async () => {
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+
+            await service.listDocuments(WORK_ID, USER_ID, {
+                class: 'legal' as KbDocumentClass,
+                tag: 'gdpr',
+                locked: true,
+                limit: 10,
+            });
+
+            expect(docRepo.list).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: WORK_ID,
+                    classes: ['legal'],
+                    tag: 'gdpr',
+                    locked: true,
+                    limit: 10,
+                }),
+            );
+        });
+    });
+
+    describe('getDocument', () => {
+        it('returns the body DTO when found', async () => {
+            const doc = buildDocument({
+                metadata: { body: '# Voice\n\nFriendly and direct.' },
+            });
+            docRepo.findByWorkOrPath.mockResolvedValue(doc);
+
+            const result = await service.getDocument(WORK_ID, doc.id, USER_ID);
+
+            expect(result.body).toContain('Friendly and direct');
+            expect(result.assets).toEqual([]);
+        });
+
+        it('throws NotFoundException when missing', async () => {
+            docRepo.findByWorkOrPath.mockResolvedValue(null);
+
+            await expect(service.getDocument(WORK_ID, 'missing', USER_ID)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+    });
+
+    describe('createDocument', () => {
+        it('persists with derived slug + word/token counts', async () => {
+            docRepo.pathExists.mockResolvedValue(false);
+            const persisted = buildDocument({
+                path: 'brand/voice.md',
+                slug: 'voice',
+                wordCount: 5,
+                tokenCount: 5,
+                metadata: { body: 'Hello world from the brand voice doc.' },
+            });
+            docRepo.create.mockResolvedValue(persisted);
+
+            const result = await service.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/voice.md',
+                title: 'Brand voice',
+                class: 'brand' as KbDocumentClass,
+                body: 'Hello world from the brand voice doc.',
+                tags: ['brand'],
+            });
+
+            expect(ownership.ensureCanEdit).toHaveBeenCalledWith(WORK_ID, USER_ID);
+            expect(docRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: WORK_ID,
+                    organizationId: null,
+                    path: 'brand/voice.md',
+                    slug: 'voice',
+                    kbDocumentClass: 'brand',
+                }),
+            );
+            expect(tagRepo.upsertBySlug).toHaveBeenCalledWith(WORK_ID, 'brand', 'brand');
+            expect(result.body).toContain('Hello world');
+        });
+
+        it('suffixes the path on collision', async () => {
+            docRepo.pathExists
+                .mockResolvedValueOnce(true)
+                .mockResolvedValueOnce(true)
+                .mockResolvedValueOnce(false);
+            docRepo.create.mockImplementation(async (data) => buildDocument({ ...data }));
+
+            await service.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/voice.md',
+                title: 'Brand voice',
+                class: 'brand' as KbDocumentClass,
+                body: 'body',
+            });
+
+            const call = docRepo.create.mock.calls[0]?.[0] as { path?: string };
+            expect(call.path).toBe('brand/voice-3.md');
+        });
+    });
+
+    describe('updateDocument', () => {
+        it('refuses to update a fully-locked doc', async () => {
+            docRepo.findById.mockResolvedValue(
+                buildDocument({ locked: true, lockMode: 'full' as KbLockMode }),
+            );
+
+            await expect(
+                service.updateDocument(WORK_ID, 'docid', USER_ID, { title: 'new' }),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+        });
+
+        it('updates word/token counts when body changes', async () => {
+            const existing = buildDocument({ metadata: { body: 'old' } });
+            docRepo.findById.mockResolvedValue(existing);
+            docRepo.update.mockResolvedValue({
+                ...existing,
+                metadata: { body: 'a new body with more words' },
+                wordCount: 6,
+                tokenCount: 7,
+            });
+
+            const result = await service.updateDocument(WORK_ID, existing.id, USER_ID, {
+                body: 'a new body with more words',
+            });
+
+            expect(docRepo.update).toHaveBeenCalled();
+            expect(result.body).toBe('a new body with more words');
+        });
+    });
+
+    describe('lockDocument / unlockDocument', () => {
+        it('requires manager+ role', async () => {
+            (ownership.ensureCanEdit as jest.Mock).mockResolvedValue({ role: 'editor' });
+            docRepo.findById.mockResolvedValue(buildDocument());
+
+            await expect(
+                service.lockDocument(WORK_ID, 'docid', USER_ID, 'full' as KbLockMode),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+        });
+
+        it('persists lock + mode when manager', async () => {
+            (ownership.ensureCanEdit as jest.Mock).mockResolvedValue({ role: 'manager' });
+            const doc = buildDocument();
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.setLock.mockResolvedValue({
+                ...doc,
+                locked: true,
+                lockMode: 'full' as KbLockMode,
+            });
+
+            const result = await service.lockDocument(
+                WORK_ID,
+                doc.id,
+                USER_ID,
+                'full' as KbLockMode,
+            );
+
+            expect(docRepo.setLock).toHaveBeenCalledWith(doc.id, true, 'full');
+            expect(result.locked).toBe(true);
+            expect(result.lockMode).toBe('full');
+        });
+    });
+
+    describe('createOrgDocument', () => {
+        it('rejects non-inheritable classes', async () => {
+            await expect(
+                service.createOrgDocument(ORG_ID, USER_ID, {
+                    path: 'brand/voice.md',
+                    title: 'Brand voice',
+                    class: 'brand' as KbDocumentClass,
+                    body: 'body',
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('accepts legal / style / seo', async () => {
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, workId: null, organizationId: ORG_ID }),
+            );
+
+            const result = await service.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'verbatim privacy text',
+            });
+
+            expect(result.organizationId).toBe(ORG_ID);
+            expect(result.workId).toBeNull();
+            expect(result.class).toBe('legal');
+        });
+    });
+
+    describe('resolveInheritableDocuments', () => {
+        it('merges org docs with Work overrides by path', async () => {
+            const orgPrivacy = buildDocument({
+                id: 'org-privacy',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'legal/privacy.md',
+                title: 'Org privacy',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+            });
+            const orgTerms = buildDocument({
+                id: 'org-terms',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'legal/terms.md',
+                title: 'Org terms',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+            });
+            const workPrivacy = buildDocument({
+                id: 'work-privacy',
+                workId: WORK_ID,
+                organizationId: null,
+                path: 'legal/privacy.md',
+                title: 'Work privacy override',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+            });
+
+            docRepo.listInheritableForOrg.mockResolvedValue([orgPrivacy, orgTerms]);
+            docRepo.listWorkOverridesForClasses.mockResolvedValue([workPrivacy]);
+
+            const result = await service.resolveInheritableDocuments(WORK_ID, ORG_ID, [
+                'legal' as KbDocumentClass,
+            ]);
+
+            const byPath = new Map(result.map((d) => [d.path, d]));
+            expect(byPath.get('legal/privacy.md')?.title).toBe('Work privacy override');
+            expect(byPath.get('legal/terms.md')?.title).toBe('Org terms');
+            expect(result).toHaveLength(2);
+        });
+
+        it('returns empty when no inheritable classes match', async () => {
+            const result = await service.resolveInheritableDocuments(WORK_ID, ORG_ID, [
+                'brand' as KbDocumentClass,
+            ]);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('restoreDocumentFromHistory', () => {
+        it('throws — feature deferred to Phase 1B', async () => {
+            await expect(service.restoreDocumentFromHistory()).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -26,6 +26,8 @@ export * from './webhook-subscription-secret.service';
 export * from './zero-friction-funnel.service';
 export * from './deploy-ready-poller.service';
 export * from './category-icon';
+export * from './knowledge-base.service';
+export * from './knowledge-base.module';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -1,0 +1,60 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DatabaseModule } from '../database/database.module';
+import {
+    WorkKnowledgeChunk,
+    WorkKnowledgeCitation,
+    WorkKnowledgeDocument,
+    WorkKnowledgeTag,
+    WorkKnowledgeUpload,
+} from '../entities';
+import { WorkKnowledgeDocumentRepository } from '../database/repositories/work-knowledge-document.repository';
+import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
+import { WorkKnowledgeTagRepository } from '../database/repositories/work-knowledge-tag.repository';
+import { WorkKnowledgeCitationRepository } from '../database/repositories/work-knowledge-citation.repository';
+import { KnowledgeBaseService } from './knowledge-base.service';
+import { WorkOwnershipService } from './work-ownership.service';
+
+/**
+ * NestJS module wiring the Knowledge Base service + repositories.
+ *
+ * Imports `WorkOwnershipService` for permission gates; that service
+ * is provided by `WorkModule` in the application graph, so consumers
+ * should make sure WorkModule is imported alongside this module or
+ * provide WorkOwnershipService via a parent module.
+ *
+ * Entities registered:
+ *  - WorkKnowledgeDocument
+ *  - WorkKnowledgeUpload
+ *  - WorkKnowledgeTag
+ *  - WorkKnowledgeCitation
+ *  - WorkKnowledgeChunk (no repo yet — Phase 2 introduces embedding code)
+ */
+@Module({
+    imports: [
+        DatabaseModule,
+        TypeOrmModule.forFeature([
+            WorkKnowledgeDocument,
+            WorkKnowledgeUpload,
+            WorkKnowledgeTag,
+            WorkKnowledgeCitation,
+            WorkKnowledgeChunk,
+        ]),
+    ],
+    providers: [
+        WorkOwnershipService,
+        WorkKnowledgeDocumentRepository,
+        WorkKnowledgeUploadRepository,
+        WorkKnowledgeTagRepository,
+        WorkKnowledgeCitationRepository,
+        KnowledgeBaseService,
+    ],
+    exports: [
+        WorkKnowledgeDocumentRepository,
+        WorkKnowledgeUploadRepository,
+        WorkKnowledgeTagRepository,
+        WorkKnowledgeCitationRepository,
+        KnowledgeBaseService,
+    ],
+})
+export class KnowledgeBaseModule {}

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -1,0 +1,573 @@
+import {
+    BadRequestException,
+    ForbiddenException,
+    Injectable,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
+import { WorkOwnershipService } from './work-ownership.service';
+import { WorkKnowledgeDocumentRepository } from '../database/repositories/work-knowledge-document.repository';
+import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
+import { WorkKnowledgeTagRepository } from '../database/repositories/work-knowledge-tag.repository';
+import { WorkKnowledgeCitationRepository } from '../database/repositories/work-knowledge-citation.repository';
+import { WorkKnowledgeDocument } from '../entities/work-knowledge-document.entity';
+import { WorkKnowledgeTag } from '../entities/work-knowledge-tag.entity';
+import {
+    KB_ORG_INHERITABLE_CLASSES,
+    KbDocumentClass,
+    KbDocumentSource,
+    KbDocumentStatus,
+    KbLockMode,
+} from '../entities/kb-types';
+import type {
+    CitationDto,
+    KbDocumentBodyDto,
+    KbDocumentClass as KbDocumentClassContract,
+    KbDocumentDto,
+    KbTagDto,
+} from '@ever-works/contracts';
+
+interface CreateDocumentInput {
+    workId: string;
+    userId: string;
+    path: string;
+    title: string;
+    class: KbDocumentClass;
+    body: string;
+    description?: string | null;
+    tags?: string[];
+    categories?: string[];
+    language?: string;
+    status?: KbDocumentStatus;
+    source?: KbDocumentSource;
+    sourceUrl?: string | null;
+    sourceUploadId?: string | null;
+    generatedByAgentRunId?: string | null;
+}
+
+interface UpdateDocumentInput {
+    title?: string;
+    description?: string | null;
+    body?: string;
+    tags?: string[];
+    categories?: string[];
+    language?: string;
+    status?: KbDocumentStatus;
+}
+
+interface ListOptions {
+    class?: KbDocumentClass;
+    status?: KbDocumentStatus;
+    tag?: string;
+    locked?: boolean;
+    language?: string;
+    q?: string;
+    limit?: number;
+    offset?: number;
+}
+
+/**
+ * KnowledgeBaseService — Phase 1A service layer for per-Work KB.
+ *
+ * Responsibilities in this phase:
+ *  - CRUD on `WorkKnowledgeDocument`, `WorkKnowledgeTag`,
+ *    `WorkKnowledgeUpload`, `WorkKnowledgeCitation`.
+ *  - Permission gating via `WorkOwnershipService`.
+ *  - Lexical search (Postgres LIKE for v1; Postgres FTS upgrade is
+ *    Phase 2 alongside semantic retrieval).
+ *  - Lock semantics (set / clear / read).
+ *  - Restore-from-history exposed as a no-op stub here; the Git
+ *    integration lands in the same PR that adds the Storage plugin
+ *    bridge (Phase 1B).
+ *
+ * Out of scope for this file (lands later):
+ *  - Two-layer DB ↔ Git sync. The body lives only in the DB row in
+ *    this phase; the Git mirroring step is added when the Storage
+ *    plugin abstraction is wired (Phase 1B).
+ *  - Embedding generation + semantic retrieval (Phase 2).
+ *  - Org overlay materialization fanout (Phase 2).
+ *  - Ingest pipeline (Phase 1B).
+ *
+ * The service is intentionally Git-agnostic for now so the schema +
+ * API contract can be reviewed and stabilized before the storage
+ * abstraction lands.
+ */
+@Injectable()
+export class KnowledgeBaseService {
+    private readonly logger = new Logger(KnowledgeBaseService.name);
+
+    constructor(
+        private readonly documentRepository: WorkKnowledgeDocumentRepository,
+        private readonly uploadRepository: WorkKnowledgeUploadRepository,
+        private readonly tagRepository: WorkKnowledgeTagRepository,
+        private readonly citationRepository: WorkKnowledgeCitationRepository,
+        private readonly ownershipService: WorkOwnershipService,
+    ) {}
+
+    // ─── DOCUMENTS — Work scope ───────────────────────────────────────────────
+
+    async listDocuments(workId: string, userId: string, opts: ListOptions = {}) {
+        await this.ownershipService.ensureCanView(workId, userId);
+
+        const { items, total } = await this.documentRepository.list({
+            workId,
+            classes: opts.class ? [opts.class] : undefined,
+            statuses: opts.status ? [opts.status] : undefined,
+            tag: opts.tag,
+            locked: opts.locked,
+            language: opts.language,
+            q: opts.q,
+            limit: opts.limit,
+            offset: opts.offset,
+        });
+
+        return { items: items.map((d) => this.toDto(d)), total };
+    }
+
+    async getDocument(
+        workId: string,
+        idOrPath: string,
+        userId: string,
+    ): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanView(workId, userId);
+
+        const doc = await this.documentRepository.findByWorkOrPath(workId, idOrPath);
+        if (!doc) {
+            throw new NotFoundException(`KB document not found: ${idOrPath}`);
+        }
+
+        return this.toBodyDto(doc);
+    }
+
+    async createDocument(input: CreateDocumentInput): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanEdit(input.workId, input.userId);
+
+        const slug = this.slugFromPath(input.path);
+        const path = await this.resolvePathCollision(input.workId, input.path);
+
+        const body = input.body ?? '';
+        const wordCount = this.countWords(body);
+        const tokenCount = this.estimateTokens(body);
+
+        const doc = await this.documentRepository.create({
+            workId: input.workId,
+            organizationId: null,
+            path,
+            slug,
+            title: input.title,
+            description: input.description ?? null,
+            kbDocumentClass: input.class,
+            tags: input.tags ?? null,
+            categories: input.categories ?? null,
+            status: input.status ?? ('active' as KbDocumentStatus),
+            locked: false,
+            lockMode: null,
+            language: input.language ?? 'en',
+            wordCount,
+            tokenCount,
+            source: input.source ?? ('user' as KbDocumentSource),
+            sourceUploadId: input.sourceUploadId ?? null,
+            sourceUrl: input.sourceUrl ?? null,
+            generatedByAgentRunId: input.generatedByAgentRunId ?? null,
+            createdById: input.userId,
+            updatedById: input.userId,
+            metadata: { body } as Record<string, unknown>,
+        });
+
+        // Ensure any new tag slugs are in the tag catalog (create-on-first-use).
+        if (input.tags?.length) {
+            await this.ensureTagsExist(input.workId, input.tags);
+        }
+
+        return this.toBodyDto(doc);
+    }
+
+    async updateDocument(
+        workId: string,
+        docId: string,
+        userId: string,
+        input: UpdateDocumentInput,
+    ): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+        this.assertNotLockedFull(existing);
+
+        const patch: Partial<WorkKnowledgeDocument> = { updatedById: userId };
+        if (input.title !== undefined) patch.title = input.title;
+        if (input.description !== undefined) patch.description = input.description;
+        if (input.tags !== undefined) patch.tags = input.tags;
+        if (input.categories !== undefined) patch.categories = input.categories;
+        if (input.language !== undefined) patch.language = input.language;
+        if (input.status !== undefined) patch.status = input.status;
+
+        if (input.body !== undefined) {
+            patch.wordCount = this.countWords(input.body);
+            patch.tokenCount = this.estimateTokens(input.body);
+            patch.metadata = {
+                ...(existing.metadata ?? {}),
+                body: input.body,
+            } as Record<string, unknown>;
+        }
+
+        const updated = await this.documentRepository.update(docId, patch);
+        if (!updated) {
+            throw new NotFoundException(`KB document not found after update: ${docId}`);
+        }
+
+        if (input.tags?.length) {
+            await this.ensureTagsExist(workId, input.tags);
+        }
+
+        return this.toBodyDto(updated);
+    }
+
+    async deleteDocument(workId: string, docId: string, userId: string): Promise<void> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+        this.assertNotLockedFull(existing);
+
+        await this.documentRepository.delete(docId);
+    }
+
+    async lockDocument(
+        workId: string,
+        docId: string,
+        userId: string,
+        mode: KbLockMode,
+    ): Promise<KbDocumentBodyDto> {
+        const access = await this.ownershipService.ensureCanEdit(workId, userId);
+        // Lock toggles require at least manager role per spec §20.
+        if (access.role !== 'owner' && access.role !== 'manager') {
+            throw new ForbiddenException('Locking a KB document requires manager+ role');
+        }
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+
+        const updated = await this.documentRepository.setLock(docId, true, mode);
+        if (!updated) {
+            throw new NotFoundException(`KB document not found after lock: ${docId}`);
+        }
+        return this.toBodyDto(updated);
+    }
+
+    async unlockDocument(
+        workId: string,
+        docId: string,
+        userId: string,
+    ): Promise<KbDocumentBodyDto> {
+        const access = await this.ownershipService.ensureCanEdit(workId, userId);
+        if (access.role !== 'owner' && access.role !== 'manager') {
+            throw new ForbiddenException('Unlocking a KB document requires manager+ role');
+        }
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+
+        const updated = await this.documentRepository.setLock(docId, false, null);
+        if (!updated) {
+            throw new NotFoundException(`KB document not found after unlock: ${docId}`);
+        }
+        return this.toBodyDto(updated);
+    }
+
+    /**
+     * Phase 1A stub. The Git integration that surfaces prior commits
+     * lands alongside the Storage plugin bridge in Phase 1B; this
+     * endpoint exists in the API surface so the contract is fixed but
+     * returns a 501-like error until the Git side is ready.
+     */
+    async restoreDocumentFromHistory(): Promise<KbDocumentBodyDto> {
+        throw new BadRequestException(
+            'restore-from-history is not yet available — Git integration lands in Phase 1B (EW-641)',
+        );
+    }
+
+    // ─── DOCUMENTS — Organization scope (inheritable: legal/style/seo) ───────
+
+    async createOrgDocument(
+        organizationId: string,
+        userId: string,
+        input: Omit<CreateDocumentInput, 'workId' | 'userId'>,
+    ): Promise<KbDocumentBodyDto> {
+        // Org-admin guard happens at the controller layer.
+        if (!(KB_ORG_INHERITABLE_CLASSES as ReadonlyArray<KbDocumentClass>).includes(input.class)) {
+            throw new BadRequestException(
+                `Organization-scoped KB documents must have class in [${KB_ORG_INHERITABLE_CLASSES.join(', ')}], got '${input.class}'`,
+            );
+        }
+
+        const slug = this.slugFromPath(input.path);
+        const body = input.body ?? '';
+        const wordCount = this.countWords(body);
+        const tokenCount = this.estimateTokens(body);
+
+        const doc = await this.documentRepository.create({
+            workId: null,
+            organizationId,
+            path: input.path,
+            slug,
+            title: input.title,
+            description: input.description ?? null,
+            kbDocumentClass: input.class,
+            tags: input.tags ?? null,
+            categories: input.categories ?? null,
+            status: input.status ?? ('active' as KbDocumentStatus),
+            locked: false,
+            lockMode: null,
+            language: input.language ?? 'en',
+            wordCount,
+            tokenCount,
+            source: 'user' as KbDocumentSource,
+            createdById: userId,
+            updatedById: userId,
+            metadata: { body } as Record<string, unknown>,
+        });
+
+        return this.toBodyDto(doc);
+    }
+
+    async listOrgDocuments(
+        organizationId: string,
+        opts: { class?: KbDocumentClass } = {},
+    ): Promise<{ items: KbDocumentDto[]; total: number }> {
+        const { items, total } = await this.documentRepository.list({
+            organizationId,
+            classes: opts.class ? [opts.class] : undefined,
+        });
+        return { items: items.map((d) => this.toDto(d)), total };
+    }
+
+    async resolveInheritableDocuments(
+        workId: string,
+        organizationId: string | null,
+        classes?: KbDocumentClass[],
+    ): Promise<KbDocumentDto[]> {
+        const targetClasses = (classes ?? [...KB_ORG_INHERITABLE_CLASSES]).filter((c) =>
+            (KB_ORG_INHERITABLE_CLASSES as ReadonlyArray<KbDocumentClass>).includes(c),
+        );
+
+        if (targetClasses.length === 0) {
+            return [];
+        }
+
+        const orgDocs = organizationId
+            ? await this.documentRepository.listInheritableForOrg(organizationId, targetClasses)
+            : [];
+
+        const workOverrides = await this.documentRepository.listWorkOverridesForClasses(
+            workId,
+            targetClasses,
+        );
+
+        // Build a map keyed by path with Work overriding org.
+        const byPath = new Map<string, WorkKnowledgeDocument>();
+        for (const d of orgDocs) {
+            byPath.set(d.path, d);
+        }
+        for (const d of workOverrides) {
+            byPath.set(d.path, d);
+        }
+
+        return [...byPath.values()].map((d) => this.toDto(d));
+    }
+
+    // ─── TAGS ────────────────────────────────────────────────────────────────
+
+    async listTags(workId: string, userId: string): Promise<KbTagDto[]> {
+        await this.ownershipService.ensureCanView(workId, userId);
+        const tags = await this.tagRepository.list(workId);
+        return tags.map(toTagDto);
+    }
+
+    async createTag(
+        workId: string,
+        userId: string,
+        input: { slug: string; name: string; color?: string | null; description?: string | null },
+    ): Promise<KbTagDto> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+
+        const existing = await this.tagRepository.findBySlug(workId, input.slug);
+        if (existing) {
+            throw new BadRequestException(`Tag with slug '${input.slug}' already exists`);
+        }
+
+        const tag = await this.tagRepository.create({
+            workId,
+            slug: input.slug,
+            name: input.name,
+            color: input.color ?? null,
+            description: input.description ?? null,
+        });
+        return toTagDto(tag);
+    }
+
+    async updateTag(
+        workId: string,
+        tagId: string,
+        userId: string,
+        patch: { name?: string; color?: string | null; description?: string | null },
+    ): Promise<KbTagDto> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+        const existing = await this.tagRepository.findById(workId, tagId);
+        if (!existing) {
+            throw new NotFoundException(`Tag not found: ${tagId}`);
+        }
+        const updated = await this.tagRepository.update(tagId, patch);
+        if (!updated) {
+            throw new NotFoundException(`Tag not found after update: ${tagId}`);
+        }
+        return toTagDto(updated);
+    }
+
+    async deleteTag(workId: string, tagId: string, userId: string): Promise<void> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+        const existing = await this.tagRepository.findById(workId, tagId);
+        if (!existing) {
+            throw new NotFoundException(`Tag not found: ${tagId}`);
+        }
+        await this.tagRepository.delete(tagId);
+    }
+
+    // ─── CITATIONS ───────────────────────────────────────────────────────────
+
+    async listCitationsForDocument(
+        workId: string,
+        docId: string,
+        userId: string,
+    ): Promise<CitationDto[]> {
+        await this.ownershipService.ensureCanView(workId, userId);
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+        const citations = await this.citationRepository.listForDocument(docId);
+        return citations.map((c) => ({
+            id: c.id,
+            documentId: c.documentId,
+            consumerType: c.consumerType,
+            consumerId: c.consumerId,
+            chunkRange: c.chunkRange ?? null,
+            relevanceScore: c.relevanceScore ?? null,
+            createdAt: c.createdAt.toISOString(),
+        }));
+    }
+
+    // ─── HELPERS ─────────────────────────────────────────────────────────────
+
+    private slugFromPath(path: string): string {
+        const last = path.split('/').pop() ?? path;
+        return last.replace(/\.md$/i, '').toLowerCase();
+    }
+
+    private async resolvePathCollision(workId: string, path: string): Promise<string> {
+        let candidate = path;
+        let n = 2;
+        while (await this.documentRepository.pathExists(workId, candidate)) {
+            const dot = path.lastIndexOf('.');
+            const stem = dot >= 0 ? path.slice(0, dot) : path;
+            const ext = dot >= 0 ? path.slice(dot) : '';
+            candidate = `${stem}-${n}${ext}`;
+            n += 1;
+            if (n > 100) {
+                throw new BadRequestException(
+                    `Too many path collisions for '${path}'; refusing to suffix further`,
+                );
+            }
+        }
+        return candidate;
+    }
+
+    private assertNotLockedFull(doc: WorkKnowledgeDocument): void {
+        if (doc.locked && doc.lockMode === ('full' as KbLockMode)) {
+            throw new ForbiddenException(
+                `KB document is locked (mode=full); unlock before editing: ${doc.path}`,
+            );
+        }
+    }
+
+    private async ensureTagsExist(workId: string, slugs: string[]): Promise<void> {
+        const uniq = [...new Set(slugs)];
+        await Promise.all(uniq.map((slug) => this.tagRepository.upsertBySlug(workId, slug, slug)));
+    }
+
+    private countWords(body: string): number {
+        if (!body) return 0;
+        return body.split(/\s+/).filter(Boolean).length;
+    }
+
+    /**
+     * Cheap heuristic — ~1 token per 4 chars, English-biased. The
+     * authoritative token count for budget enforcement comes from the
+     * configured embedding provider (Phase 2).
+     */
+    private estimateTokens(body: string): number {
+        if (!body) return 0;
+        return Math.ceil(body.length / 4);
+    }
+
+    private toDto(doc: WorkKnowledgeDocument): KbDocumentDto {
+        return {
+            id: doc.id,
+            workId: doc.workId ?? null,
+            organizationId: doc.organizationId ?? null,
+            path: doc.path,
+            slug: doc.slug,
+            title: doc.title,
+            description: doc.description ?? null,
+            class: doc.kbDocumentClass as KbDocumentClassContract,
+            tags: doc.tags ?? [],
+            categories: doc.categories ?? [],
+            status: doc.status,
+            locked: doc.locked,
+            lockMode: (doc.lockMode ?? null) as KbDocumentDto['lockMode'],
+            language: doc.language,
+            wordCount: doc.wordCount ?? null,
+            tokenCount: doc.tokenCount ?? null,
+            source: doc.source,
+            sourceUploadId: doc.sourceUploadId ?? null,
+            sourceUrl: doc.sourceUrl ?? null,
+            generatedByAgentRunId: doc.generatedByAgentRunId ?? null,
+            createdById: doc.createdById ?? null,
+            updatedById: doc.updatedById ?? null,
+            createdAt: doc.createdAt.toISOString(),
+            updatedAt: doc.updatedAt.toISOString(),
+            lastCommitSha: doc.lastCommitSha ?? null,
+            lastIndexedAt: doc.lastIndexedAt ? doc.lastIndexedAt.toISOString() : null,
+        };
+    }
+
+    private toBodyDto(doc: WorkKnowledgeDocument): KbDocumentBodyDto {
+        const meta = (doc.metadata ?? {}) as { body?: string };
+        return {
+            ...this.toDto(doc),
+            body: meta.body ?? '',
+            assets: [],
+        };
+    }
+}
+
+function toTagDto(tag: WorkKnowledgeTag): KbTagDto {
+    return {
+        id: tag.id,
+        workId: tag.workId,
+        slug: tag.slug,
+        name: tag.name,
+        color: tag.color ?? null,
+        description: tag.description ?? null,
+        createdAt: tag.createdAt.toISOString(),
+        updatedAt: tag.updatedAt.toISOString(),
+    };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,3 +2,4 @@ export * from './item/index.js';
 export * from './domain/index.js';
 export * from './form/index.js';
 export * from './github/index.js';
+export * from './kb/index.js';

--- a/packages/contracts/src/kb/index.ts
+++ b/packages/contracts/src/kb/index.ts
@@ -1,0 +1,7 @@
+export * from './kb-document-class.js';
+export * from './kb-document.types.js';
+export * from './kb-upload.types.js';
+export * from './kb-tag.types.js';
+export * from './kb-citation.types.js';
+export * from './kb-search.types.js';
+export * from './kb-tree.types.js';

--- a/packages/contracts/src/kb/kb-citation.types.ts
+++ b/packages/contracts/src/kb/kb-citation.types.ts
@@ -1,0 +1,11 @@
+import type { KbCitationConsumerType } from './kb-document-class.js';
+
+export interface CitationDto {
+	id: string;
+	documentId: string;
+	consumerType: KbCitationConsumerType;
+	consumerId: string;
+	chunkRange: { start: number; end: number } | null;
+	relevanceScore: number | null;
+	createdAt: string;
+}

--- a/packages/contracts/src/kb/kb-document-class.ts
+++ b/packages/contracts/src/kb/kb-document-class.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared Knowledge Base classification + scope types.
+ *
+ * Mirrors the corresponding enums in
+ * `@ever-works/agent/entities/kb-types.ts` but lives in the contracts
+ * package so it can be consumed by Web / CLI / MCP without dragging in
+ * NestJS or TypeORM.
+ *
+ * Keep in sync with the agent-side enums — when a value is added there,
+ * add it here too. The agent's runtime enums are the source of truth;
+ * these are the wire-format mirror.
+ */
+
+export const KB_DOCUMENT_CLASSES = [
+	'brand',
+	'legal',
+	'seo',
+	'style',
+	'glossary',
+	'competitors',
+	'personas',
+	'research',
+	'output',
+	'freeform'
+] as const;
+
+export type KbDocumentClass = (typeof KB_DOCUMENT_CLASSES)[number];
+
+/**
+ * Classes that may be authored at the organization level and inherited
+ * (with Work-level override) by every Work in the org.
+ *
+ * v1: legal + style + seo only. Brand identity stays per-Work always.
+ */
+export const KB_ORG_INHERITABLE_CLASSES = ['legal', 'style', 'seo'] as const satisfies ReadonlyArray<KbDocumentClass>;
+
+export type KbInheritableClass = (typeof KB_ORG_INHERITABLE_CLASSES)[number];
+
+/**
+ * Lifecycle status of a KB document.
+ */
+export const KB_DOCUMENT_STATUSES = ['draft', 'active', 'archived'] as const;
+export type KbDocumentStatus = (typeof KB_DOCUMENT_STATUSES)[number];
+
+/**
+ * Lock mode for a KB document. `null` when unlocked.
+ */
+export const KB_LOCK_MODES = ['full', 'additions-only'] as const;
+export type KbLockMode = (typeof KB_LOCK_MODES)[number];
+
+/**
+ * Source attribution.
+ */
+export const KB_DOCUMENT_SOURCES = ['user', 'agent', 'imported', 'seeded'] as const;
+export type KbDocumentSource = (typeof KB_DOCUMENT_SOURCES)[number];
+
+/**
+ * Upload extraction lifecycle.
+ */
+export const KB_UPLOAD_EXTRACTION_STATUSES = ['pending', 'running', 'succeeded', 'failed', 'skipped'] as const;
+export type KbUploadExtractionStatus = (typeof KB_UPLOAD_EXTRACTION_STATUSES)[number];
+
+/**
+ * Polymorphic consumer of a KB citation row.
+ */
+export const KB_CITATION_CONSUMER_TYPES = [
+	'agent-run',
+	'generation-history',
+	'conversation-message',
+	'community-pr',
+	'comparison'
+] as const;
+export type KbCitationConsumerType = (typeof KB_CITATION_CONSUMER_TYPES)[number];
+
+/**
+ * Per-class org-level inheritance mode.
+ */
+export type KbInheritanceMode = 'inherit' | 'override' | 'disabled';

--- a/packages/contracts/src/kb/kb-document.types.ts
+++ b/packages/contracts/src/kb/kb-document.types.ts
@@ -1,0 +1,101 @@
+import type { KbDocumentClass, KbDocumentSource, KbDocumentStatus, KbLockMode } from './kb-document-class.js';
+
+/**
+ * Metadata-only DTO for a KB document.
+ *
+ * Returned by list endpoints + by mutation endpoints when the caller
+ * doesn't need the full Markdown body. Get-by-id returns
+ * `KbDocumentBodyDto` (this + `body` + `assets`).
+ */
+export interface KbDocumentDto {
+	id: string;
+	workId: string | null;
+	organizationId: string | null;
+	path: string;
+	slug: string;
+	title: string;
+	description: string | null;
+	class: KbDocumentClass;
+	tags: string[];
+	categories: string[];
+	status: KbDocumentStatus;
+	locked: boolean;
+	lockMode: KbLockMode | null;
+	language: string;
+	wordCount: number | null;
+	tokenCount: number | null;
+	source: KbDocumentSource;
+	sourceUploadId: string | null;
+	sourceUrl: string | null;
+	generatedByAgentRunId: string | null;
+	createdById: string | null;
+	updatedById: string | null;
+	createdAt: string;
+	updatedAt: string;
+	lastCommitSha: string | null;
+	lastIndexedAt: string | null;
+}
+
+/**
+ * Full document including Markdown body + linked asset summaries.
+ */
+export interface KbDocumentBodyDto extends KbDocumentDto {
+	body: string;
+	assets: KbAssetSummary[];
+}
+
+export interface KbAssetSummary {
+	path: string;
+	mimeType: string;
+	sizeBytes: number;
+}
+
+/**
+ * Input for creating a new KB document via the API.
+ */
+export interface CreateKbDocumentInput {
+	path: string;
+	title: string;
+	class: KbDocumentClass;
+	body: string;
+	description?: string | null;
+	tags?: string[];
+	categories?: string[];
+	language?: string;
+	status?: KbDocumentStatus;
+}
+
+/**
+ * Partial update.
+ */
+export interface UpdateKbDocumentInput {
+	title?: string;
+	description?: string | null;
+	body?: string;
+	tags?: string[];
+	categories?: string[];
+	language?: string;
+	status?: KbDocumentStatus;
+}
+
+/**
+ * Filter for `GET /api/works/:id/kb/documents`.
+ */
+export interface KbDocumentListFilter {
+	class?: KbDocumentClass | KbDocumentClass[];
+	status?: KbDocumentStatus | KbDocumentStatus[];
+	tag?: string | string[];
+	locked?: boolean;
+	language?: string;
+	source?: KbDocumentSource;
+	/** Lexical search across title + description + body via Postgres FTS. */
+	q?: string;
+	limit?: number;
+	cursor?: string;
+}
+
+export interface KbDocumentListResult {
+	items: KbDocumentDto[];
+	nextCursor: string | null;
+	total: number;
+}

--- a/packages/contracts/src/kb/kb-search.types.ts
+++ b/packages/contracts/src/kb/kb-search.types.ts
@@ -1,0 +1,17 @@
+import type { KbDocumentClass } from './kb-document-class.js';
+
+export interface KbSearchHit {
+	documentId: string;
+	path: string;
+	title: string;
+	class: KbDocumentClass;
+	snippet: string;
+	score: number;
+	chunkIndex?: number;
+	chunkRange?: { start: number; end: number };
+}
+
+export interface KbSearchResult {
+	hits: KbSearchHit[];
+	total: number;
+}

--- a/packages/contracts/src/kb/kb-tag.types.ts
+++ b/packages/contracts/src/kb/kb-tag.types.ts
@@ -1,0 +1,23 @@
+export interface KbTagDto {
+	id: string;
+	workId: string;
+	slug: string;
+	name: string;
+	color: string | null;
+	description: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface CreateKbTagInput {
+	slug: string;
+	name: string;
+	color?: string | null;
+	description?: string | null;
+}
+
+export interface UpdateKbTagInput {
+	name?: string;
+	color?: string | null;
+	description?: string | null;
+}

--- a/packages/contracts/src/kb/kb-tree.types.ts
+++ b/packages/contracts/src/kb/kb-tree.types.ts
@@ -1,0 +1,12 @@
+import type { KbDocumentClass, KbDocumentStatus } from './kb-document-class.js';
+
+export interface KbTreeNode {
+	type: 'folder' | 'document';
+	path: string;
+	name: string;
+	documentId?: string;
+	class?: KbDocumentClass;
+	status?: KbDocumentStatus;
+	locked?: boolean;
+	children?: KbTreeNode[];
+}

--- a/packages/contracts/src/kb/kb-upload.types.ts
+++ b/packages/contracts/src/kb/kb-upload.types.ts
@@ -1,0 +1,22 @@
+import type { KbUploadExtractionStatus } from './kb-document-class.js';
+
+export interface KbUploadDto {
+	id: string;
+	workId: string;
+	storageProvider: string;
+	storagePath: string;
+	originalFilename: string;
+	mimeType: string;
+	fileSize: number;
+	sha256: string;
+	normalizedFormat: string | null;
+	extractionStatus: KbUploadExtractionStatus;
+	extractionPluginId: string | null;
+	extractionError: string | null;
+	extractedDocumentId: string | null;
+	uploadedById: string | null;
+	tags: string[];
+	categories: string[];
+	createdAt: string;
+	updatedAt: string;
+}


### PR DESCRIPTION
Second slice of [EW-640](https://evertech.atlassian.net/browse/EW-640) — Phase 1A data model. Builds on the merged schema PR #905 by adding the contracts package types, agent-side repositories, the \`KnowledgeBaseService\` with full DB-side implementations, NestJS module wiring, and unit tests.

## What lands

**Contracts package** (\`packages/contracts/src/kb/\`):
- All Knowledge Base DTO interfaces — \`KbDocumentDto\`, \`KbDocumentBodyDto\`, \`KbUploadDto\`, \`KbTagDto\`, \`CitationDto\`, \`KbSearchHit\`, \`KbTreeNode\`.
- Shared enums + constants — \`KB_DOCUMENT_CLASSES\`, \`KB_ORG_INHERITABLE_CLASSES\` (legal/style/seo), statuses, lock modes, sources, extraction states, citation consumer types, inheritance modes.
- Barrel exports + integration into top-level contracts barrel.

**Agent repositories** (\`packages/agent/src/database/repositories/\`):
- \`WorkKnowledgeDocumentRepository\` — find by id / path / org-id, list with full filter set (class, status, tag, locked, language, source, lexical \`q\`, limit/offset), \`listInheritableForOrg\`, \`listWorkOverridesForClasses\`, \`pathExists\` (collision detection), \`setLock\`, \`findByWorkOrPath\` (id-vs-path heuristic).
- \`WorkKnowledgeUploadRepository\` — SHA-256 dedup lookup + list-by-status.
- \`WorkKnowledgeTagRepository\` — including \`upsertBySlug\` for create-on-first-use from autocomplete.
- \`WorkKnowledgeCitationRepository\` — append-only.

**Service** (\`packages/agent/src/services/knowledge-base.service.ts\`):
Full DB-side implementations for all Phase 1A operations:
- \`listDocuments\` / \`getDocument\` / \`createDocument\` / \`updateDocument\` / \`deleteDocument\`
- \`lockDocument\` / \`unlockDocument\` (manager+ role, enforced)
- \`createOrgDocument\` (restricted to legal/style/seo per spec D2)
- \`listOrgDocuments\` / \`resolveInheritableDocuments\` (merge org + Work with Work overriding by path)
- \`listTags\` / \`createTag\` / \`updateTag\` / \`deleteTag\`
- \`listCitationsForDocument\`
- Path-collision suffixing (\`brand/voice.md\` → \`brand/voice-2.md\` → \`brand/voice-3.md\`)
- Lock semantics: \`full\` lock blocks updates + deletes; \`additions-only\` permits the inserts that the spec describes for Phase 2 agent flows.
- Word/token counting on body changes.
- Tag auto-upsert on document create/update (so inline tag-create flows work without a separate API call).

**NestJS module** (\`knowledge-base.module.ts\`):
\`TypeOrmModule.forFeature\` for all 5 KB entities + repositories + service + WorkOwnershipService. Exports the service + repositories for downstream modules.

**Request/response DTOs** (\`packages/agent/src/dto/kb.dto.ts\`):
NestJS class-validator decorated DTOs ready to wire into the REST controller in the next PR. Body cap: 1 MB per spec D9.

**Tests** (\`__tests__/knowledge-base.service.spec.ts\`):
- List filter forwarding
- Get returns body / NotFoundException on missing
- Create derives slug, suffixes collisions, upserts tags, computes counts
- Update rejects full-locked docs, recomputes counts on body change
- Lock requires manager+ role; persists mode
- Org documents reject non-inheritable classes; accept legal/style/seo
- \`resolveInheritableDocuments\` merges org + Work with Work overriding by path
- \`restoreDocumentFromHistory\` throws (deferred to Phase 1B)

## What does NOT land in this PR

- REST endpoints in \`WorksController\` + org admin controller — **next PR**.
- Git mirroring of document bodies (two-layer sync) — Phase 1B.
- Backfill Trigger.dev job — depends on Storage plugin abstraction.
- Embedding generation + semantic retrieval — Phase 2.
- Org overlay materialization fanout job — Phase 2.

The body lives only in \`WorkKnowledgeDocument.metadata.body\` (JSON column) in this phase. The two-layer Git sync (writing sidecar \`.yml\` + \`.md\` to \`.content/kb/\`) lands in Phase 1B alongside the Storage plugin bridge. The DTO contract already returns \`body\` separately so this storage detail is hidden from API consumers and can change without breaking clients.

## Spec
\`docs/specs/features/knowledge-base/spec.md\` §6 (DB schema) + §10 (classification + inheritance) + §11 (tags) + §13 (lexical retrieval path) + §17 (agent integration).

## Test plan

- [ ] CI: \`pnpm lint\`, \`pnpm type-check\`, \`pnpm test\` green across monorepo.
- [ ] Agent package Jest run picks up the new spec file (\`pnpm --filter @ever-works/agent test\`).
- [ ] Contracts package tsup build succeeds with the new \`kb\` module.
- [ ] Reviewer verifies the path-collision suffix logic + the manager+ gate on lock/unlock.
- [ ] Reviewer verifies the inheritance merge order (Work overrides org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-640]: https://evertech.atlassian.net/browse/EW-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Base management system with document creation, editing, deletion, and organization.
  * Implemented document locking with multiple lock modes for access control.
  * Added tag system for organizing knowledge base documents.
  * Introduced organization-level inheritable documents with work-level overrides.
  * Enabled citation tracking to monitor document usage across the system.
  * Added filtering and querying capabilities for document discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->