### PR TITLE
feat(kb): lock UI + additions-only editor banner (EW-641 Phase 1B/d row 14)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2656,7 +2656,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2656,7 +2656,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2656,7 +2656,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2684,7 +2684,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2656,7 +2656,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2683,7 +2683,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2656,7 +2656,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2439,7 +2439,13 @@
                     "error": "Save failed",
                     "idle": "Idle",
                     "dirty": "Unsaved changes…",
-                    "placeholder": "Start typing to add content…"
+                    "placeholder": "Start typing to add content…",
+                    "additionsOnlyBanner": "Additions-only lock — appending new content is OK, but edits or deletions to existing lines will be rejected by the server."
+                },
+                "lockControls": {
+                    "lock": "Lock",
+                    "unlock": "Unlock",
+                    "modeLabel": "Lock mode"
                 },
                 "upload": {
                     "title": "Upload to Knowledge Base",

--- a/apps/web/src/app/actions/works/kb-lock.ts
+++ b/apps/web/src/app/actions/works/kb-lock.ts
@@ -1,0 +1,62 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { kbAPI } from '@/lib/api/kb';
+import type { ActionResult } from '@/app/actions/plugins';
+import type { KbDocumentDto, KbLockMode } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 1B/d row 14 — lock/unlock server actions invoked by the
+ * client-side `KbLockControls`.
+ *
+ * Both helpers thread the JWT cookie + API base URL through the same
+ * `kbAPI` server-only fetch helpers used by row 5's
+ * `updateKbDocumentAction`. The `ActionResult` envelope lets the client
+ * branch on success without re-throwing the inner error message —
+ * matching the existing pattern.
+ *
+ * Both actions `revalidatePath` the KB index + the nested document
+ * route so the server-rendered tree panel + the editor's full-lock
+ * branch (`<KbDocumentView>` vs `<KbEditor>`) re-render after the API
+ * round-trip lands.
+ */
+export async function lockKbDocumentAction(args: {
+    workId: string;
+    docId: string;
+    path: string;
+    mode: KbLockMode;
+}): Promise<ActionResult<KbDocumentDto>> {
+    const { workId, docId, path, mode } = args;
+    try {
+        const doc = await kbAPI.lockDocument(workId, docId, mode);
+        revalidatePath(`/works/${workId}/kb`);
+        revalidatePath(`/works/${workId}/kb/${path}`);
+        return { success: true, data: doc };
+    } catch (error) {
+        console.error('[kb-lock] failed to lock KB document:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to lock document',
+        };
+    }
+}
+
+export async function unlockKbDocumentAction(args: {
+    workId: string;
+    docId: string;
+    path: string;
+}): Promise<ActionResult<KbDocumentDto>> {
+    const { workId, docId, path } = args;
+    try {
+        const doc = await kbAPI.unlockDocument(workId, docId);
+        revalidatePath(`/works/${workId}/kb`);
+        revalidatePath(`/works/${workId}/kb/${path}`);
+        return { success: true, data: doc };
+    } catch (error) {
+        console.error('[kb-lock] failed to unlock KB document:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to unlock document',
+        };
+    }
+}

--- a/apps/web/src/app/api/works/[id]/kb/documents/[docId]/lock/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/documents/[docId]/lock/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string; docId: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 14 — proxy for the KB document lock endpoint.
+ *
+ * Bouncing through this proxy keeps the JWT cookie + API base URL
+ * handling server-side (matches the existing `kb/tags` and `kb/uploads`
+ * proxies). The upstream NestJS controller validates the body via
+ * `LockKbDocumentDto` (class-validator `@IsIn(KB_LOCK_MODES)`), so we
+ * forward the JSON body verbatim and let the API surface any 4xx.
+ *
+ * `POST /api/works/:id/kb/documents/:docId/lock`
+ *   body  → `{ mode: 'full' | 'additions-only' }`
+ *   200   → updated `KbDocumentDto`
+ */
+export async function POST(request: NextRequest, { params }: RouteContext) {
+    const { id, docId } = await params;
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    headers.set('Content-Type', 'application/json');
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    // Pass the body through verbatim. We deliberately don't parse +
+    // re-stringify — that would lose any trailing whitespace / extra
+    // keys the API validator might want to reject explicitly.
+    const body = await request.text();
+
+    const upstream = await fetch(
+        `${API_URL}/works/${id}/kb/documents/${encodeURIComponent(docId)}/lock`,
+        {
+            method: 'POST',
+            headers,
+            body,
+            cache: 'no-store',
+        },
+    );
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const json = await upstream.json().catch(() => null);
+    return NextResponse.json(json ?? null, { status: 200 });
+}

--- a/apps/web/src/app/api/works/[id]/kb/documents/[docId]/unlock/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/documents/[docId]/unlock/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string; docId: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 14 — proxy for the KB document unlock endpoint.
+ *
+ * `POST /api/works/:id/kb/documents/:docId/unlock`
+ *   no body
+ *   200   → updated `KbDocumentDto`
+ */
+export async function POST(_request: NextRequest, { params }: RouteContext) {
+    const { id, docId } = await params;
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstream = await fetch(
+        `${API_URL}/works/${id}/kb/documents/${encodeURIComponent(docId)}/unlock`,
+        {
+            method: 'POST',
+            headers,
+            cache: 'no-store',
+        },
+    );
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const json = await upstream.json().catch(() => null);
+    return NextResponse.json(json ?? null, { status: 200 });
+}

--- a/apps/web/src/components/works/detail/kb/KbEditor.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.tsx
@@ -240,6 +240,21 @@ export function KbEditor({
                 </span>
             </header>
 
+            {doc.locked && doc.lockMode === 'additions-only' ? (
+                <div
+                    data-testid="kb-editor-lock-banner"
+                    data-mode="additions-only"
+                    role="status"
+                    className={cn(
+                        'rounded-md border px-3 py-2 text-xs',
+                        'border-amber-500/30 bg-amber-500/10',
+                        'text-amber-800 dark:text-amber-200',
+                    )}
+                >
+                    🔒 {t('editor.additionsOnlyBanner')}
+                </div>
+            ) : null}
+
             <EditorSurface
                 editor={editor}
                 readOnly={readOnly}

--- a/apps/web/src/components/works/detail/kb/KbEditor.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.unit.spec.tsx
@@ -145,6 +145,30 @@ describe('KbEditor', () => {
         expect(updateListeners.size).toBe(1);
     });
 
+    it('renders the additions-only banner only when locked && lockMode === additions-only', () => {
+        // Unlocked → no banner.
+        const { unmount } = render(<KbEditor workId="work-1" doc={doc()} />);
+        expect(screen.queryByTestId('kb-editor-lock-banner')).toBeNull();
+        unmount();
+
+        // Locked in `full` mode → also no banner (the route already swaps
+        // KbEditor for KbDocumentView in that case; the guard is belt + braces).
+        const { unmount: u2 } = render(
+            <KbEditor workId="work-1" doc={doc({ locked: true, lockMode: 'full' })} readOnly />,
+        );
+        expect(screen.queryByTestId('kb-editor-lock-banner')).toBeNull();
+        u2();
+
+        // Locked in additions-only → banner appears.
+        render(
+            <KbEditor workId="work-1" doc={doc({ locked: true, lockMode: 'additions-only' })} />,
+        );
+        const banner = screen.getByTestId('kb-editor-lock-banner');
+        expect(banner.getAttribute('data-mode')).toBe('additions-only');
+        expect(banner.getAttribute('role')).toBe('status');
+        expect(banner.textContent).toContain('editor.additionsOnlyBanner');
+    });
+
     it('disables the save button when readOnly is set + skips the update listener', () => {
         render(<KbEditor workId="work-1" doc={doc({ locked: true, lockMode: 'full' })} readOnly />);
         const save = screen.getByTestId('kb-editor-save') as HTMLButtonElement;

--- a/apps/web/src/components/works/detail/kb/KbLockControls.tsx
+++ b/apps/web/src/components/works/detail/kb/KbLockControls.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useCallback, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { lockKbDocumentAction, unlockKbDocumentAction } from '@/app/actions/works/kb-lock';
+import type { KbDocumentBodyDto, KbLockMode } from '@ever-works/contracts';
+
+interface KbLockControlsProps {
+    doc: Pick<KbDocumentBodyDto, 'id' | 'workId' | 'path' | 'locked' | 'lockMode'>;
+}
+
+type LockState = {
+    locked: boolean;
+    lockMode: KbLockMode | null;
+};
+
+/**
+ * EW-641 Phase 1B/d row 14 — lock toggle + mode selector for a KB doc.
+ *
+ * Replaces the read-only lock chip in `KbSidePanel`. Keeps the
+ * `kb-side-panel-lock` test-id stable on the visible badge so Playwright
+ * selectors from row 13 keep working, then adds:
+ *  - `kb-side-panel-lock-toggle` — Lock / Unlock button
+ *  - `kb-side-panel-lock-mode`   — `<select>` (disabled when unlocked or
+ *                                  while a mutation is in-flight)
+ *
+ * Server-side branch already shipped in Phase 1A; this PR adds the
+ * Next.js proxies under
+ * `apps/web/src/app/api/works/[id]/kb/documents/[docId]/lock/route.ts`
+ * + `/unlock/route.ts`, plus matching `kbAPI.lockDocument` /
+ * `unlockDocument` helpers and the two server actions in
+ * `apps/web/src/app/actions/works/kb-lock.ts`.
+ *
+ * Optimistic UX: clicking the toggle / changing the mode immediately
+ * flips the local `state`. On server error we revert and surface the
+ * message via `data-error`. `router.refresh()` after a successful
+ * mutation re-renders the server components (tree panel + editor /
+ * doc-view branch) so the rest of the UI catches up to the new lock
+ * state without a separate refetch.
+ */
+export function KbLockControls({ doc }: KbLockControlsProps) {
+    const t = useTranslations('dashboard.workDetail.kb');
+    const router = useRouter();
+    const [state, setState] = useState<LockState>({
+        locked: doc.locked,
+        lockMode: doc.lockMode,
+    });
+    const [error, setError] = useState<string | null>(null);
+    const [isPending, startTransition] = useTransition();
+
+    const onToggle = useCallback(() => {
+        const previous = state;
+        const nextLocked = !previous.locked;
+        // Default the mode to `full` the first time we lock; subsequent
+        // re-locks (after an unlock → lock cycle) reuse whatever mode
+        // was last chosen.
+        const nextMode: KbLockMode = nextLocked ? (previous.lockMode ?? 'full') : 'full';
+        setError(null);
+        setState({ locked: nextLocked, lockMode: nextLocked ? nextMode : null });
+
+        startTransition(async () => {
+            const result = nextLocked
+                ? await lockKbDocumentAction({
+                      workId: doc.workId ?? '',
+                      docId: doc.id,
+                      path: doc.path,
+                      mode: nextMode,
+                  })
+                : await unlockKbDocumentAction({
+                      workId: doc.workId ?? '',
+                      docId: doc.id,
+                      path: doc.path,
+                  });
+
+            if (!result.success || !result.data) {
+                setState(previous);
+                setError(result.error ?? 'Lock action failed');
+                return;
+            }
+            // API is the source of truth — sync from the returned row
+            // in case a concurrent edit changed mode under us.
+            setState({
+                locked: result.data.locked,
+                lockMode: result.data.lockMode,
+            });
+            router.refresh();
+        });
+    }, [state, doc.workId, doc.id, doc.path, router]);
+
+    const onModeChange = useCallback(
+        (mode: KbLockMode) => {
+            if (!state.locked) return;
+            if (mode === state.lockMode) return;
+            const previous = state;
+            setError(null);
+            setState({ locked: true, lockMode: mode });
+
+            startTransition(async () => {
+                const result = await lockKbDocumentAction({
+                    workId: doc.workId ?? '',
+                    docId: doc.id,
+                    path: doc.path,
+                    mode,
+                });
+                if (!result.success || !result.data) {
+                    setState(previous);
+                    setError(result.error ?? 'Lock action failed');
+                    return;
+                }
+                setState({ locked: result.data.locked, lockMode: result.data.lockMode });
+                router.refresh();
+            });
+        },
+        [state, doc.workId, doc.id, doc.path, router],
+    );
+
+    const lockLabel = state.locked
+        ? `🔒 ${t(`lock.${state.lockMode ?? 'full'}`)}`
+        : t('sidePanel.unlocked');
+
+    return (
+        <div className="flex flex-col gap-2" data-error={error ?? undefined}>
+            <span
+                data-testid="kb-side-panel-lock"
+                data-locked={state.locked ? 'true' : 'false'}
+                data-kb-lock-mode={state.lockMode ?? undefined}
+                data-pending={isPending ? 'true' : undefined}
+                className={cn(
+                    'inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs',
+                    state.locked
+                        ? 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                        : 'bg-card-hover text-text-muted dark:bg-card-primary-dark/40 dark:text-text-muted-dark/70',
+                )}
+            >
+                {lockLabel}
+            </span>
+
+            <div className="flex flex-wrap items-center gap-2">
+                <Button
+                    type="button"
+                    size="sm"
+                    variant={state.locked ? 'ghost' : 'secondary'}
+                    onClick={onToggle}
+                    disabled={isPending}
+                    data-testid="kb-side-panel-lock-toggle"
+                    data-action={state.locked ? 'unlock' : 'lock'}
+                    aria-busy={isPending ? 'true' : undefined}
+                >
+                    {state.locked ? t('lockControls.unlock') : t('lockControls.lock')}
+                </Button>
+
+                <select
+                    data-testid="kb-side-panel-lock-mode"
+                    data-kb-lock-mode={state.lockMode ?? undefined}
+                    value={state.lockMode ?? 'full'}
+                    onChange={(event) => onModeChange(event.target.value as KbLockMode)}
+                    disabled={!state.locked || isPending}
+                    aria-label={t('lockControls.modeLabel')}
+                    className={cn(
+                        'rounded border px-2 py-1 text-xs',
+                        'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark/40',
+                        'text-text-secondary dark:text-text-secondary-dark/80',
+                        'disabled:cursor-not-allowed disabled:opacity-50',
+                    )}
+                >
+                    <option value="full">{t('lock.full')}</option>
+                    <option value="additions-only">{t('lock.additions-only')}</option>
+                </select>
+            </div>
+
+            {error ? (
+                <p
+                    data-testid="kb-side-panel-lock-error"
+                    className="text-xs text-red-600 dark:text-red-400"
+                >
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbLockControls.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbLockControls.unit.spec.tsx
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+const routerRefreshMock = vi.fn();
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ refresh: routerRefreshMock }),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        ...rest
+    }: {
+        children: ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+    } & Record<string, unknown>) => (
+        <button type="button" onClick={onClick} disabled={disabled} {...rest}>
+            {children}
+        </button>
+    ),
+}));
+
+const lockActionMock = vi.fn();
+const unlockActionMock = vi.fn();
+vi.mock('@/app/actions/works/kb-lock', () => ({
+    lockKbDocumentAction: (...args: unknown[]) => lockActionMock(...args),
+    unlockKbDocumentAction: (...args: unknown[]) => unlockActionMock(...args),
+}));
+
+import { KbLockControls } from './KbLockControls';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+function doc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: 'doc-1',
+        workId: 'work-1',
+        organizationId: null,
+        path: 'brand/voice.md',
+        slug: 'voice',
+        title: 'Brand voice',
+        description: null,
+        class: 'brand',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'user',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-05-22T00:00:00Z',
+        updatedAt: '2026-05-22T00:00:00Z',
+        lastCommitSha: null,
+        lastIndexedAt: null,
+        body: '',
+        assets: [],
+        ...overrides,
+    };
+}
+
+/**
+ * EW-641 Phase 1B/d row 14 — `KbLockControls` is a client component
+ * that drives the lock/unlock + mode-picker UI in the side panel.
+ *
+ * The tests pin:
+ *  - the optimistic local state flip on click
+ *  - the server-action call shape (workId, docId, path, mode)
+ *  - the rollback path when the action returns `success: false`
+ *  - the mode picker only being interactive while locked
+ *  - the stable `kb-side-panel-lock` test-id (row 13 e2e still works)
+ */
+describe('KbLockControls', () => {
+    beforeEach(() => {
+        lockActionMock.mockReset();
+        unlockActionMock.mockReset();
+        routerRefreshMock.mockReset();
+    });
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the unlocked badge + Lock button + disabled mode-select when unlocked', () => {
+        render(<KbLockControls doc={doc({ locked: false, lockMode: null })} />);
+        const badge = screen.getByTestId('kb-side-panel-lock');
+        expect(badge.getAttribute('data-locked')).toBe('false');
+        expect(badge.getAttribute('data-kb-lock-mode')).toBeNull();
+        expect(badge.textContent).toBe('sidePanel.unlocked');
+
+        const toggle = screen.getByTestId('kb-side-panel-lock-toggle') as HTMLButtonElement;
+        expect(toggle.getAttribute('data-action')).toBe('lock');
+        expect(toggle.textContent).toBe('lockControls.lock');
+
+        const mode = screen.getByTestId('kb-side-panel-lock-mode') as HTMLSelectElement;
+        expect(mode.disabled).toBe(true);
+    });
+
+    it('renders the locked badge + Unlock button + enabled mode-select when locked', () => {
+        render(<KbLockControls doc={doc({ locked: true, lockMode: 'additions-only' })} />);
+        const badge = screen.getByTestId('kb-side-panel-lock');
+        expect(badge.getAttribute('data-locked')).toBe('true');
+        expect(badge.getAttribute('data-kb-lock-mode')).toBe('additions-only');
+        expect(badge.textContent).toContain('🔒');
+        expect(badge.textContent).toContain('lock.additions-only');
+
+        const toggle = screen.getByTestId('kb-side-panel-lock-toggle') as HTMLButtonElement;
+        expect(toggle.getAttribute('data-action')).toBe('unlock');
+        expect(toggle.textContent).toBe('lockControls.unlock');
+
+        const mode = screen.getByTestId('kb-side-panel-lock-mode') as HTMLSelectElement;
+        expect(mode.disabled).toBe(false);
+        expect(mode.value).toBe('additions-only');
+    });
+
+    it('flips to locked optimistically and calls lockKbDocumentAction with mode=full', async () => {
+        lockActionMock.mockResolvedValueOnce({
+            success: true,
+            data: {
+                id: 'doc-1',
+                workId: 'work-1',
+                path: 'brand/voice.md',
+                locked: true,
+                lockMode: 'full',
+            },
+        });
+        render(<KbLockControls doc={doc({ locked: false })} />);
+        fireEvent.click(screen.getByTestId('kb-side-panel-lock-toggle'));
+
+        // Optimistic flip — even before the action resolves, the badge
+        // already shows the locked state.
+        expect(screen.getByTestId('kb-side-panel-lock').getAttribute('data-locked')).toBe('true');
+        expect(lockActionMock).toHaveBeenCalledWith({
+            workId: 'work-1',
+            docId: 'doc-1',
+            path: 'brand/voice.md',
+            mode: 'full',
+        });
+        await waitFor(() => {
+            expect(routerRefreshMock).toHaveBeenCalled();
+        });
+    });
+
+    it('flips to unlocked and calls unlockKbDocumentAction', async () => {
+        unlockActionMock.mockResolvedValueOnce({
+            success: true,
+            data: {
+                id: 'doc-1',
+                workId: 'work-1',
+                path: 'brand/voice.md',
+                locked: false,
+                lockMode: null,
+            },
+        });
+        render(<KbLockControls doc={doc({ locked: true, lockMode: 'full' })} />);
+        fireEvent.click(screen.getByTestId('kb-side-panel-lock-toggle'));
+
+        expect(screen.getByTestId('kb-side-panel-lock').getAttribute('data-locked')).toBe('false');
+        expect(unlockActionMock).toHaveBeenCalledWith({
+            workId: 'work-1',
+            docId: 'doc-1',
+            path: 'brand/voice.md',
+        });
+        await waitFor(() => {
+            expect(routerRefreshMock).toHaveBeenCalled();
+        });
+    });
+
+    it('reverts the optimistic flip + surfaces the error when the action fails', async () => {
+        lockActionMock.mockResolvedValueOnce({
+            success: false,
+            error: 'concurrent lock attempt',
+        });
+        render(<KbLockControls doc={doc({ locked: false })} />);
+        fireEvent.click(screen.getByTestId('kb-side-panel-lock-toggle'));
+
+        await waitFor(() => {
+            const error = screen.getByTestId('kb-side-panel-lock-error');
+            expect(error.textContent).toBe('concurrent lock attempt');
+        });
+        // Reverted to unlocked.
+        expect(screen.getByTestId('kb-side-panel-lock').getAttribute('data-locked')).toBe('false');
+        expect(routerRefreshMock).not.toHaveBeenCalled();
+    });
+
+    it('switching the mode picker calls lockKbDocumentAction with the new mode', async () => {
+        lockActionMock.mockResolvedValueOnce({
+            success: true,
+            data: {
+                id: 'doc-1',
+                workId: 'work-1',
+                path: 'brand/voice.md',
+                locked: true,
+                lockMode: 'additions-only',
+            },
+        });
+        render(<KbLockControls doc={doc({ locked: true, lockMode: 'full' })} />);
+        const mode = screen.getByTestId('kb-side-panel-lock-mode') as HTMLSelectElement;
+        fireEvent.change(mode, { target: { value: 'additions-only' } });
+
+        expect(lockActionMock).toHaveBeenCalledWith({
+            workId: 'work-1',
+            docId: 'doc-1',
+            path: 'brand/voice.md',
+            mode: 'additions-only',
+        });
+        await waitFor(() => {
+            expect(routerRefreshMock).toHaveBeenCalled();
+        });
+        expect(screen.getByTestId('kb-side-panel-lock').getAttribute('data-kb-lock-mode')).toBe(
+            'additions-only',
+        );
+    });
+
+    it('mode picker ignores changes while unlocked', () => {
+        render(<KbLockControls doc={doc({ locked: false })} />);
+        const mode = screen.getByTestId('kb-side-panel-lock-mode') as HTMLSelectElement;
+        // jsdom still fires the change event even on a disabled select
+        // (React doesn't synthesize a guard); the component-level guard
+        // is the one we want to verify.
+        fireEvent.change(mode, { target: { value: 'additions-only' } });
+        expect(lockActionMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/works/detail/kb/KbSidePanel.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSidePanel.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 import { cn } from '@/lib/utils/cn';
+import { KbLockControls } from './KbLockControls';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
 
 interface KbSidePanelProps {
@@ -90,21 +91,7 @@ export async function KbSidePanel({ doc }: KbSidePanelProps) {
             </Section>
 
             <Section title={t('sidePanel.sections.lock')}>
-                <span
-                    data-testid="kb-side-panel-lock"
-                    data-locked={doc.locked ? 'true' : 'false'}
-                    data-kb-lock-mode={doc.lockMode ?? undefined}
-                    className={cn(
-                        'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs',
-                        doc.locked
-                            ? 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
-                            : 'bg-card-hover dark:bg-card-primary-dark/40 text-text-muted dark:text-text-muted-dark/70',
-                    )}
-                >
-                    {doc.locked
-                        ? `🔒 ${t(`lock.${doc.lockMode ?? 'full'}`)}`
-                        : t('sidePanel.unlocked')}
-                </span>
+                <KbLockControls doc={doc} />
             </Section>
 
             <Section title={t('sidePanel.sections.tags')}>

--- a/apps/web/src/components/works/detail/kb/KbSidePanel.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSidePanel.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 
 vi.mock('next-intl/server', () => ({
     getTranslations: async () => (key: string, args?: Record<string, string | number>) => {
@@ -9,6 +10,37 @@ vi.mock('next-intl/server', () => ({
             .join(' ');
         return `${key} ${interpolated}`;
     },
+}));
+
+// KbLockControls is a client component nested inside the server-rendered
+// side panel — it pulls in next-intl, next/navigation, and the lock
+// server actions. Mock those so the side-panel spec stays focused on the
+// outer structure (the controls have their own spec).
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ refresh: () => undefined }),
+}));
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        ...rest
+    }: {
+        children: ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+    } & Record<string, unknown>) => (
+        <button type="button" onClick={onClick} disabled={disabled} {...rest}>
+            {children}
+        </button>
+    ),
+}));
+vi.mock('@/app/actions/works/kb-lock', () => ({
+    lockKbDocumentAction: vi.fn(),
+    unlockKbDocumentAction: vi.fn(),
 }));
 
 import { KbSidePanel } from './KbSidePanel';

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -4,6 +4,7 @@ import type {
     KbDocumentBodyDto,
     KbDocumentDto,
     KbDocumentListFilter,
+    KbLockMode,
     UpdateKbDocumentInput,
 } from '@ever-works/contracts';
 
@@ -75,6 +76,40 @@ export const kbAPI = {
             endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}`,
             data: input,
             method: 'PATCH',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * `POST /api/works/:id/kb/documents/:docId/lock` — lock the document
+     * in the requested mode. `full` blocks all body mutations; the
+     * `additions-only` mode lets the API enforce diff-merge semantics
+     * (additions OK, deletions/edits rejected). Returns the updated
+     * document so the UI can reflect the new lock state without a
+     * separate fetch.
+     */
+    lockDocument: async (
+        workId: string,
+        docId: string,
+        mode: KbLockMode,
+    ): Promise<KbDocumentDto> => {
+        return serverMutation<KbDocumentDto>({
+            endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/lock`,
+            data: { mode },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * `POST /api/works/:id/kb/documents/:docId/unlock` — clear the
+     * lock. No-op + 200 if the doc is already unlocked.
+     */
+    unlockDocument: async (workId: string, docId: string): Promise<KbDocumentDto> => {
+        return serverMutation<KbDocumentDto>({
+            endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/unlock`,
+            data: {},
+            method: 'POST',
             wrapInData: false,
         });
     },


### PR DESCRIPTION
## Summary

Wires the existing agent-side `lock` / `unlock` endpoints to the per-document side panel.

### Server / proxy

- New Next.js proxies under `apps/web/src/app/api/works/[id]/kb/documents/[docId]/lock/route.ts` + `/unlock/route.ts` (same JWT-cookie-forwarding shape as `kb/tags` + `kb/uploads`).
- `kbAPI.lockDocument(workId, docId, mode)` + `unlockDocument(workId, docId)` server-only helpers added.
- Server actions `lockKbDocumentAction` + `unlockKbDocumentAction` in `app/actions/works/kb-lock.ts` — matches row 5's `updateKbDocumentAction` envelope; revalidates the KB index + the nested document route.

### Client / UI

- New client component `KbLockControls.tsx`: toggle button + `<select>` mode picker. Replaces the read-only lock chip in `KbSidePanel` while keeping the `kb-side-panel-lock` test-id stable.
- Optimistic state with rollback on action error, `router.refresh()` on success so the server-rendered tree panel + editor/view branch re-render with the new lock state.
- `KbEditor` gains an **additions-only** lock banner (`kb-editor-lock-banner`, `data-mode="additions-only"`, `role="status"`). Visible only when `doc.locked && doc.lockMode === 'additions-only'` — full lock already routes to `KbDocumentView` via the existing page guard.

### Selectors locked for Playwright A12-A17

- `kb-side-panel-lock` (preserved from row 13)
- `kb-side-panel-lock-toggle` with `data-action={lock|unlock}` + `aria-busy`
- `kb-side-panel-lock-mode` (disabled when unlocked or pending)
- `kb-side-panel-lock-error`
- `kb-editor-lock-banner` with `data-mode="additions-only"`

## Test plan

- [x] `pnpm exec vitest run KbLockControls.unit.spec.tsx` — **7/7 green**
- [x] Full KB suite — **127/127 green** (including new banner case + updated side-panel mocks)
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "additions-only" lock mode for Knowledge Base documents—allows appending new content while preventing edits and deletions to existing content.
  * Introduced lock/unlock controls and mode selector to the KB editor interface.
  * Added localized UI messages for lock functionality across all supported languages.

* **Tests**
  * Added unit tests for lock control components and editor banner behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->