### PR TITLE
feat(plugin,agent): plumb KbContextBundle through StepExecutionContext

### DIFF
--- a/packages/agent/src/pipeline/pipeline-facade.service.spec.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.spec.ts
@@ -114,6 +114,30 @@ describe('PipelineFacadeService', () => {
             const ctx = service.createStepExecutionContext(makeWork() as any);
             expect(ctx.signal).toBeUndefined();
         });
+
+        // EW-641 Phase 2/b row 32b — kbContext carrier.
+        it('omits kbContext when not provided (carrier stays undefined)', () => {
+            const ctx = service.createStepExecutionContext(makeWork() as any);
+            expect(ctx.kbContext).toBeUndefined();
+        });
+
+        it('forwards the provided kbContext bundle into the StepExecutionContext', () => {
+            const bundle = {
+                alwaysInjected: [{ id: 'always-doc' }] as any,
+                queryRetrieved: [{ id: 'query-doc' }] as any,
+            };
+            const ctx = service.createStepExecutionContext(
+                makeWork() as any,
+                undefined,
+                undefined,
+                undefined,
+                bundle,
+            );
+            expect(ctx.kbContext).toBe(bundle);
+            // Both lists are reachable through the carrier without further work.
+            expect(ctx.kbContext?.alwaysInjected.map((d) => d.id)).toEqual(['always-doc']);
+            expect(ctx.kbContext?.queryRetrieved.map((d) => d.id)).toEqual(['query-doc']);
+        });
     });
 
     describe('logger prefix', () => {

--- a/packages/agent/src/pipeline/pipeline-facade.service.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.ts
@@ -32,6 +32,7 @@ import type {
     EnabledDataSource,
     FacadeOptions,
 } from '@ever-works/plugin';
+import type { KbContextBundleData } from '@ever-works/contracts';
 import { AiFacadeService } from '../facades/ai.facade';
 import { SearchFacadeService } from '../facades/search.facade';
 import { ScreenshotFacadeService } from '../facades/screenshot.facade';
@@ -78,12 +79,19 @@ export class PipelineFacadeService {
     /**
      * Create a StepExecutionContext for step executors.
      * Provides access to bound facades that automatically include work context.
+     *
+     * EW-641 Phase 2/b row 32b — accepts an optional `kbContext` carrier.
+     * When provided (orchestrator wiring lands in a follow-up sub-chunk),
+     * step executors read the resolved KB documents from
+     * `execContext.kbContext.{alwaysInjected,queryRetrieved}` without
+     * re-calling `KnowledgeBaseService.resolveContext`.
      */
     createStepExecutionContext(
         work: WorkReference,
         providerOverrides?: GenerationRequest['providers'],
         aiModelOverride?: string,
         signal?: AbortSignal,
+        kbContext?: KbContextBundleData,
     ): StepExecutionContext {
         const stepLogger: StepLogger = {
             log: (msg: string, ...args: unknown[]) =>
@@ -122,6 +130,7 @@ export class PipelineFacadeService {
             work,
             user: work.user,
             signal,
+            kbContext,
         };
     }
 

--- a/packages/agent/src/services/__tests__/kb-context-bundle.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-context-bundle.spec.ts
@@ -1,5 +1,5 @@
 import { buildKbContextBundle } from '../kb-context-bundle';
-import type { KbDocumentBodyDto } from '@ever-works/contracts';
+import type { KbContextBundleData, KbDocumentBodyDto } from '@ever-works/contracts';
 
 /**
  * Test helper — same shape as the `kb-prompt-formatter` helper so the
@@ -180,6 +180,23 @@ describe('buildKbContextBundle', () => {
             buildKbContextBundle(always, query);
             expect(always.length).toBe(alwaysLenBefore);
             expect(query.length).toBe(queryLenBefore);
+        });
+    });
+
+    describe('public contract', () => {
+        // EW-641 Phase 2/b row 32b — the agent-side bundle MUST satisfy
+        // the wire-format `KbContextBundleData` carrier in
+        // `@ever-works/contracts`. Without this, plumbing the bundle
+        // through `StepExecutionContext.kbContext` would require an
+        // unsafe widen at the call site.
+        it('is assignable to KbContextBundleData (public data carrier)', () => {
+            const doc = buildDoc({ id: 'a' });
+            const bundle = buildKbContextBundle([doc], []);
+            // Compile-time + runtime check: the bundle's data-bearing
+            // fields satisfy the public KbContextBundleData type.
+            const asData: KbContextBundleData = bundle;
+            expect(asData.alwaysInjected).toHaveLength(1);
+            expect(asData.queryRetrieved).toHaveLength(0);
         });
     });
 

--- a/packages/agent/src/services/kb-context-bundle.ts
+++ b/packages/agent/src/services/kb-context-bundle.ts
@@ -1,4 +1,4 @@
-import type { KbDocumentBodyDto } from '@ever-works/contracts';
+import type { KbContextBundleData, KbDocumentBodyDto } from '@ever-works/contracts';
 import { formatKbContext, type FormatKbContextOptions } from './kb-prompt-formatter';
 
 /**
@@ -25,7 +25,7 @@ import { formatKbContext, type FormatKbContextOptions } from './kb-prompt-format
  * **Pure.** No I/O, no module state. The factory only marshals; the
  * service layer (`resolveContext`) is the one that touches the DB.
  */
-export interface KbContextBundle {
+export interface KbContextBundle extends KbContextBundleData {
     readonly alwaysInjected: ReadonlyArray<KbDocumentBodyDto>;
     readonly queryRetrieved: ReadonlyArray<KbDocumentBodyDto>;
     format(options?: FormatKbContextOptions): string;

--- a/packages/contracts/src/kb/index.ts
+++ b/packages/contracts/src/kb/index.ts
@@ -5,3 +5,4 @@ export * from './kb-tag.types.js';
 export * from './kb-citation.types.js';
 export * from './kb-search.types.js';
 export * from './kb-tree.types.js';
+export * from './kb-context-bundle.types.js';

--- a/packages/contracts/src/kb/kb-context-bundle.types.ts
+++ b/packages/contracts/src/kb/kb-context-bundle.types.ts
@@ -1,0 +1,28 @@
+import type { KbDocumentBodyDto } from './kb-document.types.js';
+
+/**
+ * EW-641 Phase 2/b row 32b — wire-format shape of a resolved KB context
+ * bundle as carried by `StepExecutionContext.kbContext` into pipeline
+ * step executors.
+ *
+ * Data-only mirror of `KbContextBundle` (in `@ever-works/agent`). The
+ * agent-side bundle adds a `format(opts?)` method that renders the
+ * `<kb>...</kb>` block via `formatKbContext` (row 31); the data shape
+ * here is the part that:
+ *  - is safe to serialize (no methods, no cycles),
+ *  - is consumable by any pipeline plugin (in `@ever-works/plugin`'s
+ *    public package) without dragging in agent internals,
+ *  - is forwarded by `PipelineFacadeService.createStepExecutionContext`
+ *    to step executors via the engine-provided `execContext`.
+ *
+ * Priority per spec §15.4: `alwaysInjected` first (default whitelist =
+ * `brand` + `legal` + `style` + `glossary`), then `queryRetrieved`
+ * (RRF-fused lexical + semantic over the user query, when present).
+ * The agent's factory dedupes `queryRetrieved` against `alwaysInjected`
+ * by `id` before exposing — consumers can iterate the two arrays
+ * back-to-back without worrying about double-counting.
+ */
+export interface KbContextBundleData {
+	readonly alwaysInjected: ReadonlyArray<KbDocumentBodyDto>;
+	readonly queryRetrieved: ReadonlyArray<KbDocumentBodyDto>;
+}

--- a/packages/plugin/src/pipeline/step-execution-context.interface.ts
+++ b/packages/plugin/src/pipeline/step-execution-context.interface.ts
@@ -1,3 +1,4 @@
+import type { KbContextBundleData } from '@ever-works/contracts';
 import type { IAiFacade } from '../facades/ai-facade.interface.js';
 import type { ISearchFacade } from '../facades/search-facade.interface.js';
 import type { IScreenshotFacade } from '../facades/screenshot-facade.interface.js';
@@ -83,4 +84,22 @@ export interface StepExecutionContext {
 	 * Abort signal for cancellation support.
 	 */
 	readonly signal?: AbortSignal;
+
+	/**
+	 * EW-641 Phase 2/b row 32b — resolved KB context bundle for this
+	 * execution, when the agent-side orchestrator has wired the agent's
+	 * `KnowledgeBaseService.resolveContext(workId, { query? })` through
+	 * `PipelineFacadeService.createStepExecutionContext`.
+	 *
+	 * Optional so deployments that haven't wired the KB resolver yet
+	 * (older builds, isolated unit tests, OSS images without the agent
+	 * package) keep constructing identically — the carrier is here, but
+	 * the row 32c orchestrator call site is what actually populates it.
+	 *
+	 * Step plugins read `kbContext.alwaysInjected` / `.queryRetrieved`
+	 * and feed those documents into their prompts via the row 31
+	 * `formatKbContext` helper (rendered by an agent-side wrapper that
+	 * exposes `format()` on its bundle).
+	 */
+	readonly kbContext?: KbContextBundleData;
 }


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/b row 32b — thread the resolved KB context bundle through the pipeline plugin invocation surface so step executors read context without re-calling `KnowledgeBaseService.resolveContext`.
- New public type `KbContextBundleData` in `@ever-works/contracts` — data-only mirror (no methods) of the agent-side `KbContextBundle` from row 32a. Safe to import from any package.
- Optional `kbContext?: KbContextBundleData` on `StepExecutionContext` (`@ever-works/plugin`). Optional so older callers still construct identically; row 32c orchestrator wiring populates it.
- `PipelineFacadeService.createStepExecutionContext` accepts an optional 5th `kbContext` param and forwards it onto the returned context. Existing call sites (`StepPipelineExecutorService`, `FullPipelineExecutorService`) pass nothing → behavior unchanged.
- Agent's `KbContextBundle` now `extends KbContextBundleData`, locking in structural compatibility at the type system.

## Test plan
- [x] `pnpm jest kb-context-bundle.spec.ts pipeline-facade.service.spec.ts` — 43/43 green (incl. 2 new facade cases + 1 new assignability case)
- [x] `pnpm jest src/pipeline` — 394/394 green (signature change is backwards-compatible)
- [x] `@ever-works/plugin` Vitest — 199/199 green
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Step executors can now access resolved knowledge base documents within the pipeline execution context, enabling context-aware processing throughout execution steps.

* **Tests**
  * Added test coverage to validate knowledge base context handling and proper forwarding to step executors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->