### PR TITLE
feat(api): citation marker prompt on `<kb>` injection (row 34d)

### DIFF
--- a/apps/api/src/ai-conversation/openai-compat.service.spec.ts
+++ b/apps/api/src/ai-conversation/openai-compat.service.spec.ts
@@ -12,7 +12,7 @@ jest.mock('@ever-works/agent/services', () => ({
     formatKbContext: jest.fn().mockReturnValue('<kb>\n</kb>'),
 }));
 
-import { OpenAiCompatService } from './openai-compat.service';
+import { OpenAiCompatService, KB_CITATION_INSTRUCTION } from './openai-compat.service';
 import type { WorkRepository } from '@ever-works/agent/database';
 import type { AiFacadeService } from '@ever-works/agent/facades';
 import {
@@ -733,10 +733,64 @@ describe('OpenAiCompatService', () => {
             // System message prepended at index 0, original user message follows.
             expect(opts.messages).toHaveLength(2);
             expect(opts.messages[0].role).toBe('system');
-            expect(opts.messages[0].content).toBe(
+            // Content includes the formatted KB block AND the row 34d
+            // citation-instruction marker (asserted in detail below).
+            expect(opts.messages[0].content).toContain(
                 '<kb>\n## Brand voice (kb:brand/voice)\nbody\n</kb>',
             );
             expect(opts.messages[1].role).toBe('user');
+        });
+
+        // EW-641 Phase 2/c row 34d — citation marker prompt template.
+        it('appends the citation-instruction marker to the `<kb>` system message (row 34d)', async () => {
+            mockedParse.mockReturnValue([
+                { raw: '@kb:brand/voice', reference: 'brand/voice', startOffset: 6, endOffset: 21 },
+            ]);
+            kbMentionResolver.resolveMentions.mockResolvedValue([
+                {
+                    mention: {
+                        raw: '@kb:brand/voice',
+                        reference: 'brand/voice',
+                        startOffset: 6,
+                        endOffset: 21,
+                    },
+                    document: sampleDoc,
+                },
+            ] as any);
+            mockedFormat.mockReturnValue('<kb>\n## Brand voice (kb:brand/voice)\nbody\n</kb>');
+
+            await service.handleCompletion(baseDto, { userId: 'u-1', workId: 'w-1' });
+
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            // Citation instruction is present verbatim.
+            expect(opts.messages[0].content).toContain(KB_CITATION_INSTRUCTION);
+            // And it follows the kb block (block first, then instruction).
+            const content = opts.messages[0].content as string;
+            const blockIdx = content.indexOf('<kb>');
+            const instructionIdx = content.indexOf(KB_CITATION_INSTRUCTION);
+            expect(blockIdx).toBeGreaterThanOrEqual(0);
+            expect(instructionIdx).toBeGreaterThan(blockIdx);
+        });
+
+        it('does NOT include the citation instruction when no <kb> block is injected (no resolved docs)', async () => {
+            mockedParse.mockReturnValue([
+                { raw: '@kb:ghost', reference: 'ghost', startOffset: 0, endOffset: 9 },
+            ]);
+            kbMentionResolver.resolveMentions.mockResolvedValue([
+                {
+                    mention: { raw: '@kb:ghost', reference: 'ghost', startOffset: 0, endOffset: 9 },
+                    document: null,
+                },
+            ] as any);
+
+            await service.handleCompletion(baseDto, { userId: 'u-1', workId: 'w-1' });
+
+            const [opts] = aiFacade.createChatCompletion.mock.calls[0];
+            // No system message at all → no citation instruction either.
+            expect(opts.messages).toHaveLength(1);
+            for (const msg of opts.messages) {
+                expect(msg.content).not.toContain(KB_CITATION_INSTRUCTION);
+            }
         });
 
         it('does NOT prepend a `<kb>` block when all mentions resolve to null docs', async () => {

--- a/apps/api/src/ai-conversation/openai-compat.service.ts
+++ b/apps/api/src/ai-conversation/openai-compat.service.ts
@@ -32,6 +32,28 @@ type StreamingResponse = {
     destroy(error?: Error): void;
 };
 
+/**
+ * EW-641 Phase 2/c row 34d — citation marker prompt template.
+ *
+ * Appended to the `<kb>...</kb>` system message that row 34c injects
+ * when `@kb:` mentions resolve to docs. Tells the LLM to reference
+ * KB material inline using the row 17 `kb:{class}/{slug}` token
+ * format — the same shape the user-side `@kb:` mention parser
+ * understands — so:
+ *  - row 35's hover-card UI can detect `kb:{class}/{slug}` tokens
+ *    in the rendered assistant response and resolve them to docs
+ *    via the same KB endpoints the workbench uses,
+ *  - users see consistent citation shape on both sides of the
+ *    conversation,
+ *  - the format round-trips cleanly: paste a citation back at the
+ *    model, the row 34a parser picks it up again as `@kb:...`.
+ *
+ * Exported so the spec can assert verbatim presence in the
+ * injected system message without duplicating the string.
+ */
+export const KB_CITATION_INSTRUCTION =
+    'When citing material from a KB document above, reference it inline using the format `kb:{class}/{slug}` (e.g. `kb:brand/voice`). Use the exact class and slug shown in each document heading.';
+
 @Injectable()
 export class OpenAiCompatService {
     private readonly logger = new Logger(OpenAiCompatService.name);
@@ -365,9 +387,18 @@ export class OpenAiCompatService {
             if (docs.length === 0) return options;
 
             const kbBlock = formatKbContext(docs);
+            // EW-641 Phase 2/c row 34d — citation marker prompt.
+            // Tell the LLM to cite material from the injected docs
+            // using the row 17 `kb:{class}/{slug}` token format so
+            // the row 35 hover-card UI can resolve + tooltip them
+            // in the rendered assistant response. The marker is
+            // the same shape the user-side `@kb:` mention parser
+            // already understands — round-tripping cleanly between
+            // user input and assistant output.
+            const kbContent = `${kbBlock}\n\n${KB_CITATION_INSTRUCTION}`;
             const kbSystemMessage: ChatMessage = {
                 role: 'system',
-                content: kbBlock,
+                content: kbContent,
             };
 
             return {


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/c row 34d — when `OpenAiCompatService.injectKbContext` (row 34c) prepends a `<kb>...</kb>` system message, it now also appends a one-line citation-instruction marker telling the LLM to reference KB material inline as `kb:{class}/{slug}` tokens (e.g. `kb:brand/voice`).
- Same token shape `parseKbMentions` (row 34a) recognises on the user-input side — citations round-trip cleanly between user and assistant turns. Row 35's hover-card UI consumes the same format.
- New exported constant `KB_CITATION_INSTRUCTION` (single source of truth; spec asserts verbatim presence).
- Only attached when a `<kb>` block is actually injected — no marker means no resolved docs to cite.

## Test plan
- [x] `pnpm jest src/ai-conversation/openai-compat.service.spec.ts` — 29/29 green (27 prior + 2 new for the citation marker; existing prepend test relaxed from `toBe` to `toContain(kbBlock)`)
- [x] `pnpm jest src/ai-conversation` — 91/91 green across 5 files
- [x] `pnpm build --filter @ever-works/agent` — clean
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI assistant now includes citation instructions when referencing knowledge base materials, enabling properly formatted source attribution during conversations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->