### PR TITLE
feat(agent,api): Work.organizationId column + migration (row 37c)

### DIFF
--- a/apps/api/src/migrations/1779977000000-AddWorkOrganizationId.ts
+++ b/apps/api/src/migrations/1779977000000-AddWorkOrganizationId.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+/**
+ * Adds the nullable `organizationId` column to the `works` table.
+ *
+ * EW-641 Phase 2/e row 37c — foundation for row 37d's
+ * `WorkRepository.findIdsByOrganization(orgId)` lookup, which the KB
+ * org-overlay fanout enqueue path uses to resolve target Works for a
+ * given organization.
+ *
+ * Design choice: this column is intentionally **NOT** a foreign key
+ * yet. The spec (§7.6) describes an `Organization` entity for KB
+ * org-overlay membership, but no such entity has landed on develop
+ * (the existing `WorkKnowledgeDocument.organizationId` already stores
+ * a free-form UUID for the same reason — see
+ * `1779971000000-CreateWorkKnowledgeDocuments.ts`). Treating the
+ * column identically here keeps the data model coherent and lets a
+ * later migration upgrade it to a `REFERENCES organizations(id)` FK
+ * once that table exists.
+ *
+ * Forward-only, additive, nullable. Existing rows stay NULL on
+ * upgrade; org onboarding flows (out of scope here) populate it
+ * later. No read paths depend on the column today — until row 37d
+ * lands, the only effect of this migration is a harmless extra
+ * column.
+ *
+ * Index: single-column on `(organizationId)` so the row-37d
+ * `findIdsByOrganization` lookup doesn't sequential-scan `works`.
+ */
+export class AddWorkOrganizationId1779977000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasColumn('works', 'organizationId'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'organizationId',
+                    type: 'uuid',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        // Single-column index for the row-37d
+        // `findIdsByOrganization(orgId)` lookup. Named explicitly so the
+        // down-migration drops the right index even if TypeORM's auto-naming
+        // diverges between dialects (SQLite + Postgres) over time.
+        const table = await queryRunner.getTable('works');
+        const hasIndex = table?.indices.some((idx) => idx.name === 'idx_works_organization_id');
+        if (!hasIndex) {
+            await queryRunner.createIndex(
+                'works',
+                new TableIndex({
+                    name: 'idx_works_organization_id',
+                    columnNames: ['organizationId'],
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('works');
+        const hasIndex = table?.indices.some((idx) => idx.name === 'idx_works_organization_id');
+        if (hasIndex) {
+            await queryRunner.dropIndex('works', 'idx_works_organization_id');
+        }
+        if (await queryRunner.hasColumn('works', 'organizationId')) {
+            await queryRunner.dropColumn('works', 'organizationId');
+        }
+    }
+}

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -78,6 +78,29 @@ export class Work {
     @Column({ default: false })
     organization: boolean;
 
+    /**
+     * EW-641 Phase 2/e row 37c — owning organization id.
+     *
+     * Free-form UUID, NOT (yet) a foreign key to any `Organization` entity:
+     * the spec (§7.6) describes a future `Organization` entity for KB
+     * org-overlay membership, but no such entity has landed on develop yet.
+     * Treat this column the same way `WorkKnowledgeDocument.organizationId`
+     * is stored — a string that future code links to a yet-to-exist
+     * Organization table.
+     *
+     * Starts NULL for every existing Work. Population happens lazily: org
+     * onboarding flows (not in this PR) will set it on Works the org owns,
+     * and the KB org-overlay fanout (row 37d) reads it to resolve the
+     * target Work id list before dispatching the `kb-org-overlay-fanout`
+     * task. Until then, the column is harmless metadata — no read paths
+     * depend on it.
+     *
+     * Indexed (single-column) for the row-37d
+     * `WorkRepository.findIdsByOrganization(orgId)` lookup.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @Column()
     description: string;
 


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 37c — foundation that unblocks row 37d's `WorkRepository.findIdsByOrganization` lookup for the KB org-overlay fanout enqueue path.

- **Entity** (`packages/agent/src/entities/work.entity.ts`): adds nullable `organizationId?: string | null` UUID column. Deliberately NOT a `@ManyToOne(() => Organization)` foreign key — the spec §7.6 references an `Organization` entity for KB org-overlay membership but no such entity has landed on develop. Treats the column identically to how `WorkKnowledgeDocument.organizationId` is already stored (free-form UUID); a later migration can upgrade it to a real FK once `Organization` exists.

- **Migration** (`apps/api/src/migrations/1779977000000-AddWorkOrganizationId.ts`): idempotent forward-only. Adds the nullable column + single-column index `idx_works_organization_id` for the row-37d lookup. Full `down()` that drops both. Existing rows stay NULL on upgrade; org onboarding flows (out of scope here) populate the column later.

## Why this row exists

Row 37b shipped the `TriggerService.dispatchKbOrgOverlayFanout` half of the wire. Row 37d needs `WorkRepository.findIdsByOrganization(orgId)` to resolve target Works before dispatching — but that resolver can't exist until `Work` carries an `organizationId` column. This PR is the smallest deliverable foundation: column + index + migration. Behavior-changing wire-up lands in row 37d.

## Test plan

- [x] `cd packages/agent && npx jest` → 234/234 suites, 4957/4957 tests
- [x] `cd apps/api && npx jest` → 141/142 suites, 2331/2331 tests (the 1 fail is `deploy.e2e.spec.ts` failing on `@ever-works/k8s-plugin` resolution, a pre-existing unrelated develop issue)
- [x] `turbo build --filter=ever-works-api` → clean (SWC + tsc DTS)
- [x] `turbo build --filter=@ever-works/agent` → clean
- [x] `prettier@3.7.4 --check` on touched files → all formatted
- [x] Migration is idempotent (uses `hasColumn` + `indices.some` guards before mutating)
- [x] Migration includes full `down()` per the architecture rule in `docs/specs/architecture/database-migrations.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization association support to works, enabling upcoming organization-level management features and organization-based filtering capabilities.
  * Enhanced data model to support organization metadata, laying groundwork for improved organization management and overlay functionality within the knowledge base system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->