### PR TITLE
fix(agent): KB upload 500 — TimestampColumn snake_case column names

### DIFF
--- a/packages/agent/src/entities/_types.ts
+++ b/packages/agent/src/entities/_types.ts
@@ -1,14 +1,41 @@
-import { Column } from 'typeorm';
+import { Column, type ColumnOptions } from 'typeorm';
 
-export const TimestampColumn = ({ nullable = false }: { nullable?: boolean } = {}) => {
-    return Column({
+/**
+ * Portable epoch-millis timestamp column. Stores as `bigint` (works
+ * cross-DB; raw `Date` defaults to TIMESTAMP WITH TIME ZONE on
+ * Postgres and INTEGER on SQLite, breaking parity). The transformer
+ * turns the stored value back into a `Date` at read time so callers
+ * see a normal `Date` either way.
+ *
+ * `name` override: TypeORM defaults the column name to the property
+ * name verbatim, which means `extractionStartedAt` (camelCase) on
+ * the entity tries to read column `"extractionStartedAt"` from
+ * Postgres. If the migration created the column as
+ * `extraction_started_at` (snake_case — the convention used by every
+ * other `name:`-overridden column in the same entities), the query
+ * fails with `column ... does not exist`. The fix landed in EW-639
+ * after the 500 surfaced on the KB upload path in production: pass
+ * the explicit snake_case column name from the call site.
+ */
+export const TimestampColumn = ({
+    nullable = false,
+    name,
+}: { nullable?: boolean; name?: string } = {}) => {
+    // DTS-emit gotcha (CLAUDE.md): conditional spreads like
+    // `...(name && { name })` produce `string | false` and break
+    // declaration generation. Build the options imperatively.
+    const opts: ColumnOptions = {
         type: 'bigint',
         nullable,
         transformer: {
             to: (value?: Date) => (value ? value.getTime() : null),
             from: (value?: string | number) => (value ? new Date(Number(value)) : null),
         },
-    });
+    };
+    if (name) {
+        opts.name = name;
+    }
+    return Column(opts);
 };
 
 export const PortableDateColumn = ({ nullable = false }: { nullable?: boolean } = {}) => {

--- a/packages/agent/src/entities/work-knowledge-document.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-document.entity.ts
@@ -150,7 +150,11 @@ export class WorkKnowledgeDocument {
     @JoinColumn({ name: 'updated_by_id' })
     updatedBy?: ClassToObject<User> | null;
 
-    @TimestampColumn({ nullable: true })
+    // EW-639 prod-hotfix: the 1779971 migration creates this column as
+    // snake_case `last_indexed_at`; same camelCase/snake_case mismatch
+    // class as the upload entity's `extractionStartedAt`. Pass the
+    // explicit `name:` so TypeORM emits the right column in SELECTs.
+    @TimestampColumn({ nullable: true, name: 'last_indexed_at' })
     lastIndexedAt?: Date | null;
 
     @Column({ type: 'varchar', length: 40, nullable: true, name: 'last_commit_sha' })

--- a/packages/agent/src/entities/work-knowledge-upload.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-upload.entity.ts
@@ -80,10 +80,18 @@ export class WorkKnowledgeUpload {
     @Column({ type: 'text', nullable: true, name: 'extraction_error' })
     extractionError?: string | null;
 
-    @TimestampColumn({ nullable: true })
+    // EW-639 prod-hotfix: the 1779972 migration creates these columns
+    // as snake_case `extraction_started_at` / `extraction_finished_at`;
+    // without an explicit `name:` override TypeORM defaulted to the
+    // camelCase property name and Postgres rejected every upload with
+    // `QueryFailedError: column WorkKnowledgeUpload.extractionStartedAt
+    // does not exist`. Pass the snake_case names explicitly to match
+    // the migration. Same fix lands on `lastIndexedAt` over in the
+    // sibling `work-knowledge-document.entity.ts`.
+    @TimestampColumn({ nullable: true, name: 'extraction_started_at' })
     extractionStartedAt?: Date | null;
 
-    @TimestampColumn({ nullable: true })
+    @TimestampColumn({ nullable: true, name: 'extraction_finished_at' })
     extractionFinishedAt?: Date | null;
 
     /** The KB document this upload was extracted into, if any. */


### PR DESCRIPTION
## Summary

**User-reported P0**: every KB upload on production returns \`Internal server error\`.

Pulled prod API pod logs:

\`\`\`
QueryFailedError: column WorkKnowledgeUpload.extractionStartedAt does not exist
[ExceptionsHandler] at POST /api/works/.../kb/uploads
\`\`\`

### Root cause

\`TimestampColumn\` decorator in \`packages/agent/src/entities/_types.ts\` didn't accept a \`name:\` override. TypeORM defaults the SQL column name to the property name verbatim, so the entity declared \`extractionStartedAt\` (camelCase) — but the migrations (\`1779971-CreateWorkKnowledgeDocuments\`, \`1779972-CreateWorkKnowledgeUploads\`) created the matching columns as **snake_case** (\`extraction_started_at\`, \`extraction_finished_at\`, \`last_indexed_at\`) to follow the dominant convention in those entities. The entity↔DB names diverged on those three columns only. The very first DB query in \`createUpload\` — the SHA-256 dedup probe \`uploadRepository.findBySha256\` — trips on the missing column and the controller returns 500.

### Fix

1. \`TimestampColumn\` accepts an optional \`name:\` override. Built imperatively with \`if (name) opts.name = name\` per the CLAUDE.md DTS-emit gotcha (conditional spreads break declaration generation).
2. \`work-knowledge-upload.entity.ts\`: thread snake_case names through the two TimestampColumn decorators (\`extraction_started_at\` / \`extraction_finished_at\`).
3. \`work-knowledge-document.entity.ts\`: same fix for \`last_indexed_at\`.

### Why this slipped past CI

Tests run against **SQLite**, which is case-insensitive on column matching — the entity↔migration mismatch was invisible locally and in CI. **Postgres** is strict on double-quoted identifiers. SQLite e2e couldn't have caught this; it's exactly the regression class Phase 2 needs an integration probe against Postgres for. Filing a follow-up ticket.

### Verified locally

- agent jest **234/234 suites · 4975 tests** green
- prettier@3.7.4 clean

### Scope discipline

The other 33 \`@TimestampColumn\` callers across the agent package use either matching property names or are in entities whose migrations also use camelCase. **KB is the only one** that mixed snake_case in the migration with no \`name:\` on the entity. Not touching the others to keep this hotfix tight.

## Test plan

- [x] agent jest green
- [ ] CI lint-and-test green
- [ ] Post-deploy verification: retry the upload on app.ever.works → succeeds, KB doc lands in tree

## Related

- Pairs with PR #1004 (\`ActivityLogModule\` DI fix) and PR #1005 (modal dark-theme bg) — all are production hotfixes triggered by the user's KB testing session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed timestamp field handling for work knowledge documents and uploads to ensure accurate tracking of document indexing and file extraction events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->