### PR TITLE
feat(web): KbCitationRenderer + parseKbCitations web port (row 35d)

### DIFF
--- a/apps/web/src/components/works/detail/kb/KbCitationRenderer.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationRenderer.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Fragment, useMemo } from 'react';
+import { parseKbCitations } from '@/lib/kb/parse-kb-citations';
+import { KbCitationHover } from './KbCitationHover';
+
+/**
+ * EW-641 Phase 2/c row 35d — conversation-message renderer that
+ * detects `kb:{class}/{slug}` citation tokens in plain text and
+ * wraps each one in `<KbCitationHover>` (row 35c). Surrounding
+ * text segments render as-is.
+ *
+ * Bridges row 35a's parser (ported to the web side in
+ * `apps/web/src/lib/kb/parse-kb-citations.ts`) and row 35c's
+ * hover-card component so the chat surface can light up citations
+ * end-to-end without further plumbing.
+ *
+ * Scope note: this component takes RAW TEXT. Wrapping a Markdown
+ * surface (ChatMarkdown, MarkdownPreview, etc.) is out of scope —
+ * citations inside code fences would be wrapped too. The intended
+ * consumer is the assistant-message rendering path *before* the
+ * Markdown layer takes over, OR a plain-text surface where the
+ * citation should always be interactive. The follow-up row will
+ * decide whether to introduce a remark plugin so citations inside
+ * Markdown stay live too.
+ *
+ * Selectors locked:
+ *  - `kb-citation-renderer` (root wrapper, with `data-citation-count`).
+ *  - Each citation is a `<KbCitationHover>` (row 35c testids apply).
+ *
+ * Returns the wrapped text inside a `<span>` so callers can drop it
+ * inline anywhere a text node is acceptable. If the text contains
+ * no citations, renders a single `<span>` with the text — same
+ * output shape so swapping `<KbCitationRenderer>` in / out of a
+ * tree doesn't move the layout.
+ */
+
+export interface KbCitationRendererProps {
+    /** Plain text from the assistant message (or any prose surface). */
+    text: string;
+    /** Owning Work scope for citation resolution (passed through). */
+    workId: string;
+}
+
+export function KbCitationRenderer({ text, workId }: KbCitationRendererProps) {
+    const segments = useMemo(() => {
+        const citations = parseKbCitations(text);
+        if (citations.length === 0) {
+            return [{ kind: 'text' as const, value: text }];
+        }
+        const parts: Array<
+            | { kind: 'text'; value: string }
+            | { kind: 'citation'; cls: string; slug: string; raw: string; key: string }
+        > = [];
+        let cursor = 0;
+        citations.forEach((c, i) => {
+            if (c.startOffset > cursor) {
+                parts.push({ kind: 'text', value: text.slice(cursor, c.startOffset) });
+            }
+            parts.push({
+                kind: 'citation',
+                cls: c.cls,
+                slug: c.slug,
+                raw: c.raw,
+                // Keying on offset + index keeps stable identity even
+                // when the same `{cls,slug}` appears multiple times.
+                key: `${c.startOffset}-${i}`,
+            });
+            cursor = c.endOffset;
+        });
+        if (cursor < text.length) {
+            parts.push({ kind: 'text', value: text.slice(cursor) });
+        }
+        return parts;
+    }, [text]);
+
+    const citationCount = segments.filter((s) => s.kind === 'citation').length;
+
+    return (
+        <span data-testid="kb-citation-renderer" data-citation-count={citationCount}>
+            {segments.map((segment, i) => {
+                if (segment.kind === 'text') {
+                    // Use Fragment so the text segment doesn't introduce
+                    // an extra wrapping `<span>` (saves DOM nodes when
+                    // the prose is long).
+                    return <Fragment key={`t-${i}`}>{segment.value}</Fragment>;
+                }
+                return (
+                    <KbCitationHover
+                        key={segment.key}
+                        workId={workId}
+                        cls={segment.cls as Parameters<typeof KbCitationHover>[0]['cls']}
+                        slug={segment.slug}
+                        raw={segment.raw}
+                    />
+                );
+            })}
+        </span>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbCitationRenderer.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationRenderer.unit.spec.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { KbCitationRenderer } from './KbCitationRenderer';
+
+const WORK_ID = 'work-1';
+
+describe('KbCitationRenderer (row 35d)', () => {
+    it('renders plain text unchanged when there are no citations', () => {
+        render(<KbCitationRenderer workId={WORK_ID} text="the assistant says hi, no citations" />);
+        const root = screen.getByTestId('kb-citation-renderer');
+        expect(root.textContent).toBe('the assistant says hi, no citations');
+        expect(root.getAttribute('data-citation-count')).toBe('0');
+        expect(screen.queryAllByTestId('kb-citation-hover')).toHaveLength(0);
+    });
+
+    it('wraps a single citation in <KbCitationHover>', () => {
+        render(<KbCitationRenderer workId={WORK_ID} text="see kb:brand/voice today" />);
+        const root = screen.getByTestId('kb-citation-renderer');
+        expect(root.getAttribute('data-citation-count')).toBe('1');
+        const hover = screen.getByTestId('kb-citation-hover');
+        expect(hover.getAttribute('data-cls')).toBe('brand');
+        expect(hover.getAttribute('data-slug')).toBe('voice');
+        // Inner text of the hover wrapper is the raw citation token.
+        expect(hover.textContent).toContain('kb:brand/voice');
+        // Surrounding text intact.
+        expect(root.textContent).toContain('see ');
+        expect(root.textContent).toContain(' today');
+    });
+
+    it('wraps every citation in textual order, keeping plain text segments between', () => {
+        render(<KbCitationRenderer workId={WORK_ID} text="A kb:brand/voice B kb:legal/terms C" />);
+        expect(screen.getByTestId('kb-citation-renderer').getAttribute('data-citation-count')).toBe(
+            '2',
+        );
+        const hovers = screen.getAllByTestId('kb-citation-hover');
+        expect(hovers).toHaveLength(2);
+        expect(hovers[0].getAttribute('data-cls')).toBe('brand');
+        expect(hovers[1].getAttribute('data-cls')).toBe('legal');
+        // The full text including the surrounding letters survives.
+        expect(screen.getByTestId('kb-citation-renderer').textContent).toBe(
+            'A kb:brand/voice B kb:legal/terms C',
+        );
+    });
+
+    it('skips hallucinated unknown classes (parser drops them)', () => {
+        render(
+            <KbCitationRenderer
+                workId={WORK_ID}
+                text="real: kb:brand/voice and fake: kb:unknown/foo"
+            />,
+        );
+        const hovers = screen.getAllByTestId('kb-citation-hover');
+        expect(hovers).toHaveLength(1);
+        expect(hovers[0].getAttribute('data-cls')).toBe('brand');
+        // The hallucinated text is preserved verbatim in surrounding prose.
+        expect(screen.getByTestId('kb-citation-renderer').textContent).toContain(
+            'fake: kb:unknown/foo',
+        );
+    });
+
+    it('treats @kb: as plain text (that is mention syntax, not citation)', () => {
+        render(<KbCitationRenderer workId={WORK_ID} text="user typed @kb:brand/voice in chat" />);
+        // @kb: prefix is rejected by the parser — no hover wrapped.
+        expect(screen.queryAllByTestId('kb-citation-hover')).toHaveLength(0);
+        expect(screen.getByTestId('kb-citation-renderer').textContent).toBe(
+            'user typed @kb:brand/voice in chat',
+        );
+    });
+
+    it('passes workId down to each hover wrapper (URL constructed in the hover, not here)', () => {
+        // Spot-check via DOM: row 35c renders an <a> when resolved, but
+        // for an unfetched citation we can at least confirm data-cls /
+        // data-slug match what the renderer split out — the workId is
+        // used at fetch time by the hover component, not at render.
+        render(<KbCitationRenderer workId="custom-work" text="kb:legal/terms" />);
+        const hover = screen.getByTestId('kb-citation-hover');
+        expect(hover.getAttribute('data-cls')).toBe('legal');
+        expect(hover.getAttribute('data-slug')).toBe('terms');
+    });
+
+    it('handles back-to-back citations separated only by punctuation', () => {
+        render(<KbCitationRenderer workId={WORK_ID} text="kb:brand/voice, kb:legal/terms." />);
+        const hovers = screen.getAllByTestId('kb-citation-hover');
+        expect(hovers).toHaveLength(2);
+        // The trailing period should not be absorbed into the slug.
+        expect(hovers[1].getAttribute('data-slug')).toBe('terms');
+    });
+
+    it('renders multiline text with citations interleaved', () => {
+        const text = ['Brand: kb:brand/voice', '', 'Legal: kb:legal/terms'].join('\n');
+        render(<KbCitationRenderer workId={WORK_ID} text={text} />);
+        const hovers = screen.getAllByTestId('kb-citation-hover');
+        expect(hovers).toHaveLength(2);
+        // Plain text preserved verbatim (newlines + leading labels).
+        expect(screen.getByTestId('kb-citation-renderer').textContent).toContain('Brand: ');
+        expect(screen.getByTestId('kb-citation-renderer').textContent).toContain('\n\nLegal: ');
+    });
+
+    it('returns a stable DOM shape even for empty text', () => {
+        render(<KbCitationRenderer workId={WORK_ID} text="" />);
+        const root = screen.getByTestId('kb-citation-renderer');
+        expect(root.getAttribute('data-citation-count')).toBe('0');
+        expect(root.textContent).toBe('');
+    });
+});

--- a/apps/web/src/lib/kb/parse-kb-citations.ts
+++ b/apps/web/src/lib/kb/parse-kb-citations.ts
@@ -1,0 +1,102 @@
+import { KB_DOCUMENT_CLASSES, type KbDocumentClass } from '@ever-works/contracts';
+
+/**
+ * EW-641 Phase 2/c row 35d — web-side port of the agent's
+ * `parseKbCitations` (row 35a, PR #983).
+ *
+ * The agent package can't be imported from `apps/web` (web only
+ * depends on `@ever-works/contracts` + `@ever-works/plugin`, and
+ * `@ever-works/agent` pulls in NestJS / TypeORM / BullMQ which
+ * have no business in a browser bundle). This file mirrors the
+ * agent's parser so the row 35d conversation renderer can scan
+ * assistant-text on the client side without a network round-trip.
+ *
+ * Keep this file in lockstep with
+ * `packages/agent/src/services/kb-citation-parser.ts` — the regex,
+ * trim policy, and whitelist must match exactly so the same citation
+ * tokens are recognised on both sides of the API boundary (server-
+ * side resolver inputs from row 35b, client-side hover-card targets
+ * from row 35c).
+ *
+ * **Pure function.** No I/O, no module state. Returns `[]` for
+ * non-string input.
+ */
+
+export interface KbCitation {
+    readonly raw: string;
+    readonly cls: KbDocumentClass;
+    readonly slug: string;
+    readonly startOffset: number;
+    readonly endOffset: number;
+}
+
+/**
+ * Same regex as the agent-side parser:
+ *  - `(?<![@A-Za-z0-9_])` lookbehind blocks leading `@` (that's the
+ *    row 34a user-input mention syntax) and word-char prefixes.
+ *  - `kb:` literal prefix.
+ *  - `([A-Za-z0-9_-]+)` class capture, validated against the
+ *    `KB_DOCUMENT_CLASSES` whitelist post-match.
+ *  - `/` separator.
+ *  - `([A-Za-z0-9/_.\-]+)` slug capture (nested `/` paths + dotted
+ *    version slugs both supported).
+ */
+const KB_CITATION_RE = /(?<![@A-Za-z0-9_])kb:([A-Za-z0-9_-]+)\/([A-Za-z0-9/_.\-]+)/g;
+
+const KNOWN_CLASSES: ReadonlySet<string> = new Set(KB_DOCUMENT_CLASSES);
+
+/**
+ * Strip trailing punctuation (`.`, `-`, `_`, `/`) from the slug —
+ * sentence-final periods don't get absorbed. Mid-slug dots survive
+ * (`research/v2.1`).
+ */
+function trimTrailingPunctuation(slug: string): string {
+    let end = slug.length;
+    while (end > 0) {
+        const ch = slug[end - 1];
+        if (ch === '.' || ch === '-' || ch === '_' || ch === '/') {
+            end--;
+        } else {
+            break;
+        }
+    }
+    return slug.slice(0, end);
+}
+
+/**
+ * Extract every `kb:{class}/{slug}` citation from a piece of text.
+ *
+ * Citations with unknown classes (not in `KB_DOCUMENT_CLASSES`) are
+ * silently rejected — a hallucinated `kb:unknown/whatever` from a
+ * confused LLM should not surface in the hover-card UI. Returns
+ * matches in textual order.
+ */
+export function parseKbCitations(text: string): KbCitation[] {
+    if (typeof text !== 'string' || text.length === 0) return [];
+
+    const out: KbCitation[] = [];
+    for (const m of text.matchAll(KB_CITATION_RE)) {
+        if (m.index === undefined) continue;
+
+        const rawClass = m[1];
+        const rawSlug = m[2];
+
+        if (!KNOWN_CLASSES.has(rawClass)) continue;
+
+        const trimmedSlug = trimTrailingPunctuation(rawSlug);
+        if (trimmedSlug.length === 0) continue;
+
+        const droppedChars = rawSlug.length - trimmedSlug.length;
+        const fullLength = m[0].length - droppedChars;
+        const raw = m[0].slice(0, fullLength);
+
+        out.push({
+            raw,
+            cls: rawClass as KbDocumentClass,
+            slug: trimmedSlug,
+            startOffset: m.index,
+            endOffset: m.index + fullLength,
+        });
+    }
+    return out;
+}

--- a/apps/web/src/lib/kb/parse-kb-citations.unit.spec.ts
+++ b/apps/web/src/lib/kb/parse-kb-citations.unit.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { parseKbCitations, type KbCitation } from './parse-kb-citations';
+
+describe('parseKbCitations (web port — row 35d)', () => {
+    describe('boundary cases', () => {
+        it('returns [] for empty string', () => {
+            expect(parseKbCitations('')).toEqual([]);
+        });
+
+        it('returns [] for whitespace-only input', () => {
+            expect(parseKbCitations('   \n\t  ')).toEqual([]);
+        });
+
+        it('returns [] when there are no citations', () => {
+            expect(parseKbCitations('the assistant says hello, no citations here')).toEqual([]);
+        });
+
+        it('returns [] for non-string input (defensive)', () => {
+            expect(parseKbCitations(null as unknown as string)).toEqual([]);
+            expect(parseKbCitations(undefined as unknown as string)).toEqual([]);
+        });
+    });
+
+    describe('single citation (canonical whitelist)', () => {
+        it('extracts a citation at start of message', () => {
+            const out = parseKbCitations('kb:brand/voice is the source');
+            expect(out).toHaveLength(1);
+            expect(out[0]).toMatchObject({
+                raw: 'kb:brand/voice',
+                cls: 'brand',
+                slug: 'voice',
+                startOffset: 0,
+                endOffset: 14,
+            });
+        });
+
+        it('extracts a citation with class/slug in the middle of prose', () => {
+            const text = 'See kb:brand/voice for tone guidance.';
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(1);
+            expect(out[0].cls).toBe('brand');
+            expect(out[0].slug).toBe('voice');
+            expect(text.slice(out[0].startOffset, out[0].endOffset)).toBe(out[0].raw);
+        });
+
+        it.each([
+            ['brand', 'voice'],
+            ['legal', 'terms'],
+            ['seo', 'meta'],
+            ['style', 'headlines'],
+            ['glossary', 'jargon'],
+            ['competitors', 'list'],
+            ['personas', 'icp'],
+            ['research', 'q1-2026'],
+            ['output', 'report-v1'],
+            ['freeform', 'notes'],
+        ])('accepts canonical class "%s" with slug "%s"', (cls, slug) => {
+            const out = parseKbCitations(`kb:${cls}/${slug}`);
+            expect(out).toHaveLength(1);
+            expect(out[0].cls).toBe(cls);
+            expect(out[0].slug).toBe(slug);
+        });
+
+        it('accepts nested-path slugs (e.g. research/v2.1/draft)', () => {
+            const out = parseKbCitations('kb:research/v2.1/draft says so');
+            expect(out).toHaveLength(1);
+            expect(out[0].slug).toBe('v2.1/draft');
+        });
+    });
+
+    describe('multiple citations', () => {
+        it('extracts every citation in textual order', () => {
+            const text = 'see kb:brand/voice and kb:legal/terms together';
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(2);
+            expect(out[0].cls).toBe('brand');
+            expect(out[1].cls).toBe('legal');
+            expect(out[0].startOffset).toBeLessThan(out[1].startOffset);
+        });
+
+        it('handles back-to-back citations separated by punctuation', () => {
+            const out = parseKbCitations('kb:brand/voice, kb:legal/terms.');
+            expect(out).toHaveLength(2);
+        });
+
+        it('handles citations of the same doc multiple times (no parser dedup)', () => {
+            const out = parseKbCitations('kb:brand/voice ... kb:brand/voice again');
+            expect(out).toHaveLength(2);
+        });
+    });
+
+    describe('rejection paths', () => {
+        it('rejects @kb: prefix (that is row 34a mention syntax, not citation)', () => {
+            const out = parseKbCitations('see @kb:brand/voice please');
+            expect(out).toEqual([]);
+        });
+
+        it('rejects unknown class names (hallucinated by LLM)', () => {
+            const out = parseKbCitations('kb:unknown/whatever and kb:bogus/x');
+            expect(out).toEqual([]);
+        });
+
+        it('rejects word-char prefixes (acme/kb:foo is part of a longer token)', () => {
+            const out = parseKbCitations('user1kb:brand/voice');
+            expect(out).toEqual([]);
+        });
+
+        it('rejects citations where the slug starts with whitespace', () => {
+            const out = parseKbCitations('kb:brand/ voice');
+            expect(out).toEqual([]);
+        });
+    });
+
+    describe('accept paths (non-word prefixes)', () => {
+        it('accepts citations after `.` / `/` / start-of-string / whitespace / paren', () => {
+            const accepts = [
+                'kb:brand/voice', // start
+                '.kb:brand/voice', // dot
+                '/kb:brand/voice', // slash
+                ' kb:brand/voice', // space
+                '(kb:brand/voice', // open paren
+            ];
+            for (const text of accepts) {
+                const out = parseKbCitations(text);
+                expect(out).toHaveLength(1);
+                expect(out[0].cls).toBe('brand');
+            }
+        });
+    });
+
+    describe('trailing punctuation handling', () => {
+        it('strips trailing `.` from the slug (sentence-final period)', () => {
+            const text = 'see kb:brand/voice.';
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(1);
+            expect(out[0].slug).toBe('voice');
+            // Citation starts at index 4 (after "see ") and runs for
+            // `kb:brand/voice`.length (14 chars). The trailing period
+            // gets stripped, so the endOffset stops at the period — not
+            // past it.
+            expect(out[0].startOffset).toBe(4);
+            expect(out[0].endOffset).toBe(4 + 'kb:brand/voice'.length);
+            expect(text.slice(out[0].startOffset, out[0].endOffset)).toBe('kb:brand/voice');
+        });
+
+        it('strips trailing `-` / `_` / `/`', () => {
+            const out = parseKbCitations(
+                'see kb:brand/voice- and kb:legal/terms_ and kb:seo/meta/',
+            );
+            expect(out).toHaveLength(3);
+            expect(out[0].slug).toBe('voice');
+            expect(out[1].slug).toBe('terms');
+            expect(out[2].slug).toBe('meta');
+        });
+
+        it('preserves mid-slug dots (versioned slugs)', () => {
+            const out = parseKbCitations('see kb:research/v2.1 today');
+            expect(out).toHaveLength(1);
+            expect(out[0].slug).toBe('v2.1');
+        });
+    });
+
+    describe('determinism', () => {
+        it('returns identical results on repeated calls', () => {
+            const text = 'kb:brand/voice and kb:legal/terms.';
+            const a: KbCitation[] = parseKbCitations(text);
+            const b: KbCitation[] = parseKbCitations(text);
+            expect(a).toEqual(b);
+        });
+
+        it('slice invariant — text.slice(start, end) === raw for every match', () => {
+            const text = '... kb:brand/voice, kb:research/v2.1, kb:legal/terms.';
+            const out = parseKbCitations(text);
+            for (const c of out) {
+                expect(text.slice(c.startOffset, c.endOffset)).toBe(c.raw);
+            }
+        });
+    });
+
+    describe('multiline + realistic', () => {
+        it('extracts citations across newlines', () => {
+            const text = 'first line kb:brand/voice\nsecond line kb:legal/terms';
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(2);
+        });
+
+        it('handles a realistic assistant message with markdown + citations', () => {
+            const text = [
+                'According to our **brand voice** guide (kb:brand/voice), we should be friendly.',
+                '',
+                'For the legal disclaimer, see kb:legal/terms.',
+                '',
+                'And the research from Q1 is at kb:research/q1-2026.',
+            ].join('\n');
+            const out = parseKbCitations(text);
+            expect(out).toHaveLength(3);
+            expect(out.map((c) => c.slug)).toEqual(['voice', 'terms', 'q1-2026']);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/c **row 35d**. Web-side port of row 35a's `parseKbCitations` parser + new `<KbCitationRenderer>` client component that wraps each matched `kb:{class}/{slug}` token in `<KbCitationHover>` (row 35c) while preserving surrounding text.
- Web can't import `@ever-works/agent` (NestJS / TypeORM / BullMQ deps); the parser is duplicated as a pure web helper. Inline note keeps both files in lockstep.

## Surface added

- \`apps/web/src/lib/kb/parse-kb-citations.ts\` — pure parser. Same regex, same trim policy, same whitelist as the agent-side version.
- \`apps/web/src/components/works/detail/kb/KbCitationRenderer.tsx\` — \`<span data-testid="kb-citation-renderer" data-citation-count={n}>\` with React Fragments for plain text + `<KbCitationHover>` per matched citation.

## Wire-up deferred

The existing chat surface (\`ChatMessageContent\` → \`ChatMarkdown\`) doesn't thread a \`workId\` prop, and citations inside markdown code fences would be wrapped too without a remark plugin. Row 35e will pick up the actual wire-up + markdown-aware seam. The renderer is reusable today on any plain-text surface that knows the owning Work.

## Tests

41 new vitest cases:
- 32 parser-port cases (boundary / canonical whitelist / multi-citation / rejection / accept paths / trailing punctuation / determinism / multiline)
- 9 renderer cases (no-citation passthrough / single / multi-ordered / unknown-class skip / @kb: ignored / workId pass-through / back-to-back / multiline / empty text)

KB suite 237/237 green (196 prior + 41 new). \`tsc --noEmit\` clean. prettier@3.7.4 format check passes.

## Test plan

- [x] \`npx vitest run apps/web/src/lib/kb apps/web/src/components/works/detail/kb/\` → 237/237 green
- [x] \`npx tsc --noEmit\` → clean
- [x] prettier@3.7.4 --write → no diff after format
- [ ] CI green on PR

## Up next

Row 35e — wire \`<KbCitationRenderer>\` into the assistant-message render path in \`ChatMessageContent\` (or a markdown-aware alternative). Once that lands, Phase 2/c is end-to-end complete and row 36 (Phase 2/d agent tools — \`kb_search\`/\`kb_read\`/\`kb_write\`/\`kb_lock\`/\`kb_unlock\` registrations) becomes NEXT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically parsing and rendering knowledge base citations in text. Citations now display as interactive elements with hover information, improving content navigation and citation discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->