### PR TITLE
fix(web): KB modal panels are transparent in dark mode

### DIFF
--- a/apps/web/src/components/works/detail/kb/KbClassifyModal.tsx
+++ b/apps/web/src/components/works/detail/kb/KbClassifyModal.tsx
@@ -193,7 +193,17 @@ export function KbClassifyModal({
             <div
                 className={cn(
                     'w-full max-w-xl rounded-lg border border-border dark:border-border-dark',
-                    'bg-card dark:bg-card-primary-dark p-5 shadow-xl',
+                    // EW-639 dark-theme fix: `--color-card-primary-dark`
+                    // resolves to `#ffffff08` (a 3% translucent overlay,
+                    // intended for cards that sit on top of solid page
+                    // chrome). Using it as the modal panel background
+                    // made the dialog see-through in dark mode — the
+                    // page content behind the `bg-black/40` overlay
+                    // bled through. `bg-card-dark` (#1e293b, solid
+                    // slate) matches the elevated-surface convention
+                    // used by the shadcn `DialogContent` primitive
+                    // elsewhere in the app.
+                    'bg-card dark:bg-card-dark p-5 shadow-xl',
                     'flex flex-col gap-4',
                 )}
             >

--- a/apps/web/src/components/works/detail/kb/KbHistoryDialog.tsx
+++ b/apps/web/src/components/works/detail/kb/KbHistoryDialog.tsx
@@ -127,7 +127,11 @@ export function KbHistoryDialog({ workId, docId, path, open, onClose }: KbHistor
             <div
                 className={cn(
                     'w-full max-w-xl rounded-lg border shadow-2xl',
-                    'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                    // EW-639 dark-theme fix: see KbClassifyModal for context.
+                    // `card-primary-dark` is intentionally translucent
+                    // (#ffffff08) — wrong for a modal panel. `card-dark`
+                    // (#1e293b) is the solid elevated-surface convention.
+                    'border-border bg-card dark:border-border-dark dark:bg-card-dark',
                     'flex flex-col gap-2 p-4',
                 )}
             >

--- a/apps/web/src/components/works/detail/kb/KbSearchPalette.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSearchPalette.tsx
@@ -221,7 +221,11 @@ export function KbSearchPalette({
                     <div
                         className={cn(
                             'w-full max-w-xl rounded-lg border shadow-2xl',
-                            'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                            // EW-639 dark-theme fix: see KbClassifyModal /
+                            // KbHistoryDialog. `card-primary-dark` is
+                            // translucent — wrong for a modal panel. Use
+                            // `card-dark` for solid elevated-surface.
+                            'border-border bg-card dark:border-border-dark dark:bg-card-dark',
                         )}
                     >
                         <input


### PR DESCRIPTION
## Summary

User-reported production bug — the KB \"Classify upload\" modal renders see-through on the dark theme. Page content (the Knowledge Base heading, file row, etc.) bleeds through the dialog body.

### Root cause

\`dark:bg-card-primary-dark\` resolves to the CSS variable \`--color-card-primary-dark: #ffffff08\` — a 3% translucent white overlay tone designed for cards that sit ON TOP OF solid page chrome. Using it as a **modal panel** background means the dialog is essentially transparent over the \`bg-black/40\` overlay, which in dark mode lets most of the dashboard show through.

### Fix

Switch the three KB modal panels — \`KbClassifyModal\`, \`KbHistoryDialog\`, \`KbSearchPalette\` — to \`dark:bg-card-dark\` (\`--color-card-dark: #1e293b\`, solid slate-800). Matches the \`bg-surface dark:bg-surface-dark\` convention used by the shadcn \`DialogContent\` primitive elsewhere in the app — a deliberate \"elevated surface\" tone, not a translucent overlay.

Light theme is unchanged (\`bg-card\` was already solid \`#ffffff\`).

### Scope

3 file edits, ~21 lines total. Pure CSS swap — no selector changes, no a11y changes, no API impact. e2e selectors (\`kb-classify-modal\`, \`kb-history-dialog\`, \`kb-search-palette\`) and unit-test contracts unaffected.

## Test plan

- [x] prettier@3.7.4 clean
- [ ] CI lint-and-test green
- [ ] Visual verification on dark theme post-deploy

## Related

- The user also reported \"Internal server error\" on actual file upload — separate backend issue, will diagnose with API logs once accessible.
- Pairs with PR #1004 (ActivityLogModule DI fix) to unblock KB workflows end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling for modal and dialog components to improve visual consistency, background contrast, and overall appearance alignment with the app's design system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->