### PR TITLE
feat(kb): restore-from-history dialog (EW-641 Phase 1B/d row 18c)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2757,6 +2757,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2757,6 +2757,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2757,6 +2757,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2785,6 +2785,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2757,6 +2757,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2784,6 +2784,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2757,6 +2757,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2540,6 +2540,17 @@
                         "agents": "Agents"
                     }
                 },
+                "history": {
+                    "title": "Document history",
+                    "dialogLabel": "Knowledge Base document history",
+                    "close": "Close",
+                    "loading": "Loading history…",
+                    "error": "Failed to load history ({error}).",
+                    "empty": "No prior versions yet. Edits will appear here once the doc has been mirrored to Git.",
+                    "cancel": "Cancel",
+                    "restore": "Restore to {sha}",
+                    "restoring": "Restoring…"
+                },
                 "sidePanel": {
                     "title": "Document details",
                     "subtitle": "Metadata, lock state, and history for this document.",

--- a/apps/web/src/app/actions/works/kb-history.ts
+++ b/apps/web/src/app/actions/works/kb-history.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { kbAPI } from '@/lib/api/kb';
+import type { ActionResult } from '@/app/actions/plugins';
+import type { KbDocumentBodyDto, KbDocumentHistoryResult } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 1B/d row 18c — KB history server actions.
+ *
+ * The dialog is client-rendered and needs a server-action bridge to
+ * reach `kbAPI` (which is `'server-only'`). Same envelope pattern as
+ * row 5's `updateKbDocumentAction` and row 14's `lockKbDocumentAction`.
+ *
+ * - `getKbDocumentHistoryAction` — read-only list of commits touching
+ *   the doc. Returns `{ items: [] }` while the row-18b git-log impl
+ *   is pending; the dialog renders the empty state.
+ * - `restoreKbDocumentAction` — POSTs to the existing
+ *   `/restore { commitSha }` endpoint and revalidates the doc route +
+ *   KB index so the tree + editor reflect the restored body.
+ */
+export async function getKbDocumentHistoryAction(args: {
+    workId: string;
+    docId: string;
+    limit?: number;
+}): Promise<ActionResult<KbDocumentHistoryResult>> {
+    try {
+        const data = await kbAPI.getDocumentHistory(args.workId, args.docId, {
+            limit: args.limit,
+        });
+        return { success: true, data };
+    } catch (error) {
+        console.error('[kb-history] failed to fetch history:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to fetch history',
+        };
+    }
+}
+
+export async function restoreKbDocumentAction(args: {
+    workId: string;
+    docId: string;
+    path: string;
+    commitSha: string;
+}): Promise<ActionResult<KbDocumentBodyDto>> {
+    const { workId, docId, path, commitSha } = args;
+    try {
+        const data = await kbAPI.restoreDocument(workId, docId, commitSha);
+        revalidatePath(`/works/${workId}/kb`);
+        revalidatePath(`/works/${workId}/kb/${path}`);
+        return { success: true, data };
+    } catch (error) {
+        console.error('[kb-history] failed to restore document:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to restore document',
+        };
+    }
+}

--- a/apps/web/src/app/api/works/[id]/kb/documents/[docId]/history/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/documents/[docId]/history/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string; docId: string }> };
+
+/**
+ * EW-641 Phase 1B/d row 18c — KB document history proxy.
+ *
+ * Forwards `GET /api/works/:id/kb/documents/:docId/history?limit=N`
+ * to the upstream NestJS endpoint shipped in row 18a (PR #943). The
+ * upstream returns `{ items: KbDocumentCommitDto[] }`; the real
+ * git-log walk lands in row 18b — until then the upstream returns
+ * an empty list, which the dialog already handles via its empty state.
+ *
+ * Same JWT-cookie-forwarding shape as the row-14 lock proxy.
+ */
+export async function GET(request: NextRequest, { params }: RouteContext) {
+    const { id, docId } = await params;
+    const limit = request.nextUrl.searchParams.get('limit') ?? '';
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    const upstreamParams = new URLSearchParams();
+    if (limit && /^\d+$/.test(limit)) {
+        upstreamParams.set('limit', limit);
+    }
+    const query = upstreamParams.toString() ? `?${upstreamParams.toString()}` : '';
+
+    const upstream = await fetch(
+        `${API_URL}/works/${encodeURIComponent(id)}/kb/documents/${encodeURIComponent(docId)}/history${query}`,
+        {
+            method: 'GET',
+            headers,
+            cache: 'no-store',
+        },
+    );
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const json = await upstream.json().catch(() => null);
+    return NextResponse.json(json ?? { items: [] }, { status: 200 });
+}

--- a/apps/web/src/components/works/detail/kb/KbHistoryButton.tsx
+++ b/apps/web/src/components/works/detail/kb/KbHistoryButton.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { KbHistoryDialog } from './KbHistoryDialog';
+
+interface KbHistoryButtonProps {
+    workId: string;
+    docId: string;
+    path: string;
+}
+
+/**
+ * EW-641 Phase 1B/d row 18c — KB document history affordance.
+ *
+ * Replaces the disabled placeholder shipped in row 13 with a real
+ * trigger. Preserves the `kb-side-panel-history` test-id so the
+ * Playwright selectors locked in row 13 keep working without a
+ * markup shuffle.
+ */
+export function KbHistoryButton({ workId, docId, path }: KbHistoryButtonProps) {
+    const t = useTranslations('dashboard.workDetail.kb.sidePanel');
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <button
+                type="button"
+                data-testid="kb-side-panel-history"
+                data-disabled="false"
+                onClick={() => setOpen(true)}
+                className={cn(
+                    'inline-flex items-center gap-1 rounded border px-2 py-1 text-xs',
+                    'border-border dark:border-border-dark',
+                    'bg-card-hover/50 dark:bg-card-primary-dark/40',
+                    'text-text-secondary hover:bg-card-hover dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/60',
+                )}
+            >
+                {t('viewHistory')}
+            </button>
+            <KbHistoryDialog
+                workId={workId}
+                docId={docId}
+                path={path}
+                open={open}
+                onClose={() => setOpen(false)}
+            />
+        </>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbHistoryDialog.tsx
+++ b/apps/web/src/components/works/detail/kb/KbHistoryDialog.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useCallback, useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { formatDistanceToNow } from 'date-fns';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import {
+    getKbDocumentHistoryAction,
+    restoreKbDocumentAction,
+} from '@/app/actions/works/kb-history';
+import type { KbDocumentCommitDto } from '@ever-works/contracts';
+
+interface KbHistoryDialogProps {
+    workId: string;
+    docId: string;
+    /** Doc path used for `revalidatePath` after a successful restore. */
+    path: string;
+    open: boolean;
+    onClose: () => void;
+}
+
+type FetchState =
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'ready'; items: KbDocumentCommitDto[] }
+    | { status: 'error'; error: string };
+
+/**
+ * EW-641 Phase 1B/d row 18c — restore-from-history dialog.
+ *
+ * Renders a modal listing commits that touched the doc's `.md` body,
+ * newest first. Click → confirm → POST `/restore { commitSha }`.
+ *
+ * Loading + error + empty + ready states are all explicit. The
+ * "click → confirm" is a two-step interaction so the destructive
+ * action (overwriting the doc body) requires a deliberate second
+ * click rather than firing on a stray row select.
+ *
+ * Selectors locked for Playwright A12-A17:
+ *  - `kb-history-dialog` (root, `data-open=true`)
+ *  - `kb-history-empty` (when items.length === 0)
+ *  - `kb-history-loading` / `kb-history-error`
+ *  - `kb-history-row` (per commit, with `data-sha` + `data-active`)
+ *  - `kb-history-restore-confirm` (the confirmation button)
+ */
+export function KbHistoryDialog({ workId, docId, path, open, onClose }: KbHistoryDialogProps) {
+    const t = useTranslations('dashboard.workDetail.kb.history');
+    const router = useRouter();
+    const [state, setState] = useState<FetchState>({ status: 'idle' });
+    const [activeSha, setActiveSha] = useState<string | null>(null);
+    const [isRestoring, startRestore] = useTransition();
+    const [restoreError, setRestoreError] = useState<string | null>(null);
+
+    // Fetch on open; reset state on close.
+    useEffect(() => {
+        if (!open) {
+            setState({ status: 'idle' });
+            setActiveSha(null);
+            setRestoreError(null);
+            return;
+        }
+        let cancelled = false;
+        setState({ status: 'loading' });
+        void (async () => {
+            const result = await getKbDocumentHistoryAction({ workId, docId });
+            if (cancelled) return;
+            if (!result.success || !result.data) {
+                setState({
+                    status: 'error',
+                    error: result.error ?? 'Failed to load history',
+                });
+                return;
+            }
+            setState({ status: 'ready', items: result.data.items });
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [open, workId, docId]);
+
+    const onConfirmRestore = useCallback(() => {
+        if (!activeSha) return;
+        setRestoreError(null);
+        startRestore(async () => {
+            const result = await restoreKbDocumentAction({
+                workId,
+                docId,
+                path,
+                commitSha: activeSha,
+            });
+            if (!result.success) {
+                setRestoreError(result.error ?? 'Restore failed');
+                return;
+            }
+            router.refresh();
+            onClose();
+        });
+    }, [activeSha, workId, docId, path, router, onClose]);
+
+    if (!open) return null;
+
+    const formatRelative = (iso: string) => {
+        try {
+            return formatDistanceToNow(new Date(iso), { addSuffix: true });
+        } catch {
+            return iso;
+        }
+    };
+
+    return (
+        <div
+            data-testid="kb-history-dialog"
+            data-open="true"
+            role="dialog"
+            aria-modal="true"
+            aria-label={t('dialogLabel')}
+            className={cn(
+                'fixed inset-0 z-50 flex items-start justify-center',
+                'bg-black/40 px-4 pt-[12vh]',
+            )}
+            onClick={(event) => {
+                if (event.target === event.currentTarget) onClose();
+            }}
+        >
+            <div
+                className={cn(
+                    'w-full max-w-xl rounded-lg border shadow-2xl',
+                    'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                    'flex flex-col gap-2 p-4',
+                )}
+            >
+                <header className="flex items-center justify-between">
+                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('title')}
+                    </h2>
+                    <button
+                        type="button"
+                        data-testid="kb-history-close"
+                        onClick={onClose}
+                        aria-label={t('close')}
+                        className="rounded p-1 text-text-muted hover:bg-card-hover dark:text-text-muted-dark/70 dark:hover:bg-card-primary-dark/40"
+                    >
+                        ✕
+                    </button>
+                </header>
+
+                <div className="max-h-[60vh] overflow-y-auto">
+                    {state.status === 'loading' ? (
+                        <p
+                            data-testid="kb-history-loading"
+                            className="px-3 py-6 text-center text-xs text-text-muted dark:text-text-muted-dark/70"
+                        >
+                            {t('loading')}
+                        </p>
+                    ) : null}
+                    {state.status === 'error' ? (
+                        <p
+                            data-testid="kb-history-error"
+                            className="px-3 py-6 text-center text-xs text-red-600 dark:text-red-400"
+                        >
+                            {t('error', { error: state.error })}
+                        </p>
+                    ) : null}
+                    {state.status === 'ready' && state.items.length === 0 ? (
+                        <p
+                            data-testid="kb-history-empty"
+                            className="px-3 py-6 text-center text-xs text-text-muted dark:text-text-muted-dark/70"
+                        >
+                            {t('empty')}
+                        </p>
+                    ) : null}
+                    {state.status === 'ready' && state.items.length > 0 ? (
+                        <ul role="listbox" aria-label={t('dialogLabel')} className="flex flex-col">
+                            {state.items.map((commit) => {
+                                const isActive = commit.sha === activeSha;
+                                const shortSha = commit.sha.slice(0, 7);
+                                return (
+                                    <li key={commit.sha}>
+                                        <button
+                                            type="button"
+                                            data-testid="kb-history-row"
+                                            data-sha={commit.sha}
+                                            data-active={isActive ? 'true' : 'false'}
+                                            role="option"
+                                            aria-selected={isActive}
+                                            onClick={() => setActiveSha(commit.sha)}
+                                            className={cn(
+                                                'flex w-full flex-col items-start gap-1 rounded px-3 py-2 text-left text-sm',
+                                                isActive
+                                                    ? 'bg-primary/10 text-primary dark:bg-primary/20'
+                                                    : 'text-text-secondary hover:bg-card-hover dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40',
+                                            )}
+                                        >
+                                            <div className="flex w-full items-center gap-2">
+                                                <span className="font-mono text-[11px] text-text-muted dark:text-text-muted-dark/60">
+                                                    {shortSha}
+                                                </span>
+                                                <span className="grow truncate">
+                                                    {commit.message}
+                                                </span>
+                                            </div>
+                                            <div className="flex items-center gap-2 text-[11px] text-text-muted dark:text-text-muted-dark/60">
+                                                <span>{commit.authorName}</span>
+                                                <span>·</span>
+                                                <span>{formatRelative(commit.authoredAt)}</span>
+                                            </div>
+                                        </button>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    ) : null}
+                </div>
+
+                {state.status === 'ready' && state.items.length > 0 ? (
+                    <footer className="flex items-center justify-end gap-2 border-t border-border pt-2 dark:border-border-dark">
+                        {restoreError ? (
+                            <p
+                                data-testid="kb-history-restore-error"
+                                className="grow text-xs text-red-600 dark:text-red-400"
+                            >
+                                {restoreError}
+                            </p>
+                        ) : null}
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            onClick={onClose}
+                            disabled={isRestoring}
+                        >
+                            {t('cancel')}
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            data-testid="kb-history-restore-confirm"
+                            disabled={activeSha === null || isRestoring}
+                            aria-busy={isRestoring ? 'true' : undefined}
+                            onClick={onConfirmRestore}
+                        >
+                            {isRestoring
+                                ? t('restoring')
+                                : t('restore', {
+                                      sha: activeSha ? activeSha.slice(0, 7) : '',
+                                  })}
+                        </Button>
+                    </footer>
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbHistoryDialog.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbHistoryDialog.unit.spec.tsx
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+const routerRefreshMock = vi.fn();
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ refresh: routerRefreshMock }),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        ...rest
+    }: {
+        children: ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+    } & Record<string, unknown>) => (
+        <button type="button" onClick={onClick} disabled={disabled} {...rest}>
+            {children}
+        </button>
+    ),
+}));
+
+// date-fns is fine to keep — it's deterministic given a fixed reference
+// date, but the spec doesn't care about the formatted output, only
+// that the commit's `authoredAt` is rendered somewhere in the row.
+
+const getActionMock = vi.fn();
+const restoreActionMock = vi.fn();
+vi.mock('@/app/actions/works/kb-history', () => ({
+    getKbDocumentHistoryAction: (...args: unknown[]) => getActionMock(...args),
+    restoreKbDocumentAction: (...args: unknown[]) => restoreActionMock(...args),
+}));
+
+import { KbHistoryDialog } from './KbHistoryDialog';
+
+const sampleCommits = [
+    {
+        sha: 'abc1234567890abcdef',
+        message: 'Edit brand voice intro',
+        authorName: 'Ada Lovelace',
+        authoredAt: '2026-05-20T10:00:00Z',
+    },
+    {
+        sha: 'def5678901234567890',
+        message: 'Fix typo',
+        authorName: 'Grace Hopper',
+        authoredAt: '2026-05-19T08:30:00Z',
+    },
+];
+
+/**
+ * EW-641 Phase 1B/d row 18c — restore-from-history dialog tests.
+ *
+ * Pins:
+ *  - dialog doesn't render when `open=false`
+ *  - on open: fetches history via the server action
+ *  - empty state when items.length === 0
+ *  - error state when the action returns `success: false`
+ *  - row click highlights the row + enables the confirm button
+ *  - confirm click POSTs to restoreKbDocumentAction with the right
+ *    args + closes the dialog on success
+ *  - escape via the close button calls onClose
+ */
+describe('KbHistoryDialog', () => {
+    beforeEach(() => {
+        getActionMock.mockReset();
+        restoreActionMock.mockReset();
+        routerRefreshMock.mockReset();
+    });
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders nothing when open=false', () => {
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open={false}
+                onClose={() => undefined}
+            />,
+        );
+        expect(screen.queryByTestId('kb-history-dialog')).toBeNull();
+        expect(getActionMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches on open and renders the loading state then the rows', async () => {
+        getActionMock.mockResolvedValueOnce({ success: true, data: { items: sampleCommits } });
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={() => undefined}
+            />,
+        );
+        // Loading state appears synchronously after mount.
+        expect(screen.getByTestId('kb-history-loading')).toBeTruthy();
+        await waitFor(() => {
+            expect(screen.queryByTestId('kb-history-loading')).toBeNull();
+        });
+        expect(getActionMock).toHaveBeenCalledWith({ workId: 'work-1', docId: 'doc-1' });
+        const rows = screen.getAllByTestId('kb-history-row');
+        expect(rows.length).toBe(2);
+        expect(rows[0].getAttribute('data-sha')).toBe('abc1234567890abcdef');
+        expect(rows[0].getAttribute('data-active')).toBe('false');
+        expect(rows[0].textContent).toContain('abc1234'); // short sha
+        expect(rows[0].textContent).toContain('Edit brand voice intro');
+        expect(rows[0].textContent).toContain('Ada Lovelace');
+    });
+
+    it('renders the empty state when items.length === 0', async () => {
+        getActionMock.mockResolvedValueOnce({ success: true, data: { items: [] } });
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={() => undefined}
+            />,
+        );
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-history-empty')).toBeTruthy();
+        });
+        // Restore footer shouldn't render when there are no commits.
+        expect(screen.queryByTestId('kb-history-restore-confirm')).toBeNull();
+    });
+
+    it('renders the error state when the action returns success:false', async () => {
+        getActionMock.mockResolvedValueOnce({ success: false, error: 'upstream 503' });
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={() => undefined}
+            />,
+        );
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-history-error').textContent).toContain('upstream 503');
+        });
+    });
+
+    it('clicking a row highlights it + enables the confirm button', async () => {
+        getActionMock.mockResolvedValueOnce({ success: true, data: { items: sampleCommits } });
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={() => undefined}
+            />,
+        );
+        await waitFor(() => expect(screen.getAllByTestId('kb-history-row').length).toBe(2));
+
+        const confirm = screen.getByTestId('kb-history-restore-confirm') as HTMLButtonElement;
+        expect(confirm.disabled).toBe(true);
+
+        fireEvent.click(screen.getAllByTestId('kb-history-row')[1]);
+        expect(screen.getAllByTestId('kb-history-row')[1].getAttribute('data-active')).toBe('true');
+        expect(confirm.disabled).toBe(false);
+    });
+
+    it('confirm posts to restoreKbDocumentAction and closes the dialog on success', async () => {
+        getActionMock.mockResolvedValueOnce({ success: true, data: { items: sampleCommits } });
+        restoreActionMock.mockResolvedValueOnce({ success: true, data: {} });
+        const onClose = vi.fn();
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={onClose}
+            />,
+        );
+        await waitFor(() => expect(screen.getAllByTestId('kb-history-row').length).toBe(2));
+        fireEvent.click(screen.getAllByTestId('kb-history-row')[0]);
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kb-history-restore-confirm'));
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        expect(restoreActionMock).toHaveBeenCalledWith({
+            workId: 'work-1',
+            docId: 'doc-1',
+            path: 'brand/voice.md',
+            commitSha: 'abc1234567890abcdef',
+        });
+        await waitFor(() => {
+            expect(routerRefreshMock).toHaveBeenCalled();
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+
+    it('surfaces the restore error and keeps the dialog open', async () => {
+        getActionMock.mockResolvedValueOnce({ success: true, data: { items: sampleCommits } });
+        restoreActionMock.mockResolvedValueOnce({ success: false, error: 'forbidden' });
+        const onClose = vi.fn();
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={onClose}
+            />,
+        );
+        await waitFor(() => expect(screen.getAllByTestId('kb-history-row').length).toBe(2));
+        fireEvent.click(screen.getAllByTestId('kb-history-row')[0]);
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kb-history-restore-confirm'));
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-history-restore-error').textContent).toContain(
+                'forbidden',
+            );
+        });
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('closes via the close button', () => {
+        getActionMock.mockResolvedValueOnce({ success: true, data: { items: [] } });
+        const onClose = vi.fn();
+        render(
+            <KbHistoryDialog
+                workId="work-1"
+                docId="doc-1"
+                path="brand/voice.md"
+                open
+                onClose={onClose}
+            />,
+        );
+        fireEvent.click(screen.getByTestId('kb-history-close'));
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/works/detail/kb/KbSidePanel.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSidePanel.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 import { cn } from '@/lib/utils/cn';
+import { KbHistoryButton } from './KbHistoryButton';
 import { KbLockControls } from './KbLockControls';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
 
@@ -186,23 +187,30 @@ export async function KbSidePanel({ doc }: KbSidePanelProps) {
             ) : null}
 
             <Section title={t('sidePanel.sections.history')}>
-                <button
-                    type="button"
-                    data-testid="kb-side-panel-history"
-                    data-disabled="true"
-                    disabled
-                    aria-disabled="true"
-                    title={t('sidePanel.historyComingSoon')}
-                    className={cn(
-                        'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
-                        'border border-border dark:border-border-dark',
-                        'bg-card-hover/50 dark:bg-card-primary-dark/40',
-                        'text-text-muted dark:text-text-muted-dark/70',
-                        'cursor-not-allowed opacity-70',
-                    )}
-                >
-                    {t('sidePanel.viewHistory')}
-                </button>
+                {doc.workId ? (
+                    <KbHistoryButton workId={doc.workId} docId={doc.id} path={doc.path} />
+                ) : (
+                    // Org-level docs don't have a per-Work git mirror;
+                    // keep the disabled placeholder for them until row
+                    // 18d wires the org-namespace history endpoint.
+                    <button
+                        type="button"
+                        data-testid="kb-side-panel-history"
+                        data-disabled="true"
+                        disabled
+                        aria-disabled="true"
+                        title={t('sidePanel.historyComingSoon')}
+                        className={cn(
+                            'inline-flex items-center gap-1 rounded border px-2 py-1 text-xs',
+                            'border-border dark:border-border-dark',
+                            'bg-card-hover/50 dark:bg-card-primary-dark/40',
+                            'text-text-muted dark:text-text-muted-dark/70',
+                            'cursor-not-allowed opacity-70',
+                        )}
+                    >
+                        {t('sidePanel.viewHistory')}
+                    </button>
+                )}
             </Section>
         </aside>
     );

--- a/apps/web/src/components/works/detail/kb/KbSidePanel.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSidePanel.unit.spec.tsx
@@ -42,6 +42,10 @@ vi.mock('@/app/actions/works/kb-lock', () => ({
     lockKbDocumentAction: vi.fn(),
     unlockKbDocumentAction: vi.fn(),
 }));
+vi.mock('@/app/actions/works/kb-history', () => ({
+    getKbDocumentHistoryAction: vi.fn(),
+    restoreKbDocumentAction: vi.fn(),
+}));
 
 import { KbSidePanel } from './KbSidePanel';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
@@ -207,8 +211,23 @@ describe('KbSidePanel', () => {
         expect(counts.textContent).toContain('sidePanel.wordCount count=100');
     });
 
-    it('renders the disabled "view history" placeholder button (row 18 will wire it)', async () => {
-        render(await KbSidePanel({ doc: doc() }));
+    it('renders the enabled "view history" button when doc.workId is set (row 18c)', async () => {
+        render(await KbSidePanel({ doc: doc({ workId: 'work-1' }) }));
+        const btn = screen.getByTestId('kb-side-panel-history') as HTMLButtonElement;
+        expect(btn.tagName).toBe('BUTTON');
+        expect(btn.disabled).toBe(false);
+        expect(btn.getAttribute('data-disabled')).toBe('false');
+        // KbHistoryButton scopes useTranslations to
+        // `dashboard.workDetail.kb.sidePanel`, so the key passed to the
+        // i18n mock is bare `viewHistory` (not the dotted form). The
+        // org-level placeholder above scopes to `dashboard.workDetail.kb`,
+        // so its key includes the `sidePanel.` prefix — same string in
+        // production but the mock surfaces the difference.
+        expect(btn.textContent).toBe('viewHistory');
+    });
+
+    it('falls back to the disabled placeholder for org-level docs (workId === null)', async () => {
+        render(await KbSidePanel({ doc: doc({ workId: null }) }));
         const btn = screen.getByTestId('kb-side-panel-history') as HTMLButtonElement;
         expect(btn.tagName).toBe('BUTTON');
         expect(btn.disabled).toBe(true);

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -3,6 +3,7 @@ import { serverFetch, serverMutation } from './server-api';
 import type {
     KbDocumentBodyDto,
     KbDocumentDto,
+    KbDocumentHistoryResult,
     KbDocumentListFilter,
     KbLockMode,
     UpdateKbDocumentInput,
@@ -109,6 +110,46 @@ export const kbAPI = {
         return serverMutation<KbDocumentDto>({
             endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/unlock`,
             data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * `GET /api/works/:id/kb/documents/:docId/history?limit=N` — list
+     * Git commits that touched the doc's sidecar `.md`. Returns
+     * `{ items: KbDocumentCommitDto[] }`. Backend (row 18a, PR #943)
+     * stubs to `[]` until row 18b lands the real git-log walk; the
+     * dialog handles the empty case via its own empty-state copy.
+     */
+    getDocumentHistory: async (
+        workId: string,
+        docId: string,
+        opts: { limit?: number } = {},
+    ): Promise<KbDocumentHistoryResult> => {
+        const params = new URLSearchParams();
+        if (typeof opts.limit === 'number') params.set('limit', String(opts.limit));
+        const query = params.toString() ? `?${params.toString()}` : '';
+        return serverFetch<KbDocumentHistoryResult>(
+            `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/history${query}`,
+        );
+    },
+
+    /**
+     * `POST /api/works/:id/kb/documents/:docId/restore` — restore the
+     * doc body to the supplied commit SHA. Already wired in Phase 1A
+     * (controller endpoint exists since `restoreDocumentFromHistory`
+     * landed with the original mirror service); row 18c just exposes
+     * it via the same `kbAPI` surface the dialog uses.
+     */
+    restoreDocument: async (
+        workId: string,
+        docId: string,
+        commitSha: string,
+    ): Promise<KbDocumentBodyDto> => {
+        return serverMutation<KbDocumentBodyDto>({
+            endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/restore`,
+            data: { commitSha },
             method: 'POST',
             wrapInData: false,
         });


### PR DESCRIPTION
## Summary

Lights up the **placeholder button shipped in row 13**. Operators click "View Git history" in `KbSidePanel`, get a modal listing prior commits, pick one, confirm, and the doc body is restored via the existing `/restore` endpoint (Phase 1A).

The stub backend (row 18a, PR #943) returns `[]` until row 18b lands the real git-log walk — the dialog's **empty state** handles that gracefully, so this PR is fully functional even before 18b.

### Architecture

- Next.js proxy at `apps/web/.../kb/documents/[docId]/history/route.ts` forwarding `?limit=N` + JWT cookie.
- `kbAPI.getDocumentHistory` + `kbAPI.restoreDocument` server-only helpers.
- Server actions `getKbDocumentHistoryAction` + `restoreKbDocumentAction` (same envelope as rows 5 + 14; restore revalidates KB index + doc route).
- `KbHistoryDialog.tsx` — explicit loading / error / empty / ready states, two-step click-then-confirm UX so the destructive restore needs a deliberate second click. `date-fns` `formatDistanceToNow` for relative timestamps.
- `KbHistoryButton.tsx` — client wrapper rendering the trigger button + managing dialog open state. `KbSidePanel` swaps the disabled placeholder for `<KbHistoryButton>` when `doc.workId` is set, falls back to the placeholder for org-level docs.

### Selectors locked for Playwright A12-A17

- `kb-side-panel-history` (preserved from row 13 — now enabled for per-Work docs)
- `kb-history-dialog` (`data-open=true`)
- `kb-history-loading` / `kb-history-error` / `kb-history-empty`
- `kb-history-row` (per commit, `data-sha` + `data-active`)
- `kb-history-close` / `kb-history-restore-confirm` / `kb-history-restore-error`

## Test plan

- [x] `pnpm exec vitest run KbHistoryDialog.unit.spec.tsx` — **8/8 green**
- [x] `KbSidePanel.unit.spec.tsx` — split into "workId set → enabled" + "workId null → disabled placeholder" cases
- [x] Full KB suite — **177/177 green**
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview
- [ ] `lint-and-test (22.x)`

### Row 18 status after this PR

- **18a** (PR #943) done ✓
- **18b** (real git-log walk in mirror service) — still carved, blocking nothing the user sees
- **18c** (this PR) done ✓ → row 18 is **operator-visible complete**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document history viewing for Knowledge Base documents, allowing users to access previous versions.
  * Enabled document restoration functionality, letting users restore Knowledge Base documents to earlier commit versions.
  * Multi-language support added for all history-related UI elements across 21 locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->