### PR TITLE
feat(agent): KbAgentToolsService — wraps KnowledgeBaseService (row 36)

### DIFF
--- a/packages/agent/src/services/__tests__/kb-agent-tools.service.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-agent-tools.service.spec.ts
@@ -1,0 +1,325 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { KbAgentToolsService, type KbToolResult } from '../kb-agent-tools.service';
+import { KnowledgeBaseService } from '../knowledge-base.service';
+import type { KbDocumentBodyDto, KbDocumentDto } from '@ever-works/contracts';
+
+const WORK_ID = 'work-1';
+const USER_ID = 'user-1';
+
+/** Type-narrow helpers — TS doesn't always narrow generic
+ *  discriminated unions through plain `if` branches, so we use
+ *  explicit user-defined type guards. Both happy-path and error-
+ *  path tests use these so a wrong variant surfaces as a test
+ *  failure rather than a TS type error. */
+function isOk<T>(r: KbToolResult<T>): r is { ok: true; data: T } {
+    return r.ok;
+}
+
+function expectOk<T>(r: KbToolResult<T>): T {
+    if (!isOk(r)) {
+        throw new Error(`expected ok:true result, got error: ${r.error}`);
+    }
+    return r.data;
+}
+
+function expectErr<T>(r: KbToolResult<T>): string {
+    if (isOk(r)) {
+        throw new Error('expected ok:false result, got data');
+    }
+    return r.error;
+}
+
+function makeBody(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: overrides.id ?? 'doc-1',
+        workId: overrides.workId ?? WORK_ID,
+        organizationId: overrides.organizationId ?? null,
+        path: overrides.path ?? 'brand/voice.md',
+        slug: overrides.slug ?? 'voice',
+        title: overrides.title ?? 'Brand voice',
+        description: overrides.description ?? null,
+        class: overrides.class ?? 'brand',
+        tags: overrides.tags ?? [],
+        categories: overrides.categories ?? [],
+        status: overrides.status ?? 'active',
+        locked: overrides.locked ?? false,
+        lockMode: overrides.lockMode ?? null,
+        language: overrides.language ?? 'en',
+        wordCount: overrides.wordCount ?? null,
+        tokenCount: overrides.tokenCount ?? null,
+        source: overrides.source ?? 'user',
+        sourceUploadId: overrides.sourceUploadId ?? null,
+        sourceUrl: overrides.sourceUrl ?? null,
+        generatedByAgentRunId: overrides.generatedByAgentRunId ?? null,
+        createdById: overrides.createdById ?? null,
+        updatedById: overrides.updatedById ?? null,
+        createdAt: overrides.createdAt ?? '2026-05-23T00:00:00.000Z',
+        updatedAt: overrides.updatedAt ?? '2026-05-23T00:00:00.000Z',
+        lastCommitSha: overrides.lastCommitSha ?? null,
+        body: overrides.body ?? 'body',
+        assets: overrides.assets ?? [],
+    } as KbDocumentBodyDto;
+}
+
+function makeDtoFromBody(b: KbDocumentBodyDto): KbDocumentDto {
+    // Stripped form for the list response (no body / assets).
+    const { body: _b, assets: _a, ...rest } = b;
+    return rest as KbDocumentDto;
+}
+
+describe('KbAgentToolsService', () => {
+    let service: KbAgentToolsService;
+    let kb: {
+        listDocuments: jest.Mock;
+        getDocument: jest.Mock;
+        createDocument: jest.Mock;
+        updateDocument: jest.Mock;
+        lockDocument: jest.Mock;
+        unlockDocument: jest.Mock;
+    };
+
+    beforeEach(async () => {
+        kb = {
+            listDocuments: jest.fn(),
+            getDocument: jest.fn(),
+            createDocument: jest.fn(),
+            updateDocument: jest.fn(),
+            lockDocument: jest.fn(),
+            unlockDocument: jest.fn(),
+        };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [KbAgentToolsService, { provide: KnowledgeBaseService, useValue: kb }],
+        }).compile();
+        service = module.get(KbAgentToolsService);
+    });
+
+    describe('kbSearch', () => {
+        it('returns { ok: true, data: { items, total } } on happy path', async () => {
+            const doc = makeBody({ id: 'd1' });
+            kb.listDocuments.mockResolvedValueOnce({
+                items: [makeDtoFromBody(doc)],
+                total: 1,
+            });
+
+            const result = await service.kbSearch(WORK_ID, USER_ID, { q: 'voice', limit: 5 });
+            const data = expectOk(result);
+            expect(data.total).toBe(1);
+            expect(data.items).toHaveLength(1);
+            expect(kb.listDocuments).toHaveBeenCalledWith(WORK_ID, USER_ID, {
+                q: 'voice',
+                class: undefined,
+                status: undefined,
+                limit: 5,
+            });
+        });
+
+        it('clamps limit to <=50 and defaults to 20 when omitted', async () => {
+            kb.listDocuments.mockResolvedValueOnce({ items: [], total: 0 });
+
+            await service.kbSearch(WORK_ID, USER_ID, { limit: 999 });
+            expect(kb.listDocuments).toHaveBeenLastCalledWith(
+                WORK_ID,
+                USER_ID,
+                expect.objectContaining({ limit: 50 }),
+            );
+
+            kb.listDocuments.mockResolvedValueOnce({ items: [], total: 0 });
+            await service.kbSearch(WORK_ID, USER_ID, {});
+            expect(kb.listDocuments).toHaveBeenLastCalledWith(
+                WORK_ID,
+                USER_ID,
+                expect.objectContaining({ limit: 20 }),
+            );
+
+            kb.listDocuments.mockResolvedValueOnce({ items: [], total: 0 });
+            await service.kbSearch(WORK_ID, USER_ID, { limit: 0 });
+            expect(kb.listDocuments).toHaveBeenLastCalledWith(
+                WORK_ID,
+                USER_ID,
+                expect.objectContaining({ limit: 1 }),
+            );
+        });
+
+        it('returns { ok: false, error } when ensureCanView denies access', async () => {
+            kb.listDocuments.mockRejectedValueOnce(new ForbiddenException('no access'));
+
+            const result = await service.kbSearch(WORK_ID, USER_ID, {});
+            expect(expectErr(result)).toMatch(/no access|Forbidden/);
+        });
+
+        it('forwards optional class + status filters verbatim', async () => {
+            kb.listDocuments.mockResolvedValueOnce({ items: [], total: 0 });
+            await service.kbSearch(WORK_ID, USER_ID, {
+                q: 'foo',
+                class: 'brand',
+                status: 'archived',
+            });
+            expect(kb.listDocuments).toHaveBeenCalledWith(WORK_ID, USER_ID, {
+                q: 'foo',
+                class: 'brand',
+                status: 'archived',
+                limit: 20,
+            });
+        });
+    });
+
+    describe('kbRead', () => {
+        it('returns the doc body on happy path', async () => {
+            const doc = makeBody({ id: 'd1' });
+            kb.getDocument.mockResolvedValueOnce(doc);
+
+            const result = await service.kbRead(WORK_ID, USER_ID, 'brand/voice.md');
+            const data = expectOk(result);
+            expect(data.id).toBe('d1');
+            expect(kb.getDocument).toHaveBeenCalledWith(WORK_ID, 'brand/voice.md', USER_ID);
+        });
+
+        it('returns { ok: false, error } on NotFound', async () => {
+            kb.getDocument.mockRejectedValueOnce(new NotFoundException('missing'));
+
+            const result = await service.kbRead(WORK_ID, USER_ID, 'brand/ghost');
+            expect(expectErr(result)).toContain('missing');
+        });
+    });
+
+    describe('kbWrite', () => {
+        it('updates an existing doc when the path matches', async () => {
+            const existing = makeBody({ id: 'd1', path: 'brand/voice.md' });
+            const updated = makeBody({
+                id: 'd1',
+                path: 'brand/voice.md',
+                title: 'Brand voice v2',
+                body: 'new body',
+            });
+            kb.getDocument.mockResolvedValueOnce(existing);
+            kb.updateDocument.mockResolvedValueOnce(updated);
+
+            const result = await service.kbWrite(WORK_ID, USER_ID, {
+                path: 'brand/voice.md',
+                title: 'Brand voice v2',
+                class: 'brand',
+                body: 'new body',
+            });
+
+            const data = expectOk(result);
+            expect(data.action).toBe('updated');
+            expect(data.document.id).toBe('d1');
+            expect(kb.updateDocument).toHaveBeenCalledWith(
+                WORK_ID,
+                'd1',
+                USER_ID,
+                expect.objectContaining({ title: 'Brand voice v2', body: 'new body' }),
+            );
+            expect(kb.createDocument).not.toHaveBeenCalled();
+        });
+
+        it('creates a new doc when the path does not exist (NotFound)', async () => {
+            const created = makeBody({
+                id: 'd2',
+                path: 'brand/manifesto.md',
+                source: 'agent',
+            });
+            kb.getDocument.mockRejectedValueOnce(new NotFoundException('miss'));
+            kb.createDocument.mockResolvedValueOnce(created);
+
+            const result = await service.kbWrite(WORK_ID, USER_ID, {
+                path: 'brand/manifesto.md',
+                title: 'Brand manifesto',
+                class: 'brand',
+                body: 'hello',
+                generatedByAgentRunId: 'run-99',
+            });
+
+            const data = expectOk(result);
+            expect(data.action).toBe('created');
+            // Source stamped 'agent' + run id forwarded.
+            expect(kb.createDocument).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: WORK_ID,
+                    userId: USER_ID,
+                    path: 'brand/manifesto.md',
+                    title: 'Brand manifesto',
+                    class: 'brand',
+                    body: 'hello',
+                    source: 'agent',
+                    generatedByAgentRunId: 'run-99',
+                }),
+            );
+            expect(kb.updateDocument).not.toHaveBeenCalled();
+        });
+
+        it('returns { ok: false, error } when ensureCanEdit denies the upsert', async () => {
+            // The probe succeeds; updateDocument throws Forbidden.
+            const existing = makeBody({ id: 'd1' });
+            kb.getDocument.mockResolvedValueOnce(existing);
+            kb.updateDocument.mockRejectedValueOnce(new ForbiddenException('viewer cannot edit'));
+
+            const result = await service.kbWrite(WORK_ID, USER_ID, {
+                path: 'brand/voice.md',
+                title: 't',
+                class: 'brand',
+                body: 'b',
+            });
+            expect(expectErr(result)).toMatch(/viewer|Forbidden/);
+        });
+
+        it('propagates non-NotFound probe errors as tool errors (does not silently create)', async () => {
+            // Probe throws something OTHER than NotFound — should NOT
+            // fall through to createDocument, must surface as ok:false.
+            kb.getDocument.mockRejectedValueOnce(new ForbiddenException('no view access'));
+
+            const result = await service.kbWrite(WORK_ID, USER_ID, {
+                path: 'brand/voice.md',
+                title: 't',
+                class: 'brand',
+                body: 'b',
+            });
+            expect(expectErr(result)).toMatch(/no view access|Forbidden/);
+            expect(kb.createDocument).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('kbLock', () => {
+        it('returns the locked doc on happy path', async () => {
+            const locked = makeBody({ id: 'd1', locked: true, lockMode: 'full' });
+            kb.lockDocument.mockResolvedValueOnce(locked);
+
+            const result = await service.kbLock(WORK_ID, USER_ID, 'd1', 'full');
+            const data = expectOk(result);
+            expect(data.locked).toBe(true);
+            expect(data.lockMode).toBe('full');
+            expect(kb.lockDocument).toHaveBeenCalledWith(WORK_ID, 'd1', USER_ID, 'full');
+        });
+
+        it('returns { ok: false, error } when role gate denies (editor cannot lock)', async () => {
+            kb.lockDocument.mockRejectedValueOnce(
+                new ForbiddenException('Locking a KB document requires manager+ role'),
+            );
+
+            const result = await service.kbLock(WORK_ID, USER_ID, 'd1', 'full');
+            expect(expectErr(result)).toMatch(/manager\+/);
+        });
+    });
+
+    describe('kbUnlock', () => {
+        it('returns the unlocked doc on happy path', async () => {
+            const unlocked = makeBody({ id: 'd1', locked: false, lockMode: null });
+            kb.unlockDocument.mockResolvedValueOnce(unlocked);
+
+            const result = await service.kbUnlock(WORK_ID, USER_ID, 'd1');
+            const data = expectOk(result);
+            expect(data.locked).toBe(false);
+            expect(kb.unlockDocument).toHaveBeenCalledWith(WORK_ID, 'd1', USER_ID);
+        });
+
+        it('returns { ok: false, error } on role-gate denial', async () => {
+            kb.unlockDocument.mockRejectedValueOnce(
+                new ForbiddenException('Unlocking a KB document requires manager+ role'),
+            );
+
+            const result = await service.kbUnlock(WORK_ID, USER_ID, 'd1');
+            expect(expectErr(result)).toMatch(/manager\+/);
+        });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -37,6 +37,7 @@ export * from './kb-context-bundle';
 export * from './kb-mention-parser';
 export * from './kb-mention-resolver.service';
 export * from './kb-citation-parser';
+export * from './kb-agent-tools.service';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-agent-tools.service.ts
+++ b/packages/agent/src/services/kb-agent-tools.service.ts
@@ -1,0 +1,285 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type {
+    KbDocumentBodyDto,
+    KbDocumentClass,
+    KbDocumentDto,
+    KbDocumentStatus,
+    KbLockMode,
+} from '@ever-works/contracts';
+import { KnowledgeBaseService } from './knowledge-base.service';
+import type {
+    KbDocumentClass as KbDocumentClassEnum,
+    KbDocumentSource as KbDocumentSourceEnum,
+    KbDocumentStatus as KbDocumentStatusEnum,
+    KbLockMode as KbLockModeEnum,
+} from '../entities/kb-types';
+
+/**
+ * EW-641 Phase 2/d row 36 — `KbAgentToolsService`: tool-shaped wrapper
+ * around `KnowledgeBaseService` that the agent-pipeline plugin family
+ * (row 36b) will register as LLM-callable tool definitions
+ * (`kb_search` / `kb_read` / `kb_write` / `kb_lock` / `kb_unlock`).
+ *
+ * Why a separate service:
+ *  - LLM tool inputs are narrower than the service's full CRUD shape
+ *    (no `userId` per call — it's bound to the agent run's user; no
+ *    `source` / `generatedByAgentRunId` — the wrapper stamps those
+ *    to `'agent'` / the current run id when caller passes it).
+ *  - Tool callers want upsert-by-path semantics for writes (the LLM
+ *    doesn't think in terms of "did this doc id exist yet?"). The
+ *    wrapper does an existence probe and dispatches to create vs
+ *    update accordingly.
+ *  - Errors should map to compact tool-error strings instead of
+ *    throwing HttpException subclasses (which the pipeline runner
+ *    can't easily surface back to the LLM). Each method returns a
+ *    discriminated `{ ok: true, ... } | { ok: false, error: string }`
+ *    so the pipeline can pass-through to a tool response.
+ *
+ * Permission gates are inherited from `KnowledgeBaseService` —
+ * `ensureCanView` for read/search, `ensureCanEdit` for write/lock/
+ * unlock. Forbidden / NotFound errors bubble up as `ok: false`.
+ *
+ * The actual Vercel-AI-SDK tool registration (the `tools: { kb_search,
+ * kb_read, ... }` map handed to `streamText`) lives in row 36b under
+ * `packages/plugins/agent-pipeline/` — keeping it out of this row
+ * holds the diff to one focused PR.
+ */
+
+// ─── Input / output shapes ─────────────────────────────────────────
+
+export interface KbSearchToolInput {
+    /** Free-text query. Empty/whitespace → pure-list path. */
+    readonly q?: string;
+    /** Optional class filter (`brand` / `legal` / …). */
+    readonly class?: KbDocumentClass;
+    /** Optional status filter; defaults to `active` upstream. */
+    readonly status?: KbDocumentStatus;
+    /** Page size; default 20, clamped to ≤50. */
+    readonly limit?: number;
+}
+
+export interface KbWriteToolInput {
+    /** Canonical `<class>/<slug>.md`-style path. Used as the upsert key. */
+    readonly path: string;
+    /** Document title (required on create; ignored on update if absent). */
+    readonly title: string;
+    /** KB class — required on create; ignored on update. */
+    readonly class: KbDocumentClass;
+    /** Markdown body. */
+    readonly body: string;
+    /** Optional metadata. */
+    readonly description?: string | null;
+    readonly tags?: string[];
+    readonly categories?: string[];
+    readonly language?: string;
+    /** When supplied, stamped onto the row so the audit trail credits
+     *  the originating agent run. */
+    readonly generatedByAgentRunId?: string | null;
+}
+
+/** Discriminated tool result so the pipeline doesn't have to catch. */
+export type KbToolResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+export interface KbSearchToolResult {
+    readonly items: ReadonlyArray<KbDocumentDto>;
+    readonly total: number;
+}
+
+export interface KbWriteToolResult {
+    readonly document: KbDocumentBodyDto;
+    readonly action: 'created' | 'updated';
+}
+
+/** Maximum results the LLM can request from `kb_search` per call.
+ *  Mirrors the row 15 search-palette cap so the search surface is
+ *  consistent across user/agent callers. */
+const SEARCH_LIMIT_CAP = 50;
+
+@Injectable()
+export class KbAgentToolsService {
+    private readonly logger = new Logger(KbAgentToolsService.name);
+
+    constructor(private readonly knowledgeBaseService: KnowledgeBaseService) {}
+
+    /**
+     * `kb_search` — query the KB for docs matching `q` (RRF-blended
+     * lexical + semantic per row 30c), optionally filtered by class /
+     * status. Returns metadata-only DTOs (no body) so the LLM doesn't
+     * pay token cost for full doc bodies before deciding which to read.
+     */
+    async kbSearch(
+        workId: string,
+        userId: string,
+        input: KbSearchToolInput = {},
+    ): Promise<KbToolResult<KbSearchToolResult>> {
+        try {
+            const limit = this.clampLimit(input.limit, SEARCH_LIMIT_CAP);
+            const result = await this.knowledgeBaseService.listDocuments(workId, userId, {
+                q: input.q,
+                class: input.class as KbDocumentClassEnum | undefined,
+                status: input.status as KbDocumentStatusEnum | undefined,
+                limit,
+            });
+            return { ok: true, data: { items: result.items, total: result.total } };
+        } catch (err) {
+            return this.toErrorResult(err, 'kb_search');
+        }
+    }
+
+    /**
+     * `kb_read` — fetch a single doc by id or `<class>/<slug>[.md]`
+     * path. Returns the full body DTO so the LLM can quote/cite.
+     */
+    async kbRead(
+        workId: string,
+        userId: string,
+        idOrPath: string,
+    ): Promise<KbToolResult<KbDocumentBodyDto>> {
+        try {
+            const doc = await this.knowledgeBaseService.getDocument(workId, idOrPath, userId);
+            return { ok: true, data: doc };
+        } catch (err) {
+            return this.toErrorResult(err, 'kb_read');
+        }
+    }
+
+    /**
+     * `kb_write` — upsert by path. If a doc with the same path already
+     * exists, applies the update patch (title/body/tags/etc.); otherwise
+     * creates a new doc. Source is stamped `'agent'` so the activity
+     * log + budget integration can distinguish agent-authored content.
+     */
+    async kbWrite(
+        workId: string,
+        userId: string,
+        input: KbWriteToolInput,
+    ): Promise<KbToolResult<KbWriteToolResult>> {
+        try {
+            const existing = await this.tryFindByPath(workId, input.path, userId);
+
+            if (existing) {
+                const patch: Parameters<KnowledgeBaseService['updateDocument']>[3] = {
+                    title: input.title,
+                    body: input.body,
+                };
+                if (input.description !== undefined) patch.description = input.description;
+                if (input.tags !== undefined) patch.tags = input.tags;
+                if (input.categories !== undefined) patch.categories = input.categories;
+                if (input.language !== undefined) patch.language = input.language;
+                const updated = await this.knowledgeBaseService.updateDocument(
+                    workId,
+                    existing.id,
+                    userId,
+                    patch,
+                );
+                return { ok: true, data: { document: updated, action: 'updated' } };
+            }
+
+            // Contracts ship class/source as string-unions; the agent's
+            // internal entities use enums. Cast at the boundary per the
+            // operator's standing rule for KB controller→service hops
+            // (KbDocumentClass + KbDocumentSource).
+            const created = await this.knowledgeBaseService.createDocument({
+                workId,
+                userId,
+                path: input.path,
+                title: input.title,
+                class: input.class as KbDocumentClassEnum,
+                body: input.body,
+                description: input.description ?? null,
+                tags: input.tags,
+                categories: input.categories,
+                language: input.language,
+                source: 'agent' as KbDocumentSourceEnum,
+                generatedByAgentRunId: input.generatedByAgentRunId ?? null,
+            });
+            return { ok: true, data: { document: created, action: 'created' } };
+        } catch (err) {
+            return this.toErrorResult(err, 'kb_write');
+        }
+    }
+
+    /**
+     * `kb_lock` — set the lock mode (`full` / `additions-only`) on a
+     * doc. Requires manager+ role (gate enforced in
+     * `KnowledgeBaseService.lockDocument`).
+     */
+    async kbLock(
+        workId: string,
+        userId: string,
+        docId: string,
+        mode: KbLockMode,
+    ): Promise<KbToolResult<KbDocumentBodyDto>> {
+        try {
+            const updated = await this.knowledgeBaseService.lockDocument(
+                workId,
+                docId,
+                userId,
+                mode as KbLockModeEnum,
+            );
+            return { ok: true, data: updated };
+        } catch (err) {
+            return this.toErrorResult(err, 'kb_lock');
+        }
+    }
+
+    /**
+     * `kb_unlock` — clear the lock on a doc. Requires manager+ role
+     * (gate enforced in `KnowledgeBaseService.unlockDocument`).
+     */
+    async kbUnlock(
+        workId: string,
+        userId: string,
+        docId: string,
+    ): Promise<KbToolResult<KbDocumentBodyDto>> {
+        try {
+            const updated = await this.knowledgeBaseService.unlockDocument(workId, docId, userId);
+            return { ok: true, data: updated };
+        } catch (err) {
+            return this.toErrorResult(err, 'kb_unlock');
+        }
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────
+
+    /** Clamp `limit` to [1, cap] with a default of 20 when omitted. */
+    private clampLimit(raw: number | undefined, cap: number): number {
+        if (typeof raw !== 'number' || !Number.isFinite(raw)) return 20;
+        const clamped = Math.max(1, Math.min(Math.floor(raw), cap));
+        return clamped;
+    }
+
+    /**
+     * Look up a doc by path WITHOUT throwing — returns null on miss so
+     * `kb_write` can choose between create vs update without catching
+     * a NotFoundException inside happy-path code.
+     */
+    private async tryFindByPath(
+        workId: string,
+        path: string,
+        userId: string,
+    ): Promise<KbDocumentBodyDto | null> {
+        try {
+            const doc = await this.knowledgeBaseService.getDocument(workId, path, userId);
+            return doc;
+        } catch (err) {
+            // NotFoundException is the expected "create" path; let any
+            // other exception bubble so kbWrite's outer catch surfaces
+            // it as a tool error.
+            if ((err as Error)?.name === 'NotFoundException') return null;
+            if ((err as { status?: number })?.status === 404) return null;
+            throw err;
+        }
+    }
+
+    /**
+     * Convert any thrown error into a `{ ok: false, error }` result.
+     * Logs the original at debug level so a flaky tool call doesn't
+     * spam warn-level logs, but the trace is recoverable when needed.
+     */
+    private toErrorResult<T>(err: unknown, tool: string): KbToolResult<T> {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.debug(`KB tool ${tool} failed: ${message}`);
+        return { ok: false, error: message };
+    }
+}

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -18,6 +18,7 @@ import { KnowledgeBaseService } from './knowledge-base.service';
 import { KnowledgeBaseGitMirrorService } from './knowledge-base-git-mirror.service';
 import { KnowledgeBaseBufferExtractorService } from './knowledge-base-buffer-extractor.service';
 import { KbMentionResolverService } from './kb-mention-resolver.service';
+import { KbAgentToolsService } from './kb-agent-tools.service';
 import { WorkOwnershipService } from './work-ownership.service';
 
 /**
@@ -71,6 +72,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseGitMirrorService,
         KnowledgeBaseBufferExtractorService,
         KbMentionResolverService,
+        KbAgentToolsService,
     ],
     exports: [
         WorkKnowledgeDocumentRepository,
@@ -82,6 +84,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseGitMirrorService,
         KnowledgeBaseBufferExtractorService,
         KbMentionResolverService,
+        KbAgentToolsService,
     ],
 })
 export class KnowledgeBaseModule {}


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/d kick-off. Service-layer foundation for LLM-callable KB tools (`kb_search` / `kb_read` / `kb_write` / `kb_lock` / `kb_unlock`).
- Plugin-side registration into the Vercel-AI-SDK tool map lives in row 36b under `packages/plugins/agent-pipeline/` — out of scope here to keep the diff focused.

## Public API

```ts
@Injectable()
export class KbAgentToolsService {
    constructor(private knowledgeBaseService: KnowledgeBaseService) {}

    kbSearch(workId, userId, input: KbSearchToolInput): Promise<KbToolResult<KbSearchToolResult>>
    kbRead(workId, userId, idOrPath: string): Promise<KbToolResult<KbDocumentBodyDto>>
    kbWrite(workId, userId, input: KbWriteToolInput): Promise<KbToolResult<KbWriteToolResult>>
    kbLock(workId, userId, docId, mode: KbLockMode): Promise<KbToolResult<KbDocumentBodyDto>>
    kbUnlock(workId, userId, docId): Promise<KbToolResult<KbDocumentBodyDto>>
}

export type KbToolResult<T> = { ok: true; data: T } | { ok: false; error: string };
```

Each method swallows thrown HttpExceptions and returns the discriminated result so the pipeline runner doesn't need a try/catch.

## Behavior notes

- `kbSearch` clamps \`limit\` to [1, 50] (default 20).
- `kbWrite` upserts by path: existence probe via `getDocument(path)` → hit = update, NotFound = create with `source: 'agent'` + optional `generatedByAgentRunId`. Non-NotFound probe errors surface as tool errors (no silent fallthrough).
- `kbLock` / `kbUnlock` inherit the manager+ role gate from `KnowledgeBaseService`.
- Cast contracts string-unions → agent enums at the boundary per the standing rule.

## Tests

14 new jest cases — KbAgentToolsService suite green; full agent services suite 1122/1122 green (44/44 files). DTS build (`tsc -p tsconfig.types.json`) clean. prettier@3.7.4 format check passes.

## Lesson recorded

TS narrowing of GENERIC discriminated unions via plain `if (r.ok) throw new Error('unreachable')` doesn't always trigger — TypeScript refused to narrow `KbToolResult<T>` through the throw. Switched the test helpers to user-defined type guards (`r is { ok: true; data: T }`), which narrow reliably. Pattern documented inline.

## Test plan

- [x] \`npx jest src/services\` → 44 suites / 1122 tests green
- [x] \`npx tsc -p tsconfig.types.json\` → clean
- [x] prettier@3.7.4 --write → no diff after format
- [ ] CI green on PR

## Up next

Row 36b — plugin-side tool registration in \`packages/plugins/agent-pipeline/\` so generation steps gain LLM-callable KB CRUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Knowledge Base Agent Tools Service providing search, read, write, lock, and unlock operations for knowledge base documents with built-in error handling.

* **Tests**
  * Added comprehensive test suite covering all knowledge base tool behaviors including document searching, reading, writing, and locking operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->