### PR TITLE
feat(kb): wire viewer dispatcher in doc detail page (EW-641 Phase 1B/d row 21b)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { workAPI } from '@/lib/api';
@@ -11,6 +12,14 @@ import { KbEditor } from '@/components/works/detail/kb/KbEditor';
 import { KbSearchPalette } from '@/components/works/detail/kb/KbSearchPalette';
 import { KbSidePanel } from '@/components/works/detail/kb/KbSidePanel';
 import { KbUploadZone } from '@/components/works/detail/kb/KbUploadZone';
+import { KbPdfViewer } from '@/components/works/detail/kb/viewers/KbPdfViewer';
+import { KbXlsxViewer } from '@/components/works/detail/kb/viewers/KbXlsxViewer';
+import { KbDocxViewer } from '@/components/works/detail/kb/viewers/KbDocxViewer';
+import { KbImageViewer } from '@/components/works/detail/kb/viewers/KbImageViewer';
+import { KbVideoViewer } from '@/components/works/detail/kb/viewers/KbVideoViewer';
+import { KbAudioViewer } from '@/components/works/detail/kb/viewers/KbAudioViewer';
+import { pickKbViewer, type KbViewerKind } from '@/components/works/detail/kb/viewers/pick-viewer';
+import type { KbDocumentBodyDto, KbUploadDto } from '@ever-works/contracts';
 
 type Params = {
     params: Promise<{ id: string; path: string[] }>;
@@ -49,9 +58,14 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
  *
  * Renders the full three-pane shell so the user keeps the tree on the
  * left while reading: the active row in the tree is highlighted via
- * the `activePath` prop. The editor pane shows the doc via
- * `<KbDocumentView>` (read-only Markdown for now; row 5 swaps that for
- * the Tiptap-based editor + autosave).
+ * the `activePath` prop. The editor pane swaps between three modes:
+ *  - Full-lock docs render `KbDocumentView` (read-only Markdown).
+ *  - Docs sourced from a binary upload (PDF / XLSX / DOCX / image /
+ *    video / audio) render the matching viewer from `viewers/` (row
+ *    21b dispatcher). The viewer fetches the bytes from the row-21a
+ *    `GET /works/:id/kb/uploads/:uploadId/download` endpoint via the
+ *    `url` prop.
+ *  - Everything else renders the `KbEditor` (Tiptap + autosave).
  *
  * Errors: 404 → `notFound()`; other backend failures bubble to the
  * dashboard error boundary (matches the activity / items pages —
@@ -77,21 +91,17 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
         throw error;
     }
 
-    // Also fetch the tree list so the left pane is populated. A
-    // failure here is non-fatal — the editor pane still renders.
+    // Tree list + (optional) source-upload row alongside the doc. Tree
+    // failures fall back to an empty tree; upload-row failures fall back
+    // to the markdown editor path (treat an orphaned `sourceUploadId`
+    // as "not a binary doc").
+    const upload = await loadSourceUpload(id, doc);
     const list = await Promise.all([workAPI.get(id), kbAPI.listDocuments(id, { limit: 200 })])
         .then(([, docs]) => docs)
         .catch((error) => {
             console.error('[kb-tree] failed to list KB documents:', error);
             return { items: [], total: 0 };
         });
-
-    // Full-lock docs (`locked && lockMode === 'full'`) stay on the
-    // read-only viewer so accidental edits don't bounce off the API
-    // with a 403. `additions-only` locks still render the editor; the
-    // server enforces the actual restriction on save (row 14 surfaces
-    // an explicit UI for this — for now we trust the API's response).
-    const fullyLocked = doc.locked && doc.lockMode === 'full';
 
     return (
         <div className="flex flex-col gap-4">
@@ -102,11 +112,98 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
             <KbShell
                 workId={id}
                 treeSlot={<KbTreePanel workId={id} documents={list.items} activePath={doc.path} />}
-                editorSlot={
-                    fullyLocked ? <KbDocumentView doc={doc} /> : <KbEditor workId={id} doc={doc} />
-                }
+                editorSlot={renderEditorSlot(id, doc, upload)}
                 asideSlot={<KbSidePanel doc={doc} />}
             />
         </div>
     );
+}
+
+/**
+ * Fetch the source upload row when the doc references one. Returns
+ * `null` for org-overlay docs (no upload), AI-generated docs (no
+ * upload), or orphaned references (404 from the API — survives the
+ * upload-row delete with the doc still present).
+ */
+async function loadSourceUpload(
+    workId: string,
+    doc: KbDocumentBodyDto,
+): Promise<KbUploadDto | null> {
+    if (!doc.sourceUploadId) return null;
+    try {
+        return await kbAPI.getUpload(workId, doc.sourceUploadId);
+    } catch (error) {
+        if (error instanceof ApiResponseError && error.statusCode === 404) {
+            return null;
+        }
+        // Network / 5xx errors fall back to the markdown path rather
+        // than throwing — the editor still works, just without the
+        // binary preview. Log so operators see the underlying issue.
+        console.error('[kb-viewer] failed to load source upload:', error);
+        return null;
+    }
+}
+
+/**
+ * Decide which component renders the editor slot. Full-lock docs stay
+ * on the read-only Markdown viewer (row 4); docs whose source upload's
+ * MIME maps to a binary viewer mount the matching viewer (row 21b);
+ * everything else continues to render the Tiptap editor (row 5).
+ *
+ * The viewers receive a `url` pointing at the row-21a download proxy.
+ * Sandboxing lives on the API response headers (CSP +
+ * X-Content-Type-Options: nosniff), so we don't need to add any
+ * client-side restrictions here.
+ */
+function renderEditorSlot(
+    workId: string,
+    doc: KbDocumentBodyDto,
+    upload: KbUploadDto | null,
+): ReactNode {
+    const fullyLocked = doc.locked && doc.lockMode === 'full';
+    if (fullyLocked) {
+        return <KbDocumentView doc={doc} />;
+    }
+    const kind: KbViewerKind = upload ? pickKbViewer(upload.mimeType) : 'text';
+    if (upload && kind !== 'text') {
+        const url = `/api/works/${workId}/kb/uploads/${upload.id}/download`;
+        const sizeBytes = upload.fileSize;
+        const filename = upload.originalFilename;
+        switch (kind) {
+            case 'pdf':
+                return <KbPdfViewer url={url} sizeBytes={sizeBytes} filename={filename} />;
+            case 'xlsx':
+                return <KbXlsxViewer url={url} sizeBytes={sizeBytes} filename={filename} />;
+            case 'docx':
+                return <KbDocxViewer url={url} sizeBytes={sizeBytes} filename={filename} />;
+            case 'image':
+                return (
+                    <KbImageViewer
+                        url={url}
+                        sizeBytes={sizeBytes}
+                        filename={filename}
+                        alt={doc.title || filename}
+                    />
+                );
+            case 'video':
+                return (
+                    <KbVideoViewer
+                        url={url}
+                        sizeBytes={sizeBytes}
+                        filename={filename}
+                        mimeType={upload.mimeType}
+                    />
+                );
+            case 'audio':
+                return (
+                    <KbAudioViewer
+                        url={url}
+                        sizeBytes={sizeBytes}
+                        filename={filename}
+                        mimeType={upload.mimeType}
+                    />
+                );
+        }
+    }
+    return <KbEditor workId={workId} doc={doc} />;
 }

--- a/apps/web/src/components/works/detail/kb/viewers/pick-viewer.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/pick-viewer.ts
@@ -1,0 +1,56 @@
+/**
+ * EW-641 Phase 1B/d row 21b — pure helper that decides which KB viewer
+ * to mount for a given upload MIME type.
+ *
+ * Keeping this a side-effect-free pure function (no React import, no
+ * filesystem / network access) so:
+ *  - The doc detail page can call it during server-render without
+ *    triggering a client-boundary mount.
+ *  - Vitest can exercise every branch (and the unknown-mime fallback)
+ *    with a plain TypeScript spec — no jsdom needed.
+ *
+ * Returns `'text'` for markdown / plain / unknown MIMEs so the existing
+ * `KbEditor` / `KbDocumentView` rendering path stays the default. Binary
+ * viewers (`KbPdfViewer`, `KbXlsxViewer`, `KbDocxViewer`, `KbImageViewer`,
+ * `KbVideoViewer`, `KbAudioViewer`) take over only when the MIME is
+ * unambiguously theirs.
+ *
+ * Caller note: dispatch on a non-`'text'` result ONLY when the doc has a
+ * non-null `sourceUploadId` (otherwise there's no URL to point the viewer
+ * at). Markdown / plain MIMEs always fall through to `'text'` because the
+ * KB stores the rendered body in `doc.body` and there is nothing to
+ * stream — the editor renders that body directly.
+ */
+
+export type KbViewerKind = 'pdf' | 'xlsx' | 'docx' | 'image' | 'video' | 'audio' | 'text';
+
+const PDF_MIME = 'application/pdf';
+const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+/**
+ * Pick the viewer kind from a MIME type.
+ *
+ * - `null` / `undefined` / empty → `'text'` (treated as "no binary
+ *   payload — render the markdown body").
+ * - Case-insensitive on the bare MIME; parameters after `;` (e.g.
+ *   `text/html; charset=utf-8`) are stripped before matching so a
+ *   server-side `Content-Type` header round-tripped through the upload
+ *   row still classifies correctly.
+ * - CSV is intentionally NOT mapped to `xlsx` — the XLSX viewer parses
+ *   workbook formats via `exceljs`, which would reject a plain CSV. CSV
+ *   falls through to `'text'` and the markdown editor renders it as a
+ *   monospaced block.
+ */
+export function pickKbViewer(mimeType: string | null | undefined): KbViewerKind {
+    if (!mimeType) return 'text';
+    const bare = mimeType.split(';')[0].trim().toLowerCase();
+    if (bare.length === 0) return 'text';
+    if (bare === PDF_MIME) return 'pdf';
+    if (bare === XLSX_MIME) return 'xlsx';
+    if (bare === DOCX_MIME) return 'docx';
+    if (bare.startsWith('image/')) return 'image';
+    if (bare.startsWith('video/')) return 'video';
+    if (bare.startsWith('audio/')) return 'audio';
+    return 'text';
+}

--- a/apps/web/src/components/works/detail/kb/viewers/pick-viewer.unit.spec.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/pick-viewer.unit.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { pickKbViewer } from './pick-viewer';
+
+describe('pickKbViewer', () => {
+    it('returns "text" for null / undefined / empty inputs', () => {
+        expect(pickKbViewer(null)).toBe('text');
+        expect(pickKbViewer(undefined)).toBe('text');
+        expect(pickKbViewer('')).toBe('text');
+        expect(pickKbViewer('   ')).toBe('text');
+    });
+
+    it('maps application/pdf to "pdf"', () => {
+        expect(pickKbViewer('application/pdf')).toBe('pdf');
+        expect(pickKbViewer('APPLICATION/PDF')).toBe('pdf');
+        expect(pickKbViewer('application/pdf; charset=binary')).toBe('pdf');
+    });
+
+    it('maps the openxml spreadsheet MIME to "xlsx"', () => {
+        expect(
+            pickKbViewer('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+        ).toBe('xlsx');
+    });
+
+    it('maps the openxml word document MIME to "docx"', () => {
+        expect(
+            pickKbViewer('application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+        ).toBe('docx');
+    });
+
+    it('maps image/* to "image"', () => {
+        expect(pickKbViewer('image/png')).toBe('image');
+        expect(pickKbViewer('image/jpeg')).toBe('image');
+        expect(pickKbViewer('image/webp')).toBe('image');
+        expect(pickKbViewer('image/svg+xml')).toBe('image');
+    });
+
+    it('maps video/* to "video"', () => {
+        expect(pickKbViewer('video/mp4')).toBe('video');
+        expect(pickKbViewer('video/webm')).toBe('video');
+    });
+
+    it('maps audio/* to "audio"', () => {
+        expect(pickKbViewer('audio/mpeg')).toBe('audio');
+        expect(pickKbViewer('audio/ogg')).toBe('audio');
+        expect(pickKbViewer('audio/wav')).toBe('audio');
+    });
+
+    it('falls through to "text" for text/markdown, text/plain, text/csv', () => {
+        // The KB editor / viewer pane already renders these from doc.body —
+        // no need to swap to a binary viewer. CSV intentionally falls
+        // through (the XLSX viewer parses via exceljs which rejects plain
+        // CSV).
+        expect(pickKbViewer('text/markdown')).toBe('text');
+        expect(pickKbViewer('text/plain')).toBe('text');
+        expect(pickKbViewer('text/csv')).toBe('text');
+        expect(pickKbViewer('text/html')).toBe('text');
+    });
+
+    it('falls through to "text" for unknown / off-list MIMEs', () => {
+        expect(pickKbViewer('application/octet-stream')).toBe('text');
+        expect(pickKbViewer('application/zip')).toBe('text');
+        expect(pickKbViewer('application/x-this-does-not-exist')).toBe('text');
+    });
+
+    it('strips Content-Type parameters and lowercases before matching', () => {
+        expect(pickKbViewer('Image/PNG; charset=binary')).toBe('image');
+        expect(pickKbViewer('  video/MP4  ')).toBe('video');
+    });
+});

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -6,6 +6,7 @@ import type {
     KbDocumentHistoryResult,
     KbDocumentListFilter,
     KbLockMode,
+    KbUploadDto,
     UpdateKbDocumentInput,
 } from '@ever-works/contracts';
 
@@ -113,6 +114,24 @@ export const kbAPI = {
             method: 'POST',
             wrapInData: false,
         });
+    },
+
+    /**
+     * `GET /api/works/:id/kb/uploads/:uploadId` — read a single upload
+     * row (metadata only; the persisted bytes live behind the row-21a
+     * `/download` route). The doc detail page calls this when the doc
+     * has a `sourceUploadId` so the viewer dispatcher (row 21b) can
+     * decide whether to mount `KbPdfViewer` / `KbXlsxViewer` /
+     * `KbDocxViewer` / image / video / audio based on `upload.mimeType`.
+     *
+     * Errors propagate as `ApiResponseError` — callers may catch 404 to
+     * fall back to the markdown viewer when the upload reference is
+     * orphaned.
+     */
+    getUpload: async (workId: string, uploadId: string): Promise<KbUploadDto> => {
+        return serverFetch<KbUploadDto>(
+            `/works/${workId}/kb/uploads/${encodeURIComponent(uploadId)}`,
+        );
     },
 
     /**


### PR DESCRIPTION
## Summary

- New `pickKbViewer(mimeType): 'pdf' | 'xlsx' | 'docx' | 'image' | 'video' | 'audio' | 'text'` pure helper at `apps/web/src/components/works/detail/kb/viewers/pick-viewer.ts`. Side-effect-free, plain TS — runs at server-render and is exercised by vitest with 10 cases (no jsdom required). Strips Content-Type parameters + lowercases before matching, so MIMEs round-tripped through the upload row classify correctly. CSV intentionally falls through to `'text'` (the XLSX viewer parses via exceljs which rejects plain CSV).
- `kbAPI.getUpload(workId, uploadId): Promise<KbUploadDto>` server-only helper added to `apps/web/src/lib/api/kb.ts`.
- Doc detail page now fetches the source upload when `doc.sourceUploadId` is set (404 / 5xx falls back to the markdown path), runs `pickKbViewer(upload.mimeType)`, and dispatches to `KbPdfViewer` / `KbXlsxViewer` / `KbDocxViewer` / `KbImageViewer` / `KbVideoViewer` / `KbAudioViewer`. All receive `url=/api/works/${id}/kb/uploads/${upload.id}/download` (row 21a streamed-bytes endpoint) + `sizeBytes=upload.fileSize` + `filename=upload.originalFilename`; video / audio also pass `mimeType` through.
- Existing flows preserved: full-lock docs still render `KbDocumentView`; text MIMEs (and orphaned upload refs) still render `KbEditor`.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm build --filter='!./apps/docs'` — full workspace build green (3m08s, 58/58)
- [x] `npx vitest run src/components/works/detail/kb` — KB suite 187/187 (177 prior + 10 new `pick-viewer` cases)
- [ ] CI `lint-and-test (22.x)` — runs on PR, expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: row 21c (A14 viewer-cap e2e) can be written against the now-working dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Knowledge base documents now support viewing multiple file formats. You can display and interact with PDF files, Excel spreadsheets, Word documents, images, videos, and audio files directly within the knowledge base interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->