### PR TITLE
feat(agent): KbPromptFormatter for standardized KB context block

### DIFF
--- a/packages/agent/src/services/__tests__/kb-prompt-formatter.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-prompt-formatter.spec.ts
@@ -1,0 +1,156 @@
+import { formatKbContext } from '../kb-prompt-formatter';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+/**
+ * Test helper: build a KbDocumentBodyDto with sensible defaults; tests
+ * override the bits they care about.
+ */
+function buildDoc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: overrides.id ?? 'doc-id',
+        workId: overrides.workId ?? 'work-1',
+        organizationId: overrides.organizationId ?? null,
+        path: overrides.path ?? 'brand/voice.md',
+        slug: overrides.slug ?? 'voice',
+        title: overrides.title ?? 'Brand voice',
+        description: overrides.description ?? null,
+        class: overrides.class ?? 'brand',
+        tags: overrides.tags ?? [],
+        categories: overrides.categories ?? [],
+        status: overrides.status ?? 'active',
+        locked: overrides.locked ?? false,
+        lockMode: overrides.lockMode ?? null,
+        language: overrides.language ?? 'en',
+        wordCount: overrides.wordCount ?? null,
+        tokenCount: overrides.tokenCount ?? null,
+        source: overrides.source ?? 'user',
+        sourceUploadId: overrides.sourceUploadId ?? null,
+        sourceUrl: overrides.sourceUrl ?? null,
+        generatedByAgentRunId: overrides.generatedByAgentRunId ?? null,
+        createdById: overrides.createdById ?? null,
+        updatedById: overrides.updatedById ?? null,
+        createdAt: overrides.createdAt ?? '2026-05-22T00:00:00.000Z',
+        updatedAt: overrides.updatedAt ?? '2026-05-22T00:00:00.000Z',
+        lastCommitSha: overrides.lastCommitSha ?? null,
+        body: overrides.body ?? 'default body',
+        assets: overrides.assets ?? [],
+    } as KbDocumentBodyDto;
+}
+
+describe('formatKbContext', () => {
+    describe('boundary cases', () => {
+        it('returns minimal <kb></kb> shell for empty input', () => {
+            expect(formatKbContext([])).toBe('<kb>\n</kb>');
+        });
+
+        it('throws RangeError on negative maxChars', () => {
+            expect(() => formatKbContext([], { maxChars: -1 })).toThrow(RangeError);
+        });
+
+        it('throws RangeError on non-finite maxChars', () => {
+            expect(() => formatKbContext([], { maxChars: Number.NaN })).toThrow(RangeError);
+            expect(() => formatKbContext([], { maxChars: Number.POSITIVE_INFINITY })).toThrow(
+                RangeError,
+            );
+        });
+
+        it('returns truncation-only shell when maxChars is too small for even the headings', () => {
+            const doc = buildDoc({ title: 'A', body: 'hi' });
+            const out = formatKbContext([doc], { maxChars: 5 });
+            // Headings + frame can't fit → minimal shell + marker.
+            expect(out).toContain('<kb>');
+            expect(out).toContain('</kb>');
+            expect(out).toContain('[…truncated]');
+        });
+    });
+
+    describe('single-doc formatting', () => {
+        it('wraps the doc with kb tags, heading, citation, and body', () => {
+            const doc = buildDoc({
+                title: 'Brand voice',
+                slug: 'voice',
+                class: 'brand',
+                body: 'Friendly and direct.',
+            });
+            const out = formatKbContext([doc]);
+            expect(out).toBe('<kb>\n## Brand voice (kb:brand/voice)\nFriendly and direct.\n</kb>');
+        });
+
+        it('includes empty body verbatim (still emits the heading)', () => {
+            const doc = buildDoc({
+                title: 'Empty',
+                slug: 'empty',
+                class: 'freeform',
+                body: '',
+            });
+            const out = formatKbContext([doc]);
+            expect(out).toContain('## Empty (kb:freeform/empty)');
+            expect(out.startsWith('<kb>\n')).toBe(true);
+            expect(out.endsWith('\n</kb>')).toBe(true);
+        });
+    });
+
+    describe('multi-doc formatting', () => {
+        it('joins docs with the \\n---\\n thematic break', () => {
+            const docs = [
+                buildDoc({ title: 'First', slug: 'first', class: 'brand', body: 'one' }),
+                buildDoc({ title: 'Second', slug: 'second', class: 'legal', body: 'two' }),
+            ];
+            const out = formatKbContext(docs);
+            expect(out).toBe(
+                '<kb>\n## First (kb:brand/first)\none\n---\n## Second (kb:legal/second)\ntwo\n</kb>',
+            );
+        });
+
+        it('preserves input order (deterministic — caller controls ordering)', () => {
+            const docs = [
+                buildDoc({ title: 'Z', slug: 'z', class: 'brand', body: 'z body' }),
+                buildDoc({ title: 'A', slug: 'a', class: 'brand', body: 'a body' }),
+            ];
+            const out = formatKbContext(docs);
+            // 'Z' must appear before 'A' in the output.
+            const zIdx = out.indexOf('## Z (');
+            const aIdx = out.indexOf('## A (');
+            expect(zIdx).toBeGreaterThanOrEqual(0);
+            expect(aIdx).toBeGreaterThan(zIdx);
+        });
+    });
+
+    describe('truncation', () => {
+        it('does not truncate when block fits under maxChars', () => {
+            const doc = buildDoc({ title: 'Short', slug: 's', class: 'brand', body: 'tiny' });
+            const out = formatKbContext([doc], { maxChars: 10_000 });
+            expect(out).not.toContain('[…truncated]');
+        });
+
+        it('clips the last doc body and appends [...truncated] marker when over cap', () => {
+            const docs = [
+                buildDoc({ title: 'Doc A', slug: 'a', class: 'brand', body: 'AAAA'.repeat(50) }),
+                buildDoc({ title: 'Doc B', slug: 'b', class: 'brand', body: 'BBBB'.repeat(50) }),
+            ];
+            // Pick a cap that lets the first doc fit but clips the second.
+            const out = formatKbContext(docs, { maxChars: 280 });
+
+            // Both headings still present (we never split a heading).
+            expect(out).toContain('## Doc A (kb:brand/a)');
+            expect(out).toContain('## Doc B (kb:brand/b)');
+            // Final marker present, length respected within the budget.
+            expect(out.endsWith('[…truncated]\n</kb>')).toBe(true);
+            expect(out.length).toBeLessThanOrEqual(280);
+        });
+
+        it('uses the default 16000-char cap when maxChars is unspecified', () => {
+            const docs = [
+                buildDoc({
+                    title: 'Huge',
+                    slug: 'huge',
+                    class: 'brand',
+                    body: 'X'.repeat(20_000),
+                }),
+            ];
+            const out = formatKbContext(docs);
+            expect(out.length).toBeLessThanOrEqual(16_000);
+            expect(out).toContain('[…truncated]');
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -32,6 +32,7 @@ export * from './knowledge-base-buffer-extractor.service';
 export * from './knowledge-base.module';
 export * from './kb-chunker';
 export * from './kb-rrf';
+export * from './kb-prompt-formatter';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-prompt-formatter.ts
+++ b/packages/agent/src/services/kb-prompt-formatter.ts
@@ -1,0 +1,159 @@
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 2/b row 31 — standardized KB context block formatter.
+ *
+ * Every Phase 2/b pipeline injects a `<kb>...</kb>` block carrying the
+ * resolved KB documents (the union of always-injected + query-retrieved
+ * docs per spec §15). Centralizing the format here means we can:
+ *  - tune the block once and every consumer picks it up (no drift
+ *    between pipelines)
+ *  - keep token budgets predictable by enforcing a single `maxChars`
+ *    cap with deterministic truncation
+ *  - swap to a different format (XML attributes vs heading-prefixed
+ *    sections, citation footers, etc.) without re-touching every
+ *    pipeline call site
+ *
+ * Wire format (spec §15.6):
+ *
+ *   <kb>
+ *   ## {title} (kb:{class}/{slug})
+ *   {body}
+ *   ---
+ *   ## {title} (kb:{class}/{slug})
+ *   {body}
+ *   </kb>
+ *
+ * - Opening/closing `<kb>` tags on their own lines so prompts can use
+ *   them as delimiters (LLM is told "the KB is between `<kb>` tags").
+ * - `kb:{class}/{slug}` citation reference matches the `@kb:` mention
+ *   parser format (row 17). Citations rendered by the conversation UI
+ *   (row 34/35) link straight back to the workbench doc page.
+ * - Per-doc body verbatim — chunk-aware formatting belongs to row 30's
+ *   retrieval blend; this formatter takes whole-doc DTOs and stitches.
+ * - Docs joined by `\n---\n` (markdown thematic break). Models pick up
+ *   "separate documents" cue without us needing to over-engineer the
+ *   delimiter.
+ *
+ * **Truncation contract.** If the concatenated block exceeds `maxChars`
+ * (default 16 000), truncate the LAST document's body — never split
+ * a title/citation line. Append `[…truncated]` so the model knows
+ * content was clipped (and budget-aware prompt steps can warn the
+ * user). Earlier docs are kept whole; an `<kb></kb>` shell will
+ * always be returned (callers can rely on the delimiters).
+ *
+ * **Determinism.** Input order preserved exactly — callers (row 32's
+ * `KbContextBundle.format`) decide ordering via spec §15.4's priority
+ * (always-injected first, then RRF-ranked query-retrieved).
+ *
+ * **Pure function.** No I/O, no module state. Safe for any context
+ * (pipeline step, eval harness, unit test).
+ */
+
+export interface FormatKbContextOptions {
+    /**
+     * Hard cap on the returned string length, in chars. Defaults to
+     * 16 000 — a safe floor for gpt-4o-mini context windows with
+     * headroom for the surrounding system prompt + user message. When
+     * exceeded, the last doc's body is truncated and `[…truncated]`
+     * is appended.
+     */
+    maxChars?: number;
+}
+
+const DEFAULT_MAX_CHARS = 16_000;
+const TRUNCATION_MARKER = '\n[…truncated]';
+const OPEN_TAG = '<kb>';
+const CLOSE_TAG = '</kb>';
+const DOC_SEPARATOR = '\n---\n';
+
+/**
+ * Build the `<kb>...</kb>` context block from a list of KB documents.
+ *
+ * Returns `<kb>\n</kb>` for empty input — callers can always treat the
+ * tags as present and parse between them. The opening + closing tags
+ * are always returned even when over-cap; only body text is trimmed.
+ */
+export function formatKbContext(
+    docs: ReadonlyArray<KbDocumentBodyDto>,
+    options: FormatKbContextOptions = {},
+): string {
+    const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+    if (!Number.isFinite(maxChars) || maxChars < 0) {
+        throw new RangeError(
+            `formatKbContext: maxChars must be a non-negative finite number (got ${maxChars})`,
+        );
+    }
+
+    if (docs.length === 0) {
+        return `${OPEN_TAG}\n${CLOSE_TAG}`;
+    }
+
+    // First-pass: build per-doc full entries. The slug + class come
+    // straight from the DTO so the citation reference matches the row
+    // 17 `@kb:` mention syntax.
+    const entries = docs.map((doc) => {
+        const cite = `kb:${doc.class}/${doc.slug}`;
+        const heading = `## ${doc.title} (${cite})`;
+        const body = doc.body ?? '';
+        return { heading, body, full: `${heading}\n${body}` };
+    });
+
+    // Concat candidate. Cheap O(n) join — we'll measure and clip if
+    // needed in pass 2.
+    const joined = entries.map((e) => e.full).join(DOC_SEPARATOR);
+    const fullBlock = `${OPEN_TAG}\n${joined}\n${CLOSE_TAG}`;
+
+    if (fullBlock.length <= maxChars) {
+        return fullBlock;
+    }
+
+    // Over budget — keep all headings, trim from the last doc body
+    // backward, then append the truncation marker. We never split a
+    // heading line; if even the headings + delimiters don't fit, the
+    // entire block degrades to `<kb>\n[…truncated]\n</kb>`.
+    const fixedFrame = OPEN_TAG.length + 1 + CLOSE_TAG.length + 1 + TRUNCATION_MARKER.length; // \n on each side
+    // Reserve space for every heading + every doc separator and the
+    // final newline before the close tag.
+    const headingsBudget = entries.map((e) => e.heading.length).reduce((acc, n) => acc + n, 0);
+    const separatorsBudget = (entries.length - 1) * DOC_SEPARATOR.length;
+    // Per-heading we also need a trailing "\n" before its body.
+    const headingNewlinesBudget = entries.length;
+    const reservedNonBody = fixedFrame + headingsBudget + separatorsBudget + headingNewlinesBudget;
+
+    if (reservedNonBody >= maxChars) {
+        // Even the shells + headings overshoot — return the minimal
+        // truncation-only block. Pathological case; logged via the
+        // marker but callers shouldn't ever feed this.
+        return `${OPEN_TAG}${TRUNCATION_MARKER}\n${CLOSE_TAG}`;
+    }
+
+    const totalBodyBudget = maxChars - reservedNonBody;
+    // Distribute body budget: keep earlier docs whole, trim from the
+    // last. Walk forward summing body lengths until we'd overflow,
+    // then clip the offender + truncate everything after.
+    const pieces: string[] = [];
+    let bodyUsed = 0;
+    for (let i = 0; i < entries.length; i++) {
+        const e = entries[i];
+        if (i > 0) pieces.push(DOC_SEPARATOR);
+        pieces.push(`${e.heading}\n`);
+        const remainingBudget = totalBodyBudget - bodyUsed;
+        if (remainingBudget <= 0) {
+            // No room for this doc's body — its heading is in but the
+            // body is implicit "truncated". Stop adding more entries.
+            break;
+        }
+        if (e.body.length <= remainingBudget) {
+            pieces.push(e.body);
+            bodyUsed += e.body.length;
+        } else {
+            // Clip this doc and stop.
+            pieces.push(e.body.slice(0, remainingBudget));
+            bodyUsed = totalBodyBudget;
+            break;
+        }
+    }
+
+    return `${OPEN_TAG}\n${pieces.join('')}${TRUNCATION_MARKER}\n${CLOSE_TAG}`;
+}


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/b row 31 — standardize the `<kb>...</kb>` context block format that every Phase 2/b pipeline injects.
- New pure function `formatKbContext(docs, opts?)` in `packages/agent/src/services/kb-prompt-formatter.ts`; exported via barrel.
- Hard cap at `opts.maxChars ?? 16000` chars with a deterministic truncation contract (keep every heading, trim the last body, append `[…truncated]`).

Wire format per spec §15.6:
```
<kb>
## {title} (kb:{class}/{slug})
{body}
---
## {title} (kb:{class}/{slug})
{body}
</kb>
```

Citation reference matches the row 17 `@kb:` mention parser so the conversation UI can link back to the workbench doc page (rows 34/35).

## Test plan
- [x] `pnpm jest src/services/__tests__/kb-prompt-formatter.spec.ts` — 11/11 green (boundary, single-doc, multi-doc, truncation)
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized knowledge base context formatting with configurable character limits (default 16,000 characters).
  * Supports document heading and citation inclusion with intelligent truncation when capacity is exceeded.
  * Preserves document order and validates input parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->