### PR TITLE
feat(web): KbCitationHover — kb:{class}/{slug} hover popover (row 35c)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2757,6 +2757,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2757,6 +2757,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2757,6 +2757,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2785,6 +2785,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2757,6 +2757,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2784,6 +2784,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2757,6 +2757,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2540,6 +2540,12 @@
                         "agents": "Agents"
                     }
                 },
+                "citation": {
+                    "loading": "Loading citation…",
+                    "missing": "Citation \"{raw}\" not found in this knowledge base.",
+                    "error": "Failed to resolve citation ({error}).",
+                    "open": "Open document"
+                },
                 "history": {
                     "title": "Document history",
                     "dialogLabel": "Knowledge Base document history",

--- a/apps/web/src/app/api/works/[id]/kb/citations/[cls]/[...slug]/route.ts
+++ b/apps/web/src/app/api/works/[id]/kb/citations/[cls]/[...slug]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = {
+    params: Promise<{ id: string; cls: string; slug: string[] }>;
+};
+
+/**
+ * EW-641 Phase 2/c row 35c — single-citation resolution proxy for the
+ * `<KbCitationHover>` client component.
+ *
+ * `GET /api/works/:id/kb/citations/:cls/:...slug`
+ *   200 → `{ document: KbDocumentBodyDto }` when the citation resolves,
+ *   200 → `{ document: null }` when no visible KB doc matches (404 from
+ *         upstream is rewritten to a 200+null so the popover can render
+ *         a clean "not found" affordance without a fetch error path),
+ *   401 → forwards the upstream auth failure verbatim,
+ *   5xx → forwards upstream errors verbatim (popover renders error state).
+ *
+ * Slug resolution order — matches row 35b's `KbMentionResolverService`
+ * resolveOne contract so a citation rendered by the LLM resolves the
+ * same way as the row 34a `@kb:` user-input mention path:
+ *  1. Try `<cls>/<slugSegments>.md` first (canonical stored form for
+ *     user-authored docs — the row 17 wikilink picker elides `.md`,
+ *     so the LLM is likely to mirror that pattern when citing).
+ *  2. If 404, fall back to `<cls>/<slugSegments>` as-is (covers UUIDs +
+ *     agent-generated output paths that may not carry `.md`).
+ *  3. If both miss → `{ document: null }`.
+ *
+ * Mirrors `kb/search/route.ts` shape: server-side JWT cookie forward,
+ * `cache: 'no-store'`, content-type passthrough for non-success replies.
+ */
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+    const { id, cls, slug } = await params;
+
+    // Defensive: empty class or empty slug → nothing meaningful to resolve.
+    const slugJoined = (slug ?? []).filter((seg) => seg && seg.length > 0).join('/');
+    if (!cls || cls.length === 0 || slugJoined.length === 0) {
+        return NextResponse.json({ document: null }, { status: 200 });
+    }
+
+    const token = await getAuthAccessCookie();
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    // Try canonical `.md` first, then bare `<cls>/<slug>` (row 35b parity).
+    const hasExtension = /\.[A-Za-z0-9]+$/.test(slugJoined);
+    const attempts = hasExtension
+        ? [`${cls}/${slugJoined}`]
+        : [`${cls}/${slugJoined}.md`, `${cls}/${slugJoined}`];
+
+    let lastUpstream: Response | null = null;
+    for (const path of attempts) {
+        const upstream = await fetch(
+            `${API_URL}/works/${encodeURIComponent(id)}/kb/documents/${encodeURIComponent(path)}`,
+            { method: 'GET', headers, cache: 'no-store' },
+        );
+        if (upstream.ok) {
+            const json = await upstream.json().catch(() => null);
+            return NextResponse.json({ document: json ?? null }, { status: 200 });
+        }
+        lastUpstream = upstream;
+        // 404 → keep trying the next path. Any other status (401/403/5xx)
+        // is upstream's verdict — surface it immediately rather than
+        // firing speculative retries against auth/quota walls.
+        if (upstream.status !== 404) break;
+    }
+
+    if (lastUpstream && lastUpstream.status === 404) {
+        // Distinct from a fetch-error: the proxy successfully reached
+        // the API and the citation simply doesn't point at a visible
+        // doc. Row 35c's popover surfaces this as `data-status="missing"`.
+        return NextResponse.json({ document: null }, { status: 200 });
+    }
+
+    if (lastUpstream) {
+        const upstreamContentType = lastUpstream.headers.get('content-type') ?? 'application/json';
+        const text = await lastUpstream.text().catch(() => '');
+        return new Response(text, {
+            status: lastUpstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+
+    // Should be unreachable (loop ran at least once) — fall through to
+    // a clean "missing" response.
+    return NextResponse.json({ document: null }, { status: 200 });
+}

--- a/apps/web/src/components/works/detail/kb/KbCitationHover.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationHover.tsx
@@ -1,0 +1,302 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { KbDocumentBodyDto, KbDocumentClass } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 2/c row 35c — hover-card for assistant-text
+ * `kb:{class}/{slug}` citation tokens.
+ *
+ * Wraps a single citation span in the conversation message renderer
+ * (row 35d will lift the row 35a `parseKbCitations` output and emit
+ * one `<KbCitationHover>` per token). On hover, debounced 150 ms to
+ * avoid storming the resolver as the user scrolls, the component
+ * fetches `/api/works/:id/kb/citations/:cls/:...slug` (row 35c proxy
+ * route — tries `.md` first, falls back to bare path; mirrors row
+ * 35b's `KbMentionResolverService.resolveOne` semantics).
+ *
+ * The popover surface is a plain absolutely-positioned `<div role="tooltip">`
+ * — no Radix / HeadlessUI dep, consistent with the lightweight
+ * `KbSearchPalette` approach (PR #938). The popover stays open while
+ * either the wrapper span OR the popover itself is hovered/focused
+ * so users can navigate to the resolved doc via the in-popover link.
+ *
+ * Selectors locked for Playwright A18 (row 43) + row 35 future e2e:
+ *  - `kb-citation-hover` (the wrapper span — always rendered, with
+ *    `data-cls={cls}` + `data-slug={slug}` + `data-open=<bool>`),
+ *  - `kb-citation-popover` (the popover root — rendered only while
+ *    open, with `data-status={loading|resolved|missing|error}`),
+ *  - `kb-citation-popover-title` / `-class` / `-path` / `-snippet` /
+ *    `-link` (resolved-state slots),
+ *  - `kb-citation-popover-loading` / `-missing` / `-error` (non-
+ *    resolved-state copy).
+ *
+ * Snippet length is capped at 240 chars + ellipsis so the popover
+ * stays small. The full body lives one click away via the
+ * `kb-citation-popover-link` to `/works/:id/kb/:cls/:slug`.
+ */
+
+/** Maximum snippet chars in the popover before truncating with `…`. */
+const SNIPPET_CHAR_CAP = 240;
+
+/** Hover debounce — wait this long after `pointerenter` before fetching. */
+const HOVER_DEBOUNCE_MS = 150;
+
+/** Default popover route prefix — overridable so the component can be
+ *  remounted under a different locale/route shell without surgery. */
+const DEFAULT_KB_ROUTE_PREFIX = '/works';
+
+export interface KbCitationHoverProps {
+    /** Owning Work scope. Used for the resolution fetch + the popover link. */
+    workId: string;
+    /** Class segment (`brand` / `legal` / etc — validated by row 35a parser). */
+    cls: KbDocumentClass;
+    /** Slug segment (`voice`, `terms`, `research/v2.1`, …). */
+    slug: string;
+    /** Raw matched text from row 35a (defaults to `kb:{cls}/{slug}` if absent). */
+    raw?: string;
+    /** Override the 150 ms debounce — used by the unit spec. */
+    debounceMs?: number;
+    /** Override the `/works` route prefix — used by the unit spec / locale shells. */
+    routePrefix?: string;
+}
+
+type FetchState =
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'resolved'; document: KbDocumentBodyDto }
+    | { status: 'missing' }
+    | { status: 'error'; error: string };
+
+interface CitationResolveResponse {
+    document: KbDocumentBodyDto | null;
+}
+
+/** Compute the popover snippet from the resolved doc body. */
+function buildSnippet(body: string | null | undefined): string {
+    if (!body) return '';
+    const trimmed = body.trim();
+    if (trimmed.length <= SNIPPET_CHAR_CAP) return trimmed;
+    return `${trimmed.slice(0, SNIPPET_CHAR_CAP)}…`;
+}
+
+export function KbCitationHover({
+    workId,
+    cls,
+    slug,
+    raw,
+    debounceMs = HOVER_DEBOUNCE_MS,
+    routePrefix = DEFAULT_KB_ROUTE_PREFIX,
+}: KbCitationHoverProps) {
+    const t = useTranslations('dashboard.workDetail.kb.citation');
+    const [open, setOpen] = useState(false);
+    const [state, setState] = useState<FetchState>({ status: 'idle' });
+    const fetchedRef = useRef(false);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+    const wrapperRef = useRef<HTMLSpanElement | null>(null);
+    const popoverRef = useRef<HTMLDivElement | null>(null);
+    const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const display = raw ?? `kb:${cls}/${slug}`;
+
+    const runFetch = useCallback(() => {
+        if (fetchedRef.current) {
+            // Already resolved (or in-flight) for this citation — keep the
+            // existing state when the hover re-opens the popover.
+            return;
+        }
+        fetchedRef.current = true;
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+        setState({ status: 'loading' });
+        void (async () => {
+            try {
+                const slugPath = encodeURIComponent(slug);
+                const response = await fetch(
+                    `/api/works/${encodeURIComponent(workId)}/kb/citations/${encodeURIComponent(cls)}/${slugPath}`,
+                    { signal: controller.signal, cache: 'no-store' },
+                );
+                if (!response.ok) {
+                    setState({ status: 'error', error: `HTTP ${response.status}` });
+                    return;
+                }
+                const json = (await response.json()) as CitationResolveResponse;
+                if (!json || json.document === null) {
+                    setState({ status: 'missing' });
+                    return;
+                }
+                setState({ status: 'resolved', document: json.document });
+            } catch (error) {
+                if ((error as Error).name === 'AbortError') return;
+                setState({
+                    status: 'error',
+                    error: error instanceof Error ? error.message : 'fetch-failed',
+                });
+                // Allow a retry on the next hover so a transient blip
+                // doesn't permanently mark this citation un-resolvable.
+                fetchedRef.current = false;
+            }
+        })();
+    }, [workId, cls, slug]);
+
+    const armOpen = useCallback(() => {
+        if (closeTimerRef.current !== null) {
+            clearTimeout(closeTimerRef.current);
+            closeTimerRef.current = null;
+        }
+        if (debounceRef.current !== null) {
+            clearTimeout(debounceRef.current);
+        }
+        debounceRef.current = setTimeout(() => {
+            setOpen(true);
+            runFetch();
+        }, debounceMs);
+    }, [debounceMs, runFetch]);
+
+    const disarmOpen = useCallback(() => {
+        if (debounceRef.current !== null) {
+            clearTimeout(debounceRef.current);
+            debounceRef.current = null;
+        }
+        // Small grace period so a tiny mouse-out-mouse-back into the
+        // popover doesn't tear it down. Plays nicely with users scrubbing
+        // across a long sentence of citations.
+        closeTimerRef.current = setTimeout(() => setOpen(false), 80);
+    }, []);
+
+    // Click outside / Escape closes immediately.
+    useEffect(() => {
+        if (!open) return;
+        function onDocPointerDown(event: PointerEvent) {
+            const target = event.target as Node | null;
+            if (!target) return;
+            if (wrapperRef.current?.contains(target)) return;
+            if (popoverRef.current?.contains(target)) return;
+            setOpen(false);
+        }
+        function onKey(event: KeyboardEvent) {
+            if (event.key === 'Escape') setOpen(false);
+        }
+        document.addEventListener('pointerdown', onDocPointerDown);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('pointerdown', onDocPointerDown);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [open]);
+
+    // Clear pending timers on unmount.
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+            if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current);
+            abortRef.current?.abort();
+        };
+    }, []);
+
+    const resolvedDoc = state.status === 'resolved' ? state.document : null;
+    const docHref = resolvedDoc
+        ? `${routePrefix}/${encodeURIComponent(workId)}/kb/${encodeURIComponent(cls)}/${encodeURIComponent(slug)}`
+        : null;
+
+    return (
+        <span
+            ref={wrapperRef}
+            data-testid="kb-citation-hover"
+            data-cls={cls}
+            data-slug={slug}
+            data-open={open ? 'true' : 'false'}
+            className="relative inline-block"
+            onPointerEnter={armOpen}
+            onPointerLeave={disarmOpen}
+            onFocus={armOpen}
+            onBlur={disarmOpen}
+            tabIndex={0}
+        >
+            <span
+                className={cn(
+                    'cursor-help underline decoration-dotted underline-offset-2',
+                    'text-text-primary dark:text-text-primary-dark',
+                    'hover:bg-card-hover/40 dark:hover:bg-card-primary-dark/30 rounded-sm px-0.5',
+                )}
+            >
+                {display}
+            </span>
+            {open ? (
+                <div
+                    ref={popoverRef}
+                    role="tooltip"
+                    data-testid="kb-citation-popover"
+                    data-status={state.status === 'idle' ? 'loading' : state.status}
+                    className={cn(
+                        'absolute left-0 top-full z-50 mt-1 w-72 rounded-md border p-3 text-xs shadow-md',
+                        'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                        'text-text-primary dark:text-text-primary-dark',
+                    )}
+                    onPointerEnter={armOpen}
+                    onPointerLeave={disarmOpen}
+                >
+                    {(state.status === 'idle' || state.status === 'loading') && (
+                        <div data-testid="kb-citation-popover-loading">{t('loading')}</div>
+                    )}
+                    {state.status === 'missing' && (
+                        <div data-testid="kb-citation-popover-missing">
+                            {t('missing', { raw: display })}
+                        </div>
+                    )}
+                    {state.status === 'error' && (
+                        <div data-testid="kb-citation-popover-error">
+                            {t('error', { error: state.error })}
+                        </div>
+                    )}
+                    {state.status === 'resolved' && resolvedDoc && (
+                        <>
+                            <div
+                                className="text-text-primary dark:text-text-primary-dark text-sm font-semibold"
+                                data-testid="kb-citation-popover-title"
+                            >
+                                {resolvedDoc.title}
+                            </div>
+                            <div
+                                className="text-text-secondary dark:text-text-secondary-dark/80 mt-1 flex items-center gap-2 text-[11px]"
+                                data-testid="kb-citation-popover-meta"
+                            >
+                                <span
+                                    data-testid="kb-citation-popover-class"
+                                    className="bg-card-primary/30 dark:bg-card-primary-dark/50 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide"
+                                >
+                                    {resolvedDoc.class}
+                                </span>
+                                <span
+                                    data-testid="kb-citation-popover-path"
+                                    className="truncate font-mono"
+                                >
+                                    {resolvedDoc.path}
+                                </span>
+                            </div>
+                            <div
+                                data-testid="kb-citation-popover-snippet"
+                                className="text-text-secondary dark:text-text-secondary-dark/80 mt-2 line-clamp-4 whitespace-pre-wrap"
+                            >
+                                {buildSnippet(resolvedDoc.body)}
+                            </div>
+                            {docHref ? (
+                                <a
+                                    href={docHref}
+                                    data-testid="kb-citation-popover-link"
+                                    className="text-link dark:text-link-dark mt-2 inline-block text-[11px] hover:underline"
+                                >
+                                    {t('open')}
+                                </a>
+                            ) : null}
+                        </>
+                    )}
+                </div>
+            ) : null}
+        </span>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbCitationHover.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationHover.unit.spec.tsx
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, args?: Record<string, string | number>) => {
+        if (!args) return key;
+        const interpolated = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${key} ${interpolated}`;
+    },
+}));
+
+import { KbCitationHover } from './KbCitationHover';
+
+const WORK_ID = 'work-1';
+
+function makeDoc(
+    overrides: Partial<{
+        id: string;
+        title: string;
+        class: string;
+        path: string;
+        body: string;
+    }> = {},
+) {
+    return {
+        id: 'doc-1',
+        workId: WORK_ID,
+        organizationId: null,
+        path: 'brand/voice.md',
+        slug: 'voice',
+        title: 'Brand voice',
+        description: null,
+        class: 'brand',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'user',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-05-23T00:00:00.000Z',
+        updatedAt: '2026-05-23T00:00:00.000Z',
+        lastCommitSha: null,
+        body: 'The voice is friendly, terse, and a bit irreverent. Use first-person plural sparingly.',
+        assets: [],
+        ...overrides,
+    };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+describe('KbCitationHover', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        // Real timers throughout — `waitFor` from @testing-library uses
+        // `setTimeout` internally to poll, and mixing fake timers with
+        // an async-fetch flow hangs `waitFor` even when we only fake
+        // `setTimeout`. Tests use `debounceMs={0}` to run the hover
+        // path immediately; the "debounce gates the fetch" timing
+        // surface is covered separately via a dedicated test.
+        fetchMock = vi.fn();
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the citation token with stable testid + data attributes (no fetch on mount)', () => {
+        render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" />);
+        const wrapper = screen.getByTestId('kb-citation-hover');
+        expect(wrapper).toBeTruthy();
+        expect(wrapper.getAttribute('data-cls')).toBe('brand');
+        expect(wrapper.getAttribute('data-slug')).toBe('voice');
+        expect(wrapper.getAttribute('data-open')).toBe('false');
+        expect(wrapper.textContent).toContain('kb:brand/voice');
+        expect(screen.queryByTestId('kb-citation-popover')).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('uses the supplied `raw` text when provided', () => {
+        render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" raw="kb:brand/voice." />);
+        expect(screen.getByTestId('kb-citation-hover').textContent).toContain('kb:brand/voice.');
+    });
+
+    it('does not fetch before the hover debounce fires', async () => {
+        vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+        try {
+            render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" debounceMs={150} />);
+            const wrapper = screen.getByTestId('kb-citation-hover');
+            fireEvent.pointerEnter(wrapper);
+
+            // 50 ms in — below the 150 ms debounce — no fetch yet.
+            await act(async () => {
+                vi.advanceTimersByTime(50);
+            });
+            expect(fetchMock).not.toHaveBeenCalled();
+            expect(wrapper.getAttribute('data-open')).toBe('false');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('opens popover + fetches resolution on pointerenter', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ document: makeDoc() }));
+
+        render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" debounceMs={0} />);
+        const wrapper = screen.getByTestId('kb-citation-hover');
+
+        fireEvent.pointerEnter(wrapper);
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+        const url = fetchMock.mock.calls[0][0] as string;
+        expect(url).toBe('/api/works/work-1/kb/citations/brand/voice');
+
+        await waitFor(() => {
+            const popover = screen.getByTestId('kb-citation-popover');
+            expect(popover.getAttribute('data-status')).toBe('resolved');
+        });
+        expect(screen.getByTestId('kb-citation-popover-title').textContent).toBe('Brand voice');
+        expect(screen.getByTestId('kb-citation-popover-class').textContent).toBe('brand');
+        expect(screen.getByTestId('kb-citation-popover-path').textContent).toBe('brand/voice.md');
+        expect(screen.getByTestId('kb-citation-popover-snippet').textContent).toContain(
+            'The voice is friendly',
+        );
+        const link = screen.getByTestId('kb-citation-popover-link') as HTMLAnchorElement;
+        expect(link.getAttribute('href')).toBe('/works/work-1/kb/brand/voice');
+    });
+
+    it('shows missing state when the proxy returns `{ document: null }`', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ document: null }));
+
+        render(<KbCitationHover workId={WORK_ID} cls="legal" slug="ghost" debounceMs={0} />);
+        fireEvent.pointerEnter(screen.getByTestId('kb-citation-hover'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-citation-popover').getAttribute('data-status')).toBe(
+                'missing',
+            );
+        });
+        expect(screen.getByTestId('kb-citation-popover-missing')).toBeTruthy();
+        expect(screen.queryByTestId('kb-citation-popover-title')).toBeNull();
+    });
+
+    it('shows error state when the proxy responds non-2xx', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'boom' }, 500));
+
+        render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" debounceMs={0} />);
+        fireEvent.pointerEnter(screen.getByTestId('kb-citation-hover'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-citation-popover').getAttribute('data-status')).toBe(
+                'error',
+            );
+        });
+        expect(screen.getByTestId('kb-citation-popover-error').textContent).toContain('HTTP 500');
+    });
+
+    it('builds the proxy URL with multi-segment slug', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ document: makeDoc() }));
+        render(
+            <KbCitationHover
+                workId={WORK_ID}
+                cls="research"
+                slug="v2.1/final-draft"
+                debounceMs={0}
+            />,
+        );
+        fireEvent.pointerEnter(screen.getByTestId('kb-citation-hover'));
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+        const url = fetchMock.mock.calls[0][0] as string;
+        // encodeURIComponent encodes `/` to `%2F` so the catch-all
+        // [...slug] segment receives the slug as one dynamic value.
+        expect(url).toBe('/api/works/work-1/kb/citations/research/v2.1%2Ffinal-draft');
+    });
+
+    it('truncates long doc bodies to 240 chars + ellipsis in the popover snippet', async () => {
+        const longBody = 'x'.repeat(500);
+        fetchMock.mockResolvedValueOnce(jsonResponse({ document: makeDoc({ body: longBody }) }));
+        render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" debounceMs={0} />);
+        fireEvent.pointerEnter(screen.getByTestId('kb-citation-hover'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-citation-popover-snippet')).toBeTruthy();
+        });
+        const snippet = screen.getByTestId('kb-citation-popover-snippet').textContent ?? '';
+        expect(snippet.length).toBe(241); // 240 chars + the ellipsis
+        expect(snippet.endsWith('…')).toBe(true);
+    });
+
+    it('Escape closes the popover', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ document: makeDoc() }));
+        render(<KbCitationHover workId={WORK_ID} cls="brand" slug="voice" debounceMs={0} />);
+        fireEvent.pointerEnter(screen.getByTestId('kb-citation-hover'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-citation-popover')).toBeTruthy();
+        });
+        fireEvent.keyDown(document, { key: 'Escape' });
+        await waitFor(() => {
+            expect(screen.queryByTestId('kb-citation-popover')).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/c **row 35c**. New `<KbCitationHover>` client component wraps a single assistant-text `kb:{class}/{slug}` citation token (parsed by row 35a) with a hover-triggered popover that resolves the doc via row 35b's `KbMentionResolverService.resolveCitations` semantics and shows title / class / path / 240-char snippet + a link to the full doc viewer.
- New Next.js proxy `/api/works/[id]/kb/citations/[cls]/[...slug]` mirrors row 35b's `resolveOne` retry contract — `<cls>/<slug>.md` first, then bare `<cls>/<slug>`; upstream 404 rewritten to `{ document: null }` for clean popover-missing state.
- i18n keys added across all 21 locales (`dashboard.workDetail.kb.citation.*`).

## Selectors locked (Playwright A18 / future row 35 e2e)

- `kb-citation-hover` wrapper span (`data-cls` / `data-slug` / `data-open`)
- `kb-citation-popover` root (`data-status={loading\|resolved\|missing\|error}`)
- `kb-citation-popover-{title,class,path,snippet,link}` resolved-state slots
- `kb-citation-popover-{loading,missing,error}` non-resolved-state copy

## Behavior details

- 150 ms `pointerenter` debounce — avoids storming the resolver as the user scrolls past many citations.
- 80 ms `pointerleave` grace period — a tiny mouse-out into the popover doesn't tear it down.
- Per-mount cache — re-hover doesn't refetch; cache resets on `Error` so a transient blip recovers on the next hover.
- ESC + click-outside close the popover immediately.
- 240-char snippet cap with ellipsis keeps the popover compact.

## Tests

9 new vitest cases (KB suite 196/196 green = 187 prior + 9 new):
1. render + stable testid/data-attrs + no fetch on mount
2. `raw` prop passthrough
3. debounce gates the fetch (no fetch before 150 ms)
4. hover → fetch → resolved state + all popover slots populated
5. missing state when proxy returns `{ document: null }`
6. error state on 500
7. multi-segment slug URL builds correctly (`v2.1/final-draft` → `%2F`-encoded path)
8. 240-char body truncation
9. ESC closes the popover

`tsc --noEmit` clean. Prettier@3.7.4 format check passes.

## Lesson recorded

`vi.useFakeTimers()` — even narrowed to `{ toFake: ['setTimeout', 'clearTimeout'] }` — still hangs `@testing-library/react`'s `waitFor` because `waitFor` polls via `setTimeout`. Pattern: use `debounceMs={0}` in fetch-path tests with real timers; only fake timers for the "debounce gate" test that asserts no-fetch before the delay.

## Test plan

- [x] \`npx vitest run apps/web/src/components/works/detail/kb/\` → 196/196 green
- [x] \`npx tsc --noEmit\` → clean
- [x] prettier@3.7.4 --write → no diff
- [ ] CI green on PR

## Up next

Row 35d — Conversation message renderer wires row 35a's `parseKbCitations` + this component together. Surface TBD; will land in a fresh PR alongside the conversation message React tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive citation hover tooltips in Knowledge Base that display document details on hover.
  * Users can now open referenced documents directly from citations.
  * Citation interface now shows loading, missing, and error states.

* **Internationalization**
  * Added citation-related UI text translations for 20+ languages, including Arabic, Chinese, French, German, Japanese, Korean, Portuguese, Russian, Spanish, and more.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->