### PR TITLE
feat(kb): wikilink rewriter for the doc viewer (EW-641 Phase 1B/d row 16a)

### DIFF
--- a/apps/web/src/components/works/detail/kb/KbDocumentView.tsx
+++ b/apps/web/src/components/works/detail/kb/KbDocumentView.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import { cn } from '@/lib/utils/cn';
 import { MarkdownPreview } from '@/components/works/detail/items/MarkdownPreview';
+import { rewriteWikilinks } from './wikilink-md';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
 
 interface KbDocumentViewProps {
@@ -98,7 +99,9 @@ export async function KbDocumentView({ doc }: KbDocumentViewProps) {
                 )}
             >
                 {doc.body && doc.body.trim().length > 0 ? (
-                    <MarkdownPreview content={doc.body} />
+                    <MarkdownPreview
+                        content={doc.workId ? rewriteWikilinks(doc.body, doc.workId) : doc.body}
+                    />
                 ) : (
                     <p className="text-sm italic text-text-muted dark:text-text-muted-dark/60">
                         {t('document.emptyBody')}

--- a/apps/web/src/components/works/detail/kb/KbDocumentView.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbDocumentView.unit.spec.tsx
@@ -117,4 +117,34 @@ describe('KbDocumentView', () => {
         render(await KbDocumentView({ doc: doc({ description: 'How we talk to customers' }) }));
         expect(screen.getByText('How we talk to customers')).toBeTruthy();
     });
+
+    it('rewrites [[Title|path]] wikilinks to /works/:id/kb/:path markdown links', async () => {
+        render(
+            await KbDocumentView({
+                doc: doc({
+                    workId: 'work-1',
+                    body: 'See [[Brand voice|brand/voice.md]] for tone.',
+                }),
+            }),
+        );
+        // The MarkdownPreview mock surfaces its `content` prop as
+        // textContent, so the rewrite is visible there.
+        expect(screen.getByTestId('markdown-preview-mock').textContent).toBe(
+            'See [Brand voice](/works/work-1/kb/brand/voice.md) for tone.',
+        );
+    });
+
+    it('leaves the body untouched when doc.workId is null (org-level docs)', async () => {
+        render(
+            await KbDocumentView({
+                doc: doc({
+                    workId: null,
+                    body: '[[brand/voice.md]] stays raw',
+                }),
+            }),
+        );
+        expect(screen.getByTestId('markdown-preview-mock').textContent).toBe(
+            '[[brand/voice.md]] stays raw',
+        );
+    });
 });

--- a/apps/web/src/components/works/detail/kb/wikilink-md.ts
+++ b/apps/web/src/components/works/detail/kb/wikilink-md.ts
@@ -1,0 +1,110 @@
+/**
+ * EW-641 Phase 1B/d row 16 — wikilink ↔ markdown preprocessor.
+ *
+ * The KB editor (row 6) writes wikilinks in Obsidian-style syntax:
+ *   `[[Brand voice|brand/voice.md]]`
+ *   `[[brand/voice.md]]` (path-only — label defaults to the basename)
+ *
+ * To keep the renderer simple (and to avoid pulling in a remark plugin
+ * with its own sanitiser surface area), we lift the wikilink syntax up
+ * to vanilla CommonMark before `react-markdown` runs:
+ *   `[Brand voice](/works/<workId>/kb/brand/voice.md)`
+ *
+ * Constraints:
+ *  - Inside ``` code fences or `inline code` we leave wikilinks alone
+ *    (they're sample syntax, not real links).
+ *  - The target is path-only (no schemes, no leading slash, no `..`
+ *    segments) — a path containing `://` or starting with `/` is left
+ *    untouched so we never accidentally synthesise an unsafe href.
+ *  - Empty target → no replacement.
+ *  - Pipe present but label empty → fall back to the path basename.
+ *
+ * Stable selectors live on the rendered `<a>` indirectly via the
+ * markdown anchor — Playwright A12-A17 keys off the visible link text
+ * + href shape rather than a `data-*` attr, matching how Markdown
+ * links elsewhere in the dashboard are tested.
+ */
+
+const WIKILINK_RE = /\[\[([^\]\n|]+?)(?:\|([^\]\n]+?))?\]\]/g;
+const FENCE_RE = /```[\s\S]*?```/g;
+const INLINE_CODE_RE = /`[^`\n]*`/g;
+
+/**
+ * Returns `true` if the given path is safe to use as a relative KB
+ * route segment. Rejects:
+ *  - empty / whitespace
+ *  - URL schemes (`http://`, `javascript:`, etc.)
+ *  - absolute paths (`/foo`)
+ *  - `..` traversal segments
+ *  - paths containing whitespace (Markdown link targets break otherwise)
+ */
+// Allowed path chars are deliberately conservative: alphanumerics plus
+// the few punctuation marks needed for slug-style paths (`_`, `-`, `.`,
+// `/`). This rejects URL schemes (`javascript:`, `data:`), query
+// strings (`?`), fragments (`#`), and any whitespace — anything that
+// could synthesise an unsafe href below.
+const SAFE_PATH_RE = /^[a-zA-Z0-9_\-./]+$/;
+
+function isSafePath(target: string): boolean {
+    const t = target.trim();
+    if (t.length === 0) return false;
+    if (!SAFE_PATH_RE.test(t)) return false;
+    if (t.startsWith('/')) return false;
+    const segments = t.split('/');
+    return !segments.some((seg) => seg === '..' || seg === '.');
+}
+
+function basename(path: string): string {
+    const last = path.split('/').pop() ?? path;
+    return last.replace(/\.md$/i, '');
+}
+
+/**
+ * Rewrites `[[Label|path]]` and `[[path]]` wikilinks in `source` to
+ * standard Markdown links pointing at `/works/<workId>/kb/<path>`.
+ * Code fences and inline-code spans are preserved verbatim.
+ */
+export function rewriteWikilinks(source: string, workId: string): string {
+    if (source.length === 0) return source;
+
+    // Mask code fences + inline code so the wikilink RE can't touch
+    // them. We track byte offsets so we can splice them back after.
+    type Mask = { start: number; end: number; text: string };
+    const masks: Mask[] = [];
+
+    function collect(re: RegExp) {
+        re.lastIndex = 0;
+        let match;
+        while ((match = re.exec(source)) !== null) {
+            masks.push({
+                start: match.index,
+                end: match.index + match[0].length,
+                text: match[0],
+            });
+        }
+    }
+    collect(FENCE_RE);
+    collect(INLINE_CODE_RE);
+    masks.sort((a, b) => a.start - b.start);
+
+    function isMasked(idx: number): boolean {
+        for (const m of masks) {
+            if (idx >= m.start && idx < m.end) return true;
+            if (m.start > idx) return false;
+        }
+        return false;
+    }
+
+    return source.replace(WIKILINK_RE, (full, rawLabelOrPath, rawPath, offset) => {
+        if (isMasked(offset)) return full;
+        // `[[path]]` form vs `[[label|path]]` form.
+        const path = (rawPath ?? rawLabelOrPath).trim();
+        if (!isSafePath(path)) return full;
+        const label =
+            rawPath !== undefined && rawPath !== null
+                ? rawLabelOrPath.trim() || basename(path)
+                : basename(path);
+        const href = `/works/${encodeURIComponent(workId)}/kb/${path}`;
+        return `[${label}](${href})`;
+    });
+}

--- a/apps/web/src/components/works/detail/kb/wikilink-md.unit.spec.ts
+++ b/apps/web/src/components/works/detail/kb/wikilink-md.unit.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { rewriteWikilinks } from './wikilink-md';
+
+describe('rewriteWikilinks', () => {
+    const work = 'work-1';
+
+    it('rewrites a label|path wikilink to a markdown link', () => {
+        expect(rewriteWikilinks('See [[Brand voice|brand/voice.md]] for tone.', work)).toBe(
+            'See [Brand voice](/works/work-1/kb/brand/voice.md) for tone.',
+        );
+    });
+
+    it('rewrites a path-only wikilink and uses the basename without .md as label', () => {
+        expect(rewriteWikilinks('See [[brand/voice.md]] for tone.', work)).toBe(
+            'See [voice](/works/work-1/kb/brand/voice.md) for tone.',
+        );
+    });
+
+    it('falls back to basename when label is empty', () => {
+        expect(rewriteWikilinks('[[ |legal/notice.md]]', work)).toBe(
+            '[notice](/works/work-1/kb/legal/notice.md)',
+        );
+    });
+
+    it('rewrites multiple wikilinks in one paragraph', () => {
+        const out = rewriteWikilinks('First [[a.md]] and second [[b/c.md]].', work);
+        expect(out).toBe(
+            'First [a](/works/work-1/kb/a.md) and second [c](/works/work-1/kb/b/c.md).',
+        );
+    });
+
+    it('leaves wikilinks inside fenced code blocks alone', () => {
+        const source = 'Before [[a.md]]\n\n```\n[[b.md]]\n```\n\nAfter [[c.md]]';
+        const out = rewriteWikilinks(source, work);
+        expect(out).toContain('Before [a](/works/work-1/kb/a.md)');
+        expect(out).toContain('```\n[[b.md]]\n```');
+        expect(out).toContain('After [c](/works/work-1/kb/c.md)');
+    });
+
+    it('leaves wikilinks inside inline code spans alone', () => {
+        expect(rewriteWikilinks('Use `[[brand/voice.md]]` for tone', work)).toBe(
+            'Use `[[brand/voice.md]]` for tone',
+        );
+    });
+
+    it('rejects URL-scheme targets (defence-in-depth against XSS via wikilink)', () => {
+        expect(rewriteWikilinks('[[evil|javascript:alert(1)]]', work)).toBe(
+            '[[evil|javascript:alert(1)]]',
+        );
+        expect(rewriteWikilinks('[[mal|https://evil.example/x]]', work)).toBe(
+            '[[mal|https://evil.example/x]]',
+        );
+    });
+
+    it('rejects absolute paths + `..` traversal', () => {
+        expect(rewriteWikilinks('[[abs|/etc/passwd]]', work)).toBe('[[abs|/etc/passwd]]');
+        expect(rewriteWikilinks('[[trav|../secrets.md]]', work)).toBe('[[trav|../secrets.md]]');
+        expect(rewriteWikilinks('[[trav|brand/../legal.md]]', work)).toBe(
+            '[[trav|brand/../legal.md]]',
+        );
+    });
+
+    it('rejects targets containing whitespace', () => {
+        expect(rewriteWikilinks('[[bad|path with space.md]]', work)).toBe(
+            '[[bad|path with space.md]]',
+        );
+    });
+
+    it('returns the source unchanged when no wikilinks are present', () => {
+        expect(rewriteWikilinks('Plain text with [a normal](link.md).', work)).toBe(
+            'Plain text with [a normal](link.md).',
+        );
+    });
+
+    it('handles the empty source string', () => {
+        expect(rewriteWikilinks('', work)).toBe('');
+    });
+
+    it('URL-encodes the workId segment so a forced slash in workId cannot escape the route', () => {
+        expect(rewriteWikilinks('[[a.md]]', 'work/with/slashes')).toBe(
+            '[a](/works/work%2Fwith%2Fslashes/kb/a.md)',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Row 16a (rendering side) — lifts Obsidian-style wikilinks to vanilla CommonMark before `MarkdownPreview` runs, so the read-only KB viewer can resolve `[[Title|brand/voice.md]]` to a real anchor without dragging in a remark plugin.

Row 16b (editor side: Tiptap `[[` suggestion popover) is carved as the next NEXT chunk in the handoff.

### Behaviour

| Source | Rendered |
|---|---|
| `[[Brand voice\|brand/voice.md]]` | `[Brand voice](/works/<id>/kb/brand/voice.md)` |
| `[[brand/voice.md]]` | `[voice](/works/<id>/kb/brand/voice.md)` (basename label) |
| `[[ \|legal/notice.md]]` | `[notice](/works/<id>/kb/legal/notice.md)` (empty label → basename) |
| Inside ` ``` ` / `` ` `` | unchanged (sample syntax) |
| `[[evil\|javascript:alert(1)]]` | unchanged (allowlist + segment checks) |
| `[[abs\|/etc/passwd]]`, `[[trav\|../x.md]]` | unchanged |

### Defence-in-depth

`isSafePath` allowlists `[a-zA-Z0-9_\-./]+` + rejects:
- URL schemes (`javascript:`, `data:`, `http://`)
- Absolute paths (`/…`)
- `..` traversal segments
- Whitespace in targets

`workId` is `encodeURIComponent`-wrapped before being interpolated into the href.

### Wiring

`KbDocumentView` runs `rewriteWikilinks(doc.body, doc.workId)` before handing to `MarkdownPreview`. Org-level docs (`doc.workId === null`) skip the rewrite — the org-namespace router lands later.

## Test plan

- [x] `pnpm exec vitest run wikilink-md.unit.spec.ts` — **12/12 green** (rewriter)
- [x] `pnpm exec vitest run KbDocumentView.unit.spec.tsx` — 2 new cases (with-workId + null-workId)
- [x] Full KB suite — **151/151 green**
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wikilinks in work-specific knowledge base documents are now converted to standard Markdown links. Organization-level documents remain unaffected. Unsafe paths are blocked to ensure document safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->