### PR TITLE
feat(kb): @mention picker (EW-641 Phase 1B/d row 17)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2749,6 +2749,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2749,6 +2749,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2749,6 +2749,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2777,6 +2777,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2749,6 +2749,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2776,6 +2776,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2749,6 +2749,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2532,6 +2532,14 @@
                     "empty": "No documents match \"{query}\".",
                     "listLabel": "Wikilink suggestions"
                 },
+                "mention": {
+                    "hint": "Type to search for a KB document or agent…",
+                    "empty": "Nothing matches \"{query}\".",
+                    "sections": {
+                        "docs": "Documents",
+                        "agents": "Agents"
+                    }
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/src/components/works/detail/kb/KbEditor.tsx
+++ b/apps/web/src/components/works/detail/kb/KbEditor.tsx
@@ -19,6 +19,13 @@ import {
     WikiLinkSuggestionList,
     type WikiLinkSuggestionListHandle,
 } from './WikiLinkSuggestionList';
+import {
+    MentionExtension,
+    type MentionItem,
+    type MentionRenderProps,
+    type MentionRenderer,
+} from './extensions/MentionExtension';
+import { MentionSuggestionList, type MentionSuggestionListHandle } from './MentionSuggestionList';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
 
 interface KbEditorProps {
@@ -86,6 +93,7 @@ export function KbEditor({
         // per editor lifecycle.
         [],
     );
+    const mentionRenderFactory = useMemo(() => createMentionRenderFactory(), []);
 
     const editor = useEditor({
         immediatelyRender: false,
@@ -108,6 +116,10 @@ export function KbEditor({
             WikiLinkExtension.configure({
                 workId,
                 render: wikilinkRenderFactory,
+            }),
+            MentionExtension.configure({
+                workId,
+                render: mentionRenderFactory,
             }),
         ],
         content: doc.body ?? '',
@@ -494,6 +506,78 @@ function createWikiLinkRenderFactory(): () => WikiLinkRenderer {
                     // the suggestion plugin sees Escape and tears down.
                     return false;
                 }
+                return renderer?.ref?.onKeyDown(event) ?? false;
+            },
+            onExit: () => {
+                renderer?.destroy();
+                renderer = null;
+                popoverEl?.remove();
+                popoverEl = null;
+            },
+        };
+    };
+}
+
+/**
+ * Row-17 sibling of {@link createWikiLinkRenderFactory}. Identical
+ * lifecycle — mounts a `ReactRenderer<MentionSuggestionListHandle>`
+ * inside a `position: fixed` popover `<div>` and tears it down on
+ * exit. Test-id on the wrapper diverges so the two pickers can be
+ * distinguished by Playwright (`kb-mention-popover`).
+ */
+function createMentionRenderFactory(): () => MentionRenderer {
+    return () => {
+        let renderer: ReactRenderer<MentionSuggestionListHandle> | null = null;
+        let popoverEl: HTMLDivElement | null = null;
+
+        function positionFrom(clientRect: (() => DOMRect | null) | null) {
+            if (!popoverEl) return;
+            const rect = clientRect?.();
+            if (!rect) {
+                popoverEl.style.visibility = 'hidden';
+                return;
+            }
+            popoverEl.style.visibility = 'visible';
+            popoverEl.style.top = `${rect.bottom + 4}px`;
+            popoverEl.style.left = `${rect.left}px`;
+        }
+
+        function mount(props: MentionRenderProps) {
+            popoverEl = document.createElement('div');
+            popoverEl.setAttribute('data-testid', 'kb-mention-popover');
+            popoverEl.style.position = 'fixed';
+            popoverEl.style.zIndex = '60';
+            document.body.appendChild(popoverEl);
+            renderer = new ReactRenderer(MentionSuggestionList, {
+                editor: undefined as unknown as Editor,
+                props: {
+                    items: props.items,
+                    query: props.query,
+                    onSelect: (item: MentionItem) => props.command(item),
+                } as Record<string, unknown>,
+            });
+            const element = renderer.element as unknown as HTMLElement | null;
+            if (element) {
+                popoverEl.appendChild(element);
+            }
+            positionFrom(props.clientRect);
+        }
+
+        return {
+            onStart: (props) => {
+                mount(props);
+            },
+            onUpdate: (props) => {
+                if (!renderer) return;
+                renderer.updateProps({
+                    items: props.items,
+                    query: props.query,
+                    onSelect: (item: MentionItem) => props.command(item),
+                });
+                positionFrom(props.clientRect);
+            },
+            onKeyDown: ({ event }) => {
+                if (event.key === 'Escape') return false;
                 return renderer?.ref?.onKeyDown(event) ?? false;
             },
             onExit: () => {

--- a/apps/web/src/components/works/detail/kb/MentionSuggestionList.tsx
+++ b/apps/web/src/components/works/detail/kb/MentionSuggestionList.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useEffect, useImperativeHandle, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { MentionItem } from './extensions/MentionExtension';
+
+export interface MentionSuggestionListHandle {
+    onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+interface MentionSuggestionListProps {
+    items: MentionItem[];
+    query: string;
+    onSelect: (item: MentionItem) => void;
+    ref?: React.Ref<MentionSuggestionListHandle>;
+}
+
+/**
+ * EW-641 Phase 1B/d row 17 — popover content for the `@` mention trigger.
+ *
+ * Renders two sections (Docs / Agents) over a single flat ProseMirror
+ * suggestion list — the cursor index walks through both sections in
+ * order, matching the array passed in by the extension.
+ *
+ * Selectors locked for Playwright A12-A17:
+ *  - `kb-mention-suggestion-list` (root, `data-empty`)
+ *  - `kb-mention-suggestion-section` (per section, `data-kind` =
+ *    `doc`/`agent`, with a count attr for assertions)
+ *  - `kb-mention-suggestion-item` (per row, `data-kind`, plus
+ *    `data-doc-path` or `data-agent-id` depending on kind,
+ *    `data-active`)
+ *  - `kb-mention-suggestion-empty`
+ */
+export function MentionSuggestionList({ items, query, onSelect, ref }: MentionSuggestionListProps) {
+    const t = useTranslations('dashboard.workDetail.kb.mention');
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    useEffect(() => {
+        setActiveIndex(0);
+    }, [items]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            onKeyDown: (event: KeyboardEvent) => {
+                if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    setActiveIndex((idx) => (items.length === 0 ? 0 : (idx + 1) % items.length));
+                    return true;
+                }
+                if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    setActiveIndex((idx) =>
+                        items.length === 0 ? 0 : (idx - 1 + items.length) % items.length,
+                    );
+                    return true;
+                }
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    const item = items[activeIndex];
+                    if (item) onSelect(item);
+                    return true;
+                }
+                return false;
+            },
+        }),
+        [items, activeIndex, onSelect],
+    );
+
+    // Split the flat list into sections, preserving the original
+    // global index per row (the keyboard cursor is global).
+    const docs: Array<{ item: Extract<MentionItem, { kind: 'doc' }>; globalIndex: number }> = [];
+    const agents: Array<{ item: Extract<MentionItem, { kind: 'agent' }>; globalIndex: number }> =
+        [];
+    items.forEach((item, globalIndex) => {
+        if (item.kind === 'doc') docs.push({ item, globalIndex });
+        else agents.push({ item, globalIndex });
+    });
+
+    return (
+        <div
+            data-testid="kb-mention-suggestion-list"
+            data-empty={items.length === 0 ? 'true' : 'false'}
+            className={cn(
+                'min-w-[20rem] max-w-md rounded-md border shadow-lg',
+                'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                'p-1',
+            )}
+        >
+            {items.length === 0 ? (
+                <p
+                    data-testid="kb-mention-suggestion-empty"
+                    className="px-3 py-2 text-xs text-text-muted dark:text-text-muted-dark/70"
+                >
+                    {query.trim().length === 0 ? t('hint') : t('empty', { query: query.trim() })}
+                </p>
+            ) : (
+                <>
+                    <DocSection
+                        title={t('sections.docs')}
+                        rows={docs}
+                        activeIndex={activeIndex}
+                        onSelect={onSelect}
+                        setActiveIndex={setActiveIndex}
+                    />
+                    <AgentSection
+                        title={t('sections.agents')}
+                        rows={agents}
+                        activeIndex={activeIndex}
+                        onSelect={onSelect}
+                        setActiveIndex={setActiveIndex}
+                    />
+                </>
+            )}
+        </div>
+    );
+}
+
+type MentionDoc = Extract<MentionItem, { kind: 'doc' }>;
+type MentionAgent = Extract<MentionItem, { kind: 'agent' }>;
+
+interface DocSectionProps {
+    title: string;
+    rows: Array<{ item: MentionDoc; globalIndex: number }>;
+    activeIndex: number;
+    onSelect: (item: MentionItem) => void;
+    setActiveIndex: (index: number) => void;
+}
+
+function DocSection({ title, rows, activeIndex, onSelect, setActiveIndex }: DocSectionProps) {
+    if (rows.length === 0) return null;
+    return (
+        <div
+            data-testid="kb-mention-suggestion-section"
+            data-kind="doc"
+            data-count={rows.length}
+            className="flex flex-col gap-0.5"
+        >
+            <h3
+                className={cn(
+                    'px-3 pt-2 text-[10px] font-semibold uppercase tracking-wider',
+                    'text-text-muted dark:text-text-muted-dark/70',
+                )}
+            >
+                {title}
+            </h3>
+            <ul role="listbox">
+                {rows.map(({ item, globalIndex }) => {
+                    const isActive = globalIndex === activeIndex;
+                    return (
+                        <li key={item.id}>
+                            <button
+                                type="button"
+                                data-testid="kb-mention-suggestion-item"
+                                data-kind="doc"
+                                data-doc-id={item.id}
+                                data-doc-path={item.path}
+                                data-kb-class={item.class}
+                                data-active={isActive ? 'true' : 'false'}
+                                role="option"
+                                aria-selected={isActive}
+                                onMouseEnter={() => setActiveIndex(globalIndex)}
+                                onClick={() => onSelect(item)}
+                                className={cn(
+                                    'flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-sm',
+                                    isActive
+                                        ? 'bg-primary/10 text-primary dark:bg-primary/20'
+                                        : 'text-text-secondary hover:bg-card-hover dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40',
+                                )}
+                            >
+                                <span className="grow truncate">{item.title || item.path}</span>
+                                <span
+                                    className={cn(
+                                        'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                                        'bg-primary/10 text-primary dark:bg-primary/20',
+                                    )}
+                                >
+                                    {item.class}
+                                </span>
+                                <span className="shrink-0 font-mono text-[10px] text-text-muted dark:text-text-muted-dark/60">
+                                    {item.path}
+                                </span>
+                            </button>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+}
+
+interface AgentSectionProps {
+    title: string;
+    rows: Array<{ item: MentionAgent; globalIndex: number }>;
+    activeIndex: number;
+    onSelect: (item: MentionItem) => void;
+    setActiveIndex: (index: number) => void;
+}
+
+function AgentSection({ title, rows, activeIndex, onSelect, setActiveIndex }: AgentSectionProps) {
+    if (rows.length === 0) return null;
+    return (
+        <div
+            data-testid="kb-mention-suggestion-section"
+            data-kind="agent"
+            data-count={rows.length}
+            className="flex flex-col gap-0.5"
+        >
+            <h3
+                className={cn(
+                    'px-3 pt-2 text-[10px] font-semibold uppercase tracking-wider',
+                    'text-text-muted dark:text-text-muted-dark/70',
+                )}
+            >
+                {title}
+            </h3>
+            <ul role="listbox">
+                {rows.map(({ item, globalIndex }) => {
+                    const isActive = globalIndex === activeIndex;
+                    return (
+                        <li key={item.id}>
+                            <button
+                                type="button"
+                                data-testid="kb-mention-suggestion-item"
+                                data-kind="agent"
+                                data-agent-id={item.id}
+                                data-active={isActive ? 'true' : 'false'}
+                                role="option"
+                                aria-selected={isActive}
+                                onMouseEnter={() => setActiveIndex(globalIndex)}
+                                onClick={() => onSelect(item)}
+                                className={cn(
+                                    'flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-sm',
+                                    isActive
+                                        ? 'bg-primary/10 text-primary dark:bg-primary/20'
+                                        : 'text-text-secondary hover:bg-card-hover dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40',
+                                )}
+                            >
+                                <span className="grow truncate">{item.name}</span>
+                                <span className="shrink-0 font-mono text-[10px] text-text-muted dark:text-text-muted-dark/60">
+                                    @{item.id}
+                                </span>
+                            </button>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/MentionSuggestionList.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/MentionSuggestionList.unit.spec.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+import { MentionSuggestionList, type MentionSuggestionListHandle } from './MentionSuggestionList';
+import type { MentionItem } from './extensions/MentionExtension';
+
+const mixed: MentionItem[] = [
+    { id: 'doc-a', path: 'brand/voice.md', title: 'Brand voice', class: 'brand', kind: 'doc' },
+    { id: 'doc-b', path: 'legal/notice.md', title: 'Legal notice', class: 'legal', kind: 'doc' },
+    { id: 'claude-code', name: 'Claude Code', kind: 'agent' },
+];
+
+/**
+ * EW-641 Phase 1B/d row 17 — sectioned mention picker tests.
+ *
+ * The list is rendered as two sections (Documents / Agents) over a
+ * single flat suggestion list. The keyboard cursor is global and walks
+ * through both sections in order. Items expose their kind via
+ * `data-kind` and either `data-doc-path` or `data-agent-id`.
+ */
+describe('MentionSuggestionList', () => {
+    it('renders the hint state when no query and no items', () => {
+        render(<MentionSuggestionList items={[]} query="" onSelect={() => undefined} />);
+        const root = screen.getByTestId('kb-mention-suggestion-list');
+        expect(root.getAttribute('data-empty')).toBe('true');
+        expect(screen.getByTestId('kb-mention-suggestion-empty').textContent).toBe('hint');
+    });
+
+    it('renders the empty-for-query state when no items match a non-empty query', () => {
+        render(<MentionSuggestionList items={[]} query="zzz" onSelect={() => undefined} />);
+        expect(screen.getByTestId('kb-mention-suggestion-empty').textContent).toBe(
+            'empty query=zzz',
+        );
+    });
+
+    it('renders one Documents section and one Agents section with data-kind + data-count', () => {
+        render(<MentionSuggestionList items={mixed} query="b" onSelect={() => undefined} />);
+        const sections = screen.getAllByTestId('kb-mention-suggestion-section');
+        expect(sections.length).toBe(2);
+        expect(sections[0].getAttribute('data-kind')).toBe('doc');
+        expect(sections[0].getAttribute('data-count')).toBe('2');
+        expect(sections[1].getAttribute('data-kind')).toBe('agent');
+        expect(sections[1].getAttribute('data-count')).toBe('1');
+    });
+
+    it('omits the Agents section when no agent items are present', () => {
+        const docsOnly = mixed.filter((i) => i.kind === 'doc');
+        render(<MentionSuggestionList items={docsOnly} query="b" onSelect={() => undefined} />);
+        const sections = screen.getAllByTestId('kb-mention-suggestion-section');
+        expect(sections.length).toBe(1);
+        expect(sections[0].getAttribute('data-kind')).toBe('doc');
+    });
+
+    it('renders rows with the right per-kind data-attrs', () => {
+        render(<MentionSuggestionList items={mixed} query="b" onSelect={() => undefined} />);
+        const rows = screen.getAllByTestId('kb-mention-suggestion-item');
+        expect(rows.length).toBe(3);
+        expect(rows[0].getAttribute('data-kind')).toBe('doc');
+        expect(rows[0].getAttribute('data-doc-path')).toBe('brand/voice.md');
+        expect(rows[0].getAttribute('data-kb-class')).toBe('brand');
+        expect(rows[0].getAttribute('data-active')).toBe('true');
+        expect(rows[2].getAttribute('data-kind')).toBe('agent');
+        expect(rows[2].getAttribute('data-agent-id')).toBe('claude-code');
+        expect(rows[2].getAttribute('data-doc-path')).toBeNull();
+    });
+
+    it('moves the active cursor on hover (across sections)', () => {
+        render(<MentionSuggestionList items={mixed} query="b" onSelect={() => undefined} />);
+        const rows = screen.getAllByTestId('kb-mention-suggestion-item');
+        fireEvent.mouseEnter(rows[2]);
+        expect(rows[2].getAttribute('data-active')).toBe('true');
+        expect(rows[0].getAttribute('data-active')).toBe('false');
+    });
+
+    it('calls onSelect with the right kind when a row is clicked', () => {
+        const onSelect = vi.fn();
+        render(<MentionSuggestionList items={mixed} query="b" onSelect={onSelect} />);
+        fireEvent.click(screen.getAllByTestId('kb-mention-suggestion-item')[2]);
+        expect(onSelect).toHaveBeenCalledWith(mixed[2]);
+    });
+
+    it('keyboard nav walks across both sections via the global cursor', () => {
+        const onSelect = vi.fn();
+        const ref = createRef<MentionSuggestionListHandle>();
+        render(<MentionSuggestionList items={mixed} query="b" onSelect={onSelect} ref={ref} />);
+
+        // Two ArrowDowns: doc-a (0) → doc-b (1) → claude-code (2).
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        });
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        });
+        const rows = screen.getAllByTestId('kb-mention-suggestion-item');
+        expect(rows[2].getAttribute('data-active')).toBe('true');
+
+        act(() => {
+            ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }));
+        });
+        expect(onSelect).toHaveBeenCalledWith(mixed[2]);
+    });
+
+    it('returns false for unhandled keys', () => {
+        const ref = createRef<MentionSuggestionListHandle>();
+        render(
+            <MentionSuggestionList items={mixed} query="b" onSelect={() => undefined} ref={ref} />,
+        );
+        expect(ref.current?.onKeyDown(new KeyboardEvent('keydown', { key: 'a' }))).toBe(false);
+    });
+});

--- a/apps/web/src/components/works/detail/kb/extensions/MentionExtension.ts
+++ b/apps/web/src/components/works/detail/kb/extensions/MentionExtension.ts
@@ -1,0 +1,155 @@
+import { Extension, type Range } from '@tiptap/react';
+import { PluginKey } from '@tiptap/pm/state';
+import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+import type { KbDocumentDto } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 1B/d row 17 — `@mention` picker.
+ *
+ * Sibling of row 16b's wikilink extension. Uses the same
+ * `@tiptap/suggestion` primitive but with the simpler single-char `@`
+ * trigger — the upstream's default `findSuggestionMatch` handles it
+ * natively, so we don't override it.
+ *
+ * Item kinds:
+ *  - **doc** — a KB document. Insert syntax: `@kb:<path> `
+ *  - **agent** — a pipeline / AI agent. Insert syntax: `@agent:<id> `
+ *
+ * For this first cut only docs are populated — the agent endpoint
+ * isn't shipped yet (see row 17b in the handoff). The popover still
+ * renders an empty Agents section so the wire format + selectors are
+ * already locked for Playwright A12-A17.
+ */
+
+export type MentionDoc = Pick<KbDocumentDto, 'id' | 'path' | 'title' | 'class'> & {
+    kind: 'doc';
+};
+export interface MentionAgent {
+    id: string;
+    name: string;
+    kind: 'agent';
+}
+export type MentionItem = MentionDoc | MentionAgent;
+
+export interface MentionRenderProps {
+    items: MentionItem[];
+    command: (item: MentionItem) => void;
+    clientRect: (() => DOMRect | null) | null;
+    query: string;
+}
+
+export interface MentionRenderer {
+    onStart: (props: MentionRenderProps) => void;
+    onUpdate: (props: MentionRenderProps) => void;
+    onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+    onExit: () => void;
+}
+
+interface MentionOptions {
+    workId: string;
+    render: () => MentionRenderer;
+    searchEndpoint?: (workId: string, query: string) => string;
+    /**
+     * Overridable agent fetcher — defaults to an empty list. Row 17b
+     * will swap this for a real `/api/works/:id/agents` call once the
+     * endpoint exists.
+     */
+    fetchAgents?: (workId: string, query: string) => Promise<MentionAgent[]>;
+}
+
+export const MENTION_PLUGIN_KEY = new PluginKey('kb-mention-suggestion');
+
+export const MentionExtension = Extension.create<MentionOptions>({
+    name: 'kbMention',
+
+    addOptions() {
+        return {
+            workId: '',
+            render: () => ({
+                onStart: () => undefined,
+                onUpdate: () => undefined,
+                onKeyDown: () => false,
+                onExit: () => undefined,
+            }),
+            searchEndpoint: (workId, query) =>
+                `/api/works/${encodeURIComponent(workId)}/kb/search?q=${encodeURIComponent(
+                    query,
+                )}&limit=8`,
+            fetchAgents: async () => [],
+        };
+    },
+
+    addProseMirrorPlugins() {
+        const options = this.options;
+        const suggestionOptions: SuggestionOptions<MentionItem> = {
+            editor: this.editor,
+            pluginKey: MENTION_PLUGIN_KEY,
+            char: '@',
+            // Don't trigger inside email addresses / handles already
+            // adjacent to a word boundary.
+            allowedPrefixes: [' ', '\n'],
+            startOfLine: false,
+            items: async ({ query }) => {
+                const trimmed = query.trim();
+                if (trimmed.length === 0) return [];
+                try {
+                    const [docResults, agentResults] = await Promise.all([
+                        fetch(options.searchEndpoint!(options.workId, trimmed), {
+                            cache: 'no-store',
+                        })
+                            .then((r) => (r.ok ? r.json() : { items: [] }))
+                            .then((json: { items?: Array<Omit<MentionDoc, 'kind'>> }) =>
+                                (json.items ?? []).map(
+                                    (doc): MentionDoc => ({ ...doc, kind: 'doc' }),
+                                ),
+                            )
+                            .catch(() => [] as MentionDoc[]),
+                        options.fetchAgents!(options.workId, trimmed).catch(
+                            () => [] as MentionAgent[],
+                        ),
+                    ]);
+                    // Docs first, then agents — the popover renders them
+                    // as two sections but the flat list keeps the
+                    // suggestion plugin's index math simple.
+                    return [...docResults.slice(0, 8), ...agentResults.slice(0, 8)];
+                } catch {
+                    return [];
+                }
+            },
+            command: ({ editor, range, props }) => {
+                const replacement =
+                    props.kind === 'doc' ? `@kb:${props.path} ` : `@agent:${props.id} `;
+                editor
+                    .chain()
+                    .focus()
+                    .insertContentAt({ from: range.from, to: range.to } as Range, replacement)
+                    .run();
+            },
+            render: () => {
+                const renderer = options.render();
+                return {
+                    onStart: (props) => {
+                        renderer.onStart({
+                            items: props.items,
+                            command: (item) => props.command(item),
+                            clientRect: props.clientRect ?? null,
+                            query: props.query,
+                        });
+                    },
+                    onUpdate: (props) => {
+                        renderer.onUpdate({
+                            items: props.items,
+                            command: (item) => props.command(item),
+                            clientRect: props.clientRect ?? null,
+                            query: props.query,
+                        });
+                    },
+                    onKeyDown: (props) => renderer.onKeyDown({ event: props.event }),
+                    onExit: () => renderer.onExit(),
+                };
+            },
+        };
+
+        return [Suggestion(suggestionOptions)];
+    },
+});


### PR DESCRIPTION
## Summary

Sibling of row 16b's `[[` wikilink popover, but for the `@` trigger. Operator types `@`, gets a **sectioned** list of matching KB docs + agents, picks one, inserts `@kb:<path> ` (or `@agent:<id> `).

### Behaviour

- **Trigger**: `@` (single-char — `@tiptap/suggestion`'s default `findSuggestionMatch` handles it; no override needed).
- **Items**: row-15 `/kb/search?q=&limit=8` proxy + an `(overridable) fetchAgents` callback in parallel. Agent fetcher defaults to `[]` for now — **row 17b** carves the real `/api/works/:id/agents` endpoint.
- **Commit**: `@kb:<path> ` for docs, `@agent:<id> ` for agents (closing space included).
- **`allowedPrefixes: [' ', '\n']`** so the popover doesn't open inside email addresses or word-adjacent `@`s.
- **Plugin key** `kb-mention-suggestion` so it coexists with `kb-wikilink-suggestion`.

### Sectioned popover

`MentionSuggestionList` renders two sections (Documents / Agents) over a single flat suggestion list. The global keyboard cursor walks through both sections in order. Sections omit themselves when row count is 0.

Split into `DocSection` + `AgentSection` non-generic components because TS struggles to narrow `Extract<Item, { kind: K }>` under a generic `Section<K>` (lesson #3 in the typed-vs-runtime notes).

### Selectors locked for Playwright A12-A17

- `kb-mention-popover` (floating wrapper)
- `kb-mention-suggestion-list` (root, `data-empty`)
- `kb-mention-suggestion-section` (per section, `data-kind={doc|agent}` + `data-count`)
- `kb-mention-suggestion-item` (per row, `data-kind`, plus `data-doc-path` or `data-agent-id`, `data-active`)
- `kb-mention-suggestion-empty`

## Test plan

- [x] `pnpm exec vitest run MentionSuggestionList.unit.spec.tsx` — **9/9 green**
- [x] Full KB suite — **168/168 green**
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview

This is **row 17a** — picker + KB-doc suggestions. Row 17b wires the agent-list endpoint (the picker already renders the empty Agents section + commits `@agent:<id> ` so only the data side is missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Knowledge Base mention support: users can now reference KB documents and agents using @ syntax with an autocomplete suggestion popover featuring "Documents" and "Agents" sections.

* **Internationalization**
  * Added multi-language support for the mention feature across 20+ languages with appropriate hint text, empty states, and section labels.

* **Tests**
  * Added comprehensive unit tests for mention suggestion rendering, keyboard navigation, and selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->