### PR TITLE
feat(agent): hybrid markdown chunker for KB semantic retrieval

### DIFF
--- a/packages/agent/src/services/__tests__/kb-chunker.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-chunker.spec.ts
@@ -1,0 +1,212 @@
+import { chunkMarkdown } from '../kb-chunker';
+
+describe('chunkMarkdown', () => {
+    describe('boundary cases', () => {
+        it('returns [] for empty input', () => {
+            expect(chunkMarkdown('')).toEqual([]);
+        });
+
+        it('returns [] for whitespace-only input', () => {
+            expect(chunkMarkdown('   \n\n\t\n')).toEqual([]);
+        });
+
+        it('throws on non-positive maxTokens', () => {
+            expect(() => chunkMarkdown('hi', { maxTokens: 0 })).toThrow(RangeError);
+            expect(() => chunkMarkdown('hi', { maxTokens: -1 })).toThrow(RangeError);
+        });
+
+        it('throws on overlap >= maxTokens', () => {
+            expect(() => chunkMarkdown('hi', { maxTokens: 10, overlap: 10 })).toThrow(RangeError);
+            expect(() => chunkMarkdown('hi', { maxTokens: 10, overlap: 11 })).toThrow(RangeError);
+        });
+
+        it('throws on negative overlap', () => {
+            expect(() => chunkMarkdown('hi', { overlap: -1 })).toThrow(RangeError);
+        });
+    });
+
+    describe('single-section bodies (no H2/H3)', () => {
+        it('returns one chunk with undefined headingPath when no H2/H3 present', () => {
+            const body = 'just some prose\nacross a couple lines\n';
+            const chunks = chunkMarkdown(body);
+            expect(chunks).toHaveLength(1);
+            expect(chunks[0]).toEqual({
+                index: 0,
+                content: body,
+                headingPath: undefined,
+                charStart: 0,
+                charEnd: body.length,
+            });
+        });
+
+        it('treats H1 as content (not a split point)', () => {
+            const body = '# The Title\n\nSome intro text under the H1.\n';
+            const chunks = chunkMarkdown(body);
+            expect(chunks).toHaveLength(1);
+            expect(chunks[0].headingPath).toBeUndefined();
+            expect(chunks[0].content).toBe(body);
+        });
+    });
+
+    describe('heading-aware splits', () => {
+        it('splits at H2 boundaries and attaches headingPath', () => {
+            const body = '# Title\nintro paragraph\n\n## Brand voice\nbody A\n\n## Legal\nbody B\n';
+            const chunks = chunkMarkdown(body);
+            expect(chunks).toHaveLength(3);
+            // Leading section before any H2: no headingPath
+            expect(chunks[0].headingPath).toBeUndefined();
+            expect(chunks[0].content).toContain('# Title');
+            expect(chunks[0].content).toContain('intro paragraph');
+            // Each H2 gets its own chunk including the heading line.
+            expect(chunks[1].headingPath).toEqual(['Brand voice']);
+            expect(chunks[1].content.startsWith('## Brand voice')).toBe(true);
+            expect(chunks[1].content).toContain('body A');
+            expect(chunks[2].headingPath).toEqual(['Legal']);
+            expect(chunks[2].content.startsWith('## Legal')).toBe(true);
+            expect(chunks[2].content).toContain('body B');
+        });
+
+        it('nests H3 under the active H2 in headingPath', () => {
+            const body =
+                '## Brand voice\nintro\n\n### Examples\nexample A\n\n### Counterexamples\nexample B\n\n## Legal\nlegal text\n';
+            const chunks = chunkMarkdown(body);
+            // Sections: H2 Brand voice (intro), H3 Examples, H3 Counterexamples,
+            // H2 Legal — 4 chunks.
+            expect(chunks).toHaveLength(4);
+            expect(chunks[0].headingPath).toEqual(['Brand voice']);
+            expect(chunks[1].headingPath).toEqual(['Brand voice', 'Examples']);
+            expect(chunks[2].headingPath).toEqual(['Brand voice', 'Counterexamples']);
+            expect(chunks[3].headingPath).toEqual(['Legal']);
+        });
+
+        it('clears the H3 from headingPath when a new H2 opens', () => {
+            const body = '## A\nbody\n\n### A1\nbody\n\n## B\nbody under B without any H3\n';
+            const chunks = chunkMarkdown(body);
+            expect(chunks).toHaveLength(3);
+            expect(chunks[0].headingPath).toEqual(['A']);
+            expect(chunks[1].headingPath).toEqual(['A', 'A1']);
+            // H3 must NOT leak into the next H2's section.
+            expect(chunks[2].headingPath).toEqual(['B']);
+        });
+
+        it('treats H3 without a preceding H2 as a top-level heading', () => {
+            const body = '### Loose H3\nbody under loose H3\n';
+            const chunks = chunkMarkdown(body);
+            expect(chunks).toHaveLength(1);
+            expect(chunks[0].headingPath).toEqual(['Loose H3']);
+        });
+    });
+
+    describe('fenced code block masking', () => {
+        it('ignores ## inside a backtick fence', () => {
+            const body = [
+                '## Real heading',
+                'body',
+                '',
+                '```ts',
+                '// the next line LOOKS like a heading but is in code',
+                '## not a heading',
+                '```',
+                'still in Real heading section',
+                '',
+            ].join('\n');
+            const chunks = chunkMarkdown(body);
+            // One chunk only — the fenced `## not a heading` must not
+            // open a new section.
+            expect(chunks).toHaveLength(1);
+            expect(chunks[0].headingPath).toEqual(['Real heading']);
+            expect(chunks[0].content).toContain('## not a heading');
+            expect(chunks[0].content).toContain('still in Real heading section');
+        });
+
+        it('ignores ### inside a tilde fence', () => {
+            const body = ['~~~markdown', '### nope', '~~~', '## actual heading', 'body'].join('\n');
+            const chunks = chunkMarkdown(body);
+            // Sections: leading body (fenced block has no heading) + H2.
+            expect(chunks.map((c) => c.headingPath)).toEqual([undefined, ['actual heading']]);
+        });
+
+        it('does not close a backtick fence with tildes', () => {
+            const body = ['```', '## fake heading', '~~~', 'still in fence', '```'].join('\n');
+            const chunks = chunkMarkdown(body);
+            // Everything between the ``` markers is a single block; no headings.
+            expect(chunks).toHaveLength(1);
+            expect(chunks[0].headingPath).toBeUndefined();
+        });
+    });
+
+    describe('sliding window fallback', () => {
+        it('subdivides an oversized section with overlap', () => {
+            // 600 chars ≈ 150 tokens. With maxTokens=40 (160 chars window)
+            // and overlap=10 (40 char overlap, step 120 chars), expect
+            // multiple chunks.
+            const body = '## Big section\n' + 'a'.repeat(600);
+            const chunks = chunkMarkdown(body, { maxTokens: 40, overlap: 10 });
+            expect(chunks.length).toBeGreaterThan(1);
+
+            // Every chunk inherits the section's headingPath.
+            for (const c of chunks) expect(c.headingPath).toEqual(['Big section']);
+
+            // Chunks step forward by (40-10)*4 = 120 chars but window
+            // size is 40*4 = 160 chars — so chunks[1].charStart should
+            // be chunks[0].charStart + 120 and they should overlap by
+            // 40 chars.
+            const step = chunks[1].charStart - chunks[0].charStart;
+            expect(step).toBe(120);
+            const overlap = chunks[0].charEnd - chunks[1].charStart;
+            expect(overlap).toBe(40);
+
+            // Last chunk's charEnd must equal the section's actual end.
+            const last = chunks[chunks.length - 1];
+            expect(last.charEnd).toBe(body.length);
+        });
+
+        it('keeps each sub-chunk under the cap', () => {
+            const body = '## Big\n' + 'x'.repeat(2_000);
+            const chunks = chunkMarkdown(body, { maxTokens: 50, overlap: 5 });
+            for (const c of chunks) {
+                // window = 50 * 4 = 200 chars; final chunk may be shorter.
+                expect(c.content.length).toBeLessThanOrEqual(200);
+            }
+        });
+
+        it('preserves a small section verbatim alongside an oversized neighbour', () => {
+            const small = '## Small\nshort body\n';
+            const huge = '## Huge\n' + 'y'.repeat(4_000);
+            const body = small + huge;
+            const chunks = chunkMarkdown(body, { maxTokens: 50, overlap: 5 });
+            // First chunk is the small section as a single chunk.
+            expect(chunks[0].headingPath).toEqual(['Small']);
+            expect(chunks[0].content).toBe(small);
+            // The rest are sub-chunks of the huge section.
+            for (let i = 1; i < chunks.length; i++) {
+                expect(chunks[i].headingPath).toEqual(['Huge']);
+            }
+            expect(chunks.length).toBeGreaterThan(2);
+        });
+    });
+
+    describe('offsets and ordering', () => {
+        it('emits monotonically increasing index values starting at 0', () => {
+            const body = '## A\n' + 'a'.repeat(200) + '\n\n## B\nB body\n';
+            const chunks = chunkMarkdown(body, { maxTokens: 20, overlap: 5 });
+            for (let i = 0; i < chunks.length; i++) {
+                expect(chunks[i].index).toBe(i);
+            }
+        });
+
+        it('charStart/charEnd reconstruct the original body for single-section docs', () => {
+            const body = 'no headings here\njust prose\n';
+            const [chunk] = chunkMarkdown(body);
+            expect(body.slice(chunk.charStart, chunk.charEnd)).toBe(chunk.content);
+        });
+
+        it('charStart of section N+1 equals charEnd of section N (no gaps)', () => {
+            const body = '## A\nbody A\n\n## B\nbody B\n\n## C\nbody C\n';
+            const chunks = chunkMarkdown(body);
+            for (let i = 1; i < chunks.length; i++) {
+                expect(chunks[i].charStart).toBe(chunks[i - 1].charEnd);
+            }
+        });
+    });
+});

--- a/packages/agent/src/services/kb-chunker.ts
+++ b/packages/agent/src/services/kb-chunker.ts
@@ -1,0 +1,256 @@
+/**
+ * Hybrid chunker for KB document bodies.
+ *
+ * EW-641 Phase 2/a row 28. Produces `KbChunk[]` from a markdown body
+ * using a heading-aware split (H2/H3) with a 512-token fixed-size
+ * fallback (sliding window with 64-token overlap) for any section that
+ * exceeds the cap. The resulting array is consumed by row 29's
+ * embedding Trigger.dev task and persisted as `WorkKnowledgeChunk` rows
+ * keyed by `(workId, id)` (see `work-knowledge-chunk.entity.ts`).
+ *
+ * **Tokenizer choice.** We approximate token count as
+ * `Math.ceil(text.length / 4)` — OpenAI's published heuristic for
+ * English text. `js-tiktoken` is in the workspace as a transitive
+ * LangChain dep, but pulling it in here costs ~6 MiB of ranks JSON
+ * loaded on first call, which is wasteful for a function that runs
+ * inside a Trigger.dev task on every doc save. If retrieval quality
+ * regressions trace back to chunk-size drift we can swap in `js-tiktoken`
+ * locally without changing the call sites — the `estimateTokens` seam
+ * is the only thing that needs to flip.
+ *
+ * **Heading semantics.** H1 is intentionally NOT a split point: spec
+ * docs typically have one H1 (the title) and chunking on it would
+ * produce a single oversized chunk that immediately falls into the
+ * sliding-window path, throwing away the structural information. H2
+ * opens a new top-level section; H3 nests under the most recent H2 and
+ * REPLACES any previous H3 in `headingPath`. Lines inside fenced code
+ * blocks (``` … ``` or ~~~ … ~~~) never count as headings — common
+ * markdown pitfall (a code sample showing `## heading` would otherwise
+ * spuriously split the section).
+ *
+ * **Sliding window.** When a section is over the cap, slide a window
+ * of `maxTokens * CHARS_PER_TOKEN` chars forward with
+ * `overlap * CHARS_PER_TOKEN` overlap. Each sub-chunk inherits its
+ * parent section's `headingPath` so retrieval can still cite the
+ * section that produced it. The character offsets in `charStart` /
+ * `charEnd` are relative to the ORIGINAL body, not the section — that
+ * way row 30's citation-rendering can compute exact spans without
+ * tracking offsets through the sectioning.
+ *
+ * **Pure function.** No I/O, no module-scoped state. Safe to call from
+ * any context (Trigger.dev task, unit test, dev preview).
+ */
+
+export interface KbChunk {
+    /** 0-based ordinal within the produced array. */
+    index: number;
+    /**
+     * The chunk text. INCLUDES the heading line(s) that opened the
+     * section so embeddings see "Brand voice / Examples" context not
+     * just the body bullets.
+     */
+    content: string;
+    /**
+     * The stack of H2/H3 headings the chunk lives under, outer-most
+     * first. Empty for the leading section before any H2/H3 heading.
+     * Example: `['Brand voice', 'Examples']` for an H3 nested under an
+     * H2.
+     */
+    headingPath?: string[];
+    /** Inclusive char offset into the original body where the chunk starts. */
+    charStart: number;
+    /** Exclusive char offset where the chunk ends. */
+    charEnd: number;
+}
+
+export interface ChunkMarkdownOptions {
+    /** Soft cap in tokens before the sliding-window fallback fires. Default 512. */
+    maxTokens?: number;
+    /** Window overlap in tokens. Default 64. */
+    overlap?: number;
+}
+
+const DEFAULT_MAX_TOKENS = 512;
+const DEFAULT_OVERLAP = 64;
+/**
+ * OpenAI's published heuristic for English text. Far from perfect for
+ * code/JSON/multilingual bodies but it's deterministic and pure — see
+ * the module docstring for the tradeoff vs `js-tiktoken`.
+ */
+const CHARS_PER_TOKEN = 4;
+
+/** Internal record of a heading-defined section before chunking. */
+interface Section {
+    /** Heading path active at the START of this section. */
+    headingPath: string[];
+    /** Section text, including any leading heading line(s). */
+    content: string;
+    charStart: number;
+    charEnd: number;
+}
+
+function estimateTokens(text: string): number {
+    return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Walk the body line-by-line splitting at H2/H3 heading boundaries,
+ * tracking a heading stack and skipping code fences. Returns at least
+ * one section even for body-only input (with `headingPath: []`).
+ */
+function splitIntoSections(body: string): Section[] {
+    if (body.length === 0) return [];
+
+    const sections: Section[] = [];
+    let h2: string | null = null;
+    let h3: string | null = null;
+
+    /** Char offset where the CURRENT (in-progress) section starts. */
+    let sectionStart = 0;
+    let sectionHeadingPath: string[] = [];
+
+    let cursor = 0;
+    let inFence = false;
+    let fenceMarker: string | null = null;
+
+    const pushSection = (endOffset: number, nextHeadingPath: string[]) => {
+        if (endOffset > sectionStart) {
+            sections.push({
+                headingPath: [...sectionHeadingPath],
+                content: body.slice(sectionStart, endOffset),
+                charStart: sectionStart,
+                charEnd: endOffset,
+            });
+        }
+        sectionStart = endOffset;
+        sectionHeadingPath = nextHeadingPath;
+    };
+
+    while (cursor < body.length) {
+        // Find end of this line (exclusive of the newline). Track the
+        // newline length so the next iteration starts past it.
+        const newlineIdx = body.indexOf('\n', cursor);
+        const lineEndExclusive = newlineIdx === -1 ? body.length : newlineIdx;
+        const line = body.slice(cursor, lineEndExclusive);
+
+        // Code fence toggling — track the marker so a ``` block isn't
+        // closed by a ~~~ and vice versa.
+        const fenceMatch = /^(```+|~~~+)/.exec(line);
+        if (fenceMatch) {
+            const marker = fenceMatch[1][0]; // '`' or '~'
+            if (!inFence) {
+                inFence = true;
+                fenceMarker = marker;
+            } else if (fenceMarker === marker) {
+                inFence = false;
+                fenceMarker = null;
+            }
+        }
+
+        if (!inFence) {
+            const h2Match = /^##\s+(.+?)\s*$/.exec(line);
+            const h3Match = /^###\s+(.+?)\s*$/.exec(line);
+            if (h2Match) {
+                h2 = h2Match[1];
+                h3 = null;
+                pushSection(cursor, [h2]);
+            } else if (h3Match) {
+                h3 = h3Match[1];
+                pushSection(cursor, h2 ? [h2, h3] : [h3]);
+            }
+        }
+
+        cursor = newlineIdx === -1 ? body.length : newlineIdx + 1;
+    }
+
+    // Flush the trailing section.
+    pushSection(body.length, []);
+
+    return sections;
+}
+
+/**
+ * Sub-divide a single oversized section with a sliding window. The
+ * window slides forward by `(maxTokens - overlap) * CHARS_PER_TOKEN`
+ * chars each step; the last window snaps to the section end so we don't
+ * lose tail bytes. The returned chunks' `headingPath` is inherited from
+ * the caller; offsets are relative to the original body.
+ */
+function slidingWindow(
+    section: Section,
+    maxTokens: number,
+    overlap: number,
+): Array<{ content: string; charStart: number; charEnd: number }> {
+    const windowChars = maxTokens * CHARS_PER_TOKEN;
+    const stepChars = Math.max(1, (maxTokens - overlap) * CHARS_PER_TOKEN);
+
+    const out: Array<{ content: string; charStart: number; charEnd: number }> = [];
+    let start = section.charStart;
+    const sectionEnd = section.charEnd;
+
+    while (start < sectionEnd) {
+        const end = Math.min(start + windowChars, sectionEnd);
+        out.push({
+            content: section.content.slice(start - section.charStart, end - section.charStart),
+            charStart: start,
+            charEnd: end,
+        });
+        if (end >= sectionEnd) break;
+        start += stepChars;
+    }
+
+    return out;
+}
+
+/**
+ * Chunk a markdown document body for embedding. Returns an empty array
+ * for empty / whitespace-only bodies.
+ */
+export function chunkMarkdown(body: string, opts: ChunkMarkdownOptions = {}): KbChunk[] {
+    const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+    const overlap = opts.overlap ?? DEFAULT_OVERLAP;
+
+    if (maxTokens <= 0) {
+        throw new RangeError(`chunkMarkdown: maxTokens must be > 0 (got ${maxTokens})`);
+    }
+    if (overlap < 0 || overlap >= maxTokens) {
+        throw new RangeError(
+            `chunkMarkdown: overlap must be in [0, maxTokens) (got overlap=${overlap}, maxTokens=${maxTokens})`,
+        );
+    }
+
+    if (!body || body.trim() === '') return [];
+
+    const sections = splitIntoSections(body);
+    const chunks: KbChunk[] = [];
+    let index = 0;
+
+    for (const section of sections) {
+        // Strip pure-whitespace sections (e.g. blank line between two
+        // back-to-back H2s) without inflating chunk count.
+        if (section.content.trim() === '') continue;
+
+        if (estimateTokens(section.content) <= maxTokens) {
+            chunks.push({
+                index: index++,
+                content: section.content,
+                headingPath: section.headingPath.length > 0 ? [...section.headingPath] : undefined,
+                charStart: section.charStart,
+                charEnd: section.charEnd,
+            });
+            continue;
+        }
+
+        for (const sub of slidingWindow(section, maxTokens, overlap)) {
+            chunks.push({
+                index: index++,
+                content: sub.content,
+                headingPath: section.headingPath.length > 0 ? [...section.headingPath] : undefined,
+                charStart: sub.charStart,
+                charEnd: sub.charEnd,
+            });
+        }
+    }
+
+    return chunks;
+}


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/a row 28 — pure function `chunkMarkdown(body, opts?)` in `packages/agent/src/services/kb-chunker.ts` producing `KbChunk[]` for the upcoming row 29 embedding Trigger.dev task.
- Heading-aware split at H2/H3 with stack-based `headingPath` tracking (e.g. `['Brand voice', 'Examples']`); new H2 clears the H3 from the stack.
- Code-fence masking (``` and `~~~`) suppresses heading detection inside code blocks; different markers don't close each other (matches CommonMark).
- 512-token / 64-token-overlap sliding window for oversized sections. Offsets in `charStart`/`charEnd` are relative to the original body so row 30's citation renderer can compute exact spans.
- Token count uses `Math.ceil(chars / 4)` heuristic. `js-tiktoken` is in the workspace transitively but its ranks JSON costs ~6 MiB on first call — wasteful per-task overhead. The `estimateTokens` seam can flip to tiktoken later without changing the call sites.

## Test plan

- [x] Local: `npx jest src/services/__tests__/kb-chunker.spec.ts` — 20/20 green in 5.4s
- [x] `pnpm format:check` — formatting clean (prettier@3.7.4)
- [ ] CI: lint-and-test (22.x) green

Coverage:
- boundary cases (empty, whitespace, `RangeError` on bad opts) — 5 cases
- single-section bodies (no H2/H3, H1-only) — 2 cases
- heading-aware splits (H2 only, nested H3, H3 cleared on new H2, loose H3) — 4 cases
- fenced code blocks (backtick, tilde, mixed-marker non-closing) — 3 cases
- sliding window (step + overlap + cap + tail-snap) — 3 cases
- offsets and ordering (monotone index, no-gap charStart/charEnd) — 3 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown chunking functionality with heading-aware document splitting.
  * Automatic handling of large sections using sliding-window sub-chunking.
  * Configurable chunk size limits and overlap parameters.
  * Proper parsing of fenced code blocks to avoid treating code content as document structure.

* **Tests**
  * Added comprehensive test suite for markdown chunking behavior, including boundary cases, heading structure handling, and output validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->