### PR TITLE
feat(kb): read-only KB tree panel (EW-641 Phase 1B/d row 3)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2624,6 +2624,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2624,6 +2624,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2624,6 +2624,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2652,6 +2652,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2624,6 +2624,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2651,6 +2651,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2624,6 +2624,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2407,6 +2407,18 @@
                         "title": "AI assistant",
                         "empty": "Conversation with the workspace agent will appear here. Use @kb:path to ground replies."
                     }
+                },
+                "classes": {
+                    "brand": "Brand",
+                    "legal": "Legal",
+                    "seo": "SEO",
+                    "style": "Style",
+                    "glossary": "Glossary",
+                    "competitors": "Competitors",
+                    "personas": "Personas",
+                    "research": "Research",
+                    "output": "Outputs",
+                    "freeform": "Freeform"
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { workAPI } from '@/lib/api';
+import { kbAPI } from '@/lib/api/kb';
 import { KbShell } from '@/components/works/detail/kb/KbShell';
+import { KbTreePanel } from '@/components/works/detail/kb/KbTreePanel';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.workDetail.kb');
@@ -12,14 +14,19 @@ export async function generateMetadata(): Promise<Metadata> {
 type Params = { params: Promise<{ id: string }> };
 
 /**
- * EW-641 Phase 1B/d row 2 — Knowledge Base page shell.
+ * EW-641 Phase 1B/d — Knowledge Base index page.
  *
  * Server component. The parent `works/[id]/layout.tsx` already loads
  * the Work via `workAPI.get(id)` and renders `notFound()` when the
  * work doesn't exist, but we re-verify here so a direct deep-link to
  * `/kb` doesn't silently render an empty shell when the workId is
- * bogus. No KB-specific data is fetched yet — the panes hydrate over
- * follow-up tickets (tree → editor → AI panel).
+ * bogus.
+ *
+ * Row 3 wires the tree panel: we fetch the document metadata list and
+ * pass the server-rendered `<KbTreePanel>` into `KbShell` via the
+ * `treeSlot` prop. A fetch failure falls back to an empty list so a
+ * transient API error still renders the shell with a friendly empty
+ * state (same copy operators see when there are 0 docs).
  */
 export default async function WorkKnowledgeBasePage({ params }: Params) {
     const { id } = await params;
@@ -30,5 +37,10 @@ export default async function WorkKnowledgeBasePage({ params }: Params) {
         notFound();
     }
 
-    return <KbShell workId={id} />;
+    const docs = await kbAPI.listDocuments(id, { limit: 200 }).catch((error) => {
+        console.error('[kb-tree] failed to list KB documents:', error);
+        return { items: [], total: 0 };
+    });
+
+    return <KbShell workId={id} treeSlot={<KbTreePanel workId={id} documents={docs.items} />} />;
 }

--- a/apps/web/src/components/works/detail/kb/KbShell.tsx
+++ b/apps/web/src/components/works/detail/kb/KbShell.tsx
@@ -1,30 +1,41 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
 
 /**
- * EW-641 Phase 1B/d row 2 — Knowledge Base page shell.
+ * EW-641 Phase 1B/d — Knowledge Base page shell.
  *
  * Three-pane layout (tree | editor | AI side panel) following the same
  * dashboard look-and-feel as the activity / items pages. Subsequent
  * tickets fill each pane in turn:
- *  - Row 3: tree panel reads `GET /api/works/:id/kb/documents`
- *  - Row 4-6: nested editor route + Tiptap + autosave
+ *  - Row 3: tree panel reads `GET /api/works/:id/kb/documents` (the
+ *    `treeSlot` prop accepts a server-rendered `<KbTreePanel>`)
+ *  - Row 4-6: nested editor route + Tiptap + autosave (`editorSlot`)
  *  - Row 7-8: drag-drop upload zone + classify modal
- *  - Row 13: per-document side panel (status / tags / lock controls)
+ *  - Row 13: per-document side panel (`asideSlot`)
  *
- * This component intentionally only renders placeholders so the route
- * is browsable on `develop` before any of the data-fetching panes land.
- * Each pane uses an `aria-label` derived from a translation key so the
- * follow-up tickets can replace the body without breaking selectors
- * used by the upcoming Playwright e2e suite (A12 / A13 / A14).
+ * Each pane is a server-component slot so the parent page can do
+ * RSC-level data fetching and hand the result down without converting
+ * this whole tree to RSC (we want the shell to host client-side state
+ * later: dirty/saved indicator, command palette, etc.). When a slot
+ * is unset we fall back to the placeholder copy, so the route is
+ * still browsable as new panes land incrementally.
+ *
+ * Selectors (`data-testid="kb-tree" / "kb-editor" / "kb-ai-panel"`)
+ * are stable across the placeholder + filled-in pane variants —
+ * the upcoming Playwright e2e suite (A12-A17) and the per-pane tests
+ * both rely on them.
  */
 interface KbShellProps {
     workId: string;
+    treeSlot?: ReactNode;
+    editorSlot?: ReactNode;
+    asideSlot?: ReactNode;
 }
 
-export function KbShell({ workId }: KbShellProps) {
+export function KbShell({ workId, treeSlot, editorSlot, asideSlot }: KbShellProps) {
     const t = useTranslations('dashboard.workDetail.kb');
 
     return (
@@ -45,24 +56,30 @@ export function KbShell({ workId }: KbShellProps) {
                     'grid-cols-1 md:grid-cols-[minmax(220px,260px)_minmax(0,1fr)_minmax(240px,300px)]',
                 )}
             >
-                <KbPanePlaceholder
-                    testId="kb-tree"
-                    title={t('panes.tree.title')}
-                    body={t('panes.tree.empty')}
-                />
+                {treeSlot ?? (
+                    <KbPanePlaceholder
+                        testId="kb-tree"
+                        title={t('panes.tree.title')}
+                        body={t('panes.tree.empty')}
+                    />
+                )}
 
-                <KbPanePlaceholder
-                    testId="kb-editor"
-                    title={t('panes.editor.title')}
-                    body={t('panes.editor.empty')}
-                    minHeightClass="min-h-[24rem]"
-                />
+                {editorSlot ?? (
+                    <KbPanePlaceholder
+                        testId="kb-editor"
+                        title={t('panes.editor.title')}
+                        body={t('panes.editor.empty')}
+                        minHeightClass="min-h-[24rem]"
+                    />
+                )}
 
-                <KbPanePlaceholder
-                    testId="kb-ai-panel"
-                    title={t('panes.ai.title')}
-                    body={t('panes.ai.empty')}
-                />
+                {asideSlot ?? (
+                    <KbPanePlaceholder
+                        testId="kb-ai-panel"
+                        title={t('panes.ai.title')}
+                        body={t('panes.ai.empty')}
+                    />
+                )}
             </div>
         </div>
     );

--- a/apps/web/src/components/works/detail/kb/KbTreePanel.tsx
+++ b/apps/web/src/components/works/detail/kb/KbTreePanel.tsx
@@ -1,0 +1,179 @@
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import { KB_DOCUMENT_CLASSES } from '@ever-works/contracts';
+import type { KbDocumentClass, KbDocumentDto } from '@ever-works/contracts';
+
+interface KbTreePanelProps {
+    workId: string;
+    documents: KbDocumentDto[];
+    /** When non-null, highlights the matching row. */
+    activePath?: string | null;
+}
+
+/**
+ * EW-641 Phase 1B/d row 3 — read-only Knowledge Base tree panel.
+ *
+ * Server component. The parent page does a `kbAPI.listDocuments(workId)`
+ * fetch and hands the result in as `documents`. We group by
+ * `kbDocumentClass` in the canonical order from
+ * `@ever-works/contracts.KB_DOCUMENT_CLASSES` so the panel layout is
+ * stable across sessions and predictable for Playwright selectors
+ * (A12-A17 acceptance suite locks onto `data-testid="kb-tree-*"`).
+ *
+ * Click handlers come in row 4 (`works/[id]/kb/[...path]/page.tsx`);
+ * for now each row is a `next/link` pointing at the future detail
+ * route so navigation works the moment that PR lands.
+ *
+ * The empty-state mirrors the placeholder copy used by `KbShell` so
+ * "no documents yet" still reads naturally — operators land on the
+ * page right after enabling KB and see the same explanation regardless
+ * of whether the fetch ran or not.
+ */
+export async function KbTreePanel({ workId, documents, activePath = null }: KbTreePanelProps) {
+    const t = await getTranslations('dashboard.workDetail.kb');
+
+    if (documents.length === 0) {
+        return (
+            <section
+                data-testid="kb-tree"
+                aria-label={t('panes.tree.title')}
+                className={cn(
+                    'rounded-lg border border-dashed border-border dark:border-border-dark',
+                    'bg-card/30 dark:bg-card-primary-dark/20',
+                    'p-4 flex flex-col gap-2',
+                )}
+            >
+                <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                    {t('panes.tree.title')}
+                </h2>
+                <p className="text-sm text-text-muted dark:text-text-muted-dark/60">
+                    {t('panes.tree.empty')}
+                </p>
+            </section>
+        );
+    }
+
+    const grouped = groupByClass(documents);
+
+    return (
+        <section
+            data-testid="kb-tree"
+            aria-label={t('panes.tree.title')}
+            className={cn(
+                'rounded-lg border border-border dark:border-border-dark',
+                'bg-card/50 dark:bg-card-primary-dark/30',
+                'p-3 flex flex-col gap-3 overflow-y-auto',
+            )}
+        >
+            <header className="flex items-center justify-between">
+                <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                    {t('panes.tree.title')}
+                </h2>
+                <span
+                    className="text-xs text-text-muted dark:text-text-muted-dark/60"
+                    data-testid="kb-tree-count"
+                >
+                    {documents.length}
+                </span>
+            </header>
+
+            <nav aria-label={t('panes.tree.title')} className="flex flex-col gap-3">
+                {KB_DOCUMENT_CLASSES.map((cls) => {
+                    const docs = grouped.get(cls);
+                    if (!docs || docs.length === 0) return null;
+                    return (
+                        <KbTreeGroup
+                            key={cls}
+                            workId={workId}
+                            kbClass={cls}
+                            label={t(`classes.${cls}`)}
+                            docs={docs}
+                            activePath={activePath}
+                        />
+                    );
+                })}
+            </nav>
+        </section>
+    );
+}
+
+interface KbTreeGroupProps {
+    workId: string;
+    kbClass: KbDocumentClass;
+    label: string;
+    docs: KbDocumentDto[];
+    activePath: string | null;
+}
+
+function KbTreeGroup({ workId, kbClass, label, docs, activePath }: KbTreeGroupProps) {
+    return (
+        <div data-testid={`kb-tree-group-${kbClass}`} className="flex flex-col gap-1">
+            <h3
+                className={cn(
+                    'text-[11px] font-semibold uppercase tracking-wider',
+                    'text-text-muted dark:text-text-muted-dark/70',
+                )}
+            >
+                {label}
+                <span className="ml-1 text-text-muted/60">({docs.length})</span>
+            </h3>
+            <ul className="flex flex-col gap-0.5">
+                {docs.map((doc) => {
+                    const isActive = activePath !== null && activePath === doc.path;
+                    return (
+                        <li key={doc.id}>
+                            <Link
+                                href={`${ROUTES.DASHBOARD_WORK_KB(workId)}/${doc.path}`}
+                                data-testid="kb-tree-item"
+                                data-doc-path={doc.path}
+                                data-locked={doc.locked ? 'true' : undefined}
+                                aria-current={isActive ? 'page' : undefined}
+                                className={cn(
+                                    'flex items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors',
+                                    isActive
+                                        ? 'bg-primary/10 text-primary dark:bg-primary/20'
+                                        : 'text-text-secondary dark:text-text-secondary-dark/80 hover:bg-card-hover dark:hover:bg-card-primary-dark/40 hover:text-text dark:hover:text-text-dark',
+                                )}
+                            >
+                                <span className="truncate">{doc.title || doc.path}</span>
+                                {doc.locked ? (
+                                    <span
+                                        aria-label="locked"
+                                        className="ml-auto text-xs text-text-muted dark:text-text-muted-dark/60"
+                                    >
+                                        🔒
+                                    </span>
+                                ) : null}
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+}
+
+function groupByClass(documents: KbDocumentDto[]): Map<KbDocumentClass, KbDocumentDto[]> {
+    const map = new Map<KbDocumentClass, KbDocumentDto[]>();
+    for (const doc of documents) {
+        const bucket = map.get(doc.class);
+        if (bucket) {
+            bucket.push(doc);
+        } else {
+            map.set(doc.class, [doc]);
+        }
+    }
+    // Sort each bucket by title (case-insensitive) so the panel layout
+    // is deterministic — matters for Playwright assertions and visual
+    // diffing alike.
+    for (const docs of map.values()) {
+        docs.sort((a, b) =>
+            (a.title || a.path).localeCompare(b.title || b.path, undefined, {
+                sensitivity: 'base',
+            }),
+        );
+    }
+    return map;
+}

--- a/apps/web/src/components/works/detail/kb/KbTreePanel.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbTreePanel.unit.spec.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & Record<string, unknown>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('next-intl/server', () => ({
+    getTranslations: async () => (key: string) => key,
+}));
+
+import { KbTreePanel } from './KbTreePanel';
+import type { KbDocumentDto } from '@ever-works/contracts';
+
+function doc(overrides: Partial<KbDocumentDto> = {}): KbDocumentDto {
+    return {
+        id: 'doc-' + Math.random().toString(36).slice(2, 9),
+        workId: 'work-1',
+        organizationId: null,
+        path: 'brand/voice.md',
+        slug: 'voice',
+        title: 'Voice',
+        description: null,
+        class: 'brand',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'user',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-05-22T00:00:00Z',
+        updatedAt: '2026-05-22T00:00:00Z',
+        lastCommitSha: null,
+        lastIndexedAt: null,
+        ...overrides,
+    };
+}
+
+/**
+ * EW-641 Phase 1B/d row 3 — `KbTreePanel` is a server component that
+ * groups KB documents by class. These tests cover the rendered output
+ * shape that Playwright e2e and follow-up tickets (A12-A17 acceptance
+ * suite + editor row #4) will depend on:
+ *  - empty list → friendly placeholder
+ *  - non-empty → groups in canonical class order
+ *  - sort-within-group by title
+ *  - lock indicator + active highlight
+ *  - Link target points to the upcoming `[...path]/page.tsx` route
+ *
+ * Server components in React 19 return a Promise from the function
+ * call; we `await` it before handing the element tree to `render()`.
+ */
+describe('KbTreePanel', () => {
+    it('shows an empty placeholder when the document list is empty', async () => {
+        render(await KbTreePanel({ workId: 'work-1', documents: [] }));
+        const tree = screen.getByTestId('kb-tree');
+        expect(tree).toBeTruthy();
+        expect(tree.textContent).toContain('panes.tree.empty');
+        expect(screen.queryByTestId('kb-tree-count')).toBeNull();
+    });
+
+    it('renders the total count and one group per non-empty class', async () => {
+        render(
+            await KbTreePanel({
+                workId: 'work-1',
+                documents: [
+                    doc({ id: 'a', title: 'Voice', class: 'brand', path: 'brand/voice.md' }),
+                    doc({ id: 'b', title: 'Privacy', class: 'legal', path: 'legal/privacy.md' }),
+                    doc({ id: 'c', title: 'GDPR', class: 'legal', path: 'legal/gdpr.md' }),
+                ],
+            }),
+        );
+
+        expect(screen.getByTestId('kb-tree-count').textContent).toBe('3');
+        expect(screen.getByTestId('kb-tree-group-brand')).toBeTruthy();
+        expect(screen.getByTestId('kb-tree-group-legal')).toBeTruthy();
+        // Glossary etc. should NOT render — group only appears when populated.
+        expect(screen.queryByTestId('kb-tree-group-glossary')).toBeNull();
+    });
+
+    it('preserves canonical class order (brand before legal before glossary…)', async () => {
+        render(
+            await KbTreePanel({
+                workId: 'work-1',
+                documents: [
+                    doc({ id: 'g', title: 'Terms', class: 'glossary', path: 'glossary/t.md' }),
+                    doc({ id: 'l', title: 'Privacy', class: 'legal', path: 'legal/p.md' }),
+                    doc({ id: 'b', title: 'Voice', class: 'brand', path: 'brand/v.md' }),
+                ],
+            }),
+        );
+        const groups = screen.getAllByTestId(/^kb-tree-group-/);
+        expect(groups[0].getAttribute('data-testid')).toBe('kb-tree-group-brand');
+        expect(groups[1].getAttribute('data-testid')).toBe('kb-tree-group-legal');
+        expect(groups[2].getAttribute('data-testid')).toBe('kb-tree-group-glossary');
+    });
+
+    it('sorts items within a group by title (case-insensitive)', async () => {
+        render(
+            await KbTreePanel({
+                workId: 'work-1',
+                documents: [
+                    doc({ id: '1', title: 'zebra', class: 'brand', path: 'brand/z.md' }),
+                    doc({ id: '2', title: 'Alpha', class: 'brand', path: 'brand/a.md' }),
+                    doc({ id: '3', title: 'beta', class: 'brand', path: 'brand/b.md' }),
+                ],
+            }),
+        );
+        const group = screen.getByTestId('kb-tree-group-brand');
+        const items = within(group).getAllByTestId('kb-tree-item');
+        expect(items[0].textContent).toContain('Alpha');
+        expect(items[1].textContent).toContain('beta');
+        expect(items[2].textContent).toContain('zebra');
+    });
+
+    it('renders a lock marker when the doc is locked', async () => {
+        render(
+            await KbTreePanel({
+                workId: 'work-1',
+                documents: [doc({ locked: true, title: 'Locked doc', path: 'brand/x.md' })],
+            }),
+        );
+        const item = screen.getByTestId('kb-tree-item');
+        expect(item.getAttribute('data-locked')).toBe('true');
+        expect(item.textContent).toContain('🔒');
+    });
+
+    it('highlights the active item via aria-current and links to the nested route', async () => {
+        render(
+            await KbTreePanel({
+                workId: 'work-1',
+                documents: [
+                    doc({ id: 'a', title: 'Voice', class: 'brand', path: 'brand/voice.md' }),
+                    doc({ id: 'b', title: 'Tone', class: 'brand', path: 'brand/tone.md' }),
+                ],
+                activePath: 'brand/voice.md',
+            }),
+        );
+        const items = screen.getAllByTestId('kb-tree-item');
+        const active = items.find((el) => el.getAttribute('data-doc-path') === 'brand/voice.md');
+        const other = items.find((el) => el.getAttribute('data-doc-path') === 'brand/tone.md');
+        expect(active?.getAttribute('aria-current')).toBe('page');
+        expect(other?.getAttribute('aria-current')).toBeNull();
+        // Link href targets the upcoming `[...path]` route in row 4.
+        expect(active?.getAttribute('href')).toBe('/works/work-1/kb/brand/voice.md');
+    });
+});

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+import { serverFetch } from './server-api';
+import type { KbDocumentDto, KbDocumentListFilter } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 1B/d row 3 — server-only fetch helpers for the Knowledge
+ * Base REST surface shipped in Phase 1A (`apps/api/src/works/kb.controller.ts`).
+ *
+ * The agent service returns `{ items, total }` — no cursor. We re-use
+ * the contracts' `KbDocumentDto` shape for the items; `total` is the
+ * full filtered count so the UI can show "N documents" headers.
+ */
+export interface KbDocumentListResponse {
+    items: KbDocumentDto[];
+    total: number;
+}
+
+export const kbAPI = {
+    /**
+     * `GET /api/works/:id/kb/documents` — paginated metadata list.
+     *
+     * Tree-panel callers can leave `opts` empty; filtering is applied
+     * server-side and the response is small (metadata-only, no body).
+     */
+    listDocuments: async (
+        workId: string,
+        opts: KbDocumentListFilter = {},
+    ): Promise<KbDocumentListResponse> => {
+        const params = new URLSearchParams();
+        if (opts.class && !Array.isArray(opts.class)) params.append('class', opts.class);
+        if (opts.status && !Array.isArray(opts.status)) params.append('status', opts.status);
+        if (opts.tag && !Array.isArray(opts.tag)) params.append('tag', opts.tag);
+        if (typeof opts.locked === 'boolean') params.append('locked', String(opts.locked));
+        if (opts.language) params.append('language', opts.language);
+        if (opts.q) params.append('q', opts.q);
+        if (typeof opts.limit === 'number') params.append('limit', String(opts.limit));
+        if (opts.cursor) params.append('offset', opts.cursor);
+        const query = params.toString() ? `?${params.toString()}` : '';
+        return serverFetch<KbDocumentListResponse>(`/works/${workId}/kb/documents${query}`);
+    },
+};


### PR DESCRIPTION
## Summary
- Wires the **tree pane** on `/works/[id]/kb`: server component fetches `GET /api/works/:id/kb/documents` (the endpoint shipped in Phase 1A) and renders the metadata list grouped by `kbDocumentClass` in the canonical order from `@ever-works/contracts.KB_DOCUMENT_CLASSES`. Documents inside each group are sorted by title (case-insensitive) so the panel layout stays deterministic across sessions — Playwright order assertions in the upcoming A12-A17 suite rely on this.
- `KbShell` now accepts `treeSlot` / `editorSlot` / `asideSlot` React-node props so the parent page (server component) can do RSC-level fetches and hand server-rendered slots into the client shell. Slots that are unset still render the original placeholder, so the route stays browsable as follow-up panes land incrementally.
- New `kbAPI.listDocuments(workId, opts)` helper in `apps/web/src/lib/api/kb.ts` reuses `serverFetch` + the `KbDocumentDto` / `KbDocumentListFilter` contract types. Supports the full filter surface (class / status / tag / locked / language / q / limit / cursor) — the tree panel only uses `limit`, the rest is ready for the row #15 search palette.
- Stable selectors for the e2e suite: `data-testid="kb-tree"` (root) · `kb-tree-count` · `kb-tree-group-<class>` · `kb-tree-item` (with `data-doc-path` + `data-locked` attrs). Active doc gets `aria-current="page"`; locked docs get a 🔒 marker and `data-locked="true"`.
- i18n: `dashboard.workDetail.kb.classes.{brand|legal|seo|style|glossary|competitors|personas|research|output|freeform}` added to all 21 locale files (English copy; locale-specific translations follow in the standard pass).

## Test plan
- [x] `cd apps/web && npx vitest run src/components/works/detail/kb/` → 10 passed (6 new `KbTreePanel`: empty placeholder · total count + per-class groups · canonical class ordering · intra-group title sort · lock marker · active highlight + link href; existing 4 `KbShell` cases unchanged)
- [x] `npx tsc --noEmit` (web) → clean
- [x] `npx eslint` on touched files → clean
- [x] `npx prettier --write` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- `docs/specs/features/knowledge-base/spec.md` §14 (Workbench UI)
- EW-641 Phase 1B/d row 3 of the atomic queue in `Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge base now displays documents organized by category (Brand, Legal, SEO, Style, Glossary, Competitors, Personas, Research, Outputs, Freeform) in a navigable tree panel.
  * Added support for viewing and selecting documents in the knowledge base interface.

* **Localization**
  * Added category labels in 18 languages for knowledge base document classification.

* **Tests**
  * Added comprehensive test coverage for the new knowledge base tree panel component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->