### PR TITLE
feat(api): inject KB <kb> block on @kb: mentions in conversations (row 34c)

### DIFF
--- a/apps/api/src/ai-conversation/ai-conversation.module.ts
+++ b/apps/api/src/ai-conversation/ai-conversation.module.ts
@@ -1,13 +1,18 @@
 import { Module } from '@nestjs/common';
 import { FacadesModule } from '@ever-works/agent/facades';
 import { DatabaseModule } from '@ever-works/agent/database';
+import { KnowledgeBaseModule } from '@ever-works/agent/services';
 import { OpenAiCompatController } from './openai-compat.controller';
 import { OpenAiCompatService } from './openai-compat.service';
 import { ConversationController } from './conversation.controller';
 import { ConversationTitleService } from './conversation-title.service';
 
 @Module({
-    imports: [FacadesModule, DatabaseModule],
+    // EW-641 Phase 2/c row 34c — KnowledgeBaseModule brings
+    // `KbMentionResolverService` into scope so `OpenAiCompatService`
+    // can resolve `@kb:` mentions in user messages and inject a
+    // `<kb>...</kb>` system message before the LLM call.
+    imports: [FacadesModule, DatabaseModule, KnowledgeBaseModule],
     controllers: [OpenAiCompatController, ConversationController],
     providers: [OpenAiCompatService, ConversationTitleService],
 })

--- a/apps/api/src/ai-conversation/openai-compat.controller.spec.ts
+++ b/apps/api/src/ai-conversation/openai-compat.controller.spec.ts
@@ -1,5 +1,13 @@
 jest.mock('@ever-works/agent/database', () => ({}));
 jest.mock('@ever-works/agent/facades', () => ({}));
+// EW-641 Phase 2/c row 34c — `OpenAiCompatService` now imports the
+// agent/services barrel for KB mention injection. Stub it here to
+// keep the controller spec free of agent transitive deps.
+jest.mock('@ever-works/agent/services', () => ({
+    KbMentionResolverService: class {},
+    parseKbMentions: jest.fn().mockReturnValue([]),
+    formatKbContext: jest.fn().mockReturnValue('<kb>\n</kb>'),
+}));
 
 import { OpenAiCompatController } from './openai-compat.controller';
 import { OpenAiCompatService } from './openai-compat.service';

--- a/apps/api/src/ai-conversation/openai-compat.service.spec.ts
+++ b/apps/api/src/ai-conversation/openai-compat.service.spec.ts
@@ -1,9 +1,28 @@
 jest.mock('@ever-works/agent/database', () => ({}));
 jest.mock('@ever-works/agent/facades', () => ({}));
 
+// EW-641 Phase 2/c row 34c — stub the agent/services barrel.
+// `parseKbMentions` + `formatKbContext` are pure, but mocking them as
+// jest.fn() lets the tests assert "no-op when nothing matched" without
+// shipping fixture KB docs. The default fn() returns undefined, which
+// the service treats as "no mentions / empty block" gracefully.
+jest.mock('@ever-works/agent/services', () => ({
+    KbMentionResolverService: class {},
+    parseKbMentions: jest.fn().mockReturnValue([]),
+    formatKbContext: jest.fn().mockReturnValue('<kb>\n</kb>'),
+}));
+
 import { OpenAiCompatService } from './openai-compat.service';
 import type { WorkRepository } from '@ever-works/agent/database';
 import type { AiFacadeService } from '@ever-works/agent/facades';
+import {
+    KbMentionResolverService,
+    parseKbMentions,
+    formatKbContext,
+} from '@ever-works/agent/services';
+
+const mockedParse = parseKbMentions as unknown as jest.Mock;
+const mockedFormat = formatKbContext as unknown as jest.Mock;
 
 type ResMock = {
     write: jest.Mock;
@@ -43,8 +62,14 @@ describe('OpenAiCompatService', () => {
         Pick<AiFacadeService, 'createChatCompletion' | 'createStreamingChatCompletion'>
     >;
     let workRepository: jest.Mocked<Pick<WorkRepository, 'findByUser'>>;
+    let kbMentionResolver: jest.Mocked<Pick<KbMentionResolverService, 'resolveMentions'>>;
 
     beforeEach(() => {
+        // Reset the agent/services mock functions before each test so a
+        // prior test's mockReturnValue doesn't leak into this one.
+        mockedParse.mockReset().mockReturnValue([]);
+        mockedFormat.mockReset().mockReturnValue('<kb>\n</kb>');
+
         aiFacade = {
             createChatCompletion: jest.fn(),
             createStreamingChatCompletion: jest.fn(),
@@ -52,9 +77,13 @@ describe('OpenAiCompatService', () => {
         workRepository = {
             findByUser: jest.fn().mockResolvedValue([]),
         } as any;
+        kbMentionResolver = {
+            resolveMentions: jest.fn().mockResolvedValue([]),
+        } as any;
         service = new OpenAiCompatService(
             aiFacade as unknown as AiFacadeService,
             workRepository as unknown as WorkRepository,
+            kbMentionResolver as unknown as KbMentionResolverService,
         );
     });
 
@@ -623,6 +652,155 @@ describe('OpenAiCompatService', () => {
             const body = JSON.parse(endArg);
             expect(body.error.message).not.toContain('abcdef1234567890ghijk');
             expect(body.error.message).toContain('[redacted]');
+        });
+    });
+
+    // EW-641 Phase 2/c row 34c — `@kb:` mentions in the latest user
+    // message resolve into KB docs and get prepended as a `<kb>` system
+    // message before the LLM call.
+    describe('handleCompletion — kbContext injection (row 34c)', () => {
+        const baseDto = {
+            model: 'gpt-4o',
+            messages: [{ role: 'user', content: 'hello @kb:brand/voice' }],
+        } as any;
+
+        const sampleDoc = {
+            id: 'doc-1',
+            workId: 'w-1',
+            organizationId: null,
+            path: 'brand/voice.md',
+            slug: 'voice',
+            title: 'Brand voice',
+            class: 'brand',
+        } as any;
+
+        beforeEach(() => {
+            aiFacade.createChatCompletion.mockResolvedValue({
+                id: 'x',
+                created: 0,
+                model: 'm',
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: 'assistant', content: 'ok' },
+                        finishReason: 'stop',
+                    },
+                ],
+            } as any);
+        });
+
+        it('passes messages through unchanged when no mentions are parsed', async () => {
+            mockedParse.mockReturnValue([]);
+
+            await service.handleCompletion(baseDto, { userId: 'u-1', workId: 'w-1' });
+
+            expect(kbMentionResolver.resolveMentions).not.toHaveBeenCalled();
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            // No KB system message prepended.
+            expect(opts.messages).toHaveLength(1);
+            expect(opts.messages[0].role).toBe('user');
+        });
+
+        it('prepends a `<kb>` system message when mentions resolve to docs', async () => {
+            mockedParse.mockReturnValue([
+                { raw: '@kb:brand/voice', reference: 'brand/voice', startOffset: 6, endOffset: 21 },
+            ]);
+            kbMentionResolver.resolveMentions.mockResolvedValue([
+                {
+                    mention: {
+                        raw: '@kb:brand/voice',
+                        reference: 'brand/voice',
+                        startOffset: 6,
+                        endOffset: 21,
+                    },
+                    document: sampleDoc,
+                },
+            ] as any);
+            mockedFormat.mockReturnValue('<kb>\n## Brand voice (kb:brand/voice)\nbody\n</kb>');
+
+            await service.handleCompletion(baseDto, { userId: 'u-1', workId: 'w-1' });
+
+            // resolver called with (workId, userId, mentions).
+            expect(kbMentionResolver.resolveMentions).toHaveBeenCalledWith(
+                'w-1',
+                'u-1',
+                expect.any(Array),
+            );
+            // formatKbContext called with just the resolved (non-null) docs.
+            expect(mockedFormat).toHaveBeenCalledWith([sampleDoc]);
+
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            // System message prepended at index 0, original user message follows.
+            expect(opts.messages).toHaveLength(2);
+            expect(opts.messages[0].role).toBe('system');
+            expect(opts.messages[0].content).toBe(
+                '<kb>\n## Brand voice (kb:brand/voice)\nbody\n</kb>',
+            );
+            expect(opts.messages[1].role).toBe('user');
+        });
+
+        it('does NOT prepend a `<kb>` block when all mentions resolve to null docs', async () => {
+            mockedParse.mockReturnValue([
+                { raw: '@kb:ghost', reference: 'ghost', startOffset: 0, endOffset: 9 },
+            ]);
+            kbMentionResolver.resolveMentions.mockResolvedValue([
+                {
+                    mention: { raw: '@kb:ghost', reference: 'ghost', startOffset: 0, endOffset: 9 },
+                    document: null,
+                },
+            ] as any);
+
+            await service.handleCompletion(baseDto, { userId: 'u-1', workId: 'w-1' });
+
+            expect(mockedFormat).not.toHaveBeenCalled();
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            expect(opts.messages).toHaveLength(1);
+        });
+
+        it('skips injection entirely when no workId can be resolved', async () => {
+            mockedParse.mockReturnValue([
+                { raw: '@kb:brand/voice', reference: 'brand/voice', startOffset: 0, endOffset: 15 },
+            ]);
+
+            await service.handleCompletion(baseDto, { userId: 'u-1' });
+
+            expect(kbMentionResolver.resolveMentions).not.toHaveBeenCalled();
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            expect(opts.messages).toHaveLength(1);
+        });
+
+        it('finds the latest user message even when later messages have non-string content', async () => {
+            mockedParse.mockReturnValue([]);
+            const dto = {
+                model: 'gpt-4o',
+                messages: [
+                    { role: 'user', content: 'older message with @kb:brand/voice' },
+                    { role: 'assistant', content: 'reply' },
+                    // Latest user message — but content is null (e.g., multimodal placeholder).
+                    { role: 'user', content: null },
+                ],
+            } as any;
+
+            await service.handleCompletion(dto, { userId: 'u-1', workId: 'w-1' });
+
+            // Latest user message is the null-content one — v1 skips
+            // when latest user content is non-string. We don't scan
+            // earlier messages.
+            expect(mockedParse).not.toHaveBeenCalled();
+        });
+
+        it('degrades gracefully when resolveMentions throws — passes original messages through', async () => {
+            mockedParse.mockReturnValue([
+                { raw: '@kb:brand/voice', reference: 'brand/voice', startOffset: 6, endOffset: 21 },
+            ]);
+            kbMentionResolver.resolveMentions.mockRejectedValue(new Error('kb backend down'));
+
+            await service.handleCompletion(baseDto, { userId: 'u-1', workId: 'w-1' });
+
+            // No throw bubbles up; original messages preserved.
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            expect(opts.messages).toHaveLength(1);
+            expect(opts.messages[0].role).toBe('user');
         });
     });
 });

--- a/apps/api/src/ai-conversation/openai-compat.service.ts
+++ b/apps/api/src/ai-conversation/openai-compat.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AiFacadeService, type FacadeOptions } from '@ever-works/agent/facades';
 import { WorkRepository } from '@ever-works/agent/database';
+import {
+    KbMentionResolverService,
+    formatKbContext,
+    parseKbMentions,
+} from '@ever-works/agent/services';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
 import type {
     ChatMessage,
     ChatCompletionOptions,
@@ -33,6 +39,7 @@ export class OpenAiCompatService {
     constructor(
         private readonly aiFacade: AiFacadeService,
         private readonly workRepository: WorkRepository,
+        private readonly kbMentionResolver: KbMentionResolverService,
     ) {}
 
     /**
@@ -43,7 +50,8 @@ export class OpenAiCompatService {
         facadeOptions: FacadeOptions,
     ): Promise<OpenAiChatCompletionResponse> {
         const resolved = await this.resolveWorkContext(facadeOptions);
-        const options = this.mapToInternalOptions(dto);
+        const baseOptions = this.mapToInternalOptions(dto);
+        const options = await this.injectKbContext(baseOptions, resolved);
 
         const response = await this.aiFacade.createChatCompletion(options, resolved);
 
@@ -60,7 +68,8 @@ export class OpenAiCompatService {
         res: StreamingResponse,
     ): Promise<void> {
         const resolved = await this.resolveWorkContext(facadeOptions);
-        const options = this.mapToInternalOptions(dto);
+        const baseOptions = this.mapToInternalOptions(dto);
+        const options = await this.injectKbContext(baseOptions, resolved);
 
         try {
             const stream = this.aiFacade.createStreamingChatCompletion(
@@ -294,6 +303,104 @@ export class OpenAiCompatService {
         }
 
         return options;
+    }
+
+    /**
+     * EW-641 Phase 2/c row 34c — scan the latest user message for `@kb:`
+     * mentions (row 34a `parseKbMentions`), resolve each against the
+     * Knowledge Base (row 34b `KbMentionResolverService.resolveMentions`),
+     * and prepend a `<kb>...</kb>` system message (row 31 `formatKbContext`)
+     * carrying the resolved docs so the LLM has them in context.
+     *
+     * Layout choice: we **prepend** a fresh system message at index 0
+     * rather than mutating an existing system message in-place. Both
+     * OpenAI- and Anthropic-compatible providers tolerate multiple
+     * system messages (or the gateway flattens them); inserting at
+     * the head also keeps the user's own carefully-crafted system
+     * prompt (if any) intact and downstream of the KB context.
+     *
+     * Idempotence: row 17's mention picker writes the raw `@kb:` token
+     * into the user message; the LLM doesn't see anything special on
+     * its end. The injected `<kb>` block is what carries the document
+     * text. Citations on the response come from row 34d (system-prompt
+     * instruction OR deterministic post-process).
+     *
+     * Degraded paths (all yield the unmodified `options`):
+     *  - no `workId` resolvable (anonymous / no work scope) — can't
+     *    look up docs anyway,
+     *  - latest user message is missing or non-string content (v1
+     *    only scans string content; content-part arrays are a v2
+     *    concern),
+     *  - no `@kb:` mentions parsed,
+     *  - all mentions resolve to `null` documents (404 / forbidden /
+     *    resolver-error — row 34b already swallowed those gracefully).
+     *
+     * The whole thing is wrapped in try/catch so a KB hiccup never
+     * breaks the chat completion request — the conversation continues
+     * exactly as it would have without the KB feature.
+     */
+    private async injectKbContext(
+        options: ChatCompletionOptions,
+        facadeOptions: FacadeOptions,
+    ): Promise<ChatCompletionOptions> {
+        const { workId, userId } = facadeOptions;
+        if (!workId || !userId) return options;
+
+        // v1 only scans string-content user messages. content-part
+        // arrays (vision / multimodal) are a v2 concern; document
+        // the limitation inline so a future contributor knows where
+        // to extend.
+        const latestUser = this.findLatestUserStringMessage(options.messages);
+        if (!latestUser) return options;
+
+        try {
+            const mentions = parseKbMentions(latestUser);
+            if (mentions.length === 0) return options;
+
+            const resolved = await this.kbMentionResolver.resolveMentions(workId, userId, mentions);
+            const docs: KbDocumentBodyDto[] = resolved
+                .map((r) => r.document)
+                .filter((d): d is KbDocumentBodyDto => d !== null);
+
+            if (docs.length === 0) return options;
+
+            const kbBlock = formatKbContext(docs);
+            const kbSystemMessage: ChatMessage = {
+                role: 'system',
+                content: kbBlock,
+            };
+
+            return {
+                ...options,
+                messages: [kbSystemMessage, ...options.messages],
+            };
+        } catch (err) {
+            // Any unexpected failure → log + carry on with the
+            // unmodified options. The user's conversation continues;
+            // the LLM just doesn't get the extra KB grounding.
+            this.logger.warn(
+                `KB context injection failed for work=${workId}: ${(err as Error).message}. Continuing without injected KB.`,
+            );
+            return options;
+        }
+    }
+
+    /**
+     * Find the most recent user-role message whose `content` is a
+     * plain string. Walks from the end so a multi-turn conversation
+     * picks up the just-sent user message, ignoring earlier turns.
+     */
+    private findLatestUserStringMessage(messages: ReadonlyArray<ChatMessage>): string | null {
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const m = messages[i];
+            if (m.role !== 'user') continue;
+            if (typeof m.content === 'string') return m.content;
+            // Non-string user content (content parts / multimodal) —
+            // skip in v1; row 34c v2 would walk the content parts and
+            // scan each `text` part. Documented limitation, not a bug.
+            return null;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/c row 34c — wires row 34a parser + row 34b resolver into `OpenAiCompatService` so chat-completion requests with `@kb:<reference>` mentions in the latest user message get the referenced KB docs materialized into a `<kb>...</kb>` system message (via row 31 `formatKbContext`).
- Applies to both `handleCompletion` (non-streaming) and `handleStreamingCompletion` paths uniformly.
- DI wiring: `AiConversationModule` now imports `KnowledgeBaseModule` (from `@ever-works/agent/services`) — `KbMentionResolverService` is exported by that module per PR #980.
- Degraded paths (all pass-through, never throw): no workId/userId; latest user message missing OR non-string content; no mentions; all mentions resolve to null docs; unexpected resolver error.

## Test plan
- [x] `pnpm jest src/ai-conversation/openai-compat.service.spec.ts` — 27/27 green (21 prior + 6 new for kbContext injection)
- [x] `pnpm jest src/ai-conversation` — 89/89 green across 5 files (controller spec mock updated)
- [x] `pnpm jest` (full API suite) — 141/142 suites, 2329/2329 tests (pre-existing `deploy.e2e.spec.ts` resolve failure for `@ever-works/k8s-plugin` is unrelated and unchanged from develop)
- [x] `pnpm build --filter @ever-works/agent` — clean, 0 TSC issues
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now reference Knowledge Base documents directly in chat messages using `@kb:` mention syntax.
  * The system automatically parses these mentions, resolves referenced documents, and injects relevant KB context into conversations before sending to the LLM.
  * Graceful error handling ensures conversations proceed normally if KB mentions cannot be resolved or context is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->