### PR TITLE
feat(kb): real git-log walk for history dialog (EW-641 Phase 1B/d row 18b)

### DIFF
--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -548,6 +548,26 @@ export class GitFacadeService implements IGitFacade {
         return null;
     }
 
+    /**
+     * EW-641 Phase 1B/d row 18b — list commits touching `path`, newest
+     * first. Optional capability; providers that don't implement it
+     * (the contract's `listFileCommits?` is `?`-marked) return `[]`
+     * here so the KB history dialog renders its empty state gracefully.
+     */
+    async listFileCommits(
+        owner: string,
+        repo: string,
+        path: string,
+        options: GitFacadeOptions,
+        limit?: number,
+    ): Promise<GitCommit[]> {
+        const { plugin, token } = await this.resolvePluginAndToken(options);
+        if (plugin.listFileCommits) {
+            return plugin.listFileCommits(owner, repo, path, token, limit);
+        }
+        return [];
+    }
+
     async getReadme(
         owner: string,
         repo: string,

--- a/packages/agent/src/services/__tests__/knowledge-base-git-mirror.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base-git-mirror.service.spec.ts
@@ -85,6 +85,7 @@ describe('KnowledgeBaseGitMirrorService', () => {
             commit: jest.fn().mockResolvedValue(COMMIT_SHA),
             push: jest.fn().mockResolvedValue(undefined),
             getFileContent: jest.fn(),
+            listFileCommits: jest.fn().mockResolvedValue([]),
         };
 
         workRepository = {
@@ -378,6 +379,82 @@ describe('KnowledgeBaseGitMirrorService', () => {
 
             expect(result.restored).toBe(false);
             expect(documentRepository.update).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listDocumentHistory', () => {
+        it('fans out to gitFacade.listFileCommits with the resolved KB path', async () => {
+            const commits = [
+                {
+                    sha: 'abc1234',
+                    message: 'Edit brand voice',
+                    author: { name: 'Ada', email: 'ada@example.test' },
+                    date: '2026-05-20T10:00:00Z',
+                },
+                {
+                    sha: 'def5678',
+                    message: 'Initial brand seed',
+                    author: { name: 'Grace', email: 'grace@example.test' },
+                    date: '2026-05-19T08:30:00Z',
+                },
+            ];
+            gitFacade.listFileCommits.mockResolvedValueOnce(commits);
+
+            const result = await service.listDocumentHistory(WORK_ID, DOC_ID, 25);
+
+            // The path the facade gets is `.content/kb/` joined with the
+            // doc's relative path, scoping the log to just this doc's body.
+            expect(gitFacade.listFileCommits).toHaveBeenCalledWith(
+                'ever-works',
+                'demo-data',
+                '.content/kb/brand/voice.md',
+                expect.objectContaining({
+                    providerId: 'github',
+                    userId: USER_ID,
+                    workId: WORK_ID,
+                }),
+                25,
+            );
+            expect(result).toEqual([
+                {
+                    sha: 'abc1234',
+                    message: 'Edit brand voice',
+                    authorName: 'Ada',
+                    authoredAt: '2026-05-20T10:00:00Z',
+                },
+                {
+                    sha: 'def5678',
+                    message: 'Initial brand seed',
+                    authorName: 'Grace',
+                    authoredAt: '2026-05-19T08:30:00Z',
+                },
+            ]);
+        });
+
+        it('returns [] when the plugin returns nothing (capability not implemented)', async () => {
+            gitFacade.listFileCommits.mockResolvedValueOnce([]);
+            const result = await service.listDocumentHistory(WORK_ID, DOC_ID, 10);
+            expect(result).toEqual([]);
+        });
+
+        it('handles a missing author.name gracefully', async () => {
+            gitFacade.listFileCommits.mockResolvedValueOnce([
+                {
+                    sha: 'abc1234',
+                    message: 'Bot commit',
+                    author: { name: undefined, email: '' },
+                    date: '2026-05-20T10:00:00Z',
+                },
+            ]);
+            const result = await service.listDocumentHistory(WORK_ID, DOC_ID, 10);
+            expect(result[0].authorName).toBe('');
+        });
+
+        it('throws NotFoundException when the document does not exist', async () => {
+            documentRepository.findById.mockResolvedValueOnce(null);
+            await expect(service.listDocumentHistory(WORK_ID, DOC_ID, 25)).rejects.toThrow(
+                'KB document not found for history',
+            );
         });
     });
 

--- a/packages/agent/src/services/knowledge-base-git-mirror.service.ts
+++ b/packages/agent/src/services/knowledge-base-git-mirror.service.ts
@@ -268,29 +268,60 @@ export class KnowledgeBaseGitMirrorService {
     }
 
     /**
-     * EW-641 Phase 1B/d row 18 — list commits that touched a KB
-     * document's sidecar `.md` file.
+     * EW-641 Phase 1B/d row 18b — list commits that touched a KB
+     * document's sidecar `.md` file, newest first.
      *
-     * **Stub today (row 18a)**: returns `[]`. Row 18b lands the real
-     * git-log walk — likely via a new optional `listFileCommits`
-     * capability on the git-provider plugin contract (GitHub's
-     * `octokit.rest.repos.listCommits({ path })` is the natural impl)
-     * or, failing that, isomorphic-git's `git.log({ filepath })` over
-     * the local clone. Whichever path lands, the return shape is
-     * locked here so the controller + frontend don't have to budge.
-     *
-     * The doc's `path` is the relative key under `.content/kb/`. We
-     * resolve it the same way `restoreDocumentFromGit` does, then
-     * compose `${KB_ROOT}/${doc.path}` to scope the log query.
+     * Resolves the doc the same way `restoreDocumentFromGit` does
+     * (DB row → Work → repo owner/name + relative KB path), then fans
+     * out to the Git provider plugin's optional `listFileCommits`
+     * capability via the facade. Providers that don't implement the
+     * capability surface as `[]` — the KB history dialog already
+     * renders an empty state for that case (row 18c).
      */
     async listDocumentHistory(
-        _workId: string,
-        _documentId: string,
-        _limit: number,
+        workId: string,
+        documentId: string,
+        limit: number,
     ): Promise<
         ReadonlyArray<{ sha: string; message: string; authorName: string; authoredAt: string }>
     > {
-        return [];
+        const doc = await this.documentRepository.findById(workId, documentId);
+        if (!doc) {
+            throw new NotFoundException(`KB document not found for history: ${documentId}`);
+        }
+
+        const work = await this.workRepository.findById(workId);
+        if (!work) {
+            throw new NotFoundException(`Work not found for history: ${workId}`);
+        }
+
+        const workOwner = work.user as User | undefined;
+        if (!workOwner?.id) {
+            return [];
+        }
+
+        const owner = work.getRepoOwner('data');
+        const repo = work.getDataRepo();
+        const relPath = path.posix.join(KnowledgeBaseGitMirrorService.KB_ROOT, doc.path);
+
+        const commits = await this.gitFacade.listFileCommits(
+            owner,
+            repo,
+            relPath,
+            {
+                providerId: work.gitProvider,
+                userId: workOwner.id,
+                workId: work.id,
+            },
+            limit,
+        );
+
+        return commits.map((commit) => ({
+            sha: commit.sha,
+            message: commit.message,
+            authorName: commit.author?.name ?? '',
+            authoredAt: commit.date,
+        }));
     }
 
     // ─── INTERNAL ─────────────────────────────────────────────────────────────

--- a/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/git-provider.interface.ts
@@ -325,6 +325,19 @@ export interface IGitProviderPlugin extends IPlugin, IGitOperations {
 		ref?: string,
 		token?: string
 	): Promise<{ content: string; encoding: string } | null>;
+
+	/**
+	 * EW-641 Phase 1B/d row 18b — list commits that touched the given
+	 * file path, newest first. Powers the KB "View Git history" dialog
+	 * (`KnowledgeBaseService.getDocumentHistory` →
+	 * `KnowledgeBaseGitMirrorService.listDocumentHistory` → here).
+	 *
+	 * Optional — providers that don't implement it surface as
+	 * `{ items: [] }` to the dialog, which already handles the empty
+	 * state. Default `limit` is 25; implementations should cap at 100.
+	 */
+	listFileCommits?(owner: string, repo: string, path: string, token: string, limit?: number): Promise<GitCommit[]>;
+
 	getReadme?(
 		owner: string,
 		repo: string,

--- a/packages/plugins/github/src/github-api.service.ts
+++ b/packages/plugins/github/src/github-api.service.ts
@@ -770,6 +770,53 @@ export class GitHubApiService {
 		}
 	}
 
+	/**
+	 * EW-641 Phase 1B/d row 18b — list commits touching `path` via
+	 * `GET /repos/{owner}/{repo}/commits?path=…`. Newest first, capped
+	 * to `[1, 100]` (the GitHub `per_page` limit).
+	 */
+	async listFileCommits(
+		owner: string,
+		repo: string,
+		path: string,
+		token: string,
+		limit?: number,
+		baseUrl?: string
+	): Promise<GitCommit[]> {
+		const octokit = this.createOctokit(token, baseUrl);
+		const perPage = typeof limit === 'number' ? Math.min(Math.max(Math.floor(limit), 1), 100) : 25;
+
+		try {
+			const { data } = await octokit.rest.repos.listCommits({
+				owner,
+				repo,
+				path,
+				per_page: perPage
+			});
+
+			// Some commits are signed by GitHub Actions / bots where the
+			// `commit.author.name` field is set but `data.author` (the
+			// repo-user record) is null — fall back to the commit-level
+			// author so the dialog still shows a meaningful display name.
+			return data.map(
+				(row): GitCommit => ({
+					sha: row.sha,
+					message: row.commit.message,
+					author: {
+						name: row.commit.author?.name ?? row.author?.login ?? '',
+						email: row.commit.author?.email ?? ''
+					},
+					date: row.commit.author?.date ?? row.commit.committer?.date ?? ''
+				})
+			);
+		} catch (err) {
+			if (err instanceof RequestError && err.status === 404) {
+				return [];
+			}
+			throw err;
+		}
+	}
+
 	async getReadme(
 		owner: string,
 		repo: string,

--- a/packages/plugins/github/src/github.plugin.ts
+++ b/packages/plugins/github/src/github.plugin.ts
@@ -400,6 +400,17 @@ export class GitHubPlugin implements IPlugin, IGitProviderPlugin, IOAuthPlugin {
 		return this.apiService.getFileContent(owner, repo, path, token || '', ref, settings.apiBaseUrl);
 	}
 
+	async listFileCommits(
+		owner: string,
+		repo: string,
+		path: string,
+		token: string,
+		limit?: number
+	): Promise<GitCommit[]> {
+		const settings = await this.getSettings();
+		return this.apiService.listFileCommits(owner, repo, path, token, limit, settings.apiBaseUrl);
+	}
+
 	async getReadme(
 		owner: string,
 		repo: string,


### PR DESCRIPTION
## Summary

Replaces the row-18a stub (`KnowledgeBaseGitMirrorService.listDocumentHistory → []`) with a real per-file commit log. Operators clicking "View Git history" in `KbSidePanel` (PR #944) now see actual commits from GitHub instead of the empty state.

### Plugin contract

- New optional `listFileCommits(owner, repo, path, token, limit?): Promise<GitCommit[]>` on `IGitProviderPlugin`, alongside the existing `getFileContent?`.
- Optional + same shape so providers that don't implement it surface as `[]` (the dialog already handles that case from row 18c).

### GitHub plugin

- Thin pass-through to `GitHubApiService.listFileCommits` using `octokit.rest.repos.listCommits({ owner, repo, path, per_page })`.
- `per_page` clamped to `[1, 100]` (GitHub's hard cap).
- Falls back to `commit.author.name` then `author.login` so bot-authored commits still surface a meaningful display name. 404 → `[]`.

### GitFacade

- New `listFileCommits(owner, repo, path, options, limit?)` wrapper mirroring `getFileContent`. Returns `[]` when the resolved plugin doesn't implement the capability.

### KbGitMirrorService

- Replaces the stub. Resolves doc → Work → repo owner/name + relative path (`KB_ROOT + doc.path`), fans out via the facade, maps `GitCommit → { sha, message, authorName, authoredAt }` for the contract shape.

## Test plan

- [x] `pnpm --filter @ever-works/agent test -- knowledge-base-git-mirror.service` — **24/24 green** (4 new history cases)
- [x] `pnpm --filter @ever-works/agent test -- knowledge-base.service` — **26/26 green** (row-18a getDocumentHistory tests still pass)
- [x] `pnpm --filter @ever-works/contracts build` clean
- [x] `pnpm --filter @ever-works/plugin build` clean
- [x] `pnpm --filter @ever-works/agent build` clean
- [x] `pnpm --filter @ever-works/github-plugin build` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] Vercel preview
- [ ] `lint-and-test (22.x)`

### Row 18 status after this PR

- 18a (PR #943) — endpoint scaffold ✓
- 18b (this PR) — real git-log ✓
- 18c (PR #944) — frontend dialog ✓

**Row 18 closed.** History dialog is now end-to-end functional against a real GitHub backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge base document history feature is now fully functional, enabling users to view complete commit history for tracked documents including messages, author information, and timestamps from connected git repositories.
  * Added support for retrieving file-level commit history from git providers.

* **Tests**
  * Added comprehensive test coverage for document history retrieval and transformation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->