### PR TITLE
feat(agent): KbContextBundle + KnowledgeBaseService.resolveContext

### DIFF
--- a/packages/agent/src/entities/kb-types.ts
+++ b/packages/agent/src/entities/kb-types.ts
@@ -53,6 +53,28 @@ export const KB_ORG_INHERITABLE_CLASSES: ReadonlyArray<KbDocumentClass> = [
 export type KbInheritableClass = (typeof KB_ORG_INHERITABLE_CLASSES)[number];
 
 /**
+ * EW-641 Phase 2/b row 32a — classes auto-injected as `alwaysInjected`
+ * context on every Phase 2/b pipeline run (spec §15.4 priority list).
+ *
+ * Rationale: these four classes carry "always-relevant" guidance that
+ * shouldn't depend on the user's query — brand voice, legal constraints,
+ * editorial style, and term-substitution rules ground every generation.
+ * The query-retrieved set (driven by RRF over the user's `q`) layers
+ * additional context on top.
+ *
+ * Per-Work overrides live on `WorkKbConfig.retrievalConfig.classFilters`
+ * (a row 41 budget-gauge concern); this constant is the default.
+ */
+export const KB_ALWAYS_INJECTED_CLASSES: ReadonlyArray<KbDocumentClass> = [
+    KbDocumentClass.BRAND,
+    KbDocumentClass.LEGAL,
+    KbDocumentClass.STYLE,
+    KbDocumentClass.GLOSSARY,
+] as const;
+
+export type KbAlwaysInjectedClass = (typeof KB_ALWAYS_INJECTED_CLASSES)[number];
+
+/**
  * Lifecycle status of a KB document. Mirrors the `status` enums on
  * other content-bearing entities (items, comparisons) for consistency.
  */

--- a/packages/agent/src/services/__tests__/kb-context-bundle.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-context-bundle.spec.ts
@@ -1,0 +1,201 @@
+import { buildKbContextBundle } from '../kb-context-bundle';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+/**
+ * Test helper — same shape as the `kb-prompt-formatter` helper so the
+ * two specs read the same. Override only the fields the test cares about.
+ */
+function buildDoc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: overrides.id ?? 'doc-id',
+        workId: overrides.workId ?? 'work-1',
+        organizationId: overrides.organizationId ?? null,
+        path: overrides.path ?? 'brand/voice.md',
+        slug: overrides.slug ?? 'voice',
+        title: overrides.title ?? 'Brand voice',
+        description: overrides.description ?? null,
+        class: overrides.class ?? 'brand',
+        tags: overrides.tags ?? [],
+        categories: overrides.categories ?? [],
+        status: overrides.status ?? 'active',
+        locked: overrides.locked ?? false,
+        lockMode: overrides.lockMode ?? null,
+        language: overrides.language ?? 'en',
+        wordCount: overrides.wordCount ?? null,
+        tokenCount: overrides.tokenCount ?? null,
+        source: overrides.source ?? 'user',
+        sourceUploadId: overrides.sourceUploadId ?? null,
+        sourceUrl: overrides.sourceUrl ?? null,
+        generatedByAgentRunId: overrides.generatedByAgentRunId ?? null,
+        createdById: overrides.createdById ?? null,
+        updatedById: overrides.updatedById ?? null,
+        createdAt: overrides.createdAt ?? '2026-05-23T00:00:00.000Z',
+        updatedAt: overrides.updatedAt ?? '2026-05-23T00:00:00.000Z',
+        lastCommitSha: overrides.lastCommitSha ?? null,
+        body: overrides.body ?? 'default body',
+        assets: overrides.assets ?? [],
+    } as KbDocumentBodyDto;
+}
+
+describe('buildKbContextBundle', () => {
+    describe('boundary cases', () => {
+        it('returns an empty bundle when both inputs are empty', () => {
+            const bundle = buildKbContextBundle([], []);
+            expect(bundle.alwaysInjected).toEqual([]);
+            expect(bundle.queryRetrieved).toEqual([]);
+            expect(bundle.format()).toBe('<kb>\n</kb>');
+        });
+
+        it('handles alwaysInjected-only input', () => {
+            const doc = buildDoc({
+                id: 'a',
+                title: 'Voice',
+                slug: 'voice',
+                class: 'brand',
+                body: 'short',
+            });
+            const bundle = buildKbContextBundle([doc], []);
+            expect(bundle.alwaysInjected).toHaveLength(1);
+            expect(bundle.queryRetrieved).toHaveLength(0);
+            expect(bundle.format()).toBe('<kb>\n## Voice (kb:brand/voice)\nshort\n</kb>');
+        });
+
+        it('handles queryRetrieved-only input', () => {
+            const doc = buildDoc({
+                id: 'q',
+                title: 'Research note',
+                slug: 'note',
+                class: 'research',
+                body: 'detail',
+            });
+            const bundle = buildKbContextBundle([], [doc]);
+            expect(bundle.alwaysInjected).toHaveLength(0);
+            expect(bundle.queryRetrieved).toHaveLength(1);
+            expect(bundle.format()).toBe(
+                '<kb>\n## Research note (kb:research/note)\ndetail\n</kb>',
+            );
+        });
+    });
+
+    describe('priority + dedup', () => {
+        it('emits alwaysInjected first, then queryRetrieved', () => {
+            const always = buildDoc({
+                id: 'a',
+                title: 'Brand',
+                slug: 'brand',
+                class: 'brand',
+                body: 'a',
+            });
+            const query = buildDoc({
+                id: 'b',
+                title: 'Research',
+                slug: 'r',
+                class: 'research',
+                body: 'b',
+            });
+            const out = buildKbContextBundle([always], [query]).format();
+            const aIdx = out.indexOf('## Brand (');
+            const bIdx = out.indexOf('## Research (');
+            expect(aIdx).toBeGreaterThanOrEqual(0);
+            expect(bIdx).toBeGreaterThan(aIdx);
+        });
+
+        it('drops queryRetrieved entries that duplicate alwaysInjected by id', () => {
+            const shared = buildDoc({
+                id: 'shared',
+                title: 'Voice',
+                slug: 'voice',
+                class: 'brand',
+                body: 'always-version',
+            });
+            const sharedFromQuery = buildDoc({
+                id: 'shared',
+                title: 'Voice (semantic)',
+                slug: 'voice',
+                class: 'brand',
+                body: 'query-version — should be dropped',
+            });
+            const extraQuery = buildDoc({
+                id: 'extra',
+                title: 'Extra',
+                slug: 'extra',
+                class: 'research',
+                body: 'extra',
+            });
+            const bundle = buildKbContextBundle([shared], [sharedFromQuery, extraQuery]);
+
+            expect(bundle.queryRetrieved.map((d) => d.id)).toEqual(['extra']);
+            const out = bundle.format();
+            // Always-injected copy survives, query-version is gone.
+            expect(out).toContain('always-version');
+            expect(out).not.toContain('should be dropped');
+        });
+
+        it('dedupes queryRetrieved entries that repeat within the list itself', () => {
+            const a = buildDoc({ id: 'x', title: 'A', slug: 'a', class: 'research', body: 'A1' });
+            const aAgain = buildDoc({
+                id: 'x',
+                title: 'A again',
+                slug: 'a',
+                class: 'research',
+                body: 'A2',
+            });
+            const bundle = buildKbContextBundle([], [a, aAgain]);
+            expect(bundle.queryRetrieved.map((d) => d.id)).toEqual(['x']);
+            // First wins (deterministic).
+            expect(bundle.queryRetrieved[0].title).toBe('A');
+        });
+
+        it('preserves input order within each list (deterministic)', () => {
+            const a = buildDoc({ id: '1', title: 'Z', slug: 'z', class: 'brand', body: 'z' });
+            const b = buildDoc({ id: '2', title: 'A', slug: 'a', class: 'brand', body: 'a' });
+            const c = buildDoc({ id: '3', title: 'M', slug: 'm', class: 'research', body: 'm' });
+            const d = buildDoc({ id: '4', title: 'B', slug: 'b', class: 'research', body: 'b' });
+
+            const out = buildKbContextBundle([a, b], [c, d]).format();
+            const zIdx = out.indexOf('## Z (');
+            const aIdx = out.indexOf('## A (');
+            const mIdx = out.indexOf('## M (');
+            const bIdx = out.indexOf('## B (');
+            // alwaysInjected order: Z, A — then queryRetrieved: M, B.
+            expect(zIdx).toBeLessThan(aIdx);
+            expect(aIdx).toBeLessThan(mIdx);
+            expect(mIdx).toBeLessThan(bIdx);
+        });
+    });
+
+    describe('immutability', () => {
+        it('returns frozen alwaysInjected + queryRetrieved arrays', () => {
+            const doc = buildDoc({ id: 'a' });
+            const bundle = buildKbContextBundle([doc], []);
+            expect(Object.isFrozen(bundle.alwaysInjected)).toBe(true);
+            expect(Object.isFrozen(bundle.queryRetrieved)).toBe(true);
+        });
+
+        it('does not mutate caller-owned input arrays', () => {
+            const always: KbDocumentBodyDto[] = [buildDoc({ id: 'a' })];
+            const query: KbDocumentBodyDto[] = [buildDoc({ id: 'b' })];
+            const alwaysLenBefore = always.length;
+            const queryLenBefore = query.length;
+            buildKbContextBundle(always, query);
+            expect(always.length).toBe(alwaysLenBefore);
+            expect(query.length).toBe(queryLenBefore);
+        });
+    });
+
+    describe('format options', () => {
+        it('forwards maxChars to formatKbContext (truncation honoured)', () => {
+            const doc = buildDoc({
+                id: 'big',
+                title: 'Big',
+                slug: 'big',
+                class: 'brand',
+                body: 'X'.repeat(500),
+            });
+            const bundle = buildKbContextBundle([doc], []);
+            const truncated = bundle.format({ maxChars: 100 });
+            expect(truncated.length).toBeLessThanOrEqual(100);
+            expect(truncated).toContain('[…truncated]');
+        });
+    });
+});

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -298,6 +298,168 @@ describe('KnowledgeBaseService', () => {
         });
     });
 
+    describe('resolveContext', () => {
+        // EW-641 Phase 2/b row 32a — the bundle the pipeline plugin
+        // invocation reads (row 32b wires it in). The default test
+        // module doesn't wire `chunkRepository` / `aiFacade`, so
+        // `semanticSearch` returns []; the bundle therefore only ever
+        // contains the always-injected docs unless we reflect a stub
+        // in (mirror's the `mirrorService` pattern above).
+
+        it('returns alwaysInjected docs without query (semantic not consulted)', async () => {
+            const brandDoc = buildDocument({
+                id: 'b-1',
+                kbDocumentClass: 'brand' as KbDocumentClass,
+                path: 'brand/voice.md',
+                slug: 'voice',
+                title: 'Brand voice',
+                metadata: { body: 'Friendly.' },
+            });
+            const legalDoc = buildDocument({
+                id: 'l-1',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+                path: 'legal/terms.md',
+                slug: 'terms',
+                title: 'Terms',
+                metadata: { body: 'Verbatim.' },
+            });
+            docRepo.list.mockResolvedValue({ items: [brandDoc, legalDoc], total: 2 });
+
+            const bundle = await service.resolveContext(WORK_ID);
+
+            // System op — must NOT call ensureCanView (pipeline plugin
+            // is the trust boundary).
+            expect(ownership.ensureCanView).not.toHaveBeenCalled();
+
+            expect(bundle.alwaysInjected.map((d) => d.id)).toEqual(['b-1', 'l-1']);
+            expect(bundle.queryRetrieved).toEqual([]);
+
+            // Always-injected whitelist + active-only filter is what the
+            // service forwards to the repo.
+            expect(docRepo.list).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: WORK_ID,
+                    classes: expect.arrayContaining(['brand', 'legal', 'style', 'glossary']),
+                    statuses: ['active'],
+                }),
+            );
+
+            const rendered = bundle.format();
+            expect(rendered).toContain('<kb>');
+            expect(rendered).toContain('## Brand voice (kb:brand/voice)');
+            expect(rendered).toContain('## Terms (kb:legal/terms)');
+            expect(rendered).toContain('</kb>');
+        });
+
+        it('returns alwaysInjected only when query is set but embedder is unavailable', async () => {
+            const brandDoc = buildDocument({
+                id: 'b-2',
+                kbDocumentClass: 'brand' as KbDocumentClass,
+                metadata: { body: 'B body' },
+            });
+            docRepo.list.mockResolvedValue({ items: [brandDoc], total: 1 });
+
+            const bundle = await service.resolveContext(WORK_ID, { query: 'hello world' });
+
+            // No embedder/chunkRepo wired in the default module ⇒
+            // semanticSearch returns []; queryRetrieved degrades to [].
+            expect(bundle.queryRetrieved).toEqual([]);
+            expect(bundle.alwaysInjected).toHaveLength(1);
+        });
+
+        it('treats whitespace-only query as no query (semantic skipped)', async () => {
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+            // Sentinel — if semantic were consulted we'd see a mocked
+            // call below. The default module has no `chunkRepository`,
+            // so reflect a strict stub in and assert it stays untouched.
+            const chunkRepoStub = { findNearestByEmbedding: jest.fn() };
+            (service as unknown as { chunkRepository: typeof chunkRepoStub }).chunkRepository =
+                chunkRepoStub;
+
+            await service.resolveContext(WORK_ID, { query: '   \n  ' });
+
+            expect(chunkRepoStub.findNearestByEmbedding).not.toHaveBeenCalled();
+        });
+
+        it('layers queryRetrieved (semantic hits) on top of alwaysInjected, dedup by id', async () => {
+            const sharedId = '00000000-0000-0000-0000-0000000000aa';
+            const sharedAlways = buildDocument({
+                id: sharedId,
+                kbDocumentClass: 'brand' as KbDocumentClass,
+                path: 'brand/voice.md',
+                slug: 'voice',
+                title: 'Brand voice',
+                metadata: { body: 'Always copy' },
+            });
+            const semanticOnly = buildDocument({
+                id: 'semantic-only',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                path: 'research/note.md',
+                slug: 'note',
+                title: 'Research note',
+                metadata: { body: 'Semantic body' },
+            });
+
+            // Stub out semantic deps so semanticSearch returns chunks.
+            const aiFacadeStub = {
+                embed: jest.fn().mockResolvedValue({ embeddings: [[0.1, 0.2, 0.3]] }),
+            };
+            const chunkRepoStub = {
+                findNearestByEmbedding: jest.fn().mockResolvedValue([
+                    {
+                        id: 'c1',
+                        workId: WORK_ID,
+                        documentId: sharedId,
+                        chunkIndex: 0,
+                        content: 'chunk a',
+                        distance: 0.1,
+                    },
+                    {
+                        id: 'c2',
+                        workId: WORK_ID,
+                        documentId: 'semantic-only',
+                        chunkIndex: 0,
+                        content: 'chunk b',
+                        distance: 0.2,
+                    },
+                ]),
+            };
+            (service as unknown as { chunkRepository: typeof chunkRepoStub }).chunkRepository =
+                chunkRepoStub;
+            (service as unknown as { aiFacade: typeof aiFacadeStub }).aiFacade = aiFacadeStub;
+
+            // First call (alwaysInjected fetch) returns sharedAlways.
+            docRepo.list.mockResolvedValue({ items: [sharedAlways], total: 1 });
+            // For the per-id semantic materialization, findById serves
+            // both ids — including the dup we'll drop.
+            docRepo.findById.mockImplementation(async (_workId: string, docId: string) => {
+                if (docId === sharedId) return sharedAlways;
+                if (docId === 'semantic-only') return semanticOnly;
+                return null;
+            });
+
+            const bundle = await service.resolveContext(WORK_ID, {
+                query: 'voice tone',
+                limit: 5,
+            });
+
+            // alwaysInjected wins the dedup: only the semantic-only doc
+            // survives in queryRetrieved.
+            expect(bundle.alwaysInjected.map((d) => d.id)).toEqual([sharedId]);
+            expect(bundle.queryRetrieved.map((d) => d.id)).toEqual(['semantic-only']);
+
+            const rendered = bundle.format();
+            // Both docs rendered, in priority order.
+            const brandIdx = rendered.indexOf('## Brand voice (kb:brand/voice)');
+            const researchIdx = rendered.indexOf('## Research note (kb:research/note)');
+            expect(brandIdx).toBeGreaterThanOrEqual(0);
+            expect(researchIdx).toBeGreaterThan(brandIdx);
+            // The semantic body of the dup is NOT in the rendered output
+            // (alwaysInjected copy is what got emitted).
+            expect(rendered).toContain('Always copy');
+        });
+    });
+
     describe('getDocumentHistory', () => {
         it('returns an empty history when the mirror service is not wired', async () => {
             const doc = buildDocument();

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -33,6 +33,7 @@ export * from './knowledge-base.module';
 export * from './kb-chunker';
 export * from './kb-rrf';
 export * from './kb-prompt-formatter';
+export * from './kb-context-bundle';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-context-bundle.ts
+++ b/packages/agent/src/services/kb-context-bundle.ts
@@ -1,0 +1,75 @@
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+import { formatKbContext, type FormatKbContextOptions } from './kb-prompt-formatter';
+
+/**
+ * EW-641 Phase 2/b row 32a — `KbContextBundle` value type returned by
+ * `KnowledgeBaseService.resolveContext(workId, opts)`.
+ *
+ * Spec §15.4 priority: `alwaysInjected` first (default whitelist =
+ * brand + legal + style + glossary; configurable per-Work via
+ * `WorkKbConfig.retrievalConfig.classFilters` — row 41 budget gauge),
+ * then `queryRetrieved` (RRF-fused lexical + semantic over the user's
+ * query, when present). The bundle is the single value plumbed into
+ * the pipeline plugin invocation (row 32b), so individual pipelines
+ * never need to know how the context was assembled.
+ *
+ * `format(opts)` delegates to `formatKbContext` (row 31) — every
+ * Phase 2/b consumer gets the same `<kb>...</kb>` block shape and the
+ * same truncation contract without re-implementing it.
+ *
+ * **Determinism.** Input order is preserved; the bundle factory
+ * dedupes `queryRetrieved` against `alwaysInjected` by `id` (always-
+ * injected wins — if `brand/voice` is both always-injected AND a
+ * top RRF hit, it appears once, in the always-injected slot).
+ *
+ * **Pure.** No I/O, no module state. The factory only marshals; the
+ * service layer (`resolveContext`) is the one that touches the DB.
+ */
+export interface KbContextBundle {
+    readonly alwaysInjected: ReadonlyArray<KbDocumentBodyDto>;
+    readonly queryRetrieved: ReadonlyArray<KbDocumentBodyDto>;
+    format(options?: FormatKbContextOptions): string;
+}
+
+/**
+ * Build a `KbContextBundle` from two doc lists, deduping `queryRetrieved`
+ * against `alwaysInjected` by `id`.
+ *
+ * The returned bundle's `format()` concatenates the two lists in
+ * priority order (alwaysInjected first) and delegates to `formatKbContext`.
+ *
+ * Pure factory — safe for any context (service code, eval harness,
+ * tests). Callers (notably `KnowledgeBaseService.resolveContext`) are
+ * responsible for the actual data fetches.
+ */
+export function buildKbContextBundle(
+    alwaysInjected: ReadonlyArray<KbDocumentBodyDto>,
+    queryRetrieved: ReadonlyArray<KbDocumentBodyDto>,
+): KbContextBundle {
+    const alwaysIds = new Set<string>();
+    for (const d of alwaysInjected) alwaysIds.add(d.id);
+
+    // Dedup queryRetrieved by id (within the list itself AND against
+    // alwaysInjected). A doc that survived RRF + appears in the always-
+    // injected whitelist would otherwise be emitted twice; keep the
+    // alwaysInjected copy and drop the duplicate from queryRetrieved.
+    const seenQuery = new Set<string>();
+    const dedupedQueryRetrieved: KbDocumentBodyDto[] = [];
+    for (const d of queryRetrieved) {
+        if (alwaysIds.has(d.id)) continue;
+        if (seenQuery.has(d.id)) continue;
+        seenQuery.add(d.id);
+        dedupedQueryRetrieved.push(d);
+    }
+
+    const frozenAlways = Object.freeze([...alwaysInjected]);
+    const frozenQuery = Object.freeze(dedupedQueryRetrieved);
+
+    return {
+        alwaysInjected: frozenAlways,
+        queryRetrieved: frozenQuery,
+        format(options?: FormatKbContextOptions): string {
+            return formatKbContext([...frozenAlways, ...frozenQuery], options);
+        },
+    };
+}

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -25,9 +25,11 @@ import { WorkKnowledgeCitationRepository } from '../database/repositories/work-k
 import { WorkKnowledgeChunkRepository } from '../database/repositories/work-knowledge-chunk.repository';
 import { AiFacadeService } from '../facades/ai.facade';
 import { rrfBlend } from './kb-rrf';
+import { buildKbContextBundle, type KbContextBundle } from './kb-context-bundle';
 import { WorkKnowledgeDocument } from '../entities/work-knowledge-document.entity';
 import { WorkKnowledgeTag } from '../entities/work-knowledge-tag.entity';
 import {
+    KB_ALWAYS_INJECTED_CLASSES,
     KB_ORG_INHERITABLE_CLASSES,
     KbDocumentClass,
     KbDocumentSource,
@@ -372,6 +374,100 @@ export class KnowledgeBaseService {
         const doc = await this.documentRepository.findByWorkOrPath(workId, documentId);
         if (!doc) return null;
         return this.toBodyDto(doc);
+    }
+
+    /**
+     * EW-641 Phase 2/b row 32a — resolve the KB context bundle that
+     * Phase 2/b pipelines inject into agent runs.
+     *
+     * Spec §15.4 priority:
+     *   1. `alwaysInjected` — all `active` docs whose class is in the
+     *      default `KB_ALWAYS_INJECTED_CLASSES` whitelist (brand /
+     *      legal / style / glossary). Per-Work `classFilters` override
+     *      is a row 41 (budget gauge) concern; for now we use the
+     *      constant whitelist directly.
+     *   2. `queryRetrieved` — docs underlying the top RRF-fused chunks
+     *      from `semanticSearch(workId, query, limit)` when `opts.query`
+     *      is set. Chunks are deduped by `documentId` (first occurrence
+     *      = best-ranking chunk), then full docs are fetched by id to
+     *      populate body text for `formatKbContext`.
+     *
+     * This is a SYSTEM operation — the pipeline plugin caller is the
+     * trust boundary. No `ensureCanView`: row 32b's plugin invocation
+     * is system-context (the agent run is already authorized at the
+     * generation entry point). Mirrors `getDocumentBodyForEmbedding`'s
+     * no-gate pattern (row 29b2b) and `semanticSearch`'s SYSTEM op
+     * stance (row 30a).
+     *
+     * Graceful degradation:
+     *  - No `query` → `queryRetrieved` is `[]`; only always-injected
+     *    docs are returned. Pipelines still get useful grounding.
+     *  - `semanticSearch` returns `[]` (no embedder configured, no
+     *    chunks indexed yet, SQLite e2e env) → same outcome.
+     *
+     * The pipeline plumbing (row 32b) calls `bundle.format(opts)` to
+     * render the `<kb>...</kb>` block — `formatKbContext` (row 31)
+     * handles the truncation contract uniformly across consumers.
+     */
+    async resolveContext(
+        workId: string,
+        opts: { query?: string; limit?: number } = {},
+    ): Promise<KbContextBundle> {
+        const alwaysInjected = await this.fetchAlwaysInjectedDocs(workId);
+
+        const trimmedQuery = opts.query?.trim() ?? '';
+        const queryRetrieved =
+            trimmedQuery.length > 0
+                ? await this.fetchQueryRetrievedDocs(workId, trimmedQuery, opts.limit ?? 8)
+                : [];
+
+        return buildKbContextBundle(alwaysInjected, queryRetrieved);
+    }
+
+    /**
+     * Helper for `resolveContext` — fetch the default always-injected
+     * KB documents for a Work. Returns a materialized body DTO list so
+     * `formatKbContext` can render each entry directly.
+     */
+    private async fetchAlwaysInjectedDocs(workId: string): Promise<KbDocumentBodyDto[]> {
+        const { items } = await this.documentRepository.list({
+            workId,
+            classes: [...KB_ALWAYS_INJECTED_CLASSES],
+            statuses: [KbDocumentStatus.ACTIVE],
+        });
+        return items.map((d) => this.toBodyDto(d));
+    }
+
+    /**
+     * Helper for `resolveContext` — run semantic retrieval, dedupe to
+     * unique document IDs, and materialize each as a body DTO.
+     *
+     * Bounded N+1: callers cap `limit` (default 8); production hot-path
+     * metrics can move this to `findByIds(workId, docIds)` once
+     * `WorkKnowledgeDocumentRepository` grows that batch method.
+     */
+    private async fetchQueryRetrievedDocs(
+        workId: string,
+        query: string,
+        limit: number,
+    ): Promise<KbDocumentBodyDto[]> {
+        const chunks = await this.semanticSearch(workId, query, limit);
+        if (chunks.length === 0) return [];
+
+        const seen = new Set<string>();
+        const orderedDocIds: string[] = [];
+        for (const c of chunks) {
+            if (seen.has(c.documentId)) continue;
+            seen.add(c.documentId);
+            orderedDocIds.push(c.documentId);
+        }
+
+        const results: KbDocumentBodyDto[] = [];
+        for (const docId of orderedDocIds) {
+            const doc = await this.documentRepository.findById(workId, docId);
+            if (doc) results.push(this.toBodyDto(doc));
+        }
+        return results;
     }
 
     /**


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/b row 32a — value type + service method that assembles the KB context bundle Phase 2/b pipelines will inject.
- `KbContextBundle` is a frozen value object with `alwaysInjected` + `queryRetrieved` doc lists and a `format(opts?)` method that delegates to `formatKbContext` (row 31).
- `buildKbContextBundle(always, query)` dedupes `queryRetrieved` against `alwaysInjected` by id (always-injected wins) — pure factory.
- `KnowledgeBaseService.resolveContext(workId, { query?, limit? })` pulls `alwaysInjected` from the spec §15.4 default whitelist (`brand` / `legal` / `style` / `glossary`) and `queryRetrieved` from `semanticSearch` → dedup by `documentId` → body-DTO materialization. SYSTEM op (no `ensureCanView`; the pipeline plugin caller is the trust boundary, same pattern as `getDocumentBodyForEmbedding`). Degrades gracefully to always-injected-only when the embedder is unavailable.
- Row 32b will plumb this bundle into the pipeline plugin invocation signature in a follow-up PR.

## Test plan
- [x] `pnpm jest kb-context-bundle.spec.ts` — 11/11 green (boundary, priority + dedup, immutability, format options)
- [x] `pnpm jest knowledge-base.service.spec.ts` — 44/44 green (4 new `resolveContext` cases)
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic injection of core knowledge base documents (brand, legal, style, glossary) as always-included context for agent operations.
  * New context resolution capability that intelligently combines always-injected documents with semantically relevant search results, with built-in deduplication for cleaner context handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->