### PR TITLE
feat(agent): KB org-overlay fanout enqueue from createOrgDocument (row 37d)

### DIFF
--- a/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
+++ b/packages/agent/src/database/repositories/__tests__/work.repository.spec.ts
@@ -1117,4 +1117,44 @@ describe('WorkRepository', () => {
             expect(partial.sourceValidationNextRunAt).toBe(nextRunAt);
         });
     });
+
+    // EW-641 Phase 2/e row 37d — `findIdsByOrganization` resolves
+    // target Works for the KB org-overlay fanout enqueue.
+    describe('findIdsByOrganization', () => {
+        it('returns empty array (no DB hit) when organizationId is falsy', async () => {
+            const result = await service.findIdsByOrganization('');
+            expect(result).toEqual([]);
+            expect(repository.find).not.toHaveBeenCalled();
+        });
+
+        it('queries by organizationId with id-only projection ordered ASC', async () => {
+            repository.find.mockResolvedValueOnce([
+                { id: 'w-a' },
+                { id: 'w-b' },
+                { id: 'w-c' },
+            ] as Work[]);
+
+            const result = await service.findIdsByOrganization('org-1');
+
+            expect(result).toEqual(['w-a', 'w-b', 'w-c']);
+            expect(repository.find).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { organizationId: 'org-1' },
+                    order: { id: 'ASC' },
+                }),
+            );
+            // id-only projection — avoids hydrating user / every column for
+            // an enqueue payload that only needs ids.
+            const call = repository.find.mock.calls[0][0] as {
+                select?: { id?: boolean };
+            };
+            expect(call.select).toEqual({ id: true });
+        });
+
+        it('returns [] when the org has no Works', async () => {
+            repository.find.mockResolvedValueOnce([]);
+            const result = await service.findIdsByOrganization('org-empty');
+            expect(result).toEqual([]);
+        });
+    });
 });

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -451,6 +451,40 @@ export class WorkRepository {
         return await this.repository.find({ where: { userId } });
     }
 
+    /**
+     * EW-641 Phase 2/e row 37d — list every Work id under an organization.
+     *
+     * Used by `KnowledgeBaseService.enqueueOrgOverlayFanout` to resolve
+     * the target Work id list BEFORE dispatching the
+     * `kb-org-overlay-fanout` Trigger.dev task — the row-37 task body is
+     * pure-iteration and expects pre-resolved ids in its payload.
+     *
+     * Returns raw id strings only — the task body iterates ids and calls
+     * `KnowledgeBaseGitMirrorService.materializeOrgDocument(workId, ...)`,
+     * which fetches its own Work row. Hydrating full entities + the
+     * `user` relation here would be wasted I/O for an enqueue payload.
+     *
+     * Ordered by `id ASC` for deterministic enqueue payloads (helps
+     * with cross-run diffing in Trigger.dev tags + payload snapshots).
+     * Returns `[]` when `organizationId` is falsy so callers don't
+     * need a separate guard.
+     *
+     * `organizationId` is a free-form UUID on `Work` (column added in
+     * row 37c) and is NOT yet an FK — see the entity docstring for the
+     * deliberate design choice.
+     */
+    async findIdsByOrganization(organizationId: string): Promise<string[]> {
+        if (!organizationId) {
+            return [];
+        }
+        const rows = await this.repository.find({
+            where: { organizationId },
+            select: { id: true } as never,
+            order: { id: 'ASC' },
+        });
+        return rows.map((w) => w.id);
+    }
+
     async updateLastPullRequest(
         id: string,
         lastPullRequest: Work['lastPullRequest'],

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -7,6 +7,9 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.service';
 import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
+import { KB_ORG_OVERLAY_FANOUT_DISPATCHER } from '../../tasks/kb-org-overlay-fanout-dispatcher';
+import { KB_MIRROR_DOCUMENT_DISPATCHER } from '../../tasks/kb-mirror-document-dispatcher';
+import { WorkRepository } from '../../database/repositories/work.repository';
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
 import { WorkKnowledgeUploadRepository } from '../../database/repositories/work-knowledge-upload.repository';
@@ -725,6 +728,215 @@ describe('KnowledgeBaseService', () => {
             expect(result.organizationId).toBe(ORG_ID);
             expect(result.workId).toBeNull();
             expect(result.class).toBe('legal');
+        });
+    });
+
+    // EW-641 Phase 2/e row 37d — org-overlay fanout enqueue from
+    // `createOrgDocument`. The base test module doesn't wire the
+    // fanout dispatcher or `WorkRepository`, so these cases build a
+    // fresh service with those providers and assert the row-37d
+    // contract end-to-end (resolver → dispatcher).
+    describe('createOrgDocument — org-overlay fanout enqueue (row 37d)', () => {
+        type FanoutCall = {
+            organizationId: string;
+            documentId: string;
+            workIds: ReadonlyArray<string>;
+            operation: 'upsert' | 'delete';
+            path: string;
+            class: string;
+        };
+
+        async function buildWithFanout(opts: {
+            workIds?: string[];
+            findThrows?: boolean;
+            dispatchThrows?: boolean;
+        }) {
+            const workIds = opts.workIds ?? ['work-a', 'work-b'];
+            const workRepoMock = {
+                findIdsByOrganization: opts.findThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest.fn().mockResolvedValue(workIds),
+            };
+            const fanoutDispatcher = {
+                dispatchKbOrgOverlayFanout: opts.dispatchThrows
+                    ? jest.fn().mockRejectedValue(new Error('trigger boom'))
+                    : jest.fn().mockResolvedValue('run-id'),
+            };
+            const mirrorDispatcher = {
+                dispatchKbMirrorDocument: jest.fn().mockResolvedValue('mirror-run-id'),
+            };
+
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    { provide: WorkKnowledgeDocumentRepository, useValue: docRepo },
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: WorkKnowledgeTagRepository, useValue: tagRepo },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                    },
+                    { provide: WorkOwnershipService, useValue: ownership },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: ActivityLogService, useValue: activityLog },
+                    { provide: KB_EMBED_DOCUMENT_DISPATCHER, useValue: embedDispatcher },
+                    { provide: KB_MIRROR_DOCUMENT_DISPATCHER, useValue: mirrorDispatcher },
+                    { provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER, useValue: fanoutDispatcher },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                ],
+            }).compile();
+
+            return {
+                service: module.get(KnowledgeBaseService),
+                fanoutDispatcher,
+                mirrorDispatcher,
+                workRepoMock,
+            };
+        }
+
+        it('enqueues fanout with resolved workIds for an inheritable org doc', async () => {
+            const {
+                service: svc,
+                fanoutDispatcher,
+                mirrorDispatcher,
+                workRepoMock,
+            } = await buildWithFanout({ workIds: ['work-a', 'work-b'] });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({
+                    ...data,
+                    id: 'org-doc-1',
+                    workId: null,
+                    organizationId: ORG_ID,
+                }),
+            );
+
+            await svc.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'verbatim',
+            });
+
+            expect(workRepoMock.findIdsByOrganization).toHaveBeenCalledWith(ORG_ID);
+            expect(fanoutDispatcher.dispatchKbOrgOverlayFanout).toHaveBeenCalledTimes(1);
+            const call = fanoutDispatcher.dispatchKbOrgOverlayFanout.mock.calls[0][0] as FanoutCall;
+            expect(call.organizationId).toBe(ORG_ID);
+            expect(call.documentId).toBe('org-doc-1');
+            expect(call.workIds).toEqual(['work-a', 'work-b']);
+            expect(call.operation).toBe('upsert');
+            expect(call.path).toBe('legal/privacy.md');
+            expect(call.class).toBe('legal');
+            // Per-Work `kb-mirror-document` MUST NOT fire for an org-scope
+            // row — that path writes to `.content/kb/<path>` (work-owned)
+            // and would collide with overlay precedence semantics.
+            expect(mirrorDispatcher.dispatchKbMirrorDocument).not.toHaveBeenCalled();
+        });
+
+        it('skips fanout dispatch when the org has zero Works', async () => {
+            const {
+                service: svc,
+                fanoutDispatcher,
+                workRepoMock,
+            } = await buildWithFanout({ workIds: [] });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, workId: null, organizationId: ORG_ID }),
+            );
+
+            await svc.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'body',
+            });
+
+            expect(workRepoMock.findIdsByOrganization).toHaveBeenCalledWith(ORG_ID);
+            expect(fanoutDispatcher.dispatchKbOrgOverlayFanout).not.toHaveBeenCalled();
+        });
+
+        it('swallows WorkRepository errors so the API write still succeeds', async () => {
+            const { service: svc, fanoutDispatcher } = await buildWithFanout({
+                findThrows: true,
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, workId: null, organizationId: ORG_ID }),
+            );
+
+            // Should not throw — `enqueueOrgOverlayFanout` is fire-and-forget.
+            await expect(
+                svc.createOrgDocument(ORG_ID, USER_ID, {
+                    path: 'legal/privacy.md',
+                    title: 'Privacy policy',
+                    class: 'legal' as KbDocumentClass,
+                    body: 'body',
+                }),
+            ).resolves.toBeDefined();
+
+            expect(fanoutDispatcher.dispatchKbOrgOverlayFanout).not.toHaveBeenCalled();
+        });
+
+        it('swallows dispatcher errors so the API write still succeeds', async () => {
+            const { service: svc, fanoutDispatcher } = await buildWithFanout({
+                workIds: ['work-a'],
+                dispatchThrows: true,
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, workId: null, organizationId: ORG_ID }),
+            );
+
+            await expect(
+                svc.createOrgDocument(ORG_ID, USER_ID, {
+                    path: 'legal/privacy.md',
+                    title: 'Privacy policy',
+                    class: 'legal' as KbDocumentClass,
+                    body: 'body',
+                }),
+            ).resolves.toBeDefined();
+
+            expect(fanoutDispatcher.dispatchKbOrgOverlayFanout).toHaveBeenCalledTimes(1);
+        });
+
+        it('still creates the doc when neither dispatcher nor repo are wired (degraded)', async () => {
+            // Uses the base `service` from the outer beforeEach — it has
+            // neither KB_ORG_OVERLAY_FANOUT_DISPATCHER nor WorkRepository
+            // wired. The mutation must still succeed (Phase 3 reconciliation
+            // catches drift).
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, workId: null, organizationId: ORG_ID }),
+            );
+
+            const result = await service.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'body',
+            });
+
+            expect(result.organizationId).toBe(ORG_ID);
+        });
+
+        it('does NOT enqueue fanout from createDocument (Work-scope path)', async () => {
+            const {
+                service: svc,
+                fanoutDispatcher,
+                mirrorDispatcher,
+            } = await buildWithFanout({ workIds: ['work-a', 'work-b'] });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'work-doc-1' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/voice.md',
+                title: 'Brand voice',
+                class: 'brand' as KbDocumentClass,
+                body: 'work-scoped body',
+            });
+
+            // Work-scope rows use the per-Work mirror path only — never
+            // the org-overlay fanout (verifies the call-site is org-only).
+            expect(fanoutDispatcher.dispatchKbOrgOverlayFanout).not.toHaveBeenCalled();
+            expect(mirrorDispatcher.dispatchKbMirrorDocument).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -38,6 +38,8 @@ import {
 } from '../entities/kb-types';
 import { KB_MIRROR_DOCUMENT_DISPATCHER, type KbMirrorDocumentDispatcher } from '../tasks';
 import { KB_EMBED_DOCUMENT_DISPATCHER, type KbEmbedDocumentDispatcher } from '../tasks';
+import { KB_ORG_OVERLAY_FANOUT_DISPATCHER, type KbOrgOverlayFanoutDispatcher } from '../tasks';
+import { WorkRepository } from '../database/repositories/work.repository';
 import type {
     CitationDto,
     KbDocumentBodyDto,
@@ -168,6 +170,24 @@ export class KnowledgeBaseService {
         // lexical-only ranking.
         @Optional() private readonly chunkRepository?: WorkKnowledgeChunkRepository,
         @Optional() private readonly aiFacade?: AiFacadeService,
+        // EW-641 Phase 2/e row 37d — org-overlay fanout dispatcher.
+        // Optional so isolated unit tests + deployments without
+        // Trigger.dev wired still construct; when absent, org docs
+        // persist in the DB but per-Work `.org/` materialization
+        // defers to the Phase 3 reconciliation job (spec §9.6).
+        // Fire-and-forget shape mirrors `mirrorDispatcher` /
+        // `embedDispatcher` — failures are logged but never bubble
+        // to the user-facing API write.
+        @Optional()
+        @Inject(KB_ORG_OVERLAY_FANOUT_DISPATCHER)
+        private readonly orgOverlayDispatcher?: KbOrgOverlayFanoutDispatcher,
+        // EW-641 Phase 2/e row 37d — used by `enqueueOrgOverlayFanout`
+        // to resolve the target Work id list for an org via the
+        // row-37c `organizationId` column. Optional so existing
+        // isolated unit tests (which don't provide WorkRepository)
+        // keep constructing — when absent, the enqueue degrades to
+        // a no-op log and defers to Phase 3 reconciliation.
+        @Optional() private readonly workRepository?: WorkRepository,
     ) {}
 
     /**
@@ -228,6 +248,66 @@ export class KnowledgeBaseService {
         } catch (error) {
             this.logger.warn(
                 `Failed to enqueue KB embed for doc ${documentId} (work=${workId}): ${(error as Error).message}`,
+            );
+        }
+    }
+
+    /**
+     * EW-641 Phase 2/e row 37d — enqueue a Trigger.dev
+     * `kb-org-overlay-fanout` run for one org-scope document mutation
+     * (upsert or delete).
+     *
+     * Resolves the target Work id list via
+     * `WorkRepository.findIdsByOrganization(orgId)` BEFORE dispatching
+     * so the task body stays pure-iteration with no DB pagination
+     * concerns (per the row-37 design). The dispatcher AND the
+     * repository are both `@Optional()` — when either is missing
+     * the call is a no-op and the Phase 3 reconciliation job
+     * (spec §9.6) eventually catches per-Work drift.
+     *
+     * Fire-and-forget: failures are logged but never bubble to the
+     * user-facing API caller, matching `enqueueMirror` / `enqueueEmbed`.
+     *
+     * Returns early when the org has zero Works so the caller doesn't
+     * pay for an empty dispatch (and the Trigger.dev tags stay clean
+     * — `targets:0` would be a misleading signal in production telemetry).
+     *
+     * NOT called from the per-Work `createDocument` / `updateDocument`
+     * / `deleteDocument` paths — those only touch `workId !== null`
+     * rows and use the existing `enqueueMirror` per-Work fanout. The
+     * single producer on develop today is `createOrgDocument`;
+     * `updateOrgDocument` / `deleteOrgDocument` are tracked as
+     * follow-up rows (37e) since those service methods don't yet exist.
+     */
+    private async enqueueOrgOverlayFanout(
+        organizationId: string,
+        documentId: string,
+        operation: 'upsert' | 'delete',
+        docPath: string,
+        docClass: string,
+    ): Promise<void> {
+        if (!this.orgOverlayDispatcher || !this.workRepository) {
+            return;
+        }
+        try {
+            const workIds = await this.workRepository.findIdsByOrganization(organizationId);
+            if (workIds.length === 0) {
+                this.logger.debug(
+                    `Skipping KB org-overlay fanout for ${operation} ${docPath} (org=${organizationId}): no Works in org`,
+                );
+                return;
+            }
+            await this.orgOverlayDispatcher.dispatchKbOrgOverlayFanout({
+                organizationId,
+                documentId,
+                workIds,
+                operation,
+                path: docPath,
+                class: docClass,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to enqueue KB org-overlay fanout for ${operation} ${docPath} (org=${organizationId}): ${(error as Error).message}`,
             );
         }
     }
@@ -866,6 +946,20 @@ export class KnowledgeBaseService {
             updatedById: userId,
             metadata: { body } as Record<string, unknown>,
         });
+
+        // EW-641 Phase 2/e row 37d — fan the org overlay out to every
+        // Work in the org so `.content/kb/.org/<doc.path>` is
+        // materialized in each Work's data repo. Per-Work `enqueueMirror`
+        // is NOT used here — that path writes to `.content/kb/<path>`
+        // (work-owned), which would collide with overlay precedence
+        // semantics in spec §7.6.
+        await this.enqueueOrgOverlayFanout(
+            organizationId,
+            doc.id,
+            'upsert',
+            doc.path,
+            doc.kbDocumentClass,
+        );
 
         return this.toBodyDto(doc);
     }


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 37d — **closes Phase 2/e end-to-end**. Wires the producer side of the org-overlay fanout against row 37c's `Work.organizationId` column + row 37b's `TriggerService.dispatchKbOrgOverlayFanout` dispatcher.

### `WorkRepository.findIdsByOrganization(orgId)`

Id-only projection via `find({ where:{ organizationId }, select:{ id:true }, order:{ id:'ASC' } })`. Returns `[]` when `organizationId` is falsy. ASC ordering for deterministic enqueue payloads (helps cross-run diffing in Trigger.dev tags + payload snapshots).

### `KnowledgeBaseService.enqueueOrgOverlayFanout` + call site

New private helper: resolves target workIds via the repository method, returns early if list is empty (avoids misleading `targets:0` telemetry), dispatches with the resolved ids. Fire-and-forget: errors logged but never bubble to the API caller.

The dispatcher and repository are both `@Optional()` so existing isolated unit tests keep constructing — when either is missing the enqueue degrades to a no-op log and defers to Phase 3 reconciliation (spec §9.6).

Called from `createOrgDocument` after the repo create. NOT called from the per-Work `createDocument` / `updateDocument` / `deleteDocument` paths — those touch workId-set rows and use the existing per-Work `enqueueMirror`.

### Phase 2/e complete

After this row the full chain works end-to-end:

```
createOrgDocument (KB service)
  → enqueueOrgOverlayFanout helper
    → WorkRepository.findIdsByOrganization(orgId) (resolves target Works)
    → TriggerService.dispatchKbOrgOverlayFanout (enqueues task)
      → kbOrgOverlayFanoutTask (iterates workIds)
        → KnowledgeBaseGitMirrorService.materializeOrgDocument / removeOrgDocument
          → writes .content/kb/.org/<class>/<slug>.{yml,md} per Work
```

Row 38 (Workbench inherited-docs affordance) becomes NEXT.

## Test plan

- [x] 3 new jest cases on `WorkRepository.findIdsByOrganization` (empty-orgId guard, id-only projection + ASC ordering, no-Works branch)
- [x] 6 new jest cases on `KnowledgeBaseService.createOrgDocument`: happy path + per-Work mirror NOT called, zero-Works skip, WorkRepository throws → still creates doc, dispatcher throws → still creates doc, degraded (no DI) → still creates doc, `createDocument` (Work-scope) does NOT enqueue fanout
- [x] `cd packages/agent && npx jest` → 234/234 suites, 4966/4966 tests (9 new)
- [x] `turbo build --filter=@ever-works/agent` → clean
- [x] `prettier@3.7.4 --check` on touched files → all formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization-level knowledge base documents are now automatically distributed and materialized across all works within the organization, with resilience to handling missing dependencies and dispatcher failures.

* **Tests**
  * Added comprehensive test coverage for organization-scoped knowledge base distribution, verifying fanout dispatch, error resilience, and graceful degradation when components are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->