### PR TITLE
feat(kb): document history endpoint scaffold (EW-641 Phase 1B/d row 18a)

### DIFF
--- a/apps/api/src/works/kb.controller.ts
+++ b/apps/api/src/works/kb.controller.ts
@@ -201,6 +201,32 @@ export class KbController {
         return this.kb.restoreDocumentFromHistory(workId, docId, auth.userId, body.commitSha);
     }
 
+    @Get('works/:id/kb/documents/:docId/history')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'List Git commits that touched a KB document',
+        description:
+            'Returns the commit log for the sidecar `.md` body under `.content/kb/`, newest first. Powers the history dialog (row 18) — operators click a row to feed the SHA back into the existing `/restore` endpoint.',
+    })
+    @ApiQuery({
+        name: 'limit',
+        required: false,
+        description: 'Max commits to return (1-100, default 25)',
+    })
+    @ApiResponse({ status: 200, description: 'Commit history' })
+    @ApiResponse({ status: 404, description: 'Document not found' })
+    async getDocumentHistory(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') workId: string,
+        @Param('docId') docId: string,
+        @Query('limit') limit?: string,
+    ) {
+        const parsedLimit = limit && /^\d+$/.test(limit) ? Number(limit) : undefined;
+        return this.kb.getDocumentHistory(workId, docId, auth.userId, {
+            limit: parsedLimit,
+        });
+    }
+
     @Get('works/:id/kb/documents/:docId/citations')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'List citations referencing a KB document' })

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -211,6 +211,78 @@ describe('KnowledgeBaseService', () => {
         });
     });
 
+    describe('getDocumentHistory', () => {
+        it('returns an empty history when the mirror service is not wired', async () => {
+            const doc = buildDocument();
+            docRepo.findByWorkOrPath.mockResolvedValue(doc);
+            // The default test module doesn't wire `KnowledgeBaseGitMirrorService`,
+            // so the stub should short-circuit to `{ items: [] }` rather than
+            // throw — operators on OSS deployments without git-provider plugin
+            // still see the dialog, just empty.
+            const result = await service.getDocumentHistory(WORK_ID, doc.id, USER_ID);
+            expect(result).toEqual({ items: [] });
+        });
+
+        it('throws NotFoundException when the document is missing', async () => {
+            docRepo.findByWorkOrPath.mockResolvedValue(null);
+            await expect(
+                service.getDocumentHistory(WORK_ID, 'missing', USER_ID),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('enforces canView (the same gate as listDocuments / getDocument)', async () => {
+            const doc = buildDocument();
+            docRepo.findByWorkOrPath.mockResolvedValue(doc);
+            ownership.ensureCanView.mockRejectedValueOnce(new ForbiddenException('nope'));
+            await expect(
+                service.getDocumentHistory(WORK_ID, doc.id, USER_ID),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+        });
+
+        it('clamps the limit to [1, 100] and forwards it to the mirror service', async () => {
+            const doc = buildDocument();
+            docRepo.findByWorkOrPath.mockResolvedValue(doc);
+            const mirror = { listDocumentHistory: jest.fn().mockResolvedValue([]) };
+            // Reflection-assign the mirror service onto the existing
+            // singleton — the NestJS testing module doesn't provide one
+            // (it's `@Optional()` in the constructor), and rebuilding a
+            // full module just to inject a 1-method stub would dwarf
+            // the test it's there to support.
+            (service as unknown as { mirrorService: typeof mirror }).mirrorService = mirror;
+
+            await service.getDocumentHistory(WORK_ID, doc.id, USER_ID, { limit: 999 });
+            expect(mirror.listDocumentHistory).toHaveBeenCalledWith(WORK_ID, doc.id, 100);
+
+            mirror.listDocumentHistory.mockClear();
+            await service.getDocumentHistory(WORK_ID, doc.id, USER_ID, { limit: 0 });
+            expect(mirror.listDocumentHistory).toHaveBeenCalledWith(WORK_ID, doc.id, 1);
+
+            mirror.listDocumentHistory.mockClear();
+            await service.getDocumentHistory(WORK_ID, doc.id, USER_ID);
+            expect(mirror.listDocumentHistory).toHaveBeenCalledWith(WORK_ID, doc.id, 25);
+        });
+
+        it('copies the mirror service result into a mutable items array', async () => {
+            const doc = buildDocument();
+            docRepo.findByWorkOrPath.mockResolvedValue(doc);
+            const commits = Object.freeze([
+                {
+                    sha: 'abc1234',
+                    message: 'edit voice',
+                    authorName: 'Ada',
+                    authoredAt: '2026-05-22T00:00:00Z',
+                },
+            ]);
+            const mirror = { listDocumentHistory: jest.fn().mockResolvedValue(commits) };
+            (service as unknown as { mirrorService: typeof mirror }).mirrorService = mirror;
+
+            const result = await service.getDocumentHistory(WORK_ID, doc.id, USER_ID);
+            expect(result.items).toEqual(commits);
+            // Should be a copy — pushing to it doesn't throw on a frozen source.
+            expect(() => result.items.push(commits[0])).not.toThrow();
+        });
+    });
+
     describe('createDocument', () => {
         it('persists with derived slug + word/token counts', async () => {
             docRepo.pathExists.mockResolvedValue(false);

--- a/packages/agent/src/services/knowledge-base-git-mirror.service.ts
+++ b/packages/agent/src/services/knowledge-base-git-mirror.service.ts
@@ -267,6 +267,32 @@ export class KnowledgeBaseGitMirrorService {
         return { restored: true, body };
     }
 
+    /**
+     * EW-641 Phase 1B/d row 18 — list commits that touched a KB
+     * document's sidecar `.md` file.
+     *
+     * **Stub today (row 18a)**: returns `[]`. Row 18b lands the real
+     * git-log walk — likely via a new optional `listFileCommits`
+     * capability on the git-provider plugin contract (GitHub's
+     * `octokit.rest.repos.listCommits({ path })` is the natural impl)
+     * or, failing that, isomorphic-git's `git.log({ filepath })` over
+     * the local clone. Whichever path lands, the return shape is
+     * locked here so the controller + frontend don't have to budge.
+     *
+     * The doc's `path` is the relative key under `.content/kb/`. We
+     * resolve it the same way `restoreDocumentFromGit` does, then
+     * compose `${KB_ROOT}/${doc.path}` to scope the log query.
+     */
+    async listDocumentHistory(
+        _workId: string,
+        _documentId: string,
+        _limit: number,
+    ): Promise<
+        ReadonlyArray<{ sha: string; message: string; authorName: string; authoredAt: string }>
+    > {
+        return [];
+    }
+
     // ─── INTERNAL ─────────────────────────────────────────────────────────────
 
     /**

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -37,6 +37,7 @@ import type {
     KbDocumentBodyDto,
     KbDocumentClass as KbDocumentClassContract,
     KbDocumentDto,
+    KbDocumentHistoryResult,
     KbTagDto,
 } from '@ever-works/contracts';
 
@@ -214,6 +215,50 @@ export class KnowledgeBaseService {
         }
 
         return this.toBodyDto(doc);
+    }
+
+    /**
+     * EW-641 Phase 1B/d row 18 — list the Git commits that touched a
+     * KB document's sidecar `.md` body. Returns `{ items: [] }` when
+     * the mirror service isn't wired (test envs, OSS deployments
+     * without git-provider plugin), or when the file has no commits
+     * yet (newly-created doc whose first mirror is still queued).
+     *
+     * Same `ensureCanView` access pattern as `listDocuments` /
+     * `getDocument`: anyone who can read the doc can read its history.
+     * Restore (the destructive side) lives on the existing
+     * `restoreDocumentFromHistory` path and gates on `manager+`.
+     *
+     * **Stub today**: the real `listDocumentHistoryFromGit` impl on
+     * `KnowledgeBaseGitMirrorService` lands in row 18b — that PR
+     * walks the local clone with isomorphic-git or fans out to the
+     * git-provider plugin's commits endpoint. The contract + access
+     * gate are locked here so the frontend (row 18c) can build
+     * against the real wire format.
+     */
+    async getDocumentHistory(
+        workId: string,
+        docId: string,
+        userId: string,
+        opts: { limit?: number } = {},
+    ): Promise<KbDocumentHistoryResult> {
+        await this.ownershipService.ensureCanView(workId, userId);
+
+        const doc = await this.documentRepository.findByWorkOrPath(workId, docId);
+        if (!doc) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+
+        if (!this.mirrorService) {
+            return { items: [] };
+        }
+
+        const limit = typeof opts.limit === 'number' ? Math.min(Math.max(opts.limit, 1), 100) : 25;
+        const items = await this.mirrorService.listDocumentHistory(workId, doc.id, limit);
+        // `items` is a `ReadonlyArray<…>` on the mirror service to
+        // prevent accidental mutation of the upstream's cache; copy it
+        // into a mutable array for the contract's `items: T[]` shape.
+        return { items: [...items] };
     }
 
     async createDocument(input: CreateDocumentInput): Promise<KbDocumentBodyDto> {

--- a/packages/agent/src/user-research/__tests__/limits.spec.ts
+++ b/packages/agent/src/user-research/__tests__/limits.spec.ts
@@ -68,5 +68,4 @@ describe('UserResearchLimitsService', () => {
         }
         await expect(svc.assertCanRun('u2')).resolves.toBeUndefined();
     });
-
 });

--- a/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
+++ b/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
@@ -105,15 +105,12 @@ describe('resolveSearchProviderIds', () => {
             { id: 'local-search' },
         ]);
         const settings = {
-            getSettings: jest
-                .fn()
-                .mockResolvedValueOnce({ apiKey: '' })
-                .mockResolvedValueOnce({}),
+            getSettings: jest.fn().mockResolvedValueOnce({ apiKey: '' }).mockResolvedValueOnce({}),
         };
 
-        await expect(
-            resolveSearchProviderIds(registry, 'u-1', settings as never),
-        ).resolves.toEqual(['local-search']);
+        await expect(resolveSearchProviderIds(registry, 'u-1', settings as never)).resolves.toEqual(
+            ['local-search'],
+        );
         expect(settings.getSettings).toHaveBeenCalledWith('tavily', {
             userId: 'u-1',
             includeSecrets: true,
@@ -133,9 +130,9 @@ describe('resolveSearchProviderIds', () => {
         ]);
         const settings = { getSettings: jest.fn().mockResolvedValue({}) };
 
-        await expect(
-            resolveSearchProviderIds(registry, 'u-1', settings as never),
-        ).resolves.toEqual(['env-search']);
+        await expect(resolveSearchProviderIds(registry, 'u-1', settings as never)).resolves.toEqual(
+            ['env-search'],
+        );
     });
 });
 

--- a/packages/contracts/src/kb/kb-document.types.ts
+++ b/packages/contracts/src/kb/kb-document.types.ts
@@ -99,3 +99,19 @@ export interface KbDocumentListResult {
 	nextCursor: string | null;
 	total: number;
 }
+
+/**
+ * A single commit touching a KB document, surfaced by the row-18 KB
+ * history endpoint. Backed by the Git provider plugin's commit log over
+ * the file path under `.content/kb/`.
+ */
+export interface KbDocumentCommitDto {
+	sha: string;
+	message: string;
+	authorName: string;
+	authoredAt: string;
+}
+
+export interface KbDocumentHistoryResult {
+	items: KbDocumentCommitDto[];
+}


### PR DESCRIPTION
## Summary

Locks the wire format for the row-18 history dialog so the frontend (row 18c) can build against a real endpoint. The actual git-log walk lands in row 18b.

### Contract

- New `KbDocumentCommitDto = { sha, message, authorName, authoredAt }`.
- New `KbDocumentHistoryResult = { items: KbDocumentCommitDto[] }`.

### Service

- `KnowledgeBaseService.getDocumentHistory(workId, docId, userId, opts)`:
  - Same `ensureCanView` gate as `listDocuments` / `getDocument` — anyone who can read the doc can read its history. Restore (destructive) stays on `restoreDocumentFromHistory` with `manager+`.
  - Limit clamped to `[1, 100]`, default 25.
  - Returns `{ items: [] }` when the mirror service isn't wired (test envs, OSS deployments without git-provider plugin).
- `KnowledgeBaseGitMirrorService.listDocumentHistory(workId, docId, limit)` — **stub** returning `[]` for now. Row 18b lands the real impl.

### Controller

- `GET /api/works/:id/kb/documents/:docId/history?limit=N` returning `{ items: KbDocumentCommitDto[] }`.

## Test plan

- [x] `pnpm --filter @ever-works/agent test -- knowledge-base.service` — **26/26 green** (4 new history cases: empty items when mirror not wired, NotFound on missing doc, ensureCanView gate, limit clamping + mutable items copy)
- [x] `pnpm --filter @ever-works/contracts build` clean
- [x] `pnpm --filter @ever-works/agent build` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview
- [ ] `lint-and-test (22.x)`

### Carved follow-ups

- **Row 18b**: real git-log walk in `KnowledgeBaseGitMirrorService` (likely via a new optional `listFileCommits` capability on the git-provider plugin contract — GitHub's `octokit.rest.repos.listCommits({ path })` is the natural impl).
- **Row 18c**: `KbHistoryDialog` client component + KbSidePanel button wiring (the placeholder button shipped in row 13 with `data-testid="kb-side-panel-history"` is ready to enable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View Git commit history for knowledge base documents via a new API endpoint, with optional pagination limit (clamped/defaulted).
* **Tests**
  * Added unit tests covering history retrieval, access control, limit clamping, missing-mirror behavior, and error cases.
* **Contracts / API Docs**
  * New response types for document commit history and updated API metadata for the history route.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->