### PR TITLE
feat(web): KbTreePanel inherited-from-organization section (row 38a)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2614,7 +2614,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "مُورَّث من المنظمة",
+                            "description": "مستندات للقراءة فقط مملوكة لمنظمتك. افتح أحدها للعرض أو لتجاوزه محليًا.",
+                            "lockedLabel": "موروث (للقراءة فقط)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2614,7 +2614,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Наследени от организацията",
+                            "description": "Документи само за четене, притежавани от вашата организация. Отворете един, за да го прегледате или замените локално.",
+                            "lockedLabel": "Наследен (само за четене)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2614,7 +2614,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Von der Organisation geerbt",
+                            "description": "Schreibgeschützte Dokumente, die Ihrer Organisation gehören. Öffnen Sie eines, um es anzuzeigen oder lokal zu überschreiben.",
+                            "lockedLabel": "Geerbt (schreibgeschützt)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2642,7 +2642,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Inherited from organization",
+                            "description": "Read-only documents owned by your organization. Open one to view it or override it locally.",
+                            "lockedLabel": "Inherited (read-only)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2614,7 +2614,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Heredados de la organización",
+                            "description": "Documentos de solo lectura propiedad de tu organización. Abre uno para verlo o sobrescribirlo localmente.",
+                            "lockedLabel": "Heredado (solo lectura)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2641,7 +2641,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Hérités de l'organisation",
+                            "description": "Documents en lecture seule appartenant à votre organisation. Ouvrez-en un pour le consulter ou le remplacer localement.",
+                            "lockedLabel": "Hérité (lecture seule)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2614,7 +2614,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "בירושה מהארגון",
+                            "description": "מסמכים לקריאה בלבד בבעלות הארגון שלך. פתחו אחד כדי להציג או לעקוף אותו מקומית.",
+                            "lockedLabel": "בירושה (לקריאה בלבד)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "संगठन से विरासत में मिले",
+                            "description": "आपके संगठन के स्वामित्व वाले केवल-पठनीय दस्तावेज़। देखने या स्थानीय रूप से ओवरराइड करने के लिए खोलें।",
+                            "lockedLabel": "विरासत में मिला (केवल पढ़ने योग्य)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Diwarisi dari organisasi",
+                            "description": "Dokumen baca-saja yang dimiliki organisasi Anda. Buka salah satu untuk melihat atau mengganti secara lokal.",
+                            "lockedLabel": "Diwarisi (hanya-baca)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Ereditati dall'organizzazione",
+                            "description": "Documenti di sola lettura di proprietà della tua organizzazione. Aprine uno per visualizzarlo o sovrascriverlo localmente.",
+                            "lockedLabel": "Ereditato (sola lettura)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "組織から継承",
+                            "description": "組織が所有する読み取り専用のドキュメント。表示するか、ローカルでオーバーライドするには開いてください。",
+                            "lockedLabel": "継承(読み取り専用)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "조직에서 상속됨",
+                            "description": "조직이 소유한 읽기 전용 문서입니다. 보거나 로컬에서 재정의하려면 하나를 여세요.",
+                            "lockedLabel": "상속됨(읽기 전용)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Overgenomen van organisatie",
+                            "description": "Alleen-lezen documenten van uw organisatie. Open er een om hem te bekijken of lokaal te overschrijven.",
+                            "lockedLabel": "Overgenomen (alleen-lezen)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Odziedziczone z organizacji",
+                            "description": "Dokumenty tylko do odczytu należące do Twojej organizacji. Otwórz jeden, aby go wyświetlić lub zastąpić lokalnie.",
+                            "lockedLabel": "Odziedziczony (tylko do odczytu)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Herdados da organização",
+                            "description": "Documentos somente leitura pertencentes à sua organização. Abra um para visualizar ou substituí-lo localmente.",
+                            "lockedLabel": "Herdado (somente leitura)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Унаследовано от организации",
+                            "description": "Документы только для чтения, принадлежащие вашей организации. Откройте один, чтобы просмотреть или переопределить локально.",
+                            "lockedLabel": "Унаследован (только для чтения)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "รับช่วงต่อจากองค์กร",
+                            "description": "เอกสารแบบอ่านอย่างเดียวที่เป็นขององค์กรของคุณ เปิดดูหรือสร้างเวอร์ชันท้องถิ่นทับ",
+                            "lockedLabel": "รับช่วงต่อ (อ่านอย่างเดียว)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Kuruluştan devralındı",
+                            "description": "Kuruluşunuza ait salt okunur belgeler. Görüntülemek veya yerel olarak geçersiz kılmak için birini açın.",
+                            "lockedLabel": "Devralındı (salt okunur)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Успадковано з організації",
+                            "description": "Документи лише для читання, що належать вашій організації. Відкрийте один, щоб переглянути або перевизначити локально.",
+                            "lockedLabel": "Успадковано (лише читання)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "Kế thừa từ tổ chức",
+                            "description": "Tài liệu chỉ đọc thuộc sở hữu của tổ chức của bạn. Mở một tài liệu để xem hoặc ghi đè cục bộ.",
+                            "lockedLabel": "Kế thừa (chỉ đọc)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2397,7 +2397,12 @@
                 "panes": {
                     "tree": {
                         "title": "Documents",
-                        "empty": "Document tree appears here once you upload or create a KB document."
+                        "empty": "Document tree appears here once you upload or create a KB document.",
+                        "inheritedSection": {
+                            "title": "继承自组织",
+                            "description": "由您的组织拥有的只读文档。打开以查看或在本地覆盖。",
+                            "lockedLabel": "继承(只读)"
+                        }
                     },
                     "editor": {
                         "title": "Editor",

--- a/apps/web/src/components/works/detail/kb/KbTreePanel.tsx
+++ b/apps/web/src/components/works/detail/kb/KbTreePanel.tsx
@@ -8,6 +8,21 @@ import type { KbDocumentClass, KbDocumentDto } from '@ever-works/contracts';
 interface KbTreePanelProps {
     workId: string;
     documents: KbDocumentDto[];
+    /**
+     * EW-641 Phase 2/e row 38a — inherited org-overlay documents that
+     * this Work's organization owns. Rendered as a distinct "Inherited
+     * from organization" section ABOVE the per-class groups so operators
+     * can tell at-a-glance which docs are owned locally vs which come
+     * from the org tier. Each row gets a lock-overlay marker so the
+     * read-only nature is visually obvious before the user navigates.
+     *
+     * The actual API wire-up (`kbAPI.listInheritableDocuments` +
+     * passing it down from the KB page server component) lands in row
+     * 38b — until then the parent passes `[]` and the section is a
+     * no-op. Defaulting to `[]` here keeps the prop optional + back-compat
+     * with every existing call site (KbShell.tsx, KbTreePanel.unit.spec).
+     */
+    inheritedDocuments?: KbDocumentDto[];
     /** When non-null, highlights the matching row. */
     activePath?: string | null;
 }
@@ -30,11 +45,25 @@ interface KbTreePanelProps {
  * "no documents yet" still reads naturally — operators land on the
  * page right after enabling KB and see the same explanation regardless
  * of whether the fetch ran or not.
+ *
+ * EW-641 Phase 2/e row 38a — also renders an "Inherited from
+ * organization" section above the per-class groups when
+ * `inheritedDocuments` is non-empty. Inherited rows are scoped to
+ * `kb-tree-inherited-{cls}-{slug}` data-testids + carry a lock-overlay
+ * marker so the read-only nature is visible without navigating. The
+ * empty-state placeholder is only shown when BOTH the Work-owned and
+ * the inherited lists are empty (otherwise the inherited section
+ * itself is meaningful content even with no Work-owned docs).
  */
-export async function KbTreePanel({ workId, documents, activePath = null }: KbTreePanelProps) {
+export async function KbTreePanel({
+    workId,
+    documents,
+    inheritedDocuments = [],
+    activePath = null,
+}: KbTreePanelProps) {
     const t = await getTranslations('dashboard.workDetail.kb');
 
-    if (documents.length === 0) {
+    if (documents.length === 0 && inheritedDocuments.length === 0) {
         return (
             <section
                 data-testid="kb-tree"
@@ -80,6 +109,15 @@ export async function KbTreePanel({ workId, documents, activePath = null }: KbTr
             </header>
 
             <nav aria-label={t('panes.tree.title')} className="flex flex-col gap-3">
+                {inheritedDocuments.length > 0 ? (
+                    <KbInheritedSection
+                        workId={workId}
+                        documents={inheritedDocuments}
+                        sectionTitle={t('panes.tree.inheritedSection.title')}
+                        sectionEmptyDescription={t('panes.tree.inheritedSection.description')}
+                        lockedLabel={t('panes.tree.inheritedSection.lockedLabel')}
+                    />
+                ) : null}
                 {KB_DOCUMENT_CLASSES.map((cls) => {
                     const docs = grouped.get(cls);
                     if (!docs || docs.length === 0) return null;
@@ -155,6 +193,90 @@ function KbTreeGroup({ workId, kbClass, label, docs, activePath }: KbTreeGroupPr
     );
 }
 
+interface KbInheritedSectionProps {
+    workId: string;
+    documents: KbDocumentDto[];
+    sectionTitle: string;
+    sectionEmptyDescription: string;
+    lockedLabel: string;
+}
+
+/**
+ * EW-641 Phase 2/e row 38a — "Inherited from organization" section
+ * rendered above the Work-owned per-class groups. Rows are sorted
+ * (class ASC, then title ASC case-insensitive) for deterministic
+ * Playwright assertions. Each row uses
+ * `data-testid="kb-tree-inherited-<class>-<slug>"` selectors so the
+ * upcoming A19/A20 e2e (row 38e) can target exactly one inherited
+ * doc by class + slug without race-prone position math.
+ *
+ * The lock-overlay marker (🔒) is rendered ALWAYS on inherited rows
+ * — these docs are read-only at the tier level (the user's Work can't
+ * mutate the org doc directly). Row 38d adds the "Override locally"
+ * CTA on the detail page; the lock here is the at-a-glance affordance.
+ *
+ * Link targets the same `[...path]` route as Work-owned docs; row 38c
+ * teaches the detail page to detect inherited rows (no Work-owned
+ * override at the same path) and switch to read-only mode.
+ */
+function KbInheritedSection({
+    workId,
+    documents,
+    sectionTitle,
+    sectionEmptyDescription,
+    lockedLabel,
+}: KbInheritedSectionProps) {
+    const sorted = sortInherited(documents);
+
+    return (
+        <div data-testid="kb-tree-inherited" className="flex flex-col gap-1">
+            <h3
+                className={cn(
+                    'text-[11px] font-semibold uppercase tracking-wider',
+                    'text-text-muted dark:text-text-muted-dark/70',
+                )}
+            >
+                {sectionTitle}
+                <span className="ml-1 text-text-muted/60">({sorted.length})</span>
+            </h3>
+            <p
+                className="text-[11px] text-text-muted dark:text-text-muted-dark/60"
+                data-testid="kb-tree-inherited-description"
+            >
+                {sectionEmptyDescription}
+            </p>
+            <ul className="flex flex-col gap-0.5">
+                {sorted.map((doc) => (
+                    <li key={doc.id}>
+                        <Link
+                            href={`${ROUTES.DASHBOARD_WORK_KB(workId)}/${doc.path}`}
+                            data-testid={`kb-tree-inherited-${doc.class}-${doc.slug}`}
+                            data-doc-path={doc.path}
+                            data-doc-class={doc.class}
+                            data-source="inherited"
+                            className={cn(
+                                'flex items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors',
+                                'text-text-secondary dark:text-text-secondary-dark/80',
+                                'hover:bg-card-hover dark:hover:bg-card-primary-dark/40',
+                                'hover:text-text dark:hover:text-text-dark',
+                            )}
+                        >
+                            <span className="truncate">{doc.title || doc.path}</span>
+                            <span
+                                aria-label={lockedLabel}
+                                title={lockedLabel}
+                                className="ml-auto text-xs text-text-muted dark:text-text-muted-dark/60"
+                            >
+                                🔒
+                            </span>
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
 function groupByClass(documents: KbDocumentDto[]): Map<KbDocumentClass, KbDocumentDto[]> {
     const map = new Map<KbDocumentClass, KbDocumentDto[]>();
     for (const doc of documents) {
@@ -176,4 +298,22 @@ function groupByClass(documents: KbDocumentDto[]): Map<KbDocumentClass, KbDocume
         );
     }
     return map;
+}
+
+function sortInherited(documents: KbDocumentDto[]): KbDocumentDto[] {
+    return [...documents].sort((a, b) => {
+        // Primary: canonical class order from KB_DOCUMENT_CLASSES so
+        // `brand` shows before `legal` shows before `seo`. Falls back
+        // to lexicographic-by-class if the class isn't in the canonical
+        // list (defensive — KbDocumentClass is closed at the contract
+        // layer but the runtime can drift).
+        const aIdx = KB_DOCUMENT_CLASSES.indexOf(a.class);
+        const bIdx = KB_DOCUMENT_CLASSES.indexOf(b.class);
+        const aRank = aIdx === -1 ? KB_DOCUMENT_CLASSES.length : aIdx;
+        const bRank = bIdx === -1 ? KB_DOCUMENT_CLASSES.length : bIdx;
+        if (aRank !== bRank) return aRank - bRank;
+        return (a.title || a.path).localeCompare(b.title || b.path, undefined, {
+            sensitivity: 'base',
+        });
+    });
 }

--- a/apps/web/src/components/works/detail/kb/KbTreePanel.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbTreePanel.unit.spec.tsx
@@ -163,4 +163,177 @@ describe('KbTreePanel', () => {
         // Link href targets the upcoming `[...path]` route in row 4.
         expect(active?.getAttribute('href')).toBe('/works/work-1/kb/brand/voice.md');
     });
+
+    // ─── EW-641 Phase 2/e row 38a — "Inherited from organization" section ───
+
+    describe('inheritedDocuments — "Inherited from organization" section', () => {
+        it('does NOT render the inherited section when inheritedDocuments is omitted', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [doc({ title: 'Voice', class: 'brand', path: 'brand/v.md' })],
+                }),
+            );
+            expect(screen.queryByTestId('kb-tree-inherited')).toBeNull();
+        });
+
+        it('does NOT render the inherited section when inheritedDocuments is empty', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [doc({ title: 'Voice', class: 'brand', path: 'brand/v.md' })],
+                    inheritedDocuments: [],
+                }),
+            );
+            expect(screen.queryByTestId('kb-tree-inherited')).toBeNull();
+        });
+
+        it('shows the empty placeholder only when BOTH lists are empty', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [],
+                    inheritedDocuments: [],
+                }),
+            );
+            const tree = screen.getByTestId('kb-tree');
+            expect(tree.textContent).toContain('panes.tree.empty');
+            // No header / count / inherited section in pure-empty state.
+            expect(screen.queryByTestId('kb-tree-count')).toBeNull();
+            expect(screen.queryByTestId('kb-tree-inherited')).toBeNull();
+        });
+
+        it('renders the inherited section ABOVE per-class groups when both populate', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [
+                        doc({ id: 'w1', title: 'Voice', class: 'brand', path: 'brand/v.md' }),
+                    ],
+                    inheritedDocuments: [
+                        doc({
+                            id: 'org-1',
+                            title: 'Privacy',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                            workId: null,
+                            organizationId: 'org-1',
+                        }),
+                    ],
+                }),
+            );
+            const inherited = screen.getByTestId('kb-tree-inherited');
+            const brand = screen.getByTestId('kb-tree-group-brand');
+            // DOM order: inherited section comes first inside the <nav>.
+            expect(
+                inherited.compareDocumentPosition(brand) & Node.DOCUMENT_POSITION_FOLLOWING,
+            ).toBeTruthy();
+        });
+
+        it('emits class+slug-scoped data-testid + lock marker + inherited data-source on each row', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [],
+                    inheritedDocuments: [
+                        doc({
+                            id: 'org-l',
+                            title: 'Privacy',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                            workId: null,
+                            organizationId: 'org-1',
+                        }),
+                    ],
+                }),
+            );
+            const row = screen.getByTestId('kb-tree-inherited-legal-privacy');
+            expect(row.getAttribute('data-source')).toBe('inherited');
+            expect(row.getAttribute('data-doc-class')).toBe('legal');
+            expect(row.getAttribute('data-doc-path')).toBe('legal/privacy.md');
+            // Lock-overlay marker is always present on inherited rows
+            // — the read-only nature is conveyed at-a-glance.
+            expect(row.textContent).toContain('🔒');
+            // Links to the same nested route shape; row 38c teaches the
+            // detail page to switch to read-only based on inherited
+            // status (no Work-owned override at the same path).
+            expect(row.getAttribute('href')).toBe('/works/work-1/kb/legal/privacy.md');
+        });
+
+        it('sorts inherited rows by canonical class order then by title (case-insensitive)', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [],
+                    inheritedDocuments: [
+                        // Seed order is intentionally noisy.
+                        doc({
+                            id: '1',
+                            title: 'zebra',
+                            class: 'style',
+                            slug: 'z',
+                            path: 'style/z.md',
+                        }),
+                        doc({
+                            id: '2',
+                            title: 'Alpha',
+                            class: 'legal',
+                            slug: 'a',
+                            path: 'legal/a.md',
+                        }),
+                        doc({
+                            id: '3',
+                            title: 'beta',
+                            class: 'legal',
+                            slug: 'b',
+                            path: 'legal/b.md',
+                        }),
+                        doc({
+                            id: '4',
+                            title: 'Charlie',
+                            class: 'style',
+                            slug: 'c',
+                            path: 'style/c.md',
+                        }),
+                    ],
+                }),
+            );
+            // KB_DOCUMENT_CLASSES canonical order places `legal` before
+            // `style`. Within each, titles are sorted case-insensitive ASC.
+            const inheritedSection = screen.getByTestId('kb-tree-inherited');
+            const rows = within(inheritedSection).getAllByRole('link');
+            expect(rows[0].getAttribute('data-doc-path')).toBe('legal/a.md');
+            expect(rows[1].getAttribute('data-doc-path')).toBe('legal/b.md');
+            expect(rows[2].getAttribute('data-doc-path')).toBe('style/c.md');
+            expect(rows[3].getAttribute('data-doc-path')).toBe('style/z.md');
+        });
+
+        it('renders the i18n section title + description copy', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [],
+                    inheritedDocuments: [
+                        doc({
+                            id: 'org-l',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                        }),
+                    ],
+                }),
+            );
+            const inherited = screen.getByTestId('kb-tree-inherited');
+            // The test next-intl mock returns the message key itself —
+            // verifies the component does call getTranslations() for both
+            // the section title and the description copy. Real translations
+            // are exercised by the messages/*.json catalogs.
+            expect(inherited.textContent).toContain('panes.tree.inheritedSection.title');
+            expect(screen.getByTestId('kb-tree-inherited-description').textContent).toBe(
+                'panes.tree.inheritedSection.description',
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 38a — first atomic chunk of the Workbench inherited-docs affordance. **UI-only** this row; the API wire-up (`kbAPI.listInheritableDocuments` + plumb into KB page) lands in row 38b. Until then the parent passes `inheritedDocuments=[]` and the section is a no-op.

## Changes

### `KbTreePanel.tsx`

- New `inheritedDocuments?: KbDocumentDto[]` prop (default `[]`).
- When non-empty, renders an **"Inherited from organization"** section ABOVE the per-class groups. Rows sorted by canonical class order then title (case-insensitive ASC) for deterministic Playwright assertions.
- Each inherited row carries:
    - `data-testid="kb-tree-inherited-{class}-{slug}"` selector — lets the row 38e A19/A20 e2e target one row precisely.
    - `data-source="inherited"` attribute — lets row 38c detail page detect inherited routes.
    - Lock-overlay marker (🔒) + tooltip — at-a-glance read-only affordance before the user navigates.
    - `href` pointing at the standard nested `[...path]` route.
- **Empty-state placeholder** now only fires when BOTH `documents` AND `inheritedDocuments` are empty. Otherwise the inherited section itself is meaningful content even with no Work-owned docs.

### i18n

- 3 new keys under `dashboard.workDetail.kb.panes.tree.inheritedSection`:
    - `title` — section heading
    - `description` — explainer copy
    - `lockedLabel` — aria-label/title for the lock-overlay marker
- Translations added to all 21 locales (`en`, `ar`, `bg`, `de`, `es`, `fr`, `he`, `hi`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `th`, `tr`, `uk`, `vi`, `zh`).

## Test plan

- [x] `cd apps/web && npx vitest run src/components/works/detail/kb/KbTreePanel.unit.spec.tsx` → 13/13 (6 prior + 7 new)
    - prop omitted → section absent
    - prop empty → section absent
    - both lists empty → placeholder shown, no header / count / inherited section
    - DOM order (inherited section before per-class groups when both populate)
    - selector + `data-source="inherited"` + `data-doc-class` + `data-doc-path` + lock marker shape per row
    - sort by canonical class order then title case-insensitive
    - i18n keys plumbed (title + description)
- [x] `prettier@3.7.4 --check` on touched files → all formatted
- [x] `turbo build --filter=@ever-works/contracts` → clean (consumer of `KbDocumentDto`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Knowledge Base tree panel now displays documents inherited from the organization in a dedicated read-only section with a lock indicator.
  * Internationalization support added for inherited documents UI across 21 languages.

* **Tests**
  * Added comprehensive test coverage for inherited documents rendering, ordering, and metadata attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->