### PR TITLE
feat(agent,tasks): wire KB embed dispatcher from KnowledgeBaseService

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.service';
+import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
 import { WorkKnowledgeUploadRepository } from '../../database/repositories/work-knowledge-upload.repository';
@@ -75,6 +76,7 @@ describe('KnowledgeBaseService', () => {
         isAvailable: jest.Mock;
     }>;
     let activityLog: jest.Mocked<{ log: jest.Mock }>;
+    let embedDispatcher: jest.Mocked<{ dispatchKbEmbedDocument: jest.Mock }>;
 
     beforeEach(async () => {
         const docRepoMock: Partial<jest.Mocked<WorkKnowledgeDocumentRepository>> = {
@@ -127,6 +129,10 @@ describe('KnowledgeBaseService', () => {
 
         const activityLogMock = { log: jest.fn() };
 
+        const embedDispatcherMock = {
+            dispatchKbEmbedDocument: jest.fn().mockResolvedValue('run-id'),
+        };
+
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 KnowledgeBaseService,
@@ -140,6 +146,7 @@ describe('KnowledgeBaseService', () => {
                 { provide: WorkOwnershipService, useValue: ownershipMock },
                 { provide: KB_STORAGE_PLUGIN, useValue: storageMock },
                 { provide: ActivityLogService, useValue: activityLogMock },
+                { provide: KB_EMBED_DOCUMENT_DISPATCHER, useValue: embedDispatcherMock },
             ],
         }).compile();
 
@@ -150,6 +157,7 @@ describe('KnowledgeBaseService', () => {
         ownership = module.get(WorkOwnershipService);
         storage = module.get(KB_STORAGE_PLUGIN);
         activityLog = module.get(ActivityLogService);
+        embedDispatcher = module.get(KB_EMBED_DOCUMENT_DISPATCHER);
     });
 
     describe('listDocuments', () => {
@@ -362,6 +370,26 @@ describe('KnowledgeBaseService', () => {
             const call = docRepo.create.mock.calls[0]?.[0] as { path?: string };
             expect(call.path).toBe('brand/voice-3.md');
         });
+
+        it('enqueues the embed task with the new docId after create', async () => {
+            docRepo.pathExists.mockResolvedValue(false);
+            const persisted = buildDocument({ id: 'doc-99', metadata: { body: 'hi' } });
+            docRepo.create.mockResolvedValue(persisted);
+
+            await service.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            expect(embedDispatcher.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-99',
+            });
+        });
     });
 
     describe('updateDocument', () => {
@@ -391,6 +419,32 @@ describe('KnowledgeBaseService', () => {
 
             expect(docRepo.update).toHaveBeenCalled();
             expect(result.body).toBe('a new body with more words');
+        });
+
+        it('enqueues embed task when body changes', async () => {
+            const existing = buildDocument({ id: 'doc-50', metadata: { body: 'old' } });
+            docRepo.findById.mockResolvedValue(existing);
+            docRepo.update.mockResolvedValue({
+                ...existing,
+                metadata: { body: 'new body' },
+            });
+
+            await service.updateDocument(WORK_ID, existing.id, USER_ID, { body: 'new body' });
+
+            expect(embedDispatcher.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-50',
+            });
+        });
+
+        it('skips embed enqueue when only title/tags/etc change (body unchanged)', async () => {
+            const existing = buildDocument({ id: 'doc-50', metadata: { body: 'same' } });
+            docRepo.findById.mockResolvedValue(existing);
+            docRepo.update.mockResolvedValue({ ...existing, title: 'New title' });
+
+            await service.updateDocument(WORK_ID, existing.id, USER_ID, { title: 'New title' });
+
+            expect(embedDispatcher.dispatchKbEmbedDocument).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -32,6 +32,7 @@ import {
     KbLockMode,
 } from '../entities/kb-types';
 import { KB_MIRROR_DOCUMENT_DISPATCHER, type KbMirrorDocumentDispatcher } from '../tasks';
+import { KB_EMBED_DOCUMENT_DISPATCHER, type KbEmbedDocumentDispatcher } from '../tasks';
 import type {
     CitationDto,
     KbDocumentBodyDto,
@@ -146,6 +147,14 @@ export class KnowledgeBaseService {
         // construct; when absent, the service falls back to the
         // built-in text-passthrough check.
         @Optional() private readonly bufferExtractor?: KnowledgeBaseBufferExtractorService,
+        // EW-641 Phase 2/a row 29c — KB embedding dispatcher. Optional
+        // so deployments without Trigger.dev wired still construct.
+        // Fire-and-forget pattern mirrors `mirrorDispatcher` — chunks
+        // remain stale on dispatch failure but retrieval falls back to
+        // lexical via row 30's RRF blend.
+        @Optional()
+        @Inject(KB_EMBED_DOCUMENT_DISPATCHER)
+        private readonly embedDispatcher?: KbEmbedDocumentDispatcher,
     ) {}
 
     /**
@@ -178,6 +187,34 @@ export class KnowledgeBaseService {
         } catch (error) {
             this.logger.warn(
                 `Failed to enqueue KB mirror for ${operation} ${docPath} (work=${workId}): ${(error as Error).message}`,
+            );
+        }
+    }
+
+    /**
+     * EW-641 Phase 2/a row 29c — enqueue the chunk + embed pipeline
+     * for a single document. Called from createDocument / updateDocument
+     * (only when body changes) / restoreDocumentFromHistory.
+     *
+     * Same fire-and-forget shape as `enqueueMirror`: failures are
+     * logged but never bubble to the API caller. If the dispatcher is
+     * absent (Trigger.dev not wired in this deployment) the embed is
+     * a no-op — row 30's RRF retrieval falls back to lexical, and the
+     * Phase 3 reconciliation job (spec §17.7) catches docs whose
+     * `lastEmbeddedAt` falls behind their `updatedAt`. No `delete`
+     * variant: the `onDelete: 'CASCADE'` FK on `work_knowledge_chunks`
+     * (work-knowledge-chunk.entity.ts) clears chunk rows when the
+     * parent document row is dropped — no separate enqueue needed.
+     */
+    private async enqueueEmbed(workId: string, documentId: string): Promise<void> {
+        if (!this.embedDispatcher) {
+            return;
+        }
+        try {
+            await this.embedDispatcher.dispatchKbEmbedDocument({ workId, documentId });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to enqueue KB embed for doc ${documentId} (work=${workId}): ${(error as Error).message}`,
             );
         }
     }
@@ -339,6 +376,7 @@ export class KnowledgeBaseService {
         }
 
         await this.enqueueMirror(input.workId, doc.id, 'upsert', doc.path, doc.kbDocumentClass);
+        await this.enqueueEmbed(input.workId, doc.id);
 
         return this.toBodyDto(doc);
     }
@@ -390,6 +428,13 @@ export class KnowledgeBaseService {
             updated.path,
             updated.kbDocumentClass,
         );
+        // Row 29c — re-embed only when the body actually changed.
+        // Title/tags/description edits don't move chunks, so the prior
+        // embeddings stay valid; re-running the embed task would waste
+        // an API call + churn the chunk table for nothing.
+        if (input.body !== undefined) {
+            await this.enqueueEmbed(workId, updated.id);
+        }
 
         return this.toBodyDto(updated);
     }
@@ -520,6 +565,9 @@ export class KnowledgeBaseService {
             updated.path,
             updated.kbDocumentClass,
         );
+        // Row 29c — a restore changes the body to the historical
+        // version; chunks must re-embed to match.
+        await this.enqueueEmbed(workId, updated.id);
 
         return this.toBodyDto(updated);
     }

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -7,6 +7,7 @@ import {
     WEBHOOK_DELIVERY_DISPATCHER,
     KB_MIRROR_DOCUMENT_DISPATCHER,
     KB_BACKFILL_SKELETON_DISPATCHER,
+    KB_EMBED_DOCUMENT_DISPATCHER,
 } from '@ever-works/agent/tasks';
 
 @Global()
@@ -37,6 +38,10 @@ import {
             provide: KB_BACKFILL_SKELETON_DISPATCHER,
             useExisting: TriggerService,
         },
+        {
+            provide: KB_EMBED_DOCUMENT_DISPATCHER,
+            useExisting: TriggerService,
+        },
     ],
     exports: [
         TriggerService,
@@ -46,6 +51,7 @@ import {
         WEBHOOK_DELIVERY_DISPATCHER,
         KB_MIRROR_DOCUMENT_DISPATCHER,
         KB_BACKFILL_SKELETON_DISPATCHER,
+        KB_EMBED_DOCUMENT_DISPATCHER,
     ],
 })
 export class TriggerModule {}

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -14,6 +14,8 @@ import {
     KbMirrorDocumentDispatcher,
     KbBackfillSkeletonPayload,
     KbBackfillSkeletonDispatcher,
+    KbEmbedDocumentPayload,
+    KbEmbedDocumentDispatcher,
 } from '@ever-works/agent/tasks';
 import { workGenerationTask } from '../tasks/trigger/work-generation.task';
 import { workImportTask } from '../tasks/trigger/work-import.task';
@@ -21,6 +23,7 @@ import { templateCustomizationTask } from '../tasks/trigger/template-customizati
 import { webhookDeliveryTask } from '../tasks/trigger/webhook-delivery.task';
 import { kbMirrorDocumentTask } from '../tasks/trigger/kb-mirror-document.task';
 import { kbBackfillSkeletonTask } from '../tasks/trigger/kb-backfill-skeleton.task';
+import { kbEmbedDocumentTask } from '../tasks/trigger/kb-embed-document.task';
 
 @Injectable()
 export class TriggerService
@@ -30,7 +33,8 @@ export class TriggerService
         TemplateCustomizationDispatcher,
         WebhookDeliveryDispatcher,
         KbMirrorDocumentDispatcher,
-        KbBackfillSkeletonDispatcher
+        KbBackfillSkeletonDispatcher,
+        KbEmbedDocumentDispatcher
 {
     private readonly logger = new Logger(TriggerService.name);
     private configured = false;
@@ -232,6 +236,36 @@ export class TriggerService
             return handle.id;
         } catch (error) {
             this.logger.error('Failed to dispatch kb-backfill-skeleton task', error as Error);
+            return null;
+        }
+    }
+
+    /**
+     * EW-641 Phase 2/a row 29c — enqueue a chunk + embed run for a
+     * single KB document. Called by `KnowledgeBaseService.{create,update,
+     * restore}Document` immediately after the mirror enqueue. The
+     * `concurrencyKey` keyed on `workId` serializes per-Work runs so a
+     * paragraph edited + saved twice quickly produces sensible final
+     * state (the chunk table is overwritten via row 29a's
+     * delete-then-insert transaction). Returns the Trigger.dev run id
+     * (or `null` when Trigger.dev is disabled / disposed — KB retrieval
+     * falls back to lexical via row 30 RRF until the dispatch lands).
+     */
+    async dispatchKbEmbedDocument(payload: KbEmbedDocumentPayload): Promise<string | null> {
+        if (!this.ensureConfigured()) {
+            return null;
+        }
+
+        try {
+            const handle = await kbEmbedDocumentTask.trigger(payload, {
+                tags: ['kb-embed-document', `work:${payload.workId}`, `doc:${payload.documentId}`],
+                machine: this.machine() as any,
+                concurrencyKey: `kb-embed:${payload.workId}`,
+            });
+
+            return handle.id;
+        } catch (error) {
+            this.logger.error('Failed to dispatch kb-embed-document task', error as Error);
             return null;
         }
     }


### PR DESCRIPTION
## Summary

EW-641 Phase 2/a **row 29c**. Closes the row-29 sub-chain — KB document mutations now automatically enqueue the chunk + embed Trigger.dev task (PR #966's body) so retrieval has fresh embeddings without manual triggering.

**Agent side (`KnowledgeBaseService`):**
- `@Optional() @Inject(KB_EMBED_DOCUMENT_DISPATCHER)` constructor injection (optional — works in deployments without Trigger.dev).
- `enqueueEmbed(workId, documentId)` helper mirroring `enqueueMirror` (fire-and-forget, warn on failure, never bubbles).
- `createDocument` enqueues after the mirror enqueue.
- `updateDocument` enqueues only when `input.body !== undefined` — title/tags/description edits don't shift chunks, so re-embedding would be wasted API calls.
- `restoreDocumentFromHistory` enqueues (historical body = chunks must re-embed).
- No `delete` variant — `onDelete: 'CASCADE'` on `work_knowledge_chunks` cleans up automatically.

**Tasks side:**
- `TriggerModule` provides `KB_EMBED_DOCUMENT_DISPATCHER` as `useExisting: TriggerService` (same shape as `KB_MIRROR_DOCUMENT_DISPATCHER`).
- `TriggerService` implements `KbEmbedDocumentDispatcher`. `dispatchKbEmbedDocument({ workId, documentId })` triggers `kbEmbedDocumentTask` with `concurrencyKey: 'kb-embed:' + workId` — per-Work serialisation so back-to-back saves of the same doc produce the latest chunks (row 29a's transaction guards retrievers).

## Test plan

- [x] Local: `jest src/services/__tests__/knowledge-base.service.spec.ts` — **36/36** (33 prior + 3 new):
  - createDocument enqueues with the new docId
  - updateDocument with `{ body: ... }` enqueues
  - updateDocument with title-only patch does NOT enqueue
- [x] `turbo build --filter @ever-works/agent --filter @ever-works/trigger-tasks` — clean.
- [x] `prettier@3.7.4 --check` — clean.
- [ ] CI: lint-and-test (22.x) green.

## What's next

Row 30 — RRF retrieval blend in `KnowledgeBaseService.search`. Replace lexical-only with reciprocal-rank-fusion of lexical + semantic. Filter `WHERE workId = $1` always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge base documents now automatically embed when created, updated (if content changes), or restored from history, enhancing search and retrieval capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->