### PR TITLE
feat(agent): KbMentionResolverService.resolveCitations — row 35b

### DIFF
--- a/packages/agent/src/services/__tests__/kb-mention-resolver.service.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-mention-resolver.service.spec.ts
@@ -3,7 +3,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { KbMentionResolverService } from '../kb-mention-resolver.service';
 import { KnowledgeBaseService } from '../knowledge-base.service';
 import type { KbMention } from '../kb-mention-parser';
-import type { KbDocumentBodyDto } from '@ever-works/contracts';
+import type { KbCitation } from '../kb-citation-parser';
+import type { KbDocumentBodyDto, KbDocumentClass } from '@ever-works/contracts';
 
 const WORK_ID = 'work-1';
 const USER_ID = 'user-1';
@@ -11,6 +12,17 @@ const USER_ID = 'user-1';
 function mention(reference: string, startOffset = 0): KbMention {
     const raw = `@kb:${reference}`;
     return { raw, reference, startOffset, endOffset: startOffset + raw.length };
+}
+
+function citation(cls: KbDocumentClass, slug: string, startOffset = 0): KbCitation {
+    const raw = `kb:${cls}/${slug}`;
+    return {
+        raw,
+        cls,
+        slug,
+        startOffset,
+        endOffset: startOffset + raw.length,
+    };
 }
 
 function buildDoc(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
@@ -203,6 +215,100 @@ describe('KbMentionResolverService', () => {
             ]);
             expect(out).toHaveLength(2);
             expect(out.every((r) => r.document === null)).toBe(true);
+        });
+    });
+
+    // EW-641 Phase 2/c row 35b — bridges row 35a `parseKbCitations`
+    // output to the existing `resolveMentions` machinery so the
+    // `<CitationHover>` UI (row 35c) gets a `ResolvedKbCitation[]`
+    // shape to render. Each citation is synthesized into a
+    // `KbMention` (`reference = ${cls}/${slug}`); dedup behavior is
+    // inherited from `resolveMentions`.
+    describe('resolveCitations (row 35b)', () => {
+        it('returns [] for an empty citation list (skips KB calls)', async () => {
+            const out = await service.resolveCitations(WORK_ID, USER_ID, []);
+            expect(out).toEqual([]);
+            expect(kbService.getDocument).not.toHaveBeenCalled();
+        });
+
+        it('resolves a single citation to a document and pairs it back to the originating citation', async () => {
+            const doc = buildDoc({ id: 'd1', path: 'brand/voice.md', slug: 'voice' });
+            kbService.getDocument.mockResolvedValueOnce(doc);
+
+            const c = citation('brand', 'voice', 12);
+            const out = await service.resolveCitations(WORK_ID, USER_ID, [c]);
+
+            expect(out).toHaveLength(1);
+            expect(out[0].citation).toBe(c);
+            expect(out[0].document).toBe(doc);
+            // Citation `kb:brand/voice` → synthesized reference `brand/voice`
+            // — `getDocument` receives the same path it would for the
+            // row 34a `@kb:brand/voice` user-input mention.
+            expect(kbService.getDocument).toHaveBeenCalledWith(WORK_ID, 'brand/voice', USER_ID);
+        });
+
+        it('preserves textual order across multiple citations', async () => {
+            const d1 = buildDoc({ id: 'd1', path: 'brand/voice.md' });
+            const d2 = buildDoc({ id: 'd2', path: 'legal/terms.md' });
+            kbService.getDocument.mockResolvedValueOnce(d1).mockResolvedValueOnce(d2);
+
+            const c1 = citation('brand', 'voice', 0);
+            const c2 = citation('legal', 'terms', 30);
+            const out = await service.resolveCitations(WORK_ID, USER_ID, [c1, c2]);
+
+            expect(out).toHaveLength(2);
+            expect(out[0].citation).toBe(c1);
+            expect(out[0].document).toBe(d1);
+            expect(out[1].citation).toBe(c2);
+            expect(out[1].document).toBe(d2);
+        });
+
+        it('returns null doc for an unknown citation (preserves the citation row)', async () => {
+            // Direct miss → `.md` retry miss (synthesized reference
+            // `brand/ghost` has no dot, so the `.md` retry fires).
+            kbService.getDocument
+                .mockRejectedValueOnce(new NotFoundException('miss'))
+                .mockRejectedValueOnce(new NotFoundException('miss'));
+
+            const c = citation('brand', 'ghost');
+            const out = await service.resolveCitations(WORK_ID, USER_ID, [c]);
+
+            expect(out).toHaveLength(1);
+            expect(out[0].citation).toBe(c);
+            expect(out[0].document).toBeNull();
+        });
+
+        it('dedupes by document.id when two citations point at the same doc (first occurrence wins)', async () => {
+            const doc = buildDoc({ id: 'd1', path: 'brand/voice.md' });
+            kbService.getDocument.mockResolvedValueOnce(doc).mockResolvedValueOnce(doc);
+
+            const c1 = citation('brand', 'voice', 0);
+            const c2 = citation('brand', 'voice', 50);
+            const out = await service.resolveCitations(WORK_ID, USER_ID, [c1, c2]);
+
+            // Inherits `resolveMentions` dedup: second occurrence drops.
+            expect(out).toHaveLength(1);
+            expect(out[0].citation).toBe(c1);
+            expect(out[0].document).toBe(doc);
+        });
+
+        it('mixes resolvable + missing in a single batch and keeps both citation rows', async () => {
+            const d1 = buildDoc({ id: 'd1' });
+            kbService.getDocument
+                .mockResolvedValueOnce(d1)
+                // ghost — direct miss + .md retry miss
+                .mockRejectedValueOnce(new NotFoundException('miss'))
+                .mockRejectedValueOnce(new NotFoundException('miss'));
+
+            const c1 = citation('brand', 'voice', 0);
+            const c2 = citation('legal', 'ghost', 30);
+            const out = await service.resolveCitations(WORK_ID, USER_ID, [c1, c2]);
+
+            expect(out).toHaveLength(2);
+            expect(out[0].citation).toBe(c1);
+            expect(out[0].document).toBe(d1);
+            expect(out[1].citation).toBe(c2);
+            expect(out[1].document).toBeNull();
         });
     });
 });

--- a/packages/agent/src/services/kb-mention-resolver.service.ts
+++ b/packages/agent/src/services/kb-mention-resolver.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import type { KbDocumentBodyDto } from '@ever-works/contracts';
 import { KnowledgeBaseService } from './knowledge-base.service';
 import type { KbMention } from './kb-mention-parser';
+import type { KbCitation } from './kb-citation-parser';
 
 /**
  * EW-641 Phase 2/c row 34b — resolves parsed `@kb:` mentions
@@ -50,6 +51,21 @@ export interface ResolvedKbMention {
     readonly document: KbDocumentBodyDto | null;
 }
 
+/**
+ * Result row from `KbMentionResolverService.resolveCitations`
+ * (EW-641 Phase 2/c row 35b).
+ *
+ * Companion to `ResolvedKbMention`: pairs an assistant-side
+ * `kb:{class}/{slug}` citation (parsed by row 35a's `parseKbCitations`)
+ * with the resolved `KbDocumentBodyDto`, or `null` when the citation
+ * doesn't match any visible doc. Row 35c `<CitationHover>` consumes
+ * this shape to render the hover-card content.
+ */
+export interface ResolvedKbCitation {
+    readonly citation: KbCitation;
+    readonly document: KbDocumentBodyDto | null;
+}
+
 @Injectable()
 export class KbMentionResolverService {
     private readonly logger = new Logger(KbMentionResolverService.name);
@@ -90,6 +106,78 @@ export class KbMentionResolverService {
             out.push({ mention, document: doc });
         }
         return out;
+    }
+
+    /**
+     * Resolve every parsed assistant-text citation
+     * (`kb:{class}/{slug}` token from row 35a) to its KB document
+     * (or `null` if the citation doesn't match any visible doc).
+     *
+     * Implementation strategy (row 35b): synthesize a `KbMention`
+     * for each citation with `reference = ${cls}/${slug}`, delegate
+     * to `resolveMentions`, then re-pair each resolved entry back
+     * to its originating citation via object identity on the
+     * `mention` field. This keeps a single resolution path (one
+     * `.md`-retry policy, one graceful-degradation contract, one
+     * dedup-by-`document.id` rule) instead of duplicating logic.
+     *
+     * @param workId - Work scope for the lookup.
+     * @param userId - User performing the lookup; `getDocument`
+     *   gates on `ensureCanView` for this user, so an unauthorized
+     *   citation yields `null` instead of a leak.
+     * @param citations - Parsed citations from row 35a's
+     *   `parseKbCitations`.
+     * @returns Resolved entries in textual order, deduplicated by
+     *   `document.id` (first occurrence wins — inherits the dedup
+     *   semantics from `resolveMentions`).
+     */
+    async resolveCitations(
+        workId: string,
+        userId: string,
+        citations: ReadonlyArray<KbCitation>,
+    ): Promise<ResolvedKbCitation[]> {
+        if (citations.length === 0) return [];
+
+        // Build parallel arrays so we can re-pair via object identity
+        // on the `mention` field that `resolveMentions` preserves in
+        // its returned entries (see the `out.push({ mention, ... })`
+        // line above — same KbMention instance is threaded through).
+        const synthesizedMentions: KbMention[] = citations.map((c) =>
+            this.synthesizeMentionFromCitation(c),
+        );
+        const mentionToCitation = new Map<KbMention, KbCitation>();
+        for (let i = 0; i < synthesizedMentions.length; i++) {
+            mentionToCitation.set(synthesizedMentions[i], citations[i]);
+        }
+
+        const resolved = await this.resolveMentions(workId, userId, synthesizedMentions);
+
+        // `resolveMentions` preserves input order with later duplicates
+        // dropped; the surviving entries carry the EXACT KbMention
+        // objects we passed in, so identity lookup recovers the
+        // originating citation safely.
+        return resolved.map((r) => ({
+            citation: mentionToCitation.get(r.mention) as KbCitation,
+            document: r.document,
+        }));
+    }
+
+    /**
+     * Build a `KbMention` shell from a `KbCitation` so the existing
+     * `resolveMentions` plumbing (lookup → `.md` retry → exception
+     * swallow → dedup) handles both surfaces. `reference` is the
+     * canonical `${cls}/${slug}` path; `raw` adds the `@kb:` prefix
+     * so the synthesized mention is structurally a valid output of
+     * row 34a's parser (helpful for logging consistency).
+     */
+    private synthesizeMentionFromCitation(citation: KbCitation): KbMention {
+        const reference = `${citation.cls}/${citation.slug}`;
+        return {
+            raw: `@kb:${reference}`,
+            reference,
+            startOffset: citation.startOffset,
+            endOffset: citation.endOffset,
+        };
     }
 
     /**


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/c **row 35b**. Bridges row 35a's `parseKbCitations` output to the existing `resolveMentions` machinery so row 35c's `<CitationHover>` UI has `KbDocumentBodyDto` data to render in popovers.
- New `resolveCitations(workId, userId, citations: KbCitation[]): Promise<ResolvedKbCitation[]>` method on `KbMentionResolverService`. Synthesizes a `KbMention` per citation (`reference = ${cls}/${slug}`), delegates to `resolveMentions`, then re-pairs each resolved entry back to its originating `KbCitation` via object-identity lookup on the threaded `mention` field.
- Single resolution path → shared `.md`-retry policy + graceful-degradation contract + dedup-by-`document.id` rule between user-input mentions (row 34c) and assistant-text citations (row 35c).

## Public API addition

```ts
export interface ResolvedKbCitation {
    readonly citation: KbCitation;
    readonly document: KbDocumentBodyDto | null;
}

async resolveCitations(
    workId: string,
    userId: string,
    citations: ReadonlyArray<KbCitation>,
): Promise<ResolvedKbCitation[]>
```

## Tests

6 new jest cases inside the existing `KbMentionResolverService` describe:
1. empty citation list → \`[]\` (no KB calls)
2. single citation → resolves doc, pairs back to originating citation
3. multiple citations → ordered + correct citation-doc pairing
4. unknown citation → null doc, citation row preserved
5. dedup by doc.id when two citations point at same doc (first occurrence wins, inherits resolveMentions semantics)
6. mixed resolvable + missing in one batch → both rows preserved

18/18 mention-resolver spec green (12 prior + 6 new). Full DTS build clean.

## Test plan

- [x] \`pnpm jest --testPathPatterns='kb-mention-resolver'\` green
- [x] \`npx tsc -p tsconfig.types.json\` clean
- [x] prettier@3.7.4 format check passes
- [ ] Drives CI green on PR

## Up next

Row 35c — \`<CitationHover>\` React component in \`apps/web/src/components/conversation/\` that consumes \`resolveCitations\`. Row 35d — conversation message renderer wires the row 35a parser + row 35c hover-card together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KB citation resolution functionality supporting batch processing with proper deduplication and citation-to-document association.

* **Tests**
  * Comprehensive test coverage for citation resolution including empty inputs, single/multi-citation handling, unresolved citations, and deduplication scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->