### PR TITLE
feat(openai-plugin): wire createEmbedding settings + text-embedding-3-small default (EW-641 Phase 2/a row 27)

### DIFF
--- a/packages/plugin/src/abstract/base-ai-provider.ts
+++ b/packages/plugin/src/abstract/base-ai-provider.ts
@@ -47,6 +47,13 @@ export abstract class BaseAiProvider extends BasePlugin implements IAiProviderPl
 		if (s.baseUrl) config.baseURL = s.baseUrl as string;
 		if (s.temperature !== undefined) config.temperature = s.temperature as number;
 		if (s.maxTokens !== undefined) config.maxTokens = s.maxTokens as number;
+		// EW-641 Phase 2/a row 27 — propagate the embedding-model setting so
+		// `aiOps.createEmbedding(options, resolvedConfig)` picks it up when
+		// `options.model` is unset. Without this, OpenAI-style configs that
+		// only declare `embeddingModel` in plugin settings (not in the
+		// per-call options) would throw "Embedding model must be specified"
+		// inside `AiOperations.createEmbedding`.
+		if (s.embeddingModel) config.embeddingModel = s.embeddingModel as string;
 		return config;
 	}
 

--- a/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
@@ -229,6 +229,17 @@ export interface EmbeddingOptions {
 	readonly input: string | readonly string[];
 	/** Embedding dimensions (if model supports) */
 	readonly dimensions?: number;
+	/**
+	 * Resolved settings for this operation. Mirrors
+	 * `ChatCompletionOptions.settings` so the facade can thread
+	 * user/work-scoped values (`apiKey`, `embeddingModel`, `baseUrl`)
+	 * through to the embedding call without a separate plumbing
+	 * surface. Plugins should prefer these over their stored defaults
+	 * — `BaseAiProvider.resolveConfig` handles the merge.
+	 *
+	 * Added by EW-641 Phase 2/a row 27 (PR following #957).
+	 */
+	readonly settings?: PluginSettings;
 }
 
 /**

--- a/packages/plugins/openai/src/__tests__/openai.plugin.spec.ts
+++ b/packages/plugins/openai/src/__tests__/openai.plugin.spec.ts
@@ -65,6 +65,18 @@ describe('OpenAiPlugin', () => {
 			expect(props).toHaveProperty('complexModel');
 		});
 
+		it('should expose embeddingModel with text-embedding-3-small default for Phase 2 KB retrieval', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('embeddingModel');
+			const schema = props.embeddingModel as Record<string, unknown>;
+			expect(schema.type).toBe('string');
+			expect(schema.default).toBe('text-embedding-3-small');
+			// Global scope (not user) so a fresh sign-up inherits the
+			// operator-pinned model without configuring it themselves —
+			// matches the other model selectors.
+			expect(schema['x-scope']).toBe('global');
+		});
+
 		it('should have temperature and maxTokens settings', () => {
 			const props = plugin.settingsSchema.properties!;
 			expect(props).toHaveProperty('temperature');
@@ -164,6 +176,95 @@ describe('OpenAiPlugin', () => {
 
 		it('should throw when plugin not loaded', async () => {
 			await expect(plugin.askJson('test')).rejects.toThrow('Plugin not loaded');
+		});
+	});
+
+	describe('createEmbedding', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'openai',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should throw when plugin not loaded', async () => {
+			await expect(plugin.createEmbedding({ input: 'hello' })).rejects.toThrow('OpenAI plugin not loaded');
+		});
+
+		it('should delegate to aiOps.createEmbedding with options + resolved config', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+			aiOpsInstance.createEmbedding.mockResolvedValue({
+				model: 'text-embedding-3-small',
+				embeddings: [[0.1, 0.2]]
+			});
+
+			await plugin.createEmbedding({ input: 'hello' });
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.objectContaining({ input: 'hello' }),
+				expect.objectContaining({ embeddingModel: 'text-embedding-3-small' })
+			);
+		});
+
+		it('should preserve options.input array shape and forward dimensions', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+			aiOpsInstance.createEmbedding.mockResolvedValue({
+				model: 'text-embedding-3-small',
+				embeddings: [
+					[0.1, 0.2],
+					[0.3, 0.4]
+				]
+			});
+
+			await plugin.createEmbedding({
+				input: ['first', 'second'],
+				dimensions: 512
+			});
+
+			const [firstArg] = aiOpsInstance.createEmbedding.mock.calls[0] as [{ input: unknown; dimensions: unknown }];
+			expect(firstArg.input).toEqual(['first', 'second']);
+			expect(firstArg.dimensions).toBe(512);
+		});
+
+		it('should honor a user-provided embeddingModel setting over the text-embedding-3-small default', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+			aiOpsInstance.createEmbedding.mockResolvedValue({
+				model: 'text-embedding-3-large',
+				embeddings: [[0.1]]
+			});
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				settings: { embeddingModel: 'text-embedding-3-large' }
+			});
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({ embeddingModel: 'text-embedding-3-large' })
+			);
+		});
+
+		it('should NOT inject the default when options.model is explicitly set', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+			aiOpsInstance.createEmbedding.mockResolvedValue({
+				model: 'text-embedding-ada-002',
+				embeddings: [[0.1]]
+			});
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				model: 'text-embedding-ada-002'
+			});
+
+			// options.model takes precedence inside AiOperations.createEmbedding —
+			// the resolved config should NOT carry a fallback embeddingModel, so
+			// the caller's explicit choice wins.
+			const [, configArg] = aiOpsInstance.createEmbedding.mock.calls[0] as [unknown, { embeddingModel?: string }];
+			expect(configArg.embeddingModel).toBeUndefined();
 		});
 	});
 

--- a/packages/plugins/openai/src/openai.plugin.ts
+++ b/packages/plugins/openai/src/openai.plugin.ts
@@ -72,6 +72,15 @@ export class OpenAiPlugin extends BaseAiProvider {
 				'x-widget': 'model-select',
 				'x-scope': 'global'
 			},
+			embeddingModel: {
+				type: 'string',
+				title: 'Embedding Model',
+				description:
+					"Used by the Knowledge Base's semantic search to turn documents into vectors. text-embedding-3-small is the cheapest (1c/1M tokens) and a strong default for English-heavy KBs.",
+				default: 'text-embedding-3-small',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
 			temperature: {
 				type: 'number',
 				title: 'Temperature',
@@ -137,7 +146,20 @@ export class OpenAiPlugin extends BaseAiProvider {
 		if (!this.aiOps) {
 			throw new Error('OpenAI plugin not loaded');
 		}
-		return this.aiOps.createEmbedding(options);
+		// EW-641 Phase 2/a row 27 — thread per-call `options.settings`
+		// through `BaseAiProvider.resolveConfig` so `apiKey` +
+		// `embeddingModel` from user/work-scoped settings reach the
+		// underlying LangChain `OpenAIEmbeddings` call. Final fallback to
+		// `text-embedding-3-small` (OpenAI's default KB-workload embedding
+		// model, 1536-dim, cheapest in the embedding tier) so callers that
+		// supply neither `options.model` nor a settings override still get
+		// a working call instead of the "Embedding model must be specified"
+		// throw from `AiOperations.createEmbedding`.
+		const resolvedConfig = this.resolveConfig(options.settings);
+		if (!options.model && !resolvedConfig.embeddingModel) {
+			resolvedConfig.embeddingModel = 'text-embedding-3-small';
+		}
+		return this.aiOps.createEmbedding(options, resolvedConfig);
 	}
 
 	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {


### PR DESCRIPTION
## Summary

Row 27's check was "OpenAI plugin implements createEmbedding with text-embedding-3-small default". `OpenAiPlugin.createEmbedding` already existed but delegated to `aiOps.createEmbedding(options)` with NO config override — so the user's `embeddingModel` setting (and `apiKey`) never reached `AiOperations.createEmbedding`, which then threw "Embedding model must be specified".

## Changes

- **`EmbeddingOptions`** gains an optional `settings?: PluginSettings` field — mirrors `ChatCompletionOptions.settings` so the facade can thread user/work-scoped values through to the embedding call. Existing callers stay source-compatible.
- **`BaseAiProvider.resolveConfig`** propagates `s.embeddingModel` into `config.embeddingModel`. Without this, even the settings-schema default would be lost.
- **`OpenAiPlugin.createEmbedding`** now calls `this.resolveConfig(options.settings)` (matching the chat / askJson surfaces) AND falls back to `text-embedding-3-small` when neither `options.model` nor the resolved `config.embeddingModel` is set. Fallback only applies when the caller hasn't explicitly picked a model.
- **OpenAI plugin `settingsSchema`** adds `embeddingModel` with `default: 'text-embedding-3-small'`, `x-scope: global`, `x-widget: 'model-select'` (consistent with the other model selectors so the Workbench UI renders the same dropdown).

## Tests

- 5 new vitest cases on `createEmbedding`: throws-when-unloaded, default threading via resolved config, array-input + dimensions preservation, user-override of `embeddingModel`, explicit `options.model` skips the default-injection.
- Schema test asserts the new key + default + global scope.
- `pnpm test` in `packages/plugins/openai`: 23/23 green (18 prior + 5 new).
- `pnpm build --filter='@ever-works/contracts' --filter='@ever-works/plugin'`: clean.

## Test plan

- [x] `pnpm format:check` — green locally
- [x] `pnpm build --filter='@ever-works/contracts' --filter='@ever-works/plugin'` — green
- [x] `cd packages/plugins/openai && pnpm test` — 23/23 green
- [ ] CI `lint-and-test (22.x)` — expected green
- [ ] CodeRabbit review — expected pass
- [ ] After merge: row 28 (Hybrid chunker in `packages/agent/src/services/kb-chunker.ts`) becomes the next NEXT and consumes this provider implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedding model configuration support with `text-embedding-3-small` as the default for semantic search operations
  * Improved configuration propagation to ensure embedding settings are properly applied throughout the system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->