### PR TITLE
feat(kb): autosave debounce + dirty/saved indicator (EW-641 Phase 1B/d row 6)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2655,6 +2655,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2655,6 +2655,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2655,6 +2655,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2683,6 +2683,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2655,6 +2655,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2682,6 +2682,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2655,6 +2655,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2438,6 +2438,7 @@
                     "saved": "Saved",
                     "error": "Save failed",
                     "idle": "Idle",
+                    "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
                 }
             }

--- a/apps/web/src/components/works/detail/kb/KbEditor.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useTransition } from 'react';
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { useEditor, EditorContent, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -21,38 +21,53 @@ interface KbEditorProps {
      * watching the save bounce off the server with a 403.
      */
     readOnly?: boolean;
+    /**
+     * Override the autosave debounce. Tests pass a smaller value so the
+     * debounced path is exercisable inside `vi.useFakeTimers`; product
+     * code leaves it at the default 800ms (spec §14 acceptance A13).
+     */
+    autosaveDebounceMs?: number;
 }
 
-type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+type SaveStatus = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+
+const DEFAULT_AUTOSAVE_DEBOUNCE_MS = 800;
 
 /**
- * EW-641 Phase 1B/d row 5 — basic Tiptap editor for KB documents.
+ * EW-641 Phase 1B/d row 6 — Tiptap editor with 800ms debounced autosave
+ * + dirty/saved indicator.
  *
- * Wraps `@tiptap/react` + StarterKit + Link + `tiptap-markdown` so the
- * round-trip between the editor model and the API's Markdown body is
- * lossless for the basics (headings, lists, code blocks, links, etc.).
- * Autosave + dirty/saved indicator come in row 6 — this PR ships a
- * manual save button so the upload → edit → save loop is testable end
- * to end before the debounce + activity-log wiring lands.
+ * Builds on row 5's manual-save editor:
+ *  - `editor.on('update')` flips status `idle → dirty` and arms a
+ *    `setTimeout` that fires the same save path the manual button uses.
+ *    Successive edits within the window reset the timer (debounce).
+ *  - The manual "Save" button stays around as a "save now" affordance:
+ *    it clears the pending timer and runs the save immediately.
+ *  - The status pill cycles `idle → dirty → saving → saved → idle`
+ *    (with `error` short-circuiting). The `data-status` attribute is
+ *    the canonical Playwright assertion target (A13).
+ *  - When the in-flight save resolves we read the freshly returned
+ *    body so the dirty comparison resets to the server-confirmed
+ *    state — typing during the save still re-arms the timer afterwards.
  *
- * Selectors locked for the upcoming Playwright suite (A12-A17):
- *  - `data-testid="kb-editor"` (root, same as the row #4 read-only
- *    view so tests that pre-date this PR keep working)
- *  - `data-testid="kb-editor-body"` (the contenteditable surface)
- *  - `data-testid="kb-editor-save"` (the save button)
- *  - `data-testid="kb-editor-status"` (the saving/saved/error pill;
- *    autosave in row 6 keeps the same selector)
- *
- * Tiptap on React 19 strict mode needs `immediatelyRender: false` —
- * the editor's initial commit happens after mount instead of during
- * render, which avoids the "useSyncExternalStore inside render"
- * warning + double-mount content duplication.
+ * Tiptap on React 19 strict mode needs `immediatelyRender: false`.
  */
-export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
+export function KbEditor({
+    workId,
+    doc,
+    readOnly = false,
+    autosaveDebounceMs = DEFAULT_AUTOSAVE_DEBOUNCE_MS,
+}: KbEditorProps) {
     const t = useTranslations('dashboard.workDetail.kb');
     const [status, setStatus] = useState<SaveStatus>('idle');
     const [error, setError] = useState<string | null>(null);
     const [, startTransition] = useTransition();
+
+    // Track the last body confirmed by the server so the autosave
+    // debounce can short-circuit when nothing has actually changed.
+    const lastSavedBodyRef = useRef<string>(doc.body ?? '');
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const savingRef = useRef(false);
 
     const editor = useEditor({
         immediatelyRender: false,
@@ -85,22 +100,26 @@ export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
         },
     });
 
-    const onSave = useCallback(() => {
+    const flush = useCallback(() => {
         if (!editor) return;
-        setError(null);
-        setStatus('saving');
-        // Tiptap's markdown extension exposes a `getMarkdown()` helper
-        // through the editor storage. Round-trip through that so the
-        // saved payload matches what `tiptap-markdown` would parse back
-        // on the next mount.
-        const body = (
-            editor.storage as Record<string, { getMarkdown?: () => string }>
-        ).markdown?.getMarkdown?.();
+        if (savingRef.current) return; // already saving; the next edit re-arms
+
+        const body = readMarkdown(editor);
         if (typeof body !== 'string') {
             setStatus('error');
             setError('Could not serialize editor content as Markdown.');
             return;
         }
+        if (body === lastSavedBodyRef.current) {
+            // Nothing meaningful changed (e.g. focus toggled); skip the
+            // network round-trip and settle back to `idle`.
+            setStatus('idle');
+            return;
+        }
+
+        savingRef.current = true;
+        setError(null);
+        setStatus('saving');
 
         startTransition(async () => {
             const result = await updateKbDocumentAction({
@@ -108,7 +127,9 @@ export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
                 docId: doc.id,
                 body: { body },
             });
+            savingRef.current = false;
             if (result.success) {
+                lastSavedBodyRef.current = result.data?.body ?? body;
                 setStatus('saved');
             } else {
                 setStatus('error');
@@ -116,6 +137,50 @@ export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
             }
         });
     }, [editor, doc.id, workId]);
+
+    // Subscribe to editor updates → arm the autosave debounce.
+    useEffect(() => {
+        if (!editor) return;
+        if (readOnly) return;
+        const onUpdate = () => {
+            // Don't downgrade an in-flight save to dirty — the next
+            // settled state (`saved` / `error`) will reflect the latest
+            // server response. We still re-arm the timer so the typing
+            // that happened mid-save flushes once the request returns.
+            if (!savingRef.current) {
+                setStatus('dirty');
+            }
+            if (debounceRef.current !== null) {
+                clearTimeout(debounceRef.current);
+            }
+            debounceRef.current = setTimeout(() => {
+                debounceRef.current = null;
+                flush();
+            }, autosaveDebounceMs);
+        };
+        editor.on('update', onUpdate);
+        return () => {
+            editor.off('update', onUpdate);
+        };
+    }, [editor, readOnly, autosaveDebounceMs, flush]);
+
+    // Clean up any pending debounce on unmount.
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current !== null) {
+                clearTimeout(debounceRef.current);
+                debounceRef.current = null;
+            }
+        };
+    }, []);
+
+    const onSaveNow = useCallback(() => {
+        if (debounceRef.current !== null) {
+            clearTimeout(debounceRef.current);
+            debounceRef.current = null;
+        }
+        flush();
+    }, [flush]);
 
     return (
         <section
@@ -184,7 +249,7 @@ export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
             <footer className="flex items-center gap-3">
                 <SaveButton
                     disabled={readOnly || !editor || status === 'saving'}
-                    onClick={onSave}
+                    onClick={onSaveNow}
                     saving={status === 'saving'}
                     label={t('editor.save')}
                     savingLabel={t('editor.saving')}
@@ -194,6 +259,7 @@ export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
                     error={error}
                     labels={{
                         idle: t('editor.idle'),
+                        dirty: t('editor.dirty'),
                         saving: t('editor.saving'),
                         saved: t('editor.saved'),
                         error: t('editor.error'),
@@ -202,6 +268,18 @@ export function KbEditor({ workId, doc, readOnly = false }: KbEditorProps) {
             </footer>
         </section>
     );
+}
+
+/**
+ * Pull the Markdown body out of Tiptap's storage. The `tiptap-markdown`
+ * extension installs a `markdown.getMarkdown()` helper on the editor
+ * storage — that's the lossless round-trip path. We narrow the storage
+ * type defensively because Tiptap's storage map is typed as
+ * `Record<string, any>` upstream.
+ */
+function readMarkdown(editor: Editor): string | undefined {
+    const storage = editor.storage as Record<string, { getMarkdown?: () => string }>;
+    return storage.markdown?.getMarkdown?.();
 }
 
 interface EditorSurfaceProps {
@@ -265,6 +343,7 @@ function SaveButton({ disabled, onClick, saving, label, savingLabel }: SaveButto
 
 interface SaveStatusPillLabels {
     idle: string;
+    dirty: string;
     saving: string;
     saved: string;
     error: string;
@@ -289,16 +368,20 @@ function SaveStatusPill({ status, error, labels }: SaveStatusPillProps) {
                       ? 'text-red-600 dark:text-red-400'
                       : status === 'saving'
                         ? 'text-text-muted dark:text-text-muted-dark/70'
-                        : 'sr-only',
+                        : status === 'dirty'
+                          ? 'text-amber-700 dark:text-amber-300'
+                          : 'sr-only',
             )}
         >
             {status === 'saved'
                 ? labels.saved
                 : status === 'saving'
                   ? labels.saving
-                  : status === 'error'
-                    ? (error ?? labels.error)
-                    : labels.idle}
+                  : status === 'dirty'
+                    ? labels.dirty
+                    : status === 'error'
+                      ? (error ?? labels.error)
+                      : labels.idle}
         </span>
     );
 }

--- a/apps/web/src/components/works/detail/kb/KbEditor.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
@@ -8,16 +8,32 @@ vi.mock('next-intl', () => ({
 
 // Tiptap pulls in ProseMirror which doesn't play well with jsdom in
 // the harness — stub the bits this unit test cares about so the spec
-// focuses on the wiring (save action, status pill, selectors) rather
-// than re-asserting Tiptap's own behaviour. The mock exposes a real
-// `storage.markdown.getMarkdown()` so the save path round-trips.
+// focuses on the wiring (save action, status pill, debounce, selectors)
+// rather than re-asserting Tiptap's own behaviour.
+//
+// `editorMock.storage.markdown.getMarkdown()` is the lossless markdown
+// round-trip the editor uses on save. `editorMock.on('update', cb)`
+// captures the autosave listener so tests can fire a synthetic edit.
 let mockMarkdown = '';
+type Listener = () => void;
+const updateListeners = new Set<Listener>();
+const editorMock = {
+    storage: {
+        markdown: { getMarkdown: () => mockMarkdown },
+    },
+    on: (event: string, cb: Listener) => {
+        if (event === 'update') updateListeners.add(cb);
+    },
+    off: (event: string, cb: Listener) => {
+        if (event === 'update') updateListeners.delete(cb);
+    },
+};
+function fireEditorUpdate() {
+    updateListeners.forEach((cb) => cb());
+}
+
 vi.mock('@tiptap/react', () => ({
-    useEditor: () => ({
-        storage: {
-            markdown: { getMarkdown: () => mockMarkdown },
-        },
-    }),
+    useEditor: () => editorMock,
     EditorContent: ({ editor: _editor }: { editor: unknown }) => (
         <div data-testid="kb-editor-body" contentEditable />
     ),
@@ -94,17 +110,21 @@ function doc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
 }
 
 /**
- * EW-641 Phase 1B/d row 5 — `KbEditor` glues Tiptap to the
- * `updateKbDocumentAction` server action. These tests exercise the
- * wiring rather than Tiptap itself: render shape, save click triggers
- * the action with the markdown round-trip output, status pill flips
- * `idle → saving → saved | error`, locked docs disable the save
- * button. Tiptap's own behaviour stays out of scope.
+ * EW-641 Phase 1B/d row 6 — `KbEditor` adds debounced autosave +
+ * dirty/saved indicator on top of the row 5 manual save. These tests
+ * cover both: render shape, manual save path, locked behaviour, debounce
+ * coalescing, dirty → saving → saved transitions, error pill text,
+ * and the "no-op skip" when the body hasn't actually changed.
  */
 describe('KbEditor', () => {
     beforeEach(() => {
         updateActionMock.mockReset();
-        mockMarkdown = '# Voice\n\nUpdated body.';
+        updateListeners.clear();
+        mockMarkdown = '# Voice\n\nClear, confident.'; // matches the initial doc body
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it('renders the editor body, header chips, and save button', () => {
@@ -119,18 +139,28 @@ describe('KbEditor', () => {
         expect(meta.textContent).toContain('classes.brand');
         expect(meta.textContent).toContain('status.active');
         expect(meta.textContent).toContain('brand/voice.md');
+
+        // No autosave listener should be wired when no edits have happened —
+        // but the component must have subscribed exactly once.
+        expect(updateListeners.size).toBe(1);
     });
 
-    it('disables the save button when readOnly is set', () => {
+    it('disables the save button when readOnly is set + skips the update listener', () => {
         render(<KbEditor workId="work-1" doc={doc({ locked: true, lockMode: 'full' })} readOnly />);
         const save = screen.getByTestId('kb-editor-save') as HTMLButtonElement;
         expect(save.disabled).toBe(true);
         const lockEl = screen.getByTestId('kb-document-meta').querySelector('[data-locked="true"]');
         expect(lockEl).not.toBeNull();
+        // readOnly = no autosave subscription (it'd never save anyway).
+        expect(updateListeners.size).toBe(0);
     });
 
-    it('PATCHes the body via the server action and flips the status to saved', async () => {
-        updateActionMock.mockResolvedValueOnce({ success: true, data: doc() });
+    it('PATCHes the body via the server action and flips the status to saved (manual)', async () => {
+        mockMarkdown = '# Voice\n\nUpdated body.';
+        updateActionMock.mockResolvedValueOnce({
+            success: true,
+            data: doc({ body: mockMarkdown }),
+        });
         render(<KbEditor workId="work-1" doc={doc()} />);
 
         await act(async () => {
@@ -153,6 +183,7 @@ describe('KbEditor', () => {
     });
 
     it('surfaces the action error on the status pill', async () => {
+        mockMarkdown = '# Voice\n\nUpdated body.';
         updateActionMock.mockResolvedValueOnce({ success: false, error: 'boom' });
         render(<KbEditor workId="work-1" doc={doc()} />);
 
@@ -172,5 +203,92 @@ describe('KbEditor', () => {
         const root = screen.getByTestId('kb-editor');
         expect(root.getAttribute('data-doc-id')).toBe('abc-123');
         expect(root.getAttribute('data-doc-path')).toBe('legal/privacy.md');
+    });
+
+    it('shows `dirty` immediately on edit, then autosaves after the debounce', async () => {
+        vi.useFakeTimers();
+        mockMarkdown = '# Voice\n\nedited';
+        updateActionMock.mockResolvedValueOnce({
+            success: true,
+            data: doc({ body: mockMarkdown }),
+        });
+        render(<KbEditor workId="work-1" doc={doc()} autosaveDebounceMs={500} />);
+
+        // Synthesise an editor edit.
+        act(() => {
+            fireEditorUpdate();
+        });
+        expect(screen.getByTestId('kb-editor-status').getAttribute('data-status')).toBe('dirty');
+
+        // Advance halfway → still dirty, no save yet.
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+        });
+        expect(updateActionMock).not.toHaveBeenCalled();
+        expect(screen.getByTestId('kb-editor-status').getAttribute('data-status')).toBe('dirty');
+
+        // Cross the debounce threshold → save fires.
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await vi.runAllTimersAsync();
+        });
+        expect(updateActionMock).toHaveBeenCalledTimes(1);
+
+        // Swap back to real timers so waitFor's polling actually
+        // advances — under fake timers waitFor never re-checks and
+        // the test times out.
+        vi.useRealTimers();
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-editor-status').getAttribute('data-status')).toBe(
+                'saved',
+            );
+        });
+    });
+
+    it('coalesces rapid edits into a single autosave (debounce reset)', async () => {
+        vi.useFakeTimers();
+        mockMarkdown = '# Voice\n\nedit';
+        updateActionMock.mockResolvedValueOnce({
+            success: true,
+            data: doc({ body: mockMarkdown }),
+        });
+        render(<KbEditor workId="work-1" doc={doc()} autosaveDebounceMs={500} />);
+
+        // Three rapid edits within the debounce window.
+        for (let i = 0; i < 3; i += 1) {
+            act(() => {
+                fireEditorUpdate();
+            });
+            await act(async () => {
+                vi.advanceTimersByTime(200);
+            });
+        }
+        // 3 × 200ms = 600ms of fake time elapsed but the last edit reset
+        // the timer twice, so total wait since last edit < 500ms → no save.
+        expect(updateActionMock).not.toHaveBeenCalled();
+
+        // Settle past the debounce now.
+        await act(async () => {
+            vi.advanceTimersByTime(500);
+            await vi.runAllTimersAsync();
+        });
+        expect(updateActionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the save when the body matches the last-saved value', async () => {
+        vi.useFakeTimers();
+        // mockMarkdown still equals the initial doc body → flush should
+        // settle back to `idle` without calling the server action.
+        render(<KbEditor workId="work-1" doc={doc()} autosaveDebounceMs={500} />);
+
+        act(() => {
+            fireEditorUpdate();
+        });
+        await act(async () => {
+            vi.advanceTimersByTime(600);
+            await vi.runAllTimersAsync();
+        });
+        expect(updateActionMock).not.toHaveBeenCalled();
+        expect(screen.getByTestId('kb-editor-status').getAttribute('data-status')).toBe('idle');
     });
 });


### PR DESCRIPTION
## Summary
- Extends the row #5 manual-save editor with **800ms debounced autosave** + a richer status pill. The save path itself is unchanged — the same \`updateKbDocumentAction\` fires whether the user clicks "Save" or just stops typing for 800ms.
- New \`dirty\` \`SaveStatus\` added between \`idle\` and \`saving\`. Pill cycles \`idle → dirty → saving → saved → idle\` (or \`error\`). \`data-status="dirty"\` is the canonical A13 Playwright assertion target.
- Centralised save path (\`flush\`):
  - Refuses to run when a save is already in flight (the next \`update\` event re-arms the timer, so typing mid-save still flushes once the response settles).
  - Compares the current markdown to \`lastSavedBodyRef.current\` and short-circuits to \`idle\` when nothing changed — no round-trips for focus toggles or Tiptap's own no-op updates on mount.
  - On success, advances \`lastSavedBodyRef\` to the server-confirmed body so subsequent dirty checks stay accurate even if the API normalises the body.
- Pending debounce cleared on unmount.
- i18n: \`dashboard.workDetail.kb.editor.dirty\` ("Unsaved changes…") added to all 21 locales.

## Test plan
- [x] \`cd apps/web && npx vitest run src/components/works/detail/kb/\` → 25 passed (4 KbShell · 6 KbTreePanel · 7 KbDocumentView · 8 KbEditor: 5 prior + 3 new for autosave — synthetic update flips to \`dirty\` and autosaves after the debounce · three rapid edits coalesce into one save · identical-body short-circuits to \`idle\` with no network call).
- [x] \`npx tsc --noEmit\` (web) → clean
- [x] \`npx eslint\` on touched files → clean
- [x] \`npx prettier --write\` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- \`docs/specs/features/knowledge-base/spec.md\` §14 acceptance A13 (edit + autosave → "Saved" indicator + persistence on refresh)
- EW-641 Phase 1B/d row 6 of the atomic queue in \`Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge Base editor now displays an "Unsaved changes" indicator to track modification status.
  * Autosave functionality added to the Knowledge Base editor with debounced saves to reduce server requests.
  * Manual save button remains available for immediate saves.
  * Editor status now shows dirty, saving, saved, or error states clearly.

* **Localization**
  * Added multilingual support for the unsaved changes message across 20+ languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->