### PR TITLE
feat(agent,api,web): inherited-doc body endpoint + detail-page fallback (row 38c-2)

### DIFF
--- a/apps/api/src/works/org-kb.controller.ts
+++ b/apps/api/src/works/org-kb.controller.ts
@@ -93,4 +93,23 @@ export class OrgKbController {
     ) {
         return this.kb.resolveInheritableDocuments(workId, orgId ?? null);
     }
+
+    @Get('works/:id/kb/inheritable/:idOrPath(*)')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Read the body of one inherited (org-scope) KB document',
+        description:
+            'Returns the org-scope KbDocumentBodyDto rendered by the workbench detail page when the user navigates to an inherited row from the row-38a tree. Accepts either a UUID or a slash-separated path (e.g. `legal/privacy.md`). Permission gate is `ensureCanView(workId)` — anyone who can see the Work can read its inherited org docs (consistent with `resolveInheritable`).',
+    })
+    @ApiQuery({ name: 'orgId', required: true })
+    @ApiResponse({ status: 200, description: 'Inherited KB document body' })
+    @ApiResponse({ status: 404, description: 'No org-scope row at that path/id' })
+    async getInheritedDocument(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id') workId: string,
+        @Param('idOrPath') idOrPath: string,
+        @Query('orgId') orgId: string,
+    ) {
+        return this.kb.getInheritedDocument(workId, orgId, idOrPath, auth.userId);
+    }
 }

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
@@ -79,29 +79,64 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
         notFound();
     }
 
+    // EW-641 Phase 2/e row 38c-2 — fetch the Work itself (not just
+    // check for existence) so we can read `work.organizationId` for
+    // the inherited-doc fallback below.
+    const workResponse = await workAPI.get(id).catch(() => null);
+    const work = workResponse?.work ?? null;
+    if (!work) {
+        notFound();
+    }
+
     // Parent layout already verifies the Work exists, so we lean on the
     // doc fetch as the single source of truth for "this URL is valid".
+    // EW-641 Phase 2/e row 38c-2 — if the Work-scope doc isn't found,
+    // fall back to the inherited (org-scope) doc the Work overlays.
+    // 404 is taken only when neither the Work nor the org has a row.
     let doc;
+    let isInherited = false;
     try {
         doc = await kbAPI.getDocument(id, joined);
     } catch (error) {
-        if (error instanceof ApiResponseError && error.statusCode === 404) {
+        if (!(error instanceof ApiResponseError) || error.statusCode !== 404) {
+            throw error;
+        }
+        if (work.organizationId) {
+            try {
+                doc = await kbAPI.getInheritedDocument(id, work.organizationId, joined);
+                isInherited = true;
+            } catch (inheritedError) {
+                if (
+                    inheritedError instanceof ApiResponseError &&
+                    inheritedError.statusCode === 404
+                ) {
+                    notFound();
+                }
+                throw inheritedError;
+            }
+        } else {
             notFound();
         }
-        throw error;
     }
 
-    // Tree list + (optional) source-upload row alongside the doc. Tree
-    // failures fall back to an empty tree; upload-row failures fall back
-    // to the markdown editor path (treat an orphaned `sourceUploadId`
-    // as "not a binary doc").
-    const upload = await loadSourceUpload(id, doc);
-    const list = await Promise.all([workAPI.get(id), kbAPI.listDocuments(id, { limit: 200 })])
-        .then(([, docs]) => docs)
-        .catch((error) => {
-            console.error('[kb-tree] failed to list KB documents:', error);
-            return { items: [], total: 0 };
-        });
+    // Inherited docs never have a source upload — they live in the
+    // org's overlay folder, not in any per-Work upload pipeline. Skip
+    // the upload fetch entirely so a 404 there doesn't get logged.
+    const upload = isInherited ? null : await loadSourceUpload(id, doc);
+    const list = await kbAPI.listDocuments(id, { limit: 200 }).catch((error) => {
+        console.error('[kb-tree] failed to list KB documents:', error);
+        return { items: [], total: 0 };
+    });
+
+    // Plumb the inheritable list into the tree panel so the
+    // "Inherited from organization" section keeps populating on the
+    // detail page too (matches the row-38b plumbing on the index page).
+    const inheritedDocuments = work.organizationId
+        ? await kbAPI.listInheritableDocuments(id, work.organizationId).catch((error) => {
+              console.error('[kb-tree] failed to list inheritable KB documents:', error);
+              return [];
+          })
+        : [];
 
     return (
         <div className="flex flex-col gap-4">
@@ -111,8 +146,15 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
             <KbUploadZone workId={id} targetClass={doc.class} />
             <KbShell
                 workId={id}
-                treeSlot={<KbTreePanel workId={id} documents={list.items} activePath={doc.path} />}
-                editorSlot={renderEditorSlot(id, doc, upload)}
+                treeSlot={
+                    <KbTreePanel
+                        workId={id}
+                        documents={list.items}
+                        inheritedDocuments={inheritedDocuments}
+                        activePath={doc.path}
+                    />
+                }
+                editorSlot={renderEditorSlot(id, doc, upload, isInherited)}
                 asideSlot={<KbSidePanel doc={doc} />}
             />
         </div>
@@ -159,7 +201,15 @@ function renderEditorSlot(
     workId: string,
     doc: KbDocumentBodyDto,
     upload: KbUploadDto | null,
+    isInherited: boolean,
 ): ReactNode {
+    // EW-641 Phase 2/e row 38c-2 — inherited org-overlay docs render
+    // through the read-only viewer with the "Inherited from
+    // organization" banner (row 38c). The editor swap happens here at
+    // the route level, never inside `KbDocumentView` itself.
+    if (isInherited) {
+        return <KbDocumentView doc={doc} isInherited />;
+    }
     const fullyLocked = doc.locked && doc.lockMode === 'full';
     if (fullyLocked) {
         return <KbDocumentView doc={doc} />;

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -79,6 +79,32 @@ export const kbAPI = {
     },
 
     /**
+     * `GET /api/works/:id/kb/inheritable/:idOrPath?orgId=<id>` — read the
+     * body of one inherited (org-scope) KB document.
+     *
+     * EW-641 Phase 2/e row 38c-2 — the workbench detail page calls this
+     * as a fallback when `getDocument(workId, joined)` 404s, so clicking
+     * an inherited tree row (row 38a/38b) actually surfaces the
+     * read-only doc instead of a dead link. Pairs with row 38c's
+     * `<KbDocumentView isInherited />` for the render path.
+     *
+     * Path segments are URL-encoded individually so embedded slashes
+     * survive — the wildcard `:idOrPath(*)` route param on the
+     * controller side preserves the slash separator. The `orgId` is
+     * sent as a query param (mirrors `listInheritableDocuments`).
+     */
+    getInheritedDocument: async (
+        workId: string,
+        orgId: string,
+        idOrPath: string,
+    ): Promise<KbDocumentBodyDto> => {
+        const encodedPath = idOrPath.split('/').map(encodeURIComponent).join('/');
+        return serverFetch<KbDocumentBodyDto>(
+            `/works/${workId}/kb/inheritable/${encodedPath}?orgId=${encodeURIComponent(orgId)}`,
+        );
+    },
+
+    /**
      * `GET /api/works/:id/kb/documents/:idOrPath` — full document with
      * Markdown body + asset summaries. The backend accepts either a
      * UUID or the canonical `<class>/<slug>.md`-style path; we encode

--- a/apps/web/src/lib/api/kb.unit.spec.ts
+++ b/apps/web/src/lib/api/kb.unit.spec.ts
@@ -85,4 +85,58 @@ describe('kbAPI', () => {
             expect(result).toBe(rows);
         });
     });
+
+    describe('getInheritedDocument (row 38c-2)', () => {
+        it('calls /works/:id/kb/inheritable/:path?orgId=<uuid> for a slash-separated path', async () => {
+            const body = {
+                id: 'org-doc-1',
+                workId: null,
+                organizationId: 'org-uuid-1',
+                path: 'legal/privacy.md',
+                slug: 'privacy',
+                class: 'legal',
+                title: 'Privacy',
+                body: 'Org privacy text.',
+            } as unknown;
+            serverFetchMock.mockResolvedValueOnce(body);
+
+            const result = await kbAPI.getInheritedDocument(
+                'work-1',
+                'org-uuid-1',
+                'legal/privacy.md',
+            );
+
+            expect(result).toBe(body);
+            expect(serverFetchMock).toHaveBeenCalledTimes(1);
+            // Path segments encoded individually so the `/` stays as a
+            // route separator for the controller's wildcard param.
+            expect(serverFetchMock).toHaveBeenCalledWith(
+                '/works/work-1/kb/inheritable/legal/privacy.md?orgId=org-uuid-1',
+            );
+        });
+
+        it('calls /works/:id/kb/inheritable/:id?orgId=<uuid> for a UUID id', async () => {
+            // UUIDs have no `/` so encoding is a no-op; this verifies
+            // the helper doesn't accidentally double-encode hyphens.
+            serverFetchMock.mockResolvedValueOnce({} as unknown);
+
+            await kbAPI.getInheritedDocument('work-1', 'org-1', 'd0e1f2-uuid');
+
+            expect(serverFetchMock).toHaveBeenCalledWith(
+                '/works/work-1/kb/inheritable/d0e1f2-uuid?orgId=org-1',
+            );
+        });
+
+        it('URL-encodes path segments AND orgId for safety against reserved chars', async () => {
+            serverFetchMock.mockResolvedValueOnce({} as unknown);
+
+            await kbAPI.getInheritedDocument('work-1', 'org with spaces', 'legal/has space.md');
+
+            // The space in the segment is encoded; the `/` separator is
+            // preserved. The orgId query is also encoded.
+            expect(serverFetchMock).toHaveBeenCalledWith(
+                '/works/work-1/kb/inheritable/legal/has%20space.md?orgId=org%20with%20spaces',
+            );
+        });
+    });
 });

--- a/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
@@ -61,6 +61,28 @@ export class WorkKnowledgeDocumentRepository {
         });
     }
 
+    /**
+     * EW-641 Phase 2/e row 38c-2 — look up an org-scope KB document by
+     * `(organizationId, path)`. Sibling to `findOrgById`; used by
+     * `KnowledgeBaseService.getInheritedDocument` so the workbench
+     * detail page can render an inherited doc body when the Work-scope
+     * `findByWorkOrPath` 404s.
+     *
+     * `workId IS NULL` is asserted at the DB level so a Work-scope row
+     * that happens to share the same path can NEVER leak via this
+     * lookup. The composite `(organizationId, path)` uniqueness
+     * (migration `1779971000000-CreateWorkKnowledgeDocuments`) means
+     * at most one row matches.
+     */
+    async findOrgByPath(
+        organizationId: string,
+        path: string,
+    ): Promise<WorkKnowledgeDocument | null> {
+        return this.repository.findOne({
+            where: { organizationId, path, workId: IsNull() },
+        });
+    }
+
     async list(
         opts: KbDocumentListOptions,
     ): Promise<{ items: WorkKnowledgeDocument[]; total: number }> {

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -86,6 +86,7 @@ describe('KnowledgeBaseService', () => {
             findById: jest.fn(),
             findByPath: jest.fn(),
             findOrgById: jest.fn(),
+            findOrgByPath: jest.fn(),
             findByWorkOrPath: jest.fn(),
             list: jest.fn(),
             listInheritableForOrg: jest.fn(),
@@ -251,6 +252,83 @@ describe('KnowledgeBaseService', () => {
             await expect(service.getDocument(WORK_ID, 'missing', USER_ID)).rejects.toBeInstanceOf(
                 NotFoundException,
             );
+        });
+    });
+
+    // EW-641 Phase 2/e row 38c-2 — read the body of an org-scope doc
+    // that the user's Work inherits from. Used by the workbench detail
+    // page as a fallback when the per-Work getDocument 404s.
+    describe('getInheritedDocument', () => {
+        it('uses findOrgByPath when idOrPath looks like a path (contains "/" or ends in .md)', async () => {
+            const orgDoc = buildDocument({
+                id: 'org-doc-1',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'legal/privacy.md',
+                slug: 'privacy',
+                kbDocumentClass: 'legal' as KbDocumentClass,
+                metadata: { body: 'Verbatim privacy text.' },
+            });
+            docRepo.findOrgByPath.mockResolvedValue(orgDoc);
+
+            const result = await service.getInheritedDocument(
+                WORK_ID,
+                ORG_ID,
+                'legal/privacy.md',
+                USER_ID,
+            );
+
+            expect(ownership.ensureCanView).toHaveBeenCalledWith(WORK_ID, USER_ID);
+            expect(docRepo.findOrgByPath).toHaveBeenCalledWith(ORG_ID, 'legal/privacy.md');
+            expect(docRepo.findOrgById).not.toHaveBeenCalled();
+            expect(result.id).toBe('org-doc-1');
+            expect(result.workId).toBeNull();
+            expect(result.organizationId).toBe(ORG_ID);
+            expect(result.body).toContain('Verbatim privacy text');
+        });
+
+        it('uses findOrgById when idOrPath is a bare id (no "/" or .md)', async () => {
+            const orgDoc = buildDocument({
+                id: 'org-doc-2',
+                workId: null,
+                organizationId: ORG_ID,
+                path: 'style/voice.md',
+                kbDocumentClass: 'style' as KbDocumentClass,
+            });
+            docRepo.findOrgById.mockResolvedValue(orgDoc);
+
+            await service.getInheritedDocument(WORK_ID, ORG_ID, 'org-doc-2', USER_ID);
+
+            expect(docRepo.findOrgById).toHaveBeenCalledWith(ORG_ID, 'org-doc-2');
+            expect(docRepo.findOrgByPath).not.toHaveBeenCalled();
+        });
+
+        it('throws NotFoundException when no org-scope row matches the path', async () => {
+            docRepo.findOrgByPath.mockResolvedValue(null);
+
+            await expect(
+                service.getInheritedDocument(WORK_ID, ORG_ID, 'legal/missing.md', USER_ID),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('throws NotFoundException when no org-scope row matches the id', async () => {
+            docRepo.findOrgById.mockResolvedValue(null);
+
+            await expect(
+                service.getInheritedDocument(WORK_ID, ORG_ID, 'nonexistent-id', USER_ID),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('enforces canView on the Work (same gate as getDocument)', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new ForbiddenException('no access'));
+
+            await expect(
+                service.getInheritedDocument(WORK_ID, ORG_ID, 'legal/privacy.md', USER_ID),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+
+            // No DB lookup ran because the gate rejected first.
+            expect(docRepo.findOrgByPath).not.toHaveBeenCalled();
+            expect(docRepo.findOrgById).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -425,6 +425,49 @@ export class KnowledgeBaseService {
     }
 
     /**
+     * EW-641 Phase 2/e row 38c-2 — read the body of an org-scope KB
+     * document that the user's Work inherits from. Used by the
+     * workbench detail page (`apps/web/.../[id]/kb/[...path]/page.tsx`)
+     * as a fallback when the per-Work `getDocument` 404s — so clicking
+     * an inherited tree row (row 38a/38b) actually surfaces a viewable
+     * read-only doc instead of a dead link.
+     *
+     * Permission model: the caller must have view access to `workId`
+     * — the Work is the user's entry point and the gate. Org-tier docs
+     * are visible to anyone who can see the Work; this is consistent
+     * with `resolveInheritableDocuments` (no extra org-membership
+     * check). A future org-admin role gate would tighten this; not in
+     * this PR.
+     *
+     * Path-vs-id resolution uses the same heuristic as
+     * `findByWorkOrPath` — anything containing `/` or ending in `.md`
+     * is a path; otherwise a doc id. `NotFoundException` when no
+     * org-scope row at `(organizationId, idOrPath)` (e.g. user navigated
+     * to a Work-scope path that doesn't exist either).
+     */
+    async getInheritedDocument(
+        workId: string,
+        organizationId: string,
+        idOrPath: string,
+        userId: string,
+    ): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanView(workId, userId);
+
+        const isPath = idOrPath.includes('/') || idOrPath.endsWith('.md');
+        const doc = isPath
+            ? await this.documentRepository.findOrgByPath(organizationId, idOrPath)
+            : await this.documentRepository.findOrgById(organizationId, idOrPath);
+
+        if (!doc) {
+            throw new NotFoundException(
+                `KB inherited document not found: org=${organizationId} ${idOrPath}`,
+            );
+        }
+
+        return this.toBodyDto(doc);
+    }
+
+    /**
      * EW-641 Phase 2/a row 29b2b — system-op helper used by the
      * `kb-embed-document` Trigger.dev task to fetch a document body
      * without a user-bound `ensureCanView` gate.


### PR DESCRIPTION
## Summary

EW-641 Phase 2/e row 38c-2 — final piece of the inherited-docs read-only chain. After this row, clicking an inherited tree entry (rows 38a/38b) actually renders the read-only viewer with the "Inherited from organization" banner (row 38c) populated with the org doc's body — end-to-end.

## Changes

- **`packages/agent/src/database/repositories/work-knowledge-document.repository.ts`**: new `findOrgByPath(orgId, path)` sibling to `findOrgById`. Asserts `workId IS NULL` so a Work-scope row sharing the path can never leak. Backed by the existing `(organizationId, path)` composite uniqueness from migration `1779971000000`.

- **`packages/agent/src/services/knowledge-base.service.ts`**: new `getInheritedDocument(workId, orgId, idOrPath, userId)` method. Gated by `ensureCanView(workId)` (Work is the user's entry; org visibility follows the same model as `resolveInheritableDocuments`). Path-vs-id heuristic mirrors `findByWorkOrPath` (`/` or `.md` ⇒ path). `NotFoundException` when no row matches.

- **`apps/api/src/works/org-kb.controller.ts`**: new `GET /api/works/:id/kb/inheritable/:idOrPath(*)?orgId=<id>` returning `KbDocumentBodyDto`. Wildcard route param preserves the slash separator in paths like `legal/privacy.md`.

- **`apps/web/src/lib/api/kb.ts`**: new `kbAPI.getInheritedDocument(workId, orgId, idOrPath)` calling the new endpoint with per-segment URL encoding.

- **`apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx`**: fetch the Work itself (not just the existence check) so we can read `work.organizationId`. On Work-scope 404, fall back to `kbAPI.getInheritedDocument`. Render `<KbDocumentView isInherited />` (row 38c) when the fallback succeeds. Plumb `inheritedDocuments` into `<KbTreePanel>` (row 38a) so the inherited section keeps populating on the detail page. Skip the upload fetch entirely on inherited docs.

## Test plan

- [x] 5 new jest cases on `KnowledgeBaseService.getInheritedDocument`:
    - `path-like` idOrPath uses `findOrgByPath`
    - `id-like` idOrPath uses `findOrgById`
    - `NotFoundException` for path-not-found
    - `NotFoundException` for id-not-found
    - `ensureCanView` gate rejects before any DB lookup
- [x] `cd packages/agent && npx jest` → 234/234 suites, 4971/4971 tests (5 new)
- [x] 3 new vitest cases on `kbAPI.getInheritedDocument`:
    - slash-separated path URL shape
    - UUID id URL shape
    - URL-encoding of reserved characters in both path segments and orgId
- [x] `cd apps/web && npx vitest run src/lib/api/kb.unit.spec.ts` → 9/9 (6 prior + 3 new)
- [x] `turbo build --filter=ever-works-api` → clean (Found 0 issues)
- [x] `turbo build --filter=@ever-works/agent` → clean
- [x] `cd apps/web && npx tsc --noEmit` → clean
- [x] `prettier@3.7.4 --check` on touched files → all formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now access and view organization-level knowledge base documents that are inherited by their work or team.
  * When a work-specific knowledge base document is unavailable, the system automatically displays the corresponding organization-level version as a fallback.
  * Inherited documents display in read-only mode to maintain document integrity and prevent accidental modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->