### PR TITLE
feat(agent): orchestrator populates execContext.kbContext via resolveContext

### DIFF
--- a/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
@@ -537,10 +537,13 @@ describe('StepPipelineExecutorService', () => {
 
             await service.execute(standardPlugin, mockWork, requestWithProviders, mockExisting);
 
-            // Verify facade service was called with provider overrides
+            // Verify facade service was called with provider overrides.
+            // 5th arg is `kbContext` (EW-641 row 32c) — undefined when
+            // KnowledgeBaseService is not injected.
             expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
                 mockWork,
                 requestWithProviders.providers,
+                undefined,
                 undefined,
                 undefined,
             );
@@ -552,6 +555,7 @@ describe('StepPipelineExecutorService', () => {
             // Verify facade service was called without provider overrides
             expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
                 mockWork,
+                undefined,
                 undefined,
                 undefined,
                 undefined,
@@ -571,6 +575,59 @@ describe('StepPipelineExecutorService', () => {
                 mockWork,
                 undefined,
                 'openai/gpt-4.1',
+                undefined,
+                undefined,
+            );
+        });
+
+        // EW-641 Phase 2/b row 32c — orchestrator populates execContext.kbContext.
+        it('forwards the resolved KB bundle as the 5th arg when KnowledgeBaseService is wired', async () => {
+            const bundle = {
+                alwaysInjected: [{ id: 'b1' }],
+                queryRetrieved: [{ id: 'q1' }],
+            };
+            const kbStub = { resolveContext: jest.fn().mockResolvedValue(bundle) };
+            (service as any).knowledgeBaseService = kbStub;
+
+            const requestWithPrompt: GenerationRequest = {
+                prompt: 'voice tone',
+                config: {},
+            };
+
+            await service.execute(standardPlugin, mockWork, requestWithPrompt, mockExisting);
+
+            expect(kbStub.resolveContext).toHaveBeenCalledTimes(1);
+            expect(kbStub.resolveContext).toHaveBeenCalledWith(mockWork.id, {
+                query: 'voice tone',
+            });
+            // Bundle reaches the facade as the 5th positional arg of every
+            // per-step createStepExecutionContext call.
+            expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
+                mockWork,
+                undefined,
+                undefined,
+                undefined,
+                bundle,
+            );
+        });
+
+        it('degrades gracefully when resolveContext throws (kbContext stays undefined)', async () => {
+            const kbStub = {
+                resolveContext: jest.fn().mockRejectedValue(new Error('kb down')),
+            };
+            (service as any).knowledgeBaseService = kbStub;
+            // Silence the expected warn log.
+            jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+
+            await service.execute(standardPlugin, mockWork, mockRequest, mockExisting);
+
+            expect(kbStub.resolveContext).toHaveBeenCalled();
+            // 5th arg stays undefined even though resolveContext rejected.
+            expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
+                mockWork,
+                undefined,
+                undefined,
+                undefined,
                 undefined,
             );
         });

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
@@ -86,11 +86,14 @@ describe('FullPipelineExecutorService', () => {
             );
 
             // facade.createStepExecutionContext invoked with documented positional args.
+            // 5th arg is `kbContext` (EW-641 row 32c) — undefined when
+            // KnowledgeBaseService is not injected (the default ctor here).
             expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
                 work,
                 request.providers,
                 request.aiModel,
                 undefined, // no signal in options
+                undefined, // no kbContext (no KB service wired)
             );
 
             // plugin.execute received {...options, execContext, onLogEntry}.
@@ -137,6 +140,7 @@ describe('FullPipelineExecutorService', () => {
                 request.providers,
                 request.aiModel,
                 signal,
+                undefined,
             );
         });
 
@@ -168,6 +172,110 @@ describe('FullPipelineExecutorService', () => {
 
             // The wrapper REPLACES the plugin's duration with its own measurement.
             expect(result.duration).toBe(2500);
+        });
+    });
+
+    // EW-641 Phase 2/b row 32c — orchestrator populates execContext.kbContext
+    // by calling KnowledgeBaseService.resolveContext once per run. The bundle
+    // is forwarded as the 5th positional arg to createStepExecutionContext.
+    describe('execute — kbContext wiring (row 32c)', () => {
+        const work = { id: 'w-kb' } as any;
+        const request = { providers: { p: 'x' }, aiModel: 'gpt', prompt: 'voice tone' } as any;
+        const existing = { items: [] } as any;
+
+        it('resolves the KB bundle and forwards it as the 5th arg when KnowledgeBaseService is wired', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+
+            const bundle = {
+                alwaysInjected: [{ id: 'b1' }] as any,
+                queryRetrieved: [{ id: 'q1' }] as any,
+            };
+            const kbService = { resolveContext: jest.fn().mockResolvedValue(bundle) };
+
+            const wired = new FullPipelineExecutorService(
+                eventEmitter,
+                facadeService,
+                contextFactory,
+                kbService as any,
+            );
+            jest.spyOn((wired as any).logger, 'log').mockImplementation(() => undefined);
+            jest.spyOn((wired as any).logger, 'error').mockImplementation(() => undefined);
+            jest.spyOn((wired as any).logger, 'warn').mockImplementation(() => undefined);
+
+            await wired.execute(plugin, work, request, existing);
+
+            expect(kbService.resolveContext).toHaveBeenCalledTimes(1);
+            expect(kbService.resolveContext).toHaveBeenCalledWith('w-kb', { query: 'voice tone' });
+
+            expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
+                work,
+                request.providers,
+                request.aiModel,
+                undefined,
+                bundle,
+            );
+        });
+
+        it('does not call resolveContext when work.id is empty (test/fixture path)', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const kbService = { resolveContext: jest.fn() };
+
+            const wired = new FullPipelineExecutorService(
+                eventEmitter,
+                facadeService,
+                contextFactory,
+                kbService as any,
+            );
+            jest.spyOn((wired as any).logger, 'log').mockImplementation(() => undefined);
+            jest.spyOn((wired as any).logger, 'error').mockImplementation(() => undefined);
+
+            await wired.execute(plugin, { id: '' } as any, request, existing);
+
+            expect(kbService.resolveContext).not.toHaveBeenCalled();
+            // Carrier stays undefined.
+            expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
+                expect.objectContaining({ id: '' }),
+                request.providers,
+                request.aiModel,
+                undefined,
+                undefined,
+            );
+        });
+
+        it('degrades gracefully when resolveContext throws (logs warn, kbContext stays undefined)', async () => {
+            const plugin = makePlugin();
+            plugin.execute.mockResolvedValue(makeValidResult());
+            const kbService = {
+                resolveContext: jest.fn().mockRejectedValue(new Error('db down')),
+            };
+
+            const wired = new FullPipelineExecutorService(
+                eventEmitter,
+                facadeService,
+                contextFactory,
+                kbService as any,
+            );
+            jest.spyOn((wired as any).logger, 'log').mockImplementation(() => undefined);
+            jest.spyOn((wired as any).logger, 'error').mockImplementation(() => undefined);
+            const warnSpy = jest
+                .spyOn((wired as any).logger, 'warn')
+                .mockImplementation(() => undefined);
+
+            await wired.execute(plugin, work, request, existing);
+
+            // resolveContext threw → bundle is undefined → plugin runs as if no KB.
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('KB context resolution failed'),
+            );
+            expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
+                work,
+                request.providers,
+                request.aiModel,
+                undefined,
+                undefined,
+            );
         });
     });
 

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type {
     WorkReference,
@@ -13,11 +13,13 @@ import type {
     PipelineFailedPayload,
 } from '@ever-works/plugin';
 import type { GenerationStepLog } from '@ever-works/contracts/api';
+import type { KbContextBundleData } from '@ever-works/contracts';
 import { buildErrorPipelineResult, createEmptyPipelineOutputs } from '@ever-works/plugin';
 import { PipelineEvents } from './step-pipeline-executor.service';
 import { PipelineFacadeService } from './pipeline-facade.service';
 import { validatePipelineResult } from './validators';
 import { PluginContextFactoryService } from '../plugins/services/plugin-context-factory.service';
+import { KnowledgeBaseService } from '../services/knowledge-base.service';
 
 /**
  * Executor for self-managed pipeline plugins.
@@ -34,7 +36,34 @@ export class FullPipelineExecutorService {
         private readonly eventEmitter: EventEmitter2,
         private readonly facadeService: PipelineFacadeService,
         private readonly contextFactory: PluginContextFactoryService,
+        // EW-641 Phase 2/b row 32c — same KB resolver as the step-orchestrated
+        // executor. Optional so OSS images / isolated unit tests without
+        // KB wiring still construct (and `execContext.kbContext` stays
+        // undefined for those callers).
+        @Optional() private readonly knowledgeBaseService?: KnowledgeBaseService,
     ) {}
+
+    /**
+     * EW-641 Phase 2/b row 32c — same try/catch resolver as the step
+     * executor uses. A KB hiccup must never break generation; on failure
+     * we log + return undefined so the step plugin sees no kbContext.
+     */
+    private async resolveKbContextSafe(
+        work: WorkReference,
+        request: GenerationRequest,
+    ): Promise<KbContextBundleData | undefined> {
+        if (!this.knowledgeBaseService || !work.id) return undefined;
+        try {
+            return await this.knowledgeBaseService.resolveContext(work.id, {
+                query: request.prompt,
+            });
+        } catch (err) {
+            this.logger.warn(
+                `KB context resolution failed for work=${work.id}: ${(err as Error).message}. Continuing without kbContext.`,
+            );
+            return undefined;
+        }
+    }
 
     /**
      * Execute using a pipeline plugin
@@ -77,6 +106,11 @@ export class FullPipelineExecutorService {
             );
         }
 
+        // EW-641 Phase 2/b row 32c — resolve KB bundle once before the
+        // plugin executes; the bundle rides on the same execContext that
+        // facades use.
+        const kbContext = await this.resolveKbContextSafe(work, request);
+
         try {
             // Create execContext for the plugin to use facades
             const execContext = this.facadeService.createStepExecutionContext(
@@ -84,6 +118,7 @@ export class FullPipelineExecutorService {
                 request.providers,
                 request.aiModel,
                 options?.signal,
+                kbContext,
             );
 
             // Delegate to the plugin's execute method with execContext

--- a/packages/agent/src/pipeline/step-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/step-pipeline-executor.service.ts
@@ -30,11 +30,13 @@ import {
     isPipelineModifierPlugin,
 } from '@ever-works/plugin';
 import type { GenerationStepLog } from '@ever-works/contracts/api';
+import type { KbContextBundleData } from '@ever-works/contracts';
 import { PipelineBuilderService } from './pipeline-builder.service';
 import { PipelineFacadeService } from './pipeline-facade.service';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { PluginContextFactoryService } from '../plugins/services/plugin-context-factory.service';
 import { ExecutablePipelineRunner } from './executable-pipeline.class';
+import { KnowledgeBaseService } from '../services/knowledge-base.service';
 
 export interface CheckpointData {
     stepIndex: number;
@@ -100,7 +102,42 @@ export class StepPipelineExecutorService {
         private readonly facadeService: PipelineFacadeService,
         private readonly contextFactory: PluginContextFactoryService,
         @Optional() @Inject(CACHE_MANAGER) private readonly cacheManager?: Cache,
+        // EW-641 Phase 2/b row 32c — resolve the KB context bundle once
+        // per pipeline run and thread it down to `createStepExecutionContext`.
+        // Optional so deployments without the KB module (OSS images,
+        // isolated unit tests, legacy bootstraps) keep constructing
+        // identically — `execContext.kbContext` stays `undefined` then.
+        @Optional() private readonly knowledgeBaseService?: KnowledgeBaseService,
     ) {}
+
+    /**
+     * EW-641 Phase 2/b row 32c — resolve the KB context bundle for a
+     * pipeline run, swallowing all errors so a KB hiccup never breaks
+     * generation. Returns `undefined` when the KB service isn't wired
+     * or `work.id` is empty (test fixtures), or when resolveContext
+     * throws.
+     *
+     * Called once at the entry point (`execute` / `executeWithContext`),
+     * then forwarded through `executePipeline` → `executeStep` →
+     * `createStepExecutionContext` so each step plugin reads the same
+     * bundle without re-querying.
+     */
+    private async resolveKbContextSafe(
+        work: WorkReference,
+        request: GenerationRequest,
+    ): Promise<KbContextBundleData | undefined> {
+        if (!this.knowledgeBaseService || !work.id) return undefined;
+        try {
+            return await this.knowledgeBaseService.resolveContext(work.id, {
+                query: request.prompt,
+            });
+        } catch (err) {
+            this.logger.warn(
+                `KB context resolution failed for work=${work.id}: ${(err as Error).message}. Continuing without kbContext.`,
+            );
+            return undefined;
+        }
+    }
 
     async execute(
         plugin: IPipelinePlugin,
@@ -135,8 +172,11 @@ export class StepPipelineExecutorService {
             );
         }
 
+        // EW-641 Phase 2/b row 32c — resolve KB bundle once per run.
+        const kbContext = await this.resolveKbContextSafe(work, request);
+
         try {
-            return await this.executePipeline(plugin, context, options, onProgress);
+            return await this.executePipeline(plugin, context, options, onProgress, kbContext);
         } finally {
             removeInterceptor?.();
         }
@@ -147,6 +187,7 @@ export class StepPipelineExecutorService {
         context: IPipelineContext,
         options?: PipelineExecutionOptions,
         onProgress?: PipelineProgressCallback,
+        kbContext?: KbContextBundleData,
     ): Promise<PipelineResult> {
         const startTime = Date.now();
         const work = context.work;
@@ -203,6 +244,7 @@ export class StepPipelineExecutorService {
                                 plugin.id,
                                 options,
                                 onProgress,
+                                kbContext,
                             ),
                         ),
                     );
@@ -220,6 +262,7 @@ export class StepPipelineExecutorService {
                                 plugin.id,
                                 options,
                                 onProgress,
+                                kbContext,
                             ),
                     );
                     await this.runWithConcurrencyLimit(stepThunks, concurrency);
@@ -284,6 +327,7 @@ export class StepPipelineExecutorService {
         pipelineId: string,
         options?: PipelineExecutionOptions,
         onProgress?: PipelineProgressCallback,
+        kbContext?: KbContextBundleData,
     ): Promise<void> {
         const onLogEntry = options?.onLogEntry;
 
@@ -355,7 +399,7 @@ export class StepPipelineExecutorService {
                 throw new Error(`No executor found for step "${step.id}"`);
             }
 
-            await this.executeStep(step, executor, plugin, context, options);
+            await this.executeStep(step, executor, plugin, context, options, kbContext);
 
             const durationMs = Date.now() - stepStartTime;
             const metrics = this.createStepMetrics(step, stepStartTime, true);
@@ -412,7 +456,11 @@ export class StepPipelineExecutorService {
         options?: PipelineExecutionOptions,
         onProgress?: PipelineProgressCallback,
     ): Promise<PipelineResult> {
-        return this.executePipeline(plugin, context, options, onProgress);
+        // EW-641 Phase 2/b row 32c — also resolve KB bundle on the
+        // resume-from-checkpoint path so a resumed pipeline gets the
+        // same KB grounding as a fresh run.
+        const kbContext = await this.resolveKbContextSafe(context.work, context.request);
+        return this.executePipeline(plugin, context, options, onProgress, kbContext);
     }
 
     async resumeFromCheckpoint(
@@ -467,12 +515,14 @@ export class StepPipelineExecutorService {
         plugin: IPipelinePlugin,
         context: IPipelineContext,
         options?: PipelineExecutionOptions,
+        kbContext?: KbContextBundleData,
     ): Promise<void> {
         const execContext = this.facadeService.createStepExecutionContext(
             context.work,
             context.request.providers,
             context.request.aiModel,
             options?.signal,
+            kbContext,
         );
 
         if (executor.type === 'builtin') {


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/b row 32c — both pipeline executors now call `KnowledgeBaseService.resolveContext` once per run and forward the bundle as the 5th positional arg of `createStepExecutionContext`, so every step plugin reads the same `execContext.kbContext` without re-querying.
- `StepPipelineExecutorService` and `FullPipelineExecutorService` each add a private `resolveKbContextSafe(work, request)` helper backed by `@Optional() KnowledgeBaseService`. SYSTEM op — no `ensureCanView` (executor is the trust boundary, same pattern as row 29b2b).
- Threading path in the step executor: `execute` / `executeWithContext` (entry points) → `executePipeline` → `processStep` → `executeStep` → `createStepExecutionContext`. Resume-from-checkpoint re-resolves too, so resumed runs get fresh KB grounding.
- Graceful degradation: KB service absent OR `work.id` empty OR `resolveContext` throws → bundle stays `undefined`, plugin runs as-if-no-KB. Generation never breaks on a KB hiccup; warnings are logged via `logger.warn`.
- `@Optional()` injection means OSS images / isolated unit tests construct identically. **Module-wiring** to actually populate the dep in production (so `PipelineModule` can resolve `KnowledgeBaseService`) is the next sub-chunk (row 32d).

## Test plan
- [x] `pnpm jest src/pipeline` — 399/399 green (5 existing 4-arg `createStepExecutionContext` assertions updated to expect the new 5th `kbContext` arg)
- [x] 5 new cases: 3 in full-executor spec (wired bundle forwarded, empty workId skips resolve, throws → graceful) + 2 in step-executor spec (wired bundle reaches facade, throws → graceful)
- [x] `pnpm test` (full agent suite) — 4847/4847 green
- [x] `pnpm build --filter @ever-works/agent` — clean, 0 TSC issues, DTS emit succeeds
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Integrated KnowledgeBase service into pipeline execution. KB context is now resolved once per pipeline run and passed to all step executors for enhanced grounding.
  * Implemented graceful error handling: pipelines continue operating normally if the KnowledgeBase service is unavailable or context resolution fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->