### PR TITLE
fix(kb): import FacadesModule in KnowledgeBaseModule (EW-641 hotfix)

### DIFF
--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '../database/database.module';
+import { FacadesModule } from '../facades/facades.module';
 import {
     WorkKnowledgeChunk,
     WorkKnowledgeCitation,
@@ -25,10 +26,16 @@ import { WorkOwnershipService } from './work-ownership.service';
  * provide WorkOwnershipService via a parent module.
  *
  * EW-641 Phase 1B/a — `KnowledgeBaseGitMirrorService` is also exported.
- * It depends on `GitFacadeService`, which is provided by the API-side
- * `FacadesModule`. Importers that need the mirror service (the
- * Trigger.dev `kb-mirror-document` task) must ensure `FacadesModule` is
- * available in their dependency graph.
+ * It depends on `GitFacadeService`, which is provided by `FacadesModule`.
+ * The original Phase 1B/a docstring asked importers to add `FacadesModule`
+ * themselves; that didn't actually work because NestJS DI only walks a
+ * module's *own* `imports`, not its consumers' imports. Result: the API
+ * boot died with `UnknownDependenciesException: KnowledgeBaseGitMirrorService
+ * (?, WorkRepository, ...)` and develop E2E went red on `652d1a4d`.
+ *
+ * Fix: import `FacadesModule` directly. No circular dep — `FacadesModule`
+ * imports only `DatabaseModule + UsageModule + BudgetsModule`, none of
+ * which depend on KB.
  *
  * Entities registered:
  *  - WorkKnowledgeDocument
@@ -40,6 +47,7 @@ import { WorkOwnershipService } from './work-ownership.service';
 @Module({
     imports: [
         DatabaseModule,
+        FacadesModule,
         TypeOrmModule.forFeature([
             WorkKnowledgeDocument,
             WorkKnowledgeUpload,


### PR DESCRIPTION
## Summary

Hotfix for the `UnknownDependenciesException` that's been crashing the API on boot since PR #916 (EW-641 Phase 1B/a) merged. Develop E2E has been red on every commit since [`652d1a4d`](https://github.com/ever-works/ever-works/commit/652d1a4d) because of this — including the EW-644 merge that just landed.

The error in CI logs:

```
[Nest] ERROR [ExceptionHandler] UnknownDependenciesException: Nest can't resolve
dependencies of the KnowledgeBaseGitMirrorService (?, WorkRepository,
WorkKnowledgeDocumentRepository). Please make sure that the argument
GitFacadeService at index [0] is available in the KnowledgeBaseModule module.
```

The Phase 1B/a docstring asked importers to add `FacadesModule` themselves, but NestJS DI only walks a module's own `imports` — it doesn't inherit from consumers. So even though `WorkModule` and `TriggerInternalModule` both import `FacadesModule` *and* `KnowledgeBaseModule` at the same level, `KnowledgeBaseModule` still can't resolve `GitFacadeService` for its own providers.

## Fix

One-line: import `FacadesModule` directly into `KnowledgeBaseModule`.

No circular dep — `FacadesModule` only imports `DatabaseModule`, `UsageModule`, `BudgetsModule`. None of those reach into KB.

## Verified locally

- `pnpm build`: **58/58 turbo tasks green**.
- API boots cleanly:

```
[NestApplication] Nest application successfully started
```

(same env shape as CI: `DATABASE_TYPE=sqlite DATABASE_IN_MEMORY=true`)

## Develop E2E history

| Time (UTC) | SHA | Event | E2E |
| --- | --- | --- | --- |
| 17:30 | `0ec1924b` |  | ✅ green |
| 22:06 | `652d1a4d` | PR #916 KB merge | ❌ red ← bug introduced |
| 22:37 | `0065af1c` |  | ❌ red |
| 22:43 | `5a874d9f` | PR #910 EW-644 merge | ❌ red (same cause) |

## Test plan

- [x] Local `pnpm build` clean
- [x] Local API boot clean (no `UnknownDependenciesException`)
- [ ] CI green
- [ ] AI bot review clean
- [ ] Develop E2E green after merge

Refs: EW-641 (Phase 1B/a), EW-644 (the merge that surfaced this in the post-merge develop E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module dependency management to ensure proper initialization and resolution of knowledge base services without requiring additional configuration from consumers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->