### PR TITLE
feat(kb): CmdK search palette (EW-641 Phase 1B/d row 15)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2734,6 +2734,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2734,6 +2734,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2734,6 +2734,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2762,6 +2762,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2734,6 +2734,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2761,6 +2761,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2734,6 +2734,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2517,6 +2517,16 @@
                     "download": "Download audio",
                     "unsupported": "Your browser does not support inline audio playback."
                 },
+                "search": {
+                    "triggerLabel": "Search KB…",
+                    "dialogLabel": "Knowledge Base search",
+                    "inputLabel": "Search query",
+                    "placeholder": "Type to search documents…",
+                    "hint": "Type at least {min} characters to search.",
+                    "loading": "Searching…",
+                    "empty": "No documents match \"{query}\".",
+                    "error": "Search failed ({error})."
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
@@ -8,6 +8,7 @@ import { KbShell } from '@/components/works/detail/kb/KbShell';
 import { KbTreePanel } from '@/components/works/detail/kb/KbTreePanel';
 import { KbDocumentView } from '@/components/works/detail/kb/KbDocumentView';
 import { KbEditor } from '@/components/works/detail/kb/KbEditor';
+import { KbSearchPalette } from '@/components/works/detail/kb/KbSearchPalette';
 import { KbSidePanel } from '@/components/works/detail/kb/KbSidePanel';
 import { KbUploadZone } from '@/components/works/detail/kb/KbUploadZone';
 
@@ -94,6 +95,9 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
 
     return (
         <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-end">
+                <KbSearchPalette workId={id} />
+            </div>
             <KbUploadZone workId={id} targetClass={doc.class} />
             <KbShell
                 workId={id}

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
@@ -6,6 +6,7 @@ import { kbAPI } from '@/lib/api/kb';
 import { KbShell } from '@/components/works/detail/kb/KbShell';
 import { KbTreePanel } from '@/components/works/detail/kb/KbTreePanel';
 import { KbUploadZone } from '@/components/works/detail/kb/KbUploadZone';
+import { KbSearchPalette } from '@/components/works/detail/kb/KbSearchPalette';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.workDetail.kb');
@@ -45,6 +46,9 @@ export default async function WorkKnowledgeBasePage({ params }: Params) {
 
     return (
         <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-end">
+                <KbSearchPalette workId={id} />
+            </div>
             <KbUploadZone workId={id} />
             <KbShell workId={id} treeSlot={<KbTreePanel workId={id} documents={docs.items} />} />
         </div>

--- a/apps/web/src/app/api/works/[id]/kb/search/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/search/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 15 — lexical KB search proxy for the CmdK
+ * palette.
+ *
+ * Phase 1A shipped `q` as a filter on `GET /works/:id/kb/documents`
+ * (Postgres FTS across title + description + body — see
+ * `KbDocumentListFilter.q` in `@ever-works/contracts`). Rather than
+ * spinning up a parallel `/search` route on the agent side we proxy
+ * straight to that endpoint here. The row 30 RRF rewrite (Phase 2)
+ * will swap the underlying ranker without changing this contract.
+ *
+ * `GET /api/works/:id/kb/search?q=&limit=`
+ *   200 → `{ items: KbDocumentDto[]; total: number }` (verbatim
+ *         passthrough from the upstream).
+ *
+ * Server-side proxy keeps the JWT cookie + `API_URL` resolution on the
+ * server (matches `kb/tags` and `kb/uploads`). Empty `q` short-circuits
+ * to an empty result so the client doesn't have to special-case it.
+ */
+export async function GET(request: NextRequest, { params }: RouteContext) {
+    const { id } = await params;
+    const q = (request.nextUrl.searchParams.get('q') ?? '').trim();
+    const limitRaw = request.nextUrl.searchParams.get('limit');
+    const limit = limitRaw && /^\d+$/.test(limitRaw) ? Math.min(Number(limitRaw), 50) : 20;
+
+    if (q.length === 0) {
+        return NextResponse.json({ items: [], total: 0 }, { status: 200 });
+    }
+
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstreamParams = new URLSearchParams();
+    upstreamParams.set('q', q);
+    upstreamParams.set('limit', String(limit));
+
+    const upstream = await fetch(
+        `${API_URL}/works/${id}/kb/documents?${upstreamParams.toString()}`,
+        {
+            method: 'GET',
+            headers,
+            cache: 'no-store',
+        },
+    );
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const json = await upstream.json().catch(() => null);
+    return NextResponse.json(json ?? { items: [], total: 0 }, { status: 200 });
+}

--- a/apps/web/src/components/works/detail/kb/KbSearchPalette.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSearchPalette.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { ROUTES } from '@/lib/constants';
+import type { KbDocumentDto } from '@ever-works/contracts';
+
+interface KbSearchPaletteProps {
+    workId: string;
+    /** Override the 250 ms debounce — used by the unit spec. */
+    debounceMs?: number;
+}
+
+interface SearchResponse {
+    items: KbDocumentDto[];
+    total: number;
+}
+
+type FetchState =
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'ready'; items: KbDocumentDto[]; total: number }
+    | { status: 'error'; error: string };
+
+const DEFAULT_DEBOUNCE_MS = 250;
+const MIN_QUERY_LENGTH = 2;
+const MAX_RESULTS = 20;
+
+/**
+ * EW-641 Phase 1B/d row 15 — CmdK-style search palette for the KB.
+ *
+ * Lightweight implementation (no `cmdk` dep) so the bundle stays
+ * lean — the surface is small enough to roll by hand: global keyboard
+ * listener, a centered dialog with a single input, debounced fetch
+ * against `/api/works/:id/kb/search?q=…`, arrow-key navigation, Enter
+ * to open, Esc to close.
+ *
+ * Mounted once per KB page (index + nested). The trigger button is
+ * always visible so mouse-only operators don't need to remember the
+ * shortcut.
+ *
+ * Selectors locked for Playwright A12-A17:
+ *  - `kb-search-trigger` (button shown inline above the shell)
+ *  - `kb-search-palette` (dialog root, `data-open` boolean)
+ *  - `kb-search-input`
+ *  - `kb-search-result` (per result, with `data-doc-id` + `data-doc-path`
+ *    + `data-kb-class` + `data-active` for the keyboard cursor)
+ *  - `kb-search-empty` (rendered when the query is non-trivial but the
+ *    upstream returned zero rows)
+ *  - `kb-search-loading` / `kb-search-error`
+ */
+export function KbSearchPalette({
+    workId,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+}: KbSearchPaletteProps) {
+    const t = useTranslations('dashboard.workDetail.kb.search');
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState('');
+    const [state, setState] = useState<FetchState>({ status: 'idle' });
+    const [activeIndex, setActiveIndex] = useState(0);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+
+    // Global ⌘K / Ctrl+K to open. Single window-level listener; the
+    // dialog itself owns Esc-to-close + Enter-to-open-result.
+    useEffect(() => {
+        function onKey(event: KeyboardEvent) {
+            if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                setOpen((prev) => !prev);
+            }
+        }
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, []);
+
+    // Focus the input when the dialog opens, reset transient state when
+    // it closes.
+    useEffect(() => {
+        if (open) {
+            inputRef.current?.focus();
+        } else {
+            setQuery('');
+            setState({ status: 'idle' });
+            setActiveIndex(0);
+            abortRef.current?.abort();
+            if (debounceRef.current !== null) {
+                clearTimeout(debounceRef.current);
+                debounceRef.current = null;
+            }
+        }
+    }, [open]);
+
+    // Debounced fetch on query change.
+    useEffect(() => {
+        if (!open) return;
+        const trimmed = query.trim();
+        if (trimmed.length < MIN_QUERY_LENGTH) {
+            setState({ status: 'idle' });
+            setActiveIndex(0);
+            return;
+        }
+        if (debounceRef.current !== null) {
+            clearTimeout(debounceRef.current);
+        }
+        debounceRef.current = setTimeout(() => {
+            abortRef.current?.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+            setState({ status: 'loading' });
+            void (async () => {
+                try {
+                    const params = new URLSearchParams({ q: trimmed, limit: String(MAX_RESULTS) });
+                    const response = await fetch(
+                        `/api/works/${encodeURIComponent(workId)}/kb/search?${params.toString()}`,
+                        { signal: controller.signal, cache: 'no-store' },
+                    );
+                    if (!response.ok) {
+                        setState({ status: 'error', error: `HTTP ${response.status}` });
+                        return;
+                    }
+                    const json = (await response.json()) as SearchResponse;
+                    setState({
+                        status: 'ready',
+                        items: json.items ?? [],
+                        total: json.total ?? json.items?.length ?? 0,
+                    });
+                    setActiveIndex(0);
+                } catch (error) {
+                    if ((error as Error).name === 'AbortError') return;
+                    setState({
+                        status: 'error',
+                        error: error instanceof Error ? error.message : 'Search failed',
+                    });
+                }
+            })();
+        }, debounceMs);
+
+        return () => {
+            if (debounceRef.current !== null) {
+                clearTimeout(debounceRef.current);
+                debounceRef.current = null;
+            }
+        };
+    }, [query, open, workId, debounceMs]);
+
+    const navigateToDoc = useCallback(
+        (doc: KbDocumentDto) => {
+            setOpen(false);
+            router.push(`${ROUTES.DASHBOARD_WORK_KB(workId)}/${doc.path}`);
+        },
+        [router, workId],
+    );
+
+    const onInputKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (state.status !== 'ready') {
+                if (event.key === 'Escape') setOpen(false);
+                return;
+            }
+            const items = state.items;
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setActiveIndex((idx) => (items.length === 0 ? 0 : (idx + 1) % items.length));
+            } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setActiveIndex((idx) =>
+                    items.length === 0 ? 0 : (idx - 1 + items.length) % items.length,
+                );
+            } else if (event.key === 'Enter') {
+                event.preventDefault();
+                const doc = items[activeIndex];
+                if (doc) navigateToDoc(doc);
+            } else if (event.key === 'Escape') {
+                event.preventDefault();
+                setOpen(false);
+            }
+        },
+        [state, activeIndex, navigateToDoc],
+    );
+
+    return (
+        <>
+            <button
+                type="button"
+                data-testid="kb-search-trigger"
+                onClick={() => setOpen(true)}
+                className={cn(
+                    'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs',
+                    'border-border bg-card/40 dark:border-border-dark dark:bg-card-primary-dark/30',
+                    'text-text-secondary dark:text-text-secondary-dark/80',
+                    'hover:bg-card-hover dark:hover:bg-card-primary-dark/50',
+                )}
+            >
+                <span aria-hidden="true">🔍</span>
+                <span>{t('triggerLabel')}</span>
+                <kbd className="ml-2 rounded border border-border/60 bg-card/70 px-1 py-0.5 font-mono text-[10px] text-text-muted dark:border-border-dark/60 dark:bg-card-primary-dark/60 dark:text-text-muted-dark/70">
+                    ⌘K
+                </kbd>
+            </button>
+
+            {open ? (
+                <div
+                    data-testid="kb-search-palette"
+                    data-open="true"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label={t('dialogLabel')}
+                    className={cn(
+                        'fixed inset-0 z-50 flex items-start justify-center',
+                        'bg-black/40 px-4 pt-[15vh]',
+                    )}
+                    onClick={(event) => {
+                        if (event.target === event.currentTarget) setOpen(false);
+                    }}
+                >
+                    <div
+                        className={cn(
+                            'w-full max-w-xl rounded-lg border shadow-2xl',
+                            'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                        )}
+                    >
+                        <input
+                            ref={inputRef}
+                            data-testid="kb-search-input"
+                            type="search"
+                            value={query}
+                            placeholder={t('placeholder')}
+                            aria-label={t('inputLabel')}
+                            onChange={(event) => setQuery(event.target.value)}
+                            onKeyDown={onInputKeyDown}
+                            className={cn(
+                                'w-full rounded-t-lg border-b bg-transparent px-4 py-3 text-sm outline-hidden',
+                                'border-border placeholder:text-text-muted dark:border-border-dark',
+                                'text-text dark:text-text-dark dark:placeholder:text-text-muted-dark/60',
+                            )}
+                        />
+                        <div className="max-h-[50vh] overflow-y-auto p-1">
+                            {state.status === 'loading' ? (
+                                <p
+                                    data-testid="kb-search-loading"
+                                    className="px-3 py-4 text-center text-xs text-text-muted dark:text-text-muted-dark/70"
+                                >
+                                    {t('loading')}
+                                </p>
+                            ) : null}
+                            {state.status === 'error' ? (
+                                <p
+                                    data-testid="kb-search-error"
+                                    className="px-3 py-4 text-center text-xs text-red-600 dark:text-red-400"
+                                >
+                                    {t('error', { error: state.error })}
+                                </p>
+                            ) : null}
+                            {state.status === 'idle' && query.trim().length < MIN_QUERY_LENGTH ? (
+                                <p className="px-3 py-4 text-center text-xs text-text-muted dark:text-text-muted-dark/70">
+                                    {t('hint', { min: MIN_QUERY_LENGTH })}
+                                </p>
+                            ) : null}
+                            {state.status === 'ready' && state.items.length === 0 ? (
+                                <p
+                                    data-testid="kb-search-empty"
+                                    className="px-3 py-4 text-center text-xs text-text-muted dark:text-text-muted-dark/70"
+                                >
+                                    {t('empty', { query: query.trim() })}
+                                </p>
+                            ) : null}
+                            {state.status === 'ready' && state.items.length > 0 ? (
+                                <ul role="listbox" aria-label={t('dialogLabel')}>
+                                    {state.items.map((doc, index) => {
+                                        const isActive = index === activeIndex;
+                                        return (
+                                            <li key={doc.id}>
+                                                <button
+                                                    type="button"
+                                                    data-testid="kb-search-result"
+                                                    data-doc-id={doc.id}
+                                                    data-doc-path={doc.path}
+                                                    data-kb-class={doc.class}
+                                                    data-active={isActive ? 'true' : 'false'}
+                                                    role="option"
+                                                    aria-selected={isActive}
+                                                    onMouseEnter={() => setActiveIndex(index)}
+                                                    onClick={() => navigateToDoc(doc)}
+                                                    className={cn(
+                                                        'flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm',
+                                                        isActive
+                                                            ? 'bg-primary/10 text-primary dark:bg-primary/20'
+                                                            : 'text-text-secondary hover:bg-card-hover dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40',
+                                                    )}
+                                                >
+                                                    <span className="grow truncate">
+                                                        {doc.title || doc.path}
+                                                    </span>
+                                                    <span
+                                                        className={cn(
+                                                            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                                                            'bg-primary/10 text-primary dark:bg-primary/20',
+                                                        )}
+                                                    >
+                                                        {doc.class}
+                                                    </span>
+                                                    <span className="shrink-0 font-mono text-[10px] text-text-muted dark:text-text-muted-dark/60">
+                                                        {doc.path}
+                                                    </span>
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            ) : null}
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+        </>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbSearchPalette.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSearchPalette.unit.spec.tsx
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push: pushMock }),
+}));
+
+import { KbSearchPalette } from './KbSearchPalette';
+
+function jsonResponse(items: unknown[], total?: number): Response {
+    return new Response(JSON.stringify({ items, total: total ?? items.length }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+function makeDoc(
+    overrides: Partial<{ id: string; path: string; title: string; class: string }> = {},
+) {
+    return {
+        id: 'doc-1',
+        workId: 'work-1',
+        organizationId: null,
+        path: 'brand/voice.md',
+        slug: 'voice',
+        title: 'Brand voice',
+        description: null,
+        class: 'brand',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'user',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-05-22T00:00:00Z',
+        updatedAt: '2026-05-22T00:00:00Z',
+        lastCommitSha: null,
+        lastIndexedAt: null,
+        ...overrides,
+    };
+}
+
+/**
+ * EW-641 Phase 1B/d row 15 — search palette tests.
+ *
+ * The palette owns three things worth pinning:
+ *  1. ⌘K / Ctrl+K global keyboard listener opens the dialog.
+ *  2. Debounced fetch — successive keystrokes coalesce into a single
+ *     `/api/works/:id/kb/search?q=…` GET.
+ *  3. Selecting a result navigates via `router.push` and closes.
+ *
+ * Plus the empty-state, hint-state, and Escape-to-close affordances.
+ */
+describe('KbSearchPalette', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        pushMock.mockReset();
+        fetchSpy = vi.fn();
+        vi.stubGlobal('fetch', fetchSpy);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it('renders only the trigger button when closed', () => {
+        render(<KbSearchPalette workId="work-1" />);
+        expect(screen.getByTestId('kb-search-trigger')).toBeTruthy();
+        expect(screen.queryByTestId('kb-search-palette')).toBeNull();
+    });
+
+    it('opens the palette on ⌘K and focuses the input', async () => {
+        render(<KbSearchPalette workId="work-1" />);
+        await act(async () => {
+            fireEvent.keyDown(window, { key: 'k', metaKey: true });
+            await Promise.resolve();
+        });
+        const palette = screen.getByTestId('kb-search-palette');
+        expect(palette.getAttribute('data-open')).toBe('true');
+        expect(document.activeElement).toBe(screen.getByTestId('kb-search-input'));
+    });
+
+    it('opens the palette on Ctrl+K as well', () => {
+        render(<KbSearchPalette workId="work-1" />);
+        act(() => {
+            fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+        });
+        expect(screen.getByTestId('kb-search-palette')).toBeTruthy();
+    });
+
+    it('opens via the trigger button click', () => {
+        render(<KbSearchPalette workId="work-1" />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        expect(screen.getByTestId('kb-search-palette')).toBeTruthy();
+    });
+
+    it('shows the min-length hint until the query is long enough', () => {
+        render(<KbSearchPalette workId="work-1" />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        const input = screen.getByTestId('kb-search-input') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'a' } });
+        expect(screen.queryByTestId('kb-search-loading')).toBeNull();
+        // The hint key is rendered (mock returns the key + interpolation).
+        expect(screen.getByText(/hint min=2/)).toBeTruthy();
+    });
+
+    it('fires a debounced fetch and renders the result rows', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            jsonResponse([
+                makeDoc({ id: 'a', title: 'Brand voice', path: 'brand/voice.md', class: 'brand' }),
+                makeDoc({
+                    id: 'b',
+                    title: 'Legal notice',
+                    path: 'legal/notice.md',
+                    class: 'legal',
+                }),
+            ]),
+        );
+        render(<KbSearchPalette workId="work-1" debounceMs={100} />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        const input = screen.getByTestId('kb-search-input') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'br' } });
+        fireEvent.change(input, { target: { value: 'bra' } });
+        fireEvent.change(input, { target: { value: 'brand' } });
+
+        // Before the debounce window elapses, no fetch should have fired.
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        // Advance past the debounce + flush microtasks so the
+        // `setState` after the awaited json() commits inside `act`.
+        await act(async () => {
+            vi.advanceTimersByTime(150);
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toContain('/api/works/work-1/kb/search?q=brand');
+
+        const rows = screen.getAllByTestId('kb-search-result');
+        expect(rows.length).toBe(2);
+        expect(rows[0].getAttribute('data-doc-id')).toBe('a');
+        expect(rows[0].getAttribute('data-doc-path')).toBe('brand/voice.md');
+        expect(rows[0].getAttribute('data-kb-class')).toBe('brand');
+        expect(rows[0].getAttribute('data-active')).toBe('true');
+        expect(rows[1].getAttribute('data-active')).toBe('false');
+    });
+
+    it('renders the empty state when the upstream returns zero results', async () => {
+        fetchSpy.mockResolvedValueOnce(jsonResponse([]));
+        render(<KbSearchPalette workId="work-1" debounceMs={50} />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        fireEvent.change(screen.getByTestId('kb-search-input'), { target: { value: 'zzz' } });
+        await act(async () => {
+            vi.advanceTimersByTime(100);
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        expect(screen.getByTestId('kb-search-empty')).toBeTruthy();
+        expect(screen.queryByTestId('kb-search-result')).toBeNull();
+    });
+
+    it('navigates to the doc on row click and closes the palette', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            jsonResponse([
+                makeDoc({ id: 'a', title: 'Brand voice', path: 'brand/voice.md', class: 'brand' }),
+            ]),
+        );
+        render(<KbSearchPalette workId="work-1" debounceMs={50} />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        fireEvent.change(screen.getByTestId('kb-search-input'), { target: { value: 'br' } });
+        await act(async () => {
+            vi.advanceTimersByTime(100);
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        fireEvent.click(screen.getByTestId('kb-search-result'));
+        expect(pushMock).toHaveBeenCalledWith('/works/work-1/kb/brand/voice.md');
+        expect(screen.queryByTestId('kb-search-palette')).toBeNull();
+    });
+
+    it('navigates via Enter on the focused result', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            jsonResponse([
+                makeDoc({ id: 'a', title: 'Brand voice', path: 'brand/voice.md', class: 'brand' }),
+                makeDoc({ id: 'b', title: 'Legal', path: 'legal/notice.md', class: 'legal' }),
+            ]),
+        );
+        render(<KbSearchPalette workId="work-1" debounceMs={50} />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        const input = screen.getByTestId('kb-search-input') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'br' } });
+        await act(async () => {
+            vi.advanceTimersByTime(100);
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        fireEvent.keyDown(input, { key: 'Enter' });
+        expect(pushMock).toHaveBeenCalledWith('/works/work-1/kb/legal/notice.md');
+    });
+
+    it('closes on Escape', () => {
+        render(<KbSearchPalette workId="work-1" />);
+        fireEvent.click(screen.getByTestId('kb-search-trigger'));
+        const input = screen.getByTestId('kb-search-input') as HTMLInputElement;
+        fireEvent.keyDown(input, { key: 'Escape' });
+        expect(screen.queryByTestId('kb-search-palette')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Lightweight CmdK-style search palette so operators can jump to any KB document by title/body text without scrolling the tree.

### Server / proxy

- New Next.js proxy `apps/web/.../kb/search/route.ts`: `GET /api/works/:id/kb/search?q=&limit=` translates to the existing agent `GET /works/:id/kb/documents?q=` (Phase 1A shipped `q` as a filter on the list route — the row 30 RRF rewrite will swap the ranker without changing this contract).
- Empty `q` short-circuits to `{ items: [], total: 0 }`; `limit` clamped to 50.
- No new agent-side endpoint needed.

### Client / UI

- `KbSearchPalette.tsx` — **no `cmdk` dep**, ~250 LOC hand-rolled:
  - Global ⌘K / Ctrl+K listener
  - Centered modal overlay, click-outside + Esc to close
  - Debounced fetch (250 ms) via `AbortController` so successive keystrokes coalesce
  - Arrow-key navigation, Enter to navigate, mouse-hover to highlight
  - Trigger button always visible inline above the shell
- Mounted on both KB pages — index + nested.

### Selectors locked for Playwright A12-A17

- `kb-search-trigger`
- `kb-search-palette` (`data-open=true`)
- `kb-search-input`
- `kb-search-result` (per row, with `data-doc-id`, `data-doc-path`, `data-kb-class`, `data-active`)
- `kb-search-empty` / `kb-search-loading` / `kb-search-error`

## Test plan

- [x] `pnpm exec vitest run KbSearchPalette.unit.spec.tsx` — **10/10 green**
- [x] Full KB suite — **137/137 green**
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Knowledge Base search functionality with keyboard shortcut support (⌘K/Ctrl+K), allowing users to quickly search and navigate KB documents with debounced search results and keyboard navigation
* Extended search UI support across all supported languages (21 locales)

## Tests
* Added comprehensive unit tests covering search behavior, keyboard navigation, and user interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->