### PR TITLE
feat(agent): RRF-blended KB search in listDocuments

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -195,6 +195,38 @@ describe('KnowledgeBaseService', () => {
                 }),
             );
         });
+
+        it('falls back to lexical-only when q is set but semantic returns nothing (no embedder configured)', async () => {
+            // Default test module doesn't wire `aiFacade` / `chunkRepository`,
+            // so semanticSearch returns []. The RRF blend short-circuits
+            // and the row-30c path delivers lexical-only with the
+            // requested limit/offset preserved.
+            const docs = [
+                buildDocument({ id: 'd1', title: 'first' }),
+                buildDocument({ id: 'd2', title: 'second' }),
+            ];
+            docRepo.list.mockResolvedValue({ items: docs, total: 2 });
+
+            const result = await service.listDocuments(WORK_ID, USER_ID, {
+                q: 'voice',
+                limit: 10,
+            });
+
+            // q was passed through to the repo (lexical leg).
+            expect(docRepo.list).toHaveBeenCalledWith(expect.objectContaining({ q: 'voice' }));
+            expect(result.items.map((d) => d.id)).toEqual(['d1', 'd2']);
+            expect(result.total).toBe(2);
+        });
+
+        it('treats whitespace-only q as no q (preserves existing list behavior)', async () => {
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+
+            await service.listDocuments(WORK_ID, USER_ID, { q: '   \t  ' });
+
+            // The repo call should receive q: undefined (not the whitespace string),
+            // matching the existing pre-row-30c contract.
+            expect(docRepo.list).toHaveBeenCalledWith(expect.objectContaining({ q: undefined }));
+        });
     });
 
     describe('getDocument', () => {

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -24,6 +24,7 @@ import { WorkKnowledgeTagRepository } from '../database/repositories/work-knowle
 import { WorkKnowledgeCitationRepository } from '../database/repositories/work-knowledge-citation.repository';
 import { WorkKnowledgeChunkRepository } from '../database/repositories/work-knowledge-chunk.repository';
 import { AiFacadeService } from '../facades/ai.facade';
+import { rrfBlend } from './kb-rrf';
 import { WorkKnowledgeDocument } from '../entities/work-knowledge-document.entity';
 import { WorkKnowledgeTag } from '../entities/work-knowledge-tag.entity';
 import {
@@ -234,19 +235,96 @@ export class KnowledgeBaseService {
     async listDocuments(workId: string, userId: string, opts: ListOptions = {}) {
         await this.ownershipService.ensureCanView(workId, userId);
 
-        const { items, total } = await this.documentRepository.list({
-            workId,
-            classes: opts.class ? [opts.class] : undefined,
-            statuses: opts.status ? [opts.status] : undefined,
-            tag: opts.tag,
-            locked: opts.locked,
-            language: opts.language,
-            q: opts.q,
-            limit: opts.limit,
-            offset: opts.offset,
-        });
+        const trimmedQ = opts.q?.trim() ?? '';
 
-        return { items: items.map((d) => this.toDto(d)), total };
+        // No query → pure list (existing behavior). The KB tree panel
+        // (row 14), the inheritable-docs API, and any non-search caller
+        // hits this branch unchanged.
+        if (trimmedQ.length === 0) {
+            const { items, total } = await this.documentRepository.list({
+                workId,
+                classes: opts.class ? [opts.class] : undefined,
+                statuses: opts.status ? [opts.status] : undefined,
+                tag: opts.tag,
+                locked: opts.locked,
+                language: opts.language,
+                q: undefined,
+                limit: opts.limit,
+                offset: opts.offset,
+            });
+            return { items: items.map((d) => this.toDto(d)), total };
+        }
+
+        // EW-641 Phase 2/a row 30c — RRF blend of lexical (LIKE filter
+        // in v1, Postgres FTS in a follow-up) + semantic (pgvector
+        // k-NN). Fetch 2× the requested limit from each leg so the
+        // blend has enough candidates to merge before clipping.
+        const requestedLimit = opts.limit ?? 20;
+        const requestedOffset = opts.offset ?? 0;
+        const fusionLimit = Math.max(requestedLimit * 2, 20);
+
+        const [lexicalRes, semanticChunks] = await Promise.all([
+            this.documentRepository.list({
+                workId,
+                classes: opts.class ? [opts.class] : undefined,
+                statuses: opts.status ? [opts.status] : undefined,
+                tag: opts.tag,
+                locked: opts.locked,
+                language: opts.language,
+                q: trimmedQ,
+                limit: fusionLimit,
+                offset: 0,
+            }),
+            this.semanticSearch(workId, trimmedQ, fusionLimit),
+        ]);
+
+        // No semantic signal (no embedder configured, no chunks yet,
+        // SQLite e2e env, etc.) — fall back to lexical-only ordering
+        // with the originally requested offset + limit, preserving the
+        // pre-row-30c contract.
+        if (semanticChunks.length === 0) {
+            const sliced = lexicalRes.items.slice(
+                requestedOffset,
+                requestedOffset + requestedLimit,
+            );
+            return { items: sliced.map((d) => this.toDto(d)), total: lexicalRes.total };
+        }
+
+        // Build the per-list rankings for `rrfBlend`. Semantic returns
+        // chunk rows, so dedupe by `documentId` keeping the FIRST
+        // occurrence (best-ranking chunk for each doc).
+        const lexicalRanking = lexicalRes.items.map((d) => ({ documentId: d.id }));
+        const semanticRanking: { documentId: string }[] = [];
+        const seenSem = new Set<string>();
+        for (const c of semanticChunks) {
+            if (seenSem.has(c.documentId)) continue;
+            seenSem.add(c.documentId);
+            semanticRanking.push({ documentId: c.documentId });
+        }
+
+        const blended = rrfBlend([lexicalRanking, semanticRanking]);
+
+        // Materialize the blended order. Lexical items already have
+        // full doc objects — reuse them; for docs that only appear in
+        // semantic, fetch by id (N+1 here is bounded by `fusionLimit`
+        // ≤ ~40 in practice; row 30d can batch via a `findByIds` if
+        // hot-path metrics show it).
+        const lexicalById = new Map<string, WorkKnowledgeDocument>();
+        for (const d of lexicalRes.items) lexicalById.set(d.id, d);
+
+        const materialized: WorkKnowledgeDocument[] = [];
+        for (const { documentId } of blended) {
+            const cached = lexicalById.get(documentId);
+            if (cached) {
+                materialized.push(cached);
+                continue;
+            }
+            const fetched = await this.documentRepository.findById(workId, documentId);
+            if (fetched) materialized.push(fetched);
+        }
+
+        const sliced = materialized.slice(requestedOffset, requestedOffset + requestedLimit);
+        return { items: sliced.map((d) => this.toDto(d)), total: materialized.length };
     }
 
     async getDocument(


### PR DESCRIPTION
## Summary

EW-641 Phase 2/a **row 30c**. Closes the row-30 sub-chain (30a/30b/30c). `KnowledgeBaseService.listDocuments` now reciprocal-rank-fuses lexical + semantic when `q` is set; falls back to lexical-only otherwise.

**Behavior:**
- `q` empty/undefined → pure lexical list (existing tree-panel / inheritable callers unchanged).
- `q` non-empty → fetch 2× limit candidates from lexical (existing `documentRepository.list` with q-filter) and `semanticSearch` (row 30a) in parallel.
- Semantic empty (no embedder, no chunks, SQLite) → slice lexical at the requested offset+limit. Preserves pre-row-30c contract.
- Otherwise: dedupe semantic by documentId (best-rank chunk per doc), build rankings = [lexical, semantic], call `rrfBlend` (row 30b). Materialize: lexical hits already have full doc rows; semantic-only docs `findById` (bounded N+1 — row 30d follow-up can batch).
- `total` = blended union size (lexical ∪ semantic deduped).

**Contract preserved:** existing palette + proxy at `apps/web/.../kb/search/route.ts` keeps calling `/works/:id/kb/documents?q=...`. Ranker is now hybrid; route stays identical.

## Test plan

- [x] Local: `jest src/services/__tests__/knowledge-base.service.spec.ts` — **41/41** (39 prior + 2 new):
  - q set with no embedder wired → lexical-only fallback (semantic returns [] branch)
  - whitespace-only q treated as no q (repo receives `q: undefined`)
- [x] `turbo build --filter @ever-works/agent` — clean.
- [x] `prettier@3.7.4 --check` — clean.
- [ ] CI: lint-and-test (22.x) green.
- [ ] End-to-end semantic validation deferred to row 47 (A22 e2e — embedding within 60s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced document search with intelligent fallback handling when advanced search features are unavailable
  * Improved query processing with better handling of whitespace and empty queries
  * Better result ordering and pagination accuracy across different search methods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->