### PR TITLE
fix(e2e): cross-process TEST_USER credential propagation for KB specs (EW-641 Phase 1B/d)

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,8 +1,11 @@
 import { test as setup, expect } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { TEST_USER } from './helpers/test-user';
 import { registerViaAPI } from './helpers/auth';
 
 const authFile = 'e2e/.auth/user.json';
+const credentialsFile = 'e2e/.auth/test-user.json';
 
 /**
  * Global setup: create a test user and save authenticated browser state.
@@ -115,4 +118,20 @@ setup('authenticate', async ({ page, baseURL }) => {
 
     // 5. Save the browser state (cookies, localStorage)
     await page.context().storageState({ path: authFile });
+
+    // 6. Persist the TEST_USER credentials so OTHER spec processes can
+    //    log in via API with the SAME email/password the setup project
+    //    just registered. Without this, every spec that imports
+    //    `helpers/test-user.ts` runs a fresh `const suffix =
+    //    Date.now().toString(36)` at module load (each worker is its own
+    //    Node process), producing a different email — `loginViaAPI`
+    //    then 401s with "Invalid email or password". Specs needing a
+    //    bearer token import `loadSeededTestUser()` from
+    //    `helpers/seeded-test-user.ts` to read this file instead.
+    mkdirSync(dirname(credentialsFile), { recursive: true });
+    writeFileSync(
+        credentialsFile,
+        JSON.stringify({ ...TEST_USER, generatedAt: new Date().toISOString() }, null, 2),
+        'utf8',
+    );
 });

--- a/apps/web/e2e/helpers/seeded-test-user.ts
+++ b/apps/web/e2e/helpers/seeded-test-user.ts
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+/**
+ * Credentials of the test user registered by `global-setup.ts`. Read
+ * back by spec processes that need to `loginViaAPI` for a bearer token
+ * — the bare `helpers/test-user.ts` module is NOT a safe source for
+ * those creds because every worker / spec file evaluates its
+ * `Date.now()` suffix independently (each Playwright worker is its own
+ * Node process). global-setup writes this file alongside the
+ * storageState; tests read it via `loadSeededTestUser()`.
+ */
+export interface SeededTestUser {
+    name: string;
+    email: string;
+    password: string;
+}
+
+const CREDENTIALS_FILE = 'e2e/.auth/test-user.json';
+
+let cached: SeededTestUser | undefined;
+
+/**
+ * Read the JSON file `global-setup.ts` writes after registering the
+ * test user. Cached after the first read so repeat callers in the same
+ * spec process don't re-stat the file. Throws a descriptive error if
+ * the file is missing — the setup project must have run first.
+ *
+ * Falls back to env-var overrides (E2E_TEST_USER_EMAIL /
+ * E2E_TEST_USER_PASSWORD) so operators running specs against a shared
+ * staging environment can point at a pre-existing account without
+ * re-running global-setup.
+ */
+export function loadSeededTestUser(): SeededTestUser {
+    if (cached) return cached;
+
+    const overrideEmail = process.env.E2E_TEST_USER_EMAIL;
+    const overridePassword = process.env.E2E_TEST_USER_PASSWORD;
+    if (overrideEmail && overridePassword) {
+        cached = {
+            name: process.env.E2E_TEST_USER_NAME ?? overrideEmail,
+            email: overrideEmail,
+            password: overridePassword,
+        };
+        return cached;
+    }
+
+    if (!existsSync(CREDENTIALS_FILE)) {
+        throw new Error(
+            `loadSeededTestUser: ${CREDENTIALS_FILE} not found. The "setup" Playwright project must run before specs that call this helper. Either run \`pnpm exec playwright test\` (which runs setup as a dependency project) or set E2E_TEST_USER_EMAIL + E2E_TEST_USER_PASSWORD to point at a pre-existing account.`,
+        );
+    }
+    const raw = readFileSync(CREDENTIALS_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<SeededTestUser>;
+    if (!parsed.email || !parsed.password) {
+        throw new Error(
+            `loadSeededTestUser: ${CREDENTIALS_FILE} is missing email or password fields. Re-run the setup project to regenerate.`,
+        );
+    }
+    cached = {
+        name: parsed.name ?? parsed.email,
+        email: parsed.email,
+        password: parsed.password,
+    };
+    return cached;
+}

--- a/apps/web/e2e/kb-activity-log.spec.ts
+++ b/apps/web/e2e/kb-activity-log.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { API_BASE, authedHeaders, createWorkViaAPI, loginViaAPI } from './helpers/api';
-import { TEST_USER } from './helpers/test-user';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { seedKbMarkdownDoc } from './helpers/kb-fixtures';
 
 /**
@@ -52,9 +52,10 @@ test.describe('Knowledge Base — A15 activity log sequence', () => {
     }) => {
         test.setTimeout(120_000);
 
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;

--- a/apps/web/e2e/kb-dedup.spec.ts
+++ b/apps/web/e2e/kb-dedup.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { API_BASE, authedHeaders, createWorkViaAPI, loginViaAPI } from './helpers/api';
-import { TEST_USER } from './helpers/test-user';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { seedKbMarkdownDoc } from './helpers/kb-fixtures';
 
 /**
@@ -59,9 +59,10 @@ test.describe('Knowledge Base — A17 SHA-256 dedup', () => {
     }) => {
         test.setTimeout(120_000);
 
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;

--- a/apps/web/e2e/kb-edit-autosave.spec.ts
+++ b/apps/web/e2e/kb-edit-autosave.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { TEST_USER } from './helpers/test-user';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { createWorkViaAPI, loginViaAPI } from './helpers/api';
 import { seedKbMarkdownDoc } from './helpers/kb-fixtures';
 
@@ -40,10 +40,14 @@ test.describe('Knowledge Base — A13 edit + autosave', () => {
         // compile cost, then autosave debounces + commits.
         test.setTimeout(180_000);
 
-        // 1. Mint a bearer token for the test user.
+        // 1. Mint a bearer token for the test user — read the
+        //    credentials global-setup wrote so this spec's worker uses
+        //    the SAME email it registered (the bare `TEST_USER` module
+        //    isn't shared across Node processes).
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         // 2. Create a fresh Work and seed one markdown doc inside it via

--- a/apps/web/e2e/kb-extraction-retry.spec.ts
+++ b/apps/web/e2e/kb-extraction-retry.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { API_BASE, authedHeaders, createWorkViaAPI, loginViaAPI } from './helpers/api';
-import { TEST_USER } from './helpers/test-user';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { seedKbSkippedUpload } from './helpers/kb-fixtures';
 
 /**
@@ -55,9 +55,10 @@ test.describe('Knowledge Base — A16 retry-extraction', () => {
     }) => {
         test.setTimeout(120_000);
 
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;

--- a/apps/web/e2e/kb-upload.spec.ts
+++ b/apps/web/e2e/kb-upload.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { TEST_USER } from './helpers/test-user';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { createWorkViaAPI, loginViaAPI } from './helpers/api';
 
 /**
@@ -41,13 +41,19 @@ test.describe('Knowledge Base — A12 drag-drop upload', () => {
         // suite uses for navigation-heavy authenticated flows.
         test.setTimeout(180_000);
 
-        // 1. Mint a bearer token for the same TEST_USER the storageState
-        //    was signed in as. We can't pull it out of cookies here — the
-        //    web's session cookie is opaque — so re-login via /api/auth
-        //    is the standard pattern (other specs do the same).
+        // 1. Mint a bearer token for the same user the storageState
+        //    was signed in as. We can't pull it out of cookies here —
+        //    the web's session cookie is opaque — so re-login via
+        //    /api/auth. Importing `TEST_USER` directly from
+        //    `helpers/test-user.ts` is unsafe across spec workers
+        //    because each Node process re-evaluates the module's
+        //    `Date.now()` suffix; the global-setup project writes the
+        //    real credentials to disk and `loadSeededTestUser()` reads
+        //    them back.
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         // 2. Create a fresh Work for this run so the KB tree starts

--- a/apps/web/e2e/kb-viewer-size-cap.spec.ts
+++ b/apps/web/e2e/kb-viewer-size-cap.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { TEST_USER } from './helpers/test-user';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
 import { createWorkViaAPI, loginViaAPI } from './helpers/api';
 import { seedKbBinaryDoc } from './helpers/kb-fixtures';
 
@@ -52,9 +52,10 @@ test.describe('Knowledge Base — A14 viewer size caps', () => {
     test('PDF under 30 MiB renders inline via KbPdfViewer', async ({ page, request }) => {
         test.setTimeout(180_000);
 
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
@@ -84,9 +85,10 @@ test.describe('Knowledge Base — A14 viewer size caps', () => {
     test('XLSX over 5 MiB shows download fallback via KbXlsxViewer', async ({ page, request }) => {
         test.setTimeout(180_000);
 
+        const testUser = loadSeededTestUser();
         const { access_token } = await loginViaAPI(request, {
-            email: TEST_USER.email,
-            password: TEST_USER.password,
+            email: testUser.email,
+            password: testUser.password,
         });
 
         const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;


### PR DESCRIPTION
## Summary

- Every KB e2e spec on develop has been failing since PR #946 with `loginViaAPI failed (401): Invalid email or password`. Root cause: `apps/web/e2e/helpers/test-user.ts` builds `TEST_USER` from `Date.now().toString(36)` at module load — each Playwright worker (setup vs chromium) is a separate Node process, so the suffix DIFFERS between the worker that registers the user and the worker that tries to log in via API.
- The dashboard-authenticated specs sidestep this by relying on the shared `storageState` cookie from global-setup. KB specs that need a bearer token (so they can call `/api/works` and `/api/works/:id/kb/...`) cannot — they hit `/api/auth/login` with credentials, which is when the cross-process suffix divergence bites.

## Fix

- `apps/web/e2e/global-setup.ts` now writes the actual registered TEST_USER it used to `e2e/.auth/test-user.json` (alongside the existing `user.json` storageState).
- New `apps/web/e2e/helpers/seeded-test-user.ts` exports `loadSeededTestUser()` which reads that file. Supports `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` env-var overrides so operators can run specs against a shared staging environment without re-running global-setup.
- All 6 KB specs that use `loginViaAPI` (kb-upload, kb-edit-autosave, kb-viewer-size-cap, kb-activity-log, kb-extraction-retry, kb-dedup) swap `import { TEST_USER } from './helpers/test-user'` for the new helper. `kb-smoke.spec.ts` doesn't call loginViaAPI so it's untouched.

## Verification

```
$ pnpm exec playwright test --list | grep kb-
  [chromium] › kb-activity-log.spec.ts:50:9 › Knowledge Base — A15 activity log sequence › ...
  [chromium] › kb-dedup.spec.ts:57:9 › Knowledge Base — A17 SHA-256 dedup › ...
  [chromium] › kb-edit-autosave.spec.ts:37:9 › Knowledge Base — A13 edit + autosave › ...
  [chromium] › kb-extraction-retry.spec.ts:53:9 › Knowledge Base — A16 retry-extraction › ...
  [chromium] › kb-smoke.spec.ts:24:9 › Knowledge Base — e2e harness smoke › ...
  [chromium] › kb-upload.spec.ts:34:9 › Knowledge Base — A12 drag-drop upload › ...
  [chromium] › kb-viewer-size-cap.spec.ts:52:9 › Knowledge Base — A14 viewer size caps › PDF ...
  [chromium] › kb-viewer-size-cap.spec.ts:85:9 › Knowledge Base — A14 viewer size caps › XLSX ...
```

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm exec playwright test --list` — all 8 KB specs resolve under `[chromium]`, no other specs broken
- [x] `grep -rn TEST_USER apps/web/e2e/kb-*.spec.ts` — only explanatory comments left, no actual imports/usages
- [ ] CI `lint-and-test (22.x)` — expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: next push to develop triggers `e2e.yml`. The 6 fixed specs should now reach actual KB behaviour assertions instead of dying at the API login step. Any subsequent failures are real KB issues to debug, not credential plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test infrastructure with improved test user credential management to ensure consistent and reliable test execution across test workers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->