### PR TITLE
feat(agent): KbMentionResolverService — @kb: → KbDocumentBodyDto (row 34b)

### DIFF
--- a/packages/agent/src/services/__tests__/kb-mention-resolver.service.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-mention-resolver.service.spec.ts
@@ -1,0 +1,208 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { KbMentionResolverService } from '../kb-mention-resolver.service';
+import { KnowledgeBaseService } from '../knowledge-base.service';
+import type { KbMention } from '../kb-mention-parser';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+
+const WORK_ID = 'work-1';
+const USER_ID = 'user-1';
+
+function mention(reference: string, startOffset = 0): KbMention {
+    const raw = `@kb:${reference}`;
+    return { raw, reference, startOffset, endOffset: startOffset + raw.length };
+}
+
+function buildDoc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: overrides.id ?? 'doc-1',
+        workId: overrides.workId ?? WORK_ID,
+        organizationId: overrides.organizationId ?? null,
+        path: overrides.path ?? 'brand/voice.md',
+        slug: overrides.slug ?? 'voice',
+        title: overrides.title ?? 'Brand voice',
+        description: overrides.description ?? null,
+        class: overrides.class ?? 'brand',
+        tags: overrides.tags ?? [],
+        categories: overrides.categories ?? [],
+        status: overrides.status ?? 'active',
+        locked: overrides.locked ?? false,
+        lockMode: overrides.lockMode ?? null,
+        language: overrides.language ?? 'en',
+        wordCount: overrides.wordCount ?? null,
+        tokenCount: overrides.tokenCount ?? null,
+        source: overrides.source ?? 'user',
+        sourceUploadId: overrides.sourceUploadId ?? null,
+        sourceUrl: overrides.sourceUrl ?? null,
+        generatedByAgentRunId: overrides.generatedByAgentRunId ?? null,
+        createdById: overrides.createdById ?? null,
+        updatedById: overrides.updatedById ?? null,
+        createdAt: overrides.createdAt ?? '2026-05-23T00:00:00.000Z',
+        updatedAt: overrides.updatedAt ?? '2026-05-23T00:00:00.000Z',
+        lastCommitSha: overrides.lastCommitSha ?? null,
+        body: overrides.body ?? 'body',
+        assets: overrides.assets ?? [],
+    } as KbDocumentBodyDto;
+}
+
+describe('KbMentionResolverService', () => {
+    let service: KbMentionResolverService;
+    let kbService: { getDocument: jest.Mock };
+
+    beforeEach(async () => {
+        kbService = { getDocument: jest.fn() };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                KbMentionResolverService,
+                { provide: KnowledgeBaseService, useValue: kbService },
+            ],
+        }).compile();
+        service = module.get(KbMentionResolverService);
+    });
+
+    describe('boundary cases', () => {
+        it('returns [] for empty mentions list (skips KB calls)', async () => {
+            const out = await service.resolveMentions(WORK_ID, USER_ID, []);
+            expect(out).toEqual([]);
+            expect(kbService.getDocument).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('happy path resolution', () => {
+        it('resolves a single class/slug reference to a document', async () => {
+            const doc = buildDoc({ id: 'd1', path: 'brand/voice.md', slug: 'voice' });
+            kbService.getDocument.mockResolvedValueOnce(doc);
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [mention('brand/voice')]);
+            expect(out).toHaveLength(1);
+            expect(out[0].document).toBe(doc);
+            expect(out[0].mention.reference).toBe('brand/voice');
+            // SYSTEM-userId boundary: the gate uses the *user* — we pass it through.
+            expect(kbService.getDocument).toHaveBeenCalledWith(WORK_ID, 'brand/voice', USER_ID);
+        });
+
+        it('retries with `.md` suffix when the direct lookup misses', async () => {
+            const doc = buildDoc({ id: 'd1', path: 'brand/voice.md' });
+            kbService.getDocument
+                .mockRejectedValueOnce(new NotFoundException('not found'))
+                .mockResolvedValueOnce(doc);
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [mention('brand/voice')]);
+            expect(out[0].document).toBe(doc);
+            expect(kbService.getDocument).toHaveBeenNthCalledWith(
+                1,
+                WORK_ID,
+                'brand/voice',
+                USER_ID,
+            );
+            expect(kbService.getDocument).toHaveBeenNthCalledWith(
+                2,
+                WORK_ID,
+                'brand/voice.md',
+                USER_ID,
+            );
+        });
+
+        it('does NOT retry with `.md` when the reference already has an extension', async () => {
+            kbService.getDocument.mockRejectedValueOnce(new NotFoundException('not found'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [
+                mention('brand/voice.md'),
+            ]);
+            expect(out[0].document).toBeNull();
+            // Only the direct call — no retry.
+            expect(kbService.getDocument).toHaveBeenCalledTimes(1);
+        });
+
+        it('does NOT retry with `.md` when the reference contains a dot (likely versioned slug)', async () => {
+            kbService.getDocument.mockRejectedValueOnce(new NotFoundException('not found'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [mention('research/v2.1')]);
+            expect(out[0].document).toBeNull();
+            expect(kbService.getDocument).toHaveBeenCalledTimes(1);
+        });
+
+        it('preserves mention order across multiple resolutions', async () => {
+            const d1 = buildDoc({ id: 'd1', path: 'brand/voice.md' });
+            const d2 = buildDoc({ id: 'd2', path: 'legal/terms.md' });
+            kbService.getDocument.mockResolvedValueOnce(d1).mockResolvedValueOnce(d2);
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [
+                mention('brand/voice', 0),
+                mention('legal/terms', 20),
+            ]);
+            expect(out.map((r) => r.document?.id)).toEqual(['d1', 'd2']);
+        });
+    });
+
+    describe('graceful misses', () => {
+        it('returns null doc for unresolved references (NotFoundException after .md retry)', async () => {
+            kbService.getDocument
+                .mockRejectedValueOnce(new NotFoundException('not found'))
+                .mockRejectedValueOnce(new NotFoundException('not found'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [mention('ghost')]);
+            expect(out).toHaveLength(1);
+            expect(out[0].document).toBeNull();
+        });
+
+        it('returns null doc on ForbiddenException (access denied — no leak)', async () => {
+            kbService.getDocument.mockRejectedValueOnce(new ForbiddenException('nope'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [mention('brand/voice')]);
+            expect(out[0].document).toBeNull();
+        });
+
+        it('returns null doc on unexpected errors (DB outage etc. — no throw bubbles up)', async () => {
+            kbService.getDocument.mockRejectedValueOnce(new Error('connection refused'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [mention('brand/voice')]);
+            expect(out[0].document).toBeNull();
+        });
+
+        it('mixes resolvable + missing in a single batch', async () => {
+            const d1 = buildDoc({ id: 'd1' });
+            kbService.getDocument
+                .mockResolvedValueOnce(d1)
+                // ghost — both attempts miss
+                .mockRejectedValueOnce(new NotFoundException('miss'))
+                .mockRejectedValueOnce(new NotFoundException('miss'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [
+                mention('brand/voice', 0),
+                mention('ghost', 20),
+            ]);
+            expect(out.map((r) => r.document?.id ?? null)).toEqual(['d1', null]);
+        });
+    });
+
+    describe('dedup by document.id', () => {
+        it('collapses two mentions of the same doc to one resolved entry (first occurrence wins)', async () => {
+            const doc = buildDoc({ id: 'd1' });
+            kbService.getDocument.mockResolvedValueOnce(doc).mockResolvedValueOnce(doc);
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [
+                mention('brand/voice', 0),
+                mention('brand/voice', 50),
+            ]);
+            expect(out).toHaveLength(1);
+            expect(out[0].mention.startOffset).toBe(0);
+        });
+
+        it('does NOT dedup null misses (each unresolved mention stays in the result)', async () => {
+            // Two distinct ghosts — each gets a not-found pair (direct + retry).
+            kbService.getDocument
+                .mockRejectedValueOnce(new NotFoundException('miss'))
+                .mockRejectedValueOnce(new NotFoundException('miss'))
+                .mockRejectedValueOnce(new NotFoundException('miss'))
+                .mockRejectedValueOnce(new NotFoundException('miss'));
+
+            const out = await service.resolveMentions(WORK_ID, USER_ID, [
+                mention('ghost-a', 0),
+                mention('ghost-b', 20),
+            ]);
+            expect(out).toHaveLength(2);
+            expect(out.every((r) => r.document === null)).toBe(true);
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -35,6 +35,7 @@ export * from './kb-rrf';
 export * from './kb-prompt-formatter';
 export * from './kb-context-bundle';
 export * from './kb-mention-parser';
+export * from './kb-mention-resolver.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-mention-resolver.service.ts
+++ b/packages/agent/src/services/kb-mention-resolver.service.ts
@@ -1,0 +1,152 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+import { KnowledgeBaseService } from './knowledge-base.service';
+import type { KbMention } from './kb-mention-parser';
+
+/**
+ * EW-641 Phase 2/c row 34b — resolves parsed `@kb:` mentions
+ * (from row 34a `parseKbMentions`) to concrete KB documents via
+ * `KnowledgeBaseService.getDocument`.
+ *
+ * Surfaces:
+ *  - row 34c (`OpenaiCompatService` injection) calls this once per
+ *    user message to materialize the docs that need to land in the
+ *    `<kb>...</kb>` system-prompt block (row 31 `formatKbContext`),
+ *  - row 35 hover-card UI calls this against the assistant's
+ *    response to confirm citation targets,
+ *  - eval/test harnesses can drive it directly.
+ *
+ * Each `mention.reference` is interpreted by `KnowledgeBaseService.
+ * getDocument` (which delegates to `documentRepository.findByWorkOrPath`)
+ * — its existing heuristic already covers UUID ids and `class/slug`
+ * paths. We additionally retry with a `.md` suffix when the first
+ * lookup misses, because the wire format `@kb:brand/voice` typically
+ * maps to the stored path `brand/voice.md` (row 17's mention picker
+ * elides the extension for readability).
+ *
+ * Access gate. `getDocument` runs `ensureCanView` for `userId`, so a
+ * user who can't see a doc gets a graceful `null` here rather than
+ * a leak. That keeps the AI-conversation surface from exposing docs
+ * the user isn't supposed to know exist.
+ *
+ * Dedup. Two mentions of the same document collapse to one resolved
+ * entry — first textual occurrence wins (preserves the order row 34c
+ * uses to render the `<kb>` block, and matches the conversational
+ * intuition that the first reference is the most relevant).
+ */
+
+/**
+ * Result row from `KbMentionResolverService.resolveMentions`.
+ *
+ * - `mention` is the originating parsed mention from row 34a.
+ * - `document` is the resolved doc body DTO, or `null` if the
+ *   reference didn't match any visible doc (404 / access denied /
+ *   `.md`-suffix-retry-still-missed). Row 34c skips `null` entries
+ *   when building the `<kb>` block; row 35 hover-card can show a
+ *   "not found" affordance.
+ */
+export interface ResolvedKbMention {
+    readonly mention: KbMention;
+    readonly document: KbDocumentBodyDto | null;
+}
+
+@Injectable()
+export class KbMentionResolverService {
+    private readonly logger = new Logger(KbMentionResolverService.name);
+
+    constructor(private readonly knowledgeBaseService: KnowledgeBaseService) {}
+
+    /**
+     * Resolve every parsed mention to its KB document (or `null`
+     * if the reference doesn't match any visible doc).
+     *
+     * @param workId - Work scope for the lookup.
+     * @param userId - User performing the lookup; `getDocument`
+     *   gates on `ensureCanView` for this user, so an unauthorized
+     *   reference yields `null` instead of a leak.
+     * @param mentions - Parsed mentions from row 34a's `parseKbMentions`.
+     * @returns Resolved entries in mention order, deduplicated by
+     *   `document.id` (first occurrence wins).
+     */
+    async resolveMentions(
+        workId: string,
+        userId: string,
+        mentions: ReadonlyArray<KbMention>,
+    ): Promise<ResolvedKbMention[]> {
+        if (mentions.length === 0) return [];
+
+        const out: ResolvedKbMention[] = [];
+        const seenDocIds = new Set<string>();
+
+        for (const mention of mentions) {
+            const doc = await this.resolveOne(workId, userId, mention.reference);
+            if (doc && seenDocIds.has(doc.id)) {
+                // Same doc cited multiple times → collapse to the
+                // first occurrence (preserves order + avoids duplicate
+                // sections in the row 34c `<kb>` block).
+                continue;
+            }
+            if (doc) seenDocIds.add(doc.id);
+            out.push({ mention, document: doc });
+        }
+        return out;
+    }
+
+    /**
+     * Resolve a single reference. Tries the reference as-is first,
+     * then retries with `.md` appended when the first attempt is a
+     * miss and the reference doesn't already carry an extension.
+     */
+    private async resolveOne(
+        workId: string,
+        userId: string,
+        reference: string,
+    ): Promise<KbDocumentBodyDto | null> {
+        const direct = await this.tryGetDocument(workId, userId, reference);
+        if (direct) return direct;
+
+        // `getDocument` already handles UUIDs + path-with-slash via
+        // `findByWorkOrPath`. The common miss is `@kb:brand/voice`
+        // when the stored path is `brand/voice.md`. Retry once with
+        // the suffix appended; skip the retry if the reference already
+        // looks file-extensioned to avoid double-suffixing.
+        if (reference.endsWith('.md') || reference.includes('.')) {
+            return null;
+        }
+        return this.tryGetDocument(workId, userId, `${reference}.md`);
+    }
+
+    /**
+     * Wrap `KnowledgeBaseService.getDocument` so a miss / forbidden
+     * read becomes a graceful `null` (instead of bubbling
+     * `NotFoundException` / `ForbiddenException`). Any other error
+     * (e.g. DB outage) is logged + returns `null` so a flaky resolve
+     * doesn't poison the entire conversation message.
+     */
+    private async tryGetDocument(
+        workId: string,
+        userId: string,
+        reference: string,
+    ): Promise<KbDocumentBodyDto | null> {
+        try {
+            const result = await this.knowledgeBaseService.getDocument(workId, reference, userId);
+            // Defensively normalize undefined → null so callers can
+            // distinguish "resolved nothing" from "service contract
+            // returned a real doc". `getDocument` is documented to
+            // throw on miss, but if a stub or future variant returns
+            // undefined we still want a sane sentinel.
+            return result ?? null;
+        } catch (err) {
+            if (err instanceof NotFoundException) return null;
+            // Forbidden / unexpected error — treat as not-resolved.
+            // The user sees their message go through; the LLM just
+            // doesn't get that specific KB doc as context.
+            this.logger.debug(
+                `KB mention resolution skipped for "${reference}" (work=${workId}, user=${userId}): ${
+                    (err as Error).message
+                }`,
+            );
+            return null;
+        }
+    }
+}

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -17,6 +17,7 @@ import { WorkKnowledgeChunkRepository } from '../database/repositories/work-know
 import { KnowledgeBaseService } from './knowledge-base.service';
 import { KnowledgeBaseGitMirrorService } from './knowledge-base-git-mirror.service';
 import { KnowledgeBaseBufferExtractorService } from './knowledge-base-buffer-extractor.service';
+import { KbMentionResolverService } from './kb-mention-resolver.service';
 import { WorkOwnershipService } from './work-ownership.service';
 
 /**
@@ -69,6 +70,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseService,
         KnowledgeBaseGitMirrorService,
         KnowledgeBaseBufferExtractorService,
+        KbMentionResolverService,
     ],
     exports: [
         WorkKnowledgeDocumentRepository,
@@ -79,6 +81,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseService,
         KnowledgeBaseGitMirrorService,
         KnowledgeBaseBufferExtractorService,
+        KbMentionResolverService,
     ],
 })
 export class KnowledgeBaseModule {}


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/c row 34b — new `KbMentionResolverService` resolves parsed `@kb:` mentions (from row 34a `parseKbMentions`) to concrete KB documents via `KnowledgeBaseService.getDocument`.
- Resolution strategy: direct call first (handles UUIDs + class/slug paths via `findByWorkOrPath`); if miss AND reference has no extension AND no dot, retry once with `.md` suffix appended. Skip retry when reference already has `.md` or a dot to avoid double-suffixing version-style slugs like `research/v2.1`.
- Access gate: user's `userId` threaded through so `ensureCanView` runs — unauthorized access yields graceful `null` (no leak).
- Graceful misses: NotFoundException, ForbiddenException, AND unexpected errors (DB outage etc.) all yield `null` doc. Conversation message still goes through; LLM just doesn't get that specific KB doc as context.
- Dedup: two mentions of the same `document.id` collapse to one result row (first occurrence wins).
- Wired into `KnowledgeBaseModule` providers + exports.

## Test plan
- [x] `pnpm jest kb-mention-resolver.service.spec.ts` — 12/12 green (boundary 1, happy path 5, graceful misses 4, dedup 2)
- [x] `pnpm test` (full agent suite) — 4891/4891 green
- [x] `pnpm build --filter @ever-works/agent` — clean, 0 TSC issues
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge base mention resolution that intelligently resolves document references and handles file extension variations automatically.
  * Enhanced error handling for document lookup failures, preventing interruptions in conversation flow.
  * Implemented deduplication to avoid redundant document processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->