### PR TITLE
feat(kb): inline PDF viewer with 30 MiB size cap (EW-641 Phase 1B/d row 9)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2682,6 +2682,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2682,6 +2682,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2682,6 +2682,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2710,6 +2710,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2682,6 +2682,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2709,6 +2709,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2682,6 +2682,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2465,6 +2465,12 @@
                     "removeTag": "Remove tag {tag}",
                     "cancel": "Cancel",
                     "confirm": "Upload {count, plural, one {# file} other {# files}}"
+                },
+                "pdf": {
+                    "label": "PDF viewer",
+                    "tooLargeTitle": "PDF too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
+                    "download": "Download PDF"
                 }
             }
         },

--- a/apps/web/src/components/works/detail/kb/viewers/KbPdfViewer.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbPdfViewer.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Spec §14.5 (inline-viewer size thresholds): PDFs above 30 MiB
+ * render as a download fallback instead of the inline canvas. The
+ * threshold is exposed as a prop so tests don't have to allocate
+ * 30 MiB Files / strings.
+ */
+export const KB_PDF_INLINE_MAX_BYTES = 30 * 1024 * 1024;
+
+const KbPdfViewerCanvas = dynamic(
+    () =>
+        import('./KbPdfViewerCanvas').then((m) => ({
+            default: m.KbPdfViewerCanvas,
+        })),
+    { ssr: false },
+);
+
+interface KbPdfViewerProps {
+    /** Pre-signed URL pointing at the PDF bytes in storage. */
+    url: string;
+    /** File size in bytes (drives the inline-vs-download decision). */
+    sizeBytes: number;
+    /** Original filename — used in the download fallback + iframe title. */
+    filename: string;
+    /**
+     * Override the inline cap (defaults to {@link KB_PDF_INLINE_MAX_BYTES}).
+     * Tests use a smaller value so the fallback path is exercisable
+     * without allocating 30 MiB; product code leaves it default.
+     */
+    maxInlineBytes?: number;
+}
+
+/**
+ * EW-641 Phase 1B/d row 9 — PDF inline viewer for Knowledge Base
+ * uploads.
+ *
+ * Decides between two presentations:
+ *  - `sizeBytes <= maxInlineBytes` (default 30 MiB per spec §14.5):
+ *    lazy-loads {@link KbPdfViewerCanvas} via `next/dynamic` so the
+ *    PDF surface only ships when actually needed. Renders inside the
+ *    Workbench editor pane.
+ *  - `sizeBytes > maxInlineBytes`: renders a download-fallback card
+ *    with a direct link (operator clicks → browser saves; never
+ *    streams 100 MiB through the React tree).
+ *
+ * Selectors locked for Playwright A14 (PDF render + size-cap):
+ *  - `data-testid="kb-pdf-viewer"` (root) + `data-mode` attribute
+ *    that is either `inline` or `download` so the e2e assertion is
+ *    a single selector check.
+ *  - `data-testid="kb-pdf-download-fallback"` (fallback wrapper)
+ *  - `data-testid="kb-pdf-download-link"` (the download anchor)
+ *  - `data-testid="kb-pdf-iframe"` (inline canvas — lives in the
+ *    lazy-loaded `KbPdfViewerCanvas`).
+ */
+export function KbPdfViewer({
+    url,
+    sizeBytes,
+    filename,
+    maxInlineBytes = KB_PDF_INLINE_MAX_BYTES,
+}: KbPdfViewerProps) {
+    const t = useTranslations('dashboard.workDetail.kb.pdf');
+    const overCap = sizeBytes > maxInlineBytes;
+
+    return (
+        <section
+            data-testid="kb-pdf-viewer"
+            data-mode={overCap ? 'download' : 'inline'}
+            data-size-bytes={sizeBytes}
+            aria-label={t('label')}
+            className="flex flex-col gap-2"
+        >
+            {overCap ? (
+                <KbPdfDownloadFallback
+                    url={url}
+                    filename={filename}
+                    sizeLabel={formatBytes(sizeBytes)}
+                    capLabel={formatBytes(maxInlineBytes)}
+                    title={t('tooLargeTitle')}
+                    body={t('tooLargeBody', {
+                        size: formatBytes(sizeBytes),
+                        cap: formatBytes(maxInlineBytes),
+                    })}
+                    download={t('download')}
+                />
+            ) : (
+                <KbPdfViewerCanvas url={url} title={filename} />
+            )}
+        </section>
+    );
+}
+
+interface KbPdfDownloadFallbackProps {
+    url: string;
+    filename: string;
+    sizeLabel: string;
+    capLabel: string;
+    title: string;
+    body: string;
+    download: string;
+}
+
+function KbPdfDownloadFallback({
+    url,
+    filename,
+    sizeLabel,
+    capLabel,
+    title,
+    body,
+    download,
+}: KbPdfDownloadFallbackProps) {
+    return (
+        <div
+            data-testid="kb-pdf-download-fallback"
+            data-size-label={sizeLabel}
+            data-cap-label={capLabel}
+            className={cn(
+                'flex flex-col gap-2 rounded-md border border-dashed p-4 text-center',
+                'border-border bg-card/30 dark:border-border-dark dark:bg-card-primary-dark/20',
+            )}
+        >
+            <p className="text-sm font-medium text-text dark:text-text-dark">{title}</p>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark/70">{body}</p>
+            <div>
+                <Button asChild type="button" size="sm" variant="secondary">
+                    <a
+                        data-testid="kb-pdf-download-link"
+                        href={url}
+                        download={filename}
+                        rel="noopener noreferrer"
+                    >
+                        {download} ({sizeLabel})
+                    </a>
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Pretty-prints byte counts as `12.3 MB`. Matches the convention used
+ * by the items-import progress component (`Math.round * 10 / 10`),
+ * with `Bytes` / `KB` / `MB` / `GB` units. Stays inside ASCII so the
+ * Playwright `expect(text).toContain('30 MB')` assertion is stable.
+ */
+export function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${Math.round((bytes / 1024) * 10) / 10} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
+    return `${Math.round((bytes / (1024 * 1024 * 1024)) * 10) / 10} GB`;
+}

--- a/apps/web/src/components/works/detail/kb/viewers/KbPdfViewer.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbPdfViewer.unit.spec.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string>) => {
+        if (!args) return key;
+        // Echo the args so the body assertion can verify interpolation.
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        asChild,
+        onClick,
+        ...rest
+    }: {
+        children: ReactNode;
+        asChild?: boolean;
+        onClick?: () => void;
+    } & Record<string, unknown>) => {
+        if (asChild) {
+            // mimic shadcn `asChild` slot semantics — render the lone
+            // child verbatim so the test asserts the anchor itself.
+            return <>{children}</>;
+        }
+        return (
+            <button type="button" onClick={onClick} {...rest}>
+                {children}
+            </button>
+        );
+    },
+}));
+
+// Stub `next/dynamic` so the lazy-loaded canvas renders inline in
+// the test (no real dynamic import → no `Suspense` wait).
+vi.mock('next/dynamic', () => ({
+    __esModule: true,
+    default: (loader: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+        const StubCanvas = (props: Record<string, unknown>) => (
+            <div data-testid="kb-pdf-canvas-stub" data-url={String(props.url)}>
+                {String(props.title ?? '')}
+            </div>
+        );
+        // The dynamic loader is captured but not awaited — production
+        // path lazy-imports `KbPdfViewerCanvas`; tests just render a
+        // placeholder with the same selector shape.
+        void loader;
+        return StubCanvas;
+    },
+}));
+
+import { formatBytes, KB_PDF_INLINE_MAX_BYTES, KbPdfViewer } from './KbPdfViewer';
+
+/**
+ * EW-641 Phase 1B/d row 9 — `KbPdfViewer` flips between an inline
+ * canvas and a download fallback based on size. Selectors locked for
+ * Playwright A14 — these tests lock the boundary + the `data-mode`
+ * attribute that the e2e assertion uses.
+ */
+describe('KbPdfViewer', () => {
+    it('renders the inline canvas when size is under the cap', () => {
+        render(
+            <KbPdfViewer
+                url="https://files.example/voice.pdf"
+                sizeBytes={1024 * 1024}
+                filename="voice.pdf"
+            />,
+        );
+        const root = screen.getByTestId('kb-pdf-viewer');
+        expect(root.getAttribute('data-mode')).toBe('inline');
+        const canvas = screen.getByTestId('kb-pdf-canvas-stub');
+        expect(canvas.getAttribute('data-url')).toBe('https://files.example/voice.pdf');
+        expect(canvas.textContent).toBe('voice.pdf');
+        expect(screen.queryByTestId('kb-pdf-download-fallback')).toBeNull();
+    });
+
+    it('renders the download fallback when size is above the cap', () => {
+        // Override the cap so the test doesn't have to fake 30 MiB.
+        render(
+            <KbPdfViewer
+                url="https://files.example/huge.pdf"
+                sizeBytes={2_000_000}
+                filename="huge.pdf"
+                maxInlineBytes={1_000_000}
+            />,
+        );
+        const root = screen.getByTestId('kb-pdf-viewer');
+        expect(root.getAttribute('data-mode')).toBe('download');
+        const link = screen.getByTestId('kb-pdf-download-link') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/huge.pdf');
+        expect(link.getAttribute('download')).toBe('huge.pdf');
+        expect(screen.queryByTestId('kb-pdf-canvas-stub')).toBeNull();
+    });
+
+    it('treats exact-cap size as inline (boundary is `>`, not `>=`)', () => {
+        render(
+            <KbPdfViewer
+                url="https://files.example/edge.pdf"
+                sizeBytes={KB_PDF_INLINE_MAX_BYTES}
+                filename="edge.pdf"
+            />,
+        );
+        expect(screen.getByTestId('kb-pdf-viewer').getAttribute('data-mode')).toBe('inline');
+    });
+
+    it('interpolates the size + cap into the fallback body copy', () => {
+        render(
+            <KbPdfViewer
+                url="https://files.example/huge.pdf"
+                sizeBytes={5 * 1024 * 1024}
+                filename="huge.pdf"
+                maxInlineBytes={1 * 1024 * 1024}
+            />,
+        );
+        const fallback = screen.getByTestId('kb-pdf-download-fallback');
+        expect(fallback.getAttribute('data-size-label')).toBe('5 MB');
+        expect(fallback.getAttribute('data-cap-label')).toBe('1 MB');
+        // The mocked translator echoes `key arg1=v1 arg2=v2`, so we
+        // can assert the interpolated payload made it through.
+        expect(fallback.textContent).toContain('size=5 MB');
+        expect(fallback.textContent).toContain('cap=1 MB');
+    });
+
+    it('exposes the raw size on the root via data-size-bytes', () => {
+        render(<KbPdfViewer url="https://files.example/x.pdf" sizeBytes={4242} filename="x.pdf" />);
+        expect(screen.getByTestId('kb-pdf-viewer').getAttribute('data-size-bytes')).toBe('4242');
+    });
+});
+
+describe('formatBytes', () => {
+    it.each([
+        [0, '0 B'],
+        [512, '512 B'],
+        [1024, '1 KB'],
+        [1536, '1.5 KB'],
+        [1024 * 1024, '1 MB'],
+        [Math.round(1.5 * 1024 * 1024), '1.5 MB'],
+        [30 * 1024 * 1024, '30 MB'],
+        [1024 * 1024 * 1024, '1 GB'],
+    ])('formats %s bytes as %s', (input, expected) => {
+        expect(formatBytes(input)).toBe(expected);
+    });
+
+    it('exports the spec §14.5 default cap', () => {
+        expect(KB_PDF_INLINE_MAX_BYTES).toBe(30 * 1024 * 1024);
+    });
+});

--- a/apps/web/src/components/works/detail/kb/viewers/KbPdfViewerCanvas.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbPdfViewerCanvas.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { cn } from '@/lib/utils/cn';
+
+interface KbPdfViewerCanvasProps {
+    url: string;
+    title: string;
+    /**
+     * Sandbox: by default we permit `allow-same-origin` (PDF.js needs
+     * to fetch the file URL) but withhold `allow-scripts` so embedded
+     * PDFs can't execute JavaScript in the operator's origin. Operators
+     * uploading PDFs cannot inject XSS through annotations / forms.
+     */
+    sandbox?: string;
+}
+
+/**
+ * EW-641 Phase 1B/d row 9 — inline PDF render surface.
+ *
+ * Uses the browser's built-in PDF renderer via `<iframe>`. The
+ * follow-up row #11 (XLSX grid viewer) plus a richer
+ * `react-pdf`-based renderer (text selection, page nav, search) are
+ * scoped for the post-MVP UX pass — Chrome / Firefox / Safari all
+ * render PDFs natively in iframes today, so this ships A14 (30 MB
+ * cap render + download fallback) without bundling a PDF.js worker
+ * into every Workbench page load.
+ *
+ * Lives in its own file so the parent `KbPdfViewer` can `next/dynamic`
+ * the canvas — keeps the initial Workbench bundle lean (the iframe
+ * is trivial today but the upgrade path is to swap this canvas for a
+ * react-pdf wrapper without touching `KbPdfViewer`).
+ */
+export function KbPdfViewerCanvas({
+    url,
+    title,
+    sandbox = 'allow-same-origin',
+}: KbPdfViewerCanvasProps) {
+    return (
+        <iframe
+            src={url}
+            title={title}
+            data-testid="kb-pdf-iframe"
+            sandbox={sandbox}
+            className={cn(
+                'h-[36rem] w-full rounded-md border',
+                'border-border dark:border-border-dark',
+                'bg-card dark:bg-card-primary-dark/40',
+            )}
+        />
+    );
+}


### PR DESCRIPTION
## Summary
- Adds the **inline PDF preview surface** for KB uploads — first of the spec §14.5 viewers (XLSX grid + image/video/audio follow in rows #11-12). Acceptance A14 ("30 MB PDF renders inline; over-cap shows download fallback") is exercisable today.
- \`KbPdfViewer.tsx\` (client) decides between two presentations based on \`sizeBytes\` and a 30 MiB default cap (\`KB_PDF_INLINE_MAX_BYTES\`, overridable via \`maxInlineBytes\` prop). Under cap → lazy-loads \`KbPdfViewerCanvas\` via \`next/dynamic\` so the iframe code only ships when needed. Over cap → renders a download-fallback card with a direct \`<a download>\` anchor.
- \`KbPdfViewerCanvas.tsx\` (lazy) renders the PDF inline via the browser's built-in viewer through \`<iframe sandbox="allow-same-origin">\`. Cross-browser today; PDF.js can fetch the file but embedded scripts / forms cannot execute in the Workbench origin. The richer react-pdf renderer (text selection, search, page nav) is deferred to a follow-up UX pass — this surface ships A14 without bundling a PDF.js worker into every Workbench page load.
- Stable selectors for Playwright A14: \`kb-pdf-viewer\` (with \`data-mode={"inline"|"download"}\` + \`data-size-bytes\`), \`kb-pdf-iframe\`, \`kb-pdf-download-fallback\` (with \`data-size-label\` + \`data-cap-label\`), \`kb-pdf-download-link\`.
- \`formatBytes\` helper exported (B/KB/MB/GB, ASCII-only) so e2e \`.toContain('30 MB')\` assertions stay stable across locales.
- i18n: \`dashboard.workDetail.kb.pdf.{label, tooLargeTitle, tooLargeBody, download}\` added across all 21 locale files.

## Test plan
- [x] \`cd apps/web && npx vitest run src/components/works/detail/kb/\` → **58 passed** (14 new KbPdfViewer + 44 prior). Coverage: inline render under cap · download-fallback over cap · boundary check (\`>\` not \`>=\`) · raw size exposure · body interpolation · parametric \`formatBytes\` batch · 30 MiB constant export.
- [x] \`npx tsc --noEmit\` (web) → clean
- [x] \`npx eslint\` on touched files → clean
- [x] \`npx prettier --write\` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- \`docs/specs/features/knowledge-base/spec.md\` §14.5 (inline-viewer size thresholds) + acceptance A14
- EW-641 Phase 1B/d row 9 of the atomic queue in \`Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline PDF viewer to Knowledge Base. PDFs up to 30 MB display seamlessly within the interface; larger files offer one-click download option. Includes clear messaging when PDFs exceed preview size limits. Full internationalization support added with translation strings for 21+ languages including English, Spanish, French, German, Japanese, Chinese, and more.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->