### PR TITLE
feat(kb): DOCX read-only viewer with mammoth.browser (EW-641 Phase 1B/d row 10)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2688,6 +2688,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2688,6 +2688,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2688,6 +2688,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2716,6 +2716,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2688,6 +2688,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2715,6 +2715,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2688,6 +2688,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2471,6 +2471,14 @@
                     "tooLargeTitle": "PDF too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and view in your local PDF reader.",
                     "download": "Download PDF"
+                },
+                "docx": {
+                    "label": "DOCX viewer",
+                    "loading": "Rendering Word document…",
+                    "renderFailed": "Could not render this DOCX inline ({error}).",
+                    "tooLargeTitle": "DOCX too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
+                    "download": "Download DOCX"
                 }
             }
         },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
         "iron-session": "^8.0.4",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.542.0",
+        "mammoth": "^1.8.0",
         "next": "16.2.6",
         "next-intl": "^4.9.2",
         "nextjs-toploader": "^3.9.17",

--- a/apps/web/src/components/works/detail/kb/viewers/KbDocxViewer.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbDocxViewer.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { formatBytes } from './KbPdfViewer';
+
+/**
+ * Spec §14.5 — DOCX shares the 30 MiB inline cap with PDF. Anything
+ * larger renders as a download fallback instead of converting on the
+ * client (a 100 MiB DOCX would block the main thread for seconds).
+ */
+export const KB_DOCX_INLINE_MAX_BYTES = 30 * 1024 * 1024;
+
+const KbDocxViewerCanvas = dynamic(
+    () =>
+        import('./KbDocxViewerCanvas').then((m) => ({
+            default: m.KbDocxViewerCanvas,
+        })),
+    { ssr: false },
+);
+
+interface KbDocxViewerProps {
+    /** Pre-signed URL to the DOCX bytes in storage. */
+    url: string;
+    /** File size in bytes (drives the inline-vs-download decision). */
+    sizeBytes: number;
+    /** Original filename for the download anchor + iframe title. */
+    filename: string;
+    /**
+     * Test seam — override the cap so the fallback path is
+     * exercisable without 30 MiB of fake bytes. Production code
+     * leaves it at the default.
+     */
+    maxInlineBytes?: number;
+}
+
+/**
+ * EW-641 Phase 1B/d row 10 — DOCX read-only viewer.
+ *
+ * Mirrors the row 9 PDF viewer's size-cap pattern:
+ *  - `sizeBytes <= maxInlineBytes` (default 30 MiB per spec §14.5):
+ *    lazy-loads `KbDocxViewerCanvas` via `next/dynamic`. The canvas
+ *    fetches the DOCX, runs it through `mammoth/mammoth.browser`,
+ *    sanitises the resulting HTML, and renders inline.
+ *  - `sizeBytes > maxInlineBytes`: download-fallback card with a
+ *    direct `<a download>` anchor — operator clicks → browser saves.
+ *
+ * Selectors locked for Playwright A14 (one acceptance covers PDF +
+ * DOCX size caps together):
+ *  - `data-testid="kb-docx-viewer"` (root) + `data-mode={"inline"|"download"}`
+ *    + `data-size-bytes`
+ *  - `data-testid="kb-docx-download-fallback"` (over-cap card)
+ *  - `data-testid="kb-docx-download-link"` (download anchor)
+ *  - canvas-side selectors live in `KbDocxViewerCanvas.tsx`.
+ */
+export function KbDocxViewer({
+    url,
+    sizeBytes,
+    filename,
+    maxInlineBytes = KB_DOCX_INLINE_MAX_BYTES,
+}: KbDocxViewerProps) {
+    const t = useTranslations('dashboard.workDetail.kb.docx');
+    const overCap = sizeBytes > maxInlineBytes;
+
+    return (
+        <section
+            data-testid="kb-docx-viewer"
+            data-mode={overCap ? 'download' : 'inline'}
+            data-size-bytes={sizeBytes}
+            aria-label={t('label')}
+            className="flex flex-col gap-2"
+        >
+            {overCap ? (
+                <KbDocxDownloadFallback
+                    url={url}
+                    filename={filename}
+                    sizeLabel={formatBytes(sizeBytes)}
+                    capLabel={formatBytes(maxInlineBytes)}
+                    title={t('tooLargeTitle')}
+                    body={t('tooLargeBody', {
+                        size: formatBytes(sizeBytes),
+                        cap: formatBytes(maxInlineBytes),
+                    })}
+                    download={t('download')}
+                />
+            ) : (
+                <KbDocxViewerCanvas url={url} filename={filename} />
+            )}
+        </section>
+    );
+}
+
+interface KbDocxDownloadFallbackProps {
+    url: string;
+    filename: string;
+    sizeLabel: string;
+    capLabel: string;
+    title: string;
+    body: string;
+    download: string;
+}
+
+function KbDocxDownloadFallback({
+    url,
+    filename,
+    sizeLabel,
+    capLabel,
+    title,
+    body,
+    download,
+}: KbDocxDownloadFallbackProps) {
+    return (
+        <div
+            data-testid="kb-docx-download-fallback"
+            data-size-label={sizeLabel}
+            data-cap-label={capLabel}
+            className={cn(
+                'flex flex-col gap-2 rounded-md border border-dashed p-4 text-center',
+                'border-border bg-card/30 dark:border-border-dark dark:bg-card-primary-dark/20',
+            )}
+        >
+            <p className="text-sm font-medium text-text dark:text-text-dark">{title}</p>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark/70">{body}</p>
+            <div>
+                <Button asChild type="button" size="sm" variant="secondary">
+                    <a
+                        data-testid="kb-docx-download-link"
+                        href={url}
+                        download={filename}
+                        rel="noopener noreferrer"
+                    >
+                        {download} ({sizeLabel})
+                    </a>
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/viewers/KbDocxViewer.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbDocxViewer.unit.spec.tsx
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        asChild,
+        onClick,
+        ...rest
+    }: {
+        children: ReactNode;
+        asChild?: boolean;
+        onClick?: () => void;
+    } & Record<string, unknown>) => {
+        if (asChild) return <>{children}</>;
+        return (
+            <button type="button" onClick={onClick} {...rest}>
+                {children}
+            </button>
+        );
+    },
+}));
+
+// Stub `next/dynamic` so the canvas renders inline (no Suspense wait).
+// Production path lazy-imports KbDocxViewerCanvas; tests use a stub.
+vi.mock('next/dynamic', () => ({
+    __esModule: true,
+    default: () => {
+        const StubCanvas = (props: Record<string, unknown>) => (
+            <div
+                data-testid="kb-docx-canvas-stub"
+                data-url={String(props.url ?? '')}
+                data-filename={String(props.filename ?? '')}
+            />
+        );
+        return StubCanvas;
+    },
+}));
+
+import { KbDocxViewer, KB_DOCX_INLINE_MAX_BYTES } from './KbDocxViewer';
+
+/**
+ * EW-641 Phase 1B/d row 10 — `KbDocxViewer` mirrors the row 9 PDF
+ * viewer's size-cap pattern. These tests lock the inline-vs-download
+ * decision + selector contract the Playwright A14 suite uses.
+ */
+describe('KbDocxViewer', () => {
+    it('renders the inline canvas when size is under the cap', () => {
+        render(
+            <KbDocxViewer
+                url="https://files.example/voice.docx"
+                sizeBytes={1024 * 1024}
+                filename="voice.docx"
+            />,
+        );
+        const root = screen.getByTestId('kb-docx-viewer');
+        expect(root.getAttribute('data-mode')).toBe('inline');
+        const canvas = screen.getByTestId('kb-docx-canvas-stub');
+        expect(canvas.getAttribute('data-url')).toBe('https://files.example/voice.docx');
+        expect(canvas.getAttribute('data-filename')).toBe('voice.docx');
+        expect(screen.queryByTestId('kb-docx-download-fallback')).toBeNull();
+    });
+
+    it('renders the download fallback above the cap', () => {
+        render(
+            <KbDocxViewer
+                url="https://files.example/huge.docx"
+                sizeBytes={2_000_000}
+                filename="huge.docx"
+                maxInlineBytes={1_000_000}
+            />,
+        );
+        const root = screen.getByTestId('kb-docx-viewer');
+        expect(root.getAttribute('data-mode')).toBe('download');
+        const link = screen.getByTestId('kb-docx-download-link') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/huge.docx');
+        expect(link.getAttribute('download')).toBe('huge.docx');
+        expect(screen.queryByTestId('kb-docx-canvas-stub')).toBeNull();
+    });
+
+    it('treats exact-cap size as inline (boundary is `>`, not `>=`)', () => {
+        render(
+            <KbDocxViewer
+                url="https://files.example/edge.docx"
+                sizeBytes={KB_DOCX_INLINE_MAX_BYTES}
+                filename="edge.docx"
+            />,
+        );
+        expect(screen.getByTestId('kb-docx-viewer').getAttribute('data-mode')).toBe('inline');
+    });
+
+    it('interpolates size + cap labels into the fallback body', () => {
+        render(
+            <KbDocxViewer
+                url="https://files.example/huge.docx"
+                sizeBytes={5 * 1024 * 1024}
+                filename="huge.docx"
+                maxInlineBytes={1 * 1024 * 1024}
+            />,
+        );
+        const fallback = screen.getByTestId('kb-docx-download-fallback');
+        expect(fallback.getAttribute('data-size-label')).toBe('5 MB');
+        expect(fallback.getAttribute('data-cap-label')).toBe('1 MB');
+        expect(fallback.textContent).toContain('size=5 MB');
+        expect(fallback.textContent).toContain('cap=1 MB');
+    });
+
+    it('exposes the raw size + 30 MiB default cap', () => {
+        expect(KB_DOCX_INLINE_MAX_BYTES).toBe(30 * 1024 * 1024);
+        render(
+            <KbDocxViewer url="https://files.example/x.docx" sizeBytes={4242} filename="x.docx" />,
+        );
+        expect(screen.getByTestId('kb-docx-viewer').getAttribute('data-size-bytes')).toBe('4242');
+    });
+});
+
+// Direct canvas spec — exercises the fetch + mammoth wiring with stubs.
+// Importing the canvas at module-top would tangle with the next/dynamic
+// mock above, so this block lives in a sibling describe and re-imports
+// after the module mocks are set up.
+describe('KbDocxViewerCanvas', () => {
+    it('fetches → converts → sanitises → renders the HTML', async () => {
+        const arrayBuffer = new ArrayBuffer(8);
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            arrayBuffer: async () => arrayBuffer,
+        });
+        const convertMock = vi.fn().mockResolvedValue({
+            value: '<h2>Voice</h2><p>Brand voice <strong>matters</strong>.</p>',
+        });
+
+        const { KbDocxViewerCanvas } = await import('./KbDocxViewerCanvas');
+        render(
+            <KbDocxViewerCanvas
+                url="https://files.example/voice.docx"
+                filename="voice.docx"
+                fetchImpl={fetchMock as unknown as typeof fetch}
+                convertToHtml={convertMock}
+            />,
+        );
+
+        // Starts in loading state.
+        expect(screen.getByTestId('kb-docx-loading')).toBeTruthy();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-docx-canvas')).toBeTruthy();
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://files.example/voice.docx',
+            expect.objectContaining({ credentials: 'same-origin' }),
+        );
+        expect(convertMock).toHaveBeenCalledWith({ arrayBuffer });
+        const canvas = screen.getByTestId('kb-docx-canvas');
+        expect(canvas.innerHTML).toContain('<h2>Voice</h2>');
+        expect(canvas.innerHTML).toContain('<strong>matters</strong>');
+    });
+
+    it('surfaces a render-failure pill + download link when fetch fails', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+        const convertMock = vi.fn();
+
+        const { KbDocxViewerCanvas } = await import('./KbDocxViewerCanvas');
+        render(
+            <KbDocxViewerCanvas
+                url="https://files.example/x.docx"
+                filename="x.docx"
+                fetchImpl={fetchMock as unknown as typeof fetch}
+                convertToHtml={convertMock}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-docx-error')).toBeTruthy();
+        });
+        const err = screen.getByTestId('kb-docx-error');
+        expect(err.textContent).toContain('HTTP 503');
+        const link = err.querySelector('a') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/x.docx');
+        expect(link.getAttribute('download')).toBe('x.docx');
+        expect(convertMock).not.toHaveBeenCalled();
+    });
+
+    it('strips disallowed tags before rendering the HTML', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => new ArrayBuffer(0),
+        });
+        const convertMock = vi.fn().mockResolvedValue({
+            value: '<p>safe</p><script>alert(1)</script><p onclick="bad">click</p>',
+        });
+
+        const { KbDocxViewerCanvas } = await import('./KbDocxViewerCanvas');
+        render(
+            <KbDocxViewerCanvas
+                url="https://files.example/x.docx"
+                filename="x.docx"
+                fetchImpl={fetchMock as unknown as typeof fetch}
+                convertToHtml={convertMock}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-docx-canvas')).toBeTruthy();
+        });
+        const html = screen.getByTestId('kb-docx-canvas').innerHTML;
+        expect(html).toContain('<p>safe</p>');
+        expect(html).toContain('<p>click</p>');
+        expect(html).not.toContain('alert');
+        expect(html).not.toContain('onclick');
+        expect(html).not.toContain('<script');
+    });
+});

--- a/apps/web/src/components/works/detail/kb/viewers/KbDocxViewerCanvas.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbDocxViewerCanvas.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { sanitizeDocxHtml } from './sanitize-docx-html';
+
+interface KbDocxViewerCanvasProps {
+    url: string;
+    /** Used in the `<iframe srcdoc>` title + fallback download anchor. */
+    filename: string;
+    /**
+     * Test seam — production code leaves this undefined and the canvas
+     * dynamic-imports `mammoth/mammoth.browser` itself; specs supply a
+     * stub so vitest doesn't need the real (DOM-heavy) library.
+     */
+    convertToHtml?: (input: { arrayBuffer: ArrayBuffer }) => Promise<{
+        value: string;
+        messages?: Array<{ type?: string; message?: string }>;
+    }>;
+    /** Test seam for fetch — defaults to the global. */
+    fetchImpl?: typeof fetch;
+}
+
+type CanvasStatus = 'loading' | 'ready' | 'failed';
+
+/**
+ * EW-641 Phase 1B/d row 10 — DOCX → HTML render canvas.
+ *
+ * Fetches the original DOCX bytes from the supplied URL, hands them
+ * to `mammoth.convertToHtml` (dynamic-imported so the ~150 KB lib
+ * only ships when an operator actually opens a DOCX preview), pipes
+ * the result through {@link sanitizeDocxHtml}, and injects the HTML
+ * via `dangerouslySetInnerHTML`. The sanitiser strips anything
+ * outside the allowlist (script/style/embed/object/iframe and any
+ * `on*` event handlers) so a malicious DOCX can't XSS through the
+ * Workbench origin.
+ *
+ * Lives in its own file because the parent `KbDocxViewer` lazy-loads
+ * it via `next/dynamic`. Same pattern as the row 9 PDF viewer.
+ */
+export function KbDocxViewerCanvas({
+    url,
+    filename,
+    convertToHtml,
+    fetchImpl,
+}: KbDocxViewerCanvasProps) {
+    const t = useTranslations('dashboard.workDetail.kb.docx');
+    const [status, setStatus] = useState<CanvasStatus>('loading');
+    const [html, setHtml] = useState<string>('');
+    const [error, setError] = useState<string | null>(null);
+    // Track the in-flight request so the effect cleanup can ignore a
+    // late response if the URL changes mid-render.
+    const requestRef = useRef(0);
+
+    useEffect(() => {
+        const reqId = ++requestRef.current;
+        setStatus('loading');
+        setError(null);
+
+        const run = async () => {
+            try {
+                const fetchFn = fetchImpl ?? fetch;
+                const res = await fetchFn(url, { credentials: 'same-origin' });
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const arrayBuffer = await res.arrayBuffer();
+
+                const convert =
+                    convertToHtml ?? (await import('mammoth/mammoth.browser')).convertToHtml;
+                const result = await convert({ arrayBuffer });
+                if (reqId !== requestRef.current) return; // superseded
+
+                const safe = sanitizeDocxHtml(result.value ?? '');
+                setHtml(safe);
+                setStatus('ready');
+            } catch (e: unknown) {
+                if (reqId !== requestRef.current) return;
+                setError(e instanceof Error ? e.message : 'DOCX render failed');
+                setStatus('failed');
+            }
+        };
+        void run();
+    }, [url, convertToHtml, fetchImpl]);
+
+    if (status === 'loading') {
+        return (
+            <div
+                data-testid="kb-docx-loading"
+                aria-live="polite"
+                className={cn(
+                    'flex h-48 items-center justify-center rounded-md border',
+                    'border-border bg-card/30 text-sm text-text-muted',
+                    'dark:border-border-dark dark:bg-card-primary-dark/20 dark:text-text-muted-dark/70',
+                )}
+            >
+                {t('loading')}
+            </div>
+        );
+    }
+
+    if (status === 'failed') {
+        return (
+            <div
+                data-testid="kb-docx-error"
+                role="alert"
+                className={cn(
+                    'rounded-md border border-red-500/20 bg-red-500/5 px-4 py-3 text-sm',
+                    'text-red-700 dark:text-red-300',
+                )}
+            >
+                {t('renderFailed', { error: error ?? 'unknown error' })}{' '}
+                <a
+                    href={url}
+                    download={filename}
+                    className="ml-1 underline hover:no-underline"
+                    rel="noopener noreferrer"
+                >
+                    {t('download')}
+                </a>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            data-testid="kb-docx-canvas"
+            className={cn(
+                'prose prose-sm dark:prose-invert max-w-none',
+                'rounded-md border border-border dark:border-border-dark',
+                'bg-card dark:bg-card-primary-dark/40 px-4 py-3 overflow-auto',
+                'max-h-[36rem]',
+            )}
+            // sanitizeDocxHtml ran above — any element/attribute outside
+            // the allowlist has been stripped. Mammoth itself doesn't
+            // emit scripts, but a malicious uploader could embed
+            // `<iframe srcdoc>` or `onclick` attributes inside oMath
+            // elements; the sanitiser is the belt-and-braces guard.
+            dangerouslySetInnerHTML={{ __html: html }}
+        />
+    );
+}

--- a/apps/web/src/components/works/detail/kb/viewers/mammoth-browser.d.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/mammoth-browser.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Type shim for `mammoth/mammoth.browser`.
+ *
+ * The mammoth package ships `index.d.ts` for the Node entry only; the
+ * browser bundle (`mammoth.browser.js`) is untyped. We dynamic-import
+ * it in `KbDocxViewerCanvas.tsx` and only call `convertToHtml`, so the
+ * declared surface here matches that single function — keeping the
+ * any cast scoped instead of bleeding into the canvas itself.
+ */
+declare module 'mammoth/mammoth.browser' {
+    export interface MammothBrowserConversionResult {
+        value: string;
+        messages: Array<{ type?: string; message?: string }>;
+    }
+    export function convertToHtml(input: {
+        arrayBuffer: ArrayBuffer;
+    }): Promise<MammothBrowserConversionResult>;
+}

--- a/apps/web/src/components/works/detail/kb/viewers/sanitize-docx-html.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/sanitize-docx-html.ts
@@ -1,0 +1,156 @@
+/**
+ * EW-641 Phase 1B/d row 10 — allowlist-based HTML sanitiser for the
+ * DOCX viewer canvas.
+ *
+ * Mammoth's `convertToHtml` produces simple block markup (`<p>`,
+ * `<h1-h6>`, lists, tables, basic inline emphasis) plus the
+ * occasional `<img src="data:image/...;base64,...">` for embedded
+ * pictures. It does not emit `<script>` / `<iframe>` / `on*` event
+ * handlers under normal use — but a malicious uploader could embed
+ * raw HTML inside an oMath element or rely on a Word feature we
+ * don't know about. The sanitiser is the belt-and-braces guard:
+ * any element or attribute outside the allowlist is stripped before
+ * the HTML reaches `dangerouslySetInnerHTML`.
+ *
+ * Design:
+ *  - DOMParser based — runs in the browser; SSR callers should never
+ *    invoke this (the canvas is `next/dynamic`-loaded with ssr:false).
+ *  - Reasonably comprehensive allowlist for the elements mammoth
+ *    actually emits + a couple of nice-to-haves (`<sup>`, `<sub>`,
+ *    `<details>` blocks).
+ *  - URL schemes restricted to `http:`, `https:`, `mailto:`, and
+ *    `data:image/...` — `javascript:` href / src is dropped.
+ */
+
+const ALLOWED_TAGS = new Set([
+    'a',
+    'b',
+    'blockquote',
+    'br',
+    'code',
+    'div',
+    'em',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'hr',
+    'i',
+    'img',
+    'li',
+    'ol',
+    'p',
+    'pre',
+    'span',
+    'strong',
+    'sub',
+    'sup',
+    'table',
+    'tbody',
+    'td',
+    'tfoot',
+    'th',
+    'thead',
+    'tr',
+    'u',
+    'ul',
+]);
+
+const ALLOWED_ATTRS: Record<string, ReadonlySet<string>> = {
+    a: new Set(['href', 'title', 'rel', 'target']),
+    img: new Set(['src', 'alt', 'title', 'width', 'height']),
+    td: new Set(['colspan', 'rowspan', 'align']),
+    th: new Set(['colspan', 'rowspan', 'scope', 'align']),
+    table: new Set(['border', 'cellpadding', 'cellspacing']),
+    ol: new Set(['start', 'type']),
+};
+
+const ALLOWED_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
+
+function isSafeUrl(value: string): boolean {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return false;
+    // Data URLs only allowed for images.
+    if (/^data:image\/(png|jpe?g|gif|webp|svg\+xml);/i.test(trimmed)) return true;
+    // Absolute or scheme-relative — verify scheme.
+    if (/^[a-z][a-z0-9+\-.]*:/i.test(trimmed)) {
+        try {
+            const parsed = new URL(trimmed);
+            return ALLOWED_URL_SCHEMES.has(parsed.protocol.toLowerCase());
+        } catch {
+            return false;
+        }
+    }
+    // Relative URL (no scheme) — accept.
+    return true;
+}
+
+/**
+ * Returns a sanitised copy of the input HTML. Drops any element /
+ * attribute outside the allowlist. Always returns a string — empty
+ * input yields an empty string.
+ */
+export function sanitizeDocxHtml(html: string): string {
+    if (!html || typeof DOMParser === 'undefined') return '';
+
+    const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html');
+    const root = doc.body.firstElementChild;
+    if (!root) return '';
+
+    walk(root);
+
+    return root.innerHTML;
+}
+
+function walk(node: Element): void {
+    // Iterate over a snapshot — we mutate during traversal.
+    const children = Array.from(node.children);
+    for (const child of children) {
+        const tag = child.tagName.toLowerCase();
+        if (!ALLOWED_TAGS.has(tag)) {
+            child.remove();
+            continue;
+        }
+
+        // Strip every attribute outside the per-tag allowlist + any
+        // attribute starting with `on` (event handler).
+        const allowed = ALLOWED_ATTRS[tag] ?? new Set<string>();
+        // Snapshot the attribute names so removal during iteration
+        // doesn't shift indices.
+        const attrNames = Array.from(child.attributes).map((a) => a.name);
+        for (const name of attrNames) {
+            const lower = name.toLowerCase();
+            if (lower.startsWith('on')) {
+                child.removeAttribute(name);
+                continue;
+            }
+            if (!allowed.has(lower)) {
+                child.removeAttribute(name);
+                continue;
+            }
+            // URL-bearing attrs need extra vetting.
+            if (lower === 'href' || lower === 'src') {
+                const value = child.getAttribute(name) ?? '';
+                if (!isSafeUrl(value)) {
+                    child.removeAttribute(name);
+                }
+            }
+        }
+
+        // Force-secure outbound links.
+        if (tag === 'a' && child.hasAttribute('href')) {
+            const rel = (child.getAttribute('rel') ?? '').trim();
+            const merged = new Set(rel.split(/\s+/).filter(Boolean));
+            merged.add('noopener');
+            merged.add('noreferrer');
+            child.setAttribute('rel', Array.from(merged).join(' '));
+            if (child.getAttribute('target') !== '_blank') {
+                child.setAttribute('target', '_blank');
+            }
+        }
+
+        walk(child);
+    }
+}

--- a/apps/web/src/components/works/detail/kb/viewers/sanitize-docx-html.unit.spec.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/sanitize-docx-html.unit.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeDocxHtml } from './sanitize-docx-html';
+
+/**
+ * EW-641 Phase 1B/d row 10 — `sanitizeDocxHtml` is the belt-and-
+ * braces guard between mammoth's output and `dangerouslySetInnerHTML`.
+ * Mammoth produces tame markup under normal Word documents, but a
+ * malicious uploader could embed raw HTML; the sanitiser drops
+ * anything outside the allowlist before render.
+ */
+describe('sanitizeDocxHtml', () => {
+    it('preserves allowlisted block + inline elements', () => {
+        const html =
+            '<h2>Title</h2><p>Body with <strong>bold</strong> and <em>italic</em>.</p>' +
+            '<ul><li>One</li><li>Two</li></ul>';
+        expect(sanitizeDocxHtml(html)).toBe(html);
+    });
+
+    it('strips <script> elements entirely', () => {
+        const out = sanitizeDocxHtml('<p>Hi</p><script>alert(1)</script><p>Bye</p>');
+        expect(out).toBe('<p>Hi</p><p>Bye</p>');
+        expect(out).not.toContain('alert');
+    });
+
+    it('strips <iframe> / <object> / <embed>', () => {
+        const out = sanitizeDocxHtml(
+            '<p>x</p><iframe src="https://evil"></iframe><object data="x"></object><embed src="x">',
+        );
+        expect(out).toBe('<p>x</p>');
+    });
+
+    it('strips on* event handler attributes', () => {
+        const out = sanitizeDocxHtml('<p onclick="alert(1)" onmouseover="evil()">x</p>');
+        expect(out).toBe('<p>x</p>');
+    });
+
+    it('drops javascript: hrefs but keeps safe https links + adds rel/target', () => {
+        const out = sanitizeDocxHtml(
+            '<a href="javascript:alert(1)">bad</a><a href="https://example.com">good</a>',
+        );
+        // Bad link keeps text but loses href.
+        expect(out).toContain('<a>bad</a>');
+        // Good link gains noopener/noreferrer + target=_blank.
+        expect(out).toContain('href="https://example.com"');
+        expect(out).toContain('rel="noopener noreferrer"');
+        expect(out).toContain('target="_blank"');
+    });
+
+    it('allows mailto: and relative URLs', () => {
+        const out = sanitizeDocxHtml('<a href="mailto:x@y.com">e</a><a href="./local">r</a>');
+        expect(out).toContain('href="mailto:x@y.com"');
+        expect(out).toContain('href="./local"');
+    });
+
+    it('drops javascript: img src but keeps data:image/png', () => {
+        const out = sanitizeDocxHtml(
+            '<img src="javascript:alert(1)"><img src="data:image/png;base64,abc" alt="x">',
+        );
+        expect(out).not.toContain('javascript:');
+        expect(out).toContain('src="data:image/png;base64,abc"');
+        expect(out).toContain('alt="x"');
+    });
+
+    it('strips style/class attributes that are outside the allowlist', () => {
+        const out = sanitizeDocxHtml('<p style="color:red" class="x">hi</p>');
+        expect(out).toBe('<p>hi</p>');
+    });
+
+    it('preserves tables with allowlisted colspan/rowspan attrs', () => {
+        const html =
+            '<table><thead><tr><th colspan="2">H</th></tr></thead>' +
+            '<tbody><tr><td>a</td><td>b</td></tr></tbody></table>';
+        expect(sanitizeDocxHtml(html)).toBe(html);
+    });
+
+    it('returns empty string for empty / null input', () => {
+        expect(sanitizeDocxHtml('')).toBe('');
+        expect(sanitizeDocxHtml(null as unknown as string)).toBe('');
+    });
+
+    it('recursively prunes nested disallowed elements', () => {
+        const out = sanitizeDocxHtml(
+            '<div><p>ok<script>x</script><span onclick="bad()">span</span></p></div>',
+        );
+        expect(out).toBe('<div><p>ok<span>span</span></p></div>');
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@19.2.5)
+      mammoth:
+        specifier: ^1.8.0
+        version: 1.12.0
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary
- Adds the **inline DOCX preview surface** for KB uploads. Mirrors the row #9 PDF viewer shape so A14 (inline render + 30 MiB cap → download fallback) extends cleanly to DOCX.
- \`KbDocxViewer.tsx\` (client) decides between inline canvas (under cap) and download-fallback card (over cap). Lazy-loads \`KbDocxViewerCanvas\` via \`next/dynamic\` so the canvas + mammoth bundle only ships when an operator actually opens a DOCX preview.
- \`KbDocxViewerCanvas.tsx\` (lazy) fetches the DOCX bytes → \`mammoth/mammoth.browser.convertToHtml\` → \`sanitizeDocxHtml\` → \`dangerouslySetInnerHTML\`. Status cycles \`loading → ready | failed\`; on failure surfaces a download link.
- \`sanitize-docx-html.ts\` — allowlist DOM sanitiser. Strips \`<script>\`/\`<iframe>\`/\`<object>\`/\`<embed>\`, kills \`on*\` handlers, drops \`javascript:\` href/src, keeps mailto / data:image / http(s), force-secures outbound links with \`rel="noopener noreferrer" target="_blank"\`. Belt-and-braces between mammoth and \`dangerouslySetInnerHTML\`.
- \`mammoth-browser.d.ts\` — ambient type shim for the untyped browser entry. Declares only the \`convertToHtml({arrayBuffer})\` surface this canvas uses (mammoth's typed surface lacks the browser bundle; PR #920 lesson + the user's recurring mammoth-convertToMarkdown reminder).
- Deps: adds \`mammoth: ^1.8.0\` to \`apps/web/package.json\` (same version packages/agent uses for the server-side extractor route from PR #920).
- Stable selectors for Playwright A14: \`kb-docx-viewer\` (with \`data-mode\` + \`data-size-bytes\`), \`kb-docx-loading\`, \`kb-docx-canvas\`, \`kb-docx-error\`, \`kb-docx-download-fallback\`, \`kb-docx-download-link\`.
- i18n: \`dashboard.workDetail.kb.docx.{label, loading, renderFailed, tooLargeTitle, tooLargeBody, download}\` added across all 21 locale files.

## Test plan
- [x] \`cd apps/web && npx vitest run src/components/works/detail/kb/\` → **77 passed** (11 new sanitiser + 8 new viewer/canvas + 58 prior). Coverage: sanitiser allowlist passes safe block/inline elements; strips script/iframe/object/embed; kills on* handlers; drops javascript: href/src; keeps mailto/relative; allows data:image; strips style/class; preserves colspan/rowspan; empty-input fallback; recursive prune. Viewer: inline under cap; download over cap; boundary (\`>\` not \`>=\`); body interpolation; 30 MiB constant. Canvas: fetch → convert → sanitise → render happy path; fetch failure → error pill with download link; script-in-mammoth-output stripped before render.
- [x] \`npx tsc --noEmit\` (web) → clean
- [x] \`npx eslint\` on touched files → clean
- [x] \`npx prettier --write\` → no formatting changes outstanding
- [ ] CI green on this PR

## Spec
- \`docs/specs/features/knowledge-base/spec.md\` §14.5 (inline-viewer size thresholds) + acceptance A14
- EW-641 Phase 1B/d row 10 of the atomic queue in \`Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DOCX file preview support in Knowledge Base viewer with inline rendering for files up to 30MB; larger files trigger a download option
  * Extended DOCX viewer interface across all supported languages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->