### PR TITLE
feat(kb): classify modal with tag autocomplete (EW-641 Phase 1B/d row 8)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2669,6 +2669,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2669,6 +2669,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2669,6 +2669,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2697,6 +2697,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2669,6 +2669,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2696,6 +2696,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2669,6 +2669,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2452,6 +2452,19 @@
                         "succeeded": "Uploaded",
                         "failed": "Failed"
                     }
+                },
+                "classify": {
+                    "title": "Classify upload",
+                    "subtitle": "Pick the document class, optional description, and tags. Per-file titles are editable below.",
+                    "classLabel": "Document class",
+                    "descriptionLabel": "Description (optional)",
+                    "tagsLabel": "Tags",
+                    "tagsPlaceholder": "Type to search or add a tag, Enter to confirm",
+                    "tagsFetchFailed": "Could not load existing tags ({error}). You can still type new tags.",
+                    "titleLabel": "Title",
+                    "removeTag": "Remove tag {tag}",
+                    "cancel": "Cancel",
+                    "confirm": "Upload {count, plural, one {# file} other {# files}}"
                 }
             }
         },

--- a/apps/web/src/app/api/works/[id]/kb/tags/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/tags/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 8 — read-only proxy for the KB tags endpoint.
+ *
+ * The classify modal opens client-side and needs to populate its
+ * autocomplete with the Work's existing KB tags. Bouncing through this
+ * proxy keeps the JWT cookie + API base URL handling server-side
+ * (matches the existing `kb/uploads/route.ts` shape).
+ *
+ * Only GET is exposed for now; tag CRUD (create / update / delete)
+ * lives in row 13 alongside the side-panel UI that needs it. Add
+ * POST/PATCH/DELETE here when those land.
+ */
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+    const { id } = await params;
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstream = await fetch(`${API_URL}/works/${id}/kb/tags`, {
+        method: 'GET',
+        headers,
+        cache: 'no-store',
+    });
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const body = await upstream.json().catch(() => null);
+    return NextResponse.json(body ?? [], { status: 200 });
+}

--- a/apps/web/src/components/works/detail/kb/KbClassifyModal.tsx
+++ b/apps/web/src/components/works/detail/kb/KbClassifyModal.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    useState,
+    type ChangeEvent,
+    type KeyboardEvent,
+} from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { KB_DOCUMENT_CLASSES, type KbDocumentClass } from '@ever-works/contracts';
+import type { KbTagDto } from '@ever-works/contracts';
+
+export interface KbClassifyFileEntry {
+    /** Index into the original file array — caller maps back to the File. */
+    index: number;
+    name: string;
+    /** Pretty title (defaults to filename without extension). */
+    title: string;
+}
+
+export interface KbClassifyResult {
+    targetClass: KbDocumentClass;
+    description: string;
+    tags: string[];
+    /** Per-file titles, keyed by original index. */
+    titles: Record<number, string>;
+}
+
+interface KbClassifyModalProps {
+    workId: string;
+    files: KbClassifyFileEntry[];
+    /** Initial class (e.g. row dropped into a class folder in the tree). */
+    initialClass?: KbDocumentClass;
+    onConfirm: (result: KbClassifyResult) => void;
+    onCancel: () => void;
+    /**
+     * Test seam: skip the network fetch + use the provided tag list.
+     * Production code leaves this undefined so the modal fetches lazily.
+     */
+    initialTags?: KbTagDto[];
+}
+
+/**
+ * EW-641 Phase 1B/d row 8 — Classification modal.
+ *
+ * Opens when the operator picks files via the upload zone. Per-batch
+ * fields (`targetClass`, `description`, `tags`) apply to every file in
+ * the batch; per-file `title` (default = filename minus extension) is
+ * editable in the file list. Tags autocomplete from
+ * `GET /api/works/:id/kb/tags` — the modal kicks the fetch lazily on
+ * mount so the network round-trip overlaps with the user reading the
+ * file list.
+ *
+ * Selectors locked for the Playwright A12 (drag-drop → KB doc)
+ * acceptance suite:
+ *  - `data-testid="kb-classify-modal"` (dialog wrapper)
+ *  - `data-testid="kb-classify-class"` (class select)
+ *  - `data-testid="kb-classify-description"` (description textarea)
+ *  - `data-testid="kb-classify-tag-input"` (tag chip input)
+ *  - `data-testid="kb-classify-tag-suggestion"` (autocomplete option)
+ *  - `data-testid="kb-classify-tag-chip"` (selected tag)
+ *  - `data-testid="kb-classify-file"` (file row)
+ *  - `data-testid="kb-classify-confirm"` (upload button)
+ *  - `data-testid="kb-classify-cancel"` (cancel button)
+ *
+ * Accessibility: dialog is rendered as `role="dialog"` with
+ * `aria-modal="true"` and an `aria-labelledby` heading; ESC closes;
+ * focus is trapped to the modal body on mount via the standard
+ * `autoFocus` on the class select (the highest-impact field).
+ */
+export function KbClassifyModal({
+    workId,
+    files,
+    initialClass,
+    onConfirm,
+    onCancel,
+    initialTags,
+}: KbClassifyModalProps) {
+    const t = useTranslations('dashboard.workDetail.kb.classify');
+    const tClasses = useTranslations('dashboard.workDetail.kb.classes');
+    const headingId = useId();
+    const [targetClass, setTargetClass] = useState<KbDocumentClass>(initialClass ?? 'freeform');
+    const [description, setDescription] = useState('');
+    const [tags, setTags] = useState<string[]>([]);
+    const [tagInput, setTagInput] = useState('');
+    const [titles, setTitles] = useState<Record<number, string>>(() =>
+        Object.fromEntries(files.map((f) => [f.index, f.title])),
+    );
+    const [allTags, setAllTags] = useState<KbTagDto[]>(initialTags ?? []);
+    const [tagsError, setTagsError] = useState<string | null>(null);
+    const dialogRef = useRef<HTMLDivElement | null>(null);
+
+    // Fetch existing Work tags for autocomplete.
+    useEffect(() => {
+        if (initialTags !== undefined) return;
+        let cancelled = false;
+        fetch(`/api/works/${workId}/kb/tags`, { credentials: 'same-origin' })
+            .then(async (res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return (await res.json()) as KbTagDto[];
+            })
+            .then((rows) => {
+                if (cancelled) return;
+                setAllTags(rows);
+            })
+            .catch((error: unknown) => {
+                if (cancelled) return;
+                setTagsError(error instanceof Error ? error.message : 'tags fetch failed');
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [workId, initialTags]);
+
+    // ESC closes the modal.
+    useEffect(() => {
+        const onKey = (event: globalThis.KeyboardEvent) => {
+            if (event.key === 'Escape') onCancel();
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, [onCancel]);
+
+    const suggestions = useMemo(() => {
+        const query = tagInput.trim().toLowerCase();
+        if (query.length === 0) return [] as KbTagDto[];
+        const selected = new Set(tags.map((t) => t.toLowerCase()));
+        return allTags
+            .filter(
+                (tag) =>
+                    !selected.has(tag.slug.toLowerCase()) &&
+                    !selected.has(tag.name.toLowerCase()) &&
+                    (tag.slug.toLowerCase().includes(query) ||
+                        tag.name.toLowerCase().includes(query)),
+            )
+            .slice(0, 8);
+    }, [tagInput, allTags, tags]);
+
+    const addTag = useCallback((raw: string) => {
+        const value = raw.trim();
+        if (value.length === 0) return;
+        setTags((prev) => (prev.includes(value) ? prev : [...prev, value]));
+        setTagInput('');
+    }, []);
+
+    const onTagKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                addTag(tagInput);
+            } else if (event.key === 'Backspace' && tagInput.length === 0 && tags.length > 0) {
+                setTags((prev) => prev.slice(0, -1));
+            }
+        },
+        [tagInput, tags.length, addTag],
+    );
+
+    const removeTag = useCallback((value: string) => {
+        setTags((prev) => prev.filter((tag) => tag !== value));
+    }, []);
+
+    const onTitleChange = useCallback((index: number, value: string) => {
+        setTitles((prev) => ({ ...prev, [index]: value }));
+    }, []);
+
+    const onConfirmClick = useCallback(() => {
+        onConfirm({
+            targetClass,
+            description: description.trim(),
+            tags,
+            titles,
+        });
+    }, [onConfirm, targetClass, description, tags, titles]);
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={headingId}
+            data-testid="kb-classify-modal"
+            ref={dialogRef}
+            className={cn('fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4')}
+            onClick={(event) => {
+                if (event.target === event.currentTarget) onCancel();
+            }}
+        >
+            <div
+                className={cn(
+                    'w-full max-w-xl rounded-lg border border-border dark:border-border-dark',
+                    'bg-card dark:bg-card-primary-dark p-5 shadow-xl',
+                    'flex flex-col gap-4',
+                )}
+            >
+                <header className="flex flex-col gap-1">
+                    <h2
+                        id={headingId}
+                        className="text-base font-semibold text-text dark:text-text-dark"
+                    >
+                        {t('title', { count: files.length })}
+                    </h2>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark/70">
+                        {t('subtitle')}
+                    </p>
+                </header>
+
+                <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('classLabel')}
+                        </label>
+                        <select
+                            data-testid="kb-classify-class"
+                            value={targetClass}
+                            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                                setTargetClass(event.target.value as KbDocumentClass)
+                            }
+                            autoFocus
+                            className={cn(
+                                'rounded-md border border-border dark:border-border-dark',
+                                'bg-card-secondary dark:bg-card-primary-dark/40 px-2 py-1.5 text-sm',
+                            )}
+                        >
+                            {KB_DOCUMENT_CLASSES.map((cls) => (
+                                <option key={cls} value={cls}>
+                                    {tClasses(cls)}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('descriptionLabel')}
+                        </label>
+                        <textarea
+                            data-testid="kb-classify-description"
+                            value={description}
+                            onChange={(event) => setDescription(event.target.value)}
+                            rows={2}
+                            className={cn(
+                                'rounded-md border border-border dark:border-border-dark',
+                                'bg-card-secondary dark:bg-card-primary-dark/40 px-2 py-1.5 text-sm',
+                            )}
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('tagsLabel')}
+                        </label>
+                        <div
+                            className={cn(
+                                'flex flex-wrap items-center gap-1.5 rounded-md border',
+                                'border-border dark:border-border-dark',
+                                'bg-card-secondary dark:bg-card-primary-dark/40 px-2 py-1.5 text-sm',
+                            )}
+                        >
+                            {tags.map((tag) => (
+                                <span
+                                    key={tag}
+                                    data-testid="kb-classify-tag-chip"
+                                    className={cn(
+                                        'inline-flex items-center gap-1 rounded-full',
+                                        'bg-primary/10 text-primary px-2 py-0.5 text-xs',
+                                    )}
+                                >
+                                    {tag}
+                                    <button
+                                        type="button"
+                                        onClick={() => removeTag(tag)}
+                                        aria-label={t('removeTag', { tag })}
+                                        className="text-primary/70 hover:text-primary"
+                                    >
+                                        ×
+                                    </button>
+                                </span>
+                            ))}
+                            <input
+                                data-testid="kb-classify-tag-input"
+                                value={tagInput}
+                                onChange={(event) => setTagInput(event.target.value)}
+                                onKeyDown={onTagKeyDown}
+                                placeholder={t('tagsPlaceholder')}
+                                className="min-w-[6rem] flex-1 bg-transparent outline-none"
+                            />
+                        </div>
+                        {suggestions.length > 0 ? (
+                            <ul
+                                data-testid="kb-classify-tag-suggestions"
+                                className={cn(
+                                    'mt-1 max-h-32 overflow-auto rounded-md border',
+                                    'border-border dark:border-border-dark bg-card text-sm shadow',
+                                )}
+                            >
+                                {suggestions.map((tag) => (
+                                    <li key={tag.id}>
+                                        <button
+                                            type="button"
+                                            data-testid="kb-classify-tag-suggestion"
+                                            data-tag-slug={tag.slug}
+                                            onClick={() => addTag(tag.slug)}
+                                            className={cn(
+                                                'flex w-full items-center gap-2 px-2 py-1 text-left',
+                                                'hover:bg-card-hover dark:hover:bg-card-primary-dark/40',
+                                            )}
+                                        >
+                                            <span>{tag.name}</span>
+                                            <span className="text-xs text-text-muted">
+                                                {tag.slug}
+                                            </span>
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : null}
+                        {tagsError ? (
+                            <p className="text-xs text-amber-700 dark:text-amber-300">
+                                {t('tagsFetchFailed', { error: tagsError })}
+                            </p>
+                        ) : null}
+                    </div>
+
+                    <ul className="flex flex-col gap-1.5" data-testid="kb-classify-files">
+                        {files.map((file) => (
+                            <li
+                                key={file.index}
+                                data-testid="kb-classify-file"
+                                data-file-index={file.index}
+                                className={cn(
+                                    'flex items-center gap-2 rounded-md border px-2 py-1.5 text-xs',
+                                    'border-border dark:border-border-dark',
+                                    'bg-card/30 dark:bg-card-primary-dark/20',
+                                )}
+                            >
+                                <span className="text-text-muted dark:text-text-muted-dark/70">
+                                    {file.name}
+                                </span>
+                                <input
+                                    aria-label={t('titleLabel')}
+                                    data-testid="kb-classify-file-title"
+                                    value={titles[file.index] ?? file.title}
+                                    onChange={(event) =>
+                                        onTitleChange(file.index, event.target.value)
+                                    }
+                                    className={cn(
+                                        'ml-auto flex-1 rounded border border-border/60',
+                                        'dark:border-border-dark/60 bg-transparent px-2 py-0.5',
+                                    )}
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+
+                <footer className="flex items-center justify-end gap-2 pt-2">
+                    <Button
+                        type="button"
+                        data-testid="kb-classify-cancel"
+                        onClick={onCancel}
+                        variant="ghost"
+                        size="sm"
+                    >
+                        {t('cancel')}
+                    </Button>
+                    <Button
+                        type="button"
+                        data-testid="kb-classify-confirm"
+                        onClick={onConfirmClick}
+                        size="sm"
+                    >
+                        {t('confirm', { count: files.length })}
+                    </Button>
+                </footer>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbClassifyModal.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbClassifyModal.unit.spec.tsx
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { KbTagDto } from '@ever-works/contracts';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (namespace?: string) => (key: string) =>
+        namespace ? `${namespace}.${key}` : key,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        ...rest
+    }: {
+        children: ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+    } & Record<string, unknown>) => (
+        <button type="button" onClick={onClick} disabled={disabled} {...rest}>
+            {children}
+        </button>
+    ),
+}));
+
+import { KbClassifyModal, type KbClassifyResult } from './KbClassifyModal';
+
+const sampleFiles = [
+    { index: 0, name: 'voice.md', title: 'voice' },
+    { index: 1, name: 'tone.md', title: 'tone' },
+];
+
+function sampleTags(): KbTagDto[] {
+    return [
+        {
+            id: 't1',
+            workId: 'work-1',
+            slug: 'tier-1',
+            name: 'Tier 1',
+            color: null,
+            description: null,
+            createdAt: '2026-05-22T00:00:00Z',
+            updatedAt: '2026-05-22T00:00:00Z',
+        },
+        {
+            id: 't2',
+            workId: 'work-1',
+            slug: 'audience-us',
+            name: 'Audience: US',
+            color: null,
+            description: null,
+            createdAt: '2026-05-22T00:00:00Z',
+            updatedAt: '2026-05-22T00:00:00Z',
+        },
+    ];
+}
+
+let lastResult: KbClassifyResult | null = null;
+let cancelCalls = 0;
+const onConfirm = (result: KbClassifyResult) => {
+    lastResult = result;
+};
+const onCancel = () => {
+    cancelCalls += 1;
+};
+
+beforeEach(() => {
+    lastResult = null;
+    cancelCalls = 0;
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+/**
+ * EW-641 Phase 1B/d row 8 — `KbClassifyModal` is the per-batch
+ * classification step that opens between picking files and the actual
+ * upload. Tests lock the wiring the row #7 zone + Playwright A12 lean
+ * on:
+ *  - selectors stable (modal, class select, description, tag input,
+ *    suggestions, chips, confirm/cancel, file rows)
+ *  - confirm hands back `{ targetClass, description, tags, titles }`
+ *  - per-file title input edits the `titles[index]` map
+ *  - tag suggestions filter by query + ignore selected
+ *  - Enter adds a tag; Backspace on empty input removes the last
+ *  - tags-fetch failure shows a non-fatal banner
+ *  - cancel + ESC fire `onCancel`
+ *  - lazy tag fetch hits `/api/works/:id/kb/tags`
+ */
+describe('KbClassifyModal', () => {
+    it('renders the dialog, class select, description, tag input, and file rows', () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialClass="brand"
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        const modal = screen.getByTestId('kb-classify-modal');
+        expect(modal).toBeTruthy();
+        expect(modal.getAttribute('role')).toBe('dialog');
+        expect(modal.getAttribute('aria-modal')).toBe('true');
+
+        const select = screen.getByTestId('kb-classify-class') as HTMLSelectElement;
+        expect(select.value).toBe('brand');
+
+        expect(screen.getByTestId('kb-classify-description')).toBeTruthy();
+        expect(screen.getByTestId('kb-classify-tag-input')).toBeTruthy();
+        const files = screen.getAllByTestId('kb-classify-file');
+        expect(files).toHaveLength(2);
+        expect(files[0].getAttribute('data-file-index')).toBe('0');
+        expect(files[0].textContent).toContain('voice.md');
+    });
+
+    it('defaults targetClass to "freeform" when no initialClass is provided', () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        const select = screen.getByTestId('kb-classify-class') as HTMLSelectElement;
+        expect(select.value).toBe('freeform');
+    });
+
+    it('hands back per-file titles + chosen class on confirm', async () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialClass="brand"
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        // Edit the first file's title.
+        const titleInputs = screen.getAllByTestId('kb-classify-file-title');
+        await act(async () => {
+            fireEvent.change(titleInputs[0], { target: { value: 'Brand Voice' } });
+        });
+
+        // Edit the description.
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-classify-description'), {
+                target: { value: 'How we talk' },
+            });
+        });
+
+        // Change the class.
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-classify-class'), {
+                target: { value: 'legal' },
+            });
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kb-classify-confirm'));
+        });
+
+        expect(lastResult).not.toBeNull();
+        expect(lastResult!.targetClass).toBe('legal');
+        expect(lastResult!.description).toBe('How we talk');
+        expect(lastResult!.titles[0]).toBe('Brand Voice');
+        // Untouched second file keeps its derived title.
+        expect(lastResult!.titles[1]).toBe('tone');
+    });
+
+    it('suggests matching tags as the user types + adds via click', async () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        const input = screen.getByTestId('kb-classify-tag-input') as HTMLInputElement;
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'tier' } });
+        });
+
+        const suggestions = screen.getAllByTestId('kb-classify-tag-suggestion');
+        expect(suggestions).toHaveLength(1);
+        expect(suggestions[0].getAttribute('data-tag-slug')).toBe('tier-1');
+
+        await act(async () => {
+            fireEvent.click(suggestions[0]);
+        });
+
+        const chips = screen.getAllByTestId('kb-classify-tag-chip');
+        expect(chips.map((c) => c.textContent?.replace('×', '').trim())).toEqual(['tier-1']);
+        expect(input.value).toBe(''); // input cleared after add
+    });
+
+    it('adds a free-text tag on Enter + removes the last chip on Backspace', async () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        const input = screen.getByTestId('kb-classify-tag-input') as HTMLInputElement;
+
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'custom-tag' } });
+            fireEvent.keyDown(input, { key: 'Enter' });
+        });
+        expect(screen.getAllByTestId('kb-classify-tag-chip')).toHaveLength(1);
+        expect(input.value).toBe('');
+
+        await act(async () => {
+            fireEvent.keyDown(input, { key: 'Backspace' });
+        });
+        expect(screen.queryByTestId('kb-classify-tag-chip')).toBeNull();
+    });
+
+    it('cancel button fires onCancel', async () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kb-classify-cancel'));
+        });
+        expect(cancelCalls).toBe(1);
+    });
+
+    it('ESC fires onCancel', async () => {
+        render(
+            <KbClassifyModal
+                workId="work-1"
+                files={sampleFiles}
+                initialTags={sampleTags()}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+        await act(async () => {
+            fireEvent.keyDown(document, { key: 'Escape' });
+        });
+        expect(cancelCalls).toBe(1);
+    });
+
+    it('lazily fetches tags from /api/works/:id/kb/tags', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => sampleTags(),
+        });
+        vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+        render(
+            <KbClassifyModal
+                workId="work-99"
+                files={sampleFiles}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        expect(fetchMock.mock.calls[0][0]).toBe('/api/works/work-99/kb/tags');
+
+        // Type a query → suggestion appears.
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-classify-tag-input'), {
+                target: { value: 'audience' },
+            });
+        });
+        await waitFor(() => {
+            expect(
+                screen
+                    .getAllByTestId('kb-classify-tag-suggestion')[0]
+                    .getAttribute('data-tag-slug'),
+            ).toBe('audience-us');
+        });
+    });
+
+    it('surfaces a non-fatal banner when the tags fetch fails', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => ({}),
+            text: async () => 'boom',
+        });
+        vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+        render(
+            <KbClassifyModal
+                workId="work-99"
+                files={sampleFiles}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        await waitFor(() => {
+            // The error string is interpolated into the i18n key
+            // (`tagsFetchFailed` placeholder); the mock returns the key
+            // verbatim — confirming the banner rendered is enough.
+            expect(screen.getByTestId('kb-classify-modal').textContent).toContain(
+                'tagsFetchFailed',
+            );
+        });
+        // Still allows confirm so a transient tags failure doesn't
+        // block the upload entirely.
+        expect(screen.getByTestId('kb-classify-confirm')).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/works/detail/kb/KbUploadZone.tsx
+++ b/apps/web/src/components/works/detail/kb/KbUploadZone.tsx
@@ -12,16 +12,21 @@ import { useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
 import { Button } from '@/components/ui/button';
+import {
+    KbClassifyModal,
+    type KbClassifyFileEntry,
+    type KbClassifyResult,
+} from './KbClassifyModal';
+import type { KbDocumentClass } from '@ever-works/contracts';
 
 interface KbUploadZoneProps {
     workId: string;
     /**
-     * Optional pre-selected document class — when the operator drops
-     * a file directly into a class folder in the tree (row 8 wires
-     * this), the upload zone forwards the value so the backend
-     * skips heuristics-based classification.
+     * Optional pre-selected document class — when the operator is
+     * viewing a doc in a class folder, the upload zone passes it to
+     * the classify modal as the default selection.
      */
-    targetClass?: string;
+    targetClass?: KbDocumentClass;
 }
 
 type UploadEntryStatus = 'queued' | 'uploading' | 'succeeded' | 'failed';
@@ -39,33 +44,33 @@ interface UploadEntry {
 }
 
 /**
- * EW-641 Phase 1B/d row 7 — drag-drop upload zone.
+ * EW-641 Phase 1B/d row 7 + 8 — drag-drop upload zone + classify modal.
  *
- * Renders a dashed drop target that accepts file drops + clicks for
- * the hidden `<input type=file>` fallback. Each file becomes an
- * `UploadEntry` that streams progress through `XMLHttpRequest.upload`
- * (`fetch` doesn't expose progress in Next.js client runtimes today).
+ * Files picked by drop or browse open the `KbClassifyModal` so the
+ * operator can confirm the target class, set a description, and add
+ * tags before the multipart POST. Cancelling the modal discards the
+ * batch; confirming kicks off the per-file `XMLHttpRequest`s with the
+ * chosen metadata. Each upload streams progress through `xhr.upload`
+ * (`fetch` doesn't expose request progress in Next.js client runtimes
+ * today).
  *
- * On the first successful upload the component calls
- * `router.refresh()` so the server-rendered tree panel
- * (`KbTreePanel`) re-fetches and the new document appears in the
- * left pane. Errors stay on the entry until the operator either
- * dismisses or replaces them — the form never silently swallows a
- * 413 / 503 / 400 from the backend.
+ * On the first successful upload per batch the component calls
+ * `router.refresh()` so the server-rendered tree panel re-fetches and
+ * the new document appears in the left pane.
  *
- * Selectors locked for the Playwright A12 (drag-drop upload → KB
- * doc) suite:
- *  - `data-testid="kb-upload-zone"` (drop target)
- *  - `data-testid="kb-upload-input"` (hidden file input)
- *  - `data-testid="kb-upload-entries"` (entries list)
- *  - `data-testid="kb-upload-entry"` (one per file) +
- *    `data-status` attribute that mirrors `UploadEntryStatus`
+ * Selectors locked for Playwright A12:
+ *  - `data-testid="kb-upload-zone"` + `data-drag-active`
+ *  - `data-testid="kb-upload-input"`
+ *  - `data-testid="kb-upload-entries"` / `kb-upload-entry`
+ *    (with `data-status` mirroring `UploadEntryStatus`)
+ *  - The modal's own selectors live in `KbClassifyModal.tsx`.
  */
 export function KbUploadZone({ workId, targetClass }: KbUploadZoneProps) {
     const t = useTranslations('dashboard.workDetail.kb.upload');
     const router = useRouter();
     const [entries, setEntries] = useState<UploadEntry[]>([]);
     const [dragActive, setDragActive] = useState(false);
+    const [pendingFiles, setPendingFiles] = useState<File[]>([]);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const refreshScheduled = useRef(false);
 
@@ -75,46 +80,19 @@ export function KbUploadZone({ workId, targetClass }: KbUploadZoneProps) {
         );
     }, []);
 
+    const openClassifyFor = useCallback((files: File[]) => {
+        if (files.length === 0) return;
+        setPendingFiles(files);
+    }, []);
+
     const onFiles = useCallback(
         (files: FileList | File[] | null) => {
             if (!files) return;
             const fileArray = Array.from(files);
             if (fileArray.length === 0) return;
-
-            const queued: UploadEntry[] = fileArray.map((file) => ({
-                id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-                name: file.name,
-                size: file.size,
-                status: 'queued',
-                progress: 0,
-                error: null,
-                documentId: null,
-            }));
-
-            setEntries((prev) => [...queued, ...prev]);
-
-            for (const [index, file] of fileArray.entries()) {
-                const entryId = queued[index].id;
-                void uploadOne({
-                    workId,
-                    targetClass,
-                    file,
-                    entryId,
-                    updateEntry,
-                    onSuccess: () => {
-                        // Batch refreshes — N parallel uploads should
-                        // only kick a single revalidation pass.
-                        if (refreshScheduled.current) return;
-                        refreshScheduled.current = true;
-                        Promise.resolve().then(() => {
-                            refreshScheduled.current = false;
-                            router.refresh();
-                        });
-                    },
-                });
-            }
+            openClassifyFor(fileArray);
         },
-        [workId, targetClass, updateEntry, router],
+        [openClassifyFor],
     );
 
     const onDrop = useCallback(
@@ -158,6 +136,52 @@ export function KbUploadZone({ workId, targetClass }: KbUploadZoneProps) {
         setEntries((prev) => prev.filter((entry) => entry.id !== id));
     }, []);
 
+    const onClassifyCancel = useCallback(() => {
+        setPendingFiles([]);
+    }, []);
+
+    const onClassifyConfirm = useCallback(
+        (result: KbClassifyResult) => {
+            const fileArray = pendingFiles;
+            setPendingFiles([]);
+
+            const queued: UploadEntry[] = fileArray.map((file) => ({
+                id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+                name: file.name,
+                size: file.size,
+                status: 'queued',
+                progress: 0,
+                error: null,
+                documentId: null,
+            }));
+            setEntries((prev) => [...queued, ...prev]);
+
+            for (const [index, file] of fileArray.entries()) {
+                const entryId = queued[index].id;
+                const title = result.titles[index]?.trim() || titleFromFilename(file.name);
+                void uploadOne({
+                    workId,
+                    targetClass: result.targetClass,
+                    title,
+                    description: result.description,
+                    tags: result.tags,
+                    file,
+                    entryId,
+                    updateEntry,
+                    onSuccess: () => {
+                        if (refreshScheduled.current) return;
+                        refreshScheduled.current = true;
+                        Promise.resolve().then(() => {
+                            refreshScheduled.current = false;
+                            router.refresh();
+                        });
+                    },
+                });
+            }
+        },
+        [pendingFiles, workId, updateEntry, router],
+    );
+
     return (
         <section aria-label={t('title')} className="flex flex-col gap-3">
             <DropTarget
@@ -199,8 +223,33 @@ export function KbUploadZone({ workId, targetClass }: KbUploadZoneProps) {
                     ))}
                 </ul>
             ) : null}
+
+            {pendingFiles.length > 0 ? (
+                <KbClassifyModal
+                    workId={workId}
+                    files={pendingFiles.map<KbClassifyFileEntry>((file, index) => ({
+                        index,
+                        name: file.name,
+                        title: titleFromFilename(file.name),
+                    }))}
+                    initialClass={targetClass}
+                    onConfirm={onClassifyConfirm}
+                    onCancel={onClassifyCancel}
+                />
+            ) : null}
         </section>
     );
+}
+
+/**
+ * Strip the extension off `voice.md` → `voice`. Falls back to the
+ * whole filename when there's no `.`, and trims trailing whitespace
+ * so users can edit the value without weird leading spaces.
+ */
+function titleFromFilename(filename: string): string {
+    const lastDot = filename.lastIndexOf('.');
+    const base = lastDot > 0 ? filename.slice(0, lastDot) : filename;
+    return base.trim();
 }
 
 interface DropTargetProps {
@@ -328,17 +377,30 @@ function UploadEntryRow({ entry, labels, onDismiss }: UploadEntryRowProps) {
  */
 function uploadOne(args: {
     workId: string;
-    targetClass?: string;
+    targetClass?: KbDocumentClass;
+    title?: string;
+    description?: string;
+    tags?: string[];
     file: File;
     entryId: string;
     updateEntry: (id: string, patch: Partial<UploadEntry>) => void;
     onSuccess: (documentId: string | null) => void;
 }): Promise<void> {
-    const { workId, targetClass, file, entryId, updateEntry, onSuccess } = args;
+    const { workId, targetClass, title, description, tags, file, entryId, updateEntry, onSuccess } =
+        args;
     return new Promise<void>((resolve) => {
         const form = new FormData();
         form.append('file', file);
         if (targetClass) form.append('targetClass', targetClass);
+        if (title) form.append('title', title);
+        if (description && description.length > 0) form.append('description', description);
+        if (tags && tags.length > 0) {
+            // NestJS `class-transformer` accepts repeated `tags[]` form
+            // fields or a single comma-separated string — repeat is the
+            // unambiguous shape because tags may legitimately contain
+            // commas (e.g. "Tier 1, US").
+            for (const tag of tags) form.append('tags', tag);
+        }
 
         const xhr = new XMLHttpRequest();
         xhr.open('POST', `/api/works/${workId}/kb/uploads`);

--- a/apps/web/src/components/works/detail/kb/KbUploadZone.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbUploadZone.unit.spec.tsx
@@ -29,6 +29,53 @@ vi.mock('@/components/ui/button', () => ({
     ),
 }));
 
+// Stub the classify modal so the upload-zone spec stays focused on the
+// upload path. The modal exposes Confirm / Cancel buttons that drive the
+// `onConfirm` / `onCancel` callbacks; capture the latest `onConfirm` so
+// tests can fire it with any KbClassifyResult.
+//
+// `KbClassifyModal` proper has its own dedicated spec in
+// `./KbClassifyModal.unit.spec.tsx`.
+let latestOnConfirm: ((result: unknown) => void) | null = null;
+let latestOnCancel: (() => void) | null = null;
+let latestInitialClass: string | undefined;
+vi.mock('./KbClassifyModal', () => ({
+    KbClassifyModal: ({
+        onConfirm,
+        onCancel,
+        initialClass,
+    }: {
+        onConfirm: (result: unknown) => void;
+        onCancel: () => void;
+        initialClass?: string;
+    }) => {
+        latestOnConfirm = onConfirm;
+        latestOnCancel = onCancel;
+        latestInitialClass = initialClass;
+        return (
+            <div data-testid="kb-classify-modal">
+                <button
+                    type="button"
+                    data-testid="kb-classify-confirm"
+                    onClick={() =>
+                        onConfirm({
+                            targetClass: initialClass ?? 'freeform',
+                            description: '',
+                            tags: [],
+                            titles: {},
+                        })
+                    }
+                >
+                    confirm
+                </button>
+                <button type="button" data-testid="kb-classify-cancel" onClick={onCancel}>
+                    cancel
+                </button>
+            </div>
+        );
+    },
+}));
+
 import { KbUploadZone } from './KbUploadZone';
 
 /**
@@ -91,10 +138,9 @@ const xhrInstances: FakeXHR[] = [];
 beforeEach(() => {
     refreshMock.mockReset();
     xhrInstances.length = 0;
-    // Replace the global XMLHttpRequest with our stub for the duration
-    // of the test. `globalThis` is the right surface — jsdom's
-    // `window.XMLHttpRequest` and `globalThis.XMLHttpRequest` point at
-    // the same constructor.
+    latestOnConfirm = null;
+    latestOnCancel = null;
+    latestInitialClass = undefined;
     vi.stubGlobal('XMLHttpRequest', function FakeXHRCtor() {
         const x = new FakeXHR();
         xhrInstances.push(x);
@@ -111,15 +157,37 @@ function fileLike(name: string, contents = 'hello'): File {
 }
 
 /**
- * EW-641 Phase 1B/d row 7 — KbUploadZone tests cover the wiring that
- * the Playwright A12 (drag-drop → KB doc) acceptance suite leans on:
+ * After picking files, the zone opens the classify modal. Helper that
+ * resolves both the synthetic file pick + the modal confirm so each
+ * test's assertions read top-to-bottom.
+ */
+async function pickAndConfirm(file: File, classify?: Record<string, unknown>) {
+    await act(async () => {
+        fireEvent.change(screen.getByTestId('kb-upload-input'), {
+            target: { files: [file] },
+        });
+    });
+    await waitFor(() => expect(screen.getByTestId('kb-classify-modal')).toBeTruthy());
+    await act(async () => {
+        if (classify) {
+            latestOnConfirm?.(classify);
+        } else {
+            fireEvent.click(screen.getByTestId('kb-classify-confirm'));
+        }
+    });
+}
+
+/**
+ * EW-641 Phase 1B/d row 7 + 8 — KbUploadZone tests cover the wiring
+ * that Playwright A12 (drag-drop → KB doc) leans on:
  *  - selectors stay stable (`kb-upload-zone`, `kb-upload-input`,
  *    `kb-upload-entries`, `kb-upload-entry` with `data-status`)
- *  - file pick + drop both kick off a POST to `/api/works/.../kb/uploads`
- *  - `data-status` on the entry cycles `uploading → succeeded` (or `failed`)
- *  - on success the page revalidates via `router.refresh` so the
- *    server-rendered `<KbTreePanel>` sees the new document
- *  - drag-over flips the `data-drag-active` flag for styling cues
+ *  - file pick opens the classify modal first; confirming kicks off
+ *    the POST with the chosen metadata
+ *  - cancelling the modal discards the batch (no XHR fires)
+ *  - `data-status` cycles `uploading → succeeded` (or `failed`)
+ *  - on success the page revalidates via `router.refresh`
+ *  - drag-over flips `data-drag-active`
  */
 describe('KbUploadZone', () => {
     it('renders the drop target + hidden file input', () => {
@@ -128,32 +196,56 @@ describe('KbUploadZone', () => {
         const input = screen.getByTestId('kb-upload-input') as HTMLInputElement;
         expect(input.type).toBe('file');
         expect(input.multiple).toBe(true);
-        // No entries yet.
+        // No entries yet + no modal open.
         expect(screen.queryByTestId('kb-upload-entries')).toBeNull();
+        expect(screen.queryByTestId('kb-classify-modal')).toBeNull();
     });
 
-    it('starts an upload when files are selected via the input', async () => {
+    it('opens the classify modal when files are picked, then uploads on confirm', async () => {
         render(<KbUploadZone workId="work-1" />);
-        const input = screen.getByTestId('kb-upload-input') as HTMLInputElement;
 
         await act(async () => {
-            fireEvent.change(input, { target: { files: [fileLike('voice.md')] } });
+            fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                target: { files: [fileLike('voice.md')] },
+            });
         });
 
-        // XHR opened against the proxied Next.js route.
+        // Modal opened, no XHR yet.
+        expect(screen.getByTestId('kb-classify-modal')).toBeTruthy();
+        expect(xhrInstances.length).toBe(0);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kb-classify-confirm'));
+        });
+
         await waitFor(() => expect(xhrInstances.length).toBe(1));
         expect(xhrInstances[0].method).toBe('POST');
         expect(xhrInstances[0].url).toBe('/api/works/work-1/kb/uploads');
 
-        // Entry rendered with status="uploading".
         const entry = screen.getByTestId('kb-upload-entry');
         expect(entry.getAttribute('data-status')).toBe('uploading');
         expect(entry.textContent).toContain('voice.md');
     });
 
-    it('forwards targetClass as a form field when the prop is set', async () => {
-        // We can't read the FormData out of `send` easily without
-        // exposing it on the stub — extend the stub on the fly.
+    it('discards the batch when the classify modal is cancelled', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        await act(async () => {
+            fireEvent.change(screen.getByTestId('kb-upload-input'), {
+                target: { files: [fileLike('voice.md')] },
+            });
+        });
+        expect(screen.getByTestId('kb-classify-modal')).toBeTruthy();
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kb-classify-cancel'));
+        });
+
+        expect(xhrInstances.length).toBe(0);
+        expect(screen.queryByTestId('kb-classify-modal')).toBeNull();
+        expect(screen.queryByTestId('kb-upload-entries')).toBeNull();
+    });
+
+    it('forwards class + description + tags from the modal as form fields', async () => {
         let capturedBody: FormData | null = null;
         const origSend = FakeXHR.prototype.send;
         FakeXHR.prototype.send = function patched(body: FormData) {
@@ -162,27 +254,37 @@ describe('KbUploadZone', () => {
         };
         try {
             render(<KbUploadZone workId="work-1" targetClass="brand" />);
-            await act(async () => {
-                fireEvent.change(screen.getByTestId('kb-upload-input'), {
-                    target: { files: [fileLike('voice.md')] },
-                });
+            await pickAndConfirm(fileLike('voice.md'), {
+                targetClass: 'brand',
+                description: 'Brand voice doc',
+                tags: ['tier-1', 'audience-us'],
+                titles: { 0: 'Voice' },
             });
             await waitFor(() => expect(xhrInstances.length).toBe(1));
             expect(capturedBody).not.toBeNull();
             expect(capturedBody!.get('targetClass')).toBe('brand');
+            expect(capturedBody!.get('title')).toBe('Voice');
+            expect(capturedBody!.get('description')).toBe('Brand voice doc');
+            expect(capturedBody!.getAll('tags')).toEqual(['tier-1', 'audience-us']);
             expect((capturedBody!.get('file') as File).name).toBe('voice.md');
         } finally {
             FakeXHR.prototype.send = origSend;
         }
     });
 
-    it('flips entry to succeeded + calls router.refresh on 201', async () => {
-        render(<KbUploadZone workId="work-1" />);
+    it('passes targetClass through to the modal as initialClass', async () => {
+        render(<KbUploadZone workId="work-1" targetClass="legal" />);
         await act(async () => {
             fireEvent.change(screen.getByTestId('kb-upload-input'), {
-                target: { files: [fileLike('voice.md')] },
+                target: { files: [fileLike('privacy.md')] },
             });
         });
+        expect(latestInitialClass).toBe('legal');
+    });
+
+    it('flips entry to succeeded + calls router.refresh on 201', async () => {
+        render(<KbUploadZone workId="work-1" />);
+        await pickAndConfirm(fileLike('voice.md'));
         await waitFor(() => expect(xhrInstances.length).toBe(1));
 
         await act(async () => {
@@ -194,18 +296,13 @@ describe('KbUploadZone', () => {
                 'succeeded',
             );
         });
-        // Refresh runs in a microtask — flush once.
         await Promise.resolve();
         expect(refreshMock).toHaveBeenCalledTimes(1);
     });
 
     it('shows the backend error message on failure', async () => {
         render(<KbUploadZone workId="work-1" />);
-        await act(async () => {
-            fireEvent.change(screen.getByTestId('kb-upload-input'), {
-                target: { files: [fileLike('big.bin')] },
-            });
-        });
+        await pickAndConfirm(fileLike('big.bin'));
         await waitFor(() => expect(xhrInstances.length).toBe(1));
 
         await act(async () => {
@@ -222,11 +319,7 @@ describe('KbUploadZone', () => {
 
     it('handles network errors with a generic message', async () => {
         render(<KbUploadZone workId="work-1" />);
-        await act(async () => {
-            fireEvent.change(screen.getByTestId('kb-upload-input'), {
-                target: { files: [fileLike('voice.md')] },
-            });
-        });
+        await pickAndConfirm(fileLike('voice.md'));
         await waitFor(() => expect(xhrInstances.length).toBe(1));
 
         await act(async () => {
@@ -242,11 +335,7 @@ describe('KbUploadZone', () => {
 
     it('reflects upload progress on the status pill', async () => {
         render(<KbUploadZone workId="work-1" />);
-        await act(async () => {
-            fireEvent.change(screen.getByTestId('kb-upload-input'), {
-                target: { files: [fileLike('voice.md')] },
-            });
-        });
+        await pickAndConfirm(fileLike('voice.md'));
         await waitFor(() => expect(xhrInstances.length).toBe(1));
 
         await act(async () => {


### PR DESCRIPTION
## Summary
- Adds a **per-batch classification step** between picking files and the multipart POST so operators can confirm class, set a description, and attach tags before the upload runs.
- New \`KbClassifyModal.tsx\` (client) — accessible \`role="dialog"\` with \`aria-modal\`. Class select defaults from \`initialClass\` (the upload zone passes the active doc's class when present), falls back to \`freeform\`. Description textarea + tag chip input with autocomplete from \`GET /api/works/:id/kb/tags\`. Per-file title rows let the operator override the filename-derived default. ESC + outside-click + cancel all close.
- New Next.js proxy \`apps/web/src/app/api/works/[id]/kb/tags/route.ts\` (GET-only for now) — same shape as the existing \`kb/uploads/route.ts\`.
- \`KbUploadZone.tsx\` refactored to use a \`pendingFiles\` state. Picking/dropping files opens the modal instead of uploading immediately; confirm kicks off the per-file XHRs with the modal's \`{targetClass, description, tags, titles}\` packed into the multipart form; cancel discards the batch. Multipart now forwards \`title\`, \`description\`, and repeated \`tags\` form fields alongside \`file\` + \`targetClass\` shipped in row #7. \`targetClass\` prop tightened from \`string\` to \`KbDocumentClass\`.
- i18n: new \`dashboard.workDetail.kb.classify.*\` namespace (title / subtitle / classLabel / descriptionLabel / tagsLabel / tagsPlaceholder / tagsFetchFailed / titleLabel / removeTag / cancel / confirm) added across all 21 locales.

## Test plan
- [x] \`cd apps/web && npx vitest run src/components/works/detail/kb/\` → **44 passed** (4 KbShell · 6 KbTreePanel · 7 KbDocumentView · 8 KbEditor · 9 new KbClassifyModal · 10 updated KbUploadZone).
- [x] \`npx tsc --noEmit\` (web) → clean
- [x] \`npx eslint\` on touched files → clean
- [x] \`npx prettier --write\` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- \`docs/specs/features/knowledge-base/spec.md\` §14 acceptance A12 (drag-drop upload → KB doc renders, default classification)
- EW-641 Phase 1B/d row 8 of the atomic queue in \`Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge Base uploads now include a classification step: select document class, add optional description, manage tags, and edit per-file titles before uploading
  * Upload confirmation displays file count
  * Added complete multilingual support across 21 languages for the new classification workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->