### PR TITLE
feat(kb): nested KB document route + read-only viewer (EW-641 Phase 1B/d row 4)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2636,6 +2636,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2636,6 +2636,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2636,6 +2636,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2664,6 +2664,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2636,6 +2636,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2663,6 +2663,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2636,6 +2636,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2419,6 +2419,18 @@
                     "research": "Research",
                     "output": "Outputs",
                     "freeform": "Freeform"
+                },
+                "status": {
+                    "draft": "Draft",
+                    "active": "Active",
+                    "archived": "Archived"
+                },
+                "lock": {
+                    "full": "Locked",
+                    "additions-only": "Additions only"
+                },
+                "document": {
+                    "emptyBody": "This document has no body yet."
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { workAPI } from '@/lib/api';
+import { kbAPI } from '@/lib/api/kb';
+import { ApiResponseError } from '@/lib/api/server-api';
+import { KbShell } from '@/components/works/detail/kb/KbShell';
+import { KbTreePanel } from '@/components/works/detail/kb/KbTreePanel';
+import { KbDocumentView } from '@/components/works/detail/kb/KbDocumentView';
+
+type Params = {
+    params: Promise<{ id: string; path: string[] }>;
+};
+
+/**
+ * Joins the Next.js catch-all `path` segments into the slash-separated
+ * doc path the API uses. Each segment is already URL-decoded by Next,
+ * so we just rejoin and let the API resolve the canonical row.
+ */
+function joinPath(segments: string[]): string {
+    return segments.filter((s) => s.length > 0).join('/');
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+    const { id, path } = await params;
+    const t = await getTranslations('dashboard.workDetail.kb');
+    const joined = joinPath(path);
+
+    try {
+        const doc = await kbAPI.getDocument(id, joined);
+        return { title: `${doc.title || joined} — ${t('title')}` };
+    } catch {
+        return { title: t('title') };
+    }
+}
+
+/**
+ * EW-641 Phase 1B/d row 4 — Knowledge Base document detail page.
+ *
+ * Catch-all route `/works/[id]/kb/[...path]/page.tsx` — accepts a
+ * `path` array because doc paths look like `brand/voice.md` (the
+ * canonical `<class>/<slug>.md` shape from spec §8). We rejoin with
+ * `/`, ship the value to the API verbatim, and let
+ * `KnowledgeBaseService.getDocument` resolve either a UUID or a path.
+ *
+ * Renders the full three-pane shell so the user keeps the tree on the
+ * left while reading: the active row in the tree is highlighted via
+ * the `activePath` prop. The editor pane shows the doc via
+ * `<KbDocumentView>` (read-only Markdown for now; row 5 swaps that for
+ * the Tiptap-based editor + autosave).
+ *
+ * Errors: 404 → `notFound()`; other backend failures bubble to the
+ * dashboard error boundary (matches the activity / items pages —
+ * intentionally not swallowed so operators see a clear failure mode).
+ */
+export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) {
+    const { id, path } = await params;
+    const joined = joinPath(path);
+
+    if (!joined) {
+        notFound();
+    }
+
+    // Parent layout already verifies the Work exists, so we lean on the
+    // doc fetch as the single source of truth for "this URL is valid".
+    let doc;
+    try {
+        doc = await kbAPI.getDocument(id, joined);
+    } catch (error) {
+        if (error instanceof ApiResponseError && error.statusCode === 404) {
+            notFound();
+        }
+        throw error;
+    }
+
+    // Also fetch the tree list so the left pane is populated. A
+    // failure here is non-fatal — the editor pane still renders.
+    const list = await Promise.all([workAPI.get(id), kbAPI.listDocuments(id, { limit: 200 })])
+        .then(([, docs]) => docs)
+        .catch((error) => {
+            console.error('[kb-tree] failed to list KB documents:', error);
+            return { items: [], total: 0 };
+        });
+
+    return (
+        <KbShell
+            workId={id}
+            treeSlot={<KbTreePanel workId={id} documents={list.items} activePath={doc.path} />}
+            editorSlot={<KbDocumentView doc={doc} />}
+        />
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbDocumentView.tsx
+++ b/apps/web/src/components/works/detail/kb/KbDocumentView.tsx
@@ -1,0 +1,110 @@
+import { getTranslations } from 'next-intl/server';
+import { cn } from '@/lib/utils/cn';
+import { MarkdownPreview } from '@/components/works/detail/items/MarkdownPreview';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+interface KbDocumentViewProps {
+    doc: KbDocumentBodyDto;
+}
+
+/**
+ * EW-641 Phase 1B/d row 4 — read-only Knowledge Base document view.
+ *
+ * Server component. Renders the document header (title + class chip +
+ * status + lock marker + path) followed by the Markdown body via the
+ * existing `MarkdownPreview` client component (`react-markdown` +
+ * `remark-gfm`). The editor itself (Tiptap, autosave, dirty/saved
+ * pill) arrives in row 5 + 6 — this PR ships the read-only view so
+ * deep-linking from the tree works the moment the route lands.
+ *
+ * Selectors locked for the upcoming Playwright e2e suite (A12-A17):
+ *  - `data-testid="kb-editor"` (root, matches the placeholder slot
+ *    in `KbShell` so tests that pre-date this PR keep working)
+ *  - `data-testid="kb-document-title"`
+ *  - `data-testid="kb-document-meta"` (chip row)
+ *  - `data-testid="kb-document-body"` (Markdown render wrapper)
+ */
+export async function KbDocumentView({ doc }: KbDocumentViewProps) {
+    const t = await getTranslations('dashboard.workDetail.kb');
+
+    return (
+        <section
+            data-testid="kb-editor"
+            aria-label={t('panes.editor.title')}
+            className={cn(
+                'rounded-lg border border-border dark:border-border-dark',
+                'bg-card/50 dark:bg-card-primary-dark/30',
+                'p-4 flex flex-col gap-3 min-h-[24rem]',
+            )}
+        >
+            <header className="flex flex-col gap-2">
+                <h2
+                    data-testid="kb-document-title"
+                    className="text-lg font-semibold text-text dark:text-text-dark"
+                >
+                    {doc.title || doc.path}
+                </h2>
+                <div
+                    data-testid="kb-document-meta"
+                    className="flex items-center gap-2 text-xs flex-wrap"
+                >
+                    <span
+                        className={cn(
+                            'px-2 py-0.5 rounded-full font-medium uppercase tracking-wide',
+                            'bg-primary/10 text-primary dark:bg-primary/20',
+                        )}
+                        data-kb-class={doc.class}
+                    >
+                        {t(`classes.${doc.class}`)}
+                    </span>
+                    <span
+                        className={cn(
+                            'px-2 py-0.5 rounded-full',
+                            doc.status === 'active'
+                                ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+                                : doc.status === 'archived'
+                                  ? 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                                  : 'bg-card-hover dark:bg-card-primary-dark/40 text-text-muted dark:text-text-muted-dark/70',
+                        )}
+                        data-kb-status={doc.status}
+                    >
+                        {t(`status.${doc.status}`)}
+                    </span>
+                    {doc.locked ? (
+                        <span
+                            className="px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                            data-locked="true"
+                            data-kb-lock-mode={doc.lockMode ?? undefined}
+                        >
+                            🔒 {t(`lock.${doc.lockMode ?? 'full'}`)}
+                        </span>
+                    ) : null}
+                    <span className="ml-auto font-mono text-[11px] text-text-muted dark:text-text-muted-dark/60">
+                        {doc.path}
+                    </span>
+                </div>
+                {doc.description ? (
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark/80">
+                        {doc.description}
+                    </p>
+                ) : null}
+            </header>
+
+            <div
+                data-testid="kb-document-body"
+                className={cn(
+                    'rounded-md border border-border/60 dark:border-border-dark/60',
+                    'bg-card/70 dark:bg-card-primary-dark/10 p-4 overflow-auto',
+                )}
+            >
+                {doc.body && doc.body.trim().length > 0 ? (
+                    <MarkdownPreview content={doc.body} />
+                ) : (
+                    <p className="text-sm italic text-text-muted dark:text-text-muted-dark/60">
+                        {t('document.emptyBody')}
+                    </p>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbDocumentView.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbDocumentView.unit.spec.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl/server', () => ({
+    getTranslations: async () => (key: string) => key,
+}));
+
+// MarkdownPreview is a client component that pulls in react-markdown.
+// Stub it so the unit test focuses on KbDocumentView's structure
+// rather than re-asserting markdown rendering itself.
+vi.mock('@/components/works/detail/items/MarkdownPreview', () => ({
+    MarkdownPreview: ({ content }: { content: string }) => (
+        <div data-testid="markdown-preview-mock">{content}</div>
+    ),
+}));
+
+import { KbDocumentView } from './KbDocumentView';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+function doc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: 'doc-1',
+        workId: 'work-1',
+        organizationId: null,
+        path: 'brand/voice.md',
+        slug: 'voice',
+        title: 'Brand voice',
+        description: null,
+        class: 'brand',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'user',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-05-22T00:00:00Z',
+        updatedAt: '2026-05-22T00:00:00Z',
+        lastCommitSha: null,
+        lastIndexedAt: null,
+        body: '# Voice\n\nClear, confident, never breathless.',
+        assets: [],
+        ...overrides,
+    };
+}
+
+/**
+ * EW-641 Phase 1B/d row 4 — KbDocumentView is a server component (it
+ * uses `getTranslations`). React 19 lets server components return a
+ * Promise that `render()` resolves; we `await` the call before passing
+ * the element tree to React Testing Library.
+ *
+ * These tests lock the rendered structure that:
+ *  - the upcoming Playwright suite (A12-A17) selectors against
+ *  - the editor PR (row 5) will swap out — `data-testid="kb-editor"` +
+ *    `kb-document-body` need to stay stable across the read-only →
+ *    Tiptap transition.
+ */
+describe('KbDocumentView', () => {
+    it('renders the title, class chip, status chip, and path', async () => {
+        render(await KbDocumentView({ doc: doc() }));
+
+        expect(screen.getByTestId('kb-document-title').textContent).toBe('Brand voice');
+        const meta = screen.getByTestId('kb-document-meta');
+        expect(meta.textContent).toContain('classes.brand');
+        expect(meta.textContent).toContain('status.active');
+        expect(meta.textContent).toContain('brand/voice.md');
+    });
+
+    it('falls back to the path when the title is empty', async () => {
+        render(await KbDocumentView({ doc: doc({ title: '', path: 'legal/privacy.md' }) }));
+        expect(screen.getByTestId('kb-document-title').textContent).toBe('legal/privacy.md');
+    });
+
+    it('renders the body via MarkdownPreview when content is present', async () => {
+        render(await KbDocumentView({ doc: doc({ body: '# Heading\n\nBody' }) }));
+        const body = screen.getByTestId('kb-document-body');
+        const preview = screen.getByTestId('markdown-preview-mock');
+        expect(body.contains(preview)).toBe(true);
+        expect(preview.textContent).toBe('# Heading\n\nBody');
+    });
+
+    it('shows the empty-body placeholder when body is blank/whitespace', async () => {
+        render(await KbDocumentView({ doc: doc({ body: '   \n\n' }) }));
+        const body = screen.getByTestId('kb-document-body');
+        expect(body.textContent).toContain('document.emptyBody');
+        // No markdown preview rendered when body is empty.
+        expect(screen.queryByTestId('markdown-preview-mock')).toBeNull();
+    });
+
+    it('exposes the lock chip + data-locked when the doc is locked', async () => {
+        render(
+            await KbDocumentView({
+                doc: doc({ locked: true, lockMode: 'additions-only' }),
+            }),
+        );
+        const lockEl = screen.getByTestId('kb-document-meta').querySelector('[data-locked="true"]');
+        expect(lockEl).not.toBeNull();
+        expect(lockEl?.getAttribute('data-kb-lock-mode')).toBe('additions-only');
+        expect(lockEl?.textContent).toContain('lock.additions-only');
+    });
+
+    it('omits the lock chip when unlocked', async () => {
+        render(await KbDocumentView({ doc: doc({ locked: false }) }));
+        const meta = screen.getByTestId('kb-document-meta');
+        expect(meta.querySelector('[data-locked="true"]')).toBeNull();
+    });
+
+    it('renders the description paragraph when present', async () => {
+        render(await KbDocumentView({ doc: doc({ description: 'How we talk to customers' }) }));
+        expect(screen.getByText('How we talk to customers')).toBeTruthy();
+    });
+});

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { serverFetch } from './server-api';
-import type { KbDocumentDto, KbDocumentListFilter } from '@ever-works/contracts';
+import type { KbDocumentBodyDto, KbDocumentDto, KbDocumentListFilter } from '@ever-works/contracts';
 
 /**
  * EW-641 Phase 1B/d row 3 — server-only fetch helpers for the Knowledge
@@ -37,5 +37,18 @@ export const kbAPI = {
         if (opts.cursor) params.append('offset', opts.cursor);
         const query = params.toString() ? `?${params.toString()}` : '';
         return serverFetch<KbDocumentListResponse>(`/works/${workId}/kb/documents${query}`);
+    },
+
+    /**
+     * `GET /api/works/:id/kb/documents/:idOrPath` — full document with
+     * Markdown body + asset summaries. The backend accepts either a
+     * UUID or the canonical `<class>/<slug>.md`-style path; we encode
+     * the path so embedded slashes survive the fetch (the API decodes
+     * the segment before lookup).
+     */
+    getDocument: async (workId: string, idOrPath: string): Promise<KbDocumentBodyDto> => {
+        return serverFetch<KbDocumentBodyDto>(
+            `/works/${workId}/kb/documents/${encodeURIComponent(idOrPath)}`,
+        );
     },
 };


### PR DESCRIPTION
## Summary
- Adds the catch-all route `/works/[id]/kb/[...path]/page.tsx` so the tree links shipped in row #3 resolve to a read-only document view. Editor (Tiptap + autosave) lands in row #5; this PR ships the read-only layer so deep-linking from the tree works the moment it lands.
- New `kbAPI.getDocument(workId, idOrPath)` server-only helper. URL-encodes the path segment so embedded slashes survive the fetch (the backend accepts both UUIDs and canonical `<class>/<slug>.md` paths). Returns the full `KbDocumentBodyDto` (metadata + body + assets).
- `KbDocumentView.tsx` (server component): document header (title, class + status + optional lock chips, monospace path) followed by the Markdown body via the existing `MarkdownPreview` (`react-markdown` + `remark-gfm`). Empty body shows the friendly placeholder. Stable selectors for the upcoming Playwright suite: `data-testid="kb-editor"` (same id as the placeholder slot in `KbShell` so tests survive the read-only → Tiptap swap), `kb-document-title`, `kb-document-meta`, `kb-document-body`. Lock chip carries `data-locked="true"` + `data-kb-lock-mode` for headless assertions.
- Page wires the tree's active-row highlight via `activePath={doc.path}` (the row #3 panel already accepted the prop).
- i18n: `dashboard.workDetail.kb.{status.*, lock.*, document.emptyBody}` added to all 21 locale files (English copy; locale-specific translations follow in the standard pass).

## Test plan
- [x] `cd apps/web && npx vitest run src/components/works/detail/kb/` → 17 passed (4 `KbShell` · 6 `KbTreePanel` · 7 new `KbDocumentView`: title/meta/path · title-falls-back-to-path · MarkdownPreview with content · empty-body placeholder · lock chip + data attrs · lock chip omitted when unlocked · description paragraph)
- [x] `npx tsc --noEmit` (web) → clean
- [x] `npx eslint` on touched files → clean
- [x] `npx prettier --write` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- `docs/specs/features/knowledge-base/spec.md` §14 (Workbench UI)
- EW-641 Phase 1B/d row 4 of the atomic queue in `Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Base document viewing capability with read-only access to document content
  * Introduced document status indicators (draft, active, archived)
  * Implemented document locking mechanisms with full and additions-only modes
  * Added localized empty-document messaging

* **Internationalization**
  * Extended Knowledge Base localization support across 20+ languages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->