### PR TITLE
test(kb): A12 e2e — drag-drop upload creates KB doc (EW-641 Phase 1B/d row 19)

### DIFF
--- a/apps/web/e2e/kb-upload.spec.ts
+++ b/apps/web/e2e/kb-upload.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './helpers/test-user';
+import { createWorkViaAPI, loginViaAPI } from './helpers/api';
+
+/**
+ * EW-641 Phase 1B/d row 19 — A12 acceptance e2e.
+ *
+ * Drives a real user-visible KB upload end-to-end: logs in via API to
+ * grab a bearer token, POSTs a fresh Work, navigates to the new Work's
+ * KB page in the authenticated chromium context (storageState from
+ * global-setup), drops a markdown file onto the upload zone via the
+ * hidden `<input type=file>` behind it (per Playwright's
+ * file-upload-download pattern — no OS-level drag simulation needed),
+ * confirms the classify modal, and waits for both (a) the upload entry
+ * to reach `data-status="succeeded"` and (b) the new doc to appear in
+ * the server-rendered tree panel.
+ *
+ * Selectors:
+ *  - `kb-shell` — KB page root (KbShell.tsx)
+ *  - `kb-upload-input` — `sr-only` file input the zone forwards browse
+ *    clicks to (KbUploadZone.tsx)
+ *  - `kb-classify-modal`, `kb-classify-class`, `kb-classify-confirm` —
+ *    KbClassifyModal.tsx
+ *  - `kb-upload-entry[data-status]` — KbUploadZone status row
+ *  - `kb-tree-item[data-doc-path]` — KbTreePanel.tsx leaf link
+ *
+ * Lives in `apps/web/e2e/` so the existing `e2e.yml` workflow picks it
+ * up on push to develop / stage / main. NOT picked up by the
+ * `chromium-no-auth` project (its `testMatch` regex enumerates specific
+ * unauth specs — `kb-*` is not in it).
+ */
+
+test.describe('Knowledge Base — A12 drag-drop upload', () => {
+    test('uploading a markdown file creates a new doc visible in the tree', async ({
+        page,
+        request,
+    }) => {
+        // First-hit dashboard routes hit Next.js dev-mode compilation
+        // (~10-15s each). The KB page + classify modal + upload roundtrip
+        // chain three of those, so give the spec the same 180s budget the
+        // suite uses for navigation-heavy authenticated flows.
+        test.setTimeout(180_000);
+
+        // 1. Mint a bearer token for the same TEST_USER the storageState
+        //    was signed in as. We can't pull it out of cookies here — the
+        //    web's session cookie is opaque — so re-login via /api/auth
+        //    is the standard pattern (other specs do the same).
+        const { access_token } = await loginViaAPI(request, {
+            email: TEST_USER.email,
+            password: TEST_USER.password,
+        });
+
+        // 2. Create a fresh Work for this run so the KB tree starts
+        //    empty. Each call uses Date.now() + a random tail so parallel
+        //    workers don't collide on the slug.
+        const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        const { id: workId } = await createWorkViaAPI(request, access_token, {
+            name: `KB Upload ${runId}`,
+        });
+        expect(workId, 'createWorkViaAPI must return a non-empty work id').toBeTruthy();
+
+        // 3. Navigate to the KB page for this Work.
+        await page.goto(`/en/works/${workId}/kb`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByTestId('kb-shell')).toBeVisible({ timeout: 60_000 });
+
+        // 4. Drop the markdown buffer onto the upload zone's hidden input.
+        //    The zone keeps an `<input type=file>` with `sr-only` styling
+        //    behind the visible drop target; `setInputFiles` works on it
+        //    directly, no `dataTransfer` synthesis needed (Playwright
+        //    best practice: file-upload-download.md).
+        const uploadInput = page.getByTestId('kb-upload-input');
+        const fileName = `kb-e2e-${runId}.md`;
+        const fileBuffer = Buffer.from(
+            `# KB e2e ${runId}\n\nFirst content of the doc — uploaded by A12.\n`,
+            'utf8',
+        );
+        await uploadInput.setInputFiles({
+            name: fileName,
+            mimeType: 'text/markdown',
+            buffer: fileBuffer,
+        });
+
+        // 5. Classify modal opens — default class is 'freeform'; pick
+        //    'knowledge' so we land in a predictable group in the tree.
+        //    Leave description blank and tags empty; row 20 (A13) covers
+        //    edit+autosave separately.
+        const modal = page.getByTestId('kb-classify-modal');
+        await expect(modal).toBeVisible({ timeout: 15_000 });
+        await page.getByTestId('kb-classify-class').selectOption('knowledge');
+        await page.getByTestId('kb-classify-confirm').click();
+        // After confirm the modal unmounts.
+        await expect(modal).not.toBeVisible({ timeout: 10_000 });
+
+        // 6. The upload entry should reach `data-status="succeeded"` once
+        //    the multipart POST + extraction + commit roundtrip lands.
+        const succeededEntry = page.locator(
+            '[data-testid="kb-upload-entry"][data-status="succeeded"]',
+        );
+        await expect(succeededEntry).toBeVisible({ timeout: 60_000 });
+
+        // 7. router.refresh() (inside KbUploadZone's onSuccess) re-fetches
+        //    the server-rendered tree panel. The new doc has a path under
+        //    `knowledge/<slug>.md` derived from the title (filename minus
+        //    extension), so we match by `data-doc-path*="<runId>"`.
+        const treeItem = page.locator(`[data-testid="kb-tree-item"][data-doc-path*="${runId}"]`);
+        await expect(treeItem).toBeVisible({ timeout: 30_000 });
+    });
+});


### PR DESCRIPTION
## Summary

- `apps/web/e2e/kb-upload.spec.ts` is the first KB acceptance e2e (A12). It logs in via API for a bearer token, POSTs a fresh Work, navigates to the new Work's KB page in the authenticated chromium context (storageState from `global-setup.ts`), drops a markdown buffer onto the upload zone's hidden `<input type=file>` (per Playwright's `file-upload-download` pattern — no OS-level drag synthesis needed), confirms the classify modal with `knowledge` class, and waits for both (a) the `kb-upload-entry` row to reach `data-status="succeeded"` and (b) the new `kb-tree-item` link to appear in the server-rendered tree panel after `router.refresh()`.
- Spec lives in the existing `apps/web/e2e/` harness so the `e2e.yml` workflow picks it up automatically on push to develop / stage / main. The chromium project's `testIgnore` regex does not list `kb-*`, so the spec runs with `storageState`. Verified locally with `pnpm exec playwright test --list kb-upload`:
  ```
  [setup] › global-setup.ts:12:6 › authenticate
  [chromium] › kb-upload.spec.ts:34:9 › Knowledge Base — A12 drag-drop upload › uploading a markdown file creates a new doc visible in the tree
  Total: 2 tests in 2 files
  ```
- The `lint-and-test` CI workflow that gates this PR runs prettier + build + unit tests, not Playwright — the e2e suite green-on-develop validation happens via `e2e.yml` on the next push to develop after merge.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm exec playwright test --list kb-upload` — Playwright resolves the spec under `[chromium]` (with `storageState`)
- [ ] CI `lint-and-test (22.x)` — runs on PR, expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: next push to develop triggers `e2e.yml` which runs `kb-upload.spec.ts` end-to-end against API + Web. If that's green, A12 acceptance is met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test for Knowledge Base markdown file uploads. The test validates the complete user workflow including authentication, navigating to the Knowledge Base section, uploading a markdown file, selecting document classification, confirming successful upload, and verifying the new document appears correctly in the Knowledge Base tree view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->