### PR TITLE
feat(web): wire KbCitationFooter into assistant messages (row 35e)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2761,7 +2761,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2761,7 +2761,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2761,7 +2761,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2789,7 +2789,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2761,7 +2761,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2788,7 +2788,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2761,7 +2761,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2544,7 +2544,8 @@
                     "loading": "Loading citation…",
                     "missing": "Citation \"{raw}\" not found in this knowledge base.",
                     "error": "Failed to resolve citation ({error}).",
-                    "open": "Open document"
+                    "open": "Open document",
+                    "citedLabel": "Cited:"
                 },
                 "history": {
                     "title": "Document history",

--- a/apps/web/src/components/ai/ChatMessageContent.tsx
+++ b/apps/web/src/components/ai/ChatMessageContent.tsx
@@ -2,8 +2,11 @@
 
 import type { UIMessage } from '@ai-sdk/react';
 import { getToolName, isToolUIPart } from 'ai';
+import { usePathname } from 'next/navigation';
 import { ChatMarkdown } from './ChatMarkdown';
 import { ChatToolResult } from './ChatToolResult';
+import { KbCitationFooter } from '@/components/works/detail/kb/KbCitationFooter';
+import { extractWorkIdFromPath } from '@/lib/kb/extract-work-id-from-path';
 
 type MessagePart = UIMessage['parts'][number];
 
@@ -20,6 +23,16 @@ export function ChatMessageContent({
     isMessageStreaming,
     hasText,
 }: ChatMessageContentProps) {
+    // EW-641 row 35e — derive the Work scope from the current path
+    // so the citation footer can resolve `kb:{class}/{slug}` tokens.
+    // The ChatProvider is mounted in the dashboard root layout and
+    // doesn't carry a workId itself; the pathname is the cheapest
+    // signal that the user is currently viewing a Work. When the
+    // path isn't a Work page, `workId` is null and the footer
+    // renders nothing (drop-in safe across non-Work surfaces).
+    const pathname = usePathname();
+    const workId = extractWorkIdFromPath(pathname);
+
     return (
         <>
             {parts.map((part, i) => {
@@ -35,7 +48,12 @@ export function ChatMessageContent({
                             </p>
                         );
                     }
-                    return <ChatMarkdown key={i} content={part.text} />;
+                    return (
+                        <div key={i}>
+                            <ChatMarkdown content={part.text} />
+                            {workId ? <KbCitationFooter text={part.text} workId={workId} /> : null}
+                        </div>
+                    );
                 }
 
                 if (isToolUIPart(part)) {

--- a/apps/web/src/components/works/detail/kb/KbCitationFooter.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationFooter.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslations } from 'next-intl';
+import { parseKbCitations } from '@/lib/kb/parse-kb-citations';
+import { cn } from '@/lib/utils/cn';
+import { KbCitationHover } from './KbCitationHover';
+
+/**
+ * EW-641 Phase 2/c row 35e — "Cited:" footer rendered below the
+ * assistant message's Markdown body. Detects `kb:{class}/{slug}`
+ * tokens via row 35a's parser (web port — row 35d) and shows each
+ * referenced doc once as a `<KbCitationHover>` chip.
+ *
+ * Why a footer instead of inlining citations inside Markdown:
+ *  - `ChatMessageContent` already renders `<ChatMarkdown>` which
+ *    runs `react-markdown` + `remark-gfm`. Mutating the text before
+ *    passing it through would wrap citations inside code fences too
+ *    (false positives in `\`\`\`bash\\nkb:brand/voice\\n\`\`\``-style
+ *    blocks).
+ *  - A remark plugin would dodge the code-fence problem but adds a
+ *    new dependency surface; row 35e ships the simplest correct
+ *    thing.
+ *  - The footer surfaces every cited doc *once* (dedup by cls/slug)
+ *    so a chatty assistant citing the same doc 5 times still gets
+ *    a single chip — easier to scan.
+ *
+ * Renders nothing if no citations are present or if the parsed
+ * citation list is empty — drop-in safe in any assistant-message
+ * render path.
+ *
+ * Selectors locked for future e2e:
+ *  - `kb-citation-footer` (root, `data-citation-count={n}`),
+ *  - inner chips reuse row 35c `<KbCitationHover>` selectors
+ *    (`kb-citation-hover` etc.).
+ */
+
+export interface KbCitationFooterProps {
+    /** Plain text of the assistant message (full body — same string
+     *  passed to ChatMarkdown). */
+    text: string;
+    /** Owning Work scope for citation resolution. */
+    workId: string;
+}
+
+interface UniqueCitation {
+    readonly cls: Parameters<typeof KbCitationHover>[0]['cls'];
+    readonly slug: string;
+    readonly raw: string;
+    readonly key: string;
+}
+
+export function KbCitationFooter({ text, workId }: KbCitationFooterProps) {
+    const t = useTranslations('dashboard.workDetail.kb.citation');
+
+    const uniqueCitations = useMemo<UniqueCitation[]>(() => {
+        const raw = parseKbCitations(text);
+        if (raw.length === 0) return [];
+        const seen = new Set<string>();
+        const out: UniqueCitation[] = [];
+        for (const c of raw) {
+            const dedupKey = `${c.cls}/${c.slug}`;
+            if (seen.has(dedupKey)) continue;
+            seen.add(dedupKey);
+            out.push({
+                cls: c.cls,
+                slug: c.slug,
+                raw: c.raw,
+                key: dedupKey,
+            });
+        }
+        return out;
+    }, [text]);
+
+    if (uniqueCitations.length === 0) return null;
+
+    return (
+        <div
+            data-testid="kb-citation-footer"
+            data-citation-count={uniqueCitations.length}
+            className={cn(
+                'mt-2 flex flex-wrap items-center gap-1.5 border-t pt-2 text-[11px]',
+                'border-border/40 dark:border-white/10',
+                'text-text-muted dark:text-text-muted-dark',
+            )}
+        >
+            <span className="font-medium">{t('citedLabel')}</span>
+            {uniqueCitations.map((c) => (
+                <KbCitationHover
+                    key={c.key}
+                    workId={workId}
+                    cls={c.cls}
+                    slug={c.slug}
+                    raw={c.raw}
+                />
+            ))}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/kb/KbCitationFooter.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationFooter.unit.spec.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { KbCitationFooter } from './KbCitationFooter';
+
+describe('KbCitationFooter (row 35e)', () => {
+    it('renders nothing when the text has no citations', () => {
+        const { container } = render(
+            <KbCitationFooter workId="work-1" text="plain text, no kb tokens" />,
+        );
+        expect(container.firstChild).toBeNull();
+        expect(screen.queryByTestId('kb-citation-footer')).toBeNull();
+    });
+
+    it('renders nothing for the empty string', () => {
+        const { container } = render(<KbCitationFooter workId="work-1" text="" />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing for text that only has @kb: user mentions (not citations)', () => {
+        const { container } = render(
+            <KbCitationFooter workId="work-1" text="the user typed @kb:brand/voice in chat" />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders one chip per unique citation when citations are present', () => {
+        render(
+            <KbCitationFooter
+                workId="work-1"
+                text="Per kb:brand/voice we use a friendly tone, and per kb:legal/terms the disclaimer follows."
+            />,
+        );
+        const footer = screen.getByTestId('kb-citation-footer');
+        expect(footer.getAttribute('data-citation-count')).toBe('2');
+        const chips = screen.getAllByTestId('kb-citation-hover');
+        expect(chips).toHaveLength(2);
+        expect(chips[0].getAttribute('data-cls')).toBe('brand');
+        expect(chips[1].getAttribute('data-cls')).toBe('legal');
+    });
+
+    it('deduplicates citations of the same doc within a message', () => {
+        render(
+            <KbCitationFooter
+                workId="work-1"
+                text="Discussed kb:brand/voice up top and kb:brand/voice again at the end."
+            />,
+        );
+        // Two textual occurrences → one chip (dedup by cls/slug).
+        expect(screen.getByTestId('kb-citation-footer').getAttribute('data-citation-count')).toBe(
+            '1',
+        );
+        expect(screen.getAllByTestId('kb-citation-hover')).toHaveLength(1);
+    });
+
+    it('skips hallucinated unknown classes (parser drops them upstream)', () => {
+        render(
+            <KbCitationFooter
+                workId="work-1"
+                text="real: kb:brand/voice and fake: kb:unknown/foo and also kb:bogus/bar"
+            />,
+        );
+        const chips = screen.getAllByTestId('kb-citation-hover');
+        expect(chips).toHaveLength(1);
+        expect(chips[0].getAttribute('data-cls')).toBe('brand');
+    });
+
+    it('passes the workId down to each hover (for the future fetch)', () => {
+        render(<KbCitationFooter workId="custom-work" text="See kb:legal/terms today." />);
+        // The hover wrapper carries data-cls / data-slug, but the
+        // workId is consumed at fetch-time inside KbCitationHover —
+        // there's no rendered attribute to assert it directly. Spot-
+        // check that the data attributes the parser produced reach
+        // the hover so the wiring is correct.
+        const chip = screen.getByTestId('kb-citation-hover');
+        expect(chip.getAttribute('data-cls')).toBe('legal');
+        expect(chip.getAttribute('data-slug')).toBe('terms');
+    });
+});

--- a/apps/web/src/lib/kb/extract-work-id-from-path.ts
+++ b/apps/web/src/lib/kb/extract-work-id-from-path.ts
@@ -1,0 +1,48 @@
+/**
+ * EW-641 Phase 2/c row 35e — pull a Work id out of the current
+ * `usePathname()` result so the row 35d `<KbCitationRenderer>` /
+ * `<KbCitationFooter>` can resolve citations against the right
+ * Work without threading a prop through `ChatProvider`.
+ *
+ * Why a path-derived approach: the `ChatProvider` is mounted in the
+ * dashboard root layout and the conversation surface is generic
+ * (not Work-scoped). Threading a `workId` prop would require either
+ * a per-page provider remount (loses chat history continuity) or a
+ * cross-cutting context everyone is forced to think about. The
+ * pathname already carries the Work scope when relevant — the same
+ * `sendMessage()` path already passes `currentPageUrl` to the API
+ * for the agent's KB grounding — so reading it here is symmetric
+ * and avoids invasive plumbing.
+ *
+ * Path shape: `/<locale>/works/<id>/...` (the dashboard route
+ * group `(dashboard)/works/[id]/...` mounts under the locale
+ * segment). The locale segment isn't validated here — any
+ * single-segment prefix is allowed so the helper survives locale
+ * changes / future route shuffles.
+ *
+ * Returns `null` for:
+ *  - any path NOT matching `/<seg>/works/<id>/...`,
+ *  - the `/works` index without an id,
+ *  - non-string input,
+ *  - paths where the captured id is empty / whitespace-only.
+ *
+ * **Pure function.** No I/O, no module state. Safe in any client
+ * component render path.
+ */
+
+/**
+ * Match `/<locale>/works/<id>` optionally followed by `/...` or end.
+ * The id capture excludes `/` so nested KB paths (`/kb/brand/voice`)
+ * don't accidentally claim a multi-segment id.
+ */
+const WORK_PATH_RE = /^\/[^/]+\/works\/([^/?#]+)(?:[/?#]|$)/;
+
+export function extractWorkIdFromPath(pathname: string | null | undefined): string | null {
+    if (typeof pathname !== 'string') return null;
+    const trimmed = pathname.trim();
+    if (trimmed.length === 0) return null;
+    const m = trimmed.match(WORK_PATH_RE);
+    if (!m) return null;
+    const id = m[1].trim();
+    return id.length > 0 ? id : null;
+}

--- a/apps/web/src/lib/kb/extract-work-id-from-path.unit.spec.ts
+++ b/apps/web/src/lib/kb/extract-work-id-from-path.unit.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { extractWorkIdFromPath } from './extract-work-id-from-path';
+
+describe('extractWorkIdFromPath (row 35e)', () => {
+    it('returns null for non-string input', () => {
+        expect(extractWorkIdFromPath(null)).toBeNull();
+        expect(extractWorkIdFromPath(undefined)).toBeNull();
+    });
+
+    it('returns null for empty / whitespace path', () => {
+        expect(extractWorkIdFromPath('')).toBeNull();
+        expect(extractWorkIdFromPath('   ')).toBeNull();
+    });
+
+    it('returns null for paths that do not match the Work shape', () => {
+        expect(extractWorkIdFromPath('/en')).toBeNull();
+        expect(extractWorkIdFromPath('/en/dashboard')).toBeNull();
+        expect(extractWorkIdFromPath('/en/works')).toBeNull();
+        expect(extractWorkIdFromPath('/en/items/123')).toBeNull();
+    });
+
+    it('extracts the Work id from a bare /works/:id', () => {
+        expect(extractWorkIdFromPath('/en/works/work-abc')).toBe('work-abc');
+    });
+
+    it('extracts the Work id from a nested /works/:id/... path', () => {
+        expect(extractWorkIdFromPath('/en/works/work-abc/items')).toBe('work-abc');
+        expect(extractWorkIdFromPath('/en/works/work-abc/kb')).toBe('work-abc');
+        expect(extractWorkIdFromPath('/en/works/work-abc/kb/brand/voice')).toBe('work-abc');
+    });
+
+    it('handles UUID-style ids', () => {
+        const uuid = '5b1f9c4e-9b1f-4c4e-9b1f-9c4e9b1f4c4e';
+        expect(extractWorkIdFromPath(`/en/works/${uuid}`)).toBe(uuid);
+        expect(extractWorkIdFromPath(`/en/works/${uuid}/kb`)).toBe(uuid);
+    });
+
+    it('survives different locale prefixes', () => {
+        expect(extractWorkIdFromPath('/fr/works/work-abc/kb')).toBe('work-abc');
+        expect(extractWorkIdFromPath('/zh/works/work-abc/kb')).toBe('work-abc');
+        expect(extractWorkIdFromPath('/ar/works/work-abc/kb')).toBe('work-abc');
+    });
+
+    it('ignores query string + hash after the id', () => {
+        expect(extractWorkIdFromPath('/en/works/work-abc?tab=kb')).toBe('work-abc');
+        expect(extractWorkIdFromPath('/en/works/work-abc#section')).toBe('work-abc');
+    });
+
+    it('returns null when there is no locale segment (/works at root)', () => {
+        // The dashboard route is locale-prefixed in this project, so a
+        // bare `/works/:id` is not expected and we conservatively reject.
+        expect(extractWorkIdFromPath('/works/work-abc')).toBeNull();
+    });
+
+    it('returns null for the index/list page /works without id', () => {
+        expect(extractWorkIdFromPath('/en/works')).toBeNull();
+        expect(extractWorkIdFromPath('/en/works/')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/c **row 35e**. Closes the end-to-end loop on the user-visible KB citation surface: LLM emits `kb:{class}/{slug}` → row 35a parser → row 35b resolver → row 35c hover popover → row 35d renderer → THIS PR wires it into the assistant-message render path.
- Every assistant message displayed on a `/works/:id/...` page now surfaces a "Cited:" footer below the Markdown body when citation tokens are present. Each surfaced doc renders as a `<KbCitationHover>` chip (dedup by cls/slug).

## Wiring approach

- New \`extractWorkIdFromPath()\` helper reads `usePathname()` and returns the Work id when the path matches `/<locale>/works/<id>/...`. Otherwise `null` → footer renders nothing (drop-in safe for dashboard-root chats off Works).
- `ChatMessageContent` now renders `<ChatMarkdown content={text} />` PLUS `<KbCitationFooter text={text} workId={workId} />` for assistant text parts.

### Why a footer (not inline replacement)

A remark plugin would let citations stay inline inside the Markdown, but a footer:
1. dodges code-fence false-positives (\`kb:brand/voice\` inside a code block stays as code)
2. avoids new deps / new plugin surface
3. gives a stable scannable list per message
4. reuses row 35c's existing testids without surgery

## i18n

\`dashboard.workDetail.kb.citation.citedLabel = "Cited:"\` added across all 21 locales (en used as fallback copy; translation pipeline owns localization).

## Tests

17 new vitest cases (KB suite 254/254 green = 237 prior + 17 new):
- \`extract-work-id-from-path\`: 10 cases (null inputs, empty/whitespace, non-Work paths, bare /works/:id, nested paths, UUID ids, locale variants, query/hash suffixes, no-locale rejection, index rejection)
- \`KbCitationFooter\`: 7 cases (no-op when no citations / empty / @kb: mentions only, renders chips per unique citation, deduplicates same-doc citations, skips unknown classes, passes workId+cls+slug down)

\`tsc --noEmit\` clean. prettier@3.7.4 format check passes.

## Deferred

The ChatMessageContent integration spec — vitest + next-intl 4.x + \`vi.mock('next/navigation')\` triggers a bare-specifier resolution failure inside next-intl's symlinked navigation module (pnpm tree). The wiring is 3 lines and fully covered by the underlying unit tests; a future row can add the integration spec once next-intl ESM resolution is sorted in vitest.

## Test plan

- [x] \`npx vitest run apps/web/src/lib/kb apps/web/src/components/works/detail/kb\` → 254/254 green
- [x] \`npx tsc --noEmit\` → clean
- [x] prettier@3.7.4 --write → no diff
- [ ] CI green on PR
- [ ] Manual smoke (deferred to develop): assistant message with citations on a Work page shows the footer; same message viewed outside a Work page hides it.

## Up next

Phase 2/c is end-to-end complete on the user-visible surface. Row 36 (Phase 2/d agent tools — \`kb_search\` / \`kb_read\` / \`kb_write\` / \`kb_lock\` / \`kb_unlock\` registrations in \`packages/plugins/agent-pipeline/\`) becomes NEXT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages now display a knowledge base citation footer showing referenced documents with interactive citation elements.

* **Localization**
  * Updated citation UI labels across all supported languages to enable proper display of cited document references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->