### PR TITLE
feat(kb): Knowledge Base page shell + tab (EW-641 Phase 1B/d row 2)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1145,7 +1145,8 @@
                 "plugins": "إضافات",
                 "deploy": "نشر",
                 "members": "الأعضاء",
-                "settings": "الإعدادات"
+                "settings": "الإعدادات",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "أعضاء الفريق",
@@ -2605,6 +2606,24 @@
                     "dnsName": "الاسم:",
                     "dnsValue": "القيمة:",
                     "copyButton": "نسخ"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1145,7 +1145,8 @@
                 "plugins": "Плъгини",
                 "deploy": "Разполагане",
                 "members": "Членове",
-                "settings": "Настройки"
+                "settings": "Настройки",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Членове на екипа",
@@ -2605,6 +2606,24 @@
                     "dnsName": "Име:",
                     "dnsValue": "Стойност:",
                     "copyButton": "Копирай"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1145,7 +1145,8 @@
                 "plugins": "Plugins",
                 "deploy": "Bereitstellen",
                 "members": "Mitglieder",
-                "settings": "Einstellungen"
+                "settings": "Einstellungen",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Teammitglieder",
@@ -2605,6 +2606,24 @@
                     "dnsName": "Name:",
                     "dnsValue": "Wert:",
                     "copyButton": "Kopieren"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1173,7 +1173,8 @@
                 "plugins": "Plugins",
                 "deploy": "Deploy",
                 "members": "Members",
-                "settings": "Settings"
+                "settings": "Settings",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Team Members",
@@ -2633,6 +2634,24 @@
                     "dnsName": "Name:",
                     "dnsValue": "Value:",
                     "copyButton": "Copy"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1145,7 +1145,8 @@
                 "plugins": "Complementos",
                 "deploy": "Implementar",
                 "members": "Miembros",
-                "settings": "Configuración"
+                "settings": "Configuración",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Miembros del equipo",
@@ -2605,6 +2606,24 @@
                     "dnsName": "Nombre:",
                     "dnsValue": "Valor:",
                     "copyButton": "Copiar"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1172,7 +1172,8 @@
                 "plugins": "Extensions",
                 "deploy": "Déploiement",
                 "members": "Membres",
-                "settings": "Paramètres"
+                "settings": "Paramètres",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Membres de l'équipe",
@@ -2632,6 +2633,24 @@
                     "dnsName": "Nom :",
                     "dnsValue": "Valeur :",
                     "copyButton": "Copier"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1145,7 +1145,8 @@
                 "plugins": "תוספים",
                 "deploy": "פריסה",
                 "members": "חברים",
-                "settings": "הגדרות"
+                "settings": "הגדרות",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "חברי צוות",
@@ -2605,6 +2606,24 @@
                     "dnsName": "שם:",
                     "dnsValue": "ערך:",
                     "copyButton": "העתק"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1018,7 +1018,8 @@
                 "plugins": "प्लगइन्स",
                 "deploy": "तैनाती",
                 "members": "सदस्य",
-                "settings": "सेटिंग्स"
+                "settings": "सेटिंग्स",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "टीम सदस्य",
@@ -2388,6 +2389,24 @@
                     "dnsName": "नाम:",
                     "dnsValue": "मान:",
                     "copyButton": "कॉपी करें"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Plugin",
                 "deploy": "Penerapan",
                 "members": "Anggota",
-                "settings": "Pengaturan"
+                "settings": "Pengaturan",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Anggota Tim",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Nama:",
                     "dnsValue": "Nilai:",
                     "copyButton": "Salin"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Plugin",
                 "deploy": "Distribuzione",
                 "members": "Membri",
-                "settings": "Impostazioni"
+                "settings": "Impostazioni",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Membri del team",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Nome:",
                     "dnsValue": "Valore:",
                     "copyButton": "Copia"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1018,7 +1018,8 @@
                 "plugins": "プラグイン",
                 "deploy": "デプロイ",
                 "members": "メンバー",
-                "settings": "設定"
+                "settings": "設定",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "チームメンバー",
@@ -2388,6 +2389,24 @@
                     "dnsName": "名前：",
                     "dnsValue": "値：",
                     "copyButton": "コピー"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1018,7 +1018,8 @@
                 "plugins": "플러그인",
                 "deploy": "배포",
                 "members": "멤버",
-                "settings": "설정"
+                "settings": "설정",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "팀 멤버",
@@ -2388,6 +2389,24 @@
                     "dnsName": "이름:",
                     "dnsValue": "값:",
                     "copyButton": "복사"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Plug-ins",
                 "deploy": "Deployen",
                 "members": "Leden",
-                "settings": "Instellingen"
+                "settings": "Instellingen",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Teamleden",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Naam:",
                     "dnsValue": "Waarde:",
                     "copyButton": "Kopiëren"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Wtyczki",
                 "deploy": "Wdrożenie",
                 "members": "Członkowie",
-                "settings": "Ustawienia"
+                "settings": "Ustawienia",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Członkowie zespołu",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Nazwa:",
                     "dnsValue": "Wartość:",
                     "copyButton": "Kopiuj"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Plugins",
                 "deploy": "Implantar",
                 "members": "Membros",
-                "settings": "Configurações"
+                "settings": "Configurações",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Membros da Equipe",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Nome:",
                     "dnsValue": "Valor:",
                     "copyButton": "Copiar"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Плагины",
                 "deploy": "Развертывание",
                 "members": "Участники",
-                "settings": "Настройки"
+                "settings": "Настройки",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Участники команды",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Имя:",
                     "dnsValue": "Значение:",
                     "copyButton": "Копировать"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1018,7 +1018,8 @@
                 "plugins": "ส่วนเสริม",
                 "deploy": "เผยแพร่",
                 "members": "สมาชิก",
-                "settings": "การตั้งค่า"
+                "settings": "การตั้งค่า",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "สมาชิกทีม",
@@ -2388,6 +2389,24 @@
                     "dnsName": "ชื่อ:",
                     "dnsValue": "ค่า:",
                     "copyButton": "คัดลอก"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Eklentiler",
                 "deploy": "Dağıt",
                 "members": "Üyeler",
-                "settings": "Ayarlar"
+                "settings": "Ayarlar",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Takım Üyeleri",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Ad:",
                     "dnsValue": "Değer:",
                     "copyButton": "Kopyala"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Плагіни",
                 "deploy": "Розгортання",
                 "members": "Учасники",
-                "settings": "Налаштування"
+                "settings": "Налаштування",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Учасники команди",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Ім'я:",
                     "dnsValue": "Значення:",
                     "copyButton": "Копіювати"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1018,7 +1018,8 @@
                 "plugins": "Plugin",
                 "deploy": "Triển khai",
                 "members": "Thành viên",
-                "settings": "Cài đặt"
+                "settings": "Cài đặt",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "Thành viên đội ngũ",
@@ -2388,6 +2389,24 @@
                     "dnsName": "Tên:",
                     "dnsValue": "Giá trị:",
                     "copyButton": "Sao chép"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1018,7 +1018,8 @@
                 "plugins": "插件",
                 "deploy": "部署",
                 "members": "成员",
-                "settings": "设置"
+                "settings": "设置",
+                "kb": "Knowledge Base"
             },
             "members": {
                 "title": "团队成员",
@@ -2388,6 +2389,24 @@
                     "dnsName": "名称：",
                     "dnsValue": "值：",
                     "copyButton": "复制"
+                }
+            },
+            "kb": {
+                "title": "Knowledge Base",
+                "subtitle": "Per-Work institutional context — documents that ground generation and conversations.",
+                "panes": {
+                    "tree": {
+                        "title": "Documents",
+                        "empty": "Document tree appears here once you upload or create a KB document."
+                    },
+                    "editor": {
+                        "title": "Editor",
+                        "empty": "Select a document on the left to view or edit it. Drag a file anywhere to upload."
+                    },
+                    "ai": {
+                        "title": "AI assistant",
+                        "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
+                    }
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { workAPI } from '@/lib/api';
+import { KbShell } from '@/components/works/detail/kb/KbShell';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.workDetail.kb');
+    return { title: t('title') };
+}
+
+type Params = { params: Promise<{ id: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 2 — Knowledge Base page shell.
+ *
+ * Server component. The parent `works/[id]/layout.tsx` already loads
+ * the Work via `workAPI.get(id)` and renders `notFound()` when the
+ * work doesn't exist, but we re-verify here so a direct deep-link to
+ * `/kb` doesn't silently render an empty shell when the workId is
+ * bogus. No KB-specific data is fetched yet — the panes hydrate over
+ * follow-up tickets (tree → editor → AI panel).
+ */
+export default async function WorkKnowledgeBasePage({ params }: Params) {
+    const { id } = await params;
+
+    try {
+        await workAPI.get(id);
+    } catch {
+        notFound();
+    }
+
+    return <KbShell workId={id} />;
+}

--- a/apps/web/src/components/works/detail/WorkTabs.tsx
+++ b/apps/web/src/components/works/detail/WorkTabs.tsx
@@ -80,6 +80,26 @@ export function WorkTabs({ work }: WorkTabsProps) {
             isActive: pathname.includes('/items'),
         },
         {
+            name: t('kb'),
+            href: ROUTES.DASHBOARD_WORK_KB(work.id),
+            icon: (
+                <svg
+                    className="w-4 h-4 shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                    />
+                </svg>
+            ),
+            isActive: pathname.includes('/kb'),
+        },
+        {
             name: t('generator'),
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/generator`,
             visible: permissions.canGenerate,

--- a/apps/web/src/components/works/detail/kb/KbShell.tsx
+++ b/apps/web/src/components/works/detail/kb/KbShell.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * EW-641 Phase 1B/d row 2 — Knowledge Base page shell.
+ *
+ * Three-pane layout (tree | editor | AI side panel) following the same
+ * dashboard look-and-feel as the activity / items pages. Subsequent
+ * tickets fill each pane in turn:
+ *  - Row 3: tree panel reads `GET /api/works/:id/kb/documents`
+ *  - Row 4-6: nested editor route + Tiptap + autosave
+ *  - Row 7-8: drag-drop upload zone + classify modal
+ *  - Row 13: per-document side panel (status / tags / lock controls)
+ *
+ * This component intentionally only renders placeholders so the route
+ * is browsable on `develop` before any of the data-fetching panes land.
+ * Each pane uses an `aria-label` derived from a translation key so the
+ * follow-up tickets can replace the body without breaking selectors
+ * used by the upcoming Playwright e2e suite (A12 / A13 / A14).
+ */
+interface KbShellProps {
+    workId: string;
+}
+
+export function KbShell({ workId }: KbShellProps) {
+    const t = useTranslations('dashboard.workDetail.kb');
+
+    return (
+        <div className="flex flex-col gap-4" data-testid="kb-shell" data-work-id={workId}>
+            <header className="flex flex-col gap-1">
+                <h1 className="text-xl font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h1>
+                <p className="text-sm text-text-secondary dark:text-text-secondary-dark/70">
+                    {t('subtitle')}
+                </p>
+            </header>
+
+            <div
+                className={cn(
+                    'grid gap-4',
+                    // Single-column on small screens, three-pane from md up.
+                    'grid-cols-1 md:grid-cols-[minmax(220px,260px)_minmax(0,1fr)_minmax(240px,300px)]',
+                )}
+            >
+                <KbPanePlaceholder
+                    testId="kb-tree"
+                    title={t('panes.tree.title')}
+                    body={t('panes.tree.empty')}
+                />
+
+                <KbPanePlaceholder
+                    testId="kb-editor"
+                    title={t('panes.editor.title')}
+                    body={t('panes.editor.empty')}
+                    minHeightClass="min-h-[24rem]"
+                />
+
+                <KbPanePlaceholder
+                    testId="kb-ai-panel"
+                    title={t('panes.ai.title')}
+                    body={t('panes.ai.empty')}
+                />
+            </div>
+        </div>
+    );
+}
+
+interface KbPanePlaceholderProps {
+    testId: string;
+    title: string;
+    body: string;
+    minHeightClass?: string;
+}
+
+function KbPanePlaceholder({ testId, title, body, minHeightClass }: KbPanePlaceholderProps) {
+    return (
+        <section
+            data-testid={testId}
+            aria-label={title}
+            className={cn(
+                'rounded-lg border border-dashed border-border dark:border-border-dark',
+                'bg-card/30 dark:bg-card-primary-dark/20',
+                'p-4 flex flex-col gap-2',
+                minHeightClass,
+            )}
+        >
+            <h2 className="text-sm font-medium text-text dark:text-text-dark">{title}</h2>
+            <p className="text-sm text-text-muted dark:text-text-muted-dark/60">{body}</p>
+        </section>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbShell.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbShell.unit.spec.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { KbShell } from './KbShell';
+
+/**
+ * EW-641 Phase 1B/d row 2 — `KbShell` renders the three placeholder
+ * panes (tree / editor / AI). This spec locks the structural shape so
+ * follow-up tickets (tree-data fetch, editor, side panel) can replace
+ * each pane's body without breaking the route or the Playwright
+ * selectors that the acceptance suite (A12-A17) leans on.
+ */
+describe('KbShell', () => {
+    it('exposes the workId via data attribute (handed to data-fetching panes later)', () => {
+        const { container } = render(<KbShell workId="work-123" />);
+        const shell = container.querySelector('[data-testid="kb-shell"]');
+        expect(shell).not.toBeNull();
+        expect(shell?.getAttribute('data-work-id')).toBe('work-123');
+    });
+
+    it('renders all three placeholder panes with stable test ids', () => {
+        render(<KbShell workId="work-abc" />);
+        expect(screen.getByTestId('kb-tree')).toBeTruthy();
+        expect(screen.getByTestId('kb-editor')).toBeTruthy();
+        expect(screen.getByTestId('kb-ai-panel')).toBeTruthy();
+    });
+
+    it('uses translation keys for the header copy (no hardcoded strings)', () => {
+        render(<KbShell workId="work-abc" />);
+        // The mocked useTranslations echoes the key — so seeing "title"
+        // in the DOM proves the heading reaches for `kb.title`.
+        expect(screen.getByText('title')).toBeTruthy();
+        expect(screen.getByText('subtitle')).toBeTruthy();
+    });
+
+    it('labels each pane with the matching translation key', () => {
+        render(<KbShell workId="work-abc" />);
+        const tree = screen.getByTestId('kb-tree');
+        const editor = screen.getByTestId('kb-editor');
+        const ai = screen.getByTestId('kb-ai-panel');
+        expect(tree.getAttribute('aria-label')).toBe('panes.tree.title');
+        expect(editor.getAttribute('aria-label')).toBe('panes.editor.title');
+        expect(ai.getAttribute('aria-label')).toBe('panes.ai.title');
+    });
+});

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -73,6 +73,7 @@ export const ROUTES = {
     DASHBOARD_WORK: (id: string) => `/works/${id}`,
     DASHBOARD_WORK_ACTIVITY: (id: string) => `/works/${id}/activity`,
     DASHBOARD_WORK_ITEMS: (id: string) => `/works/${id}/items`,
+    DASHBOARD_WORK_KB: (id: string) => `/works/${id}/kb`,
     DASHBOARD_WORK_GENERATOR: (id: string) => `/works/${id}/generator`,
     DASHBOARD_WORK_SCHEDULE: (id: string) => `/works/${id}/generator/schedule`,
     DASHBOARD_WORK_HISTORY: (id: string) => `/works/${id}/generator/history`,


### PR DESCRIPTION
## Summary
- Adds the `/works/[id]/kb` route, three-pane Workbench layout, and a `WorkTabs` entry so the Knowledge Base feature is reachable from a Work's detail view ahead of the data-fetching panes landing in follow-up PRs.
- `KbShell` is a client component with a CSS-grid `tree | editor | AI panel` layout on md+ and a single column on small screens. Each pane has a stable `data-testid` (`kb-tree`, `kb-editor`, `kb-ai-panel`) so the upcoming Playwright acceptance suite (A12-A17, A18+) can lock onto these selectors as follow-up tickets replace each pane's body (row 3: tree fetch · 4-6: editor + Tiptap · 7-8: upload + classify · 13: side panel · 15: search palette).
- i18n: `tabs.kb` label + `dashboard.workDetail.kb.{title,subtitle,panes.*}` namespace seeded with English copy across all 21 locales. Non-EN translations follow in the regular translation pass.

## Test plan
- [x] `cd apps/web && npx vitest run src/components/works/detail/kb/KbShell.unit.spec.tsx` → 4 passed (workId data attr, three pane testids, translation-key wiring, aria-label per pane)
- [x] `cd apps/web && npx tsc --noEmit` → clean
- [x] `npx eslint` on touched files → clean
- [x] `npx prettier --write` on touched files → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- `docs/specs/features/knowledge-base/spec.md` §14 (Workbench UI)
- EW-641 Phase 1B/d row 2 of the atomic queue in `Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Knowledge Base feature accessible via a dedicated tab in the work detail view, providing a three-pane interface for document management, editing, and AI assistance.
  * Added full multilingual support for the Knowledge Base UI across 20+ languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->