### PR TITLE
feat(kb): wikilink editor popover (EW-641 Phase 1B/d row 16b)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2744,6 +2744,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2744,6 +2744,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2744,6 +2744,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2772,6 +2772,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2744,6 +2744,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2771,6 +2771,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2744,6 +2744,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2527,6 +2527,11 @@
                     "empty": "No documents match \"{query}\".",
                     "error": "Search failed ({error})."
                 },
+                "wikilink": {
+                    "hint": "Type to search for a KB document…",
+                    "empty": "No documents match \"{query}\".",
+                    "listLabel": "Wikilink suggestions"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
         "@tiptap/pm": "^2.10.4",
         "@tiptap/react": "^2.10.4",
         "@tiptap/starter-kit": "^2.10.4",
+        "@tiptap/suggestion": "^2.10.4",
         "ai": "^6.0.154",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",

--- a/apps/web/src/components/works/detail/kb/KbEditor.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.tsx
@@ -1,14 +1,24 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
-import { useEditor, EditorContent, type Editor } from '@tiptap/react';
+import { useEditor, EditorContent, ReactRenderer, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import { Markdown } from 'tiptap-markdown';
 import { cn } from '@/lib/utils/cn';
 import { Button } from '@/components/ui/button';
 import { updateKbDocumentAction } from '@/app/actions/works/kb-document';
+import {
+    WikiLinkExtension,
+    type WikiLinkRenderProps,
+    type WikiLinkRenderer,
+    type WikiLinkSuggestionItem,
+} from './extensions/WikiLinkExtension';
+import {
+    WikiLinkSuggestionList,
+    type WikiLinkSuggestionListHandle,
+} from './WikiLinkSuggestionList';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
 
 interface KbEditorProps {
@@ -69,6 +79,14 @@ export function KbEditor({
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const savingRef = useRef(false);
 
+    const wikilinkRenderFactory = useMemo(
+        () => createWikiLinkRenderFactory(),
+        // The factory itself is workId-agnostic — `WikiLinkExtension`
+        // closes over `workId` via its own options. Only one factory
+        // per editor lifecycle.
+        [],
+    );
+
     const editor = useEditor({
         immediatelyRender: false,
         editable: !readOnly,
@@ -86,6 +104,10 @@ export function KbEditor({
                 html: false, // raw HTML in markdown body would break the round-trip
                 breaks: true,
                 transformPastedText: true,
+            }),
+            WikiLinkExtension.configure({
+                workId,
+                render: wikilinkRenderFactory,
             }),
         ],
         content: doc.body ?? '',
@@ -399,4 +421,87 @@ function SaveStatusPill({ status, error, labels }: SaveStatusPillProps) {
                       : labels.idle}
         </span>
     );
+}
+
+/**
+ * Build a renderer factory for `WikiLinkExtension`. The factory owns a
+ * single `ReactRenderer` instance + floating popover `<div>` over the
+ * lifetime of the editor — `onStart` creates them, `onUpdate` reuses,
+ * `onExit` tears down. Positioning is `position: fixed` keyed off the
+ * `clientRect()` callback the suggestion plugin gives us (no `tippy`
+ * dep — the popover is intentionally small).
+ *
+ * `findSuggestionMatch` in the extension only fires when the cursor is
+ * inside a `[[…` chunk, so we don't need our own outside-click logic
+ * (the plugin emits `onExit` once the match falls out of scope).
+ */
+function createWikiLinkRenderFactory(): () => WikiLinkRenderer {
+    return () => {
+        let renderer: ReactRenderer<WikiLinkSuggestionListHandle> | null = null;
+        let popoverEl: HTMLDivElement | null = null;
+
+        function positionFrom(clientRect: (() => DOMRect | null) | null) {
+            if (!popoverEl) return;
+            const rect = clientRect?.();
+            if (!rect) {
+                popoverEl.style.visibility = 'hidden';
+                return;
+            }
+            popoverEl.style.visibility = 'visible';
+            popoverEl.style.top = `${rect.bottom + 4}px`;
+            popoverEl.style.left = `${rect.left}px`;
+        }
+
+        function mount(props: WikiLinkRenderProps) {
+            popoverEl = document.createElement('div');
+            popoverEl.setAttribute('data-testid', 'kb-wikilink-popover');
+            popoverEl.style.position = 'fixed';
+            popoverEl.style.zIndex = '60';
+            document.body.appendChild(popoverEl);
+            renderer = new ReactRenderer(WikiLinkSuggestionList, {
+                editor: undefined as unknown as Editor, // satisfies the type; the list doesn't read it
+                props: {
+                    items: props.items,
+                    query: props.query,
+                    onSelect: (item: WikiLinkSuggestionItem) => props.command(item),
+                } as Record<string, unknown>,
+            });
+            // `ReactRenderer.element` is an HTMLElement the renderer
+            // mounted into. We move it under our positioned popoverEl.
+            const element = renderer.element as unknown as HTMLElement | null;
+            if (element) {
+                popoverEl.appendChild(element);
+            }
+            positionFrom(props.clientRect);
+        }
+
+        return {
+            onStart: (props) => {
+                mount(props);
+            },
+            onUpdate: (props) => {
+                if (!renderer) return;
+                renderer.updateProps({
+                    items: props.items,
+                    query: props.query,
+                    onSelect: (item: WikiLinkSuggestionItem) => props.command(item),
+                });
+                positionFrom(props.clientRect);
+            },
+            onKeyDown: ({ event }) => {
+                if (event.key === 'Escape') {
+                    // Let the upstream `onExit` fire by returning true;
+                    // the suggestion plugin sees Escape and tears down.
+                    return false;
+                }
+                return renderer?.ref?.onKeyDown(event) ?? false;
+            },
+            onExit: () => {
+                renderer?.destroy();
+                renderer = null;
+                popoverEl?.remove();
+                popoverEl = null;
+            },
+        };
+    };
 }

--- a/apps/web/src/components/works/detail/kb/KbEditor.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.unit.spec.tsx
@@ -37,12 +37,34 @@ vi.mock('@tiptap/react', () => ({
     EditorContent: ({ editor: _editor }: { editor: unknown }) => (
         <div data-testid="kb-editor-body" contentEditable />
     ),
+    // WikiLinkExtension (row 16b) imports `Extension` from
+    // `@tiptap/react` (which re-exports `@tiptap/core`). Provide a
+    // minimal shape so the spec doesn't drag in the real Tiptap
+    // create-time helpers.
+    Extension: { create: () => ({ configure: () => ({}) }) },
+    ReactRenderer: class {
+        element = null;
+        ref = null;
+        updateProps() {}
+        destroy() {}
+    },
 }));
 vi.mock('@tiptap/starter-kit', () => ({
     default: { configure: () => ({}) },
 }));
 vi.mock('@tiptap/extension-link', () => ({
     default: { configure: () => ({}) },
+}));
+vi.mock('@tiptap/suggestion', () => ({
+    default: () => ({}),
+}));
+vi.mock('@tiptap/pm/state', () => ({
+    PluginKey: class {
+        constructor(name?: string) {
+            this.name = name;
+        }
+        name?: string;
+    },
 }));
 vi.mock('tiptap-markdown', () => ({
     Markdown: { configure: () => ({}) },

--- a/apps/web/src/components/works/detail/kb/WikiLinkSuggestionList.tsx
+++ b/apps/web/src/components/works/detail/kb/WikiLinkSuggestionList.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useImperativeHandle, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { WikiLinkSuggestionItem } from './extensions/WikiLinkExtension';
+
+export interface WikiLinkSuggestionListHandle {
+    /**
+     * Called by the Tiptap renderer wrapper when ProseMirror proxies a
+     * keydown event. Returning `true` tells the upstream we handled it.
+     */
+    onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+interface WikiLinkSuggestionListProps {
+    items: WikiLinkSuggestionItem[];
+    query: string;
+    onSelect: (item: WikiLinkSuggestionItem) => void;
+    ref?: React.Ref<WikiLinkSuggestionListHandle>;
+}
+
+/**
+ * EW-641 Phase 1B/d row 16b — popover content for the wikilink trigger.
+ *
+ * Rendered by `WikiLinkExtension` via `ReactRenderer` (`KbEditor`
+ * wires the renderer factory). The component is deliberately small:
+ * one `<ul>` of results, arrow-key cursor, Enter-to-commit,
+ * hover-to-highlight. Empty state covers both the "no query yet" and
+ * "query produced zero rows" cases.
+ *
+ * Stable selectors locked for Playwright A12-A17:
+ *  - `kb-wikilink-suggestion-list` (root, `data-empty`)
+ *  - `kb-wikilink-suggestion-item` (per row, with `data-doc-id`,
+ *    `data-doc-path`, `data-kb-class`, `data-active`)
+ *  - `kb-wikilink-suggestion-empty`
+ */
+export function WikiLinkSuggestionList({
+    items,
+    query,
+    onSelect,
+    ref,
+}: WikiLinkSuggestionListProps) {
+    const t = useTranslations('dashboard.workDetail.kb.wikilink');
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    // Reset the cursor whenever the items list changes (new query).
+    useEffect(() => {
+        setActiveIndex(0);
+    }, [items]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            onKeyDown: (event: KeyboardEvent) => {
+                if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    setActiveIndex((idx) => (items.length === 0 ? 0 : (idx + 1) % items.length));
+                    return true;
+                }
+                if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    setActiveIndex((idx) =>
+                        items.length === 0 ? 0 : (idx - 1 + items.length) % items.length,
+                    );
+                    return true;
+                }
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    const item = items[activeIndex];
+                    if (item) onSelect(item);
+                    return true;
+                }
+                return false;
+            },
+        }),
+        [items, activeIndex, onSelect],
+    );
+
+    return (
+        <div
+            data-testid="kb-wikilink-suggestion-list"
+            data-empty={items.length === 0 ? 'true' : 'false'}
+            className={cn(
+                'min-w-[18rem] max-w-md rounded-md border shadow-lg',
+                'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                'p-1',
+            )}
+        >
+            {items.length === 0 ? (
+                <p
+                    data-testid="kb-wikilink-suggestion-empty"
+                    className="px-3 py-2 text-xs text-text-muted dark:text-text-muted-dark/70"
+                >
+                    {query.trim().length === 0 ? t('hint') : t('empty', { query: query.trim() })}
+                </p>
+            ) : (
+                <ul role="listbox" aria-label={t('listLabel')}>
+                    {items.map((item, index) => {
+                        const isActive = index === activeIndex;
+                        return (
+                            <li key={item.id}>
+                                <button
+                                    type="button"
+                                    data-testid="kb-wikilink-suggestion-item"
+                                    data-doc-id={item.id}
+                                    data-doc-path={item.path}
+                                    data-kb-class={item.class}
+                                    data-active={isActive ? 'true' : 'false'}
+                                    role="option"
+                                    aria-selected={isActive}
+                                    onMouseEnter={() => setActiveIndex(index)}
+                                    onClick={() => onSelect(item)}
+                                    className={cn(
+                                        'flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-sm',
+                                        isActive
+                                            ? 'bg-primary/10 text-primary dark:bg-primary/20'
+                                            : 'text-text-secondary hover:bg-card-hover dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40',
+                                    )}
+                                >
+                                    <span className="grow truncate">{item.title || item.path}</span>
+                                    <span
+                                        className={cn(
+                                            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                                            'bg-primary/10 text-primary dark:bg-primary/20',
+                                        )}
+                                    >
+                                        {item.class}
+                                    </span>
+                                    <span className="shrink-0 font-mono text-[10px] text-text-muted dark:text-text-muted-dark/60">
+                                        {item.path}
+                                    </span>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/WikiLinkSuggestionList.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/WikiLinkSuggestionList.unit.spec.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+import {
+    WikiLinkSuggestionList,
+    type WikiLinkSuggestionListHandle,
+} from './WikiLinkSuggestionList';
+import type { WikiLinkSuggestionItem } from './extensions/WikiLinkExtension';
+
+const sample: WikiLinkSuggestionItem[] = [
+    { id: 'a', path: 'brand/voice.md', title: 'Brand voice', class: 'brand' },
+    { id: 'b', path: 'legal/notice.md', title: 'Legal notice', class: 'legal' },
+    { id: 'c', path: 'seo/keywords.md', title: 'SEO keywords', class: 'seo' },
+];
+
+/**
+ * EW-641 Phase 1B/d row 16b — `WikiLinkSuggestionList` is the popover
+ * content for the `[[` trigger. The tests pin:
+ *
+ *  - the empty / hint state (no query yet vs query with zero matches)
+ *  - per-row selectors + `data-active` cursor
+ *  - hover-to-highlight
+ *  - click-to-commit calling `onSelect`
+ *  - ArrowDown / ArrowUp / Enter forwarded via the exposed handle
+ */
+describe('WikiLinkSuggestionList', () => {
+    it('renders the hint state when no query and no items', () => {
+        render(<WikiLinkSuggestionList items={[]} query="" onSelect={() => undefined} />);
+        const root = screen.getByTestId('kb-wikilink-suggestion-list');
+        expect(root.getAttribute('data-empty')).toBe('true');
+        expect(screen.getByTestId('kb-wikilink-suggestion-empty').textContent).toBe('hint');
+    });
+
+    it('renders the empty-for-query state when query is non-empty but items are zero', () => {
+        render(<WikiLinkSuggestionList items={[]} query="zzz" onSelect={() => undefined} />);
+        expect(screen.getByTestId('kb-wikilink-suggestion-empty').textContent).toBe(
+            'empty query=zzz',
+        );
+    });
+
+    it('renders one row per item with stable data-attrs and an initial active cursor on row 0', () => {
+        render(<WikiLinkSuggestionList items={sample} query="b" onSelect={() => undefined} />);
+        const rows = screen.getAllByTestId('kb-wikilink-suggestion-item');
+        expect(rows.length).toBe(3);
+        expect(rows[0].getAttribute('data-doc-id')).toBe('a');
+        expect(rows[0].getAttribute('data-doc-path')).toBe('brand/voice.md');
+        expect(rows[0].getAttribute('data-kb-class')).toBe('brand');
+        expect(rows[0].getAttribute('data-active')).toBe('true');
+        expect(rows[1].getAttribute('data-active')).toBe('false');
+    });
+
+    it('moves the active cursor on hover', () => {
+        render(<WikiLinkSuggestionList items={sample} query="b" onSelect={() => undefined} />);
+        const rows = screen.getAllByTestId('kb-wikilink-suggestion-item');
+        fireEvent.mouseEnter(rows[2]);
+        expect(rows[2].getAttribute('data-active')).toBe('true');
+        expect(rows[0].getAttribute('data-active')).toBe('false');
+    });
+
+    it('calls onSelect when a row is clicked', () => {
+        const onSelect = vi.fn();
+        render(<WikiLinkSuggestionList items={sample} query="b" onSelect={onSelect} />);
+        fireEvent.click(screen.getAllByTestId('kb-wikilink-suggestion-item')[1]);
+        expect(onSelect).toHaveBeenCalledWith(sample[1]);
+    });
+
+    it('forwards ArrowDown / ArrowUp / Enter via the imperative handle', () => {
+        const onSelect = vi.fn();
+        const ref = createRef<WikiLinkSuggestionListHandle>();
+        render(<WikiLinkSuggestionList items={sample} query="b" onSelect={onSelect} ref={ref} />);
+
+        let arrowDownResult = false;
+        act(() => {
+            arrowDownResult =
+                ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' })) ?? false;
+        });
+        expect(arrowDownResult).toBe(true);
+        expect(
+            screen.getAllByTestId('kb-wikilink-suggestion-item')[1].getAttribute('data-active'),
+        ).toBe('true');
+
+        let arrowUpResult = false;
+        act(() => {
+            arrowUpResult =
+                ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowUp' })) ?? false;
+        });
+        expect(arrowUpResult).toBe(true);
+        expect(
+            screen.getAllByTestId('kb-wikilink-suggestion-item')[0].getAttribute('data-active'),
+        ).toBe('true');
+
+        let enterResult = false;
+        act(() => {
+            enterResult =
+                ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'Enter' })) ?? false;
+        });
+        expect(enterResult).toBe(true);
+        expect(onSelect).toHaveBeenCalledWith(sample[0]);
+    });
+
+    it('returns false for unhandled keys (so the editor handles them)', () => {
+        const ref = createRef<WikiLinkSuggestionListHandle>();
+        render(
+            <WikiLinkSuggestionList
+                items={sample}
+                query="b"
+                onSelect={() => undefined}
+                ref={ref}
+            />,
+        );
+        const eventA = new KeyboardEvent('keydown', { key: 'a' });
+        expect(ref.current?.onKeyDown(eventA)).toBe(false);
+    });
+
+    it('handle gracefully no-ops on empty item list', () => {
+        const ref = createRef<WikiLinkSuggestionListHandle>();
+        const onSelect = vi.fn();
+        render(<WikiLinkSuggestionList items={[]} query="" onSelect={onSelect} ref={ref} />);
+        const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        expect(ref.current?.onKeyDown(enterEvent)).toBe(true);
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/works/detail/kb/extensions/WikiLinkExtension.ts
+++ b/apps/web/src/components/works/detail/kb/extensions/WikiLinkExtension.ts
@@ -1,0 +1,152 @@
+import { Extension, type Range } from '@tiptap/react';
+import { PluginKey } from '@tiptap/pm/state';
+import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+import type { KbDocumentDto } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 1B/d row 16b — wikilink autocomplete extension.
+ *
+ * Behaviour (matches the rendering side shipped in row 16a):
+ *   1. Operator types `[[` followed by some query characters.
+ *   2. A popover lists matching docs from the row-15 search proxy.
+ *   3. Enter or click commits: `[[query` is replaced with
+ *      `[[Title|path]] ` (closing brackets + trailing space included).
+ *
+ * The renderer is supplied by `KbEditor` via the `render` option — this
+ * extension stays UI-agnostic so the same primitive can host different
+ * pickers (the row-17 `@`-mention picker reuses the shape).
+ *
+ * The default `@tiptap/suggestion` matcher is single-char (`@`, `#`).
+ * For our 2-char `[[` trigger we override `findSuggestionMatch` with a
+ * regex anchored at the cursor that captures everything between `[[`
+ * and the cursor, refusing to cross `]` or `\n` or `[` (so nested
+ * wikilinks don't confuse the matcher).
+ */
+
+export type WikiLinkSuggestionItem = Pick<KbDocumentDto, 'id' | 'path' | 'title' | 'class'>;
+
+/**
+ * Shape passed to the renderer's `onStart`/`onUpdate`. Mirrors the
+ * subset of `@tiptap/suggestion`'s render API we actually use, so the
+ * `WikiLinkSuggestionList` component doesn't have to depend on the
+ * upstream's evolving types.
+ */
+export interface WikiLinkRenderProps {
+    items: WikiLinkSuggestionItem[];
+    command: (item: WikiLinkSuggestionItem) => void;
+    clientRect: (() => DOMRect | null) | null;
+    query: string;
+}
+
+export interface WikiLinkRenderer {
+    onStart: (props: WikiLinkRenderProps) => void;
+    onUpdate: (props: WikiLinkRenderProps) => void;
+    onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+    onExit: () => void;
+}
+
+interface WikiLinkOptions {
+    workId: string;
+    render: () => WikiLinkRenderer;
+    /** Override the search endpoint (used by the unit spec). */
+    searchEndpoint?: (workId: string, query: string) => string;
+}
+
+export const WIKILINK_PLUGIN_KEY = new PluginKey('kb-wikilink-suggestion');
+
+export const WikiLinkExtension = Extension.create<WikiLinkOptions>({
+    name: 'kbWikiLink',
+
+    addOptions() {
+        return {
+            workId: '',
+            render: () => ({
+                onStart: () => undefined,
+                onUpdate: () => undefined,
+                onKeyDown: () => false,
+                onExit: () => undefined,
+            }),
+            searchEndpoint: (workId, query) =>
+                `/api/works/${encodeURIComponent(workId)}/kb/search?q=${encodeURIComponent(
+                    query,
+                )}&limit=10`,
+        };
+    },
+
+    addProseMirrorPlugins() {
+        const options = this.options;
+        const suggestionOptions: SuggestionOptions<WikiLinkSuggestionItem> = {
+            editor: this.editor,
+            pluginKey: WIKILINK_PLUGIN_KEY,
+            // `char` is required by the upstream's types but our custom
+            // matcher below ignores it.
+            char: '[[',
+            allowSpaces: true,
+            startOfLine: false,
+            findSuggestionMatch: ({ $position }) => {
+                // Scan backwards from cursor to start of paragraph.
+                const text = $position.parent.textBetween(0, $position.parentOffset, '\n', '\0');
+                const match = /\[\[([^\]\n[]*)$/.exec(text);
+                if (!match) return null;
+                const paragraphStart = $position.start();
+                const from = paragraphStart + match.index;
+                const to = $position.pos;
+                return {
+                    range: { from, to } as Range,
+                    query: match[1],
+                    text: match[0],
+                };
+            },
+            items: async ({ query }) => {
+                if (query.trim().length < 1) return [];
+                try {
+                    const response = await fetch(
+                        options.searchEndpoint!(options.workId, query.trim()),
+                        { cache: 'no-store' },
+                    );
+                    if (!response.ok) return [];
+                    const json = (await response.json()) as {
+                        items?: WikiLinkSuggestionItem[];
+                    };
+                    return (json.items ?? []).slice(0, 10);
+                } catch {
+                    return [];
+                }
+            },
+            command: ({ editor, range, props }) => {
+                const label = props.title || props.path.replace(/\.md$/i, '');
+                const replacement = `[[${label}|${props.path}]] `;
+                editor
+                    .chain()
+                    .focus()
+                    .insertContentAt({ from: range.from, to: range.to }, replacement)
+                    .run();
+            },
+            render: () => {
+                const renderer = options.render();
+                return {
+                    onStart: (props) => {
+                        renderer.onStart({
+                            items: props.items,
+                            command: (item) => props.command(item),
+                            clientRect: props.clientRect ?? null,
+                            query: props.query,
+                        });
+                    },
+                    onUpdate: (props) => {
+                        renderer.onUpdate({
+                            items: props.items,
+                            command: (item) => props.command(item),
+                            clientRect: props.clientRect ?? null,
+                            query: props.query,
+                        });
+                    },
+                    onKeyDown: (props) => renderer.onKeyDown({ event: props.event }),
+                    onExit: () => renderer.onExit(),
+                };
+            },
+        };
+
+        return [Suggestion(suggestionOptions)];
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.10.4
         version: 2.27.2
+      '@tiptap/suggestion':
+        specifier: ^2.10.4
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
       ai:
         specifier: ^6.0.154
         version: 6.0.154(zod@3.25.76)
@@ -8533,6 +8536,12 @@ packages:
 
   '@tiptap/starter-kit@2.27.2':
     resolution: {integrity: sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==}
+
+  '@tiptap/suggestion@2.27.2':
+    resolution: {integrity: sha512-dQyvCIg0hcAVeh4fCIVCxogvbp+bF+GpbUb8sNlgnGrmHXnapGxzkvrlHnvneXZxLk/j7CxmBPKJNnm4Pbx4zw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -26461,6 +26470,11 @@ snapshots:
       '@tiptap/extension-text-style': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       '@tiptap/pm': 2.27.2
 
+  '@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -34930,7 +34944,7 @@ snapshots:
       ky: 1.14.3
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
-      semver: 7.7.4
+      semver: 7.8.0
 
   package-json@8.1.1:
     dependencies:
@@ -37313,7 +37327,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5


### PR DESCRIPTION
## Summary

Closes the **editor side** of row 16. Operator types `[[`, gets a popover of matching KB docs, picks one, and `[[query` is replaced with `[[Title|path]] ` — which the renderer (row 16a, PR #939) already turns into a real anchor in `KbDocumentView`.

### Dep

- `@tiptap/suggestion@^2.10.4` (direct dep — was not transitively present).

### New files

- `extensions/WikiLinkExtension.ts` — wraps `Suggestion()` with:
  - Plugin key `kb-wikilink-suggestion` (coexists with the row-17 `@`-mention picker).
  - Custom 2-char `findSuggestionMatch` (regex `/\[\[([^\]\n[]*)$/`, anchored at cursor, refuses to cross `]`, `[`, or newline).
  - `items()` fetches `/api/works/:id/kb/search?q=&limit=10` (row-15 proxy).
  - `command()` does the `[[Title|path]] ` replacement.
  - Renderer factory injected by the host (`KbEditor`).
- `WikiLinkSuggestionList.tsx` — popover content. Single `<ul>` of results, arrow-key cursor, Enter-to-commit, hover-to-highlight, empty/hint state. Imperative handle (`React.Ref` prop) exposes `onKeyDown` so the suggestion plugin can forward keys.
- `KbEditor.tsx` — `createWikiLinkRenderFactory()` helper owns a `ReactRenderer<WikiLinkSuggestionListHandle>` + `position: fixed` popover `<div>`, repositioning via `props.clientRect()` on each update. No `tippy` dep.

### Selectors locked for Playwright A12-A17

- `kb-wikilink-suggestion-list` (root, `data-empty`)
- `kb-wikilink-suggestion-item` (per row, `data-doc-id` + `data-doc-path` + `data-kb-class` + `data-active`)
- `kb-wikilink-suggestion-empty`
- `kb-wikilink-popover` (the floating wrapper)

## Test plan

- [x] `pnpm exec vitest run WikiLinkSuggestionList.unit.spec.tsx` — **7/7 green** (hint state, empty-for-query, row shape + initial cursor, hover-to-highlight, click commits, ArrowDown/ArrowUp/Enter via handle, unhandled key returns false, empty-list no-op)
- [x] Full KB suite — **159/159 green** (KbEditor spec extended with `Extension` / `ReactRenderer` / `Suggestion` / `PluginKey` mocks)
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wikilink autocomplete support in Knowledge Base editor with keyboard-navigable suggestion list
  * Added multilingual translations for wikilink search functionality across 22 languages

* **Tests**
  * Added comprehensive unit tests for wikilink suggestion components

* **Chores**
  * Added `@tiptap/suggestion` dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->