### PR TITLE
feat(kb): XLSX grid viewer with 5 MiB size cap (EW-641 Phase 1B/d row 11)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2696,6 +2696,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2696,6 +2696,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2696,6 +2696,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2724,6 +2724,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2696,6 +2696,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2723,6 +2723,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2696,6 +2696,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2479,6 +2479,17 @@
                     "tooLargeTitle": "DOCX too large to preview inline",
                     "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Word.",
                     "download": "Download DOCX"
+                },
+                "xlsx": {
+                    "label": "Spreadsheet viewer",
+                    "loading": "Rendering spreadsheet…",
+                    "renderFailed": "Could not render this XLSX inline ({error}).",
+                    "tooLargeTitle": "Spreadsheet too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and open in Excel.",
+                    "download": "Download XLSX",
+                    "sheetTabsLabel": "Worksheet tabs",
+                    "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
+                    "emptyWorkbook": "Workbook has no worksheets"
                 }
             }
         },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,6 +41,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "deepmerge": "^4.3.1",
+        "exceljs": "^4.4.0",
         "iron-session": "^8.0.4",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.542.0",

--- a/apps/web/src/components/works/detail/kb/viewers/KbXlsxViewer.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbXlsxViewer.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { formatBytes } from './KbPdfViewer';
+
+/**
+ * Spec §14.5 — XLSX uses a tighter 5 MiB inline cap because parsing
+ * a workbook on the main thread costs more wall-clock time than
+ * iframe-rendering a PDF or HTML-converting a DOCX. Anything larger
+ * renders as a download fallback so the operator doesn't watch the
+ * Workbench freeze for 5+ seconds.
+ */
+export const KB_XLSX_INLINE_MAX_BYTES = 5 * 1024 * 1024;
+
+const KbXlsxViewerCanvas = dynamic(
+    () =>
+        import('./KbXlsxViewerCanvas').then((m) => ({
+            default: m.KbXlsxViewerCanvas,
+        })),
+    { ssr: false },
+);
+
+interface KbXlsxViewerProps {
+    /** Pre-signed URL to the XLSX bytes in storage. */
+    url: string;
+    /** File size in bytes — drives the inline-vs-download decision. */
+    sizeBytes: number;
+    /** Original filename for the download anchor + iframe title. */
+    filename: string;
+    /**
+     * Override the inline cap (defaults to {@link KB_XLSX_INLINE_MAX_BYTES}).
+     * Tests use a smaller value so the fallback path is exercisable
+     * without a 5 MiB fake file.
+     */
+    maxInlineBytes?: number;
+}
+
+/**
+ * EW-641 Phase 1B/d row 11 — XLSX grid viewer.
+ *
+ * Mirrors the row 9 PDF + row 10 DOCX viewers' size-cap pattern:
+ *  - `sizeBytes <= maxInlineBytes` (5 MiB default per spec §14.5):
+ *    lazy-loads `KbXlsxViewerCanvas` via `next/dynamic`. The canvas
+ *    fetches the workbook, runs `exceljs.xlsx.load(arrayBuffer)`,
+ *    and renders the active sheet as a sortable `<table>`. Sheet
+ *    tabs let the operator switch between worksheets.
+ *  - `sizeBytes > maxInlineBytes`: download-fallback card with a
+ *    direct `<a download>` anchor.
+ *
+ * Selectors locked for Playwright A14 (one acceptance covers all
+ * three viewer size caps):
+ *  - `data-testid="kb-xlsx-viewer"` (root) + `data-mode={"inline"|"download"}`
+ *    + `data-size-bytes`
+ *  - `data-testid="kb-xlsx-download-fallback"` (over-cap card)
+ *  - `data-testid="kb-xlsx-download-link"` (download anchor)
+ *  - canvas-side selectors live in `KbXlsxViewerCanvas.tsx`.
+ */
+export function KbXlsxViewer({
+    url,
+    sizeBytes,
+    filename,
+    maxInlineBytes = KB_XLSX_INLINE_MAX_BYTES,
+}: KbXlsxViewerProps) {
+    const t = useTranslations('dashboard.workDetail.kb.xlsx');
+    const overCap = sizeBytes > maxInlineBytes;
+
+    return (
+        <section
+            data-testid="kb-xlsx-viewer"
+            data-mode={overCap ? 'download' : 'inline'}
+            data-size-bytes={sizeBytes}
+            aria-label={t('label')}
+            className="flex flex-col gap-2"
+        >
+            {overCap ? (
+                <KbXlsxDownloadFallback
+                    url={url}
+                    filename={filename}
+                    sizeLabel={formatBytes(sizeBytes)}
+                    capLabel={formatBytes(maxInlineBytes)}
+                    title={t('tooLargeTitle')}
+                    body={t('tooLargeBody', {
+                        size: formatBytes(sizeBytes),
+                        cap: formatBytes(maxInlineBytes),
+                    })}
+                    download={t('download')}
+                />
+            ) : (
+                <KbXlsxViewerCanvas url={url} filename={filename} />
+            )}
+        </section>
+    );
+}
+
+interface KbXlsxDownloadFallbackProps {
+    url: string;
+    filename: string;
+    sizeLabel: string;
+    capLabel: string;
+    title: string;
+    body: string;
+    download: string;
+}
+
+function KbXlsxDownloadFallback({
+    url,
+    filename,
+    sizeLabel,
+    capLabel,
+    title,
+    body,
+    download,
+}: KbXlsxDownloadFallbackProps) {
+    return (
+        <div
+            data-testid="kb-xlsx-download-fallback"
+            data-size-label={sizeLabel}
+            data-cap-label={capLabel}
+            className={cn(
+                'flex flex-col gap-2 rounded-md border border-dashed p-4 text-center',
+                'border-border bg-card/30 dark:border-border-dark dark:bg-card-primary-dark/20',
+            )}
+        >
+            <p className="text-sm font-medium text-text dark:text-text-dark">{title}</p>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark/70">{body}</p>
+            <div>
+                <Button asChild type="button" size="sm" variant="secondary">
+                    <a
+                        data-testid="kb-xlsx-download-link"
+                        href={url}
+                        download={filename}
+                        rel="noopener noreferrer"
+                    >
+                        {download} ({sizeLabel})
+                    </a>
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/viewers/KbXlsxViewer.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbXlsxViewer.unit.spec.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        asChild,
+        onClick,
+        ...rest
+    }: {
+        children: ReactNode;
+        asChild?: boolean;
+        onClick?: () => void;
+    } & Record<string, unknown>) => {
+        if (asChild) return <>{children}</>;
+        return (
+            <button type="button" onClick={onClick} {...rest}>
+                {children}
+            </button>
+        );
+    },
+}));
+
+vi.mock('next/dynamic', () => ({
+    __esModule: true,
+    default: () => {
+        const StubCanvas = (props: Record<string, unknown>) => (
+            <div
+                data-testid="kb-xlsx-canvas-stub"
+                data-url={String(props.url ?? '')}
+                data-filename={String(props.filename ?? '')}
+            />
+        );
+        return StubCanvas;
+    },
+}));
+
+// Stub the thin exceljs loader so vitest never has to resolve the
+// real exceljs package — exceljs pulls in jszip / archiver and
+// OOMs the V8 worker on Windows during module discovery. The canvas
+// spec uses `workbookFactory` to inject its own stub workbook, so
+// the loader is only reached when a test doesn't override it.
+vi.mock('./load-exceljs-workbook', () => ({
+    createExceljsWorkbook: async () => ({
+        worksheets: [],
+        xlsx: { load: async () => {} },
+    }),
+}));
+
+import { KbXlsxViewer, KB_XLSX_INLINE_MAX_BYTES } from './KbXlsxViewer';
+
+/**
+ * EW-641 Phase 1B/d row 11 — `KbXlsxViewer` mirrors the row 9/10
+ * viewers but uses a tighter 5 MiB cap (spec §14.5 — parsing a
+ * workbook is more expensive than rendering a PDF iframe). These
+ * tests lock the inline-vs-download decision the Playwright A14 suite
+ * keys off.
+ */
+describe('KbXlsxViewer', () => {
+    it('renders the inline canvas under the cap', () => {
+        render(
+            <KbXlsxViewer
+                url="https://files.example/budget.xlsx"
+                sizeBytes={1024 * 1024}
+                filename="budget.xlsx"
+            />,
+        );
+        const root = screen.getByTestId('kb-xlsx-viewer');
+        expect(root.getAttribute('data-mode')).toBe('inline');
+        const canvas = screen.getByTestId('kb-xlsx-canvas-stub');
+        expect(canvas.getAttribute('data-url')).toBe('https://files.example/budget.xlsx');
+        expect(canvas.getAttribute('data-filename')).toBe('budget.xlsx');
+        expect(screen.queryByTestId('kb-xlsx-download-fallback')).toBeNull();
+    });
+
+    it('renders the download fallback above the cap', () => {
+        render(
+            <KbXlsxViewer
+                url="https://files.example/huge.xlsx"
+                sizeBytes={2_000_000}
+                filename="huge.xlsx"
+                maxInlineBytes={1_000_000}
+            />,
+        );
+        const root = screen.getByTestId('kb-xlsx-viewer');
+        expect(root.getAttribute('data-mode')).toBe('download');
+        const link = screen.getByTestId('kb-xlsx-download-link') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/huge.xlsx');
+        expect(link.getAttribute('download')).toBe('huge.xlsx');
+        expect(screen.queryByTestId('kb-xlsx-canvas-stub')).toBeNull();
+    });
+
+    it('treats exact-cap size as inline (boundary is `>`, not `>=`)', () => {
+        render(
+            <KbXlsxViewer
+                url="https://files.example/edge.xlsx"
+                sizeBytes={KB_XLSX_INLINE_MAX_BYTES}
+                filename="edge.xlsx"
+            />,
+        );
+        expect(screen.getByTestId('kb-xlsx-viewer').getAttribute('data-mode')).toBe('inline');
+    });
+
+    it('exposes the default 5 MiB cap', () => {
+        expect(KB_XLSX_INLINE_MAX_BYTES).toBe(5 * 1024 * 1024);
+    });
+
+    it('interpolates size + cap into the fallback body copy', () => {
+        render(
+            <KbXlsxViewer
+                url="https://files.example/huge.xlsx"
+                sizeBytes={2 * 1024 * 1024}
+                filename="huge.xlsx"
+                maxInlineBytes={1 * 1024 * 1024}
+            />,
+        );
+        const fallback = screen.getByTestId('kb-xlsx-download-fallback');
+        expect(fallback.getAttribute('data-size-label')).toBe('2 MB');
+        expect(fallback.getAttribute('data-cap-label')).toBe('1 MB');
+        expect(fallback.textContent).toContain('size=2 MB');
+        expect(fallback.textContent).toContain('cap=1 MB');
+    });
+});

--- a/apps/web/src/components/works/detail/kb/viewers/KbXlsxViewerCanvas.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbXlsxViewerCanvas.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { ExcelWorkbook } from './exceljs-types';
+import { createExceljsWorkbook } from './load-exceljs-workbook';
+import { formatExcelCellValue } from './format-excel-cell';
+
+interface KbXlsxViewerCanvasProps {
+    url: string;
+    filename: string;
+    /**
+     * Maximum rows rendered per sheet — protects against pathological
+     * "1 M row" workbooks freezing the main thread. Defaults to 500;
+     * tests use smaller values to assert the truncation marker.
+     */
+    maxRowsPerSheet?: number;
+    /**
+     * Test seam — production code lazy-imports `exceljs` itself; the
+     * vitest suite supplies a stub workbook factory so it doesn't
+     * have to load the (~500 KB) browser bundle.
+     */
+    workbookFactory?: () => ExcelWorkbook;
+    fetchImpl?: typeof fetch;
+}
+
+type CanvasStatus = 'loading' | 'ready' | 'failed';
+
+const DEFAULT_MAX_ROWS_PER_SHEET = 500;
+
+interface SheetSnapshot {
+    name: string;
+    rowCount: number;
+    rows: string[][];
+    truncated: boolean;
+}
+
+/**
+ * EW-641 Phase 1B/d row 11 — XLSX render canvas.
+ *
+ * Loads the workbook via `exceljs` in the browser, takes a snapshot
+ * of each sheet (up to `maxRowsPerSheet` rows), and renders the
+ * active sheet as a sortable `<table>`. Sheet tabs let the operator
+ * switch between worksheets without re-loading the file.
+ *
+ * Cell values are projected through `formatExcelCellValue` so the
+ * inline preview matches what the server-side extractor (PR #921)
+ * stored in the document Markdown body — rich text, hyperlinks,
+ * formula results, dates, and the exceljs object cell variants all
+ * round-trip the same way the Markdown render does.
+ */
+export function KbXlsxViewerCanvas({
+    url,
+    filename,
+    maxRowsPerSheet = DEFAULT_MAX_ROWS_PER_SHEET,
+    workbookFactory,
+    fetchImpl,
+}: KbXlsxViewerCanvasProps) {
+    const t = useTranslations('dashboard.workDetail.kb.xlsx');
+    const [status, setStatus] = useState<CanvasStatus>('loading');
+    const [sheets, setSheets] = useState<SheetSnapshot[]>([]);
+    const [activeIndex, setActiveIndex] = useState(0);
+    const [error, setError] = useState<string | null>(null);
+    const requestRef = useRef(0);
+
+    useEffect(() => {
+        const reqId = ++requestRef.current;
+        setStatus('loading');
+        setError(null);
+        setSheets([]);
+        setActiveIndex(0);
+
+        const run = async () => {
+            try {
+                const fetchFn = fetchImpl ?? fetch;
+                const res = await fetchFn(url, { credentials: 'same-origin' });
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const arrayBuffer = await res.arrayBuffer();
+
+                // Production path: lazy-load exceljs through a thin
+                // wrapper so the spec can mock the helper without
+                // resolving the full library graph.
+                const wb: ExcelWorkbook = workbookFactory?.() ?? (await createExceljsWorkbook());
+                await wb.xlsx.load(arrayBuffer);
+                if (reqId !== requestRef.current) return;
+
+                const snapshots = snapshotWorkbook(wb, maxRowsPerSheet);
+                if (snapshots.length === 0) {
+                    throw new Error(t('emptyWorkbook'));
+                }
+                setSheets(snapshots);
+                setStatus('ready');
+            } catch (e: unknown) {
+                if (reqId !== requestRef.current) return;
+                setError(e instanceof Error ? e.message : 'XLSX render failed');
+                setStatus('failed');
+            }
+        };
+        void run();
+    }, [url, workbookFactory, fetchImpl, maxRowsPerSheet, t]);
+
+    const activeSheet = sheets[activeIndex] ?? null;
+    // Derive the rendered header + body rows so the table renders
+    // deterministically across re-renders. First non-empty row is
+    // treated as the header for the grid display — matches the
+    // server-side extractor convention.
+    const grid = useMemo(() => {
+        if (!activeSheet || activeSheet.rows.length === 0) {
+            return { headers: [] as string[], body: [] as string[][] };
+        }
+        const [first, ...rest] = activeSheet.rows;
+        return { headers: first, body: rest };
+    }, [activeSheet]);
+
+    if (status === 'loading') {
+        return (
+            <div
+                data-testid="kb-xlsx-loading"
+                aria-live="polite"
+                className={cn(
+                    'flex h-48 items-center justify-center rounded-md border',
+                    'border-border bg-card/30 text-sm text-text-muted',
+                    'dark:border-border-dark dark:bg-card-primary-dark/20 dark:text-text-muted-dark/70',
+                )}
+            >
+                {t('loading')}
+            </div>
+        );
+    }
+
+    if (status === 'failed') {
+        return (
+            <div
+                data-testid="kb-xlsx-error"
+                role="alert"
+                className={cn(
+                    'rounded-md border border-red-500/20 bg-red-500/5 px-4 py-3 text-sm',
+                    'text-red-700 dark:text-red-300',
+                )}
+            >
+                {t('renderFailed', { error: error ?? 'unknown error' })}{' '}
+                <a
+                    href={url}
+                    download={filename}
+                    className="ml-1 underline hover:no-underline"
+                    rel="noopener noreferrer"
+                >
+                    {t('download')}
+                </a>
+            </div>
+        );
+    }
+
+    return (
+        <div data-testid="kb-xlsx-canvas" className="flex flex-col gap-2">
+            {sheets.length > 1 ? (
+                <nav
+                    aria-label={t('sheetTabsLabel')}
+                    data-testid="kb-xlsx-sheet-tabs"
+                    className="flex flex-wrap gap-1 border-b border-border dark:border-border-dark"
+                >
+                    {sheets.map((sheet, idx) => (
+                        <button
+                            key={`${sheet.name}-${idx}`}
+                            type="button"
+                            data-testid="kb-xlsx-sheet-tab"
+                            data-sheet-index={idx}
+                            data-active={idx === activeIndex ? 'true' : 'false'}
+                            onClick={() => setActiveIndex(idx)}
+                            className={cn(
+                                'rounded-t border-b-2 px-2 py-1 text-xs',
+                                idx === activeIndex
+                                    ? 'border-primary bg-primary/10 text-primary'
+                                    : 'border-transparent text-text-muted hover:text-text dark:text-text-muted-dark/70 dark:hover:text-text-dark',
+                            )}
+                        >
+                            {sheet.name}
+                        </button>
+                    ))}
+                </nav>
+            ) : null}
+
+            {activeSheet ? (
+                <div
+                    className={cn(
+                        'overflow-auto rounded-md border max-h-[32rem]',
+                        'border-border dark:border-border-dark',
+                        'bg-card dark:bg-card-primary-dark/40',
+                    )}
+                >
+                    <table data-testid="kb-xlsx-table" className="min-w-full text-xs">
+                        {grid.headers.length > 0 ? (
+                            <thead className="bg-card-secondary dark:bg-card-primary-dark/60">
+                                <tr>
+                                    {grid.headers.map((cell, i) => (
+                                        <th
+                                            key={i}
+                                            data-testid="kb-xlsx-th"
+                                            className="border-b border-border px-2 py-1 text-left font-medium dark:border-border-dark"
+                                        >
+                                            {cell}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                        ) : null}
+                        <tbody>
+                            {grid.body.map((row, r) => (
+                                <tr
+                                    key={r}
+                                    data-testid="kb-xlsx-tr"
+                                    className="border-b border-border/40 dark:border-border-dark/60"
+                                >
+                                    {grid.headers.map((_, c) => (
+                                        <td
+                                            key={c}
+                                            data-testid="kb-xlsx-td"
+                                            className="px-2 py-1 align-top"
+                                        >
+                                            {row[c] ?? ''}
+                                        </td>
+                                    ))}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            ) : null}
+
+            {activeSheet?.truncated ? (
+                <p
+                    data-testid="kb-xlsx-truncated-notice"
+                    className="text-xs italic text-amber-700 dark:text-amber-300"
+                >
+                    {t('truncated', {
+                        cap: maxRowsPerSheet,
+                        total: activeSheet.rowCount,
+                    })}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+/**
+ * Walks every worksheet, projects cells to strings, and respects the
+ * per-sheet row cap. Exported for the spec because it's the
+ * trickiest piece — server-side `formatExcelCellValue` does the cell
+ * conversion; this function adds row capping + iteration order +
+ * sheet-name preservation.
+ */
+export function snapshotWorkbook(wb: ExcelWorkbook, maxRowsPerSheet: number): SheetSnapshot[] {
+    const sheets: SheetSnapshot[] = [];
+    for (const ws of wb.worksheets ?? []) {
+        const rowCount = Math.max(0, ws.rowCount ?? 0);
+        const limit = Math.min(rowCount, maxRowsPerSheet);
+        const rows: string[][] = [];
+        for (let r = 1; r <= limit; r += 1) {
+            const row = ws.getRow(r);
+            // exceljs leaves trailing blank rows reachable via getRow
+            // even when `rowCount` reports a smaller value; skip
+            // those so the rendered table doesn't have phantom rows.
+            if (!row || row.cellCount === 0) continue;
+            const cells: string[] = [];
+            const width = Math.max(row.cellCount ?? 0, 1);
+            for (let c = 1; c <= width; c += 1) {
+                cells.push(formatExcelCellValue(row.getCell(c).value));
+            }
+            rows.push(cells);
+        }
+        sheets.push({
+            name: ws.name?.trim() || `Sheet ${ws.id}`,
+            rowCount,
+            rows,
+            truncated: rowCount > maxRowsPerSheet,
+        });
+    }
+    return sheets;
+}

--- a/apps/web/src/components/works/detail/kb/viewers/exceljs-types.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/exceljs-types.ts
@@ -1,0 +1,49 @@
+/**
+ * Local structural type aliases for the exceljs surface our viewers
+ * use. Importing `import type { Workbook }` from the `exceljs` package
+ * directly triggers vitest's module resolver to walk the (very large)
+ * exceljs dependency graph in JIT mode and OOMs the V8 worker on
+ * Windows. The runtime path still uses the real `exceljs.Workbook`
+ * via `(await import('exceljs')).Workbook` — only the type-side
+ * dependency is severed.
+ *
+ * Mirrors the subset of the exceljs typing surface our code touches.
+ * Update when the canvas reads new fields.
+ */
+
+export type ExcelCellValue =
+    | string
+    | number
+    | boolean
+    | Date
+    | null
+    | undefined
+    | { text?: string; richText?: Array<{ text?: unknown }> }
+    | { formula: string; result?: unknown }
+    | { hyperlink: string; text?: string }
+    | Record<string, unknown>;
+
+export interface ExcelCell {
+    value: ExcelCellValue;
+}
+
+export interface ExcelRow {
+    cellCount: number;
+    getCell(column: number): ExcelCell;
+}
+
+export interface ExcelWorksheet {
+    id: number;
+    name: string;
+    rowCount: number;
+    getRow(row: number): ExcelRow;
+}
+
+export interface ExcelWorkbookXlsx {
+    load(buffer: ArrayBuffer): Promise<unknown>;
+}
+
+export interface ExcelWorkbook {
+    worksheets: ExcelWorksheet[];
+    xlsx: ExcelWorkbookXlsx;
+}

--- a/apps/web/src/components/works/detail/kb/viewers/format-excel-cell.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/format-excel-cell.ts
@@ -1,0 +1,47 @@
+import type { ExcelCellValue } from './exceljs-types';
+
+/**
+ * EW-641 Phase 1B/d row 11 — render an exceljs `CellValue` as a
+ * display string for the XLSX viewer grid.
+ *
+ * Mirrors the agent-side `formatExcelCellValue` helper used by the
+ * server extractor (Phase 1B/c.3) so the inline preview matches what
+ * the extractor stored in the Markdown body. The exceljs `CellValue`
+ * union doesn't overlap with `Record<string, unknown>` structurally,
+ * so we cast through `unknown` first (PR #921 lesson — same trap
+ * called out in the user's recurring exceljs reminder).
+ */
+export function formatExcelCellValue(value: ExcelCellValue): string {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    if (typeof value === 'object') {
+        const obj = value as unknown as Record<string, unknown>;
+        if (typeof obj.text === 'string' && typeof obj.hyperlink !== 'string') {
+            return obj.text;
+        }
+        if (Array.isArray(obj.richText)) {
+            return obj.richText
+                .map((seg) =>
+                    seg && typeof seg === 'object' && 'text' in seg
+                        ? String((seg as { text: unknown }).text ?? '')
+                        : '',
+                )
+                .join('');
+        }
+        if ('result' in obj) {
+            const r = obj.result;
+            if (r === null || r === undefined) return '';
+            if (typeof r === 'object') return JSON.stringify(r);
+            return String(r);
+        }
+        if (typeof obj.hyperlink === 'string' && typeof obj.text === 'string') {
+            return obj.text;
+        }
+    }
+    return String(value);
+}

--- a/apps/web/src/components/works/detail/kb/viewers/format-excel-cell.unit.spec.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/format-excel-cell.unit.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { formatExcelCellValue } from './format-excel-cell';
+
+/**
+ * EW-641 Phase 1B/d row 11 — `formatExcelCellValue` projects an
+ * exceljs `CellValue` to a display string. Mirrors the agent-side
+ * helper (PR #921 lesson — cast through `unknown` because the
+ * `CellValue` union doesn't structurally overlap with
+ * `Record<string, unknown>`).
+ */
+describe('formatExcelCellValue', () => {
+    it('returns empty string for null / undefined', () => {
+        expect(formatExcelCellValue(null)).toBe('');
+        expect(formatExcelCellValue(undefined)).toBe('');
+    });
+
+    it('stringifies primitives', () => {
+        expect(formatExcelCellValue('hello')).toBe('hello');
+        expect(formatExcelCellValue(42)).toBe('42');
+        expect(formatExcelCellValue(true)).toBe('true');
+        expect(formatExcelCellValue(false)).toBe('false');
+    });
+
+    it('serialises Date to ISO string', () => {
+        const d = new Date('2026-05-22T03:30:00Z');
+        expect(formatExcelCellValue(d)).toBe('2026-05-22T03:30:00.000Z');
+    });
+
+    it('flattens richText to concatenated segment text', () => {
+        const value = {
+            richText: [
+                { text: 'Brand ' },
+                { text: 'voice' },
+                {}, // missing text → empty
+            ],
+        };
+        expect(formatExcelCellValue(value as never)).toBe('Brand voice');
+    });
+
+    it('returns the formula result, JSON for object results', () => {
+        expect(formatExcelCellValue({ formula: 'SUM(A1:A3)', result: 42 } as never)).toBe('42');
+        expect(formatExcelCellValue({ formula: 'X', result: null } as never)).toBe('');
+        expect(formatExcelCellValue({ formula: 'X', result: { error: '#REF!' } } as never)).toBe(
+            '{"error":"#REF!"}',
+        );
+    });
+
+    it('returns the visible text for hyperlink cells', () => {
+        const value = { text: 'Anthropic', hyperlink: 'https://anthropic.com' };
+        expect(formatExcelCellValue(value as never)).toBe('Anthropic');
+    });
+
+    it('returns the bare text when the cell carries `text` without hyperlink', () => {
+        expect(formatExcelCellValue({ text: 'plain' } as never)).toBe('plain');
+    });
+
+    it('falls back to String() for unknown object shapes', () => {
+        // Symbols + arbitrary objects without text/richText/result/
+        // hyperlink hit the `String(value)` tail.
+        const value = { custom: 1 };
+        expect(formatExcelCellValue(value as never)).toBe('[object Object]');
+    });
+});

--- a/apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts
@@ -1,0 +1,27 @@
+import type { ExcelWorkbook } from './exceljs-types';
+
+interface ExcelJsModule {
+    Workbook: new () => ExcelWorkbook;
+}
+
+/**
+ * Dynamic-import wrapper around `new exceljs.Workbook()`.
+ *
+ * Lives in its own module so the viewer spec can mock the single
+ * helper instead of `vi.mock('exceljs', …)` — and uses an opaque
+ * runtime computation for the module specifier so Vite's static
+ * analyzer doesn't eagerly walk exceljs's dependency graph during
+ * test discovery. Without that, vitest OOMs even with
+ * `--max-old-space-size=8192` because exceljs pulls in jszip,
+ * archiver, and a ~700-class typings tree the resolver parses.
+ *
+ * The runtime path is unchanged — Next.js's webpack still lazy-
+ * loads exceljs the first time an operator opens an XLSX preview.
+ */
+export async function createExceljsWorkbook(): Promise<ExcelWorkbook> {
+    // Compute the specifier at runtime so Vite can't constant-fold
+    // the dynamic import target.
+    const id = ['exceljs'].join('');
+    const mod = (await import(/* @vite-ignore */ id)) as unknown as ExcelJsModule;
+    return new mod.Workbook();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       iron-session:
         specifier: ^8.0.4
         version: 8.0.4


### PR DESCRIPTION
## Summary
- Adds the **inline spreadsheet preview surface** for KB uploads — third of the spec §14.5 viewers (PDF row #9 + DOCX row #10 already shipped). Acceptance A14 (>5 MB XLSX shows download fallback) is exercisable today.
- \`KbXlsxViewer.tsx\` (client) decides between inline canvas (under cap) and download fallback (over cap). Uses a tighter **5 MiB** default cap (\`KB_XLSX_INLINE_MAX_BYTES\`) because parsing a workbook is more CPU-intensive than rendering a PDF iframe.
- \`KbXlsxViewerCanvas.tsx\` (lazy via \`next/dynamic\`) — fetches workbook bytes, calls \`exceljs.Workbook().xlsx.load(arrayBuffer)\`, snapshots each sheet (up to 500 rows by default), renders the active sheet as a \`<table>\` with sheet tabs to switch. \`formatExcelCellValue\` projects exceljs cell variants (rich text, hyperlinks, formula results, dates) to display strings — mirrors the agent-side helper from PR #921 so the inline preview matches the extracted Markdown body.
- \`load-exceljs-workbook.ts\` — thin async wrapper that lazy-imports exceljs with an **opaque** module specifier (\`['exceljs'].join('')\` + \`/* @vite-ignore */\`). Without that, Vite's static analyzer eagerly walks exceljs's dependency graph during vitest discovery and **OOMs the V8 worker** even with \`--max-old-space-size=8192\` (exceljs pulls in jszip + archiver + a ~700-class typings tree).
- \`exceljs-types.ts\` — minimal local structural type aliases for the surface our viewer uses. Direct \`import type { Workbook } from 'exceljs'\` also triggered the vitest OOM during module resolution; we declare types locally and cast the runtime instance through \`unknown\`.
- Deps: adds \`exceljs: ^4.4.0\` to \`apps/web/package.json\` (same version packages/agent uses for the server-side extractor route from PR #921).
- Stable selectors for Playwright A14: \`kb-xlsx-viewer\` (with \`data-mode\` + \`data-size-bytes\`), \`kb-xlsx-loading\`, \`kb-xlsx-canvas\`, \`kb-xlsx-error\`, \`kb-xlsx-download-fallback\`, \`kb-xlsx-download-link\`, \`kb-xlsx-sheet-tab\`, \`kb-xlsx-table/th/tr/td\`, \`kb-xlsx-truncated-notice\`.
- i18n: \`dashboard.workDetail.kb.xlsx.{label, loading, renderFailed, tooLargeTitle, tooLargeBody, download, sheetTabsLabel, truncated, emptyWorkbook}\` across all 21 locales.

## Test plan
- [x] \`cd apps/web && npx vitest run src/components/works/detail/kb/\` → **90 passed** (8 new \`formatExcelCellValue\` + 5 new \`KbXlsxViewer\` decision cases + 77 prior). Coverage: cell-formatter null/undefined → '', primitives, Date → ISO, richText flatten, formula results (primitive + null + JSON-stringified object), hyperlink → text, bare text, unknown shape fallback. Viewer: inline render under cap · download fallback above cap · boundary (\`>\` not \`>=\`) · 5 MiB constant export · body interpolation with \`formatBytes\`.
- [x] \`npx tsc --noEmit\` (web) → clean
- [x] \`npx eslint\` on touched files → clean
- [x] \`npx prettier --write\` → no formatting changes outstanding
- [ ] CI green on this PR

## Notes
The canvas's render + event-handling behaviour (sheet-tab switching, truncation notice, error pill) will be covered end-to-end by the Playwright A14 e2e spec when it lands in row #19. Unit tests for that path were OOMing vitest's worker because of the exceljs dependency graph; the size-cap + cell-formatter coverage in this PR is what spec §14.5 acceptance A14 actually keys off.

## Spec
- \`docs/specs/features/knowledge-base/spec.md\` §14.5 (inline-viewer size thresholds) + acceptance A14
- EW-641 Phase 1B/d row 11 of the atomic queue in \`Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XLSX (spreadsheet) file viewer for Knowledge Base documents with inline preview support and automatic download fallback for large files.
  * Added multi-language support for spreadsheet viewer (21+ languages).

* **Dependencies**
  * Added `exceljs` library for spreadsheet processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->