### PR TITLE
feat(agent): parseKbMentions — pure @kb: mention parser (row 34a)

### DIFF
--- a/packages/agent/src/services/__tests__/kb-mention-parser.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-mention-parser.spec.ts
@@ -1,0 +1,198 @@
+import { parseKbMentions, type KbMention } from '../kb-mention-parser';
+
+describe('parseKbMentions', () => {
+    describe('boundary cases', () => {
+        it('returns [] for empty string', () => {
+            expect(parseKbMentions('')).toEqual([]);
+        });
+
+        it('returns [] for whitespace-only input', () => {
+            expect(parseKbMentions('   \n\t  ')).toEqual([]);
+        });
+
+        it('returns [] when there are no mentions', () => {
+            expect(parseKbMentions('just a normal message without mentions')).toEqual([]);
+        });
+
+        it('returns [] for non-string input (defensive)', () => {
+            // The signature is `string`, but JS callers might pass null/undefined.
+            // The function should defensively return [] rather than throw.
+            expect(parseKbMentions(null as unknown as string)).toEqual([]);
+            expect(parseKbMentions(undefined as unknown as string)).toEqual([]);
+        });
+    });
+
+    describe('single mention', () => {
+        it('extracts a bare slug reference at start of message', () => {
+            const out = parseKbMentions('@kb:voice please summarise');
+            expect(out).toHaveLength(1);
+            expect(out[0]).toMatchObject({
+                raw: '@kb:voice',
+                reference: 'voice',
+                startOffset: 0,
+                endOffset: 9,
+            });
+        });
+
+        it('extracts a class/slug path reference (row 31 citation format)', () => {
+            const out = parseKbMentions('check @kb:brand/voice for tone');
+            expect(out).toHaveLength(1);
+            expect(out[0]).toMatchObject({
+                raw: '@kb:brand/voice',
+                reference: 'brand/voice',
+            });
+            const { startOffset, endOffset, raw } = out[0];
+            expect('check @kb:brand/voice for tone'.slice(startOffset, endOffset)).toBe(raw);
+        });
+
+        it('accepts kebab-case + dots + underscores in references', () => {
+            const out = parseKbMentions('@kb:research/v2.1_final-draft');
+            expect(out).toHaveLength(1);
+            expect(out[0].reference).toBe('research/v2.1_final-draft');
+        });
+
+        it('extracts a UUID-style id reference', () => {
+            const id = '00000000-0000-0000-0000-000000000001';
+            const out = parseKbMentions(`see @kb:${id}`);
+            expect(out).toHaveLength(1);
+            expect(out[0].reference).toBe(id);
+        });
+    });
+
+    describe('multiple mentions', () => {
+        it('extracts every mention in textual order with correct offsets', () => {
+            const text = 'compare @kb:brand/voice and @kb:legal/terms please';
+            const out = parseKbMentions(text);
+            expect(out).toHaveLength(2);
+            expect(out[0].reference).toBe('brand/voice');
+            expect(out[1].reference).toBe('legal/terms');
+            // Offsets are in left-to-right order and slice back to raw.
+            expect(out[0].endOffset).toBeLessThan(out[1].startOffset);
+            expect(text.slice(out[0].startOffset, out[0].endOffset)).toBe(out[0].raw);
+            expect(text.slice(out[1].startOffset, out[1].endOffset)).toBe(out[1].raw);
+        });
+
+        it('reports adjacent (whitespace-separated) mentions independently', () => {
+            const out = parseKbMentions('@kb:a @kb:b @kb:c');
+            expect(out.map((m) => m.reference)).toEqual(['a', 'b', 'c']);
+        });
+
+        it("reports repeated references separately (dedup is row 34b's job)", () => {
+            const out = parseKbMentions('@kb:voice ... @kb:voice');
+            expect(out).toHaveLength(2);
+            expect(out[0].reference).toBe('voice');
+            expect(out[1].reference).toBe('voice');
+            expect(out[0].startOffset).not.toBe(out[1].startOffset);
+        });
+    });
+
+    describe('punctuation + boundary handling', () => {
+        it('does NOT include trailing comma/period in the reference', () => {
+            const out = parseKbMentions('see @kb:voice, then @kb:legal.');
+            expect(out).toHaveLength(2);
+            expect(out[0].reference).toBe('voice');
+            expect(out[1].reference).toBe('legal');
+        });
+
+        it('does NOT include trailing closing paren / bracket / brace', () => {
+            const cases: Array<[string, string]> = [
+                ['(@kb:voice)', 'voice'],
+                ['[@kb:voice]', 'voice'],
+                ['{@kb:voice}', 'voice'],
+            ];
+            for (const [text, expectedRef] of cases) {
+                const out = parseKbMentions(text);
+                expect(out).toHaveLength(1);
+                expect(out[0].reference).toBe(expectedRef);
+            }
+        });
+
+        it('does NOT include trailing quote / colon / semicolon / exclaim / question', () => {
+            const cases: Array<[string, string]> = [
+                ['@kb:voice"', 'voice'],
+                ["@kb:voice'", 'voice'],
+                ['@kb:voice:', 'voice'],
+                ['@kb:voice;', 'voice'],
+                ['@kb:voice!', 'voice'],
+                ['@kb:voice?', 'voice'],
+            ];
+            for (const [text, expectedRef] of cases) {
+                const out = parseKbMentions(text);
+                expect(out).toHaveLength(1);
+                expect(out[0].reference).toBe(expectedRef);
+            }
+        });
+
+        it('does NOT match `@kb:` when preceded by a word character (whole-word boundary)', () => {
+            // The lookbehind prevents matches inside the middle of words
+            // like email-fragments or URL-paths.
+            expect(parseKbMentions('foo@kb:bar')).toEqual([]);
+            expect(parseKbMentions('user1@kb:something')).toEqual([]);
+            expect(parseKbMentions('A@kb:bar')).toEqual([]);
+        });
+
+        it('matches `@kb:` when preceded by punctuation or whitespace or start-of-string', () => {
+            expect(parseKbMentions('@kb:bar')).toHaveLength(1);
+            expect(parseKbMentions(' @kb:bar')).toHaveLength(1);
+            expect(parseKbMentions('(@kb:bar')).toHaveLength(1);
+            expect(parseKbMentions('.@kb:bar')).toHaveLength(1);
+        });
+
+        it('requires the reference to immediately follow `@kb:` (no space)', () => {
+            expect(parseKbMentions('@kb: voice')).toEqual([]);
+            expect(parseKbMentions('@kb:  brand/voice')).toEqual([]);
+        });
+
+        it('does NOT match `@kb` without the trailing colon', () => {
+            expect(parseKbMentions('@kb voice')).toEqual([]);
+            expect(parseKbMentions('@kb-voice')).toEqual([]);
+        });
+    });
+
+    describe('determinism + immutability', () => {
+        it('returns a fresh array on each call (no shared mutable state)', () => {
+            const a = parseKbMentions('@kb:voice');
+            const b = parseKbMentions('@kb:voice');
+            expect(a).not.toBe(b);
+            expect(a).toEqual(b);
+        });
+
+        it('multiple calls on the same text yield identical results (no regex.lastIndex leak)', () => {
+            const text = '@kb:a @kb:b @kb:c';
+            const first = parseKbMentions(text);
+            const second = parseKbMentions(text);
+            const third = parseKbMentions(text);
+            expect(first).toEqual(second);
+            expect(second).toEqual(third);
+            expect(first.map((m: KbMention) => m.reference)).toEqual(['a', 'b', 'c']);
+        });
+    });
+
+    describe('multiline + larger inputs', () => {
+        it('extracts mentions across multiple lines', () => {
+            const text =
+                'first line mentions @kb:brand/voice\n' +
+                'second line skips it\n' +
+                'third has @kb:legal/terms';
+            const out = parseKbMentions(text);
+            expect(out.map((m) => m.reference)).toEqual(['brand/voice', 'legal/terms']);
+        });
+
+        it('handles a realistic conversation message with mixed content', () => {
+            const msg =
+                'Hey — when you write the headline, please use @kb:brand/voice ' +
+                'for tone and double-check the disclaimer wording against @kb:legal/disclaimer. ' +
+                'Also see @kb:style/headlines for the title-case rule.';
+            const out = parseKbMentions(msg);
+            expect(out.map((m) => m.reference)).toEqual([
+                'brand/voice',
+                'legal/disclaimer',
+                'style/headlines',
+            ]);
+            // Every offset slices back to its `raw`.
+            for (const m of out) {
+                expect(msg.slice(m.startOffset, m.endOffset)).toBe(m.raw);
+            }
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -34,6 +34,7 @@ export * from './kb-chunker';
 export * from './kb-rrf';
 export * from './kb-prompt-formatter';
 export * from './kb-context-bundle';
+export * from './kb-mention-parser';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-mention-parser.ts
+++ b/packages/agent/src/services/kb-mention-parser.ts
@@ -1,0 +1,134 @@
+/**
+ * EW-641 Phase 2/c row 34a — pure `@kb:` mention parser.
+ *
+ * The AI conversation surface (spec §15.5, rows 34/35) lets users
+ * point the model at specific KB documents inline by typing
+ * `@kb:<reference>` in their message. This module extracts those
+ * mentions from plain text so:
+ *  - row 34b can resolve each reference to a `KbDocumentBodyDto`
+ *    via `KnowledgeBaseService.findByWorkOrPath`,
+ *  - row 34c can inject the resolved docs as a `<kb>...</kb>`
+ *    context block (via row 31 `formatKbContext`) in the system
+ *    message before the LLM call,
+ *  - the row 35 hover-card UI can underline the same offsets in
+ *    the rendered message.
+ *
+ * Pure function — no I/O, no module state, no DOM. Safe to call
+ * from any context (API service, Trigger.dev task, eval harness,
+ * test). The format mirrors the row 31 citation `kb:{class}/{slug}`
+ * so a user can paste a citation back at the model and it round-
+ * trips cleanly.
+ *
+ * Reference grammar (`[A-Za-z0-9/_.\-]+`):
+ *  - alnum + `/` (path separator) + `_` + `.` + `-` — covers slugs,
+ *    nested paths (`brand/voice`), kebab-case slugs, and IDs.
+ *  - must follow `@kb:` immediately (no whitespace between `:` and
+ *    the first reference char).
+ *  - terminates at the first character outside the class — i.e.
+ *    whitespace, punctuation `,;:!?'"`, parens / brackets / braces,
+ *    or end-of-string.
+ *
+ * **Whole-word boundary at start.** `@kb:` only counts when not
+ * preceded by a "word" character (`[A-Za-z0-9_]`) — keeps us from
+ * matching inside words like `foo@kb:bar` (we want just the bare
+ * mention). Markdown-link awareness (`[@kb:x](url)`) is deferred
+ * to row 34c if anchor confusion shows up in practice; for now we
+ * extract every textual `@kb:` and let the resolver swallow misses
+ * gracefully.
+ */
+
+/**
+ * A single `@kb:` mention extracted from a piece of text.
+ *
+ * - `raw` — the full match including the `@kb:` prefix (so callers
+ *   can substitute it for a UI marker without re-deriving from
+ *   offsets).
+ * - `reference` — the bare reference (what was after `@kb:`).
+ * - `startOffset` — 0-based UTF-16 index of the leading `@`.
+ * - `endOffset` — 0-based UTF-16 index one past the last reference
+ *   char (so `text.slice(startOffset, endOffset) === raw`).
+ */
+export interface KbMention {
+    readonly raw: string;
+    readonly reference: string;
+    readonly startOffset: number;
+    readonly endOffset: number;
+}
+
+/**
+ * Regex notes:
+ *  - `(?<![A-Za-z0-9_])` — lookbehind: NOT preceded by a word char
+ *    (so `foo@kb:bar` doesn't match, but `(@kb:bar` and ` @kb:bar`
+ *    and start-of-string do).
+ *  - `@kb:` — literal prefix.
+ *  - `([A-Za-z0-9/_.\-]+)` — reference, captured. `.` is allowed
+ *    inside the reference (for version-style slugs like `v2.1`),
+ *    then post-match we strip trailing `.` so a sentence-final
+ *    period doesn't get absorbed.
+ *  - global + non-sticky so `matchAll` walks the whole string.
+ *
+ * Node 22 + modern V8 support lookbehinds and `String.prototype.matchAll`.
+ */
+const KB_MENTION_RE = /(?<![A-Za-z0-9_])@kb:([A-Za-z0-9/_.\-]+)/g;
+
+/**
+ * Strip trailing punctuation-ish characters from the captured
+ * reference. `.` is most common (sentence-final period) but `-`,
+ * `_`, and `/` can also dangle if the user trails into a thought
+ * — none of those are meaningful at the end of a real KB slug or
+ * path. We trim them in a loop so e.g. `@kb:legal...` collapses
+ * cleanly back to `legal`.
+ */
+function trimTrailingPunctuation(ref: string): string {
+    let end = ref.length;
+    while (end > 0) {
+        const ch = ref[end - 1];
+        if (ch === '.' || ch === '-' || ch === '_' || ch === '/') {
+            end--;
+        } else {
+            break;
+        }
+    }
+    return ref.slice(0, end);
+}
+
+/**
+ * Extract every `@kb:<reference>` mention from a message.
+ *
+ * - Returns `[]` for empty/whitespace input.
+ * - Mentions are returned in textual order (left-to-right).
+ * - Adjacent or repeated references are each reported separately;
+ *   row 34b is responsible for deduplication before resolution.
+ * - Offsets are UTF-16-unit based (matches `String.prototype.slice`
+ *   and `String.prototype.length`); the parser is byte-/codepoint-
+ *   agnostic since the reference grammar is ASCII-only.
+ */
+export function parseKbMentions(text: string): KbMention[] {
+    if (typeof text !== 'string' || text.length === 0) return [];
+
+    const out: KbMention[] = [];
+    for (const m of text.matchAll(KB_MENTION_RE)) {
+        // `matchAll` with a global regex always yields `m.index`
+        // (number) — but the type sig says `number | undefined`, so
+        // defensively skip if missing.
+        if (m.index === undefined) continue;
+        const fullMatch = m[0];
+        const rawReference = m[1];
+        const trimmedReference = trimTrailingPunctuation(rawReference);
+        // If everything got stripped (e.g. `@kb:....`), drop the
+        // mention entirely — no useful reference.
+        if (trimmedReference.length === 0) continue;
+
+        // Adjust offsets so the trimmed reference is what we report.
+        // `raw` includes the `@kb:` prefix (4 chars) + trimmedReference.
+        const droppedChars = rawReference.length - trimmedReference.length;
+        const raw = fullMatch.slice(0, fullMatch.length - droppedChars);
+        out.push({
+            raw,
+            reference: trimmedReference,
+            startOffset: m.index,
+            endOffset: m.index + raw.length,
+        });
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/c row 34a — new `packages/agent/src/services/kb-mention-parser.ts` exports a pure `parseKbMentions(text: string): KbMention[]` function that extracts every `@kb:<reference>` mention from a conversation message.
- Foundation for row 34: 34b resolves each reference via `KnowledgeBaseService`, 34c injects resolved docs as a `<kb>...</kb>` block (via row 31 `formatKbContext`) into the conversation system message, 34d renders the citation back on the assistant response.
- Reference grammar: `[A-Za-z0-9/_.\-]+`. Whole-word boundary at start (lookbehind blocks matches inside words like `foo@kb:bar`). Reference must follow `@kb:` immediately (no whitespace).
- Trailing-punctuation trim: `.`, `-`, `_`, `/` stripped from the END of a captured reference. Mid-reference dots survive so `research/v2.1_final-draft` parses cleanly.
- Returns `{raw, reference, startOffset, endOffset}` per mention so row 35's hover-card UI can underline the same offsets. `text.slice(startOffset, endOffset) === raw` always holds.

## Test plan
- [x] `pnpm jest kb-mention-parser.spec.ts` — 22/22 green (boundary 4, single 4, multi 3, punctuation 7, determinism 2, multiline 2)
- [x] `pnpm build --filter @ever-works/agent` — clean, 0 TSC issues
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a Knowledge Base mention parser that extracts and validates `@kb:` references from user input text, providing accurate position information for each mention to support downstream processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->