### PR TITLE
feat(agent): WorkKnowledgeChunkRepository for KB embedding writes

### DIFF
--- a/packages/agent/src/database/repositories/work-knowledge-chunk.repository.spec.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-chunk.repository.spec.ts
@@ -1,0 +1,188 @@
+import { ChunkUpsertInput, WorkKnowledgeChunkRepository } from './work-knowledge-chunk.repository';
+import { WorkKnowledgeChunk } from '../../entities/work-knowledge-chunk.entity';
+
+describe('WorkKnowledgeChunkRepository', () => {
+    let repository: {
+        find: jest.Mock;
+        count: jest.Mock;
+        manager: {
+            transaction: jest.Mock;
+        };
+    };
+    let txManager: {
+        delete: jest.Mock;
+        create: jest.Mock;
+        insert: jest.Mock;
+    };
+    let chunkRepo: WorkKnowledgeChunkRepository;
+
+    beforeEach(() => {
+        txManager = {
+            delete: jest.fn().mockResolvedValue({ affected: 0 }),
+            // Mirror real EntityManager.create: returns its second arg
+            // shape with the entity constructor applied (we just echo it).
+            create: jest.fn((_entity: unknown, value: unknown) => value),
+            insert: jest.fn().mockResolvedValue({ identifiers: [] }),
+        };
+        repository = {
+            find: jest.fn(),
+            count: jest.fn(),
+            manager: {
+                transaction: jest.fn(async (callback: (m: unknown) => unknown) =>
+                    callback(txManager),
+                ),
+            },
+        };
+        chunkRepo = new WorkKnowledgeChunkRepository(repository as never);
+    });
+
+    describe('replaceForDocument', () => {
+        it('runs delete-then-insert inside a single transaction', async () => {
+            const chunks: ChunkUpsertInput[] = [
+                {
+                    id: 'chunk-1',
+                    documentId: 'doc-1',
+                    chunkIndex: 0,
+                    content: 'first',
+                    tokenCount: 2,
+                },
+                {
+                    id: 'chunk-2',
+                    documentId: 'doc-1',
+                    chunkIndex: 1,
+                    content: 'second',
+                    tokenCount: 3,
+                },
+            ];
+
+            await chunkRepo.replaceForDocument('work-1', 'doc-1', chunks);
+
+            expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+            expect(txManager.delete).toHaveBeenCalledTimes(1);
+            expect(txManager.delete).toHaveBeenCalledWith(WorkKnowledgeChunk, {
+                workId: 'work-1',
+                documentId: 'doc-1',
+            });
+            expect(txManager.insert).toHaveBeenCalledTimes(1);
+            expect(txManager.insert).toHaveBeenCalledWith(WorkKnowledgeChunk, [
+                expect.objectContaining({
+                    id: 'chunk-1',
+                    workId: 'work-1',
+                    documentId: 'doc-1',
+                    chunkIndex: 0,
+                    content: 'first',
+                    tokenCount: 2,
+                    embedding: null,
+                    metadata: null,
+                }),
+                expect.objectContaining({
+                    id: 'chunk-2',
+                    workId: 'work-1',
+                    documentId: 'doc-1',
+                    chunkIndex: 1,
+                    content: 'second',
+                    tokenCount: 3,
+                }),
+            ]);
+        });
+
+        it('skips the insert when chunks is empty but still issues the delete', async () => {
+            await chunkRepo.replaceForDocument('work-1', 'doc-1', []);
+
+            expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+            expect(txManager.delete).toHaveBeenCalledWith(WorkKnowledgeChunk, {
+                workId: 'work-1',
+                documentId: 'doc-1',
+            });
+            expect(txManager.insert).not.toHaveBeenCalled();
+        });
+
+        it('forwards embedding and metadata when provided', async () => {
+            const chunks: ChunkUpsertInput[] = [
+                {
+                    id: 'chunk-1',
+                    documentId: 'doc-1',
+                    chunkIndex: 0,
+                    content: 'one',
+                    tokenCount: 1,
+                    embedding: [0.1, 0.2, 0.3],
+                    metadata: { headingPath: ['Brand voice'], charRange: { start: 0, end: 3 } },
+                },
+            ];
+
+            await chunkRepo.replaceForDocument('work-1', 'doc-1', chunks);
+
+            const [, inserted] = txManager.insert.mock.calls[0];
+            expect(inserted[0]).toEqual(
+                expect.objectContaining({
+                    embedding: [0.1, 0.2, 0.3],
+                    metadata: { headingPath: ['Brand voice'], charRange: { start: 0, end: 3 } },
+                }),
+            );
+        });
+
+        it("overrides the caller's workId on every row to keep the partition invariant", async () => {
+            // Even if a caller bug somehow stamps a wrong workId on the
+            // input (shouldn't be possible since the input shape doesn't
+            // carry one, but the entity does), the repo must scrub it
+            // and use the function arg.
+            const chunks: ChunkUpsertInput[] = [
+                {
+                    id: 'chunk-1',
+                    documentId: 'doc-1',
+                    chunkIndex: 0,
+                    content: 'one',
+                    tokenCount: 1,
+                },
+            ];
+
+            await chunkRepo.replaceForDocument('work-1', 'doc-1', chunks);
+
+            const [, inserted] = txManager.insert.mock.calls[0];
+            expect(inserted[0].workId).toBe('work-1');
+        });
+
+        it('lets transaction errors propagate', async () => {
+            const boom = new Error('insert failed');
+            txManager.insert.mockRejectedValueOnce(boom);
+
+            await expect(
+                chunkRepo.replaceForDocument('work-1', 'doc-1', [
+                    {
+                        id: 'chunk-1',
+                        documentId: 'doc-1',
+                        chunkIndex: 0,
+                        content: 'one',
+                        tokenCount: 1,
+                    },
+                ]),
+            ).rejects.toBe(boom);
+        });
+    });
+
+    describe('findByWorkAndDocument', () => {
+        it('queries by workId+documentId, ordered by chunkIndex ASC', async () => {
+            const row = { id: 'chunk-1' } as WorkKnowledgeChunk;
+            repository.find.mockResolvedValue([row]);
+
+            const out = await chunkRepo.findByWorkAndDocument('work-1', 'doc-1');
+
+            expect(repository.find).toHaveBeenCalledWith({
+                where: { workId: 'work-1', documentId: 'doc-1' },
+                order: { chunkIndex: 'ASC' },
+            });
+            expect(out).toEqual([row]);
+        });
+    });
+
+    describe('countByWork', () => {
+        it('counts all chunks for a work', async () => {
+            repository.count.mockResolvedValue(7);
+
+            const out = await chunkRepo.countByWork('work-1');
+
+            expect(repository.count).toHaveBeenCalledWith({ where: { workId: 'work-1' } });
+            expect(out).toBe(7);
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/work-knowledge-chunk.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-chunk.repository.ts
@@ -1,0 +1,119 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkKnowledgeChunk } from '../../entities/work-knowledge-chunk.entity';
+
+/**
+ * Input shape for `replaceForDocument`. Caller (the embedding
+ * Trigger.dev task in row 29b) is responsible for generating UUIDs +
+ * estimating token counts; this repo stays generic and doesn't bake in
+ * tokenizer choices that might drift between embedding models.
+ */
+export interface ChunkUpsertInput {
+    /** UUID — the `id` half of the composite PK. Caller generates via `randomUUID()`. */
+    id: string;
+    /** Document the chunk belongs to. (workId is passed separately.) */
+    documentId: string;
+    /** 0-based ordinal within the document. */
+    chunkIndex: number;
+    /** The chunk's text. */
+    content: string;
+    /** Token count for budget accounting. */
+    tokenCount: number;
+    /** Embedding vector, when known. Row 29b populates this before insert. */
+    embedding?: number[] | null;
+    /** Free-form per-chunk metadata (e.g. `headingPath`, `charRange`). */
+    metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Repository for `WorkKnowledgeChunk` rows.
+ *
+ * EW-641 Phase 2/a row 29a. The chunk table is partition-ready
+ * (composite PK `(workId, id)`); EVERY query path goes through a
+ * `workId` filter so a future `PARTITION BY HASH (workId)` migration
+ * is a no-op for application code.
+ *
+ * **Why `replaceForDocument` and not piecewise upsert?** A doc save
+ * typically yields a different *number* of chunks than the previous
+ * version (a paragraph added or deleted shifts every subsequent
+ * `chunkIndex`). Reconciling row-by-row would need either index-level
+ * upsert (complicated, error-prone) or a quiescence window
+ * (race-prone). Wiping the doc's chunks then inserting the new set is
+ * idempotent, fast at v1 chunk counts (low hundreds at most), and the
+ * txn boundary guarantees retrieval never sees a half-empty doc.
+ *
+ * Embedding vectors are stored via the entity's `simple-json` column
+ * declaration; the migration sets the real `vector(1536)` type. That
+ * round-trip cost is acceptable at v1; we'll revisit if it shows up as
+ * a hot path in retrieval benchmarks.
+ */
+@Injectable()
+export class WorkKnowledgeChunkRepository {
+    constructor(
+        @InjectRepository(WorkKnowledgeChunk)
+        private readonly repository: Repository<WorkKnowledgeChunk>,
+    ) {}
+
+    /**
+     * Atomically replace the chunk rows for a single document.
+     *
+     * Behaviour:
+     *  - Empty `chunks` array → DELETE only, INSERT is skipped. Use this
+     *    when re-saving an empty / whitespace-only doc body or when row
+     *    29c wants to clear chunks before unwiring.
+     *  - Non-empty → DELETE all prior rows for `(workId, documentId)`
+     *    then INSERT the new set, all inside one transaction so a
+     *    concurrent retrieval either sees the old chunk set in full or
+     *    the new one in full.
+     *
+     * Caller must ensure every input belongs to the same `documentId`
+     * (we don't filter by it — that would mask bugs). The workId on
+     * each row is set from the function arg, not the input — keeps the
+     * partition invariant local.
+     */
+    async replaceForDocument(
+        workId: string,
+        documentId: string,
+        chunks: readonly ChunkUpsertInput[],
+    ): Promise<void> {
+        await this.repository.manager.transaction(async (manager) => {
+            await manager.delete(WorkKnowledgeChunk, { workId, documentId });
+            if (chunks.length === 0) return;
+            const rows = chunks.map((c) => {
+                const row = manager.create(WorkKnowledgeChunk, {
+                    id: c.id,
+                    workId,
+                    documentId: c.documentId,
+                    chunkIndex: c.chunkIndex,
+                    content: c.content,
+                    tokenCount: c.tokenCount,
+                    embedding: c.embedding ?? null,
+                    metadata: c.metadata ?? null,
+                });
+                return row;
+            });
+            await manager.insert(WorkKnowledgeChunk, rows);
+        });
+    }
+
+    /**
+     * Read every chunk for a document, ordered by `chunkIndex` ASC.
+     * Used by row 30 (RRF retrieval) and by tests that need to verify
+     * a write landed as expected.
+     */
+    async findByWorkAndDocument(workId: string, documentId: string): Promise<WorkKnowledgeChunk[]> {
+        return this.repository.find({
+            where: { workId, documentId },
+            order: { chunkIndex: 'ASC' },
+        });
+    }
+
+    /**
+     * Count chunks for an entire Work. Useful for budget-ledger checks
+     * (row 41) and as a quick sanity gauge in tests.
+     */
+    async countByWork(workId: string): Promise<number> {
+        return this.repository.count({ where: { workId } });
+    }
+}

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -13,6 +13,7 @@ import { WorkKnowledgeDocumentRepository } from '../database/repositories/work-k
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
 import { WorkKnowledgeTagRepository } from '../database/repositories/work-knowledge-tag.repository';
 import { WorkKnowledgeCitationRepository } from '../database/repositories/work-knowledge-citation.repository';
+import { WorkKnowledgeChunkRepository } from '../database/repositories/work-knowledge-chunk.repository';
 import { KnowledgeBaseService } from './knowledge-base.service';
 import { KnowledgeBaseGitMirrorService } from './knowledge-base-git-mirror.service';
 import { KnowledgeBaseBufferExtractorService } from './knowledge-base-buffer-extractor.service';
@@ -43,7 +44,8 @@ import { WorkOwnershipService } from './work-ownership.service';
  *  - WorkKnowledgeUpload
  *  - WorkKnowledgeTag
  *  - WorkKnowledgeCitation
- *  - WorkKnowledgeChunk (no repo yet — Phase 2 introduces embedding code)
+ *  - WorkKnowledgeChunk (repo added in Phase 2/a row 29a — embedding
+ *    write path wired in rows 29b/29c)
  */
 @Module({
     imports: [
@@ -63,6 +65,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         WorkKnowledgeUploadRepository,
         WorkKnowledgeTagRepository,
         WorkKnowledgeCitationRepository,
+        WorkKnowledgeChunkRepository,
         KnowledgeBaseService,
         KnowledgeBaseGitMirrorService,
         KnowledgeBaseBufferExtractorService,
@@ -72,6 +75,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         WorkKnowledgeUploadRepository,
         WorkKnowledgeTagRepository,
         WorkKnowledgeCitationRepository,
+        WorkKnowledgeChunkRepository,
         KnowledgeBaseService,
         KnowledgeBaseGitMirrorService,
         KnowledgeBaseBufferExtractorService,


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/a **row 29a** — pure DB-layer repository for `WorkKnowledgeChunk`. Embedding logic (row 29b) and service wiring (row 29c) land in follow-ups.
- `replaceForDocument(workId, documentId, chunks: ChunkUpsertInput[])` — delete-then-insert inside a transaction so a concurrent retrieval sees the old set or the new set in full, never half-empty. Empty `chunks` → DELETE only (whitespace-only doc saves clear stale rows).
- `findByWorkAndDocument` ordered by `chunkIndex ASC` for row 30 (RRF retrieval).
- `countByWork` for row 41 budget ledgers + test gauges.
- Registered in `KnowledgeBaseModule` (providers + exports).

## Design notes

**Why delete-then-insert vs piecewise upsert?** A doc save typically yields a different *number* of chunks than the previous version (a paragraph added/removed shifts every subsequent `chunkIndex`). Row-by-row upsert needs either index-level upsert (complicated) or a quiescence window (race-prone). The transactional wipe-then-rewrite is idempotent and atomic — fine at v1 chunk counts (low hundreds at most per doc).

**`workId` invariant.** The function arg's `workId` is stamped on every row at insert time — `ChunkUpsertInput` deliberately doesn't carry a `workId` field, so the partition column stays local to the call site. (The composite PK `(workId, id)` is `PARTITION BY HASH (workId)`-ready.)

**Embedding column.** Persisted as `simple-json` here so TypeORM ignores it for schema sync; the migration sets the real `vector(1536)` type and the ivfflat index. v1 accepts the JSON round-trip cost — we revisit if it shows up as a retrieval hot path.

## Test plan

- [x] Local: `jest src/database/repositories/work-knowledge-chunk.repository.spec.ts` — 7/7 green
- [x] Local: `jest src/services/__tests__/knowledge-base.service.spec.ts` — 31/31 still green (module change is additive)
- [x] `prettier@3.7.4 --check` — clean
- [ ] CI: lint-and-test (22.x) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added repository infrastructure for managing knowledge chunks with atomic transaction support for bulk operations, document-based querying, and count aggregation.

* **Tests**
  * Comprehensive test suite added covering repository operations including transactional replacements, document queries, and work-level counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->