### PR TITLE
fix(api): make KB_STORAGE_PLUGIN globally visible to KnowledgeBaseService

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from './auth/auth.module';
 import { AuthSessionGuard } from './auth/guards/auth-session.guard';
 import { buildThrottlerConfig } from './config/throttler.config';
 import { WorksModule } from './works/works.module';
+import { KbStorageModule } from './uploads/kb-storage.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { MailModule } from './mail/mail.module';
 import { LoggingInterceptor } from './logging.interceptor';
@@ -69,6 +70,11 @@ import { DatabaseModule } from '@ever-works/agent/database';
             },
         }),
         AuthModule,
+        // KbStorageModule MUST be listed before WorksModule so the
+        // @Global() KB_STORAGE_PLUGIN provider is registered before
+        // KnowledgeBaseService's DI graph is resolved (WorksModule
+        // imports KnowledgeBaseModule, which depends on the token).
+        KbStorageModule,
         WorksModule,
         MailModule,
         TriggerInternalModule,

--- a/apps/api/src/uploads/kb-storage.module.ts
+++ b/apps/api/src/uploads/kb-storage.module.ts
@@ -1,0 +1,55 @@
+import { Global, Module } from '@nestjs/common';
+import { KB_STORAGE_PLUGIN } from '@ever-works/agent/services';
+import { getActiveStorageBackend } from './storage-backend.factory';
+
+/**
+ * EW-641 — `@Global()` provider for the KB upload pipeline's storage
+ * plugin token.
+ *
+ * **Why @Global() instead of providing inside `WorksModule`?**
+ * `KnowledgeBaseModule` lives in `@ever-works/agent/services` and is
+ * imported BY `WorksModule`. NestJS DI resolves a provider's
+ * dependencies against:
+ *
+ *   1. Its owning module's `providers` list, AND
+ *   2. Modules listed in the owning module's `imports` (transitively).
+ *
+ * It does NOT walk back up to modules that *import* the owning module
+ * (i.e., consumer modules). So when `KnowledgeBaseService` is
+ * constructed as a provider inside `KnowledgeBaseModule` and asks for
+ * `@Inject(KB_STORAGE_PLUGIN)`, NestJS only sees what `KnowledgeBaseModule`
+ * itself imports — `DatabaseModule`, `FacadesModule`. Neither provides
+ * the token.
+ *
+ * Until now the previous wiring (provider in `WorksModule.providers`)
+ * silently bound `undefined` thanks to the `@Optional()` decorator on
+ * the injection site. `KbController` then hit a `ServiceUnavailableException`
+ * on every upload with `"KB uploads require a storage plugin — not
+ * configured in this deployment"` — which is exactly what the e2e
+ * suite started seeing once the row-19 / row-22-24 KB Playwright specs
+ * actually exercised the upload route (run 26302118655 on develop).
+ *
+ * `TriggerModule` solves the identical problem for `KB_MIRROR_DOCUMENT_DISPATCHER`
+ * by being `@Global()` so its providers are visible from every DI
+ * graph. This module mirrors that pattern for the storage plugin: one
+ * provider, exported, marked `@Global()`. Imported once in
+ * `api.module.ts`, KB upload paths now resolve the local-fs (or
+ * configured) backend just like any unit test that wires the mock
+ * explicitly.
+ *
+ * Lives in `apps/api/` because the factory `getActiveStorageBackend`
+ * is API-side code (driven by API-only env vars + the API's plugin
+ * registry). The agent package can't own the wiring without
+ * introducing a circular dependency.
+ */
+@Global()
+@Module({
+    providers: [
+        {
+            provide: KB_STORAGE_PLUGIN,
+            useFactory: () => getActiveStorageBackend(),
+        },
+    ],
+    exports: [KB_STORAGE_PLUGIN],
+})
+export class KbStorageModule {}

--- a/apps/api/src/works/works.module.ts
+++ b/apps/api/src/works/works.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { DistributedTaskLockService } from '@ever-works/agent/cache';
-import { KB_STORAGE_PLUGIN, KnowledgeBaseModule, WorkModule } from '@ever-works/agent/services';
-import { getActiveStorageBackend } from '../uploads/storage-backend.factory';
+import { KnowledgeBaseModule, WorkModule } from '@ever-works/agent/services';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { AuthModule } from '@src/auth';
 import { CacheEntryRepository } from '@ever-works/agent/cache';
@@ -54,16 +53,15 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         WorkCacheWarmupService,
         WorkScheduleDispatcherCronService,
         DistributedTaskLockService,
-        // EW-641 1B/b — bind the active object-storage plugin (env-
-        // selected via STORAGE_BACKEND) to the KB ingest pipeline's
-        // injection token. The agent-side `KnowledgeBaseService` reads
-        // bytes via this plugin's `getObject` and persists uploads via
-        // `putObject`. Same backend the platform's general-purpose
-        // upload route uses; one storage plugin per deployment.
-        {
-            provide: KB_STORAGE_PLUGIN,
-            useFactory: () => getActiveStorageBackend(),
-        },
+        // EW-641 1B/b — the KB upload pipeline's storage plugin token
+        // (`KB_STORAGE_PLUGIN`) is now provided by the `@Global()`
+        // `KbStorageModule` (apps/api/src/uploads/kb-storage.module.ts),
+        // imported once at the api.module.ts level. The original
+        // in-module provider here only bound the token within
+        // `WorksModule`'s scope, which `KnowledgeBaseModule` (imported,
+        // not consumer) couldn't see — so `KnowledgeBaseService.storage`
+        // silently injected `undefined` and every upload returned 503.
+        // See the docstring on `KbStorageModule` for the DI walk.
     ],
     controllers: [
         WorksController,


### PR DESCRIPTION
## Summary

- E2E row 24c — root cause for the develop e2e.yml run [26302118655](https://github.com/ever-works/ever-works/actions/runs/26302118655) failures: every KB seed helper returned 503 `KB uploads require a storage plugin — not configured in this deployment`.
- NestJS DI resolves a provider's dependencies against the *owning* module's `providers` + that module's `imports`. It does NOT walk back up to modules that import the owning module. `KB_STORAGE_PLUGIN` was provided in `WorksModule.providers` but consumed by `KnowledgeBaseService` (inside the imported `KnowledgeBaseModule`) — so `@Optional() @Inject(KB_STORAGE_PLUGIN)` silently injected `undefined`.
- This was masked in unit tests (they wire the mock storage explicitly via `{ provide: KB_STORAGE_PLUGIN, useValue: storageMock }`) and only surfaced once the row 19/22/23/24 KB Playwright specs landed on develop and exercised the upload route.

## Fix

Extract `KbStorageModule` (apps/api/src/uploads/kb-storage.module.ts) decorated `@Global()` so its `KB_STORAGE_PLUGIN` provider is visible in every DI graph. Mirrors the pattern `TriggerModule` already uses for dispatcher tokens (`KB_MIRROR_DOCUMENT_DISPATCHER` etc — same shape, same need).

## Test plan

- [x] `turbo build --filter ever-works-api --filter @ever-works/agent --filter @ever-works/plugin` — clean.
- [x] `prettier@3.7.4 --check` — clean.
- [ ] CI: lint-and-test (22.x) green.
- [ ] **The real validation is the next develop e2e.yml run**: KB seed helpers should now succeed at upload (201) instead of 503. If that run is also green, EW-641 (Phase 1B/d) is finally unblocked for the Done transition (row 25 in the handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized knowledge base storage backend integration to improve system modularity and dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->