### PR TITLE
feat(tasks): TriggerService.dispatchKbOrgOverlayFanout + module wiring (row 37b)

### DIFF
--- a/packages/tasks/src/__tests__/trigger.service.spec.ts
+++ b/packages/tasks/src/__tests__/trigger.service.spec.ts
@@ -6,6 +6,7 @@ const {
     workGenTriggerMock,
     workImportTriggerMock,
     templateCustomizationTriggerMock,
+    kbOrgOverlayFanoutTriggerMock,
     triggerConfig,
     subscriptionsConfig,
 } = vi.hoisted(() => {
@@ -15,6 +16,7 @@ const {
         workGenTriggerMock: vi.fn(),
         workImportTriggerMock: vi.fn(),
         templateCustomizationTriggerMock: vi.fn(),
+        kbOrgOverlayFanoutTriggerMock: vi.fn(),
         triggerConfig: {
             shouldUseTrigger: vi.fn(),
             getSecretKey: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock('@ever-works/agent/tasks', () => ({
     WORK_GENERATION_DISPATCHER: Symbol('WORK_GENERATION_DISPATCHER'),
     WORK_IMPORT_DISPATCHER: Symbol('WORK_IMPORT_DISPATCHER'),
     TEMPLATE_CUSTOMIZATION_DISPATCHER: Symbol('TEMPLATE_CUSTOMIZATION_DISPATCHER'),
+    KB_ORG_OVERLAY_FANOUT_DISPATCHER: Symbol('KB_ORG_OVERLAY_FANOUT_DISPATCHER'),
 }));
 
 vi.mock('../tasks/trigger/work-generation.task', () => ({
@@ -56,6 +59,9 @@ vi.mock('../tasks/trigger/work-import.task', () => ({
 }));
 vi.mock('../tasks/trigger/template-customization.task', () => ({
     templateCustomizationTask: { trigger: templateCustomizationTriggerMock },
+}));
+vi.mock('../tasks/trigger/kb-org-overlay-fanout.task', () => ({
+    kbOrgOverlayFanoutTask: { trigger: kbOrgOverlayFanoutTriggerMock },
 }));
 
 import { TriggerService } from '../trigger/trigger.service';
@@ -267,6 +273,78 @@ describe('TriggerService', () => {
         it('returns null when the SDK throws', async () => {
             templateCustomizationTriggerMock.mockRejectedValue(new Error('boom'));
             const out = await service.dispatchTemplateCustomization({ customizationId: 'c1' });
+            expect(out).toBeNull();
+        });
+    });
+
+    // EW-641 Phase 2/e row 37b — TriggerService dispatch path for the
+    // org-overlay fanout task. The KnowledgeBaseService side of the wire
+    // lands in a follow-up row (needs `Work.organizationId` first — the
+    // entity doesn't carry that column on develop today, so the resolver
+    // can't be built yet). This test covers the dispatcher half so the
+    // wiring is exercised end-to-end on the producer side.
+    describe('dispatchKbOrgOverlayFanout', () => {
+        const samplePayload = {
+            organizationId: 'org-1',
+            documentId: 'doc-1',
+            workIds: ['w-a', 'w-b'],
+            operation: 'upsert' as const,
+            path: 'legal/privacy.md',
+            class: 'legal',
+        };
+
+        it('returns null when trigger is disabled', async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            const out = await service.dispatchKbOrgOverlayFanout(samplePayload);
+            expect(out).toBeNull();
+            expect(kbOrgOverlayFanoutTriggerMock).not.toHaveBeenCalled();
+        });
+
+        it('triggers the kbOrgOverlayFanoutTask with correct tags + concurrency key', async () => {
+            kbOrgOverlayFanoutTriggerMock.mockResolvedValue({ id: 'run_fanout_1' });
+
+            const out = await service.dispatchKbOrgOverlayFanout(samplePayload);
+
+            expect(out).toBe('run_fanout_1');
+            expect(kbOrgOverlayFanoutTriggerMock).toHaveBeenCalledWith(
+                samplePayload,
+                expect.objectContaining({
+                    tags: expect.arrayContaining([
+                        'kb-org-overlay-fanout',
+                        'op:upsert',
+                        'org:org-1',
+                        'doc:doc-1',
+                        'targets:2',
+                    ]),
+                    machine: 'small-1x',
+                    // Serializes per-org so two rapid mutations against
+                    // the same org don't race on writes to overlapping
+                    // target Works.
+                    concurrencyKey: 'kb-org-overlay:org-1',
+                }),
+            );
+        });
+
+        it('reports correct target count + op tag on delete operations', async () => {
+            kbOrgOverlayFanoutTriggerMock.mockResolvedValue({ id: 'run_fanout_del' });
+
+            await service.dispatchKbOrgOverlayFanout({
+                ...samplePayload,
+                operation: 'delete',
+                workIds: ['w-a', 'w-b', 'w-c', 'w-d'],
+            });
+
+            expect(kbOrgOverlayFanoutTriggerMock).toHaveBeenCalledWith(
+                expect.objectContaining({ operation: 'delete' }),
+                expect.objectContaining({
+                    tags: expect.arrayContaining(['op:delete', 'targets:4']),
+                }),
+            );
+        });
+
+        it('returns null when trigger() throws (caller treats as deferred sync)', async () => {
+            kbOrgOverlayFanoutTriggerMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+            const out = await service.dispatchKbOrgOverlayFanout(samplePayload);
             expect(out).toBeNull();
         });
     });

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -8,6 +8,7 @@ import {
     KB_MIRROR_DOCUMENT_DISPATCHER,
     KB_BACKFILL_SKELETON_DISPATCHER,
     KB_EMBED_DOCUMENT_DISPATCHER,
+    KB_ORG_OVERLAY_FANOUT_DISPATCHER,
 } from '@ever-works/agent/tasks';
 
 @Global()
@@ -42,6 +43,10 @@ import {
             provide: KB_EMBED_DOCUMENT_DISPATCHER,
             useExisting: TriggerService,
         },
+        {
+            provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+            useExisting: TriggerService,
+        },
     ],
     exports: [
         TriggerService,
@@ -52,6 +57,7 @@ import {
         KB_MIRROR_DOCUMENT_DISPATCHER,
         KB_BACKFILL_SKELETON_DISPATCHER,
         KB_EMBED_DOCUMENT_DISPATCHER,
+        KB_ORG_OVERLAY_FANOUT_DISPATCHER,
     ],
 })
 export class TriggerModule {}

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -16,6 +16,8 @@ import {
     KbBackfillSkeletonDispatcher,
     KbEmbedDocumentPayload,
     KbEmbedDocumentDispatcher,
+    KbOrgOverlayFanoutPayload,
+    KbOrgOverlayFanoutDispatcher,
 } from '@ever-works/agent/tasks';
 import { workGenerationTask } from '../tasks/trigger/work-generation.task';
 import { workImportTask } from '../tasks/trigger/work-import.task';
@@ -24,6 +26,7 @@ import { webhookDeliveryTask } from '../tasks/trigger/webhook-delivery.task';
 import { kbMirrorDocumentTask } from '../tasks/trigger/kb-mirror-document.task';
 import { kbBackfillSkeletonTask } from '../tasks/trigger/kb-backfill-skeleton.task';
 import { kbEmbedDocumentTask } from '../tasks/trigger/kb-embed-document.task';
+import { kbOrgOverlayFanoutTask } from '../tasks/trigger/kb-org-overlay-fanout.task';
 
 @Injectable()
 export class TriggerService
@@ -34,7 +37,8 @@ export class TriggerService
         WebhookDeliveryDispatcher,
         KbMirrorDocumentDispatcher,
         KbBackfillSkeletonDispatcher,
-        KbEmbedDocumentDispatcher
+        KbEmbedDocumentDispatcher,
+        KbOrgOverlayFanoutDispatcher
 {
     private readonly logger = new Logger(TriggerService.name);
     private configured = false;
@@ -266,6 +270,48 @@ export class TriggerService
             return handle.id;
         } catch (error) {
             this.logger.error('Failed to dispatch kb-embed-document task', error as Error);
+            return null;
+        }
+    }
+
+    /**
+     * EW-641 Phase 2/e row 37b — enqueue an org-overlay fanout run for one
+     * org-scope KB document mutation. The task body (row 37) iterates the
+     * pre-resolved `workIds` and calls `materializeOrgDocument` /
+     * `removeOrgDocument` per Work.
+     *
+     * Serializes per-org so two rapid org-doc edits don't race on writes
+     * against the same set of target Work repos. Keyed on `organizationId`
+     * (not on the cross product of org × Work) because each fanout already
+     * sequences its own Works in-task, and serializing per-Work would
+     * over-constrain throughput for orgs with many Works.
+     *
+     * Returns the Trigger.dev run id, or `null` when Trigger.dev is
+     * disabled / the dispatch threw — `KnowledgeBaseService` treats both
+     * as a deferred sync and relies on Phase 3 reconciliation to catch
+     * drift.
+     */
+    async dispatchKbOrgOverlayFanout(payload: KbOrgOverlayFanoutPayload): Promise<string | null> {
+        if (!this.ensureConfigured()) {
+            return null;
+        }
+
+        try {
+            const handle = await kbOrgOverlayFanoutTask.trigger(payload, {
+                tags: [
+                    'kb-org-overlay-fanout',
+                    `op:${payload.operation}`,
+                    `org:${payload.organizationId}`,
+                    `doc:${payload.documentId}`,
+                    `targets:${payload.workIds.length}`,
+                ],
+                machine: this.machine() as any,
+                concurrencyKey: `kb-org-overlay:${payload.organizationId}`,
+            });
+
+            return handle.id;
+        } catch (error) {
+            this.logger.error('Failed to dispatch kb-org-overlay-fanout task', error as Error);
             return null;
         }
     }


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 37b — producer-side dispatcher half of the org-overlay fanout.

- Wires `TriggerService.dispatchKbOrgOverlayFanout` against the row-37 `kbOrgOverlayFanoutTask`
- Registers `KB_ORG_OVERLAY_FANOUT_DISPATCHER` in `TriggerModule` via `useExisting: TriggerService`
- Tags: `kb-org-overlay-fanout`, `op:<upsert|delete>`, `org:<id>`, `doc:<id>`, `targets:<count>`
- Serializes per-org via `concurrencyKey: kb-org-overlay:<organizationId>` so two rapid org-doc edits don't race on writes against the same set of target Works

## Scope correction discovered this tick

The handoff's row 37b sub-list assumed `WorkRepository.findIdsByOrganization` could be implemented against an existing `Work.organizationId` column. **That column doesn't exist on `Work` on `develop`** — the entity carries an `organization: boolean` flag and `owner?: string`, but no FK to any Organization entity (Organization itself is also not yet in the entity tree; the spec references it at §7.6 but the implementation hasn't shipped).

So row 37b is split into two deliverable halves:

- **Row 37b (this PR)** — `TriggerService.dispatchKbOrgOverlayFanout` + `TriggerModule` registration. Plugs into the existing row-37 dispatcher contract; ships today.
- **Row 37c (new NEXT)** — `Work.organizationId` column (entity + TypeORM migration) + `Organization` entity skeleton if needed.
- **Row 37d** — `WorkRepository.findIdsByOrganization` helper + `KnowledgeBaseService.enqueueOrgOverlayFanout` private helper + wire into `createOrgDocument`. Becomes possible once 37c lands.

After row 37d lands, Phase 2/e is end-to-end DONE.

## Test plan

- [x] `npx vitest run src/__tests__/trigger.service.spec.ts` → 26/26 (22 prior + 4 new for the new dispatcher path)
- [x] `npx jest` in `packages/agent` → 234/234 (no agent-side changes; sanity check)
- [x] `turbo build --filter=@ever-works/trigger-tasks` → clean
- [x] `turbo build --filter=@ever-works/agent` → clean
- [x] `prettier@3.7.4 --check` on touched files → all formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for dispatching KB organization overlay fanout tasks with configurable concurrency control.

* **Tests**
  * Extended test coverage for task dispatch functionality, including validation of operation tagging, trigger invocation, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->