### PR TITLE
feat(web): kbAPI.listInheritableDocuments + plumb into KB page (row 38b)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx
@@ -33,16 +33,32 @@ type Params = { params: Promise<{ id: string }> };
 export default async function WorkKnowledgeBasePage({ params }: Params) {
     const { id } = await params;
 
+    let work;
     try {
-        await workAPI.get(id);
+        const workResponse = await workAPI.get(id);
+        work = workResponse?.work ?? null;
     } catch {
         notFound();
     }
 
-    const docs = await kbAPI.listDocuments(id, { limit: 200 }).catch((error) => {
-        console.error('[kb-tree] failed to list KB documents:', error);
-        return { items: [], total: 0 };
-    });
+    // EW-641 Phase 2/e row 38b — fetch the per-Work docs AND the
+    // inheritable org-overlay docs in parallel. The `inheritable` leg
+    // short-circuits to `[]` when the Work has no `organizationId` (row
+    // 37c column, not yet populated on every existing Work) — see
+    // `kbAPI.listInheritableDocuments`. Both legs `.catch` to a safe
+    // fallback so a transient API error in one doesn't blank the other:
+    // the page renders the half it could fetch + the empty placeholder
+    // / empty section for the half it couldn't.
+    const [docs, inheritedDocuments] = await Promise.all([
+        kbAPI.listDocuments(id, { limit: 200 }).catch((error) => {
+            console.error('[kb-tree] failed to list KB documents:', error);
+            return { items: [], total: 0 };
+        }),
+        kbAPI.listInheritableDocuments(id, work?.organizationId ?? null).catch((error) => {
+            console.error('[kb-tree] failed to list inheritable KB documents:', error);
+            return [];
+        }),
+    ]);
 
     return (
         <div className="flex flex-col gap-4">
@@ -50,7 +66,16 @@ export default async function WorkKnowledgeBasePage({ params }: Params) {
                 <KbSearchPalette workId={id} />
             </div>
             <KbUploadZone workId={id} />
-            <KbShell workId={id} treeSlot={<KbTreePanel workId={id} documents={docs.items} />} />
+            <KbShell
+                workId={id}
+                treeSlot={
+                    <KbTreePanel
+                        workId={id}
+                        documents={docs.items}
+                        inheritedDocuments={inheritedDocuments}
+                    />
+                }
+            />
         </div>
     );
 }

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -48,6 +48,37 @@ export const kbAPI = {
     },
 
     /**
+     * `GET /api/works/:id/kb/inheritable?orgId=<id>` — resolve the merged
+     * set of org-level + Work-override inheritable documents for the
+     * legal/style/seo classes (see `apps/api/src/works/org-kb.controller.ts`
+     * `resolveInheritable` → `KnowledgeBaseService.resolveInheritableDocuments`).
+     *
+     * EW-641 Phase 2/e row 38b — the KB page calls this in parallel with
+     * `listDocuments` and hands the result to
+     * `<KbTreePanel inheritedDocuments={...} />` (row 38a) so the
+     * "Inherited from organization" section actually populates.
+     *
+     * Returns `[]` (no fetch) when `orgId` is null/empty — saves a
+     * round-trip for Works whose `organizationId` column (row 37c)
+     * hasn't been populated yet. The `orgId` value is URL-encoded so
+     * opaque UUIDs survive the query string unchanged. The controller
+     * already accepts a falsy `orgId` and short-circuits to `[]`, but
+     * skipping the fetch on the client side keeps the network panel
+     * and audit log cleaner.
+     */
+    listInheritableDocuments: async (
+        workId: string,
+        orgId: string | null | undefined,
+    ): Promise<KbDocumentDto[]> => {
+        if (!orgId) {
+            return [];
+        }
+        return serverFetch<KbDocumentDto[]>(
+            `/works/${workId}/kb/inheritable?orgId=${encodeURIComponent(orgId)}`,
+        );
+    },
+
+    /**
      * `GET /api/works/:id/kb/documents/:idOrPath` — full document with
      * Markdown body + asset summaries. The backend accepts either a
      * UUID or the canonical `<class>/<slug>.md`-style path; we encode

--- a/apps/web/src/lib/api/kb.unit.spec.ts
+++ b/apps/web/src/lib/api/kb.unit.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// `kb.ts` imports `next/headers`, `getAuthAccessCookie` (cookies()), and
+// the API URL constants. Mock the whole `server-api` module so the
+// helpers run as pure URL-construction code. The mocks must be defined
+// inside `vi.hoisted` so they're available before vitest hoists the
+// `vi.mock` factory to the top of the file.
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+import { kbAPI } from './kb';
+
+describe('kbAPI', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        serverFetchMock.mockResolvedValue([]);
+    });
+
+    describe('listInheritableDocuments (row 38b)', () => {
+        it('returns [] without fetching when orgId is null', async () => {
+            const result = await kbAPI.listInheritableDocuments('work-1', null);
+            expect(result).toEqual([]);
+            expect(serverFetchMock).not.toHaveBeenCalled();
+        });
+
+        it('returns [] without fetching when orgId is undefined', async () => {
+            const result = await kbAPI.listInheritableDocuments('work-1', undefined);
+            expect(result).toEqual([]);
+            expect(serverFetchMock).not.toHaveBeenCalled();
+        });
+
+        it('returns [] without fetching when orgId is an empty string', async () => {
+            // Saves a round-trip for Works whose row-37c `organizationId`
+            // column hasn't been populated yet.
+            const result = await kbAPI.listInheritableDocuments('work-1', '');
+            expect(result).toEqual([]);
+            expect(serverFetchMock).not.toHaveBeenCalled();
+        });
+
+        it('calls /works/:id/kb/inheritable?orgId=<uuid> when orgId is set', async () => {
+            const sample = [
+                {
+                    id: 'org-doc-1',
+                    workId: null,
+                    organizationId: 'org-uuid-1',
+                    path: 'legal/privacy.md',
+                    slug: 'privacy',
+                    class: 'legal',
+                    title: 'Privacy',
+                } as unknown,
+            ];
+            serverFetchMock.mockResolvedValueOnce(sample);
+
+            const result = await kbAPI.listInheritableDocuments('work-1', 'org-uuid-1');
+
+            expect(result).toEqual(sample);
+            expect(serverFetchMock).toHaveBeenCalledTimes(1);
+            expect(serverFetchMock).toHaveBeenCalledWith(
+                '/works/work-1/kb/inheritable?orgId=org-uuid-1',
+            );
+        });
+
+        it('URL-encodes the orgId so reserved characters survive the query string', async () => {
+            // Defensive: org ids are server-issued UUIDs today, but the
+            // wire format is `string` — if an alphanumeric+dash convention
+            // ever changes, this guard keeps us correct.
+            await kbAPI.listInheritableDocuments('work-1', 'org with spaces & symbols');
+            expect(serverFetchMock).toHaveBeenCalledWith(
+                '/works/work-1/kb/inheritable?orgId=org%20with%20spaces%20%26%20symbols',
+            );
+        });
+
+        it('returns the raw array from the controller (no envelope unwrap)', async () => {
+            // The `apps/api/src/works/org-kb.controller.ts` `resolveInheritable`
+            // route returns `KbDocumentDto[]` directly — no `{ data: ... }` wrapper.
+            const rows = [{ id: 'a' }, { id: 'b' }] as unknown[];
+            serverFetchMock.mockResolvedValueOnce(rows);
+            const result = await kbAPI.listInheritableDocuments('work-1', 'org-1');
+            expect(result).toBe(rows);
+        });
+    });
+});

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -171,6 +171,14 @@ export interface Work {
     owner?: string;
     website?: string;
     organization: boolean;
+    /**
+     * EW-641 Phase 2/e row 37c — owning organization id (free-form UUID,
+     * not yet a FK; see the entity docstring for the deliberate design).
+     * Used by the KB tree-panel row 38b to fetch `inheritable` docs for
+     * the Work's org tier. `null`/`undefined` ⇒ no org-overlay docs to
+     * resolve.
+     */
+    organizationId?: string | null;
     gitProvider: string;
     deployProvider?: string;
     readmeConfig?: MarkdownReadmeConfig;


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 38b — wires the API fetch behind the row-38a "Inherited from organization" section so it actually populates end-to-end. After this row the tree panel surfaces inheritable docs without further code changes.

## Changes

- **`apps/web/src/lib/api/work.ts`**: add `organizationId?: string | null` to the web `Work` interface. The API already serializes it (row 37c added the entity column + migration); the web TypeScript just hadn't been told yet.
- **`apps/web/src/lib/api/kb.ts`**: new `listInheritableDocuments(workId, orgId | null)` calling `GET /api/works/:id/kb/inheritable?orgId=<encoded>`. Returns `[]` early (no fetch) when `orgId` is null/empty so Works whose `organizationId` column isn't populated yet save a round-trip + keep the network panel clean. Encodes the `orgId` for opaque-UUID safety.
- **`apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/page.tsx`**: promote the existence-check `workAPI.get(id)` to a captured response so the page can read `work.organizationId`. Fetch `listDocuments` + `listInheritableDocuments` in parallel via `Promise.all`; both legs `.catch` to safe fallbacks so a transient API error in one doesn't blank the other. Pass `inheritedDocuments` to `<KbTreePanel>` (row 38a's new prop).

## Test plan

- [x] 6 new vitest cases on `apps/web/src/lib/api/kb.unit.spec.ts`:
    - `orgId === null` → returns `[]`, no fetch
    - `orgId === undefined` → returns `[]`, no fetch
    - `orgId === ''` → returns `[]`, no fetch (saves a round-trip for unpopulated Works)
    - Happy path → calls `/works/:id/kb/inheritable?orgId=<value>`
    - URL-encodes reserved characters
    - Raw-array return (no envelope unwrap matching the `org-kb.controller` contract)
- [x] Existing `KbTreePanel.unit.spec.tsx` suite stays 13/13 green (no behavior change in row 38a; this row just feeds it real data)
- [x] `prettier@3.7.4 --check` on touched files → all formatted
- [x] `turbo build --filter=@ever-works/contracts` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KB dashboard now displays both work-specific and organization-level inherited documents, providing users with access to a broader knowledge base alongside their workspace-specific resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->