### PR TITLE
test(kb): A13 e2e — edit + autosave + reload persistence (EW-641 Phase 1B/d row 20)

### DIFF
--- a/apps/web/e2e/helpers/kb-fixtures.ts
+++ b/apps/web/e2e/helpers/kb-fixtures.ts
@@ -1,0 +1,73 @@
+import type { APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders } from './api';
+
+/**
+ * KB-specific fixture helpers for e2e tests.
+ *
+ * Keep these tiny: they exist so KB acceptance specs (A12-A17) can stand up
+ * the same backend state via the public API instead of driving the UI.
+ * UI-based setup is the right shape for the A12 upload spec itself, but
+ * downstream specs (A13 autosave, A14 viewers, A15 activity log, …) want a
+ * pre-seeded doc so they can focus on the behaviour under test.
+ */
+
+export interface SeedKbMarkdownDocOptions {
+    /** Filename used in the multipart upload; controls the resulting doc slug. */
+    filename: string;
+    /** Markdown body. */
+    body: string;
+    /** Optional class override; defaults to `knowledge` so the doc lands in a predictable folder. */
+    targetClass?: string;
+    /** Optional title — falls back to filename-minus-extension server-side. */
+    title?: string;
+}
+
+export interface SeededKbDoc {
+    documentId: string;
+    path: string;
+}
+
+/**
+ * POST multipart to `/api/works/:id/kb/uploads`, returning the new document's
+ * id + path. Throws if the API rejects the call (caller catches with
+ * `await expect(...).rejects.toThrow()` if testing the error case).
+ *
+ * The upload endpoint synchronously creates a KbDocument for text MIMEs
+ * (markdown / plain), so a `text/markdown` upload returns
+ * `{ upload, document: { id, path, ... } }` in one round-trip — no polling
+ * needed (Phase 1B/b spec §7.4).
+ */
+export async function seedKbMarkdownDoc(
+    request: APIRequestContext,
+    token: string,
+    workId: string,
+    opts: SeedKbMarkdownDocOptions,
+): Promise<SeededKbDoc> {
+    const res = await request.post(`${API_BASE}/api/works/${workId}/kb/uploads`, {
+        headers: authedHeaders(token),
+        multipart: {
+            file: {
+                name: opts.filename,
+                mimeType: 'text/markdown',
+                buffer: Buffer.from(opts.body, 'utf8'),
+            },
+            targetClass: opts.targetClass ?? 'knowledge',
+            ...(opts.title ? { title: opts.title } : {}),
+        },
+    });
+    if (!res.ok()) {
+        const errBody = await res.text();
+        throw new Error(`seedKbMarkdownDoc failed (${res.status()}): ${errBody}`);
+    }
+    const json = (await res.json()) as {
+        document?: { id?: string; path?: string } | null;
+    };
+    const documentId = json.document?.id;
+    const path = json.document?.path;
+    if (!documentId || !path) {
+        throw new Error(
+            `seedKbMarkdownDoc: upload accepted but response shape missing document.id/path: ${JSON.stringify(json)}`,
+        );
+    }
+    return { documentId, path };
+}

--- a/apps/web/e2e/kb-edit-autosave.spec.ts
+++ b/apps/web/e2e/kb-edit-autosave.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './helpers/test-user';
+import { createWorkViaAPI, loginViaAPI } from './helpers/api';
+import { seedKbMarkdownDoc } from './helpers/kb-fixtures';
+
+/**
+ * EW-641 Phase 1B/d row 20 — A13 acceptance e2e (edit + autosave).
+ *
+ * Seeds a KB markdown doc via the public API (`POST /api/works/:id/kb/uploads`,
+ * synchronous create for text MIMEs per spec §7.4), navigates to the per-doc
+ * editor route (`/en/works/<id>/kb/<path>`), focuses Tiptap's contentEditable
+ * surface, appends a marker substring, waits for the autosave status pill to
+ * land on `saved`, then reloads the page and asserts the appended substring
+ * is still in the editor body — proving end-to-end persistence.
+ *
+ * Selectors:
+ *  - `kb-editor` — KbEditor root (KbEditor.tsx)
+ *  - `kb-editor-status[data-status]` — autosave status pill (`idle | dirty |
+ *    saving | saved | error`)
+ *  - `[data-testid="kb-editor"] [contenteditable="true"]` — Tiptap's
+ *    ProseMirror surface. We resolve it through `kb-editor` because the
+ *    `kb-editor-body` testid is currently scoped to the placeholder (the
+ *    EditorContent wrapper drops it once Tiptap mounts) — using the
+ *    contentEditable attribute makes the test stable across mounted /
+ *    unmounted states without touching production code.
+ *
+ * The KB editor autosave debounce is 1500ms (see KbEditor.tsx's
+ * `autosaveDebounceMs`), so the `saved` assertion budgets 10s.
+ *
+ * Lives in `apps/web/e2e/` so the existing `e2e.yml` workflow picks it up
+ * on push to develop / stage / main. Skipped by the `chromium-no-auth`
+ * project (the `testMatch` regex enumerates specific unauth specs —
+ * `kb-*` is not in it).
+ */
+
+test.describe('Knowledge Base — A13 edit + autosave', () => {
+    test('appended text autosaves and survives a reload', async ({ page, request }) => {
+        // Mirrors the row-19 (A12) timing budget. First-hit dashboard +
+        // KB nested route + editor mount each pay the Next.js dev-mode
+        // compile cost, then autosave debounces + commits.
+        test.setTimeout(180_000);
+
+        // 1. Mint a bearer token for the test user.
+        const { access_token } = await loginViaAPI(request, {
+            email: TEST_USER.email,
+            password: TEST_USER.password,
+        });
+
+        // 2. Create a fresh Work and seed one markdown doc inside it via
+        //    the API (no UI driving). The seeded doc lives at
+        //    `knowledge/<slug>.md` because we pass `targetClass: knowledge`.
+        const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        const { id: workId } = await createWorkViaAPI(request, access_token, {
+            name: `KB Autosave ${runId}`,
+        });
+        expect(workId, 'createWorkViaAPI must return a non-empty work id').toBeTruthy();
+
+        const seedBody = `# A13 seed ${runId}\n\nInitial body before the edit.\n`;
+        const { path: docPath } = await seedKbMarkdownDoc(request, access_token, workId, {
+            filename: `kb-a13-${runId}.md`,
+            body: seedBody,
+        });
+        expect(docPath).toMatch(/\.md$/);
+
+        // 3. Navigate to the per-doc editor route.
+        await page.goto(`/en/works/${workId}/kb/${docPath}`, { waitUntil: 'domcontentloaded' });
+        const editor = page.getByTestId('kb-editor');
+        await expect(editor).toBeVisible({ timeout: 60_000 });
+
+        // Status pill should start at `idle` (or `saved` if the editor's
+        // initial-content effect briefly flipped it). Wait for the
+        // contentEditable surface to be ready before typing.
+        const editable = page.locator('[data-testid="kb-editor"] [contenteditable="true"]').first();
+        await expect(editable).toBeVisible({ timeout: 30_000 });
+
+        // 4. Focus the editor and append a uniquely-identifiable marker.
+        await editable.click();
+        // Move the caret to the end of the document before typing so we
+        // don't overwrite the seed heading.
+        await page.keyboard.press('Control+End');
+        const marker = `A13-marker-${runId}`;
+        // Newline first so the marker lands on its own paragraph, then
+        // the marker text. `keyboard.type` simulates real key events,
+        // which Tiptap binds onto via ProseMirror's input rules.
+        await page.keyboard.type(`\n${marker}\n`);
+
+        // 5. Autosave debounce is 1500ms; allow 10s including a network
+        //    round-trip on the slow CI runner.
+        const status = page.getByTestId('kb-editor-status');
+        await expect(status).toHaveAttribute('data-status', 'saved', { timeout: 10_000 });
+
+        // 6. Reload the page. The editor remounts and re-fetches the
+        //    persisted markdown — the marker must still be there.
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        await expect(page.getByTestId('kb-editor')).toBeVisible({ timeout: 60_000 });
+        const reloadedEditable = page
+            .locator('[data-testid="kb-editor"] [contenteditable="true"]')
+            .first();
+        await expect(reloadedEditable).toBeVisible({ timeout: 30_000 });
+        await expect(reloadedEditable).toContainText(marker, { timeout: 15_000 });
+    });
+});


### PR DESCRIPTION
## Summary

- `apps/web/e2e/kb-edit-autosave.spec.ts` is the A13 acceptance e2e. Seeds a KB markdown doc via the public upload endpoint (text MIMEs land synchronously per spec §7.4 — no polling needed), navigates to `/en/works/<id>/kb/<path>`, focuses Tiptap's contentEditable surface, appends a unique marker substring, waits for the autosave status pill to reach `data-status="saved"` (1.5s debounce + I/O budget = 10s), reloads the page and re-asserts the marker is still in the editor body. Proves the autosave + persistence path end-to-end.
- `apps/web/e2e/helpers/kb-fixtures.ts` adds `seedKbMarkdownDoc(request, token, workId, opts)`. Reused by A14-A17 — they'll all want a pre-seeded doc to focus on the behaviour under test rather than re-driving the upload flow.
- Selector note: the editor's `kb-editor-body` testid is scoped to the placeholder branch only (the EditorContent wrapper drops it once Tiptap mounts in production), so the spec uses `[data-testid="kb-editor"] [contenteditable="true"]` to target the ProseMirror surface — stable across mounted/unmounted states without touching production code. Recorded for downstream specs.
- Verified locally: `pnpm exec playwright test --list kb-edit-autosave` resolves under `[chromium]` (authenticated) — 2 tests in 2 files (setup + this one).

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm exec playwright test --list kb-edit-autosave` — Playwright resolves under `[chromium]`
- [ ] CI `lint-and-test (22.x)` — runs on PR, expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: `e2e.yml` on the next develop push runs `kb-edit-autosave.spec.ts` end-to-end against the live API + Web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test infrastructure for knowledge base document uploads and management
  * Added end-to-end test validating autosave persistence for knowledge base document editing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->