### PR TITLE
fix(api): migrate kb/inheritable catch-all route to path-to-regexp@8 syntax

### DIFF
--- a/apps/api/src/works/org-kb.controller.ts
+++ b/apps/api/src/works/org-kb.controller.ts
@@ -94,7 +94,21 @@ export class OrgKbController {
         return this.kb.resolveInheritableDocuments(workId, orgId ?? null);
     }
 
-    @Get('works/:id/kb/inheritable/:idOrPath(*)')
+    /**
+     * EW-639 Phase 2/e row 38c-2 — inherited-doc body endpoint.
+     *
+     * The catch-all segment uses `*idOrPath` instead of the legacy
+     * `:idOrPath(*)` syntax: `path-to-regexp@8` (shipped with
+     * NestJS 11.x via Express 5) rejects the legacy form at module-
+     * init time and the API crashes on boot — the failure surfaced
+     * on every push to develop's e2e workflow after row 38c-2 landed
+     * (PR #998). The new syntax binds the joined remainder of the
+     * URL (e.g. `legal/privacy.md`) to the `idOrPath` request param.
+     * Express 5 exposes catch-all segments as an array on `req.params`;
+     * we rejoin with `/` below so the service-layer heuristic still
+     * resolves either a UUID or a slash-separated path.
+     */
+    @Get('works/:id/kb/inheritable/*idOrPath')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: 'Read the body of one inherited (org-scope) KB document',
@@ -107,9 +121,10 @@ export class OrgKbController {
     async getInheritedDocument(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id') workId: string,
-        @Param('idOrPath') idOrPath: string,
+        @Param('idOrPath') idOrPath: string | string[],
         @Query('orgId') orgId: string,
     ) {
-        return this.kb.getInheritedDocument(workId, orgId, idOrPath, auth.userId);
+        const joinedIdOrPath = Array.isArray(idOrPath) ? idOrPath.join('/') : idOrPath;
+        return this.kb.getInheritedDocument(workId, orgId, joinedIdOrPath, auth.userId);
     }
 }

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -90,9 +90,10 @@ export const kbAPI = {
      * `<KbDocumentView isInherited />` for the render path.
      *
      * Path segments are URL-encoded individually so embedded slashes
-     * survive — the wildcard `:idOrPath(*)` route param on the
-     * controller side preserves the slash separator. The `orgId` is
-     * sent as a query param (mirrors `listInheritableDocuments`).
+     * survive — the wildcard `*idOrPath` route param on the
+     * controller side (path-to-regexp@8 catch-all syntax) preserves
+     * the slash separator. The `orgId` is sent as a query param
+     * (mirrors `listInheritableDocuments`).
      */
     getInheritedDocument: async (
         workId: string,


### PR DESCRIPTION
## Summary

**Develop is currently broken at API boot** — the e2e workflow has been failing on every push since row 38c-2 (PR #998) merged. Root cause:

\`\`\`
PathError [TypeError]: Unexpected ( at index 39:
/api/works/:id/kb/inheritable/:idOrPath(*)
\`\`\`

The route uses the legacy \`path-to-regexp\` v6 catch-all syntax (\`:name(*)\`), which \`path-to-regexp@8\` (shipped with NestJS 11 via Express 5) rejects at module-init time. The API crash-loops.

## Fix

\`:idOrPath(*)\` → \`*idOrPath\` (new catch-all syntax).

Express 5 exposes catch-all segments as a **string array** on \`req.params\`, so the handler now rejoins with \`/\` before delegating to the service layer (which still resolves UUID-or-path heuristically). No behaviour change from the caller's perspective.

Also corrected the stale comment in \`apps/web/src/lib/api/kb.ts\` that documented the old route shape.

## Why this slipped past CI on PR #998

- \`lint-and-test\` runs jest unit tests that import the controller as a class — never boots the Nest app.
- \`e2e\` boots the real API + Next. **This is the workflow that's been red since #998.**
- The fix unblocks promotion to stage + main.

## Test plan

- [x] No legacy \`(*)\` route patterns remain (\`grep -rn ":[A-Za-z]+(\*)" apps/api/src\`)
- [x] \`prettier@3.7.4 --check\` clean
- [ ] CI lint-and-test green
- [ ] CI e2e green (this is the canonical signal — boots the real API)
- [ ] Stage / main promotion unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced route handling for inherited knowledge base document retrieval with improved parameter processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->