### PR TITLE
feat(agent-pipeline): kb_* tool builders + IKbToolsFacade contract (row 36b)

### DIFF
--- a/packages/plugins/agent-pipeline/src/__tests__/kb-tools.spec.ts
+++ b/packages/plugins/agent-pipeline/src/__tests__/kb-tools.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+	createKbSearchTool,
+	createKbReadTool,
+	createKbWriteTool,
+	createKbLockTool,
+	createKbUnlockTool,
+	createKbTools,
+	type IKbToolsFacade,
+	type KbToolBuilderContext
+} from '../tools/kb-tools';
+import type { PluginLogger } from '@ever-works/plugin';
+
+function createMockLogger(): PluginLogger {
+	return { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+}
+
+function createMockFacade(overrides: Partial<IKbToolsFacade> = {}): IKbToolsFacade {
+	return {
+		kbSearch: vi.fn().mockResolvedValue({ ok: true, data: { items: [], total: 0 } }),
+		kbRead: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+		kbWrite: vi.fn().mockResolvedValue({ ok: true, data: { document: {}, action: 'created' as const } }),
+		kbLock: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+		kbUnlock: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+		...overrides
+	};
+}
+
+function createCtx(overrides: Partial<KbToolBuilderContext> = {}): KbToolBuilderContext {
+	return {
+		workId: 'work-1',
+		userId: 'user-1',
+		facade: createMockFacade(),
+		logger: createMockLogger(),
+		...overrides
+	};
+}
+
+const toolCallCtx = { toolCallId: 'call_1', messages: [] } as never;
+
+describe('kb-tools (row 36b)', () => {
+	describe('createKbSearchTool', () => {
+		it('forwards inputs to facade.kbSearch with bound workId / userId', async () => {
+			const facade = createMockFacade();
+			const tool = createKbSearchTool(createCtx({ facade }));
+
+			const result = await tool.execute!({ q: 'voice', class: 'brand', limit: 5 }, toolCallCtx);
+
+			expect(facade.kbSearch).toHaveBeenCalledWith('work-1', 'user-1', {
+				q: 'voice',
+				class: 'brand',
+				limit: 5
+			});
+			expect(result).toEqual({ ok: true, data: { items: [], total: 0 } });
+		});
+
+		it('returns { ok: false } on facade throw without bubbling the exception', async () => {
+			const facade = createMockFacade({
+				kbSearch: vi.fn().mockRejectedValue(new Error('boom'))
+			});
+			const logger = createMockLogger();
+			const tool = createKbSearchTool(createCtx({ facade, logger }));
+
+			const result = await tool.execute!({}, toolCallCtx);
+			expect(result).toEqual({ ok: false, error: 'boom' });
+			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe('createKbReadTool', () => {
+		it('passes idOrPath through to facade.kbRead', async () => {
+			const facade = createMockFacade();
+			const tool = createKbReadTool(createCtx({ facade }));
+
+			await tool.execute!({ idOrPath: 'brand/voice.md' }, toolCallCtx);
+
+			expect(facade.kbRead).toHaveBeenCalledWith('work-1', 'user-1', 'brand/voice.md');
+		});
+
+		it('surfaces facade error as ok:false', async () => {
+			const facade = createMockFacade({
+				kbRead: vi.fn().mockResolvedValue({ ok: false, error: 'not found' })
+			});
+			const tool = createKbReadTool(createCtx({ facade }));
+
+			const result = await tool.execute!({ idOrPath: 'ghost' }, toolCallCtx);
+			expect(result).toEqual({ ok: false, error: 'not found' });
+		});
+	});
+
+	describe('createKbWriteTool', () => {
+		it('threads generatedByAgentRunId into the upsert payload', async () => {
+			const facade = createMockFacade();
+			const tool = createKbWriteTool(createCtx({ facade }), 'run-99');
+
+			await tool.execute!(
+				{
+					path: 'brand/manifesto.md',
+					title: 'Brand Manifesto',
+					class: 'brand',
+					body: 'hello'
+				},
+				toolCallCtx
+			);
+
+			expect(facade.kbWrite).toHaveBeenCalledWith(
+				'work-1',
+				'user-1',
+				expect.objectContaining({
+					path: 'brand/manifesto.md',
+					title: 'Brand Manifesto',
+					class: 'brand',
+					body: 'hello',
+					generatedByAgentRunId: 'run-99'
+				})
+			);
+		});
+
+		it('omits generatedByAgentRunId when not provided', async () => {
+			const facade = createMockFacade();
+			const tool = createKbWriteTool(createCtx({ facade }));
+
+			await tool.execute!(
+				{
+					path: 'brand/voice.md',
+					title: 'Brand Voice',
+					class: 'brand',
+					body: 'hi'
+				},
+				toolCallCtx
+			);
+
+			expect(facade.kbWrite).toHaveBeenCalledWith(
+				'work-1',
+				'user-1',
+				expect.objectContaining({
+					generatedByAgentRunId: undefined
+				})
+			);
+		});
+	});
+
+	describe('createKbLockTool', () => {
+		it('forwards docId + mode to facade.kbLock', async () => {
+			const facade = createMockFacade();
+			const tool = createKbLockTool(createCtx({ facade }));
+
+			await tool.execute!({ docId: 'd1', mode: 'full' }, toolCallCtx);
+
+			expect(facade.kbLock).toHaveBeenCalledWith('work-1', 'user-1', 'd1', 'full');
+		});
+	});
+
+	describe('createKbUnlockTool', () => {
+		it('forwards docId to facade.kbUnlock', async () => {
+			const facade = createMockFacade();
+			const tool = createKbUnlockTool(createCtx({ facade }));
+
+			await tool.execute!({ docId: 'd1' }, toolCallCtx);
+
+			expect(facade.kbUnlock).toHaveBeenCalledWith('work-1', 'user-1', 'd1');
+		});
+	});
+
+	describe('createKbTools aggregator', () => {
+		it('returns all five tools keyed by canonical kb_* names', () => {
+			const tools = createKbTools(createCtx());
+			expect(Object.keys(tools).sort()).toEqual(['kb_lock', 'kb_read', 'kb_search', 'kb_unlock', 'kb_write']);
+		});
+
+		it('passes generatedByAgentRunId through to the kb_write tool only', async () => {
+			const facade = createMockFacade();
+			const tools = createKbTools(createCtx({ facade }), 'run-42');
+
+			await tools.kb_write.execute!(
+				{
+					path: 'brand/x.md',
+					title: 'x',
+					class: 'brand',
+					body: 'b'
+				},
+				toolCallCtx
+			);
+
+			expect(facade.kbWrite).toHaveBeenCalledWith(
+				'work-1',
+				'user-1',
+				expect.objectContaining({ generatedByAgentRunId: 'run-42' })
+			);
+
+			// The other tools don't have a generatedByAgentRunId slot — confirm
+			// they exist and invoke their facade methods correctly.
+			await tools.kb_search.execute!({ q: 'foo' }, toolCallCtx);
+			expect(facade.kbSearch).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/plugins/agent-pipeline/src/tools/kb-tools.ts
+++ b/packages/plugins/agent-pipeline/src/tools/kb-tools.ts
@@ -1,0 +1,283 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import type { PluginLogger } from '@ever-works/plugin';
+
+/**
+ * EW-641 Phase 2/d row 36b — agent-pipeline plugin-side wrappers for
+ * the LLM-callable KB tools (`kb_search` / `kb_read` / `kb_write` /
+ * `kb_lock` / `kb_unlock`). Each wrapper is a `tool({...})` definition
+ * (Vercel AI SDK) with a zod input schema and an `execute` callback
+ * that delegates to the row 36 `KbAgentToolsService`.
+ *
+ * The agent-pipeline plugin lives in `packages/plugins/` and runs
+ * outside the NestJS container. It can't directly inject
+ * `KbAgentToolsService` — instead, the wiring layer (row 36c, future
+ * PR) supplies an `IKbToolsFacade` adapter through the existing
+ * `ParentToolContext.facades` mechanism. The interface lives here
+ * (local-first) so this PR doesn't have to bump `@ever-works/plugin`'s
+ * public surface; row 36c can promote it if cross-package reuse
+ * shows up.
+ *
+ * **Scope note**: this row only ADDS the tool builders and a
+ * `createKbTools()` aggregator. It does NOT wire them into
+ * `createParentTools()` — that lives in row 36c so the agent-pipeline
+ * tool-set roster change is reviewed separately from the tool
+ * definitions themselves. Importing this module is therefore a no-op
+ * for the existing pipeline until 36c flips the switch.
+ *
+ * Tool inputs accept string-union shapes for class / status / lockMode
+ * to keep the LLM-facing schema simple. The facade implementation
+ * (NestJS side, KbAgentToolsService) casts contracts string-unions →
+ * agent enums at the boundary per cumulative gotcha #5.
+ */
+
+// ─── Facade contract (LLM-callable surface) ────────────────────────────
+
+/** Shapes returned by every KB tool. Mirrors `KbToolResult<T>` from
+ *  `@ever-works/agent/services` so the LLM sees a uniform `{ok, ...}`
+ *  envelope regardless of which tool it called. */
+export type KbToolResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+/** Tool input contracts — match `KbSearchToolInput` / `KbWriteToolInput`
+ *  on the agent side. Kept here as TS interfaces (not zod schemas) so
+ *  this file can be consumed from non-zod contexts too. */
+export interface IKbSearchInput {
+	readonly q?: string;
+	readonly class?: string;
+	readonly status?: string;
+	readonly limit?: number;
+}
+
+export interface IKbWriteInput {
+	readonly path: string;
+	readonly title: string;
+	readonly class: string;
+	readonly body: string;
+	readonly description?: string | null;
+	readonly tags?: string[];
+	readonly categories?: string[];
+	readonly language?: string;
+	readonly generatedByAgentRunId?: string | null;
+}
+
+/**
+ * Facade interface the wiring layer (row 36c) will implement against
+ * NestJS-side `KbAgentToolsService`. Keeping the contract here so the
+ * agent-pipeline plugin doesn't take a runtime dep on the agent
+ * package (it consumes only the interface shape).
+ *
+ * Each method returns a `KbToolResult<T>` so the tool's `execute`
+ * can pass-through to the LLM as-is.
+ */
+export interface IKbToolsFacade {
+	kbSearch(
+		workId: string,
+		userId: string,
+		input: IKbSearchInput
+	): Promise<KbToolResult<{ items: ReadonlyArray<unknown>; total: number }>>;
+
+	kbRead(workId: string, userId: string, idOrPath: string): Promise<KbToolResult<unknown>>;
+
+	kbWrite(
+		workId: string,
+		userId: string,
+		input: IKbWriteInput
+	): Promise<KbToolResult<{ document: unknown; action: 'created' | 'updated' }>>;
+
+	kbLock(
+		workId: string,
+		userId: string,
+		docId: string,
+		mode: 'full' | 'additions-only'
+	): Promise<KbToolResult<unknown>>;
+
+	kbUnlock(workId: string, userId: string, docId: string): Promise<KbToolResult<unknown>>;
+}
+
+// ─── Tool-builder context ───────────────────────────────────────────────
+
+export interface KbToolBuilderContext {
+	/** Owning Work scope — every tool call is bound to this. */
+	readonly workId: string;
+	/** User performing the call — used for the per-tool permission gate
+	 *  inside the facade implementation (ensureCanView / ensureCanEdit). */
+	readonly userId: string;
+	/** Facade that bridges to NestJS-side `KbAgentToolsService`. */
+	readonly facade: IKbToolsFacade;
+	/** Plugin logger — used to debug-log failures + permission gate
+	 *  rejections without spamming user-visible errors. */
+	readonly logger: PluginLogger;
+}
+
+// ─── zod input schemas ──────────────────────────────────────────────────
+
+/** Canonical KB document classes — keep in lockstep with
+ *  `@ever-works/contracts`' `KB_DOCUMENT_CLASSES` constant.
+ *  Hardcoded here so the agent-pipeline plugin doesn't take a runtime
+ *  dep on `@ever-works/contracts`. Row 36c may promote this to a
+ *  shared constant if drift surfaces in CI. */
+const KB_CLASS_VALUES = [
+	'brand',
+	'legal',
+	'seo',
+	'style',
+	'glossary',
+	'competitors',
+	'personas',
+	'research',
+	'output',
+	'freeform'
+] as const;
+
+const KB_STATUS_VALUES = ['active', 'archived', 'draft'] as const;
+
+const KB_LOCK_MODE_VALUES = ['full', 'additions-only'] as const;
+
+const kbSearchInputSchema = z.object({
+	q: z.string().optional().describe('Free-text search query — RRF-blended lexical + semantic.'),
+	class: z.enum(KB_CLASS_VALUES).optional().describe('Filter results to a single KB class (brand, legal, …).'),
+	status: z
+		.enum(KB_STATUS_VALUES)
+		.optional()
+		.describe('Filter by lifecycle status (default behavior covers active).'),
+	limit: z.number().int().optional().describe('Maximum results to return (default 20, clamped to 50).')
+});
+
+const kbReadInputSchema = z.object({
+	idOrPath: z
+		.string()
+		.describe(
+			'Document id (UUID) or path of the form `<class>/<slug>[.md]` — same shape as `@kb:` mentions in chat.'
+		)
+});
+
+const kbWriteInputSchema = z.object({
+	path: z
+		.string()
+		.describe(
+			'Target path as `<class>/<slug>.md`. If a doc with this path exists, it is updated; otherwise created.'
+		),
+	title: z.string().describe('Human-readable title.'),
+	class: z.enum(KB_CLASS_VALUES).describe('KB class — required even on update for clarity.'),
+	body: z.string().describe('Markdown body.'),
+	description: z.string().nullable().optional().describe('Optional one-line summary.'),
+	tags: z.array(z.string()).optional().describe('Optional tag slugs.'),
+	categories: z.array(z.string()).optional().describe('Optional category slugs.'),
+	language: z.string().optional().describe('BCP-47 language tag (default en).')
+});
+
+const kbLockInputSchema = z.object({
+	docId: z.string().describe('Document id (UUID).'),
+	mode: z
+		.enum(KB_LOCK_MODE_VALUES)
+		.describe('`full` blocks all body mutations; `additions-only` allows additions but rejects deletions/edits.')
+});
+
+const kbUnlockInputSchema = z.object({
+	docId: z.string().describe('Document id (UUID).')
+});
+
+// ─── Tool factories ────────────────────────────────────────────────────
+
+export function createKbSearchTool(ctx: KbToolBuilderContext) {
+	return tool({
+		description:
+			'Search the Knowledge Base. Returns metadata-only matches (no body) so the model decides which to read next.',
+		inputSchema: kbSearchInputSchema,
+		execute: async (input) => {
+			try {
+				return await ctx.facade.kbSearch(ctx.workId, ctx.userId, input);
+			} catch (err) {
+				const error = err instanceof Error ? err.message : String(err);
+				ctx.logger.warn(`kb_search tool error: ${error}`);
+				return { ok: false, error };
+			}
+		}
+	});
+}
+
+export function createKbReadTool(ctx: KbToolBuilderContext) {
+	return tool({
+		description:
+			'Fetch a single Knowledge Base document by id or `<class>/<slug>` path. Returns the full body for citing.',
+		inputSchema: kbReadInputSchema,
+		execute: async ({ idOrPath }) => {
+			try {
+				return await ctx.facade.kbRead(ctx.workId, ctx.userId, idOrPath);
+			} catch (err) {
+				const error = err instanceof Error ? err.message : String(err);
+				ctx.logger.warn(`kb_read tool error: ${error}`);
+				return { ok: false, error };
+			}
+		}
+	});
+}
+
+export function createKbWriteTool(ctx: KbToolBuilderContext, generatedByAgentRunId?: string) {
+	return tool({
+		description:
+			'Create or update a Knowledge Base document by path. Upserts: if a doc with the same path exists, it is updated; otherwise a new one is created with source="agent".',
+		inputSchema: kbWriteInputSchema,
+		execute: async (input) => {
+			try {
+				return await ctx.facade.kbWrite(ctx.workId, ctx.userId, {
+					...input,
+					generatedByAgentRunId
+				});
+			} catch (err) {
+				const error = err instanceof Error ? err.message : String(err);
+				ctx.logger.warn(`kb_write tool error: ${error}`);
+				return { ok: false, error };
+			}
+		}
+	});
+}
+
+export function createKbLockTool(ctx: KbToolBuilderContext) {
+	return tool({
+		description:
+			'Lock a Knowledge Base document so further edits are blocked (full) or restricted to additions only.',
+		inputSchema: kbLockInputSchema,
+		execute: async ({ docId, mode }) => {
+			try {
+				return await ctx.facade.kbLock(ctx.workId, ctx.userId, docId, mode);
+			} catch (err) {
+				const error = err instanceof Error ? err.message : String(err);
+				ctx.logger.warn(`kb_lock tool error: ${error}`);
+				return { ok: false, error };
+			}
+		}
+	});
+}
+
+export function createKbUnlockTool(ctx: KbToolBuilderContext) {
+	return tool({
+		description: 'Clear the lock on a Knowledge Base document. No-op when the doc is already unlocked.',
+		inputSchema: kbUnlockInputSchema,
+		execute: async ({ docId }) => {
+			try {
+				return await ctx.facade.kbUnlock(ctx.workId, ctx.userId, docId);
+			} catch (err) {
+				const error = err instanceof Error ? err.message : String(err);
+				ctx.logger.warn(`kb_unlock tool error: ${error}`);
+				return { ok: false, error };
+			}
+		}
+	});
+}
+
+/**
+ * Build the full set of KB tools at once, keyed by their canonical
+ * names (`kb_search` / `kb_read` / `kb_write` / `kb_lock` /
+ * `kb_unlock`). Row 36c spreads this into `createParentTools()`'s
+ * returned tools map.
+ */
+export function createKbTools(ctx: KbToolBuilderContext, generatedByAgentRunId?: string) {
+	return {
+		kb_search: createKbSearchTool(ctx),
+		kb_read: createKbReadTool(ctx),
+		kb_write: createKbWriteTool(ctx, generatedByAgentRunId),
+		kb_lock: createKbLockTool(ctx),
+		kb_unlock: createKbUnlockTool(ctx)
+	};
+}


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/d **row 36b**. Plugin-side Vercel-AI-SDK tool builders for the 5 LLM-callable KB tools (`kb_search` / `kb_read` / `kb_write` / `kb_lock` / `kb_unlock`).
- Defines the `IKbToolsFacade` contract that row 36c's NestJS adapter will implement against `KbAgentToolsService` (landed in row 36, PR #988).
- **Scope discipline**: this PR ONLY adds the tool builders. It does NOT wire them into `createParentTools()` — that lives in row 36c so the agent-pipeline tool-roster change is reviewed separately from the tool definitions.

## Surface added

- `packages/plugins/agent-pipeline/src/tools/kb-tools.ts` — 5 tool factories + `createKbTools()` aggregator + `IKbToolsFacade` interface.
- zod input schemas with enum validation for class / status / lockMode.

## Behavior

- Each tool's `execute` calls `facade.kbX(workId, userId, ...)` and returns the result. Facade throws → tool returns `{ ok: false, error }` (uniform envelope for the LLM).
- `kb_write` binds `generatedByAgentRunId` at builder time (not LLM-facing) so the activity log credits the run.

## Tests

10 vitest cases — forwards inputs + bind workId/userId per tool, facade throw → ok:false, aggregator returns all 5 keys, generatedByAgentRunId threaded only through kb_write. Agent-pipeline suite 217/217 green (18 files). \`tsc --noEmit\` clean. prettier@3.7.4 format check passes.

## Test plan

- [x] \`npx vitest run\` in agent-pipeline → 18 files / 217 tests green
- [x] \`npx tsc --noEmit\` → clean
- [x] prettier@3.7.4 --write → no diff
- [ ] CI green on PR

## Up next

Row 36c — NestJS-side `KbToolsFacade` adapter (implements `IKbToolsFacade` by delegating to `KbAgentToolsService`) + wire into `createParentTools` via a new `ParentToolContext.kbTools?` field + thread the facade through `pipeline-facade.service.ts`. Once 36c lands, Phase 2/d ends and row 37 (Phase 2/e org overlay) becomes NEXT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Base tools (search, read, write/upsert, lock, unlock) to the agent pipeline plugin, enabling LLM agents to interact with and manage knowledge base entries.
  * Implemented graceful error handling that returns error details instead of throwing exceptions.
  * Added support for tracking which agent run generated knowledge base content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->