### PR TITLE
test(kb): A16 e2e — retry-extraction stays skipped for off-list MIME (EW-641 Phase 1B/d row 23)

### DIFF
--- a/apps/web/e2e/helpers/kb-fixtures.ts
+++ b/apps/web/e2e/helpers/kb-fixtures.ts
@@ -141,3 +141,71 @@ export async function seedKbBinaryDoc(
     }
     return { uploadId, documentId, path };
 }
+
+export interface SeedKbSkippedUploadOptions {
+    /** Filename used in the multipart upload. */
+    filename: string;
+    /** Raw bytes. Tests can use `Buffer.from('opaque', 'utf8')` — content doesn't matter when extraction is skipped. */
+    body: Buffer;
+    /**
+     * Optional MIME override — defaults to `application/octet-stream` which
+     * has no extractor route, so the upload lands as `extractionStatus='skipped'`
+     * with `document: null`. Pass another off-list MIME (e.g.
+     * `application/x-zip-compressed`) to exercise the same branch with a
+     * different content-type.
+     */
+    mimeType?: string;
+    /** Optional class override; defaults to `knowledge`. */
+    targetClass?: string;
+}
+
+export interface SeededKbSkippedUpload {
+    uploadId: string;
+    /** Raw `extractionStatus` field as it appeared in the upload row on response. */
+    extractionStatus: string;
+}
+
+/**
+ * POST multipart with a MIME that has no extractor route, returning ONLY
+ * the upload id + its extractionStatus. Companion to `seedKbBinaryDoc` for
+ * the row 23 (A16) retry-extraction acceptance test: when the MIME is
+ * unrecognized, `KnowledgeBaseService.createUpload` short-circuits the
+ * extract+materialize path, persists the bytes, records
+ * `kb_upload_extraction_skipped`, and returns `{ upload, document: null }`.
+ * Throwing on the missing `document` field — like `seedKbBinaryDoc` does
+ * — would be wrong for this branch.
+ */
+export async function seedKbSkippedUpload(
+    request: APIRequestContext,
+    token: string,
+    workId: string,
+    opts: SeedKbSkippedUploadOptions,
+): Promise<SeededKbSkippedUpload> {
+    const res = await request.post(`${API_BASE}/api/works/${workId}/kb/uploads`, {
+        headers: authedHeaders(token),
+        multipart: {
+            file: {
+                name: opts.filename,
+                mimeType: opts.mimeType ?? 'application/octet-stream',
+                buffer: opts.body,
+            },
+            targetClass: opts.targetClass ?? 'knowledge',
+        },
+    });
+    if (!res.ok()) {
+        const errBody = await res.text();
+        throw new Error(`seedKbSkippedUpload failed (${res.status()}): ${errBody}`);
+    }
+    const json = (await res.json()) as {
+        upload?: { id?: string; extractionStatus?: string } | null;
+        document?: { id?: string } | null;
+    };
+    const uploadId = json.upload?.id;
+    const extractionStatus = json.upload?.extractionStatus;
+    if (!uploadId || typeof extractionStatus !== 'string') {
+        throw new Error(
+            `seedKbSkippedUpload: upload accepted but response shape missing fields: ${JSON.stringify(json)}`,
+        );
+    }
+    return { uploadId, extractionStatus };
+}

--- a/apps/web/e2e/kb-extraction-retry.spec.ts
+++ b/apps/web/e2e/kb-extraction-retry.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, createWorkViaAPI, loginViaAPI } from './helpers/api';
+import { TEST_USER } from './helpers/test-user';
+import { seedKbSkippedUpload } from './helpers/kb-fixtures';
+
+/**
+ * EW-641 Phase 1B/d row 23 — A16 acceptance e2e (failed/skipped extraction
+ * + retry).
+ *
+ * Exercises the retry path through the public surface:
+ *
+ *   1. Seed an upload with `application/octet-stream` — no extractor
+ *      route, so `KnowledgeBaseService.createUpload` lands the upload
+ *      with `extractionStatus='skipped'` + `document: null` and emits
+ *      `kb_upload_extraction_skipped` to the activity log.
+ *   2. Confirm the GET shape: `extractionStatus='skipped'`,
+ *      `extractedDocumentId` is null/undefined.
+ *   3. Call `POST /api/works/:id/kb/uploads/:uploadId/retry-extraction`
+ *      (the manager+ endpoint from `kb.controller.ts`). The
+ *      `KnowledgeBaseService.retryUploadExtraction` flow re-reads the
+ *      bytes from storage, re-routes through the buffer extractor;
+ *      `application/octet-stream` still has no extractor route, so it
+ *      stays skipped + emits another `kb_upload_extraction_skipped`.
+ *   4. Confirm the activity log now has ≥ 2 `kb_upload_extraction_skipped`
+ *      rows for this `(workId, uploadId)` correlation pair — proving the
+ *      retry endpoint actually runs the same code path.
+ *
+ * Pure backend assertion via Playwright's `request` fixture (same shape
+ * as A15). The retry endpoint is the manager+ surface; the TEST_USER
+ * created the Work via `createWorkViaAPI`, so they own it.
+ *
+ * For full A16 ("actually-failed PDF" path), a future PR can extend this
+ * spec with an `__TEST_FORCE_EXTRACT_FAIL__` env-flag injector that
+ * makes the buffer extractor throw mid-route. That requires a small
+ * test-only seam in `KnowledgeBaseBufferExtractorService` and is out of
+ * scope for this PR (per the row 23 plan in
+ * Workspace/knowledge/runbooks/KNOWLEDGE_BASE_HANDOFF.md).
+ */
+
+interface ActivityRow {
+    actionType: string;
+    workId: string | null;
+    createdAt: string;
+    metadata: Record<string, unknown> | null;
+}
+
+interface ActivityListResponse {
+    activities: ActivityRow[];
+    total: number;
+}
+
+test.describe('Knowledge Base — A16 retry-extraction', () => {
+    test('octet-stream upload stays skipped after retry; activity log records both attempts', async ({
+        request,
+    }) => {
+        test.setTimeout(120_000);
+
+        const { access_token } = await loginViaAPI(request, {
+            email: TEST_USER.email,
+            password: TEST_USER.password,
+        });
+
+        const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        const { id: workId } = await createWorkViaAPI(request, access_token, {
+            name: `KB Retry Extract ${runId}`,
+        });
+        expect(workId).toBeTruthy();
+
+        // 1. Seed an upload the buffer-extractor has no route for. The
+        //    bytes don't have to be valid anything — `createUpload`
+        //    persists them, marks the row skipped, and emits the
+        //    activity row without trying to parse the content.
+        const opaqueBody = Buffer.from(`KB A16 opaque payload ${runId}`, 'utf8');
+        const { uploadId, extractionStatus } = await seedKbSkippedUpload(
+            request,
+            access_token,
+            workId,
+            { filename: `kb-a16-${runId}.bin`, body: opaqueBody },
+        );
+        expect(extractionStatus).toBe('skipped');
+
+        // 2. Verify the GET surface matches the create response: the
+        //    upload row is persisted with `extractionStatus='skipped'`
+        //    and no `extractedDocumentId`.
+        const beforeRes = await request.get(
+            `${API_BASE}/api/works/${workId}/kb/uploads/${uploadId}`,
+            { headers: authedHeaders(access_token) },
+        );
+        expect(beforeRes.status(), 'GET upload after create').toBe(200);
+        const beforeBody = (await beforeRes.json()) as {
+            extractionStatus?: string;
+            extractedDocumentId?: string | null;
+        };
+        expect(beforeBody.extractionStatus).toBe('skipped');
+        expect(beforeBody.extractedDocumentId ?? null).toBeNull();
+
+        // 3. POST retry-extraction. The endpoint requires manager+ role
+        //    on the Work; createWorkViaAPI made TEST_USER the owner.
+        const retryRes = await request.post(
+            `${API_BASE}/api/works/${workId}/kb/uploads/${uploadId}/retry-extraction`,
+            { headers: authedHeaders(access_token) },
+        );
+        expect(retryRes.status(), 'POST retry-extraction').toBe(200);
+        const retryBody = (await retryRes.json()) as {
+            upload?: { extractionStatus?: string };
+            document?: unknown;
+        };
+        // The retry runs through `extractAndMaterialize`; with an
+        // unsupported MIME the doc is null and the upload status stays
+        // 'skipped'. The activity row count grows by one.
+        expect(retryBody.upload?.extractionStatus).toBe('skipped');
+        expect(retryBody.document ?? null).toBeNull();
+
+        // 4. The activity log should now have at least TWO
+        //    `kb_upload_extraction_skipped` rows correlated to this
+        //    upload — one from createUpload, one from
+        //    retryUploadExtraction. Poll because `ActivityLogService.log`
+        //    is fire-and-forget on some paths (lesson learned in A15).
+        const skippedRows = await pollForSkippedRows(
+            request,
+            access_token,
+            workId,
+            uploadId,
+            2,
+            30_000,
+            1_000,
+        );
+        expect(skippedRows.length).toBeGreaterThanOrEqual(2);
+        for (const row of skippedRows) {
+            expect(row.metadata?.uploadId).toBe(uploadId);
+        }
+    });
+});
+
+/**
+ * Poll `GET /api/activity-log?workId=<id>&actionType=kb_upload_extraction_skipped`
+ * until at least `minCount` rows for the target `uploadId` appear.
+ * Returns the matching rows sorted by `createdAt` ascending.
+ */
+async function pollForSkippedRows(
+    request: Parameters<typeof loginViaAPI>[0],
+    token: string,
+    workId: string,
+    uploadId: string,
+    minCount: number,
+    budgetMs: number,
+    intervalMs: number,
+): Promise<ActivityRow[]> {
+    const deadline = Date.now() + budgetMs;
+    let lastBody = '';
+    while (Date.now() < deadline) {
+        const res = await request.get(
+            `${API_BASE}/api/activity-log?workId=${encodeURIComponent(workId)}&actionType=kb_upload_extraction_skipped&limit=100`,
+            { headers: authedHeaders(token) },
+        );
+        if (res.ok()) {
+            const body = (await res.json()) as ActivityListResponse;
+            const ours = body.activities.filter((r) => r.metadata?.uploadId === uploadId);
+            if (ours.length >= minCount) {
+                return ours.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+            }
+            lastBody = JSON.stringify({ total: body.total, oursCount: ours.length });
+        } else {
+            lastBody = await res.text();
+        }
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new Error(
+        `pollForSkippedRows: ${budgetMs}ms budget exhausted before ${minCount} kb_upload_extraction_skipped rows for upload ${uploadId} appeared; last body: ${lastBody}`,
+    );
+}


### PR DESCRIPTION
## Summary

- `apps/web/e2e/kb-extraction-retry.spec.ts` exercises `POST /api/works/:id/kb/uploads/:uploadId/retry-extraction` through its public surface for the off-list-MIME branch:
  1. Seed an `application/octet-stream` upload via the new `seedKbSkippedUpload` helper. `KnowledgeBaseService.createUpload` lands `extractionStatus='skipped'` + `document: null` and emits the first `kb_upload_extraction_skipped` activity row.
  2. Confirm via `GET /api/works/:id/kb/uploads/:uploadId` that the row is persisted with the expected status + no `extractedDocumentId`.
  3. `POST .../retry-extraction` — re-runs the same code path; status stays `'skipped'`, document is still null, second `kb_upload_extraction_skipped` row lands.
  4. Poll the activity log until ≥ 2 skipped rows for this `(workId, uploadId)` appear (handles `ActivityLogService.log`'s fire-and-forget path, lesson learned in A15).
- `apps/web/e2e/helpers/kb-fixtures.ts` gains `seedKbSkippedUpload` (companion to `seedKbBinaryDoc`) — the existing helper threw on `document: null`, this one returns `{ uploadId, extractionStatus }` so the no-extractor branch is testable.
- Full A16 "actually-failed PDF" path (where the extractor throws mid-route) needs a test-only seam in `KnowledgeBaseBufferExtractorService` — deferred per the row 23 plan in the KB handoff. This PR covers the shippable off-list-MIME subset.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm exec playwright test --list kb-extraction-retry` — resolves under `[chromium]`
- [ ] CI `lint-and-test (22.x)` — expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: next push to develop triggers `e2e.yml` which exercises the retry endpoint + activity-log correlation end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for Knowledge Base extraction retry functionality, including handling of uploads that skip extraction and verification of extraction status tracking in activity logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->