### PR TITLE
feat(agent): import KnowledgeBaseModule into PipelineModule

### DIFF
--- a/packages/agent/src/pipeline/pipeline.module.spec.ts
+++ b/packages/agent/src/pipeline/pipeline.module.spec.ts
@@ -1,6 +1,9 @@
 jest.mock('../facades/facades.module', () => ({
     FacadesModule: class FacadesModule {},
 }));
+jest.mock('../services/knowledge-base.module', () => ({
+    KnowledgeBaseModule: class KnowledgeBaseModule {},
+}));
 
 import { PipelineModule } from './pipeline.module';
 import { PipelineBuilderService } from './pipeline-builder.service';
@@ -44,16 +47,24 @@ describe('PipelineModule', () => {
         expect(exports).toHaveLength(5);
     });
 
-    it('imports FacadesModule ONLY (PluginsModule is registered globally via forRoot)', () => {
+    it('imports FacadesModule + KnowledgeBaseModule (PluginsModule stays globally-registered)', () => {
         const imports = meta('imports') as Array<{ name?: string }>;
         const names = imports.map((m) => m?.name);
-        // The pipeline module specifically does NOT import PluginsModule —
-        // the documentation comment in the source pins this contract.
+        // FacadesModule for AI/Search/Screenshot/etc. facades.
         expect(names).toContain('FacadesModule');
+        // EW-641 Phase 2/b row 32d — KnowledgeBaseModule must be in scope
+        // so the executors' @Optional() KnowledgeBaseService injection
+        // actually resolves at runtime (NestJS DI doesn't walk a
+        // consumer's imports — the receiving module needs the provider).
+        expect(names).toContain('KnowledgeBaseModule');
+        // PluginsModule stays globally-registered via forRoot() at the
+        // app root; the pipeline module specifically does NOT import
+        // it directly (documentation comment pins this contract).
         expect(names).not.toContain('PluginsModule');
     });
 
-    it('keeps the imports list at the documented 1-module shape', () => {
-        expect(meta('imports')).toHaveLength(1);
+    it('keeps the imports list at the documented 2-module shape', () => {
+        // Pin so a future silent extra-import is a deliberate change.
+        expect(meta('imports')).toHaveLength(2);
     });
 });

--- a/packages/agent/src/pipeline/pipeline.module.ts
+++ b/packages/agent/src/pipeline/pipeline.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { FacadesModule } from '../facades/facades.module';
+import { KnowledgeBaseModule } from '../services/knowledge-base.module';
 
 import { PipelineBuilderService } from './pipeline-builder.service';
 import { StepPipelineExecutorService } from './step-pipeline-executor.service';
@@ -32,9 +33,18 @@ const EXPORTS = [
  *
  * Pipeline plugins are loaded via the plugin system, not as NestJS providers.
  * Access them via PluginRegistryService.getByCapability('pipeline').
+ *
+ * EW-641 Phase 2/b row 32d — `KnowledgeBaseModule` is imported here so
+ * the row 32c `@Optional() KnowledgeBaseService` injection on
+ * `StepPipelineExecutorService` / `FullPipelineExecutorService` actually
+ * resolves at runtime. NestJS DI does not walk a consumer's imports —
+ * the provider has to be in scope of the module that declares the
+ * receiving class, even when the dep is optional. `KnowledgeBaseModule`
+ * is self-sufficient (it imports `DatabaseModule` + `FacadesModule` and
+ * locally provides `WorkOwnershipService`), so no cascade is needed.
  */
 @Module({
-    imports: [FacadesModule],
+    imports: [FacadesModule, KnowledgeBaseModule],
     providers: PROVIDERS,
     exports: EXPORTS,
 })


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/b row 32d — finishes the row 32c wiring.
- Row 32c added the `@Optional() KnowledgeBaseService` injection on `StepPipelineExecutorService` / `FullPipelineExecutorService`, but `PipelineModule.imports` only had `FacadesModule` — so in the live API graph the dep resolved to `undefined` and `execContext.kbContext` stayed empty.
- NestJS DI doesn't walk a consumer's imports — the provider has to be in scope of the module that declares the receiving class, even when the dep is optional. Importing `KnowledgeBaseModule` here closes the gap.
- `KnowledgeBaseModule` is self-sufficient (imports `DatabaseModule` + `FacadesModule` + TypeORM features and locally provides `WorkOwnershipService`), so no cascade or @Global trick is needed.
- Spec updated: import list now expected at 2 (`FacadesModule` + `KnowledgeBaseModule`); new assertion pins that `KnowledgeBaseModule` is in the list with the WHY documented inline.

## Test plan
- [x] `pnpm jest src/pipeline` — 399/399 green (including the updated `pipeline.module.spec.ts` length + name assertions)
- [x] `pnpm test` (full agent suite) — 4847/4847 green
- [x] `pnpm build --filter @ever-works/agent` — clean, 0 TSC issues, DTS emit succeeds
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

> Note: `apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts` fails to load (`Cannot find module '@ever-works/k8s-plugin'`) — pre-existing on develop, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module dependencies to ensure proper service resolution at runtime.
  * Updated test assertions to reflect module configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->