### PR TITLE
feat(agent): parseKbCitations parser for assistant text (row 35a)

### DIFF
--- a/packages/agent/src/services/__tests__/kb-citation-parser.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-citation-parser.spec.ts
@@ -1,0 +1,237 @@
+import { parseKbCitations, type KbCitation } from '../kb-citation-parser';
+
+describe('parseKbCitations', () => {
+    describe('boundary cases', () => {
+        it('returns [] for empty string', () => {
+            expect(parseKbCitations('')).toEqual([]);
+        });
+
+        it('returns [] for whitespace-only input', () => {
+            expect(parseKbCitations('   \n\t  ')).toEqual([]);
+        });
+
+        it('returns [] when there are no citations', () => {
+            expect(parseKbCitations('the assistant says hello, no citations here')).toEqual([]);
+        });
+
+        it('returns [] for non-string input (defensive)', () => {
+            expect(parseKbCitations(null as unknown as string)).toEqual([]);
+            expect(parseKbCitations(undefined as unknown as string)).toEqual([]);
+        });
+    });
+
+    describe('single citation (canonical whitelist classes)', () => {
+        it('extracts a citation at start of message', () => {
+            const out = parseKbCitations('kb:brand/voice is the source');
+            expect(out).toHaveLength(1);
+            expect(out[0]).toMatchObject({
+                raw: 'kb:brand/voice',
+                cls: 'brand',
+                slug: 'voice',
+                startOffset: 0,
+                endOffset: 14,
+            });
+        });
+
+        it('extracts a citation with class/slug in the middle of prose', () => {
+            const text = 'See kb:brand/voice for tone guidance.';
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(1);
+            expect(out[0].cls).toBe('brand');
+            expect(out[0].slug).toBe('voice');
+            // Slice invariant.
+            expect(text.slice(out[0].startOffset, out[0].endOffset)).toBe(out[0].raw);
+        });
+
+        it.each([
+            ['brand', 'voice'],
+            ['legal', 'terms'],
+            ['seo', 'meta'],
+            ['style', 'headlines'],
+            ['glossary', 'jargon'],
+            ['competitors', 'list'],
+            ['personas', 'icp'],
+            ['research', 'q1-2026'],
+            ['output', 'report-v1'],
+            ['freeform', 'notes'],
+        ])('accepts canonical class "%s" with slug "%s"', (cls, slug) => {
+            const out = parseKbCitations(`kb:${cls}/${slug}`);
+            expect(out).toHaveLength(1);
+            expect(out[0].cls).toBe(cls);
+            expect(out[0].slug).toBe(slug);
+        });
+
+        it('accepts mid-slug dots (version-style references survive)', () => {
+            const out = parseKbCitations('kb:research/v2.1_final-draft');
+            expect(out).toHaveLength(1);
+            expect(out[0].slug).toBe('research/v2.1_final-draft'.split('/')[1]);
+            // The grammar puts the entire slug capture (after the first `/`)
+            // into `slug`, so version-style intra-slug dots survive.
+            expect(out[0].slug).toBe('v2.1_final-draft');
+        });
+
+        it('accepts nested-path slugs (slug allows internal `/`)', () => {
+            const out = parseKbCitations('see kb:brand/voice/lighthearted');
+            expect(out).toHaveLength(1);
+            expect(out[0].cls).toBe('brand');
+            expect(out[0].slug).toBe('voice/lighthearted');
+        });
+    });
+
+    describe('multiple citations', () => {
+        it('extracts every citation in textual order with correct offsets', () => {
+            const text = 'compare kb:brand/voice and kb:legal/terms please';
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(2);
+            expect(out.map((c) => c.slug)).toEqual(['voice', 'terms']);
+            expect(out[0].endOffset).toBeLessThan(out[1].startOffset);
+            for (const c of out) {
+                expect(text.slice(c.startOffset, c.endOffset)).toBe(c.raw);
+            }
+        });
+
+        it('reports adjacent citations (whitespace-separated) independently', () => {
+            const out = parseKbCitations('kb:brand/a kb:legal/b kb:style/c');
+            expect(out.map((c) => `${c.cls}/${c.slug}`)).toEqual(['brand/a', 'legal/b', 'style/c']);
+        });
+
+        it('reports the same (cls, slug) cited multiple times as separate matches', () => {
+            // Dedup is the consumer's responsibility (row 35b's resolver
+            // groups by doc id). The parser stays faithful to source
+            // textual order.
+            const out = parseKbCitations('first kb:brand/voice then later kb:brand/voice');
+            expect(out).toHaveLength(2);
+            expect(out[0].startOffset).not.toBe(out[1].startOffset);
+        });
+    });
+
+    describe('rejects non-citations + class whitelist', () => {
+        it('REJECTS `@kb:` mentions (those are row 34a, not row 35a)', () => {
+            // The leading `@` is the user-input mention marker; the
+            // hover-card is for the bare assistant-side `kb:` token only.
+            expect(parseKbCitations('@kb:brand/voice')).toEqual([]);
+            expect(parseKbCitations('see @kb:brand/voice please')).toEqual([]);
+        });
+
+        it('REJECTS classes outside KB_DOCUMENT_CLASSES whitelist', () => {
+            // Hallucinated classes from a confused LLM shouldn't surface
+            // in the hover-card UI.
+            expect(parseKbCitations('kb:knowledge/foo')).toEqual([]);
+            expect(parseKbCitations('kb:nonexistent/whatever')).toEqual([]);
+            expect(parseKbCitations('kb:BRAND/voice')).toEqual([]); // case-sensitive
+        });
+
+        it('REJECTS `kb:` glued to a word character (whole-token boundary)', () => {
+            // Lookbehind blocks word-char (letter / digit / underscore)
+            // immediately before `kb:` so we don't match inside the
+            // middle of a token. Punctuation like `.` or `/` is fine
+            // (URL fragments + sentence-final still produce citations).
+            expect(parseKbCitations('user1kb:brand/voice')).toEqual([]);
+            expect(parseKbCitations('abckb:brand/voice')).toEqual([]);
+            expect(parseKbCitations('Akb:brand/voice')).toEqual([]);
+            expect(parseKbCitations('_kb:brand/voice')).toEqual([]);
+        });
+
+        it('ACCEPTS `kb:` preceded by punctuation or whitespace or start-of-string', () => {
+            expect(parseKbCitations('kb:brand/voice')).toHaveLength(1);
+            expect(parseKbCitations(' kb:brand/voice')).toHaveLength(1);
+            expect(parseKbCitations('(kb:brand/voice)')).toHaveLength(1);
+            // `.` is not a word char — matches (sentence-final period
+            // edge case + URL paths both produce citations).
+            expect(parseKbCitations('.kb:brand/voice')).toHaveLength(1);
+            // `/` likewise — common in URLs and the LLM might emit
+            // `see /kb:brand/voice` style references.
+            expect(parseKbCitations('/kb:brand/voice')).toHaveLength(1);
+        });
+
+        it('REJECTS `kb:` without a slug (class-only)', () => {
+            expect(parseKbCitations('kb:brand')).toEqual([]);
+            expect(parseKbCitations('kb:brand/')).toEqual([]);
+        });
+    });
+
+    describe('punctuation handling', () => {
+        it('strips trailing period from the slug (sentence-final)', () => {
+            const out = parseKbCitations('See kb:brand/voice.');
+            expect(out).toHaveLength(1);
+            expect(out[0].slug).toBe('voice');
+            expect(out[0].raw).toBe('kb:brand/voice');
+        });
+
+        it('strips trailing comma + semicolon + question mark / etc.', () => {
+            const cases: Array<[string, string]> = [
+                ['kb:brand/voice,', 'voice'],
+                ['kb:brand/voice;', 'voice'],
+                ['kb:brand/voice!', 'voice'],
+                ['kb:brand/voice?', 'voice'],
+                ['kb:brand/voice"', 'voice'],
+                ['(kb:brand/voice)', 'voice'],
+            ];
+            for (const [text, expectedSlug] of cases) {
+                const out = parseKbCitations(text);
+                expect(out).toHaveLength(1);
+                expect(out[0].slug).toBe(expectedSlug);
+            }
+        });
+
+        it('preserves mid-slug dots even when trailing dot is stripped', () => {
+            const out = parseKbCitations('see kb:research/v2.1.');
+            expect(out).toHaveLength(1);
+            expect(out[0].slug).toBe('v2.1');
+        });
+    });
+
+    describe('determinism + immutability', () => {
+        it('returns a fresh array on each call', () => {
+            const a = parseKbCitations('kb:brand/voice');
+            const b = parseKbCitations('kb:brand/voice');
+            expect(a).not.toBe(b);
+            expect(a).toEqual(b);
+        });
+
+        it('multiple calls on the same text yield identical results (no regex.lastIndex leak)', () => {
+            const text = 'kb:brand/a kb:legal/b kb:style/c';
+            const first = parseKbCitations(text);
+            const second = parseKbCitations(text);
+            const third = parseKbCitations(text);
+            expect(first).toEqual(second);
+            expect(second).toEqual(third);
+            expect(first.map((c: KbCitation) => `${c.cls}/${c.slug}`)).toEqual([
+                'brand/a',
+                'legal/b',
+                'style/c',
+            ]);
+        });
+    });
+
+    describe('multiline + realistic outputs', () => {
+        it('extracts citations across multiple lines', () => {
+            const text =
+                'For the headline tone, see kb:brand/voice.\n' +
+                'For the legal copy, check kb:legal/disclaimer.\n' +
+                'For style: kb:style/headlines.';
+            const out = parseKbCitations(text);
+            expect(out.map((c) => `${c.cls}/${c.slug}`)).toEqual([
+                'brand/voice',
+                'legal/disclaimer',
+                'style/headlines',
+            ]);
+            for (const c of out) {
+                expect(text.slice(c.startOffset, c.endOffset)).toBe(c.raw);
+            }
+        });
+
+        it('handles a realistic assistant message with mixed cited + un-cited prose', () => {
+            const msg =
+                "Sure — I'll draft the headline using kb:brand/voice for tone " +
+                'and double-check the disclaimer wording against kb:legal/disclaimer. ' +
+                'I drew the title-case rule from kb:style/headlines.';
+            const out = parseKbCitations(msg);
+            expect(out.map((c) => `${c.cls}/${c.slug}`)).toEqual([
+                'brand/voice',
+                'legal/disclaimer',
+                'style/headlines',
+            ]);
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -36,6 +36,7 @@ export * from './kb-prompt-formatter';
 export * from './kb-context-bundle';
 export * from './kb-mention-parser';
 export * from './kb-mention-resolver.service';
+export * from './kb-citation-parser';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-citation-parser.ts
+++ b/packages/agent/src/services/kb-citation-parser.ts
@@ -1,0 +1,145 @@
+import { KB_DOCUMENT_CLASSES, type KbDocumentClass } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 2/c row 35a — pure `kb:{class}/{slug}` citation parser.
+ *
+ * Companion to row 34a's `parseKbMentions` (which scans `@kb:` user-
+ * input mentions). This parser scans assistant-side message text for
+ * the bare `kb:{class}/{slug}` citation tokens that row 34d's prompt
+ * instructs the LLM to emit when referencing KB documents. The row
+ * 35c `<CitationHover>` UI consumes the extracted offsets to wrap
+ * each token with a popover; the row 35b resolver materializes each
+ * `(class, slug)` pair to a `KbDocumentBodyDto` for the popover
+ * content.
+ *
+ * Format invariants (locked here, depended on by every downstream
+ * citation surface):
+ *  - Citation token is always `kb:{class}/{slug}` with no `@` prefix
+ *    (`@kb:` is the row 34a user-input mention format — distinct).
+ *  - `{class}` MUST be one of the canonical
+ *    `KB_DOCUMENT_CLASSES` from `@ever-works/contracts` — citations
+ *    with unknown classes are rejected (the LLM hallucinated; row
+ *    35c will skip them rather than make a bogus hover-card).
+ *  - `{slug}` matches `[A-Za-z0-9_.\-]+` — slugs/paths in the agent
+ *    package use these chars exclusively.
+ *  - Whole-token boundary at start: must NOT be preceded by `@`
+ *    (that would be a row 34a mention, not a citation) AND must
+ *    NOT be preceded by a word char (so URL fragments like
+ *    `acme/kb:foo` don't accidentally match).
+ *  - Trailing punctuation (`.`, `-`, `_`, `/`) is stripped from the
+ *    slug — sentence-final periods don't get absorbed. Mid-slug
+ *    dots survive (e.g. `kb:research/v2.1`).
+ *
+ * **Pure function.** No I/O, no module state. Safe in any context
+ * (API service, eval harness, web SSR, test). Returns `[]` for
+ * non-string input.
+ */
+
+/**
+ * A single `kb:{class}/{slug}` citation token extracted from a
+ * piece of assistant-message text.
+ *
+ * - `raw` — the full matched text (`kb:{class}/{slug}`). After
+ *   trailing-punctuation trim, the raw is exactly the post-trim
+ *   shape so `text.slice(startOffset, endOffset) === raw`.
+ * - `cls` — the validated `KbDocumentClass` (row 35b uses this as
+ *   the `class` field on the synthesized `KbMention` for resolution).
+ * - `slug` — the trimmed slug (post-punctuation-trim).
+ * - `startOffset` / `endOffset` — 0-based UTF-16 indices identifying
+ *   the textual span (so row 35d's renderer can `splice` in the
+ *   `<CitationHover>` component).
+ */
+export interface KbCitation {
+    readonly raw: string;
+    readonly cls: KbDocumentClass;
+    readonly slug: string;
+    readonly startOffset: number;
+    readonly endOffset: number;
+}
+
+/**
+ * Regex notes:
+ *  - `(?<![@A-Za-z0-9_])` — lookbehind: NOT preceded by `@` (row 34a
+ *    mention takes precedence) AND NOT preceded by a word char
+ *    (start-of-string / whitespace / punctuation is fine).
+ *  - `kb:` — literal prefix (no `@`).
+ *  - `([A-Za-z0-9_-]+)` — class capture. We validate against the
+ *    `KB_DOCUMENT_CLASSES` whitelist post-match; the regex is
+ *    permissive on character class because the whitelist check is
+ *    cheaper + the regex would be a 100-char alternation otherwise.
+ *  - `/` — separator.
+ *  - `([A-Za-z0-9/_.\-]+)` — slug capture (same alphabet as row 34a
+ *    references; `/` allowed inside the slug for nested paths like
+ *    `research/v2.1`).
+ *  - `g` flag — `matchAll` walks the whole string in textual order.
+ *
+ * Node 22 + modern V8 support lookbehinds and `String.prototype.matchAll`.
+ */
+const KB_CITATION_RE = /(?<![@A-Za-z0-9_])kb:([A-Za-z0-9_-]+)\/([A-Za-z0-9/_.\-]+)/g;
+
+/** Strip trailing punctuation from the slug (same set as row 34a). */
+function trimTrailingPunctuation(slug: string): string {
+    let end = slug.length;
+    while (end > 0) {
+        const ch = slug[end - 1];
+        if (ch === '.' || ch === '-' || ch === '_' || ch === '/') {
+            end--;
+        } else {
+            break;
+        }
+    }
+    return slug.slice(0, end);
+}
+
+const KNOWN_CLASSES: ReadonlySet<string> = new Set(KB_DOCUMENT_CLASSES);
+
+/**
+ * Extract every `kb:{class}/{slug}` citation from a piece of text.
+ *
+ * Citations with unknown classes are rejected (silently skipped) —
+ * a hallucinated `kb:unknown/whatever` from a confused LLM should
+ * not surface in the hover-card UI.
+ *
+ * Returns `[]` for empty / whitespace / non-string input. Offsets
+ * are UTF-16-unit based (matches `String.prototype.slice`). The
+ * parser is byte-/codepoint-agnostic since the grammar is ASCII-only.
+ */
+export function parseKbCitations(text: string): KbCitation[] {
+    if (typeof text !== 'string' || text.length === 0) return [];
+
+    const out: KbCitation[] = [];
+    for (const m of text.matchAll(KB_CITATION_RE)) {
+        // `matchAll` with a global regex yields `m.index` reliably,
+        // but the type sig says `number | undefined` — be defensive.
+        if (m.index === undefined) continue;
+
+        const rawClass = m[1];
+        const rawSlug = m[2];
+
+        // Reject unknown classes — the LLM hallucinated or the user
+        // typed a fake citation. Row 35c never gets a chance to make
+        // a bogus hover-card; row 35b never wastes a DB hit.
+        if (!KNOWN_CLASSES.has(rawClass)) continue;
+
+        const trimmedSlug = trimTrailingPunctuation(rawSlug);
+        if (trimmedSlug.length === 0) continue;
+
+        // Adjust offsets so the trimmed slug is what we report. The
+        // matched `m[0]` is `kb:{class}/{rawSlug}` (length = 3 +
+        // rawClass.length + 1 + rawSlug.length). Trimming drops only
+        // from the end of `rawSlug`, so the raw output is the same
+        // string with the trimmed suffix removed.
+        const droppedChars = rawSlug.length - trimmedSlug.length;
+        const fullLength = m[0].length - droppedChars;
+        const raw = m[0].slice(0, fullLength);
+
+        out.push({
+            raw,
+            cls: rawClass as KbDocumentClass,
+            slug: trimmedSlug,
+            startOffset: m.index,
+            endOffset: m.index + fullLength,
+        });
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary
- EW-641 Phase 2/c row 35a — pure `parseKbCitations(text: string): KbCitation[]` in the agent services barrel. Mirror of row 34a's `parseKbMentions` for the assistant-side `kb:{class}/{slug}` token format that row 34d's prompt instructs the LLM to emit.
- Validates `{class}` against `KB_DOCUMENT_CLASSES` whitelist (hallucinated classes silently rejected so they don't surface in the row 35c hover-card).
- Whole-token boundary at start blocks: leading `@` (reserved for row 34a mention format) and word-char prefixes (`user1kb:` rejected). Punctuation/`.`/`/`/whitespace/start-of-string all accept.
- Trailing punctuation `.`, `-`, `_`, `/` stripped from slug (sentence-final periods don't get absorbed; mid-slug dots like `v2.1` survive).
- Returns `{raw, cls: KbDocumentClass, slug, startOffset, endOffset}` so the row 35d renderer can `splice` `<CitationHover>` over the exact textual span.

## Test plan
- [x] `pnpm jest kb-citation-parser.spec.ts` — 33/33 green
- [x] `pnpm build --filter @ever-works/agent` — clean (DTS emit succeeds)
- [x] `prettier@3.7.4 --write` clean
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added citation extraction from assistant messages for knowledge base references, including validation and accurate offset tracking.

* **Tests**
  * Comprehensive test coverage added for citation parsing functionality, including edge cases and realistic message scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->