### PR TITLE
feat(agent,plugin): AiFacadeService.embed wrapper

### DIFF
--- a/packages/agent/src/facades/__tests__/ai.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/ai.facade.spec.ts
@@ -1225,4 +1225,150 @@ describe('AiFacadeService', () => {
             );
         });
     });
+
+    describe('embed', () => {
+        it('resolves the active plugin and forwards options + resolved settings to createEmbedding', async () => {
+            const aiPlugin = createMockAiPlugin('openai-provider', 'OpenAI');
+            const createEmbeddingMock = jest.fn().mockResolvedValue({
+                model: 'text-embedding-3-small',
+                embeddings: [[0.1, 0.2, 0.3]],
+                usage: { promptTokens: 4, completionTokens: 0, totalTokens: 4 },
+            });
+            (aiPlugin as unknown as { createEmbedding: jest.Mock }).createEmbedding =
+                createEmbeddingMock;
+
+            const registered = createRegisteredPlugin(aiPlugin, {
+                capabilities: ['ai-provider'],
+            });
+            registry.getByCapability.mockReturnValue([registered]);
+            settingsService.getSettings.mockResolvedValue({
+                apiKey: 'sk-test',
+                embeddingModel: 'text-embedding-3-small',
+            });
+
+            const result = await service.embed({ input: 'hello world' }, defaultFacadeOptions);
+
+            expect(result.embeddings).toEqual([[0.1, 0.2, 0.3]]);
+            expect(createEmbeddingMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: 'hello world',
+                    settings: expect.objectContaining({
+                        apiKey: 'sk-test',
+                        embeddingModel: 'text-embedding-3-small',
+                    }),
+                }),
+            );
+        });
+
+        it('records PluginUsage with operation=embed and totalTokens as units', async () => {
+            const aiPlugin = createMockAiPlugin('openai-provider', 'OpenAI');
+            (aiPlugin as unknown as { createEmbedding: jest.Mock }).createEmbedding = jest
+                .fn()
+                .mockResolvedValue({
+                    model: 'text-embedding-3-small',
+                    embeddings: [
+                        [0.1, 0.2],
+                        [0.3, 0.4],
+                    ],
+                    usage: { promptTokens: 7, completionTokens: 0, totalTokens: 7 },
+                });
+
+            const registered = createRegisteredPlugin(aiPlugin, {
+                capabilities: ['ai-provider'],
+            });
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await service.embed(
+                { input: ['hello', 'world'] },
+                { userId: 'user-1', workId: 'work-1' },
+            );
+
+            expect(pluginUsageService.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: 'work-1',
+                    userId: 'user-1',
+                    pluginId: 'openai-provider',
+                    units: 7,
+                    modelId: 'text-embedding-3-small',
+                    metadata: expect.objectContaining({
+                        operation: 'embed',
+                        inputCount: 2,
+                        embeddingsLength: 2,
+                    }),
+                }),
+            );
+        });
+
+        it('falls back to input-count units when the plugin omits usage (local-model branch)', async () => {
+            const aiPlugin = createMockAiPlugin('ollama-provider', 'Ollama', {
+                providerType: 'ollama',
+            });
+            (aiPlugin as unknown as { createEmbedding: jest.Mock }).createEmbedding = jest
+                .fn()
+                .mockResolvedValue({
+                    model: 'nomic-embed-text',
+                    embeddings: [[0.5, 0.6, 0.7]],
+                });
+
+            const registered = createRegisteredPlugin(aiPlugin, {
+                capabilities: ['ai-provider'],
+            });
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await service.embed({ input: ['only-one'] }, defaultFacadeOptions);
+
+            expect(pluginUsageService.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    units: 1, // input-count fallback
+                    metadata: expect.objectContaining({
+                        operation: 'embed',
+                        inputCount: 1,
+                    }),
+                }),
+            );
+        });
+
+        it('throws AiFacadeError when the resolved plugin lacks createEmbedding', async () => {
+            const aiPlugin = createMockAiPlugin('legacy-provider', 'Legacy');
+            // Plugin without createEmbedding (interface declares it optional).
+            const registered = createRegisteredPlugin(aiPlugin, {
+                capabilities: ['ai-provider'],
+            });
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await expect(service.embed({ input: 'hello' }, defaultFacadeOptions)).rejects.toThrow(
+                AiFacadeError,
+            );
+        });
+
+        it('rewraps plugin errors as AiFacadeError preserving the original cause', async () => {
+            const aiPlugin = createMockAiPlugin('openai-provider', 'OpenAI');
+            const boom = new Error('rate limited');
+            (aiPlugin as unknown as { createEmbedding: jest.Mock }).createEmbedding = jest
+                .fn()
+                .mockRejectedValue(boom);
+
+            const registered = createRegisteredPlugin(aiPlugin, {
+                capabilities: ['ai-provider'],
+            });
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await expect(
+                service.embed({ input: 'hello' }, defaultFacadeOptions),
+            ).rejects.toMatchObject({
+                name: 'AiFacadeError',
+                operation: 'embed',
+                provider: 'openai-provider',
+                cause: boom,
+            });
+        });
+
+        it('throws NoProviderError when no AI provider is configured', async () => {
+            registry.getByCapability.mockReturnValue([]);
+
+            await expect(service.embed({ input: 'hello' }, defaultFacadeOptions)).rejects.toThrow(
+                NoProviderError,
+            );
+        });
+    });
 });

--- a/packages/agent/src/facades/ai.facade.ts
+++ b/packages/agent/src/facades/ai.facade.ts
@@ -8,6 +8,8 @@ import type {
     ChatCompletionOptions,
     ChatCompletionResponse,
     ChatCompletionChunk,
+    EmbeddingOptions,
+    EmbeddingResponse,
     AiRoutingOptions,
     AiModel,
     AiProviderConfig,
@@ -437,6 +439,89 @@ export class AiFacadeService extends BaseFacadeService implements IAiFacade {
                         // Usage writes are best-effort and must not turn a successful stream into an error.
                     });
             }
+        }
+    }
+
+    /**
+     * EW-641 Phase 2/a row 29b2a — embed wrapper.
+     *
+     * Resolves the active AI provider plugin via the same chain as
+     * `createChatCompletion` (`providerOverride > work-active >
+     * defaultForCapabilities > first enabled`), threads user/work-scoped
+     * settings through `BaseAiProvider.resolveConfig` (so per-call
+     * `embeddingModel` / `apiKey` overrides win over plugin defaults —
+     * see row 27), and calls the plugin's optional `createEmbedding`
+     * method.
+     *
+     * Throws `AiFacadeError` when the resolved plugin doesn't implement
+     * `createEmbedding`. KB retrieval (row 30 RRF) catches this and
+     * falls back to lexical-only ranking so a misconfigured provider
+     * degrades cleanly rather than crashing the search endpoint.
+     *
+     * Usage is recorded under `PluginUsageCapability.AI` with
+     * `metadata.operation = 'embed'` and `units` set to the response's
+     * `totalTokens` (or input-count fallback when the plugin reports no
+     * usage — Ollama / local models often skip the token accounting).
+     */
+    async embed(
+        options: EmbeddingOptions,
+        facadeOptions: FacadeOptions,
+    ): Promise<EmbeddingResponse> {
+        const plugin = await this.resolvePlugin<IAiProviderPlugin>(
+            facadeOptions.providerOverride,
+            facadeOptions.userId,
+            facadeOptions.workId,
+        );
+
+        if (typeof plugin.createEmbedding !== 'function') {
+            throw new AiFacadeError(
+                `Active AI provider '${plugin.id}' does not implement createEmbedding`,
+                'embed',
+                plugin.id,
+            );
+        }
+
+        const settings = await this.getResolvedSettings(plugin.id, {
+            userId: facadeOptions.userId,
+            workId: facadeOptions.workId,
+        });
+
+        try {
+            const response = await plugin.createEmbedding({
+                ...options,
+                settings,
+            });
+
+            // `usage` is optional on EmbeddingResponse — fall back to
+            // input count so the ledger always has something to attribute.
+            const inputCount = Array.isArray(options.input) ? options.input.length : 1;
+            const units = response.usage?.totalTokens ?? inputCount;
+            await this.pluginUsageService?.record({
+                workId: facadeOptions.workId,
+                userId: facadeOptions.userId,
+                pluginId: plugin.id,
+                capability: PluginUsageCapability.AI,
+                units,
+                costCents: 0,
+                modelId: response.model,
+                metadata: {
+                    operation: 'embed',
+                    inputCount,
+                    promptTokens: response.usage?.promptTokens,
+                    totalTokens: response.usage?.totalTokens,
+                    embeddingsLength: response.embeddings.length,
+                },
+            });
+
+            return response;
+        } catch (err) {
+            if (err instanceof AiFacadeError) throw err;
+            throw new AiFacadeError(
+                `Embedding call failed: ${err instanceof Error ? err.message : String(err)}`,
+                'embed',
+                plugin.id,
+                err instanceof Error ? err : undefined,
+            );
         }
     }
 

--- a/packages/agent/src/pipeline/pipeline-facade.service.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.ts
@@ -16,6 +16,8 @@ import type {
     ChatCompletionOptions,
     ChatCompletionResponse,
     ChatCompletionChunk,
+    EmbeddingOptions,
+    EmbeddingResponse,
     SearchFacadeOptions,
     SearchFacadeResult,
     ScreenshotCaptureOptions,
@@ -171,6 +173,14 @@ export class PipelineFacadeService {
                     },
                     boundFacadeOptions,
                 ),
+            // EW-641 Phase 2/a row 29b2a — pipeline-bound shim that forwards
+            // to the real AiFacadeService.embed. Pipelines don't currently
+            // call embed (Phase 2/b will), but the IAiFacade contract
+            // requires the method so the binding shape stays complete.
+            embed: (
+                options: EmbeddingOptions,
+                _facadeOptions: FacadeOptions,
+            ): Promise<EmbeddingResponse> => facade.embed(options, boundFacadeOptions),
             isConfigured: () => facade.isConfigured(),
             testConnection: (_facadeOptions: FacadeOptions) =>
                 facade.testConnection(boundFacadeOptions),

--- a/packages/plugin/src/facades/ai-facade.interface.ts
+++ b/packages/plugin/src/facades/ai-facade.interface.ts
@@ -2,7 +2,9 @@ import type {
 	AiModel,
 	ChatCompletionOptions,
 	ChatCompletionResponse,
-	ChatCompletionChunk
+	ChatCompletionChunk,
+	EmbeddingOptions,
+	EmbeddingResponse
 } from '../contracts/capabilities/ai-provider.interface.js';
 import type { IBaseFacade } from './base-facade.interface.js';
 import type { FacadeOptions } from './facade-options.interface.js';
@@ -141,6 +143,31 @@ export interface IAiFacade extends IBaseFacade {
 		options: ChatCompletionOptions,
 		facadeOptions: FacadeOptions
 	): AsyncGenerator<ChatCompletionChunk>;
+
+	/**
+	 * Embed one or more inputs against the active AI provider plugin.
+	 *
+	 * EW-641 Phase 2/a row 29b2a — convenience wrapper around the active
+	 * provider's `IAiProviderPlugin.createEmbedding`. Resolves the active
+	 * plugin via the same `resolvePlugin` chain as `createChatCompletion`,
+	 * threads user/work-scoped settings (including `embeddingModel`)
+	 * through `BaseAiProvider.resolveConfig`, and records `PluginUsage`
+	 * with `capability = AI`. Throws an `AiFacadeError` when the resolved
+	 * plugin doesn't implement `createEmbedding` so KB retrieval can
+	 * surface a clear "no embedding provider configured" path (lexical
+	 * fallback per spec §15.5).
+	 *
+	 * Mirrors `createChatCompletion`'s signature. Pipelines and the KB
+	 * embedding Trigger.dev task call `embed` rather than reaching for
+	 * a plugin directly so usage tracking + provider resolution stay in
+	 * one place.
+	 *
+	 * @returns The embedding response (`{ model, embeddings, usage? }`)
+	 *          from the resolved plugin's `createEmbedding`.
+	 * @throws AiFacadeError when the resolved plugin lacks
+	 *         `createEmbedding`, or any plugin-level error (rewrapped).
+	 */
+	embed(options: EmbeddingOptions, facadeOptions: FacadeOptions): Promise<EmbeddingResponse>;
 
 	/**
 	 * Test the AI provider connection.


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/a **row 29b2a** — adds `embed(options, facadeOptions)` to `IAiFacade` + `AiFacadeService` so the upcoming KB embed Trigger.dev task body (29b2b) can call one facade method instead of reaching into a plugin directly. Same shape as `createChatCompletion`.
- Resolves the active AI provider via the existing chain (`providerOverride > work-active > defaultForCapabilities > first enabled`).
- Threads user/work-scoped settings (including `embeddingModel` from row 27) through `BaseAiProvider.resolveConfig` by passing them as `options.settings`.
- Throws `AiFacadeError` when the resolved plugin doesn't implement `createEmbedding` — KB retrieval (row 30 RRF) catches this and falls back to lexical-only ranking so a misconfigured provider degrades cleanly.
- Records `PluginUsage` with `capability=AI`, `metadata.operation='embed'`, `units=usage.totalTokens` (or input count when the plugin omits usage — Ollama/local-model branch).

## Plumbing

- Imports `EmbeddingOptions` + `EmbeddingResponse` types into `ai.facade.ts` and `pipeline-facade.service.ts`.
- Adds `embed` shim to `pipeline-facade.service.ts`'s bound IAiFacade so the type-checker stays happy; pipelines don't call embed yet (Phase 2/b will).

## Test plan

- [x] Local: `jest src/facades/__tests__/ai.facade.spec.ts` — **54/54 pass** (48 prior + 6 new on `embed`):
  - forwards options + resolved settings to createEmbedding
  - records PluginUsage with operation=embed + totalTokens units
  - input-count fallback when plugin omits usage (Ollama branch)
  - AiFacadeError when plugin lacks createEmbedding
  - rewraps plugin errors as AiFacadeError preserving cause
  - NoProviderError when no AI provider is configured
- [x] `turbo build --filter @ever-works/agent --filter @ever-works/plugin --filter ever-works-api` — clean (DTS emit + TSC + SWC all OK)
- [x] `prettier@3.7.4 --check` — clean
- [ ] CI: lint-and-test (22.x) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added embedding support to the AI service layer, enabling text-to-embedding operations through configured AI providers with automatic usage tracking and error handling.

* **Tests**
  * Added comprehensive test coverage for embedding operations, including plugin resolution, usage recording, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->