### PR TITLE
feat(kb): drag-drop upload zone (EW-641 Phase 1B/d row 7)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2657,6 +2657,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2657,6 +2657,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2657,6 +2657,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2685,6 +2685,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2657,6 +2657,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2684,6 +2684,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2657,6 +2657,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2440,6 +2440,18 @@
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
                     "placeholder": "Start typing to add content…"
+                },
+                "upload": {
+                    "title": "Upload to Knowledge Base",
+                    "hint": "Drag & drop files here, or click Browse. Markdown, HTML, PDF, DOCX, XLSX, CSV/TSV, and PPTX are extracted automatically.",
+                    "browse": "Browse files",
+                    "dismiss": "Dismiss",
+                    "status": {
+                        "queued": "Queued",
+                        "uploading": "Uploading",
+                        "succeeded": "Uploaded",
+                        "failed": "Failed"
+                    }
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
@@ -8,6 +8,7 @@ import { KbShell } from '@/components/works/detail/kb/KbShell';
 import { KbTreePanel } from '@/components/works/detail/kb/KbTreePanel';
 import { KbDocumentView } from '@/components/works/detail/kb/KbDocumentView';
 import { KbEditor } from '@/components/works/detail/kb/KbEditor';
+import { KbUploadZone } from '@/components/works/detail/kb/KbUploadZone';
 
 type Params = {
     params: Promise<{ id: string; path: string[] }>;
@@ -91,12 +92,15 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
     const fullyLocked = doc.locked && doc.lockMode === 'full';
 
     return (
-        <KbShell
-            workId={id}
-            treeSlot={<KbTreePanel workId={id} documents={list.items} activePath={doc.path} />}
-            editorSlot={
-                fullyLocked ? <KbDocumentView doc={doc} /> : <KbEditor workId={id} doc={doc} />
-            }
-        />
+        <div className="flex flex-col gap-4">
+            <KbUploadZone workId={id} targetClass={doc.class} />
+            <KbShell
+                workId={id}
+                treeSlot={<KbTreePanel workId={id} documents={list.items} activePath={doc.path} />}
+                editorSlot={
+                    fullyLocked ? <KbDocumentView doc={doc} /> : <KbEditor workId={id} doc={doc} />
+                }
+            />
+        </div>
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
@@ -5,6 +5,7 @@ import { workAPI } from '@/lib/api';
 import { kbAPI } from '@/lib/api/kb';
 import { KbShell } from '@/components/works/detail/kb/KbShell';
 import { KbTreePanel } from '@/components/works/detail/kb/KbTreePanel';
+import { KbUploadZone } from '@/components/works/detail/kb/KbUploadZone';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.workDetail.kb');
@@ -42,5 +43,10 @@ export default async function WorkKnowledgeBasePage({ params }: Params) {
         return { items: [], total: 0 };
     });
 
-    return <KbShell workId={id} treeSlot={<KbTreePanel workId={id} documents={docs.items} />} />;
+    return (
+        <div className="flex flex-col gap-4">
+            <KbUploadZone workId={id} />
+            <KbShell workId={id} treeSlot={<KbTreePanel workId={id} documents={docs.items} />} />
+        </div>
+    );
 }

--- a/apps/web/src/app/api/works/[id]/kb/uploads/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/uploads/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 7 — multipart upload proxy.
+ *
+ * Forwards `POST /api/works/[id]/kb/uploads` from the browser to the
+ * NestJS API. The browser submits multipart/form-data with a `file`
+ * part + optional `targetClass`, `title`, `description`, `tags`
+ * fields; we stream the request body upstream so the multipart
+ * boundary stays intact — NestJS's `FileInterceptor` parses it on
+ * the upstream side.
+ *
+ * Mirrors `import-items/validate/route.ts` (the only other multipart
+ * proxy in this app) so behaviour is consistent: auth cookie →
+ * `Authorization: Bearer`, `cache: 'no-store'`, surface the upstream
+ * status + body verbatim on error so the client can show the right
+ * 413 / 503 / 400 messaging.
+ */
+export async function POST(request: NextRequest, { params }: RouteContext) {
+    const { id } = await params;
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    const contentType = request.headers.get('content-type');
+    if (contentType) {
+        headers.set('Content-Type', contentType);
+    }
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstream = await fetch(`${API_URL}/works/${id}/kb/uploads`, {
+        method: 'POST',
+        headers,
+        body: request.body,
+        // Required for streaming request bodies on Node's fetch.
+        duplex: 'half',
+        cache: 'no-store',
+    } as RequestInit & { duplex: 'half' });
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const body = await upstream.json().catch(() => null);
+    return NextResponse.json(body ?? {}, { status: upstream.status });
+}

--- a/apps/web/src/components/works/detail/kb/KbUploadZone.tsx
+++ b/apps/web/src/components/works/detail/kb/KbUploadZone.tsx
@@ -1,0 +1,392 @@
+'use client';
+
+import {
+    useCallback,
+    useRef,
+    useState,
+    type ChangeEvent,
+    type DragEvent,
+    type ReactNode,
+} from 'react';
+import { useRouter } from '@/i18n/navigation';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+
+interface KbUploadZoneProps {
+    workId: string;
+    /**
+     * Optional pre-selected document class — when the operator drops
+     * a file directly into a class folder in the tree (row 8 wires
+     * this), the upload zone forwards the value so the backend
+     * skips heuristics-based classification.
+     */
+    targetClass?: string;
+}
+
+type UploadEntryStatus = 'queued' | 'uploading' | 'succeeded' | 'failed';
+
+interface UploadEntry {
+    /** Stable id for React `key` + status updates. */
+    id: string;
+    name: string;
+    size: number;
+    status: UploadEntryStatus;
+    /** Percentage 0-100, only meaningful while `uploading`. */
+    progress: number;
+    error: string | null;
+    documentId: string | null;
+}
+
+/**
+ * EW-641 Phase 1B/d row 7 — drag-drop upload zone.
+ *
+ * Renders a dashed drop target that accepts file drops + clicks for
+ * the hidden `<input type=file>` fallback. Each file becomes an
+ * `UploadEntry` that streams progress through `XMLHttpRequest.upload`
+ * (`fetch` doesn't expose progress in Next.js client runtimes today).
+ *
+ * On the first successful upload the component calls
+ * `router.refresh()` so the server-rendered tree panel
+ * (`KbTreePanel`) re-fetches and the new document appears in the
+ * left pane. Errors stay on the entry until the operator either
+ * dismisses or replaces them — the form never silently swallows a
+ * 413 / 503 / 400 from the backend.
+ *
+ * Selectors locked for the Playwright A12 (drag-drop upload → KB
+ * doc) suite:
+ *  - `data-testid="kb-upload-zone"` (drop target)
+ *  - `data-testid="kb-upload-input"` (hidden file input)
+ *  - `data-testid="kb-upload-entries"` (entries list)
+ *  - `data-testid="kb-upload-entry"` (one per file) +
+ *    `data-status` attribute that mirrors `UploadEntryStatus`
+ */
+export function KbUploadZone({ workId, targetClass }: KbUploadZoneProps) {
+    const t = useTranslations('dashboard.workDetail.kb.upload');
+    const router = useRouter();
+    const [entries, setEntries] = useState<UploadEntry[]>([]);
+    const [dragActive, setDragActive] = useState(false);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const refreshScheduled = useRef(false);
+
+    const updateEntry = useCallback((id: string, patch: Partial<UploadEntry>) => {
+        setEntries((prev) =>
+            prev.map((entry) => (entry.id === id ? { ...entry, ...patch } : entry)),
+        );
+    }, []);
+
+    const onFiles = useCallback(
+        (files: FileList | File[] | null) => {
+            if (!files) return;
+            const fileArray = Array.from(files);
+            if (fileArray.length === 0) return;
+
+            const queued: UploadEntry[] = fileArray.map((file) => ({
+                id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+                name: file.name,
+                size: file.size,
+                status: 'queued',
+                progress: 0,
+                error: null,
+                documentId: null,
+            }));
+
+            setEntries((prev) => [...queued, ...prev]);
+
+            for (const [index, file] of fileArray.entries()) {
+                const entryId = queued[index].id;
+                void uploadOne({
+                    workId,
+                    targetClass,
+                    file,
+                    entryId,
+                    updateEntry,
+                    onSuccess: () => {
+                        // Batch refreshes — N parallel uploads should
+                        // only kick a single revalidation pass.
+                        if (refreshScheduled.current) return;
+                        refreshScheduled.current = true;
+                        Promise.resolve().then(() => {
+                            refreshScheduled.current = false;
+                            router.refresh();
+                        });
+                    },
+                });
+            }
+        },
+        [workId, targetClass, updateEntry, router],
+    );
+
+    const onDrop = useCallback(
+        (event: DragEvent<HTMLDivElement>) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setDragActive(false);
+            onFiles(event.dataTransfer?.files ?? null);
+        },
+        [onFiles],
+    );
+
+    const onDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setDragActive(true);
+    }, []);
+
+    const onDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setDragActive(false);
+    }, []);
+
+    const onPick = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            const files = event.target.files;
+            onFiles(files);
+            // Reset so picking the same file twice still triggers the
+            // change event (browsers de-dup identical selections).
+            event.target.value = '';
+        },
+        [onFiles],
+    );
+
+    const onBrowseClick = useCallback(() => {
+        inputRef.current?.click();
+    }, []);
+
+    const onDismiss = useCallback((id: string) => {
+        setEntries((prev) => prev.filter((entry) => entry.id !== id));
+    }, []);
+
+    return (
+        <section aria-label={t('title')} className="flex flex-col gap-3">
+            <DropTarget
+                dragActive={dragActive}
+                onDrop={onDrop}
+                onDragOver={onDragOver}
+                onDragEnter={onDragOver}
+                onDragLeave={onDragLeave}
+                onBrowseClick={onBrowseClick}
+                title={t('title')}
+                hint={t('hint')}
+                browseLabel={t('browse')}
+            >
+                <input
+                    ref={inputRef}
+                    type="file"
+                    multiple
+                    data-testid="kb-upload-input"
+                    className="sr-only"
+                    onChange={onPick}
+                />
+            </DropTarget>
+
+            {entries.length > 0 ? (
+                <ul data-testid="kb-upload-entries" className="flex flex-col gap-1.5">
+                    {entries.map((entry) => (
+                        <UploadEntryRow
+                            key={entry.id}
+                            entry={entry}
+                            labels={{
+                                queued: t('status.queued'),
+                                uploading: t('status.uploading'),
+                                succeeded: t('status.succeeded'),
+                                failed: t('status.failed'),
+                                dismiss: t('dismiss'),
+                            }}
+                            onDismiss={onDismiss}
+                        />
+                    ))}
+                </ul>
+            ) : null}
+        </section>
+    );
+}
+
+interface DropTargetProps {
+    dragActive: boolean;
+    onDrop: (event: DragEvent<HTMLDivElement>) => void;
+    onDragOver: (event: DragEvent<HTMLDivElement>) => void;
+    onDragEnter: (event: DragEvent<HTMLDivElement>) => void;
+    onDragLeave: (event: DragEvent<HTMLDivElement>) => void;
+    onBrowseClick: () => void;
+    title: string;
+    hint: string;
+    browseLabel: string;
+    children: ReactNode;
+}
+
+function DropTarget({
+    dragActive,
+    onDrop,
+    onDragOver,
+    onDragEnter,
+    onDragLeave,
+    onBrowseClick,
+    title,
+    hint,
+    browseLabel,
+    children,
+}: DropTargetProps) {
+    return (
+        <div
+            data-testid="kb-upload-zone"
+            data-drag-active={dragActive ? 'true' : 'false'}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            onDragEnter={onDragEnter}
+            onDragLeave={onDragLeave}
+            className={cn(
+                'rounded-lg border-2 border-dashed p-6 text-center transition-colors',
+                dragActive
+                    ? 'border-primary bg-primary/5 dark:bg-primary/10'
+                    : 'border-border bg-card/30 dark:border-border-dark dark:bg-card-primary-dark/20',
+            )}
+        >
+            <p className="text-sm font-medium text-text dark:text-text-dark">{title}</p>
+            <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark/60">{hint}</p>
+            <div className="mt-3">
+                <Button type="button" size="sm" onClick={onBrowseClick}>
+                    {browseLabel}
+                </Button>
+            </div>
+            {children}
+        </div>
+    );
+}
+
+interface UploadEntryRowProps {
+    entry: UploadEntry;
+    labels: {
+        queued: string;
+        uploading: string;
+        succeeded: string;
+        failed: string;
+        dismiss: string;
+    };
+    onDismiss: (id: string) => void;
+}
+
+function UploadEntryRow({ entry, labels, onDismiss }: UploadEntryRowProps) {
+    const statusLabel =
+        entry.status === 'queued'
+            ? labels.queued
+            : entry.status === 'uploading'
+              ? `${labels.uploading} ${entry.progress}%`
+              : entry.status === 'succeeded'
+                ? labels.succeeded
+                : (entry.error ?? labels.failed);
+
+    return (
+        <li
+            data-testid="kb-upload-entry"
+            data-status={entry.status}
+            data-entry-id={entry.id}
+            className={cn(
+                'flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs',
+                'border-border dark:border-border-dark bg-card/30 dark:bg-card-primary-dark/20',
+            )}
+        >
+            <span className="flex-1 truncate font-medium text-text dark:text-text-dark">
+                {entry.name}
+            </span>
+            <span
+                className={cn(
+                    'rounded-full px-2 py-0.5',
+                    entry.status === 'succeeded'
+                        ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+                        : entry.status === 'failed'
+                          ? 'bg-red-500/10 text-red-700 dark:text-red-400'
+                          : entry.status === 'uploading'
+                            ? 'bg-primary/10 text-primary'
+                            : 'bg-card-hover text-text-muted dark:bg-card-primary-dark/40 dark:text-text-muted-dark/70',
+                )}
+            >
+                {statusLabel}
+            </span>
+            {entry.status === 'succeeded' || entry.status === 'failed' ? (
+                <button
+                    type="button"
+                    aria-label={labels.dismiss}
+                    onClick={() => onDismiss(entry.id)}
+                    className="text-text-muted hover:text-text dark:text-text-muted-dark/60 dark:hover:text-text-dark"
+                >
+                    ×
+                </button>
+            ) : null}
+        </li>
+    );
+}
+
+/**
+ * Internal upload driver — uses `XMLHttpRequest` because `fetch` in
+ * Node 22 / Next 16 client runtimes doesn't expose request-progress
+ * events (the standard `progress` listener fires on the response,
+ * not on the body upload). Server-Sent Events would also work, but
+ * XHR is the standard pattern in this codebase (see
+ * `apps/web/src/components/works/detail/items/ItemsImportClient.tsx`).
+ */
+function uploadOne(args: {
+    workId: string;
+    targetClass?: string;
+    file: File;
+    entryId: string;
+    updateEntry: (id: string, patch: Partial<UploadEntry>) => void;
+    onSuccess: (documentId: string | null) => void;
+}): Promise<void> {
+    const { workId, targetClass, file, entryId, updateEntry, onSuccess } = args;
+    return new Promise<void>((resolve) => {
+        const form = new FormData();
+        form.append('file', file);
+        if (targetClass) form.append('targetClass', targetClass);
+
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', `/api/works/${workId}/kb/uploads`);
+        xhr.responseType = 'json';
+
+        xhr.upload.addEventListener('progress', (event) => {
+            if (!event.lengthComputable) return;
+            const progress = Math.min(100, Math.round((event.loaded / event.total) * 100));
+            updateEntry(entryId, { status: 'uploading', progress });
+        });
+        xhr.addEventListener('error', () => {
+            updateEntry(entryId, { status: 'failed', error: 'Network error' });
+            resolve();
+        });
+        xhr.addEventListener('abort', () => {
+            updateEntry(entryId, { status: 'failed', error: 'Upload aborted' });
+            resolve();
+        });
+        xhr.addEventListener('load', () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                const docId =
+                    (xhr.response &&
+                        typeof xhr.response === 'object' &&
+                        (xhr.response as { document?: { id?: string } | null }).document?.id) ||
+                    null;
+                updateEntry(entryId, {
+                    status: 'succeeded',
+                    progress: 100,
+                    documentId: docId,
+                });
+                onSuccess(docId);
+            } else {
+                let message: string | null = null;
+                const body = xhr.response;
+                if (body && typeof body === 'object') {
+                    const candidate = (body as { message?: unknown }).message;
+                    if (typeof candidate === 'string') message = candidate;
+                    else if (Array.isArray(candidate)) message = candidate.join(', ');
+                }
+                updateEntry(entryId, {
+                    status: 'failed',
+                    error: message ?? `HTTP ${xhr.status}`,
+                });
+            }
+            resolve();
+        });
+
+        updateEntry(entryId, { status: 'uploading', progress: 0 });
+        xhr.send(form);
+    });
+}

--- a/apps/web/src/components/works/detail/kb/KbUploadZone.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbUploadZone.unit.spec.tsx
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+const refreshMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ refresh: refreshMock }),
+}));
+
+// shadcn Button → simple <button> stub.
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        ...rest
+    }: {
+        children: ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+    } & Record<string, unknown>) => (
+        <button type="button" onClick={onClick} disabled={disabled} {...rest}>
+            {children}
+        </button>
+    ),
+}));
+
+import { KbUploadZone } from './KbUploadZone';
+
+/**
+ * Minimal `XMLHttpRequest` stand-in: tests resolve uploads
+ * synchronously via the captured instance's helper methods. The real
+ * XHR pulls in DOM XML / event-target machinery that jsdom only
+ * partially supports — and the component only needs the four events
+ * (`load`, `error`, `abort`, `upload.progress`) to drive the UI.
+ */
+class FakeXHR {
+    public method = '';
+    public url = '';
+    public response: unknown = null;
+    public status = 0;
+    public responseType = '';
+    public readonly upload = new EventTarget();
+    private readonly self = new EventTarget();
+
+    open(method: string, url: string) {
+        this.method = method;
+        this.url = url;
+    }
+
+    send(_body: FormData) {
+        // Tests trigger completion via `complete()` / `fail()` /
+        // `errorOut()` below — `send` itself is a no-op.
+    }
+
+    addEventListener(type: string, cb: EventListener) {
+        this.self.addEventListener(type, cb);
+    }
+
+    /** Helpers used by the tests. */
+    fireProgress(loaded: number, total: number) {
+        this.upload.dispatchEvent(
+            Object.assign(new Event('progress'), {
+                lengthComputable: true,
+                loaded,
+                total,
+            }) as Event,
+        );
+    }
+    complete(response: unknown, status = 201) {
+        this.response = response;
+        this.status = status;
+        this.self.dispatchEvent(new Event('load'));
+    }
+    fail(response: unknown, status: number) {
+        this.response = response;
+        this.status = status;
+        this.self.dispatchEvent(new Event('load'));
+    }
+    errorOut() {
+        this.self.dispatchEvent(new Event('error'));
+    }
+}
+
+const xhrInstances: FakeXHR[] = [];
+
+beforeEach(() => {
+    refreshMock.mockReset();
+    xhrInstances.length = 0;
+    // Replace the global XMLHttpRequest with our stub for the duration
+    // of the test. `globalThis` is the right surface — jsdom's
+    // `window.XMLHttpRequest` and `globalThis.XMLHttpRequest` point at
+    // the same constructor.
+    vi.stubGlobal('XMLHttpRequest', function FakeXHRCtor() {
+        const x = new FakeXHR();
+        xhrInstances.push(x);
+        return x;
+    } as unknown as typeof XMLHttpRequest);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function fileLike(name: string, contents = 'hello'): File {
+    return new File([contents], name, { type: 'text/markdown' });
+}
+
+/**
+ * EW-641 Phase 1B/d row 7 — KbUploadZone tests cover the wiring that
+ * the Playwright A12 (drag-drop → KB doc) acceptance suite leans on:
+ *  - selectors stay stable (`kb-upload-zone`, `kb-upload-input`,
+ *    `kb-upload-entries`, `kb-upload-entry` with `data-status`)
+ *  - file pick + drop both kick off a POST to `/api/works/.../kb/uploads`
+ *  - `data-status` on the entry cycles `uploading → succeeded` (or `failed`)
+ *  - on success the page revalidates via `router.refresh` so the
+ *    server-rendered `<KbTreePanel>` sees the new document
+ *  - drag-over flips the `data-drag-active` flag for styling cues
+ */
+describe('KbUploadZone', () => {
+    it('renders the drop target + hidden file input', () => {
+        render(<KbUploadZone workId="work-1" />);
+        expect(screen.getByTestId('kb-upload-zone')).toBeTruthy();
+        const input = screen.getByTestId('kb-upload-input') as HTMLInputElement;
+        expect(input.type).toBe('file');
+        expect(input.multiple).toBe(true);
+        // No entries yet.
+        expect(screen.queryByTestId('kb-upload-entries')).toBeNull();
+    });
+
+    it('starts an upload when files are selected via the input', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        const input = screen.getByTestId('kb-upload-input') as HTMLInputElement;
+
+        await act(async () => {
+            fireEvent.change(input, { target: { files: [fileLike('voice.md')] } });
+        });
+
+        // XHR opened against the proxied Next.js route.
+        await waitFor(() => expect(xhrInstances.length).toBe(1));
+        expect(xhrInstances[0].method).toBe('POST');
+        expect(xhrInstances[0].url).toBe('/api/works/work-1/kb/uploads');
+
+        // Entry rendered with status="uploading".
+        const entry = screen.getByTestId('kb-upload-entry');
+        expect(entry.getAttribute('data-status')).toBe('uploading');
+        expect(entry.textContent).toContain('voice.md');
+    });
+
+    it('forwards targetClass as a form field when the prop is set', async () => {
+        // We can't read the FormData out of `send` easily without
+        // exposing it on the stub — extend the stub on the fly.
+        let capturedBody: FormData | null = null;
+        const origSend = FakeXHR.prototype.send;
+        FakeXHR.prototype.send = function patched(body: FormData) {
+            capturedBody = body;
+            return origSend.call(this, body);
+        };
+        try {
+            render(<KbUploadZone workId="work-1" targetClass="brand" />);
+            await act(async () => {
+                fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                    target: { files: [fileLike('voice.md')] },
+                });
+            });
+            await waitFor(() => expect(xhrInstances.length).toBe(1));
+            expect(capturedBody).not.toBeNull();
+            expect(capturedBody!.get('targetClass')).toBe('brand');
+            expect((capturedBody!.get('file') as File).name).toBe('voice.md');
+        } finally {
+            FakeXHR.prototype.send = origSend;
+        }
+    });
+
+    it('flips entry to succeeded + calls router.refresh on 201', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                target: { files: [fileLike('voice.md')] },
+            });
+        });
+        await waitFor(() => expect(xhrInstances.length).toBe(1));
+
+        await act(async () => {
+            xhrInstances[0].complete({ upload: { id: 'u-1' }, document: { id: 'd-1' } }, 201);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-upload-entry').getAttribute('data-status')).toBe(
+                'succeeded',
+            );
+        });
+        // Refresh runs in a microtask — flush once.
+        await Promise.resolve();
+        expect(refreshMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the backend error message on failure', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                target: { files: [fileLike('big.bin')] },
+            });
+        });
+        await waitFor(() => expect(xhrInstances.length).toBe(1));
+
+        await act(async () => {
+            xhrInstances[0].fail({ message: 'File too large' }, 413);
+        });
+
+        await waitFor(() => {
+            const entry = screen.getByTestId('kb-upload-entry');
+            expect(entry.getAttribute('data-status')).toBe('failed');
+            expect(entry.textContent).toContain('File too large');
+        });
+        expect(refreshMock).not.toHaveBeenCalled();
+    });
+
+    it('handles network errors with a generic message', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                target: { files: [fileLike('voice.md')] },
+            });
+        });
+        await waitFor(() => expect(xhrInstances.length).toBe(1));
+
+        await act(async () => {
+            xhrInstances[0].errorOut();
+        });
+
+        await waitFor(() => {
+            const entry = screen.getByTestId('kb-upload-entry');
+            expect(entry.getAttribute('data-status')).toBe('failed');
+            expect(entry.textContent).toContain('Network error');
+        });
+    });
+
+    it('reflects upload progress on the status pill', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                target: { files: [fileLike('voice.md')] },
+            });
+        });
+        await waitFor(() => expect(xhrInstances.length).toBe(1));
+
+        await act(async () => {
+            xhrInstances[0].fireProgress(50, 200);
+        });
+        const entry = screen.getByTestId('kb-upload-entry');
+        expect(entry.getAttribute('data-status')).toBe('uploading');
+        expect(entry.textContent).toContain('25%'); // 50/200
+    });
+
+    it('flips data-drag-active when dragging files over the zone', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        const zone = screen.getByTestId('kb-upload-zone');
+        expect(zone.getAttribute('data-drag-active')).toBe('false');
+
+        await act(async () => {
+            fireEvent.dragEnter(zone);
+        });
+        expect(zone.getAttribute('data-drag-active')).toBe('true');
+
+        await act(async () => {
+            fireEvent.dragLeave(zone);
+        });
+        expect(zone.getAttribute('data-drag-active')).toBe('false');
+    });
+});


### PR DESCRIPTION
## Summary
- Wires the **multipart upload flow** on the Workbench so operators can drop files onto the KB page and have them flow through the Phase 1B/b upload pipeline + 1B/c extractor.
- New Next.js multipart proxy at \`apps/web/src/app/api/works/[id]/kb/uploads/route.ts\` — same shape as the existing \`import-items/validate\` proxy: streams the request body upstream so the multipart boundary stays intact, attaches the auth cookie as \`Authorization: Bearer\`, surfaces upstream status + body verbatim on error so the client can show the right 413 / 503 / 400 messaging.
- \`KbUploadZone.tsx\` (client) — dashed drop target + hidden \`<input type=file multiple>\` fallback. Each file becomes an \`UploadEntry\` with status \`queued → uploading → succeeded | failed\` and a percentage on the pill. Uses \`XMLHttpRequest\` for the upload because \`fetch\` doesn't expose request-progress events in the Next.js client runtime today.
- On first success per batch the component calls \`router.refresh()\` (batched via a microtask flag so N parallel uploads = 1 refresh pass) → the server-rendered \`KbTreePanel\` re-fetches and the new doc appears in the left pane without a hard reload.
- Mounted above \`KbShell\` on both \`/kb\` index + nested \`[...path]\` routes. The detail route passes the doc's class as \`targetClass\` so dropping a file on a brand doc routes the new upload to the brand class.
- Selectors locked for Playwright A12: \`kb-upload-zone\` (with \`data-drag-active\`), \`kb-upload-input\`, \`kb-upload-entries\`, \`kb-upload-entry\` (with \`data-status\` + \`data-entry-id\`).
- i18n: \`dashboard.workDetail.kb.upload.{title,hint,browse,dismiss,status.*}\` added across all 21 locales.

## Test plan
- [x] \`cd apps/web && npx vitest run src/components/works/detail/kb/\` → 33 passed (4 KbShell · 6 KbTreePanel · 7 KbDocumentView · 8 KbEditor · 8 new KbUploadZone: selectors · pick triggers POST · targetClass forwarded · 201 flips to \`succeeded\` + 1× \`router.refresh\` · backend error surfaces · network error → "Network error" pill · progress event updates % · drag-enter/leave flips \`data-drag-active\`)
- [x] \`npx tsc --noEmit\` (web) → clean
- [x] \`npx eslint\` on touched files → clean
- [x] \`npx prettier --write\` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- \`docs/specs/features/knowledge-base/spec.md\` §14 acceptance A12 (drag-drop upload → KB doc renders in editor)
- EW-641 Phase 1B/d row 7 of the atomic queue in \`Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Base file upload functionality with drag-and-drop and browse options
  * Upload status tracking (queued, uploading, succeeded, failed)
  * Multilingual support for 20+ languages in upload UI
  * Automatic page refresh upon successful upload

* **Tests**
  * Added comprehensive unit tests for upload component functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->