### PR TITLE
test(kb): A14 e2e — viewer size caps (PDF inline + XLSX fallback) (EW-641 Phase 1B/d row 21c)

### DIFF
--- a/apps/web/e2e/helpers/kb-fixtures.ts
+++ b/apps/web/e2e/helpers/kb-fixtures.ts
@@ -71,3 +71,73 @@ export async function seedKbMarkdownDoc(
     }
     return { documentId, path };
 }
+
+export interface SeedKbBinaryDocOptions {
+    /** Filename used in the multipart upload; controls the resulting doc slug. */
+    filename: string;
+    /** Storage MIME type — drives both the upload row's `mimeType` and the viewer dispatcher (row 21b). */
+    mimeType: string;
+    /** Raw bytes. For viewer-cap tests, `Buffer.alloc(6 * 1024 * 1024, 0)` is plenty for a 6 MiB stub. */
+    body: Buffer;
+    /** Optional class override; defaults to `knowledge` so the doc lands in a predictable folder. */
+    targetClass?: string;
+    /** Optional title — falls back to filename-minus-extension server-side. */
+    title?: string;
+}
+
+export interface SeededKbBinaryDoc extends SeededKbDoc {
+    uploadId: string;
+}
+
+/**
+ * POST multipart with an arbitrary MIME + buffer, returning the upload id
+ * AND the resulting doc id/path. Mirrors `seedKbMarkdownDoc` but accepts
+ * binary uploads — for non-text MIMEs the API stores the bytes with
+ * `extractionStatus='skipped'`, creates a stub `WorkKnowledgeDocument`
+ * row whose `sourceUploadId` points at the upload, and the row-21b viewer
+ * dispatcher (`pickKbViewer`) mounts the matching `Kb{Pdf,Xlsx,Docx,Image,
+ * Video,Audio}Viewer`.
+ *
+ * Watch-out: the upload endpoint's per-file cap is `KB_UPLOAD_MAX_BYTES`
+ * (default 200 MiB). The 5 MiB-XLSX / 30 MiB-PDF / 10 MiB-image / etc.
+ * thresholds tested by A14 are enforced VIEWER-SIDE (each viewer's
+ * `KB_*_INLINE_MAX_BYTES`), so a 6 MiB upload here is accepted and the
+ * viewer renders the download fallback purely from the doc's
+ * `fileSize`-driven decision.
+ */
+export async function seedKbBinaryDoc(
+    request: APIRequestContext,
+    token: string,
+    workId: string,
+    opts: SeedKbBinaryDocOptions,
+): Promise<SeededKbBinaryDoc> {
+    const res = await request.post(`${API_BASE}/api/works/${workId}/kb/uploads`, {
+        headers: authedHeaders(token),
+        multipart: {
+            file: {
+                name: opts.filename,
+                mimeType: opts.mimeType,
+                buffer: opts.body,
+            },
+            targetClass: opts.targetClass ?? 'knowledge',
+            ...(opts.title ? { title: opts.title } : {}),
+        },
+    });
+    if (!res.ok()) {
+        const errBody = await res.text();
+        throw new Error(`seedKbBinaryDoc failed (${res.status()}): ${errBody}`);
+    }
+    const json = (await res.json()) as {
+        upload?: { id?: string } | null;
+        document?: { id?: string; path?: string } | null;
+    };
+    const uploadId = json.upload?.id;
+    const documentId = json.document?.id;
+    const path = json.document?.path;
+    if (!uploadId || !documentId || !path) {
+        throw new Error(
+            `seedKbBinaryDoc: upload accepted but response shape missing ids: ${JSON.stringify(json)}`,
+        );
+    }
+    return { uploadId, documentId, path };
+}

--- a/apps/web/e2e/kb-viewer-size-cap.spec.ts
+++ b/apps/web/e2e/kb-viewer-size-cap.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './helpers/test-user';
+import { createWorkViaAPI, loginViaAPI } from './helpers/api';
+import { seedKbBinaryDoc } from './helpers/kb-fixtures';
+
+/**
+ * EW-641 Phase 1B/d row 21c — A14 acceptance e2e (viewer size caps).
+ *
+ * Drives the per-MIME viewer dispatcher (row 21b) end-to-end:
+ *
+ *  A14.1 — PDF under the 30 MiB inline cap: seed a tiny valid PDF byte
+ *    stub via the public upload endpoint, navigate to the per-doc
+ *    editor route, assert that `KbPdfViewer` mounts in `data-mode="inline"`
+ *    (the lazy-loaded iframe canvas — we only check the dispatcher's
+ *    outer-container state, not the PDF.js render, so this stays fast
+ *    and stable on CI).
+ *
+ *  A14.2 — XLSX over the 5 MiB inline cap: seed a 6 MiB zero-filled
+ *    buffer (passes the upload endpoint's 200 MiB cap, fails the
+ *    KbXlsxViewer's 5 MiB viewer-side threshold), navigate, assert
+ *    that `KbXlsxViewer` mounts in `data-mode="download"` AND the
+ *    `kb-xlsx-download-fallback` card is visible.
+ *
+ * The viewer dispatcher lives in
+ * `apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx`
+ * — it fetches the source upload row when `doc.sourceUploadId` is set,
+ * runs `pickKbViewer(upload.mimeType)`, and dispatches to the matching
+ * `Kb{Pdf,Xlsx,Docx,Image,Video,Audio}Viewer`. URL points at the
+ * row-21a download proxy (`/api/works/:id/kb/uploads/:uploadId/download`).
+ *
+ * Lives in `apps/web/e2e/` so the existing `e2e.yml` workflow picks it
+ * up on push to develop / stage / main. Authenticated by the shared
+ * `storageState` from `global-setup.ts` (the chromium project's
+ * `testIgnore` regex does not enumerate `kb-*`).
+ */
+
+const PDF_MIME = 'application/pdf';
+const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+/**
+ * Minimal valid PDF byte stub. Browsers + pdf-parse accept this as a
+ * "1 page, empty content stream" PDF. Plenty for the dispatcher test —
+ * we're asserting on the outer container's `data-mode` attribute, not
+ * on the rendered PDF content.
+ */
+const MINIMAL_PDF_BYTES = Buffer.from(
+    '%PDF-1.4\n1 0 obj<<>>endobj\nxref\n0 1\n0000000000 65535 f\ntrailer<<>>\n%%EOF\n',
+    'utf8',
+);
+
+test.describe('Knowledge Base — A14 viewer size caps', () => {
+    test('PDF under 30 MiB renders inline via KbPdfViewer', async ({ page, request }) => {
+        test.setTimeout(180_000);
+
+        const { access_token } = await loginViaAPI(request, {
+            email: TEST_USER.email,
+            password: TEST_USER.password,
+        });
+
+        const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        const { id: workId } = await createWorkViaAPI(request, access_token, {
+            name: `KB PDF inline ${runId}`,
+        });
+        expect(workId, 'createWorkViaAPI must return a non-empty work id').toBeTruthy();
+
+        const { path: docPath } = await seedKbBinaryDoc(request, access_token, workId, {
+            filename: `kb-a14-pdf-${runId}.pdf`,
+            mimeType: PDF_MIME,
+            body: MINIMAL_PDF_BYTES,
+        });
+        expect(docPath).toMatch(/\.pdf$/);
+
+        await page.goto(`/en/works/${workId}/kb/${docPath}`, { waitUntil: 'domcontentloaded' });
+
+        const pdfViewer = page.locator('[data-testid="kb-pdf-viewer"]');
+        await expect(pdfViewer).toBeVisible({ timeout: 60_000 });
+        await expect(pdfViewer).toHaveAttribute('data-mode', 'inline');
+        // Confirm the download fallback did NOT render — the viewer's
+        // inline branch chose KbPdfViewerCanvas (next/dynamic), not the
+        // download-fallback card.
+        await expect(page.locator('[data-testid="kb-pdf-download-fallback"]')).toHaveCount(0);
+    });
+
+    test('XLSX over 5 MiB shows download fallback via KbXlsxViewer', async ({ page, request }) => {
+        test.setTimeout(180_000);
+
+        const { access_token } = await loginViaAPI(request, {
+            email: TEST_USER.email,
+            password: TEST_USER.password,
+        });
+
+        const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        const { id: workId } = await createWorkViaAPI(request, access_token, {
+            name: `KB XLSX over-cap ${runId}`,
+        });
+        expect(workId).toBeTruthy();
+
+        // 6 MiB zero-filled — accepted by the 200 MiB upload cap, exceeds
+        // KbXlsxViewer's 5 MiB viewer-side threshold. We don't need a
+        // real workbook because the dispatcher decides on `mimeType` +
+        // `fileSize` BEFORE the canvas runs `exceljs.xlsx.load()`. The
+        // download-fallback card renders purely from the size check.
+        const xlsxBuffer = Buffer.alloc(6 * 1024 * 1024, 0);
+        const { path: docPath } = await seedKbBinaryDoc(request, access_token, workId, {
+            filename: `kb-a14-xlsx-${runId}.xlsx`,
+            mimeType: XLSX_MIME,
+            body: xlsxBuffer,
+        });
+        expect(docPath).toMatch(/\.xlsx$/);
+
+        await page.goto(`/en/works/${workId}/kb/${docPath}`, { waitUntil: 'domcontentloaded' });
+
+        const xlsxViewer = page.locator('[data-testid="kb-xlsx-viewer"]');
+        await expect(xlsxViewer).toBeVisible({ timeout: 60_000 });
+        await expect(xlsxViewer).toHaveAttribute('data-mode', 'download');
+        await expect(page.locator('[data-testid="kb-xlsx-download-fallback"]')).toBeVisible({
+            timeout: 10_000,
+        });
+        // The download anchor's href must point at the row-21a download
+        // proxy so the operator's click streams the bytes back through
+        // the same CSP+nosniff-pinned route.
+        const downloadLink = page.locator('[data-testid="kb-xlsx-download-link"]');
+        await expect(downloadLink).toBeVisible();
+        await expect(downloadLink).toHaveAttribute(
+            'href',
+            new RegExp(`/api/works/${workId}/kb/uploads/[^/]+/download$`),
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- `apps/web/e2e/kb-viewer-size-cap.spec.ts` drives the row-21b viewer dispatcher end-to-end with two cases.
  - **A14.1 PDF inline**: seed a tiny valid PDF byte stub (`%PDF-1.4\n1 0 obj<<>>endobj\nxref\n0 1\n0000000000 65535 f\ntrailer<<>>\n%%EOF\n`) via the public upload endpoint, navigate, assert `[data-testid="kb-pdf-viewer"][data-mode="inline"]` is visible and no download fallback rendered.
  - **A14.2 XLSX over-cap**: seed `Buffer.alloc(6 * 1024 * 1024, 0)` with the openxml-spreadsheet MIME, navigate, assert `[data-testid="kb-xlsx-viewer"][data-mode="download"]` + `kb-xlsx-download-fallback` rendered, and the download anchor's `href` matches the row-21a download proxy.
- `apps/web/e2e/helpers/kb-fixtures.ts` adds `seedKbBinaryDoc(request, token, workId, opts)` (POSTs multipart with arbitrary MIME + buffer, returns `{ uploadId, documentId, path }`). Reused by future A14 follow-ups for DOCX / image / video / audio caps.
- Note on the size discipline: the upload endpoint per-file cap is 200 MiB; per-viewer caps (5 MiB XLSX, 30 MiB PDF/DOCX, 10 MiB image, 100 MiB video, 50 MiB audio) are enforced viewer-side, so a 6 MiB upload is accepted and the fallback renders purely from the `fileSize`-driven decision in `KbXlsxViewer.tsx`.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm exec playwright test --list kb-viewer-size-cap` — Playwright resolves both tests under `[chromium]` (authenticated): `PDF under 30 MiB renders inline` + `XLSX over 5 MiB shows download fallback`
- [ ] CI `lint-and-test (22.x)` — runs on PR, expected green (e2e doesn't run on PR; gated by format + build + unit tests only)
- [ ] CodeRabbit review — expected pass
- [ ] After merge: next push to develop triggers `e2e.yml` which exercises the two new specs end-to-end against the dispatcher (row 21b) + download endpoint (row 21a). If both go green, A14 acceptance is met and Phase 1B/d (rows 1-21c) is effectively complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for knowledge base viewer size handling, including inline display for smaller files and download fallback for larger files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->