### PR TITLE
docs(plugin): document embedding fallback semantics on IAiProviderPlugin.createEmbedding (EW-641 Phase 2/a row 26)

### DIFF
--- a/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
@@ -271,7 +271,49 @@ export interface IAiProviderPlugin extends IPlugin {
 	createStreamingChatCompletion(options: ChatCompletionOptions): AsyncIterable<ChatCompletionChunk>;
 
 	/**
-	 * Create embeddings
+	 * Create embeddings for one or more text inputs.
+	 *
+	 * Powers EW-641 Phase 2 (KB semantic retrieval) — the agent
+	 * `KnowledgeBaseChunker` task fans chunk text out to whichever
+	 * provider plugin the operator has configured for the `embedding`
+	 * capability, then writes the returned vectors into
+	 * `work_knowledge_chunk.embedding` (pgvector column) for RRF blend
+	 * with lexical search at query time.
+	 *
+	 * **Optional capability.** Plugin authors implement this only when
+	 * the upstream provider exposes a dedicated embeddings endpoint
+	 * (OpenAI `text-embedding-3-small`, Cohere `embed-v3`, etc.).
+	 * Providers that don't have one (e.g. Anthropic on the
+	 * 2026-05-21 launch surface) leave it `undefined` and KB falls
+	 * back to lexical-only retrieval — no semantic blend, but the
+	 * search still returns results from the Postgres FTS index.
+	 *
+	 * **Fallback selection order** (resolved by
+	 * `AiFacadeService.embed(input, opts)`):
+	 *   1. The operator-pinned embedding provider, if configured
+	 *      (`pluginSettings.embeddingProviderId`).
+	 *   2. The first AI-provider plugin in the registry whose
+	 *      `createEmbedding` is defined AND whose `isAvailable()`
+	 *      resolves true.
+	 *   3. If none qualifies, the facade throws
+	 *      `EmbeddingNotConfiguredError`. KB retrieval catches that
+	 *      and degrades to lexical-only — see
+	 *      `KnowledgeBaseService.search` for the consumer-side gate.
+	 *
+	 * **Batch semantics.** Implementations MUST accept `input` as
+	 * either a single string or an array — the response's
+	 * `embeddings` array preserves input order with the same length
+	 * (`embeddings[i]` is the vector for `input[i]`). Splitting +
+	 * rejoining batches across multiple provider calls is the
+	 * plugin's responsibility (not all providers accept the same
+	 * batch size; OpenAI caps at 2048).
+	 *
+	 * **Dimension hint.** `options.dimensions`, when provided, asks
+	 * the provider to return shorter vectors (OpenAI `dimensions`
+	 * field). Plugins that can't honor the request SHOULD ignore it
+	 * and return the model's native dimensionality — the consumer
+	 * detects the mismatch and adapts the pgvector column rather
+	 * than reject the response.
 	 */
 	createEmbedding?(options: EmbeddingOptions): Promise<EmbeddingResponse>;
 


### PR DESCRIPTION
## Summary

- The handoff's Phase 2/a row 26 ("Plugin contract: `embed(input)`") assumed the AI provider plugin interface lacked embedding support — but `createEmbedding?(options): Promise<EmbeddingResponse>` has been there since the original spec. The actionable part of the row was the fallback-semantics doc, which was missing.
- This PR documents:
  - **Consumer**: EW-641 Phase 2 KB chunker + RRF retrieval (the agent task that powers semantic search).
  - **Optional capability**: providers without a dedicated embeddings endpoint (e.g. Anthropic on 2026-05-21) leave it `undefined`; KB falls back to lexical-only retrieval.
  - **Fallback selection order**: operator-pinned provider → first-available `createEmbedding` plugin → throw `EmbeddingNotConfiguredError`. Resolved by `AiFacadeService.embed(input, opts)`; KB `search` catches the throw and degrades.
  - **Batch semantics**: `embeddings[i]` mirrors `input[i]` order; plugins split per upstream per-request caps internally.
  - **Dimension hint**: `options.dimensions` is a hint — plugins MAY ignore it and return the model's native size; consumers adapt the pgvector column rather than reject.
- Did NOT add a duplicate `embed(input)` method to the interface — would clutter the surface for marginal ergonomic gain. The simpler signature belongs on the agent-side facade (`AiFacadeService`), which can be added as a separate row 26b once the embedding-provider resolution is wired.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm build --filter='@ever-works/contracts' --filter='@ever-works/plugin'` — 2/2 successful, DTS emit clean (43 lines added, 1 deletion — pure JSDoc inside the existing optional method declaration)
- [ ] CI `lint-and-test (22.x)` — expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: row 27 (OpenAI plugin implements `createEmbedding` with `text-embedding-3-small` defaults) becomes the next NEXT and consumes this fallback contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for AI provider embedding capabilities, including workflow details, fallback selection order, and dimension mismatch handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->