### PR TITLE
feat(kb): XLSX + CSV/TSV upload extractors (EW-641 Phase 1B/c.3)

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base-buffer-extractor.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base-buffer-extractor.service.spec.ts
@@ -173,11 +173,123 @@ describe('KnowledgeBaseBufferExtractorService', () => {
         });
     });
 
+    describe('XLSX extraction', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const ExcelJS = require('exceljs');
+        const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+        async function buildXlsxBuffer(
+            sheets: Array<{ name: string; rows: unknown[][] }>,
+        ): Promise<Buffer> {
+            const wb = new ExcelJS.Workbook();
+            for (const { name, rows } of sheets) {
+                const ws = wb.addWorksheet(name);
+                for (const row of rows) {
+                    ws.addRow(row);
+                }
+            }
+            return (await wb.xlsx.writeBuffer()) as Buffer;
+        }
+
+        it('renders each sheet as a Markdown table under an h2 heading', async () => {
+            const buffer = await buildXlsxBuffer([
+                {
+                    name: 'People',
+                    rows: [
+                        ['Name', 'Role'],
+                        ['Alice', 'PM'],
+                        ['Bob', 'Eng'],
+                    ],
+                },
+                {
+                    name: 'Budgets',
+                    rows: [
+                        ['Quarter', 'Amount'],
+                        ['Q1', 1000],
+                        ['Q2', 2500],
+                    ],
+                },
+            ]);
+
+            const result = await service.extract(buffer, XLSX_MIME);
+
+            expect(result).not.toBeNull();
+            expect(result!.via).toBe('xlsx-exceljs');
+            expect(result!.markdown).toMatch(/^##\s+People/m);
+            expect(result!.markdown).toMatch(/\|\s+Name\s+\|\s+Role\s+\|/);
+            expect(result!.markdown).toMatch(/\|\s+Alice\s+\|\s+PM\s+\|/);
+            expect(result!.markdown).toMatch(/^##\s+Budgets/m);
+            expect(result!.markdown).toMatch(/\|\s+Q2\s+\|\s+2500\s+\|/);
+        });
+
+        it('escapes pipes and newlines in cell values', async () => {
+            const buffer = await buildXlsxBuffer([
+                {
+                    name: 'Tricky',
+                    rows: [['Col'], ['a|b'], ['line1\nline2']],
+                },
+            ]);
+
+            const result = await service.extract(buffer, XLSX_MIME);
+
+            expect(result!.markdown).toContain('a\\|b');
+            expect(result!.markdown).toContain('line1 line2');
+            expect(result!.markdown).not.toContain('line1\nline2');
+        });
+
+        it('emits an empty-sheet marker for sheets with no header row', async () => {
+            const buffer = await buildXlsxBuffer([{ name: 'Blank', rows: [] }]);
+            const result = await service.extract(buffer, XLSX_MIME);
+            expect(result!.markdown).toMatch(/## Blank[\s\S]*empty sheet/);
+        });
+
+        it('throws on a corrupt buffer with a clear label', async () => {
+            await expect(service.extract(Buffer.from('not-a-zip'), XLSX_MIME)).rejects.toThrow(
+                /KB XLSX extraction failed:/,
+            );
+        });
+    });
+
+    describe('CSV / TSV extraction', () => {
+        it('renders a CSV buffer as a Markdown table via papaparse', async () => {
+            const csv = 'name,role\nAlice,PM\nBob,Eng\n';
+            const result = await service.extract(Buffer.from(csv, 'utf-8'), 'text/csv');
+            expect(result).not.toBeNull();
+            expect(result!.via).toBe('csv-papaparse');
+            expect(result!.markdown).toMatch(/\|\s+name\s+\|\s+role\s+\|/);
+            expect(result!.markdown).toMatch(/\|\s+Alice\s+\|\s+PM\s+\|/);
+            expect(result!.markdown).toMatch(/\|\s+Bob\s+\|\s+Eng\s+\|/);
+        });
+
+        it('handles a TSV buffer with tab delimiter', async () => {
+            const tsv = 'name\trole\nAlice\tPM\nBob\tEng\n';
+            const result = await service.extract(
+                Buffer.from(tsv, 'utf-8'),
+                'text/tab-separated-values',
+            );
+            expect(result).not.toBeNull();
+            expect(result!.via).toBe('tsv-papaparse');
+            expect(result!.markdown).toMatch(/\|\s+Alice\s+\|\s+PM\s+\|/);
+        });
+
+        it('also accepts text/tsv alias', async () => {
+            const result = await service.extract(Buffer.from('a\tb\n1\t2\n', 'utf-8'), 'text/tsv');
+            expect(result?.via).toBe('tsv-papaparse');
+        });
+
+        it('throws on a CSV with no rows', async () => {
+            await expect(
+                service.extract(Buffer.from('\n\n\n', 'utf-8'), 'text/csv'),
+            ).rejects.toThrow(/KB delimited-text extraction produced no rows/);
+        });
+    });
+
     describe('unsupported MIME types', () => {
         it.each([
             // Legacy .doc binary format — mammoth doesn't support it.
             'application/msword',
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            // Legacy .xls binary format — exceljs only reads OOXML.
+            'application/vnd.ms-excel',
             'application/vnd.openxmlformats-officedocument.presentationml.presentation',
             'image/png',
             'video/mp4',
@@ -198,10 +310,19 @@ describe('KnowledgeBaseBufferExtractorService', () => {
                     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 ),
             ).toBe(true);
-            expect(service.supports('application/msword')).toBe(false);
             expect(
                 service.supports(
                     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                ),
+            ).toBe(true);
+            expect(service.supports('text/csv')).toBe(true);
+            expect(service.supports('text/tab-separated-values')).toBe(true);
+            expect(service.supports('text/tsv')).toBe(true);
+            expect(service.supports('application/msword')).toBe(false);
+            expect(service.supports('application/vnd.ms-excel')).toBe(false);
+            expect(
+                service.supports(
+                    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
                 ),
             ).toBe(false);
             expect(service.supports('image/png')).toBe(false);

--- a/packages/agent/src/services/knowledge-base-buffer-extractor.service.ts
+++ b/packages/agent/src/services/knowledge-base-buffer-extractor.service.ts
@@ -411,7 +411,10 @@ export class KnowledgeBaseBufferExtractorService {
             return value.toISOString();
         }
         if (typeof value === 'object') {
-            const obj = value as Record<string, unknown>;
+            // The exceljs union doesn't overlap with `Record<string, unknown>`
+            // structurally, so cast through `unknown` to satisfy the
+            // `--strict` compiler while keeping the runtime shape probe.
+            const obj = value as unknown as Record<string, unknown>;
             if (typeof obj.text === 'string') return obj.text;
             if (Array.isArray(obj.richText)) {
                 return obj.richText

--- a/packages/agent/src/services/knowledge-base-buffer-extractor.service.ts
+++ b/packages/agent/src/services/knowledge-base-buffer-extractor.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import TurndownService from 'turndown';
 import mammoth from 'mammoth';
+import * as ExcelJS from 'exceljs';
+import Papa from 'papaparse';
 // `pdf-parse`'s index.js runs a debug self-test against a bundled PDF
 // when imported as the default. Import the lib entry directly so we
 // avoid the side-effect — `pdf-parse/lib/pdf-parse.js` exposes the same
@@ -23,19 +25,24 @@ const pdfParse: (
  *
  * Spec: docs/specs/features/knowledge-base/spec.md §9.3 (extract phase).
  *
- * MIME routing as of EW-641 Phase 1B/c.2:
+ * MIME routing as of EW-641 Phase 1B/c.3:
  *  - text/markdown, text/x-markdown, application/x-markdown, text/plain →
  *    passthrough (utf-8 decode + truncation cap)
  *  - text/html, application/xhtml+xml → Turndown-based HTML → Markdown
  *  - application/pdf → `pdf-parse`, text wrapped as a fenced Markdown body
  *  - application/vnd.openxmlformats-officedocument.wordprocessingml.document
  *    (DOCX) → `mammoth.convertToHtml` → Turndown
+ *  - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (XLSX)
+ *    + XLSM → `exceljs`, each sheet rendered as a Markdown table with the
+ *    sheet name as an `## h2` heading
+ *  - text/csv → `papaparse`, rendered as a single Markdown table
+ *  - text/tab-separated-values + text/tsv → `papaparse` with `delimiter: '\t'`
  *  - everything else → `null` (caller marks `extractionStatus='skipped'`
  *    with a "no extractor route" reason)
  *
- * XLSX / CSV / PPTX / Notion arrive in follow-up commits — each needs
- * its own native Node library or extractor-plugin bridge. The routing
- * table below makes the additions one-line edits.
+ * PPTX / Notion arrive in follow-up commits — each needs its own native
+ * Node library or extractor-plugin bridge. The routing table below
+ * makes the additions one-line edits.
  */
 @Injectable()
 export class KnowledgeBaseBufferExtractorService {
@@ -68,6 +75,34 @@ export class KnowledgeBaseBufferExtractorService {
     private static readonly DOCX_MIMES = new Set([
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     ]);
+
+    /**
+     * Office spreadsheet OOXML — `.xlsx` and the macro-enabled `.xlsm`.
+     * Legacy `.xls` (application/vnd.ms-excel) is intentionally NOT
+     * included — exceljs does not read the legacy binary OLE format
+     * (BIFF8) and would error out. Operators with `.xls` files should
+     * convert + re-upload, same convention as legacy `.doc`.
+     */
+    private static readonly XLSX_MIMES = new Set([
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.ms-excel.sheet.macroenabled.12',
+    ]);
+
+    /**
+     * Comma- and tab-separated value files. `text/tsv` is non-standard
+     * but in the wild — match it for tolerance. Both go through
+     * papaparse; the TSV branch passes `delimiter: '\t'` explicitly.
+     */
+    private static readonly CSV_MIMES = new Set(['text/csv']);
+    private static readonly TSV_MIMES = new Set(['text/tab-separated-values', 'text/tsv']);
+
+    /**
+     * Row cap mirrors `items-generator`'s `PARSER_HARD_ROW_CAP` so
+     * Knowledge Base uploads don't have a different ceiling from item
+     * imports. Past this, the Markdown body would blow past the spec
+     * §22 1 MiB cap anyway.
+     */
+    private static readonly TABLE_ROW_CAP = 10_000;
 
     private readonly logger = new Logger(KnowledgeBaseBufferExtractorService.name);
     private readonly turndown: TurndownService;
@@ -125,6 +160,18 @@ export class KnowledgeBaseBufferExtractorService {
             return { markdown: await this.extractDocx(buffer), via: 'docx-mammoth' };
         }
 
+        if (KnowledgeBaseBufferExtractorService.XLSX_MIMES.has(normalized)) {
+            return { markdown: await this.extractXlsx(buffer), via: 'xlsx-exceljs' };
+        }
+
+        if (KnowledgeBaseBufferExtractorService.CSV_MIMES.has(normalized)) {
+            return { markdown: this.extractDelimitedText(buffer, ','), via: 'csv-papaparse' };
+        }
+
+        if (KnowledgeBaseBufferExtractorService.TSV_MIMES.has(normalized)) {
+            return { markdown: this.extractDelimitedText(buffer, '\t'), via: 'tsv-papaparse' };
+        }
+
         this.logger.debug(
             `KB buffer extractor: no route for ${mimeType} (normalized=${normalized})`,
         );
@@ -143,7 +190,10 @@ export class KnowledgeBaseBufferExtractorService {
             KnowledgeBaseBufferExtractorService.TEXT_PASSTHROUGH.has(normalized) ||
             KnowledgeBaseBufferExtractorService.HTML_MIMES.has(normalized) ||
             KnowledgeBaseBufferExtractorService.PDF_MIMES.has(normalized) ||
-            KnowledgeBaseBufferExtractorService.DOCX_MIMES.has(normalized)
+            KnowledgeBaseBufferExtractorService.DOCX_MIMES.has(normalized) ||
+            KnowledgeBaseBufferExtractorService.XLSX_MIMES.has(normalized) ||
+            KnowledgeBaseBufferExtractorService.CSV_MIMES.has(normalized) ||
+            KnowledgeBaseBufferExtractorService.TSV_MIMES.has(normalized)
         );
     }
 
@@ -222,6 +272,167 @@ export class KnowledgeBaseBufferExtractorService {
             throw new Error('KB DOCX extraction produced empty Markdown after Turndown pass');
         }
         return this.capInlineBody(markdown);
+    }
+
+    private async extractXlsx(buffer: Buffer): Promise<string> {
+        const workbook = new ExcelJS.Workbook();
+        try {
+            await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+        } catch (error) {
+            throw new Error(`KB XLSX extraction failed: ${(error as Error).message}`);
+        }
+        if (workbook.worksheets.length === 0) {
+            throw new Error('KB XLSX extraction found no worksheets');
+        }
+
+        const sections: string[] = [];
+        for (const sheet of workbook.worksheets) {
+            const sheetName = sheet.name?.trim() || `Sheet ${sheet.id}`;
+            const headerRow = sheet.getRow(1);
+            const headers: string[] = [];
+            headerRow.eachCell({ includeEmpty: false }, (cell) => {
+                headers.push(this.formatExcelCellValue(cell.value));
+            });
+            if (headers.length === 0) {
+                // Empty sheet — record the heading so the doc still
+                // reflects the workbook structure, then move on.
+                sections.push(`## ${sheetName}\n\n_(empty sheet)_`);
+                continue;
+            }
+
+            const rowCount = Math.min(
+                Math.max(sheet.rowCount - 1, 0),
+                KnowledgeBaseBufferExtractorService.TABLE_ROW_CAP,
+            );
+            const rows: string[][] = [];
+            for (let r = 0; r < rowCount; r += 1) {
+                const row = sheet.getRow(r + 2);
+                if (!row || row.cellCount === 0) {
+                    continue;
+                }
+                const cells: string[] = [];
+                let nonEmpty = false;
+                for (let c = 0; c < headers.length; c += 1) {
+                    const value = this.formatExcelCellValue(row.getCell(c + 1).value);
+                    if (value.length > 0) {
+                        nonEmpty = true;
+                    }
+                    cells.push(value);
+                }
+                if (nonEmpty) {
+                    rows.push(cells);
+                }
+            }
+
+            const truncationNote =
+                sheet.rowCount - 1 > KnowledgeBaseBufferExtractorService.TABLE_ROW_CAP
+                    ? `\n\n_(truncated at ${KnowledgeBaseBufferExtractorService.TABLE_ROW_CAP} of ${sheet.rowCount - 1} rows)_`
+                    : '';
+
+            sections.push(
+                `## ${sheetName}\n\n${this.renderMarkdownTable(headers, rows)}${truncationNote}`,
+            );
+        }
+
+        const markdown = sections.join('\n\n').trim();
+        if (!markdown) {
+            throw new Error('KB XLSX extraction produced empty Markdown');
+        }
+        return this.capInlineBody(markdown);
+    }
+
+    private extractDelimitedText(buffer: Buffer, delimiter: ',' | '\t'): string {
+        const text = this.decodeText(buffer);
+        let parsed: Papa.ParseResult<string[]>;
+        try {
+            parsed = Papa.parse<string[]>(text, {
+                delimiter,
+                skipEmptyLines: 'greedy',
+            });
+        } catch (error) {
+            throw new Error(`KB delimited-text extraction failed: ${(error as Error).message}`);
+        }
+        // Papaparse surfaces non-fatal parse errors on every malformed
+        // quote; tolerate them (data still makes it through) but fail
+        // fast on a totally empty result.
+        const rows = parsed.data.filter((r) => Array.isArray(r) && r.some((c) => c?.length > 0));
+        if (rows.length === 0) {
+            throw new Error('KB delimited-text extraction produced no rows');
+        }
+
+        const [header, ...body] = rows;
+        const truncated = body.slice(0, KnowledgeBaseBufferExtractorService.TABLE_ROW_CAP);
+        const truncationNote =
+            body.length > KnowledgeBaseBufferExtractorService.TABLE_ROW_CAP
+                ? `\n\n_(truncated at ${KnowledgeBaseBufferExtractorService.TABLE_ROW_CAP} of ${body.length} rows)_`
+                : '';
+
+        const markdown = `${this.renderMarkdownTable(header, truncated)}${truncationNote}`;
+        return this.capInlineBody(markdown);
+    }
+
+    /**
+     * Render a header row + N body rows as a GitHub-flavored Markdown
+     * table. Pipes and newlines in cells are escaped so the table
+     * structure stays intact.
+     */
+    private renderMarkdownTable(headers: string[], rows: string[][]): string {
+        const safeHeaders = headers.map((h) => this.escapeTableCell(h));
+        const lines: string[] = [];
+        lines.push(`| ${safeHeaders.join(' | ')} |`);
+        lines.push(`| ${safeHeaders.map(() => '---').join(' | ')} |`);
+        for (const row of rows) {
+            const cells = safeHeaders.map((_, i) => this.escapeTableCell(row[i] ?? ''));
+            lines.push(`| ${cells.join(' | ')} |`);
+        }
+        return lines.join('\n');
+    }
+
+    private escapeTableCell(value: string): string {
+        return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|').trim();
+    }
+
+    /**
+     * exceljs cell values are a union including string, number, boolean,
+     * Date, formula objects (`{ formula, result }`), rich-text objects
+     * (`{ richText: [...] }`), and hyperlinks (`{ text, hyperlink }`).
+     * Reduce everything to a plain string so the Markdown table renders
+     * predictably. Mirrors the spirit of `unwrapExcelCell` from
+     * items-generator but is local + Markdown-friendly.
+     */
+    private formatExcelCellValue(value: ExcelJS.CellValue): string {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+            return String(value);
+        }
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+        if (typeof value === 'object') {
+            const obj = value as Record<string, unknown>;
+            if (typeof obj.text === 'string') return obj.text;
+            if (Array.isArray(obj.richText)) {
+                return obj.richText
+                    .map((seg) =>
+                        seg && typeof seg === 'object' && 'text' in seg
+                            ? String((seg as { text: unknown }).text ?? '')
+                            : '',
+                    )
+                    .join('');
+            }
+            if ('result' in obj) {
+                const r = obj.result;
+                if (r === null || r === undefined) return '';
+                if (typeof r === 'object') return JSON.stringify(r);
+                return String(r);
+            }
+            if (typeof obj.hyperlink === 'string' && typeof obj.text === 'string') {
+                return `[${obj.text}](${obj.hyperlink})`;
+            }
+        }
+        return String(value);
     }
 
     /**


### PR DESCRIPTION
## Summary

Three more MIME routes on top of [#920](https://github.com/ever-works/ever-works/pull/920)'s PDF+DOCX. Same in-process buffer pattern. **No new deps** — both libs already in `packages/agent`.

| Route | Library | Output |
| --- | --- | --- |
| OOXML XLSX + macro-enabled XLSM | `exceljs` (already in agent) | One `## sheet name` + Markdown table per sheet |
| `text/csv` | `papaparse` (already in agent) | Single Markdown table |
| `text/tab-separated-values` + `text/tsv` | `papaparse` w/ `delimiter: '\t'` | Single Markdown table |
| Legacy `.xls` (`application/vnd.ms-excel`) | — | Intentionally skipped (exceljs doesn't read BIFF8) |
| PPTX | — | Next follow-up commit (separate dep: `jszip`) |

JIRA: [EW-641](https://evertech.atlassian.net/browse/EW-641)
Spec: [`docs/specs/features/knowledge-base/spec.md`](https://github.com/ever-works/ever-works/blob/develop/docs/specs/features/knowledge-base/spec.md) §9.3

## What's in here

### `KnowledgeBaseBufferExtractorService` changes

- New `XLSX_MIMES`, `CSV_MIMES`, `TSV_MIMES` Sets.
- `TABLE_ROW_CAP = 10_000` mirrors items-generator's `PARSER_HARD_ROW_CAP` so KB uploads share the same ceiling.
- `extractXlsx`: iterates worksheets, each becomes `## <name>` + a GFM Markdown table. Empty sheets render `_(empty sheet)_` so the workbook structure is preserved. Per-sheet truncation note when row count exceeds the cap.
- `extractDelimitedText`: shared CSV+TSV path; delimiter chosen from MIME.
- `renderMarkdownTable` + `escapeTableCell` handle pipes (`\|`) and newlines (collapsed to single space) so cells don't break the table.
- `formatExcelCellValue` reduces the exceljs `CellValue` union (string, number, boolean, Date, rich-text, formula `{ result }`, hyperlink `{ text, hyperlink }`) to a single Markdown-friendly string. Inline analog of items-generator's `unwrapExcelCell`.

### Tests

- **XLSX** uses a real exceljs round-trip (build a workbook in-memory, write to buffer, feed through `extract()` and assert the Markdown shape) — no mock. Covers multi-sheet rendering, pipe/newline escaping, empty-sheet marker, corrupt-buffer error path.
- **CSV** — header + 2 rows → 3-row Markdown table.
- **TSV** — tab delimiter + the `text/tsv` alias.
- Empty CSV → throws \"no rows\".
- Unsupported MIMEs updated: legacy `.xls` + PPTX still skipped.
- `supports()` now true for XLSX / CSV / TSV / `text/tsv`; still false for legacy `.doc`, `.xls`, PPTX, image, video.

## What's NOT in here

- **PPTX** — needs `jszip` + manual slide-XML traversal. Next tick.
- **Legacy `.xls` / `.doc`** — operators convert + re-upload.
- **OCR for images** — Phase 3.

## Test plan

- [ ] CI: lint / type-check / agent Jest all green.
- [ ] Manual: `curl -F file=@data.xlsx /api/works/<id>/kb/uploads` → KB doc with `## Sheet1` + table body, activity-log `extractedVia: 'xlsx-exceljs'`.
- [ ] Manual: `curl -F file=@data.csv -F file.type=text/csv ...` → KB doc with single table body, `extractedVia: 'csv-papaparse'`.
- [ ] Manual: upload a legacy `.xls` → upload row in `extractionStatus='skipped'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-641]: https://evertech.atlassian.net/browse/EW-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-buffer extraction for XLSX and CSV/TSV files in knowledge base ingestion
  * Spreadsheet and delimited-text content now render as per-sheet Markdown tables, with cell escaping and newline handling
  * Emits an “empty sheet” section for sheets without rows and appends a truncation note when tables exceed the row cap

* **Tests**
  * Expanded unit tests covering XLSX, CSV, and TSV extraction paths and error cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->