### PR TITLE
chore(e2e): bootstrap apps/web-e2e Playwright harness (EW-641 Phase 1B/d row 19a)

### DIFF
--- a/apps/web-e2e/.gitignore
+++ b/apps/web-e2e/.gitignore
@@ -1,0 +1,9 @@
+# Playwright artifacts — never check in.
+playwright-report/
+test-results/
+.cache/
+blob-report/
+
+# Local-only Playwright config overrides.
+.env
+.env.local

--- a/apps/web-e2e/README.md
+++ b/apps/web-e2e/README.md
@@ -1,0 +1,77 @@
+# `@ever-works/web-e2e` — Playwright acceptance suite
+
+End-to-end tests for `apps/web`. Bootstrapped in **EW-641 Phase 1B/d row
+19a** as the harness for the KB acceptance suite (A12-A17, rows 19-24
+of the KB Phase 1B/d handoff).
+
+## Layout
+
+```
+apps/web-e2e/
+├── package.json          # @ever-works/web-e2e (private)
+├── playwright.config.ts  # chromium-only, env-driven baseURL
+├── tsconfig.json
+└── tests/
+    └── smoke.spec.ts     # harness sanity check (no app required)
+```
+
+## Running locally
+
+```bash
+# 1. From the repo root, install workspaces (Playwright lands as a dev dep)
+pnpm install
+
+# 2. One-time: download the Chromium binary (~200 MB, cached under
+#    ~/.cache/ms-playwright). Not run by `pnpm install` because the
+#    binary is large and most contributors don't need it.
+pnpm --filter @ever-works/web-e2e exec playwright install chromium
+
+# 3. Start the platform (separate terminal):
+pnpm dev              # web on :3000 + api on :3100
+
+# 4. Run tests:
+pnpm --filter @ever-works/web-e2e test
+# or:
+cd apps/web-e2e && pnpm test
+```
+
+### Pointing at a different deployment
+
+```bash
+PLAYWRIGHT_BASE_URL=https://kb-preview.vercel.app pnpm --filter @ever-works/web-e2e test
+```
+
+### UI mode for debugging
+
+```bash
+pnpm --filter @ever-works/web-e2e exec playwright test --ui
+```
+
+### Viewing the last HTML report
+
+```bash
+pnpm --filter @ever-works/web-e2e test:report
+```
+
+## Writing tests
+
+- One spec per acceptance row (A12 → `kb-upload.spec.ts`, A13 → `kb-autosave.spec.ts`, etc).
+- Use the stable `data-testid` selectors locked by the implementation
+  PRs (search the codebase for `data-testid="kb-…"` for the canonical
+  list). Avoid hard-coding visible text — translations would break it.
+- Auth fixtures and shared setup live in `tests/_fixtures/`. Add as
+  needed; don't repeat login flows per test.
+
+## CI
+
+This package is **not yet wired into `.github/workflows/ci.yml`**. The
+acceptance suite runs in its own opt-in workflow once row 19b lands
+(spins up Postgres + the API + the web server, runs `playwright test`,
+uploads the report as an artifact). Until then, run locally before
+shipping KB UI changes that affect user-visible flows.
+
+## Versioning
+
+`@playwright/test` is pinned in `package.json`. Bumping it requires a
+sweep of `tests/` because the assertion + locator APIs have changed
+between recent majors.

--- a/apps/web-e2e/package.json
+++ b/apps/web-e2e/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@ever-works/web-e2e",
+	"version": "0.1.0",
+	"private": true,
+	"description": "End-to-end Playwright acceptance suite for apps/web. Bootstrapped in EW-641 Phase 1B/d row 19a; KB acceptance tests A12-A17 land in rows 19-24.",
+	"license": "MIT",
+	"scripts": {
+		"test": "playwright test",
+		"test:smoke": "playwright test smoke.spec.ts",
+		"test:install": "playwright install --with-deps chromium",
+		"test:ui": "playwright test --ui",
+		"test:report": "playwright show-report"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.50.0",
+		"@types/node": "^22.10.0",
+		"typescript": "^5.9.3"
+	}
+}

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * EW-641 Phase 1B/d row 19a — Playwright config for the web e2e
+ * acceptance suite (`apps/web-e2e`).
+ *
+ * Lean by design at the bootstrap stage:
+ *  - Single browser project (`chromium`) until the KB suite (A12-A17)
+ *    is stable. Cross-browser coverage is a v2 concern.
+ *  - `baseURL` is env-driven (`PLAYWRIGHT_BASE_URL`) so the same suite
+ *    runs against `pnpm dev` locally (`http://localhost:3000`) and a
+ *    preview deployment in CI (`https://<branch>.vercel.app`).
+ *  - No `webServer` block — the operator is responsible for starting
+ *    `pnpm dev` (or the CI runner spins up the platform); the test
+ *    runner doesn't fork node processes. Less moving parts at this
+ *    stage; row 19b adds an opt-in `webServer` once the suite needs
+ *    deterministic startup.
+ *  - Retries match the standard pattern (2 in CI, 0 locally) so flake
+ *    in shared infra doesn't gate the merge.
+ */
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+
+export default defineConfig({
+	testDir: './tests',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+
+	use: {
+		baseURL,
+		// Capture a trace + screenshot the first time a flake retries, so
+		// CI artifacts have something to look at without paying the
+		// overhead on every run.
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure'
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+	]
+});

--- a/apps/web-e2e/tests/smoke.spec.ts
+++ b/apps/web-e2e/tests/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * EW-641 Phase 1B/d row 19a — smoke test that proves the Playwright
+ * harness wires up before the actual KB acceptance suite (A12-A17,
+ * rows 19-24) lands.
+ *
+ * Deliberately **does not** hit `baseURL` — at the bootstrap stage we
+ * don't yet have a deterministic way to spin up the platform in CI,
+ * so this stays a pure-harness smoke. Row 19b adds the `webServer`
+ * block + a real /-route navigation once we wire up the CI workflow.
+ *
+ * Why have it at all: `playwright test` exits 0 with no tests, which
+ * would silently let a broken config land. One always-green test
+ * gives CI a concrete signal that the spec file resolves, the
+ * `@playwright/test` API is wired, and the chromium project actually
+ * runs.
+ */
+test.describe('web-e2e harness', () => {
+	test('smoke: playwright config + tsconfig resolve and the spec runs', () => {
+		// Project name confirms `playwright.config.ts` was picked up.
+		expect(test.info().project.name).toBe('chromium');
+		// `baseURL` defaults to the dev port when env is unset; otherwise
+		// it's whatever `PLAYWRIGHT_BASE_URL` was set to.
+		const baseURL = test.info().project.use.baseURL;
+		expect(typeof baseURL).toBe('string');
+		expect(baseURL).toMatch(/^https?:\/\//);
+	});
+});

--- a/apps/web-e2e/tsconfig.json
+++ b/apps/web-e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"types": ["node", "@playwright/test"]
+	},
+	"include": ["playwright.config.ts", "tests/**/*.ts"],
+	"exclude": ["node_modules", "test-results", "playwright-report"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,18 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
+  apps/web-e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.59.1
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/agent:
     dependencies:
       '@ai-sdk/openai-compatible':


### PR DESCRIPTION
## Summary

One-time meta-PR before the KB acceptance suite (A12-A17, rows 19-24) can land. Creates a private `@ever-works/web-e2e` workspace that plugs into the existing `apps/*` `pnpm-workspace` glob and runs Playwright tests against `pnpm dev`.

### Layout

| File | Purpose |
|---|---|
| `apps/web-e2e/package.json` | `@playwright/test@^1.50` + `@types/node` + `typescript`. Scripts: `test`, `test:smoke`, `test:install` (one-time chromium download), `test:ui`, `test:report` |
| `apps/web-e2e/playwright.config.ts` | chromium-only project, env-driven `baseURL` (`PLAYWRIGHT_BASE_URL` default `http://localhost:3000`), retries 2 in CI / 0 locally, `list` + `html` reporters in CI, trace + screenshot on first retry |
| `apps/web-e2e/tsconfig.json` | strict, ES2022, isolatedModules |
| `apps/web-e2e/.gitignore` | `playwright-report/`, `test-results/`, `.cache/`, `blob-report/`, `.env*` |
| `apps/web-e2e/README.md` | install browsers / run tests / point at deployments / what's deferred |
| `apps/web-e2e/tests/smoke.spec.ts` | harness sanity test — chromium registered, `baseURL` is a valid URL. No network calls |

### Why a smoke test that doesn't hit the app

`playwright test` exits 0 with zero tests, which would silently let a broken config land. One always-green test gives CI a real signal that the harness wires up.

### Deferred to row 19b

- `webServer` block + a real `/`-route navigation
- `.github/workflows/web-e2e.yml` with Postgres + API + Web service + Playwright run + report artifact upload
- Auth fixtures under `tests/_fixtures/`

## Test plan

- [x] `pnpm install` picks up the new workspace
- [x] `pnpm --filter @ever-works/web-e2e exec playwright install chromium` downloads ~200 MB
- [x] `pnpm --filter @ever-works/web-e2e test` → **1/1 green** (smoke)
- [x] `tsc --noEmit` clean
- [x] prettier@3.7.4 applied
- [ ] CodeRabbit
- [ ] `lint-and-test (22.x)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated end-to-end testing suite for the web application.

* **Documentation**
  * Added testing guidelines, setup instructions, and best practices.

* **Chores**
  * Configured testing framework with TypeScript support and environment-driven test execution.
  * Updated project `.gitignore` for test artifacts and local configuration overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->