### PR TITLE
fix(e2e): default KB seed helpers to 'freeform' targetClass

### DIFF
--- a/apps/web/e2e/helpers/kb-fixtures.ts
+++ b/apps/web/e2e/helpers/kb-fixtures.ts
@@ -16,7 +16,7 @@ export interface SeedKbMarkdownDocOptions {
     filename: string;
     /** Markdown body. */
     body: string;
-    /** Optional class override; defaults to `knowledge` so the doc lands in a predictable folder. */
+    /** Optional class override; defaults to `freeform` (a valid KbDocumentClass enum value). */
     targetClass?: string;
     /** Optional title — falls back to filename-minus-extension server-side. */
     title?: string;
@@ -51,7 +51,7 @@ export async function seedKbMarkdownDoc(
                 mimeType: 'text/markdown',
                 buffer: Buffer.from(opts.body, 'utf8'),
             },
-            targetClass: opts.targetClass ?? 'knowledge',
+            targetClass: opts.targetClass ?? 'freeform',
             ...(opts.title ? { title: opts.title } : {}),
         },
     });
@@ -79,7 +79,7 @@ export interface SeedKbBinaryDocOptions {
     mimeType: string;
     /** Raw bytes. For viewer-cap tests, `Buffer.alloc(6 * 1024 * 1024, 0)` is plenty for a 6 MiB stub. */
     body: Buffer;
-    /** Optional class override; defaults to `knowledge` so the doc lands in a predictable folder. */
+    /** Optional class override; defaults to `freeform` (a valid KbDocumentClass enum value). */
     targetClass?: string;
     /** Optional title — falls back to filename-minus-extension server-side. */
     title?: string;
@@ -119,7 +119,7 @@ export async function seedKbBinaryDoc(
                 mimeType: opts.mimeType,
                 buffer: opts.body,
             },
-            targetClass: opts.targetClass ?? 'knowledge',
+            targetClass: opts.targetClass ?? 'freeform',
             ...(opts.title ? { title: opts.title } : {}),
         },
     });
@@ -155,7 +155,7 @@ export interface SeedKbSkippedUploadOptions {
      * different content-type.
      */
     mimeType?: string;
-    /** Optional class override; defaults to `knowledge`. */
+    /** Optional class override; defaults to `freeform` (a valid KbDocumentClass enum value). */
     targetClass?: string;
 }
 
@@ -189,7 +189,7 @@ export async function seedKbSkippedUpload(
                 mimeType: opts.mimeType ?? 'application/octet-stream',
                 buffer: opts.body,
             },
-            targetClass: opts.targetClass ?? 'knowledge',
+            targetClass: opts.targetClass ?? 'freeform',
         },
     });
     if (!res.ok()) {

--- a/apps/web/e2e/kb-dedup.spec.ts
+++ b/apps/web/e2e/kb-dedup.spec.ts
@@ -99,7 +99,7 @@ test.describe('Knowledge Base — A17 SHA-256 dedup', () => {
                     mimeType: 'text/markdown',
                     buffer: Buffer.from(bodyText, 'utf8'),
                 },
-                targetClass: 'knowledge',
+                targetClass: 'freeform',
             },
         });
         expect(secondRes.status(), 'POST second upload (dedup)').toBe(201);

--- a/apps/web/e2e/kb-upload.spec.ts
+++ b/apps/web/e2e/kb-upload.spec.ts
@@ -86,13 +86,15 @@ test.describe('Knowledge Base — A12 drag-drop upload', () => {
             buffer: fileBuffer,
         });
 
-        // 5. Classify modal opens — default class is 'freeform'; pick
-        //    'knowledge' so we land in a predictable group in the tree.
-        //    Leave description blank and tags empty; row 20 (A13) covers
-        //    edit+autosave separately.
+        // 5. Classify modal opens — default class is 'freeform'; keep it
+        //    so we land in a predictable group in the tree. 'knowledge' is
+        //    NOT a valid KbDocumentClass enum value (the schema is brand |
+        //    legal | seo | style | glossary | competitors | personas |
+        //    research | output | freeform). Leave description blank and
+        //    tags empty; row 20 (A13) covers edit+autosave separately.
         const modal = page.getByTestId('kb-classify-modal');
         await expect(modal).toBeVisible({ timeout: 15_000 });
-        await page.getByTestId('kb-classify-class').selectOption('knowledge');
+        await page.getByTestId('kb-classify-class').selectOption('freeform');
         await page.getByTestId('kb-classify-confirm').click();
         // After confirm the modal unmounts.
         await expect(modal).not.toBeVisible({ timeout: 10_000 });
@@ -106,7 +108,7 @@ test.describe('Knowledge Base — A12 drag-drop upload', () => {
 
         // 7. router.refresh() (inside KbUploadZone's onSuccess) re-fetches
         //    the server-rendered tree panel. The new doc has a path under
-        //    `knowledge/<slug>.md` derived from the title (filename minus
+        //    `freeform/<slug>.md` derived from the title (filename minus
         //    extension), so we match by `data-doc-path*="<runId>"`.
         const treeItem = page.locator(`[data-testid="kb-tree-item"][data-doc-path*="${runId}"]`);
         await expect(treeItem).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
## Summary

- E2E.yml run [26297764715](https://github.com/ever-works/ever-works/actions/runs/26297764715) failed on every KB spec with a 400 from `/api/works/:id/kb/uploads`:
  > `targetClass must be one of the following values: brand, legal, seo, style, glossary, competitors, personas, research, output, freeform`
- The `KbDocumentClass` enum does NOT include `'knowledge'`, but my seed helpers (`seedKbMarkdownDoc`, `seedKbBinaryDoc`, `seedKbSkippedUpload`) defaulted to it. The classify-modal selection in `kb-upload.spec.ts` and the inline second-upload POST in `kb-dedup.spec.ts` had the same typo.
- Defaults all three helpers + both inline call-sites to `'freeform'`, which IS in the enum and matches the upload zone's own client-side default.

This unblocks the post-#956 e2e run. After PR #956 fixed cross-process credential propagation (`loginViaAPI` 401 → 200), this is the next layer down (`seedKb*` 400 → 201). Once green, EW-641 can transition to Done (Phase 1B/d row 25).

## Test plan

- [ ] CI green on push (e2e.yml fans 8 KB specs across chromium + chromium-no-auth)
- [ ] Once merged, watch the `develop` push e2e.yml run — all 6 KB-suite spec files should pass through the API without 400 on the upload seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->