### PR TITLE
feat(agent,api,web): Work.organizationId on UpdateWorkDto + Playwright A19+A20 e2e (row 38e)

### DIFF
--- a/apps/web/e2e/helpers/kb-fixtures.ts
+++ b/apps/web/e2e/helpers/kb-fixtures.ts
@@ -209,3 +209,80 @@ export async function seedKbSkippedUpload(
     }
     return { uploadId, extractionStatus };
 }
+
+export interface SeedOrgKbDocOptions {
+    /** Organization UUID. The org-KB controller (`/api/organizations/:orgId/kb/documents`) doesn't enforce membership today — any authenticated user can post for any orgId. */
+    orgId: string;
+    /** `class/slug.md` style relative path under `.content/kb/<class>/`. Phase 2/e A19 uses `legal/<slug>.md`. */
+    path: string;
+    /** Optional title — falls back to the slug. */
+    title?: string;
+    /** KbDocumentClass enum value. Spec D2 restricts org-scope docs to inheritable classes (`legal`, `style`, `seo`). */
+    targetClass?: 'legal' | 'style' | 'seo';
+    /** Markdown body. */
+    body: string;
+}
+
+/**
+ * POST a single organization-scope KB document via the public REST endpoint
+ * (`POST /api/organizations/:orgId/kb/documents`). Used by the A19 + A20
+ * Playwright specs to seed an inheritable document that a paired Work
+ * (Work.organizationId === orgId) should surface under its "Inherited from
+ * organization" tree section.
+ *
+ * Service-layer guard restricts org-scope documents to the inheritable
+ * class set (`legal | style | seo`) per spec D2 — passing another class
+ * causes the controller to 400.
+ */
+export async function seedOrgKbDoc(
+    request: APIRequestContext,
+    token: string,
+    opts: SeedOrgKbDocOptions,
+): Promise<{ documentId: string; path: string }> {
+    const targetClass = opts.targetClass ?? 'legal';
+    const res = await request.post(`${API_BASE}/api/organizations/${opts.orgId}/kb/documents`, {
+        headers: authedHeaders(token),
+        data: {
+            path: opts.path,
+            title: opts.title ?? opts.path.split('/').pop()?.replace(/\.md$/, '') ?? opts.path,
+            class: targetClass,
+            body: opts.body,
+        },
+    });
+    if (!res.ok()) {
+        const errBody = await res.text();
+        throw new Error(`seedOrgKbDoc failed (${res.status()}): ${errBody}`);
+    }
+    const json = (await res.json()) as { id?: string; path?: string };
+    if (!json.id || !json.path) {
+        throw new Error(
+            `seedOrgKbDoc: created but response shape missing id/path: ${JSON.stringify(json)}`,
+        );
+    }
+    return { documentId: json.id, path: json.path };
+}
+
+/**
+ * PATCH `Work.organizationId` via the public `/api/works/:id` update
+ * endpoint. Pairs the Work with an organization-scope KB document set so
+ * that org docs (seeded via `seedOrgKbDoc`) surface under the Work's KB
+ * tree as "inherited" rows (Phase 2/e A19+A20).
+ *
+ * The endpoint requires editor role on the Work — the access token used
+ * must belong to the Work's owner or an editor member.
+ */
+export async function setWorkOrganizationId(
+    request: APIRequestContext,
+    token: string,
+    workId: string,
+    orgId: string | null,
+): Promise<void> {
+    const res = await request.patch(`${API_BASE}/api/works/${workId}`, {
+        headers: authedHeaders(token),
+        data: { organizationId: orgId },
+    });
+    if (!res.ok()) {
+        const errBody = await res.text();
+        throw new Error(`setWorkOrganizationId failed (${res.status()}): ${errBody}`);
+    }
+}

--- a/apps/web/e2e/kb-inherited.spec.ts
+++ b/apps/web/e2e/kb-inherited.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+import { createWorkViaAPI, loginViaAPI } from './helpers/api';
+import { seedOrgKbDoc, setWorkOrganizationId } from './helpers/kb-fixtures';
+
+/**
+ * EW-641 Phase 2/e row 38e — A19 + A20 acceptance e2e.
+ *
+ * Closes the Phase 2/e inherited-docs surface end-to-end by exercising
+ * the full user journey:
+ *
+ *   A19 (inherited visible)
+ *     - Org-scope KB doc seeded at `legal/privacy.md` via the public
+ *       `POST /api/organizations/:orgId/kb/documents` endpoint.
+ *     - Work paired with that orgId via `PATCH /api/works/:id`
+ *       (`organizationId` was added to `UpdateWorkDto` in this PR).
+ *     - The Work's KB tree renders an "Inherited from organization"
+ *       section with a `kb-tree-inherited-legal-privacy` row that
+ *       deep-links to the inherited detail route.
+ *     - The detail route renders read-only — KB editor root carries
+ *       `data-inherited="true"` and the banner + "Override locally"
+ *       CTA are mounted.
+ *
+ *   A20 (Work override beats org)
+ *     - Clicking the override CTA hits the row-38d server action,
+ *       clones the inherited doc into Work scope at the same path,
+ *       and `router.push`es back to the now-Work-scope detail URL.
+ *     - The same URL now renders the editable Tiptap surface
+ *       (`kb-editor-body` is contentEditable + the banner is gone +
+ *       `data-inherited` is absent).
+ *     - On a fresh page load of the tree, the inherited row is no
+ *       longer in the inherited section (Work override masks it via
+ *       `resolveInheritableDocuments`'s path-collision filter) — the
+ *       same slug now appears as a Work-scope tree item instead.
+ *
+ * Why one shared test for A19 + A20: the override step needs the
+ * inherited surface to be live, and exercising both in one spec
+ * shares the Work + Org seed cost. Splitting them would double the
+ * seed cost and create flakiness windows where A20 starts before
+ * A19's fan-out settles.
+ *
+ * Notes:
+ *  - `/api/organizations/:orgId/kb/documents` does not enforce org
+ *    membership today (per the controller's docstring); any
+ *    authenticated user can post for any orgId. So we mint a random
+ *    UUID for the org and skip seeding an `Organization` row.
+ *  - The org-doc class is restricted to `legal | style | seo` per
+ *    spec D2 (`KB_INHERITABLE_CLASSES`); we use `legal` for parity
+ *    with the row-38e handoff plan.
+ */
+
+test.describe('Knowledge Base — A19+A20 inherited docs', () => {
+    test('inherited row appears, override clones into Work scope, then masks the inherited row', async ({
+        page,
+        request,
+    }) => {
+        // Same 180s budget the other authenticated KB specs use — first
+        // KB-page hit triggers Next dev-mode compilation, the override
+        // CTA chains a server-action roundtrip + a router.push reload.
+        test.setTimeout(180_000);
+
+        // 1. Bearer token + fresh Work owned by the seeded test user.
+        const testUser = loadSeededTestUser();
+        const { access_token } = await loginViaAPI(request, {
+            email: testUser.email,
+            password: testUser.password,
+        });
+        const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        const { id: workId } = await createWorkViaAPI(request, access_token, {
+            name: `KB Inherited ${runId}`,
+        });
+        expect(workId, 'createWorkViaAPI must return a non-empty work id').toBeTruthy();
+
+        // 2. Seed an org-scope KB doc at `legal/privacy.md`. The slug
+        //    embedded in the spec selector (`legal-privacy`) must
+        //    match `slugFromPath('legal/privacy.md')` = 'privacy'.
+        const orgId = randomUUID();
+        const docTitle = `Privacy ${runId}`;
+        const docBody = `# ${docTitle}\n\nOrganization privacy policy — inherited by every paired Work.\n`;
+        await seedOrgKbDoc(request, access_token, {
+            orgId,
+            path: 'legal/privacy.md',
+            title: docTitle,
+            targetClass: 'legal',
+            body: docBody,
+        });
+
+        // 3. Pair the Work with the org. After this, the
+        //    `/works/:id/kb/inheritable?orgId=...` endpoint surfaces the
+        //    seeded doc, and the KB page's parallel fetch picks it up
+        //    via `kbAPI.listInheritableDocuments` (row 38b).
+        await setWorkOrganizationId(request, access_token, workId, orgId);
+
+        // 4. Open the KB page and assert the inherited row is in the
+        //    "Inherited from organization" section, with the lock
+        //    marker + the expected `data-source="inherited"` data attr.
+        await page.goto(`/en/works/${workId}/kb`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByTestId('kb-shell')).toBeVisible({ timeout: 60_000 });
+
+        const inheritedSection = page.getByTestId('kb-tree-inherited');
+        await expect(inheritedSection).toBeVisible({ timeout: 30_000 });
+
+        const inheritedRow = page.getByTestId('kb-tree-inherited-legal-privacy');
+        await expect(inheritedRow).toBeVisible({ timeout: 15_000 });
+        await expect(inheritedRow).toHaveAttribute('data-source', 'inherited');
+        await expect(inheritedRow).toHaveAttribute('data-doc-path', 'legal/privacy.md');
+
+        // 5. Navigate to the inherited detail route. The page falls
+        //    back to the inherited body endpoint when the Work-scope
+        //    lookup 404s (row 38c-2), so the same URL serves both
+        //    Work-scope and inherited views — the difference is the
+        //    `data-inherited="true"` attribute + the banner.
+        await inheritedRow.click();
+        await expect(page).toHaveURL(/\/kb\/legal\/privacy\.md$/, { timeout: 15_000 });
+
+        const editorRoot = page.getByTestId('kb-editor');
+        await expect(editorRoot).toBeVisible({ timeout: 30_000 });
+        await expect(editorRoot).toHaveAttribute('data-inherited', 'true');
+
+        const banner = page.getByTestId('kb-inherited-banner');
+        await expect(banner).toBeVisible({ timeout: 10_000 });
+        // Lock marker emoji is rendered inside the banner-icon span.
+        await expect(page.getByTestId('kb-inherited-banner-icon')).toContainText('🔒');
+
+        const overrideCta = page.getByTestId('kb-inherited-override-cta');
+        await expect(overrideCta).toBeVisible();
+        await expect(overrideCta).toBeEnabled();
+
+        // 6. Click the override CTA. The row-38d server action reads
+        //    the inherited body, POSTs a clone to Work scope, then
+        //    `router.push`es to the new doc — which lives at the same
+        //    path, so the URL doesn't change, but the page re-renders
+        //    as Work-scope (banner gone, contentEditable Tiptap up).
+        await overrideCta.click();
+
+        // After the transition flips `isPending`, the banner unmounts
+        // (because the page re-fetched and the doc is no longer
+        // inherited) and the editable Tiptap surface appears. We
+        // tolerate either order — the banner may briefly stay
+        // mounted during the transition.
+        await expect(banner).not.toBeVisible({ timeout: 30_000 });
+
+        // The Work-scope view drops the `data-inherited` attribute
+        // entirely (the prop defaults to false on KbDocumentView).
+        // Wait for that to be reflected in the DOM.
+        await expect(editorRoot).not.toHaveAttribute('data-inherited', 'true', {
+            timeout: 30_000,
+        });
+
+        // The KbEditor body is mounted with `contentEditable` set —
+        // that's the canonical signal a user can now edit the doc.
+        const editorBody = page.getByTestId('kb-editor-body');
+        await expect(editorBody).toBeVisible({ timeout: 30_000 });
+        await expect(editorBody).toHaveAttribute('contenteditable', 'true');
+
+        // 7. Reload the tree and assert the override masks the
+        //    inherited row. The inherited section either disappears
+        //    entirely (the only inheritable doc is now overridden) or
+        //    the privacy row is gone from it; in both cases the
+        //    `kb-tree-inherited-legal-privacy` selector must NOT
+        //    match anymore. A Work-scope row at the same path takes
+        //    over (`kb-tree-item` with `data-doc-path="legal/privacy.md"`).
+        await page.goto(`/en/works/${workId}/kb`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByTestId('kb-shell')).toBeVisible({ timeout: 60_000 });
+
+        await expect(page.getByTestId('kb-tree-inherited-legal-privacy')).toHaveCount(0, {
+            timeout: 15_000,
+        });
+        const workScopeRow = page.locator(
+            '[data-testid="kb-tree-item"][data-doc-path="legal/privacy.md"]',
+        );
+        await expect(workScopeRow).toBeVisible({ timeout: 15_000 });
+    });
+});

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -96,4 +96,16 @@ export class UpdateWorkDto {
     @IsOptional()
     @IsIn(['pull', 'push', 'disabled'])
     activitySyncMode?: 'pull' | 'push' | 'disabled';
+
+    @ApiPropertyOptional({
+        description:
+            'Membership-scope organization UUID. Pairs the Work with an organization-scope KB document set: when set, the Workbench shows org-level docs as "inherited" under the Work\'s KB tree (Phase 2/e A19+A20). Pass `null` to clear the membership. Independent of the `organization: boolean` flag above (which controls Git repository ownership shape, not KB inheritance).',
+        nullable: true,
+    })
+    @IsString()
+    @IsOptional()
+    @Transform(({ value }) =>
+        value === null || value === '' ? null : typeof value === 'string' ? value.trim() : value,
+    )
+    organizationId?: string | null;
 }

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -167,6 +167,63 @@ describe('WorkLifecycleService', () => {
         );
     });
 
+    describe('updateWork — organizationId (EW-639 Phase 2/e)', () => {
+        const baseWork = (overrides: Record<string, unknown> = {}) =>
+            ({
+                id: 'dir-1',
+                name: 'Test Work',
+                description: 'Test description',
+                owner: 'ever-works',
+                organization: false,
+                organizationId: null,
+                readmeConfig: {},
+                gitProvider: 'github',
+                userId: user.id,
+                website: 'https://example.com',
+                websiteTemplateId: 'classic',
+                getRepoOwner: jest.fn().mockReturnValue('ever-works'),
+                getWebsiteRepo: jest.fn().mockReturnValue('test-work-website'),
+                ...overrides,
+            }) as any;
+
+        it('persists a non-null organizationId from the DTO', async () => {
+            const work = baseWork();
+            ownershipService.ensureCanEdit.mockResolvedValue({ work });
+            workRepository.update.mockResolvedValueOnce({ ...work, organizationId: 'org-42' });
+
+            await service.updateWork(work.id, { organizationId: 'org-42' } as any, user);
+
+            expect(workRepository.update).toHaveBeenCalledWith(
+                work.id,
+                expect.objectContaining({ organizationId: 'org-42' }),
+            );
+        });
+
+        it('persists organizationId: null to clear the org membership', async () => {
+            const work = baseWork({ organizationId: 'org-prior' });
+            ownershipService.ensureCanEdit.mockResolvedValue({ work });
+            workRepository.update.mockResolvedValueOnce({ ...work, organizationId: null });
+
+            await service.updateWork(work.id, { organizationId: null } as any, user);
+
+            expect(workRepository.update).toHaveBeenCalledWith(
+                work.id,
+                expect.objectContaining({ organizationId: null }),
+            );
+        });
+
+        it('leaves organizationId untouched when the DTO omits the field', async () => {
+            const work = baseWork({ organizationId: 'org-prior' });
+            ownershipService.ensureCanEdit.mockResolvedValue({ work });
+            workRepository.update.mockResolvedValueOnce({ ...work });
+
+            await service.updateWork(work.id, { name: 'renamed' } as any, user);
+
+            const updateArg = workRepository.update.mock.calls[0][1];
+            expect(updateArg).not.toHaveProperty('organizationId');
+        });
+    });
+
     it('rejects website template changes after website repository initialization', async () => {
         const work = {
             id: 'dir-1',

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -502,6 +502,16 @@ export class WorkLifecycleService {
                 updateData.activitySyncMode = updateDto.activitySyncMode;
             }
 
+            // EW-639 Phase 2/e: pair the Work with an organization-scope KB
+            // document set. `organizationId === null` clears the membership
+            // (no inheritance); a UUID makes the Work inherit org-level KB
+            // docs that aren't shadowed by a Work-scope override. The
+            // org-overlay fan-out flow (row 37) reads this column to resolve
+            // which Works receive `.content/kb/.org/...` materialization.
+            if (updateDto.organizationId !== undefined) {
+                updateData.organizationId = updateDto.organizationId;
+            }
+
             const updatedWork = await this.workRepository.update(id, updateData);
 
             if (!updatedWork) {


### PR DESCRIPTION
## Summary

Closes Phase 2/e end-to-end on the user-visible AND e2e surfaces. The inherited-docs affordance (rows 38a-38d) is now exercised top to bottom by a single Playwright spec covering both A19 (inherited visible) and A20 (Work override beats org).

### Backend
- `UpdateWorkDto` gains `organizationId?: string | null` — pairs a Work with an organization-scope KB document set without disturbing the existing `organization: boolean` (which controls Git repo ownership shape, not KB inheritance).
- `WorkLifecycleService.updateWork` applies the field when present, passes through `null` to clear the membership, and leaves the column untouched when the DTO omits the field. 3 new jest cases.

### E2E
- `seedOrgKbDoc` helper posts to `/api/organizations/:orgId/kb/documents` (no membership enforcement today — any auth'd user can post for any orgId per the controller docstring). Restricted to `legal | style | seo` per spec D2.
- `setWorkOrganizationId` helper PATCHes the new DTO field.
- `apps/web/e2e/kb-inherited.spec.ts` seeds an org doc at `legal/privacy.md`, pairs the Work with the org, asserts the inherited row + banner + override CTA, clicks override, asserts editable Tiptap + `data-inherited` cleared, then refreshes the tree to assert the override masks the inherited row.

### Verified locally
- agent jest **234/234 suites · 4974 tests** green (3 new in `work-lifecycle.service.spec.ts`)
- `apps/web` `tsc --noEmit` clean
- `prettier@3.7.4 --check` clean on all changed files

Row 38e closes Phase 2/e — rows 39+ (Phase 2/f community PR + scheduled-regen lock respect) become NEXT.

## Test plan

- [x] agent unit jest covers DTO → service passthrough for set/clear/omit
- [ ] CI lint-and-test (22.x) green
- [ ] CI e2e green (Playwright `kb-inherited.spec.ts` runs in the chromium project)
- [ ] CodeRabbit review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now maintain knowledge base documents at the organizational level.
  * Works can be associated with organizations to inherit organizational KB documents.
  * Users can override inherited documents to create work-specific versions.

* **Tests**
  * Added comprehensive end-to-end test coverage for inherited knowledge base document functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->