### PR TITLE
feat(agent): pure rrfBlend helper for KB retrieval

### DIFF
--- a/packages/agent/src/services/__tests__/kb-rrf.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-rrf.spec.ts
@@ -1,0 +1,115 @@
+import { rrfBlend } from '../kb-rrf';
+
+describe('rrfBlend', () => {
+    describe('boundary cases', () => {
+        it('returns [] for empty rankings input', () => {
+            expect(rrfBlend([])).toEqual([]);
+        });
+
+        it('returns [] when every input list is empty', () => {
+            expect(rrfBlend([[], []])).toEqual([]);
+        });
+
+        it('throws RangeError on negative k', () => {
+            expect(() => rrfBlend([], { k: -1 })).toThrow(RangeError);
+        });
+
+        it('throws RangeError on non-finite k', () => {
+            expect(() => rrfBlend([], { k: Number.POSITIVE_INFINITY })).toThrow(RangeError);
+            expect(() => rrfBlend([], { k: Number.NaN })).toThrow(RangeError);
+        });
+
+        it('accepts k = 0 (formula stays well-defined via the +1 denominator)', () => {
+            const out = rrfBlend([[{ documentId: 'a' }]], { k: 0 });
+            // rank 0 with k=0 → 1 / (0 + 0 + 1) = 1
+            expect(out).toEqual([{ documentId: 'a', score: 1 }]);
+        });
+    });
+
+    describe('single-list passthrough', () => {
+        it('preserves the rank order from a single input list', () => {
+            const out = rrfBlend([[{ documentId: 'a' }, { documentId: 'b' }, { documentId: 'c' }]]);
+            // With default k=60: ranks 0,1,2 → 1/61, 1/62, 1/63
+            expect(out.map((r) => r.documentId)).toEqual(['a', 'b', 'c']);
+            expect(out[0].score).toBeCloseTo(1 / 61, 10);
+            expect(out[1].score).toBeCloseTo(1 / 62, 10);
+            expect(out[2].score).toBeCloseTo(1 / 63, 10);
+        });
+    });
+
+    describe('multi-list blending', () => {
+        it('docs appearing in both lists outrank docs in only one (with equal rank)', () => {
+            const lexical = [{ documentId: 'a' }, { documentId: 'b' }];
+            const semantic = [{ documentId: 'b' }, { documentId: 'c' }];
+            const out = rrfBlend([lexical, semantic]);
+
+            // 'b' is rank 1 in lex (1/62) + rank 0 in sem (1/61)
+            // 'a' is rank 0 in lex (1/61) only
+            // 'c' is rank 1 in sem (1/62) only
+            // So 'b' wins, then 'a', then 'c'.
+            expect(out.map((r) => r.documentId)).toEqual(['b', 'a', 'c']);
+            expect(out[0].score).toBeCloseTo(1 / 62 + 1 / 61, 10);
+            expect(out[1].score).toBeCloseTo(1 / 61, 10);
+            expect(out[2].score).toBeCloseTo(1 / 62, 10);
+        });
+
+        it('disjoint lists produce a union ranked by per-list score', () => {
+            const lexical = [{ documentId: 'a' }, { documentId: 'b' }];
+            const semantic = [{ documentId: 'c' }, { documentId: 'd' }];
+            const out = rrfBlend([lexical, semantic]);
+
+            // All four docs at the same per-list rank → tied by score
+            // 'a' and 'c' both at 1/61; 'b' and 'd' both at 1/62.
+            // Tiebreak: documentId ASC → 'a','c' (in that order), then 'b','d'.
+            expect(out.map((r) => r.documentId)).toEqual(['a', 'c', 'b', 'd']);
+        });
+
+        it('three-list blend sums contributions correctly', () => {
+            const lex = [{ documentId: 'x' }];
+            const sem = [{ documentId: 'x' }];
+            const recent = [{ documentId: 'x' }];
+            const out = rrfBlend([lex, sem, recent]);
+
+            expect(out).toEqual([{ documentId: 'x', score: 3 / 61 }]);
+        });
+    });
+
+    describe('stability + defensiveness', () => {
+        it('breaks ties by documentId ASC (stable across runs)', () => {
+            // Two docs at the same rank in the same list → identical
+            // scores → stable tiebreak.
+            const list = [{ documentId: 'b' }, { documentId: 'a' }];
+            const out = rrfBlend([list]);
+            // Even though 'a' was at rank 1 (score 1/62) and 'b' at
+            // rank 0 (1/61), they don't tie here — 'b' wins. But the
+            // sort tiebreak in general is documented to be id ASC; the
+            // disjoint-list test above covers the tied case.
+            expect(out.map((r) => r.documentId)).toEqual(['b', 'a']);
+        });
+
+        it('ignores duplicate documentId within a single list (first occurrence wins)', () => {
+            const list = [{ documentId: 'a' }, { documentId: 'a' }, { documentId: 'b' }];
+            const out = rrfBlend([list]);
+            // 'a' counted once at rank 0 (1/61), 'b' at rank 2 (1/63).
+            // If duplicates inflated the score, 'a' would also pick up
+            // 1/62 from its second occurrence — this test guards
+            // against that bug.
+            expect(out).toEqual([
+                { documentId: 'a', score: 1 / 61 },
+                { documentId: 'b', score: 1 / 63 },
+            ]);
+        });
+
+        it('honors a custom k', () => {
+            const out = rrfBlend([[{ documentId: 'a' }]], { k: 10 });
+            expect(out).toEqual([{ documentId: 'a', score: 1 / 11 }]);
+        });
+
+        it('ignores empty inner lists without affecting other lists', () => {
+            const lex = [{ documentId: 'a' }];
+            const sem: ReadonlyArray<{ documentId: string }> = [];
+            const out = rrfBlend([lex, sem]);
+            expect(out).toEqual([{ documentId: 'a', score: 1 / 61 }]);
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -31,6 +31,7 @@ export * from './knowledge-base-git-mirror.service';
 export * from './knowledge-base-buffer-extractor.service';
 export * from './knowledge-base.module';
 export * from './kb-chunker';
+export * from './kb-rrf';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-rrf.ts
+++ b/packages/agent/src/services/kb-rrf.ts
@@ -1,0 +1,112 @@
+/**
+ * Reciprocal Rank Fusion (RRF) helper for KB retrieval.
+ *
+ * EW-641 Phase 2/a row 30b. Combines multiple ranked lists (lexical
+ * + semantic in the typical Phase 2 KB search case) into a single
+ * ranking using the standard RRF formula:
+ *
+ *   score(doc) = Σ_{list ∈ lists}  1 / (k + rank_in_list(doc) + 1)
+ *
+ * where `rank_in_list` is 0-based and the `+1` makes the top-ranked
+ * doc contribute `1/(k+1)` rather than `1/k` (the latter blows up at
+ * `k=0`).
+ *
+ * **Why RRF rather than weighted average?** Lexical and semantic
+ * scores live on different scales — TF-IDF returns unbounded
+ * positive floats, cosine distance ranges 0..2, and a model swap
+ * shifts both distributions. RRF ignores absolute scores and only
+ * uses ordinal rank, so a re-ranking from a different embedding
+ * model doesn't require re-tuning. The `k` constant (default 60 per
+ * the original Cormack et al. 2009 paper, also the LangChain /
+ * LlamaIndex default) shapes how aggressively top ranks are
+ * rewarded: lower `k` → top of each list dominates; higher `k` →
+ * more balanced blend across ranks.
+ *
+ * **Pure function.** No I/O, no module state, no side effects. Safe
+ * to call from any context (service layer, unit test, REPL).
+ *
+ * **Stability.** When two docs tie on score, ordering is broken by
+ * `documentId` ASC. Same input always produces the same output —
+ * required so the row-15 search palette doesn't flicker between
+ * re-renders against unchanged data.
+ *
+ * Consumed by row 30c (the rewrite of
+ * `KnowledgeBaseService.search` that fuses the lexical filter with
+ * `semanticSearch`'s pgvector k-NN).
+ */
+
+export interface RrfBlendOptions {
+    /**
+     * RRF dampening constant. Defaults to 60 (Cormack et al. 2009 /
+     * LangChain). Must be a non-negative finite number; `0` is
+     * accepted (the `+1` denominator prevents division by zero) but
+     * tends to make any list's top doc fully dominate if it's not in
+     * the others.
+     */
+    k?: number;
+}
+
+export interface RrfBlendResult {
+    documentId: string;
+    score: number;
+}
+
+/**
+ * Blend N ranked lists of `documentId`s using Reciprocal Rank Fusion.
+ *
+ * Each list is treated as ordered best-first (index 0 = top
+ * candidate). Duplicate `documentId`s WITHIN a single list use the
+ * FIRST occurrence's rank — callers shouldn't produce duplicates,
+ * but the guard prevents a buggy producer from silently inflating a
+ * doc's score.
+ *
+ * Returns docs ranked by total RRF score DESC, tied scores broken by
+ * `documentId` ASC for stability.
+ *
+ * @example
+ *   const lexical = [{ documentId: 'a' }, { documentId: 'b' }];
+ *   const semantic = [{ documentId: 'b' }, { documentId: 'c' }];
+ *   rrfBlend([lexical, semantic]);
+ *   // Returns:
+ *   //   { documentId: 'b', score: 1/61 + 1/61 }   // top of both
+ *   //   { documentId: 'a', score: 1/61 }          // top of lex only
+ *   //   { documentId: 'c', score: 1/62 }          // rank-1 of sem only
+ */
+export function rrfBlend(
+    rankings: ReadonlyArray<ReadonlyArray<{ documentId: string }>>,
+    options: RrfBlendOptions = {},
+): RrfBlendResult[] {
+    const k = options.k ?? 60;
+    if (!Number.isFinite(k) || k < 0) {
+        throw new RangeError(`rrfBlend: k must be a non-negative finite number (got ${k})`);
+    }
+
+    const scoreByDoc = new Map<string, number>();
+    for (const list of rankings) {
+        // Guard against accidental duplicates inside a single list —
+        // a doc should only contribute one score per list, and the
+        // first occurrence (best rank) wins.
+        const seen = new Set<string>();
+        for (let rank = 0; rank < list.length; rank++) {
+            const id = list[rank].documentId;
+            if (seen.has(id)) continue;
+            seen.add(id);
+            const contribution = 1 / (k + rank + 1);
+            scoreByDoc.set(id, (scoreByDoc.get(id) ?? 0) + contribution);
+        }
+    }
+
+    const merged: RrfBlendResult[] = [];
+    for (const [documentId, score] of scoreByDoc) {
+        merged.push({ documentId, score });
+    }
+
+    merged.sort((a, b) => {
+        if (a.score !== b.score) return b.score - a.score;
+        // Stable tiebreak by id ASC — keeps test snapshots / search
+        // palette ordering deterministic across runs.
+        return a.documentId < b.documentId ? -1 : a.documentId > b.documentId ? 1 : 0;
+    });
+
+    return merged;
+}


### PR DESCRIPTION
## Summary

EW-641 Phase 2/a **row 30b**. Pure Reciprocal Rank Fusion helper. Row 30c will use this to combine the existing lexical filter with row 30a's `semanticSearch` inside `KnowledgeBaseService.search`.

**Formula:** `score(doc) = Σ 1 / (k + rank_in_list + 1)` across all input lists. The `+1` keeps `k=0` well-defined (no division by zero). Default `k=60` per the original Cormack et al. 2009 paper / LangChain / LlamaIndex.

**Properties:**
- Pure function — no I/O, no module state.
- Empty input → `[]`. Single-list input preserves order.
- Multi-list scores sum per-doc; ties broken by `documentId` ASC for stability (no flicker across re-renders against unchanged data).
- Duplicate `documentId` within a single list uses **first** occurrence's rank only (defensive — guards against producer bugs silently inflating scores).
- `k` validated as non-negative finite; otherwise `RangeError`.

**Why RRF vs weighted average:** lexical (TF-IDF unbounded) and semantic (0..2 cosine) scores live on different scales, and a model swap shifts both distributions. Ordinal rank is the stable signal.

## Test plan

- [x] Local: `jest src/services/__tests__/kb-rrf.spec.ts` — **13/13** green:
  - boundary (5): empty input, all-empty inner lists, k<0 throws, non-finite k throws, k=0 accepted
  - single-list (1): rank order preserved
  - multi-list (3): overlap outranks singletons, disjoint produces union, three-list sums correctly
  - stability + defensiveness (4): id-ASC tiebreak, duplicate-id ignored, custom k honored, empty inner list ignored
- [x] `prettier@3.7.4 --check` — clean.
- [ ] CI: lint-and-test (22.x) green.

## Next

Row 30c — rewrite `KnowledgeBaseService.search` to call lexical (existing q-filter) + `semanticSearch` (row 30a) + `rrfBlend`, then materialize docs by id + attach matched chunk content for citation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reciprocal rank fusion service that blends multiple ranked search result lists, offering configurable fusion parameters, automatic handling of duplicate entries, and deterministic result ordering.

* **Tests**
  * Comprehensive test coverage for the new ranking service including edge cases like empty inputs, boundary conditions, multi-list blending, duplicate handling, and tie-breaking validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->