### PR TITLE
feat(kb): add GET /works/:id/kb/uploads/:uploadId/download (EW-641 Phase 1B/d row 21a)

### DIFF
--- a/apps/api/src/works/kb.controller.ts
+++ b/apps/api/src/works/kb.controller.ts
@@ -4,12 +4,14 @@ import {
     Controller,
     Delete,
     Get,
+    Header,
     HttpCode,
     HttpStatus,
     Param,
     Patch,
     Post,
     Query,
+    Res,
     UploadedFile,
     UseGuards,
     UseInterceptors,
@@ -46,6 +48,19 @@ import type {
 
 /** Per-upload byte cap — spec §9.1 default is 200 MB, tunable per tenant. */
 const KB_UPLOAD_MAX_BYTES = Number(process.env.KB_UPLOAD_MAX_BYTES) || 200 * 1024 * 1024;
+
+/**
+ * Minimal Express response surface for `@Res()`-streamed routes. Mirrors
+ * the local pattern in `uploads.controller.ts` to avoid pulling the full
+ * express type-graph into this module (it conflicts with the global
+ * `Express.Response` namespace used elsewhere in the build).
+ */
+type ServeResponse = {
+    status(code: number): ServeResponse;
+    setHeader(name: string, value: string | number): void;
+    json(body: unknown): void;
+    send(body: string | Buffer): void;
+};
 
 /**
  * Knowledge Base REST surface — per-Work routes.
@@ -384,6 +399,60 @@ export class KbController {
         @Param('uploadId') uploadId: string,
     ) {
         return this.kb.getUpload(workId, uploadId, auth.userId);
+    }
+
+    /**
+     * EW-641 Phase 1B/d row 21a — stream KB upload bytes back to the
+     * caller so per-MIME viewers (`KbPdfViewer`, `KbXlsxViewer`,
+     * `KbDocxViewer`, image/video/audio) can mount. Gated by
+     * `ensureCanView` (same gate as `GET /works/:id/kb/uploads/:uploadId`),
+     * pinned with a strict CSP + nosniff so the browser cannot
+     * reinterpret the bytes as executable HTML even when the MIME is
+     * application/xml-ish.
+     *
+     * Returns the raw buffer with the storage-recovered (or upload-row)
+     * MIME type. Cache-Control is `private, max-age=300` — same as the
+     * generic `uploads.controller.ts` `serve()` route. Content-Disposition
+     * is `inline` because the viewers iframe / `<img>` / `<video>` the
+     * URL directly; the download fallbacks attach their own `download`
+     * attribute on the anchor (KbPdfViewer / KbXlsxViewer / KbDocxViewer).
+     */
+    @Get('works/:id/kb/uploads/:uploadId/download')
+    @Header(
+        'Content-Security-Policy',
+        "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+    )
+    @Header('X-Content-Type-Options', 'nosniff')
+    @Header('Cache-Control', 'private, max-age=300')
+    @ApiOperation({
+        summary: 'Stream the persisted bytes for a KB upload',
+        description:
+            'Owner / viewer+ only. Hands the raw upload bytes back so the per-MIME viewers (KbPdfViewer, KbXlsxViewer, KbDocxViewer, image / video / audio) can render inline. CSP-pinned to default-src none + nosniff so the response is safe to embed inside an iframe or media tag.',
+    })
+    @ApiResponse({ status: 200, description: 'Raw upload bytes' })
+    @ApiResponse({ status: 404, description: 'Upload not found' })
+    @ApiResponse({ status: 503, description: 'Storage plugin not configured' })
+    async downloadUpload(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') workId: string,
+        @Param('uploadId') uploadId: string,
+        @Res() res: ServeResponse,
+    ) {
+        const { buffer, mimeType, filename } = await this.kb.getUploadBytes(
+            workId,
+            uploadId,
+            auth.userId,
+        );
+        res.setHeader('Content-Type', mimeType);
+        res.setHeader('Content-Length', buffer.length);
+        // `inline` is safe because we (a) pinned CSP `default-src 'none';
+        // frame-ancestors 'none'` so neither script execution nor
+        // top-frame nesting can fire, and (b) set nosniff so the browser
+        // won't reinterpret the bytes as HTML even if the recorded MIME
+        // is wrong. The viewers expect inline so `<iframe src>` /
+        // `<video src>` / `<img src>` Just Work.
+        res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
+        res.send(buffer);
     }
 
     @Post('works/:id/kb/uploads/:uploadId/retry-extraction')

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -705,6 +705,120 @@ describe('KnowledgeBaseService', () => {
         });
     });
 
+    describe('getUploadBytes', () => {
+        function buildUpload(overrides: Partial<WorkKnowledgeUpload> = {}): WorkKnowledgeUpload {
+            return {
+                id: '00000000-0000-0000-0000-000000000020',
+                workId: WORK_ID,
+                storageProvider: 'local-fs',
+                storagePath: 'kb-originals/brand/abc.pdf',
+                originalFilename: 'voice.pdf',
+                mimeType: 'application/pdf',
+                fileSize: 4096,
+                sha256: 'abc',
+                extractionStatus: 'skipped' as KbUploadExtractionStatus,
+                extractionStartedAt: null,
+                extractionFinishedAt: null,
+                extractionError: null,
+                extractedDocumentId: null,
+                normalizedFormat: null,
+                extractionPluginId: null,
+                uploadedById: USER_ID,
+                tags: null,
+                categories: null,
+                metadata: null,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                ...overrides,
+            } as WorkKnowledgeUpload;
+        }
+
+        it('streams stored bytes for the caller with the recovered MIME type', async () => {
+            const upload = buildUpload();
+            uploadRepo.findById.mockResolvedValueOnce(upload);
+            const buffer = Buffer.from('%PDF-1.4 fake bytes');
+            storage.getObject.mockResolvedValueOnce({
+                buffer,
+                mimeType: 'application/pdf',
+            });
+
+            const result = await service.getUploadBytes(WORK_ID, upload.id, USER_ID);
+
+            expect(ownership.ensureCanView).toHaveBeenCalledWith(WORK_ID, USER_ID);
+            expect(storage.getObject).toHaveBeenCalledWith(upload.storagePath);
+            expect(result.buffer).toBe(buffer);
+            expect(result.mimeType).toBe('application/pdf');
+            expect(result.filename).toBe(upload.originalFilename);
+            expect(result.sizeBytes).toBe(upload.fileSize);
+        });
+
+        it('falls back to the upload row mime when storage does not surface one', async () => {
+            const upload = buildUpload({
+                mimeType: 'image/png',
+                storagePath: 'kb-originals/img.png',
+            });
+            uploadRepo.findById.mockResolvedValueOnce(upload);
+            storage.getObject.mockResolvedValueOnce({
+                buffer: Buffer.from(''),
+                mimeType: undefined as unknown as string,
+            });
+
+            const result = await service.getUploadBytes(WORK_ID, upload.id, USER_ID);
+            expect(result.mimeType).toBe('image/png');
+        });
+
+        it('throws NotFoundException when the upload row is missing', async () => {
+            uploadRepo.findById.mockResolvedValueOnce(null);
+            await expect(
+                service.getUploadBytes(WORK_ID, 'missing-id', USER_ID),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(storage.getObject).not.toHaveBeenCalled();
+        });
+
+        it('throws ServiceUnavailableException when no storage plugin is wired', async () => {
+            // Re-instantiate without KB_STORAGE_PLUGIN — mirrors createUpload's bare-module test.
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    {
+                        provide: WorkKnowledgeDocumentRepository,
+                        useValue: { findById: jest.fn() },
+                    },
+                    {
+                        provide: WorkKnowledgeUploadRepository,
+                        useValue: { findById: jest.fn().mockResolvedValue(buildUpload()) },
+                    },
+                    { provide: WorkKnowledgeTagRepository, useValue: { list: jest.fn() } },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn() },
+                    },
+                    {
+                        provide: WorkOwnershipService,
+                        useValue: {
+                            ensureCanView: jest.fn().mockResolvedValue({ role: 'editor' } as any),
+                            ensureCanEdit: jest.fn(),
+                        },
+                    },
+                    { provide: ActivityLogService, useValue: { log: jest.fn() } },
+                ],
+            }).compile();
+            const bare = module.get(KnowledgeBaseService);
+            await expect(bare.getUploadBytes(WORK_ID, 'any-id', USER_ID)).rejects.toBeInstanceOf(
+                ServiceUnavailableException,
+            );
+        });
+
+        it('enforces ensureCanView before touching storage', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new ForbiddenException('nope'));
+            await expect(service.getUploadBytes(WORK_ID, 'any-id', USER_ID)).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
+            expect(uploadRepo.findById).not.toHaveBeenCalled();
+            expect(storage.getObject).not.toHaveBeenCalled();
+        });
+    });
+
     describe('restoreDocumentFromHistory', () => {
         it('rejects editor-role callers (manager+ required)', async () => {
             // Default ownership mock returns 'editor' — restore needs

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -687,6 +687,51 @@ export class KnowledgeBaseService {
     }
 
     /**
+     * EW-641 Phase 1B/d row 21a — serve the persisted upload bytes back
+     * to the browser so the per-MIME viewers (`KbPdfViewer`,
+     * `KbXlsxViewer`, `KbDocxViewer`, image / video / audio) can mount.
+     *
+     * Reuses `ensureCanView` (same gate as `getUpload`) so anyone with
+     * read access to the Work can fetch upload bytes the same way they
+     * can fetch the JSON DTO. The companion controller route attaches
+     * `Content-Security-Policy: default-src 'none'; frame-ancestors
+     * 'none'; base-uri 'none'` + `X-Content-Type-Options: nosniff` so
+     * the bytes are safe to render inline even when the MIME is HTML or
+     * SVG.
+     *
+     * Throws `NotFoundException` when the upload row is missing,
+     * `ServiceUnavailableException` when no storage plugin is wired
+     * (mirrors `createUpload` / `retryUploadExtraction`).
+     */
+    async getUploadBytes(
+        workId: string,
+        uploadId: string,
+        userId: string,
+    ): Promise<{ buffer: Buffer; mimeType: string; filename: string; sizeBytes: number }> {
+        await this.ownershipService.ensureCanView(workId, userId);
+        if (!this.storage) {
+            throw new ServiceUnavailableException(
+                'KB uploads require a storage plugin — not configured in this deployment',
+            );
+        }
+        const upload = await this.uploadRepository.findById(workId, uploadId);
+        if (!upload) {
+            throw new NotFoundException(`KB upload not found: ${uploadId}`);
+        }
+        const fetched = await this.storage.getObject(upload.storagePath);
+        return {
+            buffer: fetched.buffer,
+            // Prefer the plugin's recovered MIME (S3 returns Content-Type
+            // metadata; local-fs sniffs again); fall back to whatever the
+            // upload row recorded at create time so the response always
+            // carries a Content-Type the viewer can dispatch on.
+            mimeType: fetched.mimeType ?? upload.mimeType,
+            filename: upload.originalFilename,
+            sizeBytes: upload.fileSize,
+        };
+    }
+
+    /**
      * Receive a multipart upload and run the synchronous slice of the
      * ingest pipeline (spec §9.1–§9.4). The file bytes are already in
      * memory from `FileInterceptor` so the API handler can extract +


### PR DESCRIPTION
## Summary

- `KnowledgeBaseService.getUploadBytes(workId, uploadId, userId)` runs the same `ensureCanView` gate as `getUpload`, requires a storage plugin to be wired (`ServiceUnavailableException` otherwise), fetches the upload row, calls `storage.getObject(upload.storagePath)`, and returns `{ buffer, mimeType, filename, sizeBytes }`. The MIME prefers what the plugin recovered (S3 Content-Type metadata; local-fs sniffs again), falling back to the upload row's recorded MIME so the response always has a Content-Type the viewers can dispatch on.
- `apps/api/src/works/kb.controller.ts` adds `@Get('works/:id/kb/uploads/:uploadId/download')` mirroring the streamed-bytes pattern in `uploads.controller.ts` (CSP `default-src 'none'; frame-ancestors 'none'; base-uri 'none'` + `nosniff` + `Cache-Control: private, max-age=300` + `Content-Disposition: inline`). Safe to embed inside `<iframe>` / `<video>` / `<img>` because the strict CSP prevents script execution and frame nesting even when the MIME is HTML or SVG.
- Unblocks row 21b (web doc-detail dispatcher mounting `KbPdfViewer` / `KbXlsxViewer` / `KbDocxViewer` / image / video / audio based on `upload.mimeType`) and row 21c (A14 viewer-cap e2e). The Phase 1B/d viewers (rows 9-12) had locked their selectors for this acceptance test, but no route was actually mounting them — this PR is the API half of that wiring.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm build --filter='!./apps/docs' --filter='!./apps/web'` — green (API typechecks the new controller)
- [x] `cd packages/agent && npx jest --testPathPattern='knowledge-base.service.spec'` — 31/31 green (5 new cases: happy path, MIME fallback, NotFound, ServiceUnavailable, ensureCanView gate)
- [ ] CI `lint-and-test (22.x)` — runs on PR, expected green
- [ ] CodeRabbit review — expected pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now download knowledge base uploads directly. The feature includes security headers and proper caching controls to optimize performance while maintaining data security. File metadata like filename and MIME type are preserved during download.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->