### PR TITLE
feat(kb): PPTX upload extractor (EW-641 Phase 1B/c.4)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -221,6 +221,7 @@
         "date-fns": "^4.1.0",
         "exceljs": "^4.4.0",
         "github-slugger": "^2.0.0",
+        "jszip": "^3.10.1",
         "lodash": "^4.18.1",
         "mammoth": "^1.8.0",
         "p-map": "^7.0.4",

--- a/packages/agent/src/services/__tests__/knowledge-base-buffer-extractor.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base-buffer-extractor.service.spec.ts
@@ -16,12 +16,14 @@ const mammothMock = require('mammoth') as {
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 
 /**
- * EW-641 Phase 1B/c.2 — covers the per-MIME routing decisions taken by
- * `KnowledgeBaseBufferExtractorService` including the HTML / PDF / DOCX
- * routes. XLSX / CSV / PPTX / Notion routes arrive in follow-up commits.
+ * EW-641 Phase 1B/c — covers the per-MIME routing decisions taken by
+ * `KnowledgeBaseBufferExtractorService` including HTML / PDF / DOCX /
+ * XLSX / CSV / TSV / PPTX routes. Notion + URL routes arrive later.
  *
  * PDF + DOCX rely on third-party libs (`pdf-parse`, `mammoth`) — those
  * are mocked at module level so the unit test stays hermetic + fast.
+ * XLSX + PPTX use the real `exceljs` / `jszip` libs to build fixtures
+ * in-memory; both are pure Node and have no I/O side effects.
  */
 describe('KnowledgeBaseBufferExtractorService', () => {
     let service: KnowledgeBaseBufferExtractorService;
@@ -284,13 +286,117 @@ describe('KnowledgeBaseBufferExtractorService', () => {
         });
     });
 
+    describe('PPTX extraction', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const JSZip = require('jszip');
+        const PPTX_MIME =
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+        function slideXml(...phrases: string[]): string {
+            const paragraphs = phrases
+                .map(
+                    (p) =>
+                        `<a:p><a:r><a:t>${p
+                            .replace(/&/g, '&amp;')
+                            .replace(/</g, '&lt;')
+                            .replace(/>/g, '&gt;')}</a:t></a:r></a:p>`,
+                )
+                .join('');
+            return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree>${paragraphs}</p:spTree></p:cSld></p:sld>`;
+        }
+
+        async function buildPptxBuffer(
+            slides: Array<{ index: number; text: string[] }>,
+            extraEntries: Record<string, string> = {},
+        ): Promise<Buffer> {
+            const zip = new JSZip();
+            for (const { index, text } of slides) {
+                zip.file(`ppt/slides/slide${index}.xml`, slideXml(...text));
+            }
+            for (const [path, body] of Object.entries(extraEntries)) {
+                zip.file(path, body);
+            }
+            return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+        }
+
+        it('extracts text from each slide and labels them in numeric order', async () => {
+            const buffer = await buildPptxBuffer(
+                [
+                    // Intentionally out of order — extractor must sort numerically.
+                    { index: 2, text: ['Second deck title', 'with subtitle'] },
+                    { index: 1, text: ['Welcome to the deck'] },
+                ],
+                {
+                    // Non-slide entries should be ignored.
+                    'ppt/presentation.xml': '<?xml version="1.0"?><p:presentation/>',
+                    '[Content_Types].xml': '<?xml version="1.0"?><Types/>',
+                },
+            );
+
+            const result = await service.extract(buffer, PPTX_MIME);
+
+            expect(result).not.toBeNull();
+            expect(result!.via).toBe('pptx-jszip');
+            expect(result!.markdown).toMatch(/^##\s+Slide 1/m);
+            expect(result!.markdown).toContain('Welcome to the deck');
+            expect(result!.markdown).toMatch(/^##\s+Slide 2/m);
+            expect(result!.markdown).toContain('Second deck title with subtitle');
+            // Slide 1 heading must come before Slide 2 heading (ordering check).
+            const idx1 = result!.markdown.indexOf('## Slide 1');
+            const idx2 = result!.markdown.indexOf('## Slide 2');
+            expect(idx1).toBeGreaterThanOrEqual(0);
+            expect(idx2).toBeGreaterThan(idx1);
+        });
+
+        it('decodes XML entities back to literal characters', async () => {
+            const buffer = await buildPptxBuffer([
+                { index: 1, text: ['Smith & Jones <Co>', 'price > 100'] },
+            ]);
+            const result = await service.extract(buffer, PPTX_MIME);
+            expect(result!.markdown).toContain('Smith & Jones <Co>');
+            expect(result!.markdown).toContain('price > 100');
+            expect(result!.markdown).not.toContain('&amp;');
+            expect(result!.markdown).not.toContain('&lt;');
+        });
+
+        it('emits a `(no text)` marker for slides without `<a:t>` nodes', async () => {
+            const zip = new JSZip();
+            // Slide with no <a:t> — e.g. an image-only slide.
+            zip.file(
+                'ppt/slides/slide1.xml',
+                '<?xml version="1.0"?><p:sld><p:cSld><p:spTree></p:spTree></p:cSld></p:sld>',
+            );
+            const buffer = (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+
+            const result = await service.extract(buffer, PPTX_MIME);
+            expect(result!.markdown).toMatch(/## Slide 1[\s\S]*\(no text\)/);
+        });
+
+        it('throws when the deck contains no slides', async () => {
+            const zip = new JSZip();
+            zip.file('ppt/presentation.xml', '<?xml version="1.0"?><p:presentation/>');
+            const buffer = (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+
+            await expect(service.extract(buffer, PPTX_MIME)).rejects.toThrow(
+                /KB PPTX extraction found no slides/,
+            );
+        });
+
+        it('throws on a corrupt buffer with a clear label', async () => {
+            await expect(service.extract(Buffer.from('not-a-zip-file'), PPTX_MIME)).rejects.toThrow(
+                /KB PPTX extraction failed:/,
+            );
+        });
+    });
+
     describe('unsupported MIME types', () => {
         it.each([
             // Legacy .doc binary format — mammoth doesn't support it.
             'application/msword',
             // Legacy .xls binary format — exceljs only reads OOXML.
             'application/vnd.ms-excel',
-            'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            // Legacy .ppt binary format — jszip can't read OLE/BIFF.
+            'application/vnd.ms-powerpoint',
             'image/png',
             'video/mp4',
             'application/octet-stream',
@@ -318,13 +424,14 @@ describe('KnowledgeBaseBufferExtractorService', () => {
             expect(service.supports('text/csv')).toBe(true);
             expect(service.supports('text/tab-separated-values')).toBe(true);
             expect(service.supports('text/tsv')).toBe(true);
-            expect(service.supports('application/msword')).toBe(false);
-            expect(service.supports('application/vnd.ms-excel')).toBe(false);
             expect(
                 service.supports(
                     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
                 ),
-            ).toBe(false);
+            ).toBe(true);
+            expect(service.supports('application/msword')).toBe(false);
+            expect(service.supports('application/vnd.ms-excel')).toBe(false);
+            expect(service.supports('application/vnd.ms-powerpoint')).toBe(false);
             expect(service.supports('image/png')).toBe(false);
         });
     });

--- a/packages/agent/src/services/knowledge-base-buffer-extractor.service.ts
+++ b/packages/agent/src/services/knowledge-base-buffer-extractor.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import TurndownService from 'turndown';
 import mammoth from 'mammoth';
 import * as ExcelJS from 'exceljs';
+import JSZip from 'jszip';
 import Papa from 'papaparse';
 // `pdf-parse`'s index.js runs a debug self-test against a bundled PDF
 // when imported as the default. Import the lib entry directly so we
@@ -25,7 +26,7 @@ const pdfParse: (
  *
  * Spec: docs/specs/features/knowledge-base/spec.md §9.3 (extract phase).
  *
- * MIME routing as of EW-641 Phase 1B/c.3:
+ * MIME routing as of EW-641 Phase 1B/c.4:
  *  - text/markdown, text/x-markdown, application/x-markdown, text/plain →
  *    passthrough (utf-8 decode + truncation cap)
  *  - text/html, application/xhtml+xml → Turndown-based HTML → Markdown
@@ -37,12 +38,15 @@ const pdfParse: (
  *    sheet name as an `## h2` heading
  *  - text/csv → `papaparse`, rendered as a single Markdown table
  *  - text/tab-separated-values + text/tsv → `papaparse` with `delimiter: '\t'`
+ *  - application/vnd.openxmlformats-officedocument.presentationml.presentation
+ *    (PPTX) → `jszip` unpack → regex-extract `<a:t>` text per slide →
+ *    one `## Slide N` section per slide
  *  - everything else → `null` (caller marks `extractionStatus='skipped'`
  *    with a "no extractor route" reason)
  *
- * PPTX / Notion arrive in follow-up commits — each needs its own native
- * Node library or extractor-plugin bridge. The routing table below
- * makes the additions one-line edits.
+ * Notion + URL ingestion arrive in follow-up commits — each needs its
+ * own native Node library or extractor-plugin bridge. The routing
+ * table below makes the additions one-line edits.
  */
 @Injectable()
 export class KnowledgeBaseBufferExtractorService {
@@ -95,6 +99,28 @@ export class KnowledgeBaseBufferExtractorService {
      */
     private static readonly CSV_MIMES = new Set(['text/csv']);
     private static readonly TSV_MIMES = new Set(['text/tab-separated-values', 'text/tsv']);
+
+    /**
+     * PowerPoint OOXML format (`.pptx`). Legacy `.ppt` (BIFF binary,
+     * `application/vnd.ms-powerpoint`) is intentionally excluded —
+     * jszip can't read it, same convention as legacy `.doc`/`.xls`.
+     */
+    private static readonly PPTX_MIMES = new Set([
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ]);
+
+    /** Slide XML file path regex inside a PPTX zip. */
+    private static readonly PPTX_SLIDE_PATH_RE = /^ppt\/slides\/slide(\d+)\.xml$/;
+
+    /** Regex to extract `<a:t>...</a:t>` text nodes from slide XML. */
+    private static readonly PPTX_TEXT_RE = /<a:t[^>]*>([^<]*)<\/a:t>/g;
+
+    /**
+     * Cap on slides processed per PPTX. Same spirit as `TABLE_ROW_CAP`
+     * for spreadsheets: keep the resulting Markdown body under the
+     * spec §22 1 MiB ceiling even for very large decks.
+     */
+    private static readonly PPTX_SLIDE_CAP = 1_000;
 
     /**
      * Row cap mirrors `items-generator`'s `PARSER_HARD_ROW_CAP` so
@@ -172,6 +198,10 @@ export class KnowledgeBaseBufferExtractorService {
             return { markdown: this.extractDelimitedText(buffer, '\t'), via: 'tsv-papaparse' };
         }
 
+        if (KnowledgeBaseBufferExtractorService.PPTX_MIMES.has(normalized)) {
+            return { markdown: await this.extractPptx(buffer), via: 'pptx-jszip' };
+        }
+
         this.logger.debug(
             `KB buffer extractor: no route for ${mimeType} (normalized=${normalized})`,
         );
@@ -193,7 +223,8 @@ export class KnowledgeBaseBufferExtractorService {
             KnowledgeBaseBufferExtractorService.DOCX_MIMES.has(normalized) ||
             KnowledgeBaseBufferExtractorService.XLSX_MIMES.has(normalized) ||
             KnowledgeBaseBufferExtractorService.CSV_MIMES.has(normalized) ||
-            KnowledgeBaseBufferExtractorService.TSV_MIMES.has(normalized)
+            KnowledgeBaseBufferExtractorService.TSV_MIMES.has(normalized) ||
+            KnowledgeBaseBufferExtractorService.PPTX_MIMES.has(normalized)
         );
     }
 
@@ -369,6 +400,94 @@ export class KnowledgeBaseBufferExtractorService {
 
         const markdown = `${this.renderMarkdownTable(header, truncated)}${truncationNote}`;
         return this.capInlineBody(markdown);
+    }
+
+    /**
+     * Extract slide text from a `.pptx` deck.
+     *
+     * PPTX files are zipped OOXML: each slide lives at
+     * `ppt/slides/slideN.xml`, with the visible text inside `<a:t>`
+     * elements (the `a:` prefix is the DrawingML namespace). We avoid
+     * pulling in an XML parser dependency — a regex over `<a:t>...</a:t>`
+     * is sufficient because the contents are XML-escaped plain text by
+     * design (no nested tags). HTML entities (`&amp;`, `&lt;`, etc.)
+     * are decoded back so the resulting Markdown reads naturally.
+     */
+    private async extractPptx(buffer: Buffer): Promise<string> {
+        let zip: JSZip;
+        try {
+            zip = await JSZip.loadAsync(buffer);
+        } catch (error) {
+            throw new Error(`KB PPTX extraction failed: ${(error as Error).message}`);
+        }
+
+        // Collect slide entries with their numeric index for stable ordering.
+        const slides: Array<{ index: number; entry: JSZip.JSZipObject }> = [];
+        zip.forEach((path, entry) => {
+            if (entry.dir) {
+                return;
+            }
+            const match = KnowledgeBaseBufferExtractorService.PPTX_SLIDE_PATH_RE.exec(path);
+            if (match) {
+                slides.push({ index: Number(match[1]), entry });
+            }
+        });
+
+        if (slides.length === 0) {
+            throw new Error('KB PPTX extraction found no slides');
+        }
+
+        slides.sort((a, b) => a.index - b.index);
+        const capped = slides.slice(0, KnowledgeBaseBufferExtractorService.PPTX_SLIDE_CAP);
+
+        const sections: string[] = [];
+        for (const { index, entry } of capped) {
+            let xml: string;
+            try {
+                xml = await entry.async('string');
+            } catch (error) {
+                throw new Error(`KB PPTX slide ${index} read failed: ${(error as Error).message}`);
+            }
+            const texts: string[] = [];
+            // Reset lastIndex on the shared static regex before each use —
+            // /g regexes preserve state across calls and would skip matches
+            // otherwise.
+            KnowledgeBaseBufferExtractorService.PPTX_TEXT_RE.lastIndex = 0;
+            let m: RegExpExecArray | null;
+            while ((m = KnowledgeBaseBufferExtractorService.PPTX_TEXT_RE.exec(xml)) !== null) {
+                const decoded = this.decodeXmlEntities(m[1]);
+                if (decoded.length > 0) {
+                    texts.push(decoded);
+                }
+            }
+            const body = texts.join(' ').trim();
+            sections.push(`## Slide ${index}\n\n${body || '_(no text)_'}`);
+        }
+
+        const truncationNote =
+            slides.length > KnowledgeBaseBufferExtractorService.PPTX_SLIDE_CAP
+                ? `\n\n_(truncated at ${KnowledgeBaseBufferExtractorService.PPTX_SLIDE_CAP} of ${slides.length} slides)_`
+                : '';
+
+        const markdown = `${sections.join('\n\n')}${truncationNote}`.trim();
+        if (!markdown) {
+            throw new Error('KB PPTX extraction produced empty Markdown');
+        }
+        return this.capInlineBody(markdown);
+    }
+
+    /**
+     * Decode the five XML predefined entities. PPTX slide XML only uses
+     * these — the file format does not permit arbitrary HTML entities —
+     * so a tiny lookup beats pulling in an entity-decoder dependency.
+     */
+    private decodeXmlEntities(value: string): string {
+        return value
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&apos;/g, "'")
+            .replace(/&amp;/g, '&');
     }
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,6 +792,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lodash:
         specifier: ^4.18.1
         version: 4.18.1


### PR DESCRIPTION
## Summary
- Routes `application/vnd.openxmlformats-officedocument.presentationml.presentation` uploads through `KnowledgeBaseBufferExtractorService`, unpacking the deck with `jszip` and emitting one `## Slide N` Markdown section per slide.
- Slide text is extracted via a regex over `<a:t>…</a:t>` nodes — `.pptx` is OOXML so contents are XML-escaped plain text by design; the five XML predefined entities are decoded back. No XML parser dependency.
- Slides are sorted numerically (so `slide10.xml` doesn't come before `slide2.xml`), capped at 1 000 slides with a truncation note, and the final body honours the same 1 MiB inline cap used by every other extractor route.
- Empty decks throw `KB PPTX extraction found no slides`; corrupt zips throw `KB PPTX extraction failed: …` — matches the label convention used by the PDF/DOCX/XLSX routes.
- Legacy `.ppt` (OLE/BIFF binary, `application/vnd.ms-powerpoint`) stays intentionally unsupported. Same convention we already use for `.doc` (mammoth-only OOXML) and `.xls` (exceljs-only OOXML): operators convert + re-upload.

## Test plan
- [x] `cd packages/agent && npx jest --testPathPattern=knowledge-base-buffer-extractor` → 37 passed (5 new PPTX cases: multi-slide ordering, XML entity decoding, image-only slide marker, empty-deck throws, corrupt-zip throws)
- [x] `npx tsc --noEmit -p tsconfig.json` (agent package) → clean
- [x] `npx prettier --write` on touched files
- [ ] CI green on this PR

## Spec
- `docs/specs/features/knowledge-base/spec.md` §9.3 (extract phase)
- EW-641 Phase 1B/c.4 — follow-up to #918 (HTML), #920 (PDF/DOCX), #921 (XLSX/CSV/TSV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting text from PowerPoint (.pptx) files.

* **Tests**
  * Added comprehensive test coverage for PowerPoint extraction.

* **Chores**
  * Added jszip dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->