### PR TITLE
feat(web): KbDocumentView inherited-from-organization banner (row 38c)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -2807,6 +2807,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "إشعار مستند موروث",
+                    "bannerTitle": "موروث من المنظمة",
+                    "bannerDescription": "هذا المستند مملوك لمنظمتك وللقراءة فقط هنا. قم بتجاوزه محليًا لإنشاء نسخة قابلة للتحرير في هذا العمل.",
+                    "overrideCta": "تجاوز محليًا",
+                    "overrideCtaPendingTooltip": "متاح بمجرد شحن إجراء التجاوز في الصف 38d"
                 }
             }
         },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -2807,6 +2807,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Известие за наследен документ",
+                    "bannerTitle": "Наследен от организацията",
+                    "bannerDescription": "Този документ е собственост на вашата организация и тук е само за четене. Заменете локално, за да създадете редактируемо копие в тази Работа.",
+                    "overrideCta": "Замени локално",
+                    "overrideCtaPendingTooltip": "Налично, след като действието за замяна бъде доставено в ред 38d"
                 }
             }
         },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -2807,6 +2807,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Hinweis zu geerbtem Dokument",
+                    "bannerTitle": "Von der Organisation geerbt",
+                    "bannerDescription": "Dieses Dokument gehört Ihrer Organisation und ist hier schreibgeschützt. Lokal überschreiben, um eine bearbeitbare Kopie in dieses Work zu forken.",
+                    "overrideCta": "Lokal überschreiben",
+                    "overrideCtaPendingTooltip": "Verfügbar, sobald die Überschreibungsaktion in Zeile 38d ausgeliefert ist"
                 }
             }
         },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2670,6 +2670,13 @@
                     "output": "Outputs",
                     "freeform": "Freeform"
                 },
+                "inherited": {
+                    "bannerLabel": "Inherited document notice",
+                    "bannerTitle": "Inherited from organization",
+                    "bannerDescription": "This document is owned by your organization and is read-only here. Override locally to fork an editable copy into this Work.",
+                    "overrideCta": "Override locally",
+                    "overrideCtaPendingTooltip": "Available once the override action ships in row 38d"
+                },
                 "status": {
                     "draft": "Draft",
                     "active": "Active",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -2807,6 +2807,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Aviso de documento heredado",
+                    "bannerTitle": "Heredado de la organización",
+                    "bannerDescription": "Este documento es propiedad de tu organización y es de solo lectura aquí. Sobrescribe localmente para bifurcar una copia editable en este Trabajo.",
+                    "overrideCta": "Sobrescribir localmente",
+                    "overrideCtaPendingTooltip": "Disponible cuando se lance la acción de sobrescritura en la fila 38d"
                 }
             }
         },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2834,6 +2834,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Notification de document hérité",
+                    "bannerTitle": "Hérité de l'organisation",
+                    "bannerDescription": "Ce document appartient à votre organisation et est en lecture seule ici. Remplacez-le localement pour bifurquer une copie modifiable dans ce Work.",
+                    "overrideCta": "Remplacer localement",
+                    "overrideCtaPendingTooltip": "Disponible une fois l'action de remplacement livrée à la ligne 38d"
                 }
             }
         },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -2807,6 +2807,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "הודעת מסמך בירושה",
+                    "bannerTitle": "בירושה מהארגון",
+                    "bannerDescription": "מסמך זה בבעלות הארגון שלך והוא לקריאה בלבד כאן. עקוף מקומית כדי ליצור עותק ניתן לעריכה ב-Work זה.",
+                    "overrideCta": "עקוף מקומית",
+                    "overrideCtaPendingTooltip": "יהיה זמין לאחר שפעולת העקיפה תושק בשורה 38d"
                 }
             }
         },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "विरासत में मिले दस्तावेज़ की सूचना",
+                    "bannerTitle": "संगठन से विरासत में मिला",
+                    "bannerDescription": "यह दस्तावेज़ आपके संगठन के स्वामित्व में है और यहाँ केवल पढ़ने योग्य है। इस Work में संपादन योग्य प्रति बनाने के लिए स्थानीय रूप से ओवरराइड करें।",
+                    "overrideCta": "स्थानीय रूप से ओवरराइड करें",
+                    "overrideCtaPendingTooltip": "पंक्ति 38d में ओवरराइड कार्रवाई आने पर उपलब्ध"
                 }
             }
         },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Pemberitahuan dokumen warisan",
+                    "bannerTitle": "Diwarisi dari organisasi",
+                    "bannerDescription": "Dokumen ini dimiliki oleh organisasi Anda dan hanya-baca di sini. Ganti secara lokal untuk membuat salinan yang dapat diedit di Work ini.",
+                    "overrideCta": "Ganti secara lokal",
+                    "overrideCtaPendingTooltip": "Tersedia setelah aksi pengganti dikirim di baris 38d"
                 }
             }
         },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Notifica documento ereditato",
+                    "bannerTitle": "Ereditato dall'organizzazione",
+                    "bannerDescription": "Questo documento è di proprietà della tua organizzazione ed è di sola lettura qui. Sovrascrivi localmente per creare una copia modificabile in questo Work.",
+                    "overrideCta": "Sovrascrivi localmente",
+                    "overrideCtaPendingTooltip": "Disponibile quando l'azione di sovrascrittura sarà rilasciata nella riga 38d"
                 }
             }
         },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "継承ドキュメントの通知",
+                    "bannerTitle": "組織から継承",
+                    "bannerDescription": "このドキュメントは組織が所有しており、ここでは読み取り専用です。この Work に編集可能なコピーをフォークするには、ローカルでオーバーライドしてください。",
+                    "overrideCta": "ローカルでオーバーライド",
+                    "overrideCtaPendingTooltip": "行 38d でオーバーライドアクションが出荷されると利用可能になります"
                 }
             }
         },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "상속된 문서 알림",
+                    "bannerTitle": "조직에서 상속됨",
+                    "bannerDescription": "이 문서는 조직 소유이며 여기서는 읽기 전용입니다. 이 Work에 편집 가능한 복사본을 포크하려면 로컬에서 재정의하세요.",
+                    "overrideCta": "로컬에서 재정의",
+                    "overrideCtaPendingTooltip": "38d 행에서 재정의 작업이 출시되면 사용 가능"
                 }
             }
         },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Melding voor overgenomen document",
+                    "bannerTitle": "Overgenomen van organisatie",
+                    "bannerDescription": "Dit document is eigendom van uw organisatie en is hier alleen-lezen. Overschrijf lokaal om een bewerkbare kopie in dit Work te forken.",
+                    "overrideCta": "Lokaal overschrijven",
+                    "overrideCtaPendingTooltip": "Beschikbaar zodra de overschrijfactie wordt geleverd in rij 38d"
                 }
             }
         },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Powiadomienie o odziedziczonym dokumencie",
+                    "bannerTitle": "Odziedziczony z organizacji",
+                    "bannerDescription": "Ten dokument jest własnością Twojej organizacji i jest tutaj tylko do odczytu. Zastąp lokalnie, aby rozwidlić edytowalną kopię w tym Work.",
+                    "overrideCta": "Zastąp lokalnie",
+                    "overrideCtaPendingTooltip": "Dostępne po wydaniu akcji zastąpienia w wierszu 38d"
                 }
             }
         },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Aviso de documento herdado",
+                    "bannerTitle": "Herdado da organização",
+                    "bannerDescription": "Este documento pertence à sua organização e é somente leitura aqui. Substitua localmente para criar uma cópia editável neste Work.",
+                    "overrideCta": "Substituir localmente",
+                    "overrideCtaPendingTooltip": "Disponível quando a ação de substituição for lançada na linha 38d"
                 }
             }
         },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Уведомление о унаследованном документе",
+                    "bannerTitle": "Унаследовано от организации",
+                    "bannerDescription": "Этот документ принадлежит вашей организации и доступен здесь только для чтения. Переопределите локально, чтобы создать редактируемую копию в этом Work.",
+                    "overrideCta": "Переопределить локально",
+                    "overrideCtaPendingTooltip": "Доступно после выпуска действия переопределения в строке 38d"
                 }
             }
         },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "การแจ้งเตือนเอกสารที่รับช่วงต่อ",
+                    "bannerTitle": "รับช่วงต่อจากองค์กร",
+                    "bannerDescription": "เอกสารนี้เป็นขององค์กรของคุณและเป็นแบบอ่านอย่างเดียวที่นี่ เขียนทับในเครื่องเพื่อแยกสำเนาที่แก้ไขได้ใน Work นี้",
+                    "overrideCta": "เขียนทับในเครื่อง",
+                    "overrideCtaPendingTooltip": "พร้อมใช้งานเมื่อมีการส่งมอบการกระทำการเขียนทับในแถว 38d"
                 }
             }
         },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Devralınan belge bildirimi",
+                    "bannerTitle": "Kuruluştan devralındı",
+                    "bannerDescription": "Bu belge kuruluşunuza aittir ve burada salt okunurdur. Bu Work içine düzenlenebilir bir kopya çatallamak için yerel olarak geçersiz kılın.",
+                    "overrideCta": "Yerel olarak geçersiz kıl",
+                    "overrideCtaPendingTooltip": "38d satırında geçersiz kılma eylemi gönderildiğinde kullanılabilir"
                 }
             }
         },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Сповіщення про успадкований документ",
+                    "bannerTitle": "Успадковано з організації",
+                    "bannerDescription": "Цей документ належить вашій організації і тут доступний лише для читання. Перевизначте локально, щоб створити редагований форк у цьому Work.",
+                    "overrideCta": "Перевизначити локально",
+                    "overrideCtaPendingTooltip": "Доступно після випуску дії перевизначення в рядку 38d"
                 }
             }
         },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "Thông báo tài liệu được kế thừa",
+                    "bannerTitle": "Kế thừa từ tổ chức",
+                    "bannerDescription": "Tài liệu này thuộc sở hữu của tổ chức của bạn và chỉ đọc tại đây. Ghi đè cục bộ để fork một bản sao có thể chỉnh sửa vào Work này.",
+                    "overrideCta": "Ghi đè cục bộ",
+                    "overrideCtaPendingTooltip": "Có sẵn khi hành động ghi đè được phát hành trong dòng 38d"
                 }
             }
         },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -2590,6 +2590,13 @@
                     },
                     "viewHistory": "View Git history",
                     "historyComingSoon": "Git history view ships in the next KB drop."
+                },
+                "inherited": {
+                    "bannerLabel": "继承文档通知",
+                    "bannerTitle": "继承自组织",
+                    "bannerDescription": "此文档由您的组织拥有,此处为只读。本地覆盖可在此 Work 中创建可编辑的副本。",
+                    "overrideCta": "本地覆盖",
+                    "overrideCtaPendingTooltip": "当 38d 行的覆盖操作发布后可用"
                 }
             }
         },

--- a/apps/web/src/components/works/detail/kb/KbDocumentView.tsx
+++ b/apps/web/src/components/works/detail/kb/KbDocumentView.tsx
@@ -6,6 +6,24 @@ import type { KbDocumentBodyDto } from '@ever-works/contracts';
 
 interface KbDocumentViewProps {
     doc: KbDocumentBodyDto;
+    /**
+     * EW-641 Phase 2/e row 38c — render the "Inherited from
+     * organization" banner above the doc header. When `true`, the
+     * component is the read-only org-overlay viewer: editor surface
+     * stays mounted as `KbDocumentView` (already non-editable), and
+     * the banner explains the tier + offers an "Override locally"
+     * placeholder CTA.
+     *
+     * Defaults to `false` so every existing call site keeps the
+     * legacy read-only behaviour (full-lock docs, etc.).
+     *
+     * Page-level wiring (resolve the inherited doc body when the
+     * Work-scope `getDocument` 404s) lives in a follow-up row; the
+     * real "Override locally" server action lands in row 38d. This
+     * row ships the surface only so subsequent rows can opt in
+     * without touching this component again.
+     */
+    isInherited?: boolean;
 }
 
 /**
@@ -18,19 +36,29 @@ interface KbDocumentViewProps {
  * pill) arrives in row 5 + 6 — this PR ships the read-only view so
  * deep-linking from the tree works the moment the route lands.
  *
+ * EW-641 Phase 2/e row 38c — when `isInherited` is true, also renders
+ * an "Inherited from organization" banner above the header with an
+ * "Override locally" placeholder CTA. The component itself stays
+ * read-only either way (the editor swap happens at the parent route
+ * level by selecting `KbDocumentView` vs `KbEditor`).
+ *
  * Selectors locked for the upcoming Playwright e2e suite (A12-A17):
  *  - `data-testid="kb-editor"` (root, matches the placeholder slot
  *    in `KbShell` so tests that pre-date this PR keep working)
  *  - `data-testid="kb-document-title"`
  *  - `data-testid="kb-document-meta"` (chip row)
  *  - `data-testid="kb-document-body"` (Markdown render wrapper)
+ *  - `data-testid="kb-inherited-banner"` (row 38c — only when
+ *    `isInherited` is true; row 38d adds the working override CTA
+ *    inside this banner)
  */
-export async function KbDocumentView({ doc }: KbDocumentViewProps) {
+export async function KbDocumentView({ doc, isInherited = false }: KbDocumentViewProps) {
     const t = await getTranslations('dashboard.workDetail.kb');
 
     return (
         <section
             data-testid="kb-editor"
+            data-inherited={isInherited ? 'true' : undefined}
             aria-label={t('panes.editor.title')}
             className={cn(
                 'rounded-lg border border-border dark:border-border-dark',
@@ -38,6 +66,61 @@ export async function KbDocumentView({ doc }: KbDocumentViewProps) {
                 'p-4 flex flex-col gap-3 min-h-[24rem]',
             )}
         >
+            {isInherited ? (
+                <aside
+                    data-testid="kb-inherited-banner"
+                    role="note"
+                    aria-label={t('inherited.bannerLabel')}
+                    className={cn(
+                        'rounded-md border border-amber-500/30 dark:border-amber-400/30',
+                        'bg-amber-500/10 dark:bg-amber-400/10',
+                        'p-3 flex flex-wrap items-center gap-2 text-sm',
+                        'text-amber-900 dark:text-amber-100',
+                    )}
+                >
+                    <span
+                        aria-hidden="true"
+                        className="text-base leading-none"
+                        data-testid="kb-inherited-banner-icon"
+                    >
+                        🔒
+                    </span>
+                    <div className="flex flex-col gap-0.5 min-w-0">
+                        <span data-testid="kb-inherited-banner-title" className="font-medium">
+                            {t('inherited.bannerTitle')}
+                        </span>
+                        <span
+                            data-testid="kb-inherited-banner-description"
+                            className="text-xs text-amber-900/80 dark:text-amber-100/80"
+                        >
+                            {t('inherited.bannerDescription')}
+                        </span>
+                    </div>
+                    {/*
+                     * EW-641 Phase 2/e row 38c — "Override locally" CTA
+                     * placeholder. Renders as a disabled button this
+                     * row; row 38d wires the real server action (clone
+                     * the inherited body into a Work-scope doc + redirect).
+                     * The selector is locked NOW so the row 38e
+                     * Playwright e2e can already target it.
+                     */}
+                    <button
+                        type="button"
+                        disabled
+                        data-testid="kb-inherited-override-cta"
+                        className={cn(
+                            'ml-auto rounded-md px-3 py-1 text-xs font-medium',
+                            'bg-amber-500/20 dark:bg-amber-400/20',
+                            'text-amber-900 dark:text-amber-100',
+                            'cursor-not-allowed opacity-60',
+                            'border border-amber-500/40 dark:border-amber-400/40',
+                        )}
+                        title={t('inherited.overrideCtaPendingTooltip')}
+                    >
+                        {t('inherited.overrideCta')}
+                    </button>
+                </aside>
+            ) : null}
             <header className="flex flex-col gap-2">
                 <h2
                     data-testid="kb-document-title"

--- a/apps/web/src/components/works/detail/kb/KbDocumentView.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbDocumentView.unit.spec.tsx
@@ -147,4 +147,98 @@ describe('KbDocumentView', () => {
             '[[brand/voice.md]] stays raw',
         );
     });
+
+    // ─── EW-641 Phase 2/e row 38c — "Inherited from organization" banner ───
+
+    describe('isInherited — "Inherited from organization" banner', () => {
+        it('omits the banner when isInherited is omitted (back-compat default)', async () => {
+            render(await KbDocumentView({ doc: doc() }));
+            expect(screen.queryByTestId('kb-inherited-banner')).toBeNull();
+            expect(screen.getByTestId('kb-editor').getAttribute('data-inherited')).toBeNull();
+        });
+
+        it('omits the banner when isInherited is explicitly false', async () => {
+            render(await KbDocumentView({ doc: doc(), isInherited: false }));
+            expect(screen.queryByTestId('kb-inherited-banner')).toBeNull();
+            expect(screen.getByTestId('kb-editor').getAttribute('data-inherited')).toBeNull();
+        });
+
+        it('renders the banner with title + description + lock icon + disabled CTA when true', async () => {
+            render(
+                await KbDocumentView({
+                    doc: doc({
+                        workId: null,
+                        organizationId: 'org-1',
+                        path: 'legal/privacy.md',
+                        title: 'Privacy',
+                        class: 'legal',
+                    }),
+                    isInherited: true,
+                }),
+            );
+            const banner = screen.getByTestId('kb-inherited-banner');
+            expect(banner).toBeTruthy();
+            // Editor root signals inherited via data attribute for
+            // Playwright + downstream styling hooks.
+            expect(screen.getByTestId('kb-editor').getAttribute('data-inherited')).toBe('true');
+
+            expect(banner.getAttribute('role')).toBe('note');
+            expect(banner.getAttribute('aria-label')).toBe('inherited.bannerLabel');
+
+            // Lock-icon, title, and description selectors are stable for
+            // the upcoming A19/A20 Playwright e2e (row 38e).
+            expect(screen.getByTestId('kb-inherited-banner-icon').textContent).toContain('🔒');
+            expect(screen.getByTestId('kb-inherited-banner-title').textContent).toBe(
+                'inherited.bannerTitle',
+            );
+            expect(screen.getByTestId('kb-inherited-banner-description').textContent).toBe(
+                'inherited.bannerDescription',
+            );
+
+            // Override CTA renders as a disabled placeholder this row.
+            // Row 38d wires the real server action; the selector is
+            // locked NOW so the e2e can already target it.
+            const cta = screen.getByTestId('kb-inherited-override-cta');
+            expect(cta.tagName).toBe('BUTTON');
+            expect(cta.hasAttribute('disabled')).toBe(true);
+            expect(cta.getAttribute('title')).toBe('inherited.overrideCtaPendingTooltip');
+            expect(cta.textContent).toContain('inherited.overrideCta');
+        });
+
+        it('renders the banner above the document header (DOM order)', async () => {
+            render(
+                await KbDocumentView({
+                    doc: doc({ title: 'Privacy', path: 'legal/privacy.md' }),
+                    isInherited: true,
+                }),
+            );
+            const banner = screen.getByTestId('kb-inherited-banner');
+            const title = screen.getByTestId('kb-document-title');
+            expect(
+                banner.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING,
+            ).toBeTruthy();
+        });
+
+        it('keeps the body markdown read-only path (no editor swap inside KbDocumentView)', async () => {
+            // KbDocumentView is always non-editable; the route decides
+            // whether to mount it vs `KbEditor`. This guard just
+            // verifies the banner doesn't change the body-render path.
+            render(
+                await KbDocumentView({
+                    doc: doc({
+                        body: '# Privacy\n\nVerbatim text.',
+                        workId: null,
+                        organizationId: 'org-1',
+                    }),
+                    isInherited: true,
+                }),
+            );
+            const body = screen.getByTestId('kb-document-body');
+            const preview = screen.getByTestId('markdown-preview-mock');
+            expect(body.contains(preview)).toBe(true);
+            // org-level docs (workId=null) bypass wikilink rewriting
+            // — same fallback as the existing "org-level docs" case.
+            expect(preview.textContent).toBe('# Privacy\n\nVerbatim text.');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 38c — second atomic chunk of the Workbench inherited-docs affordance. **UI-only this row**; the page-level fallback that detects inherited docs (when Work-scope `getDocument` 404s) and the real "Override locally" server action both ship in follow-up rows. Until those land the banner only renders when a caller explicitly passes `isInherited={true}`.

## Changes

### `KbDocumentView.tsx`

- New `isInherited?: boolean` prop (default `false`; every existing call site keeps legacy behaviour).
- When `true`:
    - Editor root gets `data-inherited="true"` for Playwright + downstream styling hooks.
    - `<aside data-testid="kb-inherited-banner" role="note">` renders **above** the document header with:
        - lock-overlay icon (`kb-inherited-banner-icon`)
        - bannerTitle text (`kb-inherited-banner-title`)
        - bannerDescription explainer (`kb-inherited-banner-description`)
        - "Override locally" placeholder button (`kb-inherited-override-cta`) — `disabled` this row; row 38d wires the real server action

The selectors are locked **now** so the row 38e Playwright e2e can already target them without re-introducing churn when 38d lands.

### i18n

- 5 new keys under `dashboard.workDetail.kb.inherited`: `bannerLabel`, `bannerTitle`, `bannerDescription`, `overrideCta`, `overrideCtaPendingTooltip`.
- Translations added to all 21 locales (`en` + 20 others).

## Test plan

- [x] `cd apps/web && npx vitest run src/components/works/detail/kb/KbDocumentView.unit.spec.tsx` → 14/14 (9 prior + 5 new)
    - banner absent when `isInherited` omitted (back-compat default)
    - banner absent when explicitly `isInherited={false}`
    - banner renders with full structure when `true` (role=note, aria-label, icon + title + description + disabled CTA + tooltip)
    - DOM order: banner appears before document header
    - body markdown rendering path unchanged when banner present
- [x] `prettier@3.7.4 --check` on touched files → all formatted
- [x] `turbo build --filter=@ever-works/contracts` → clean (consumer of `KbDocumentBodyDto`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge Base documents now support an inherited state from organizational sources. An "Inherited from organization" banner displays on inherited documents, providing context about the inheritance status and a placeholder for local override functionality coming in a future release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->