### PR TITLE
feat(kb): image/video/audio viewers with size caps (EW-641 Phase 1B/d row 12)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2707,6 +2707,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2707,6 +2707,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2707,6 +2707,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2735,6 +2735,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2707,6 +2707,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2734,6 +2734,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2707,6 +2707,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2490,6 +2490,26 @@
                     "sheetTabsLabel": "Worksheet tabs",
                     "truncated": "Showing first {cap} of {total} rows. Download the file to see the rest.",
                     "emptyWorkbook": "Workbook has no worksheets"
+                },
+                "image": {
+                    "label": "Image viewer",
+                    "tooLargeTitle": "Image too large to preview inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download.",
+                    "download": "Download image"
+                },
+                "video": {
+                    "label": "Video viewer",
+                    "tooLargeTitle": "Video too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download video",
+                    "unsupported": "Your browser does not support inline video playback."
+                },
+                "audio": {
+                    "label": "Audio viewer",
+                    "tooLargeTitle": "Audio too large to stream inline",
+                    "tooLargeBody": "This file is {size}, above the {cap} inline limit. Click to download and play locally.",
+                    "download": "Download audio",
+                    "unsupported": "Your browser does not support inline audio playback."
                 }
             }
         },

--- a/apps/web/src/components/works/detail/kb/viewers/KbAudioViewer.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbAudioViewer.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { formatBytes } from './KbPdfViewer';
+import { MediaSizeFallback } from './MediaSizeFallback';
+
+/**
+ * Spec §14.5 — audio renders inline up to 50 MiB. Smaller than video
+ * because the typical KB audio asset (podcast snippet, voice memo)
+ * is a few-MB MP3; anything larger is usually a raw recording the
+ * operator would rather download than stream.
+ */
+export const KB_AUDIO_INLINE_MAX_BYTES = 50 * 1024 * 1024;
+
+interface KbAudioViewerProps {
+    url: string;
+    sizeBytes: number;
+    filename: string;
+    mimeType: string;
+    maxInlineBytes?: number;
+}
+
+/**
+ * EW-641 Phase 1B/d row 12 — inline audio viewer for KB uploads.
+ *
+ * Renders a native `<audio controls>` below the cap, download
+ * fallback above. `preload="metadata"` keeps the initial fetch
+ * minimal — just the header for duration display.
+ *
+ * Selectors locked for Playwright A14: `kb-audio-viewer` (with
+ * `data-mode` + `data-size-bytes`), `kb-audio-element`,
+ * `kb-audio-download-fallback`, `kb-audio-download-link`.
+ */
+export function KbAudioViewer({
+    url,
+    sizeBytes,
+    filename,
+    mimeType,
+    maxInlineBytes = KB_AUDIO_INLINE_MAX_BYTES,
+}: KbAudioViewerProps) {
+    const t = useTranslations('dashboard.workDetail.kb.audio');
+    const overCap = sizeBytes > maxInlineBytes;
+
+    return (
+        <section
+            data-testid="kb-audio-viewer"
+            data-mode={overCap ? 'download' : 'inline'}
+            data-size-bytes={sizeBytes}
+            aria-label={t('label')}
+            className="flex flex-col gap-2"
+        >
+            {overCap ? (
+                <MediaSizeFallback
+                    testIdPrefix="kb-audio"
+                    url={url}
+                    filename={filename}
+                    sizeBytes={sizeBytes}
+                    maxInlineBytes={maxInlineBytes}
+                    title={t('tooLargeTitle')}
+                    body={t('tooLargeBody', {
+                        size: formatBytes(sizeBytes),
+                        cap: formatBytes(maxInlineBytes),
+                    })}
+                    download={t('download')}
+                />
+            ) : (
+                <div
+                    className={cn(
+                        'rounded-md border border-border dark:border-border-dark',
+                        'bg-card dark:bg-card-primary-dark/40 p-3',
+                    )}
+                >
+                    <audio
+                        data-testid="kb-audio-element"
+                        controls
+                        preload="metadata"
+                        className="w-full"
+                    >
+                        <source src={url} type={mimeType} />
+                        {t('unsupported')}
+                    </audio>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/viewers/KbImageViewer.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbImageViewer.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { formatBytes } from './KbPdfViewer';
+import { MediaSizeFallback } from './MediaSizeFallback';
+
+/**
+ * Spec §14.5 — images render inline up to 10 MiB. Tighter than the
+ * PDF/DOCX 30 MiB cap because a 30 MiB image would lock the browser
+ * for a noticeable beat while decoding.
+ */
+export const KB_IMAGE_INLINE_MAX_BYTES = 10 * 1024 * 1024;
+
+interface KbImageViewerProps {
+    url: string;
+    sizeBytes: number;
+    filename: string;
+    /**
+     * Optional explicit alt text. Defaults to the filename so screen
+     * readers always announce something; callers with richer doc
+     * metadata (e.g. the KB doc title) can override.
+     */
+    alt?: string;
+    maxInlineBytes?: number;
+}
+
+/**
+ * EW-641 Phase 1B/d row 12 — inline image viewer for KB uploads.
+ *
+ * Renders a native `<img>` below the cap, download fallback above.
+ * Uses `loading="lazy"` so a tree-pane preview cluster doesn't
+ * fetch every image up-front, and `decoding="async"` so a large
+ * JPEG doesn't block paint.
+ *
+ * Selectors locked for Playwright A14 (one acceptance covers all
+ * §14.5 viewers): `kb-image-viewer` (with `data-mode={"inline"|
+ * "download"}` + `data-size-bytes`), `kb-image-element`,
+ * `kb-image-download-fallback`, `kb-image-download-link`.
+ */
+export function KbImageViewer({
+    url,
+    sizeBytes,
+    filename,
+    alt,
+    maxInlineBytes = KB_IMAGE_INLINE_MAX_BYTES,
+}: KbImageViewerProps) {
+    const t = useTranslations('dashboard.workDetail.kb.image');
+    const overCap = sizeBytes > maxInlineBytes;
+
+    return (
+        <section
+            data-testid="kb-image-viewer"
+            data-mode={overCap ? 'download' : 'inline'}
+            data-size-bytes={sizeBytes}
+            aria-label={t('label')}
+            className="flex flex-col gap-2"
+        >
+            {overCap ? (
+                <MediaSizeFallback
+                    testIdPrefix="kb-image"
+                    url={url}
+                    filename={filename}
+                    sizeBytes={sizeBytes}
+                    maxInlineBytes={maxInlineBytes}
+                    title={t('tooLargeTitle')}
+                    body={t('tooLargeBody', {
+                        size: formatBytes(sizeBytes),
+                        cap: formatBytes(maxInlineBytes),
+                    })}
+                    download={t('download')}
+                />
+            ) : (
+                <div
+                    className={cn(
+                        'rounded-md border border-border dark:border-border-dark',
+                        'bg-card dark:bg-card-primary-dark/40 p-2',
+                    )}
+                >
+                    {/* eslint-disable-next-line @next/next/no-img-element --
+                        next/image would require a remotePatterns allowlist for
+                        every storage backend (S3 / R2 / local / proxy). The KB
+                        proxy URL is short-lived so we render a plain <img>. */}
+                    <img
+                        data-testid="kb-image-element"
+                        src={url}
+                        alt={alt ?? filename}
+                        loading="lazy"
+                        decoding="async"
+                        className="mx-auto h-auto max-h-[36rem] w-auto max-w-full rounded"
+                    />
+                </div>
+            )}
+        </section>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/viewers/KbMediaViewers.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbMediaViewers.unit.spec.tsx
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        asChild,
+        onClick,
+        ...rest
+    }: {
+        children: ReactNode;
+        asChild?: boolean;
+        onClick?: () => void;
+    } & Record<string, unknown>) => {
+        if (asChild) return <>{children}</>;
+        return (
+            <button type="button" onClick={onClick} {...rest}>
+                {children}
+            </button>
+        );
+    },
+}));
+
+import { KbImageViewer, KB_IMAGE_INLINE_MAX_BYTES } from './KbImageViewer';
+import { KbVideoViewer, KB_VIDEO_INLINE_MAX_BYTES } from './KbVideoViewer';
+import { KbAudioViewer, KB_AUDIO_INLINE_MAX_BYTES } from './KbAudioViewer';
+
+/**
+ * EW-641 Phase 1B/d row 12 — image / video / audio viewers all share
+ * the same size-cap pattern as PDF (row 9), DOCX (row 10), and XLSX
+ * (row 11). These tests lock the inline-vs-download decision the
+ * Playwright A14 suite keys off.
+ */
+describe('KbImageViewer', () => {
+    it('renders an inline <img> under the cap', () => {
+        render(
+            <KbImageViewer
+                url="https://files.example/logo.png"
+                sizeBytes={1024 * 1024}
+                filename="logo.png"
+            />,
+        );
+        const root = screen.getByTestId('kb-image-viewer');
+        expect(root.getAttribute('data-mode')).toBe('inline');
+        const img = screen.getByTestId('kb-image-element') as HTMLImageElement;
+        expect(img.src).toBe('https://files.example/logo.png');
+        expect(img.getAttribute('loading')).toBe('lazy');
+        expect(img.getAttribute('decoding')).toBe('async');
+        expect(img.alt).toBe('logo.png');
+        expect(screen.queryByTestId('kb-image-download-fallback')).toBeNull();
+    });
+
+    it('uses the explicit alt prop when supplied', () => {
+        render(
+            <KbImageViewer
+                url="https://files.example/logo.png"
+                sizeBytes={1024}
+                filename="logo.png"
+                alt="Brand logo"
+            />,
+        );
+        expect((screen.getByTestId('kb-image-element') as HTMLImageElement).alt).toBe('Brand logo');
+    });
+
+    it('renders the download fallback above the cap', () => {
+        render(
+            <KbImageViewer
+                url="https://files.example/huge.jpg"
+                sizeBytes={20 * 1024 * 1024}
+                filename="huge.jpg"
+            />,
+        );
+        const root = screen.getByTestId('kb-image-viewer');
+        expect(root.getAttribute('data-mode')).toBe('download');
+        const link = screen.getByTestId('kb-image-download-link') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/huge.jpg');
+        expect(link.getAttribute('download')).toBe('huge.jpg');
+        expect(screen.queryByTestId('kb-image-element')).toBeNull();
+    });
+
+    it('treats exact-cap size as inline (boundary is `>`, not `>=`)', () => {
+        render(
+            <KbImageViewer
+                url="https://files.example/edge.png"
+                sizeBytes={KB_IMAGE_INLINE_MAX_BYTES}
+                filename="edge.png"
+            />,
+        );
+        expect(screen.getByTestId('kb-image-viewer').getAttribute('data-mode')).toBe('inline');
+    });
+
+    it('exposes the 10 MiB default cap', () => {
+        expect(KB_IMAGE_INLINE_MAX_BYTES).toBe(10 * 1024 * 1024);
+    });
+});
+
+describe('KbVideoViewer', () => {
+    it('renders an inline <video> with controls + metadata preload under the cap', () => {
+        render(
+            <KbVideoViewer
+                url="https://files.example/intro.mp4"
+                sizeBytes={1024 * 1024}
+                filename="intro.mp4"
+                mimeType="video/mp4"
+            />,
+        );
+        const root = screen.getByTestId('kb-video-viewer');
+        expect(root.getAttribute('data-mode')).toBe('inline');
+        const video = screen.getByTestId('kb-video-element') as HTMLVideoElement;
+        expect(video.controls).toBe(true);
+        expect(video.preload).toBe('metadata');
+        const source = video.querySelector('source') as HTMLSourceElement;
+        expect(source.src).toBe('https://files.example/intro.mp4');
+        expect(source.type).toBe('video/mp4');
+        expect(screen.queryByTestId('kb-video-download-fallback')).toBeNull();
+    });
+
+    it('renders the download fallback above the 100 MiB cap', () => {
+        render(
+            <KbVideoViewer
+                url="https://files.example/huge.mp4"
+                sizeBytes={200 * 1024 * 1024}
+                filename="huge.mp4"
+                mimeType="video/mp4"
+            />,
+        );
+        const root = screen.getByTestId('kb-video-viewer');
+        expect(root.getAttribute('data-mode')).toBe('download');
+        const link = screen.getByTestId('kb-video-download-link') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/huge.mp4');
+        expect(link.getAttribute('download')).toBe('huge.mp4');
+        expect(screen.queryByTestId('kb-video-element')).toBeNull();
+    });
+
+    it('forwards the poster prop to the <video> element', () => {
+        render(
+            <KbVideoViewer
+                url="https://files.example/intro.mp4"
+                sizeBytes={1024}
+                filename="intro.mp4"
+                mimeType="video/mp4"
+                poster="https://files.example/intro.poster.jpg"
+            />,
+        );
+        const video = screen.getByTestId('kb-video-element') as HTMLVideoElement;
+        expect(video.poster).toBe('https://files.example/intro.poster.jpg');
+    });
+
+    it('exposes the 100 MiB default cap', () => {
+        expect(KB_VIDEO_INLINE_MAX_BYTES).toBe(100 * 1024 * 1024);
+    });
+});
+
+describe('KbAudioViewer', () => {
+    it('renders an inline <audio> with controls + metadata preload under the cap', () => {
+        render(
+            <KbAudioViewer
+                url="https://files.example/voice.mp3"
+                sizeBytes={1024 * 1024}
+                filename="voice.mp3"
+                mimeType="audio/mpeg"
+            />,
+        );
+        const root = screen.getByTestId('kb-audio-viewer');
+        expect(root.getAttribute('data-mode')).toBe('inline');
+        const audio = screen.getByTestId('kb-audio-element') as HTMLAudioElement;
+        expect(audio.controls).toBe(true);
+        expect(audio.preload).toBe('metadata');
+        const source = audio.querySelector('source') as HTMLSourceElement;
+        expect(source.src).toBe('https://files.example/voice.mp3');
+        expect(source.type).toBe('audio/mpeg');
+        expect(screen.queryByTestId('kb-audio-download-fallback')).toBeNull();
+    });
+
+    it('renders the download fallback above the 50 MiB cap', () => {
+        render(
+            <KbAudioViewer
+                url="https://files.example/raw.wav"
+                sizeBytes={100 * 1024 * 1024}
+                filename="raw.wav"
+                mimeType="audio/wav"
+            />,
+        );
+        const root = screen.getByTestId('kb-audio-viewer');
+        expect(root.getAttribute('data-mode')).toBe('download');
+        const link = screen.getByTestId('kb-audio-download-link') as HTMLAnchorElement;
+        expect(link.href).toBe('https://files.example/raw.wav');
+        expect(link.getAttribute('download')).toBe('raw.wav');
+        expect(screen.queryByTestId('kb-audio-element')).toBeNull();
+    });
+
+    it('exposes the 50 MiB default cap', () => {
+        expect(KB_AUDIO_INLINE_MAX_BYTES).toBe(50 * 1024 * 1024);
+    });
+
+    it('boundary check: exact-cap size renders inline', () => {
+        render(
+            <KbAudioViewer
+                url="https://files.example/edge.mp3"
+                sizeBytes={KB_AUDIO_INLINE_MAX_BYTES}
+                filename="edge.mp3"
+                mimeType="audio/mpeg"
+            />,
+        );
+        expect(screen.getByTestId('kb-audio-viewer').getAttribute('data-mode')).toBe('inline');
+    });
+
+    it('interpolates the size + cap into the fallback body', () => {
+        render(
+            <KbAudioViewer
+                url="https://files.example/big.mp3"
+                sizeBytes={2 * 1024 * 1024}
+                filename="big.mp3"
+                mimeType="audio/mpeg"
+                maxInlineBytes={1 * 1024 * 1024}
+            />,
+        );
+        const fallback = screen.getByTestId('kb-audio-download-fallback');
+        expect(fallback.getAttribute('data-size-label')).toBe('2 MB');
+        expect(fallback.getAttribute('data-cap-label')).toBe('1 MB');
+        expect(fallback.textContent).toContain('size=2 MB');
+        expect(fallback.textContent).toContain('cap=1 MB');
+    });
+});

--- a/apps/web/src/components/works/detail/kb/viewers/KbVideoViewer.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/KbVideoViewer.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { formatBytes } from './KbPdfViewer';
+import { MediaSizeFallback } from './MediaSizeFallback';
+
+/**
+ * Spec §14.5 — video renders inline up to 100 MiB. Above that the
+ * browser would stream the whole file as a `<video>` source while
+ * the operator scrubs, blowing through their egress allowance. Show
+ * a download link so they can pull the file once and seek locally.
+ */
+export const KB_VIDEO_INLINE_MAX_BYTES = 100 * 1024 * 1024;
+
+interface KbVideoViewerProps {
+    url: string;
+    sizeBytes: number;
+    filename: string;
+    /** MIME type — used as the `type` attr on `<source>`. */
+    mimeType: string;
+    /** Optional poster image URL. */
+    poster?: string;
+    maxInlineBytes?: number;
+}
+
+/**
+ * EW-641 Phase 1B/d row 12 — inline video viewer for KB uploads.
+ *
+ * Renders a native `<video controls>` below the cap, download
+ * fallback above. `preload="metadata"` keeps the initial fetch
+ * cheap — only the moov atom + first frame, not the whole file.
+ *
+ * Selectors locked for Playwright A14: `kb-video-viewer` (with
+ * `data-mode` + `data-size-bytes`), `kb-video-element`,
+ * `kb-video-download-fallback`, `kb-video-download-link`.
+ */
+export function KbVideoViewer({
+    url,
+    sizeBytes,
+    filename,
+    mimeType,
+    poster,
+    maxInlineBytes = KB_VIDEO_INLINE_MAX_BYTES,
+}: KbVideoViewerProps) {
+    const t = useTranslations('dashboard.workDetail.kb.video');
+    const overCap = sizeBytes > maxInlineBytes;
+
+    return (
+        <section
+            data-testid="kb-video-viewer"
+            data-mode={overCap ? 'download' : 'inline'}
+            data-size-bytes={sizeBytes}
+            aria-label={t('label')}
+            className="flex flex-col gap-2"
+        >
+            {overCap ? (
+                <MediaSizeFallback
+                    testIdPrefix="kb-video"
+                    url={url}
+                    filename={filename}
+                    sizeBytes={sizeBytes}
+                    maxInlineBytes={maxInlineBytes}
+                    title={t('tooLargeTitle')}
+                    body={t('tooLargeBody', {
+                        size: formatBytes(sizeBytes),
+                        cap: formatBytes(maxInlineBytes),
+                    })}
+                    download={t('download')}
+                />
+            ) : (
+                <div
+                    className={cn(
+                        'rounded-md border border-border dark:border-border-dark',
+                        'bg-card dark:bg-card-primary-dark/40 p-2',
+                    )}
+                >
+                    <video
+                        data-testid="kb-video-element"
+                        controls
+                        preload="metadata"
+                        poster={poster}
+                        className="mx-auto h-auto max-h-[36rem] w-full rounded"
+                    >
+                        <source src={url} type={mimeType} />
+                        {t('unsupported')}
+                    </video>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/viewers/MediaSizeFallback.tsx
+++ b/apps/web/src/components/works/detail/kb/viewers/MediaSizeFallback.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { formatBytes } from './KbPdfViewer';
+
+interface MediaSizeFallbackProps {
+    /** Test-id prefix — `kb-image` / `kb-video` / `kb-audio`. */
+    testIdPrefix: string;
+    url: string;
+    filename: string;
+    sizeBytes: number;
+    maxInlineBytes: number;
+    title: string;
+    body: string;
+    download: string;
+}
+
+/**
+ * EW-641 Phase 1B/d row 12 — shared download-fallback card for the
+ * image / video / audio viewers. Mirrors the PDF + DOCX + XLSX
+ * fallback shape so the e2e selectors stay consistent across all
+ * five §14.5 viewers.
+ */
+export function MediaSizeFallback({
+    testIdPrefix,
+    url,
+    filename,
+    sizeBytes,
+    maxInlineBytes,
+    title,
+    body,
+    download,
+}: MediaSizeFallbackProps) {
+    const sizeLabel = formatBytes(sizeBytes);
+    const capLabel = formatBytes(maxInlineBytes);
+    return (
+        <div
+            data-testid={`${testIdPrefix}-download-fallback`}
+            data-size-label={sizeLabel}
+            data-cap-label={capLabel}
+            className={cn(
+                'flex flex-col gap-2 rounded-md border border-dashed p-4 text-center',
+                'border-border bg-card/30 dark:border-border-dark dark:bg-card-primary-dark/20',
+            )}
+        >
+            <p className="text-sm font-medium text-text dark:text-text-dark">{title}</p>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark/70">{body}</p>
+            <div>
+                <Button asChild type="button" size="sm" variant="secondary">
+                    <a
+                        data-testid={`${testIdPrefix}-download-link`}
+                        href={url}
+                        download={filename}
+                        rel="noopener noreferrer"
+                    >
+                        {download} ({sizeLabel})
+                    </a>
+                </Button>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Adds the last three §14.5 inline viewers so KB uploads of media render in-place when small and degrade to a download link when large.

- **KbImageViewer** — native `<img loading="lazy" decoding="async">`, **10 MiB** cap (tighter than PDF/DOCX 30 MiB because a 30 MiB image would lock the browser while decoding).
- **KbVideoViewer** — native `<video controls preload="metadata">`, **100 MiB** cap, optional `poster` prop. `metadata` preload fetches only the moov atom + first frame.
- **KbAudioViewer** — native `<audio controls preload="metadata">`, **50 MiB** cap.
- **MediaSizeFallback** — shared download-fallback card so e2e selectors stay consistent across image/video/audio (mirrors the PDF + DOCX + XLSX fallback shape).

Selectors locked for Playwright A14: `kb-{image|video|audio}-viewer` (with `data-mode` + `data-size-bytes`), `kb-{image|video|audio}-element`, `kb-{image|video|audio}-download-fallback`, `kb-{image|video|audio}-download-link`.

i18n keys added under `dashboard.workDetail.kb.{image,video,audio}.*` across all 21 locale files.

## Test plan

- [x] `pnpm exec vitest run KbMediaViewers.unit.spec.tsx` — 14/14 green
  - under-cap inline rendering (img/video/audio with expected attrs)
  - over-cap download fallback (no native element, link with `download` attr)
  - exact-cap boundary (`>` not `>=`)
  - the 10/100/50 MiB constants
  - poster + alt prop forwarding
  - size/cap label interpolation in fallback body
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 clean
- [ ] CodeRabbit
- [ ] Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline preview and playback support for images, videos, and audio files in the Knowledge Base.
  * Files exceeding size limits display a download fallback option.
  * Added comprehensive internationalization support across 18+ languages for media viewer UI text, including "too large" messaging and browser compatibility notices.

* **Tests**
  * Added unit test coverage for media viewer functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->