### PR TITLE
feat: wire KbToolsFacade adapter into agent-pipeline (row 36c)

### DIFF
--- a/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
@@ -538,11 +538,13 @@ describe('StepPipelineExecutorService', () => {
             await service.execute(standardPlugin, mockWork, requestWithProviders, mockExisting);
 
             // Verify facade service was called with provider overrides.
-            // 5th arg is `kbContext` (EW-641 row 32c) — undefined when
-            // KnowledgeBaseService is not injected.
+            // 5th arg is `kbContext` (EW-641 row 32c), 6th is `kbTools`
+            // (EW-641 row 36c) — both undefined when neither
+            // KnowledgeBaseService nor KbToolsFacadeAdapter is injected.
             expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
                 mockWork,
                 requestWithProviders.providers,
+                undefined,
                 undefined,
                 undefined,
                 undefined,
@@ -555,6 +557,7 @@ describe('StepPipelineExecutorService', () => {
             // Verify facade service was called without provider overrides
             expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
                 mockWork,
+                undefined,
                 undefined,
                 undefined,
                 undefined,
@@ -575,6 +578,7 @@ describe('StepPipelineExecutorService', () => {
                 mockWork,
                 undefined,
                 'openai/gpt-4.1',
+                undefined,
                 undefined,
                 undefined,
             );
@@ -601,13 +605,15 @@ describe('StepPipelineExecutorService', () => {
                 query: 'voice tone',
             });
             // Bundle reaches the facade as the 5th positional arg of every
-            // per-step createStepExecutionContext call.
+            // per-step createStepExecutionContext call. The 6th arg
+            // (kbTools, row 36c) stays undefined — no adapter wired.
             expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
                 mockWork,
                 undefined,
                 undefined,
                 undefined,
                 bundle,
+                undefined,
             );
         });
 
@@ -625,6 +631,7 @@ describe('StepPipelineExecutorService', () => {
             // 5th arg stays undefined even though resolveContext rejected.
             expect(facadeServiceMock.createStepExecutionContext).toHaveBeenCalledWith(
                 mockWork,
+                undefined,
                 undefined,
                 undefined,
                 undefined,

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
@@ -86,14 +86,16 @@ describe('FullPipelineExecutorService', () => {
             );
 
             // facade.createStepExecutionContext invoked with documented positional args.
-            // 5th arg is `kbContext` (EW-641 row 32c) — undefined when
-            // KnowledgeBaseService is not injected (the default ctor here).
+            // 5th arg is `kbContext` (EW-641 row 32c), 6th is `kbTools`
+            // (EW-641 row 36c) — both undefined when neither
+            // KnowledgeBaseService nor KbToolsFacadeAdapter is injected.
             expect(facadeService.createStepExecutionContext).toHaveBeenCalledWith(
                 work,
                 request.providers,
                 request.aiModel,
                 undefined, // no signal in options
                 undefined, // no kbContext (no KB service wired)
+                undefined, // no kbTools (no adapter wired)
             );
 
             // plugin.execute received {...options, execContext, onLogEntry}.
@@ -140,6 +142,7 @@ describe('FullPipelineExecutorService', () => {
                 request.providers,
                 request.aiModel,
                 signal,
+                undefined,
                 undefined,
             );
         });
@@ -214,6 +217,7 @@ describe('FullPipelineExecutorService', () => {
                 request.aiModel,
                 undefined,
                 bundle,
+                undefined,
             );
         });
 
@@ -239,6 +243,7 @@ describe('FullPipelineExecutorService', () => {
                 expect.objectContaining({ id: '' }),
                 request.providers,
                 request.aiModel,
+                undefined,
                 undefined,
                 undefined,
             );
@@ -273,6 +278,7 @@ describe('FullPipelineExecutorService', () => {
                 work,
                 request.providers,
                 request.aiModel,
+                undefined,
                 undefined,
                 undefined,
             );

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.ts
@@ -14,12 +14,14 @@ import type {
 } from '@ever-works/plugin';
 import type { GenerationStepLog } from '@ever-works/contracts/api';
 import type { KbContextBundleData } from '@ever-works/contracts';
+import type { IKbToolsFacade } from '@ever-works/plugin';
 import { buildErrorPipelineResult, createEmptyPipelineOutputs } from '@ever-works/plugin';
 import { PipelineEvents } from './step-pipeline-executor.service';
 import { PipelineFacadeService } from './pipeline-facade.service';
 import { validatePipelineResult } from './validators';
 import { PluginContextFactoryService } from '../plugins/services/plugin-context-factory.service';
 import { KnowledgeBaseService } from '../services/knowledge-base.service';
+import { KbToolsFacadeAdapter } from '../services/kb-tools-facade.adapter';
 
 /**
  * Executor for self-managed pipeline plugins.
@@ -41,6 +43,11 @@ export class FullPipelineExecutorService {
         // KB wiring still construct (and `execContext.kbContext` stays
         // undefined for those callers).
         @Optional() private readonly knowledgeBaseService?: KnowledgeBaseService,
+        // EW-641 Phase 2/d row 36c — LLM-callable KB tools facade,
+        // threaded via `execContext.kbTools` for self-managed pipeline
+        // plugins (agent-pipeline + family). Same optionality contract
+        // as `knowledgeBaseService`.
+        @Optional() private readonly kbToolsFacade?: KbToolsFacadeAdapter,
     ) {}
 
     /**
@@ -63,6 +70,17 @@ export class FullPipelineExecutorService {
             );
             return undefined;
         }
+    }
+
+    /**
+     * EW-641 Phase 2/d row 36c — resolve the LLM-callable KB tools
+     * facade for this pipeline run. Mirrors the step-executor helper
+     * of the same name (synchronous-friendly; the adapter is a
+     * singleton @Injectable).
+     */
+    private resolveKbToolsFacadeSafe(work: WorkReference): IKbToolsFacade | undefined {
+        if (!this.kbToolsFacade || !work.id) return undefined;
+        return this.kbToolsFacade;
     }
 
     /**
@@ -106,10 +124,11 @@ export class FullPipelineExecutorService {
             );
         }
 
-        // EW-641 Phase 2/b row 32c — resolve KB bundle once before the
-        // plugin executes; the bundle rides on the same execContext that
-        // facades use.
+        // EW-641 Phase 2/b row 32c + 2/d row 36c — resolve KB bundle +
+        // tools facade once before the plugin executes; both ride on
+        // the same execContext that facades use.
         const kbContext = await this.resolveKbContextSafe(work, request);
+        const kbTools = this.resolveKbToolsFacadeSafe(work);
 
         try {
             // Create execContext for the plugin to use facades
@@ -119,6 +138,7 @@ export class FullPipelineExecutorService {
                 request.aiModel,
                 options?.signal,
                 kbContext,
+                kbTools,
             );
 
             // Delegate to the plugin's execute method with execContext

--- a/packages/agent/src/pipeline/pipeline-facade.service.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.ts
@@ -31,6 +31,7 @@ import type {
     DataSourceFacadeResult,
     EnabledDataSource,
     FacadeOptions,
+    IKbToolsFacade,
 } from '@ever-works/plugin';
 import type { KbContextBundleData } from '@ever-works/contracts';
 import { AiFacadeService } from '../facades/ai.facade';
@@ -92,6 +93,7 @@ export class PipelineFacadeService {
         aiModelOverride?: string,
         signal?: AbortSignal,
         kbContext?: KbContextBundleData,
+        kbTools?: IKbToolsFacade,
     ): StepExecutionContext {
         const stepLogger: StepLogger = {
             log: (msg: string, ...args: unknown[]) =>
@@ -131,6 +133,7 @@ export class PipelineFacadeService {
             user: work.user,
             signal,
             kbContext,
+            kbTools,
         };
     }
 

--- a/packages/agent/src/pipeline/step-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/step-pipeline-executor.service.ts
@@ -29,6 +29,7 @@ import {
     createEmptyPipelineOutputs,
     isPipelineModifierPlugin,
 } from '@ever-works/plugin';
+import type { IKbToolsFacade } from '@ever-works/plugin';
 import type { GenerationStepLog } from '@ever-works/contracts/api';
 import type { KbContextBundleData } from '@ever-works/contracts';
 import { PipelineBuilderService } from './pipeline-builder.service';
@@ -37,6 +38,7 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { PluginContextFactoryService } from '../plugins/services/plugin-context-factory.service';
 import { ExecutablePipelineRunner } from './executable-pipeline.class';
 import { KnowledgeBaseService } from '../services/knowledge-base.service';
+import { KbToolsFacadeAdapter } from '../services/kb-tools-facade.adapter';
 
 export interface CheckpointData {
     stepIndex: number;
@@ -108,6 +110,15 @@ export class StepPipelineExecutorService {
         // isolated unit tests, legacy bootstraps) keep constructing
         // identically — `execContext.kbContext` stays `undefined` then.
         @Optional() private readonly knowledgeBaseService?: KnowledgeBaseService,
+        // EW-641 Phase 2/d row 36c — `KbToolsFacadeAdapter` implements
+        // the LLM-callable `IKbToolsFacade` by delegating to
+        // `KbAgentToolsService`. We thread it via
+        // `execContext.kbTools` so agent-pipeline (and any other
+        // tool-using pipeline) can register the 5 `kb_*` tools via
+        // row 36b's `createKbTools()`. Same `@Optional()` story as
+        // `knowledgeBaseService` — deployments without the KB module
+        // keep constructing identically.
+        @Optional() private readonly kbToolsFacade?: KbToolsFacadeAdapter,
     ) {}
 
     /**
@@ -137,6 +148,21 @@ export class StepPipelineExecutorService {
             );
             return undefined;
         }
+    }
+
+    /**
+     * EW-641 Phase 2/d row 36c — resolve the LLM-callable KB tools
+     * facade for this pipeline run, returning `undefined` when the
+     * adapter isn't wired (no KB module) or `work.id` is empty.
+     *
+     * Synchronous-friendly: the adapter is a singleton @Injectable, so
+     * "resolving" it is a no-op DI lookup. Wrapped in a method to mirror
+     * `resolveKbContextSafe`'s shape and to leave room for future
+     * permission gating (e.g. per-Work feature flags).
+     */
+    private resolveKbToolsFacadeSafe(work: WorkReference): IKbToolsFacade | undefined {
+        if (!this.kbToolsFacade || !work.id) return undefined;
+        return this.kbToolsFacade;
     }
 
     async execute(
@@ -172,11 +198,20 @@ export class StepPipelineExecutorService {
             );
         }
 
-        // EW-641 Phase 2/b row 32c — resolve KB bundle once per run.
+        // EW-641 Phase 2/b row 32c + 2/d row 36c — resolve KB bundle +
+        // tools facade once per run; both fan out to every step.
         const kbContext = await this.resolveKbContextSafe(work, request);
+        const kbTools = this.resolveKbToolsFacadeSafe(work);
 
         try {
-            return await this.executePipeline(plugin, context, options, onProgress, kbContext);
+            return await this.executePipeline(
+                plugin,
+                context,
+                options,
+                onProgress,
+                kbContext,
+                kbTools,
+            );
         } finally {
             removeInterceptor?.();
         }
@@ -188,6 +223,7 @@ export class StepPipelineExecutorService {
         options?: PipelineExecutionOptions,
         onProgress?: PipelineProgressCallback,
         kbContext?: KbContextBundleData,
+        kbTools?: IKbToolsFacade,
     ): Promise<PipelineResult> {
         const startTime = Date.now();
         const work = context.work;
@@ -245,6 +281,7 @@ export class StepPipelineExecutorService {
                                 options,
                                 onProgress,
                                 kbContext,
+                                kbTools,
                             ),
                         ),
                     );
@@ -263,6 +300,7 @@ export class StepPipelineExecutorService {
                                 options,
                                 onProgress,
                                 kbContext,
+                                kbTools,
                             ),
                     );
                     await this.runWithConcurrencyLimit(stepThunks, concurrency);
@@ -328,6 +366,7 @@ export class StepPipelineExecutorService {
         options?: PipelineExecutionOptions,
         onProgress?: PipelineProgressCallback,
         kbContext?: KbContextBundleData,
+        kbTools?: IKbToolsFacade,
     ): Promise<void> {
         const onLogEntry = options?.onLogEntry;
 
@@ -399,7 +438,7 @@ export class StepPipelineExecutorService {
                 throw new Error(`No executor found for step "${step.id}"`);
             }
 
-            await this.executeStep(step, executor, plugin, context, options, kbContext);
+            await this.executeStep(step, executor, plugin, context, options, kbContext, kbTools);
 
             const durationMs = Date.now() - stepStartTime;
             const metrics = this.createStepMetrics(step, stepStartTime, true);
@@ -456,11 +495,13 @@ export class StepPipelineExecutorService {
         options?: PipelineExecutionOptions,
         onProgress?: PipelineProgressCallback,
     ): Promise<PipelineResult> {
-        // EW-641 Phase 2/b row 32c — also resolve KB bundle on the
-        // resume-from-checkpoint path so a resumed pipeline gets the
-        // same KB grounding as a fresh run.
+        // EW-641 Phase 2/b row 32c + 2/d row 36c — also resolve KB
+        // bundle + tools facade on the resume-from-checkpoint path
+        // so a resumed pipeline gets the same KB grounding + tools
+        // as a fresh run.
         const kbContext = await this.resolveKbContextSafe(context.work, context.request);
-        return this.executePipeline(plugin, context, options, onProgress, kbContext);
+        const kbTools = this.resolveKbToolsFacadeSafe(context.work);
+        return this.executePipeline(plugin, context, options, onProgress, kbContext, kbTools);
     }
 
     async resumeFromCheckpoint(
@@ -516,6 +557,7 @@ export class StepPipelineExecutorService {
         context: IPipelineContext,
         options?: PipelineExecutionOptions,
         kbContext?: KbContextBundleData,
+        kbTools?: IKbToolsFacade,
     ): Promise<void> {
         const execContext = this.facadeService.createStepExecutionContext(
             context.work,
@@ -523,6 +565,7 @@ export class StepPipelineExecutorService {
             context.request.aiModel,
             options?.signal,
             kbContext,
+            kbTools,
         );
 
         if (executor.type === 'builtin') {

--- a/packages/agent/src/services/__tests__/kb-tools-facade.adapter.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-tools-facade.adapter.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { KbToolsFacadeAdapter } from '../kb-tools-facade.adapter';
+import { KbAgentToolsService } from '../kb-agent-tools.service';
+
+describe('KbToolsFacadeAdapter (row 36c)', () => {
+    let adapter: KbToolsFacadeAdapter;
+    let kbAgentTools: {
+        kbSearch: jest.Mock;
+        kbRead: jest.Mock;
+        kbWrite: jest.Mock;
+        kbLock: jest.Mock;
+        kbUnlock: jest.Mock;
+    };
+
+    beforeEach(async () => {
+        kbAgentTools = {
+            kbSearch: jest.fn().mockResolvedValue({ ok: true, data: { items: [], total: 0 } }),
+            kbRead: jest.fn().mockResolvedValue({ ok: true, data: {} }),
+            kbWrite: jest
+                .fn()
+                .mockResolvedValue({ ok: true, data: { document: {}, action: 'created' } }),
+            kbLock: jest.fn().mockResolvedValue({ ok: true, data: {} }),
+            kbUnlock: jest.fn().mockResolvedValue({ ok: true, data: {} }),
+        };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                KbToolsFacadeAdapter,
+                { provide: KbAgentToolsService, useValue: kbAgentTools },
+            ],
+        }).compile();
+        adapter = module.get(KbToolsFacadeAdapter);
+    });
+
+    it('kbSearch forwards every argument to KbAgentToolsService.kbSearch verbatim', async () => {
+        const result = await adapter.kbSearch('work-1', 'user-1', {
+            q: 'voice',
+            class: 'brand',
+            limit: 5,
+        });
+        expect(kbAgentTools.kbSearch).toHaveBeenCalledWith('work-1', 'user-1', {
+            q: 'voice',
+            class: 'brand',
+            limit: 5,
+        });
+        expect(result).toEqual({ ok: true, data: { items: [], total: 0 } });
+    });
+
+    it('kbRead forwards workId/userId/idOrPath', async () => {
+        await adapter.kbRead('work-1', 'user-1', 'brand/voice.md');
+        expect(kbAgentTools.kbRead).toHaveBeenCalledWith('work-1', 'user-1', 'brand/voice.md');
+    });
+
+    it('kbWrite forwards the full input object', async () => {
+        await adapter.kbWrite('work-1', 'user-1', {
+            path: 'brand/voice.md',
+            title: 'Voice',
+            class: 'brand',
+            body: 'hi',
+            generatedByAgentRunId: 'run-1',
+        });
+        expect(kbAgentTools.kbWrite).toHaveBeenCalledWith('work-1', 'user-1', {
+            path: 'brand/voice.md',
+            title: 'Voice',
+            class: 'brand',
+            body: 'hi',
+            generatedByAgentRunId: 'run-1',
+        });
+    });
+
+    it('kbLock forwards docId + mode', async () => {
+        await adapter.kbLock('work-1', 'user-1', 'd1', 'full');
+        expect(kbAgentTools.kbLock).toHaveBeenCalledWith('work-1', 'user-1', 'd1', 'full');
+    });
+
+    it('kbUnlock forwards docId', async () => {
+        await adapter.kbUnlock('work-1', 'user-1', 'd1');
+        expect(kbAgentTools.kbUnlock).toHaveBeenCalledWith('work-1', 'user-1', 'd1');
+    });
+
+    it('does NOT translate / transform the service result envelope', async () => {
+        // The discriminated KbToolResult must pass through unchanged so
+        // the agent-pipeline tool layer can surface { ok: false, error }
+        // to the LLM directly.
+        kbAgentTools.kbRead.mockResolvedValueOnce({ ok: false, error: 'not found' });
+        const result = await adapter.kbRead('work-1', 'user-1', 'ghost');
+        expect(result).toEqual({ ok: false, error: 'not found' });
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -38,6 +38,7 @@ export * from './kb-mention-parser';
 export * from './kb-mention-resolver.service';
 export * from './kb-citation-parser';
 export * from './kb-agent-tools.service';
+export * from './kb-tools-facade.adapter';
 export * from './utils/error-classification.utils';
 export * from './utils/error.utils';
 export * from './types/trigger-context.types';

--- a/packages/agent/src/services/kb-tools-facade.adapter.ts
+++ b/packages/agent/src/services/kb-tools-facade.adapter.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import type {
+    IKbToolsFacade,
+    IKbToolsFacadeSearchInput,
+    IKbToolsFacadeWriteInput,
+    KbToolFacadeResult,
+} from '@ever-works/plugin';
+import { KbAgentToolsService } from './kb-agent-tools.service';
+import type {
+    KbSearchToolInput,
+    KbWriteToolInput,
+} from './kb-agent-tools.service';
+
+/**
+ * EW-641 Phase 2/d row 36c — bridges `@ever-works/plugin`'s
+ * `IKbToolsFacade` to the NestJS-side `KbAgentToolsService` (row 36).
+ *
+ * Why a separate adapter:
+ *  - `KbAgentToolsService` is a NestJS @Injectable wired into
+ *    `KnowledgeBaseModule`. The agent-pipeline plugin (and any other
+ *    plugin in `packages/plugins/`) runs in plain-object world — no
+ *    DI container — so it can't depend on `KbAgentToolsService`
+ *    directly.
+ *  - The adapter exposes only the interface surface declared in
+ *    `@ever-works/plugin`. Pipeline plugins consume it via
+ *    `StepExecutionContext.kbTools`; the row 36b
+ *    `createKbTools(ctx)` factory builds Vercel-AI-SDK
+ *    `tool({ description, inputSchema, execute })` definitions
+ *    whose `execute` callbacks delegate to this facade.
+ *
+ * The adapter is a 1:1 method-name-mapping shim — every method just
+ * forwards to the corresponding `KbAgentToolsService` method. Kept
+ * as a thin layer so the row-36 service can evolve without breaking
+ * the plugin contract.
+ *
+ * Permission gates (`ensureCanView` / `ensureCanEdit` / manager+ for
+ * lock/unlock) live in `KnowledgeBaseService` two layers down; the
+ * adapter doesn't re-implement them.
+ */
+@Injectable()
+export class KbToolsFacadeAdapter implements IKbToolsFacade {
+    constructor(private readonly kbAgentTools: KbAgentToolsService) {}
+
+    kbSearch(
+        workId: string,
+        userId: string,
+        input: IKbToolsFacadeSearchInput,
+    ): Promise<KbToolFacadeResult<{ items: ReadonlyArray<unknown>; total: number }>> {
+        // The plugin-side interface uses string-union `class` / `status`
+        // for LLM friendliness. The agent-side service expects the
+        // contracts enum types. Cast at the boundary per cumulative
+        // gotcha #5 (KbDocumentClass enum vs contracts string-union).
+        return this.kbAgentTools.kbSearch(workId, userId, input as KbSearchToolInput);
+    }
+
+    kbRead(workId: string, userId: string, idOrPath: string): Promise<KbToolFacadeResult<unknown>> {
+        return this.kbAgentTools.kbRead(workId, userId, idOrPath);
+    }
+
+    kbWrite(
+        workId: string,
+        userId: string,
+        input: IKbToolsFacadeWriteInput,
+    ): Promise<KbToolFacadeResult<{ document: unknown; action: 'created' | 'updated' }>> {
+        // Same cast-at-boundary story as kbSearch for `class`.
+        return this.kbAgentTools.kbWrite(workId, userId, input as KbWriteToolInput);
+    }
+
+    kbLock(
+        workId: string,
+        userId: string,
+        docId: string,
+        mode: 'full' | 'additions-only',
+    ): Promise<KbToolFacadeResult<unknown>> {
+        return this.kbAgentTools.kbLock(workId, userId, docId, mode);
+    }
+
+    kbUnlock(workId: string, userId: string, docId: string): Promise<KbToolFacadeResult<unknown>> {
+        return this.kbAgentTools.kbUnlock(workId, userId, docId);
+    }
+}

--- a/packages/agent/src/services/kb-tools-facade.adapter.ts
+++ b/packages/agent/src/services/kb-tools-facade.adapter.ts
@@ -6,10 +6,7 @@ import type {
     KbToolFacadeResult,
 } from '@ever-works/plugin';
 import { KbAgentToolsService } from './kb-agent-tools.service';
-import type {
-    KbSearchToolInput,
-    KbWriteToolInput,
-} from './kb-agent-tools.service';
+import type { KbSearchToolInput, KbWriteToolInput } from './kb-agent-tools.service';
 
 /**
  * EW-641 Phase 2/d row 36c — bridges `@ever-works/plugin`'s

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -19,6 +19,7 @@ import { KnowledgeBaseGitMirrorService } from './knowledge-base-git-mirror.servi
 import { KnowledgeBaseBufferExtractorService } from './knowledge-base-buffer-extractor.service';
 import { KbMentionResolverService } from './kb-mention-resolver.service';
 import { KbAgentToolsService } from './kb-agent-tools.service';
+import { KbToolsFacadeAdapter } from './kb-tools-facade.adapter';
 import { WorkOwnershipService } from './work-ownership.service';
 
 /**
@@ -73,6 +74,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseBufferExtractorService,
         KbMentionResolverService,
         KbAgentToolsService,
+        KbToolsFacadeAdapter,
     ],
     exports: [
         WorkKnowledgeDocumentRepository,
@@ -85,6 +87,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseBufferExtractorService,
         KbMentionResolverService,
         KbAgentToolsService,
+        KbToolsFacadeAdapter,
     ],
 })
 export class KnowledgeBaseModule {}

--- a/packages/plugin/src/facades/index.ts
+++ b/packages/plugin/src/facades/index.ts
@@ -16,3 +16,4 @@ export * from './git-facade.interface.js';
 export * from './oauth-facade.interface.js';
 export * from './deploy-facade.interface.js';
 export * from './prompt-facade.interface.js';
+export * from './kb-tools-facade.interface.js';

--- a/packages/plugin/src/facades/kb-tools-facade.interface.ts
+++ b/packages/plugin/src/facades/kb-tools-facade.interface.ts
@@ -1,0 +1,95 @@
+/**
+ * EW-641 Phase 2/d row 36c — facade contract for LLM-callable KB
+ * tools. The agent-pipeline plugin (row 36b) builds `tool({...})`
+ * definitions whose `execute` callbacks delegate to this interface;
+ * the agent package implements it via `KbToolsFacadeAdapter` which
+ * delegates to `KbAgentToolsService` (row 36, PR #988).
+ *
+ * Living in `@ever-works/plugin` rather than co-located in the
+ * agent-pipeline plugin so:
+ *  - `StepExecutionContext.kbTools?` can carry it (mirrors how
+ *    `kbContext` carries `KbContextBundleData` from `@ever-works/contracts`),
+ *  - other pipeline plugins (claude-managed-agent, codex, etc.)
+ *    can opt-in without re-defining the contract,
+ *  - the agent-pipeline plugin's row-36b local definition can
+ *    eventually re-export this one to keep a single source of truth.
+ *
+ * **Result envelope contract**: every method returns a discriminated
+ * `{ ok: true, data } | { ok: false, error }`. The agent-side
+ * adapter swallows HttpException subclasses (NotFound/Forbidden/etc.)
+ * and surfaces them as `ok:false` strings so the pipeline runner can
+ * pass-through to the LLM without try/catch dancing.
+ *
+ * Permission gates live one layer down in `KnowledgeBaseService`:
+ * `ensureCanView` for search/read, `ensureCanEdit` for write/lock/
+ * unlock. The adapter doesn't re-implement them.
+ */
+
+/** Shared result envelope — uniform across all KB tool calls. */
+export type KbToolFacadeResult<T> =
+	| { readonly ok: true; readonly data: T }
+	| { readonly ok: false; readonly error: string };
+
+/** Input to `kbSearch` — same shape as `KbSearchToolInput` on the
+ *  agent side. */
+export interface IKbToolsFacadeSearchInput {
+	readonly q?: string;
+	/** Optional KB class filter (`brand` / `legal` / etc.). String-
+	 *  union by design — the adapter casts to the agent's enum. */
+	readonly class?: string;
+	/** Optional lifecycle status filter. */
+	readonly status?: string;
+	/** Page size; the adapter clamps to [1, 50] (default 20). */
+	readonly limit?: number;
+}
+
+/** Input to `kbWrite` — same shape as `KbWriteToolInput` on the
+ *  agent side. The wrapper passes `source: 'agent'` automatically
+ *  and forwards an optional `generatedByAgentRunId` to credit the
+ *  audit trail. */
+export interface IKbToolsFacadeWriteInput {
+	readonly path: string;
+	readonly title: string;
+	readonly class: string;
+	readonly body: string;
+	readonly description?: string | null;
+	readonly tags?: string[];
+	readonly categories?: string[];
+	readonly language?: string;
+	readonly generatedByAgentRunId?: string | null;
+}
+
+/**
+ * LLM-facing facade for KB tools — implemented by the agent-side
+ * `KbToolsFacadeAdapter`, threaded through
+ * `StepExecutionContext.kbTools`, consumed by the agent-pipeline
+ * plugin's `createKbTools()` factory.
+ *
+ * Return types use `unknown` for the success payload so this
+ * contract doesn't import contracts/agent types — the plugin layer
+ * only ever passes the result envelope through to the LLM.
+ */
+export interface IKbToolsFacade {
+	kbSearch(
+		workId: string,
+		userId: string,
+		input: IKbToolsFacadeSearchInput
+	): Promise<KbToolFacadeResult<{ items: ReadonlyArray<unknown>; total: number }>>;
+
+	kbRead(workId: string, userId: string, idOrPath: string): Promise<KbToolFacadeResult<unknown>>;
+
+	kbWrite(
+		workId: string,
+		userId: string,
+		input: IKbToolsFacadeWriteInput
+	): Promise<KbToolFacadeResult<{ document: unknown; action: 'created' | 'updated' }>>;
+
+	kbLock(
+		workId: string,
+		userId: string,
+		docId: string,
+		mode: 'full' | 'additions-only'
+	): Promise<KbToolFacadeResult<unknown>>;
+
+	kbUnlock(workId: string, userId: string, docId: string): Promise<KbToolFacadeResult<unknown>>;
+}

--- a/packages/plugin/src/pipeline/step-execution-context.interface.ts
+++ b/packages/plugin/src/pipeline/step-execution-context.interface.ts
@@ -5,6 +5,7 @@ import type { IScreenshotFacade } from '../facades/screenshot-facade.interface.j
 import type { IContentExtractorFacade } from '../facades/content-extractor-facade.interface.js';
 import type { IDataSourceFacade } from '../facades/data-source-facade.interface.js';
 import type { IPromptFacade } from '../facades/prompt-facade.interface.js';
+import type { IKbToolsFacade } from '../facades/kb-tools-facade.interface.js';
 import type { WorkReference, UserReference } from './generation-context.interface.js';
 
 /**
@@ -102,4 +103,27 @@ export interface StepExecutionContext {
 	 * exposes `format()` on its bundle).
 	 */
 	readonly kbContext?: KbContextBundleData;
+
+	/**
+	 * EW-641 Phase 2/d row 36c — LLM-callable KB tools facade. When
+	 * present, pipeline plugins that support tool-use (agent-pipeline
+	 * and friends) can build `kb_search` / `kb_read` / `kb_write` /
+	 * `kb_lock` / `kb_unlock` tools via the row 36b
+	 * `createKbTools()` factory and pass the resulting tool map to
+	 * `streamText({ tools })`. Each tool's `execute` callback
+	 * delegates to this facade.
+	 *
+	 * Populated by the same orchestrator pattern as `kbContext` (row
+	 * 32c): pipeline executors inject the NestJS-side
+	 * `KbToolsFacadeAdapter` via `@Optional()`, the
+	 * `PipelineFacadeService.createStepExecutionContext` accepts a
+	 * 6th positional `kbTools` argument, and the executors thread it
+	 * through alongside `kbContext`.
+	 *
+	 * Optional so deployments that haven't wired the agent module
+	 * yet (older builds, isolated unit tests, OSS images without the
+	 * agent package) keep constructing identically — the carrier is
+	 * here, the row-36c orchestrator call site populates it.
+	 */
+	readonly kbTools?: IKbToolsFacade;
 }

--- a/packages/plugins/agent-pipeline/src/agent-pipeline.plugin.ts
+++ b/packages/plugins/agent-pipeline/src/agent-pipeline.plugin.ts
@@ -550,7 +550,16 @@ export class AgentPipelinePlugin implements IPlugin, IPipelinePlugin<AgentPipeli
 			referenceTtlDays,
 			onReferenceProcessed: (reference) => {
 				processedReferences.push(reference);
-			}
+			},
+			// EW-641 Phase 2/d row 36c — opt-in KB tool registration.
+			// When the agent's `KbToolsFacadeAdapter` is wired (KB module
+			// present), `execContext.kbTools` is the IKbToolsFacade
+			// instance. `createParentTools` spreads `createKbTools(...)`
+			// into the tools map; otherwise the agent runs without
+			// kb_* tools (pre-row-36c behavior). `generatedByAgentRunId`
+			// stays unset until a follow-up wires the run id through —
+			// `GenerationRequest` doesn't carry one today.
+			kbTools: execContext.kbTools
 		});
 
 		const promptOptions = { work, request, existing };

--- a/packages/plugins/agent-pipeline/src/tools/kb-tools.ts
+++ b/packages/plugins/agent-pipeline/src/tools/kb-tools.ts
@@ -1,29 +1,27 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import type { PluginLogger } from '@ever-works/plugin';
+import type {
+	IKbToolsFacade,
+	IKbToolsFacadeSearchInput,
+	IKbToolsFacadeWriteInput,
+	KbToolFacadeResult,
+	PluginLogger
+} from '@ever-works/plugin';
 
 /**
  * EW-641 Phase 2/d row 36b — agent-pipeline plugin-side wrappers for
  * the LLM-callable KB tools (`kb_search` / `kb_read` / `kb_write` /
  * `kb_lock` / `kb_unlock`). Each wrapper is a `tool({...})` definition
  * (Vercel AI SDK) with a zod input schema and an `execute` callback
- * that delegates to the row 36 `KbAgentToolsService`.
+ * that delegates to row 36's `KbAgentToolsService` via the row 36c
+ * `IKbToolsFacade` adapter.
  *
  * The agent-pipeline plugin lives in `packages/plugins/` and runs
  * outside the NestJS container. It can't directly inject
- * `KbAgentToolsService` — instead, the wiring layer (row 36c, future
- * PR) supplies an `IKbToolsFacade` adapter through the existing
- * `ParentToolContext.facades` mechanism. The interface lives here
- * (local-first) so this PR doesn't have to bump `@ever-works/plugin`'s
- * public surface; row 36c can promote it if cross-package reuse
- * shows up.
- *
- * **Scope note**: this row only ADDS the tool builders and a
- * `createKbTools()` aggregator. It does NOT wire them into
- * `createParentTools()` — that lives in row 36c so the agent-pipeline
- * tool-set roster change is reviewed separately from the tool
- * definitions themselves. Importing this module is therefore a no-op
- * for the existing pipeline until 36c flips the switch.
+ * `KbAgentToolsService` — instead, the row 36c wiring layer supplies
+ * an `IKbToolsFacade` adapter (from `@ever-works/plugin`) through the
+ * `ParentToolContext.kbTools` field. This module reads it and builds
+ * the 5 tool definitions.
  *
  * Tool inputs accept string-union shapes for class / status / lockMode
  * to keep the LLM-facing schema simple. The facade implementation
@@ -31,68 +29,11 @@ import type { PluginLogger } from '@ever-works/plugin';
  * agent enums at the boundary per cumulative gotcha #5.
  */
 
-// ─── Facade contract (LLM-callable surface) ────────────────────────────
-
-/** Shapes returned by every KB tool. Mirrors `KbToolResult<T>` from
- *  `@ever-works/agent/services` so the LLM sees a uniform `{ok, ...}`
- *  envelope regardless of which tool it called. */
-export type KbToolResult<T> = { ok: true; data: T } | { ok: false; error: string };
-
-/** Tool input contracts — match `KbSearchToolInput` / `KbWriteToolInput`
- *  on the agent side. Kept here as TS interfaces (not zod schemas) so
- *  this file can be consumed from non-zod contexts too. */
-export interface IKbSearchInput {
-	readonly q?: string;
-	readonly class?: string;
-	readonly status?: string;
-	readonly limit?: number;
-}
-
-export interface IKbWriteInput {
-	readonly path: string;
-	readonly title: string;
-	readonly class: string;
-	readonly body: string;
-	readonly description?: string | null;
-	readonly tags?: string[];
-	readonly categories?: string[];
-	readonly language?: string;
-	readonly generatedByAgentRunId?: string | null;
-}
-
-/**
- * Facade interface the wiring layer (row 36c) will implement against
- * NestJS-side `KbAgentToolsService`. Keeping the contract here so the
- * agent-pipeline plugin doesn't take a runtime dep on the agent
- * package (it consumes only the interface shape).
- *
- * Each method returns a `KbToolResult<T>` so the tool's `execute`
- * can pass-through to the LLM as-is.
- */
-export interface IKbToolsFacade {
-	kbSearch(
-		workId: string,
-		userId: string,
-		input: IKbSearchInput
-	): Promise<KbToolResult<{ items: ReadonlyArray<unknown>; total: number }>>;
-
-	kbRead(workId: string, userId: string, idOrPath: string): Promise<KbToolResult<unknown>>;
-
-	kbWrite(
-		workId: string,
-		userId: string,
-		input: IKbWriteInput
-	): Promise<KbToolResult<{ document: unknown; action: 'created' | 'updated' }>>;
-
-	kbLock(
-		workId: string,
-		userId: string,
-		docId: string,
-		mode: 'full' | 'additions-only'
-	): Promise<KbToolResult<unknown>>;
-
-	kbUnlock(workId: string, userId: string, docId: string): Promise<KbToolResult<unknown>>;
-}
+// Re-exports for callers that imported these names from row 36b's
+// pre-promotion local definitions. The canonical home is now
+// `@ever-works/plugin`.
+export type { IKbToolsFacade, IKbToolsFacadeSearchInput as IKbSearchInput, IKbToolsFacadeWriteInput as IKbWriteInput };
+export type KbToolResult<T> = KbToolFacadeResult<T>;
 
 // ─── Tool-builder context ───────────────────────────────────────────────
 

--- a/packages/plugins/agent-pipeline/src/tools/parent-tools.ts
+++ b/packages/plugins/agent-pipeline/src/tools/parent-tools.ts
@@ -253,17 +253,24 @@ export function createParentTools(ctx: ParentToolContext): ParentToolsResult {
 	// `kbTools` is unset (OSS images, KB-disabled deployments) the
 	// pipeline runs with the same tool set as before — no behavior
 	// change on existing configurations.
-	const kbToolEntries = ctx.kbTools
-		? createKbTools(
-				{
-					workId: ctx.facadeOptions.workId,
-					userId: ctx.facadeOptions.userId,
-					facade: ctx.kbTools,
-					logger: ctx.logger
-				},
-				ctx.generatedByAgentRunId
-			)
-		: {};
+	//
+	// `FacadeOptions.workId` is optional in the contract; guard against
+	// the missing-workId case (test fixtures, ad-hoc CLI invocations).
+	// The agent-side facade requires a workId to scope KB operations
+	// against the right Work — without one the tools would fail at
+	// call time anyway, so we skip registration up front.
+	const kbToolEntries =
+		ctx.kbTools && ctx.facadeOptions.workId
+			? createKbTools(
+					{
+						workId: ctx.facadeOptions.workId,
+						userId: ctx.facadeOptions.userId,
+						facade: ctx.kbTools,
+						logger: ctx.logger
+					},
+					ctx.generatedByAgentRunId
+				)
+			: {};
 
 	return {
 		tools: {

--- a/packages/plugins/agent-pipeline/src/tools/parent-tools.ts
+++ b/packages/plugins/agent-pipeline/src/tools/parent-tools.ts
@@ -5,6 +5,7 @@ import type {
 	ISearchFacade,
 	IContentExtractorFacade,
 	IPromptFacade,
+	IKbToolsFacade,
 	FacadeOptions,
 	PipelineProgressCallback,
 	PipelineExecutionOptions,
@@ -24,6 +25,7 @@ import { createSearchTool, createReportProgressTool } from './facade-tools.js';
 import type { FacadeToolOptions } from './facade-tools.js';
 import { readWorkspaceOverview } from './workspace-overview.js';
 import { createFindItemsTool } from './find-items-tool.js';
+import { createKbTools } from './kb-tools.js';
 import { processUrlWorker } from '../worker/url-worker.js';
 import type { WorkerPromptOptions } from '../worker/extraction-prompt.js';
 import { processModification } from '../worker/modification-worker.js';
@@ -53,6 +55,17 @@ export interface ParentToolContext {
 	onLogEntry?: PipelineExecutionOptions['onLogEntry'];
 	referenceTtlDays?: number;
 	onReferenceProcessed?: (reference: ReferenceEntry) => void;
+	/**
+	 * EW-641 Phase 2/d row 36c — optional KB tools facade. When set,
+	 * the returned tools map gains the 5 `kb_*` tool definitions
+	 * (kb_search / kb_read / kb_write / kb_lock / kb_unlock — row 36b)
+	 * so the LLM can search, read, and mutate the Work's Knowledge
+	 * Base during generation. When unset (deployments without the
+	 * agent KB module wired), the kb tools simply aren't registered.
+	 */
+	kbTools?: IKbToolsFacade;
+	/** Optional agent-run id stamped on docs created via `kb_write`. */
+	generatedByAgentRunId?: string;
 }
 
 export interface ParentToolsResult {
@@ -234,6 +247,24 @@ export function createParentTools(ctx: ParentToolContext): ParentToolsResult {
 		execute: () => readWorkspaceOverview(ctx.workspacePath, ctx.existing.items)
 	});
 
+	// EW-641 Phase 2/d row 36c — when the agent-side `kbToolsFacade`
+	// adapter is wired (i.e. the deployment has the KB module), spread
+	// the 5 LLM-callable KB tools (row 36b) into the tools map. When
+	// `kbTools` is unset (OSS images, KB-disabled deployments) the
+	// pipeline runs with the same tool set as before — no behavior
+	// change on existing configurations.
+	const kbToolEntries = ctx.kbTools
+		? createKbTools(
+				{
+					workId: ctx.facadeOptions.workId,
+					userId: ctx.facadeOptions.userId,
+					facade: ctx.kbTools,
+					logger: ctx.logger
+				},
+				ctx.generatedByAgentRunId
+			)
+		: {};
+
 	return {
 		tools: {
 			search: createSearchTool(ctx.facades.searchFacade, ctx.facadeOptions, toolOptions),
@@ -241,7 +272,8 @@ export function createParentTools(ctx: ParentToolContext): ParentToolsResult {
 			processUrl: processUrlTool,
 			modifyItems: modifyItemsTool,
 			getWorkspaceOverview: getWorkspaceOverviewTool,
-			reportProgress: createReportProgressTool(ctx.onProgress, 1, ctx.totalSteps)
+			reportProgress: createReportProgressTool(ctx.onProgress, 1, ctx.totalSteps),
+			...kbToolEntries
 		},
 		breaker
 	};


### PR DESCRIPTION
## Summary

- EW-641 Phase 2/d **closure**. End-to-end wires LLM-callable KB tools through the platform: agent → @ever-works/plugin → agent-pipeline.
- Closes the loop started in rows 36 (service) + 36b (plugin-side tool builders).

## Layers

1. **@ever-works/plugin** — new \`IKbToolsFacade\` + result envelope in \`facades/kb-tools-facade.interface.ts\`. Added optional \`kbTools?\` to \`StepExecutionContext\`.
2. **@ever-works/agent** — new \`KbToolsFacadeAdapter\` (@Injectable) that implements the facade by delegating to row-36 \`KbAgentToolsService\`. Casts string-union → enum at the boundary per cumulative gotcha #5. Registered in \`KnowledgeBaseModule\`.
3. **PipelineFacadeService** accepts a 6th positional \`kbTools\` arg → forwards onto returned context.
4. **StepPipelineExecutorService** + **FullPipelineExecutorService** — each gain \`@Optional() kbToolsFacade?\` injection + \`resolveKbToolsFacadeSafe(work)\` helper. Threaded through executePipeline → processStep → executeStep alongside \`kbContext\`.
5. **agent-pipeline.plugin.ts** — passes \`execContext.kbTools\` to \`createParentTools\`.
6. **parent-tools.ts** — when \`ctx.kbTools\` set, spreads row-36b's \`createKbTools({...})\` into the returned tools map. Otherwise no behavior change.
7. **kb-tools.ts** (row 36b) updated to import \`IKbToolsFacade\` etc. from \`@ever-works/plugin\` instead of defining locally; re-exports under prior names for backward compatibility.

## Tests

- 6 new jest cases for \`KbToolsFacadeAdapter\` (1 passthrough per method + envelope no-translate).
- 7 existing executor assertions updated to expect the new 6th positional arg (\`undefined\` when no \`kbTools\` is wired) in \`createStepExecutionContext\` mocks.

Green:
- agent pipeline 14 suites / 409 tests
- @ever-works/plugin 14 files / 199 tests
- agent-pipeline 18 files / 217 tests
- agent services include the new adapter spec
- DTS build (\`tsc -p tsconfig.types.json\`) clean
- prettier@3.7.4 format check clean

## Phase 2/d closure

This closes Phase 2/d (agent tools). Row 37 (Phase 2/e — org-overlay fanout) becomes NEXT after merge.

## Test plan

- [x] \`npx jest src/pipeline src/services\` → green across agent
- [x] \`pnpm vitest run\` → green in @ever-works/plugin + agent-pipeline
- [x] \`tsc -p tsconfig.types.json\` clean
- [x] prettier@3.7.4 --write → no diff after format
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline plugins can access LLM-callable KB tools (search, read, write, lock, unlock) via the execution context for fresh and resumed runs when KB wiring is present.
* **APIs / Types**
  * Introduced a shared KB tools facade contract and added an optional kbTools field to the step execution context.
* **Tests**
  * Added and updated tests for the KB tools facade adapter and its integration with pipeline execution.
* **Chores**
  * Re-exported and registered the KB tools facade for module consumers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->