### PR TITLE
feat(web): short tab labels + tooltips, reorder Activity columns

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "نظرة عامة",
-                "activity": "Activity Feed",
+                "activity": "النشاط",
                 "items": "العناصر",
                 "generator": "مولد",
                 "schedule": "جدولة",
@@ -1146,7 +1146,13 @@
                 "deploy": "نشر",
                 "members": "الأعضاء",
                 "settings": "الإعدادات",
-                "kb": "Knowledge Base"
+                "kb": "قاعدة المعرفة",
+                "tooltips": {
+                    "activity": "موجز النشاط",
+                    "kb": "قاعدة المعرفة",
+                    "generator": "توليد الـWork مرة واحدة أو وفق جدول",
+                    "deploy": "نشر الـWork"
+                }
             },
             "members": {
                 "title": "أعضاء الفريق",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "Преглед",
-                "activity": "Activity Feed",
+                "activity": "Активност",
                 "items": "Елементи",
                 "generator": "Генератор",
                 "schedule": "График",
@@ -1146,7 +1146,13 @@
                 "deploy": "Разполагане",
                 "members": "Членове",
                 "settings": "Настройки",
-                "kb": "Knowledge Base"
+                "kb": "База знания",
+                "tooltips": {
+                    "activity": "Поток на активността",
+                    "kb": "База знания",
+                    "generator": "Генериране на Work — еднократно или по график",
+                    "deploy": "Разгръщане на Work"
+                }
             },
             "members": {
                 "title": "Членове на екипа",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "Übersicht",
-                "activity": "Activity Feed",
+                "activity": "Aktivität",
                 "items": "Elemente",
                 "generator": "Generator",
                 "schedule": "Zeitplan",
@@ -1146,7 +1146,13 @@
                 "deploy": "Bereitstellen",
                 "members": "Mitglieder",
                 "settings": "Einstellungen",
-                "kb": "Knowledge Base"
+                "kb": "Wissensdatenbank",
+                "tooltips": {
+                    "activity": "Aktivitäts-Feed",
+                    "kb": "Wissensdatenbank",
+                    "generator": "Work generieren – einmalig oder nach Zeitplan",
+                    "deploy": "Work bereitstellen"
+                }
             },
             "members": {
                 "title": "Teammitglieder",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1164,7 +1164,7 @@
             },
             "tabs": {
                 "overview": "Overview",
-                "activity": "Activity Feed",
+                "activity": "Activity",
                 "items": "Items",
                 "generator": "Generator",
                 "schedule": "Schedule",
@@ -1174,7 +1174,13 @@
                 "deploy": "Deploy",
                 "members": "Members",
                 "settings": "Settings",
-                "kb": "Knowledge Base"
+                "kb": "KB",
+                "tooltips": {
+                    "activity": "Activity Feed",
+                    "kb": "Knowledge Base",
+                    "generator": "Generate Work, one time or on schedule",
+                    "deploy": "Deploy Work"
+                }
             },
             "members": {
                 "title": "Team Members",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "Resumen",
-                "activity": "Activity Feed",
+                "activity": "Actividad",
                 "items": "Elementos",
                 "generator": "Generador",
                 "schedule": "Programación",
@@ -1146,7 +1146,13 @@
                 "deploy": "Implementar",
                 "members": "Miembros",
                 "settings": "Configuración",
-                "kb": "Knowledge Base"
+                "kb": "Base de conocimiento",
+                "tooltips": {
+                    "activity": "Feed de actividad",
+                    "kb": "Base de conocimiento",
+                    "generator": "Generar Work, una vez o según programación",
+                    "deploy": "Desplegar Work"
+                }
             },
             "members": {
                 "title": "Miembros del equipo",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1163,7 +1163,7 @@
             },
             "tabs": {
                 "overview": "Aperçu",
-                "activity": "Activity Feed",
+                "activity": "Activité",
                 "items": "Éléments",
                 "generator": "Générateur",
                 "schedule": "Programmation",
@@ -1173,7 +1173,13 @@
                 "deploy": "Déploiement",
                 "members": "Membres",
                 "settings": "Paramètres",
-                "kb": "Knowledge Base"
+                "kb": "Base de connaissances",
+                "tooltips": {
+                    "activity": "Fil d'activité",
+                    "kb": "Base de connaissances",
+                    "generator": "Générer le Work, ponctuellement ou planifié",
+                    "deploy": "Déployer le Work"
+                }
             },
             "members": {
                 "title": "Membres de l'équipe",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "סקירה כללית",
-                "activity": "Activity Feed",
+                "activity": "פעילות",
                 "items": "פריטים",
                 "generator": "מחולל",
                 "schedule": "לוח זמנים",
@@ -1146,7 +1146,13 @@
                 "deploy": "פריסה",
                 "members": "חברים",
                 "settings": "הגדרות",
-                "kb": "Knowledge Base"
+                "kb": "מאגר ידע",
+                "tooltips": {
+                    "activity": "פיד פעילות",
+                    "kb": "מאגר ידע",
+                    "generator": "צור Work, חד-פעמי או על פי לוח זמנים",
+                    "deploy": "פרוס Work"
+                }
             },
             "members": {
                 "title": "חברי צוות",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "अवलोकन",
-                "activity": "Activity Feed",
+                "activity": "गतिविधि",
                 "items": "आइटम",
                 "generator": "जनरेटर",
                 "schedule": "अनुसूची",
@@ -1019,7 +1019,13 @@
                 "deploy": "तैनाती",
                 "members": "सदस्य",
                 "settings": "सेटिंग्स",
-                "kb": "Knowledge Base"
+                "kb": "ज्ञान आधार",
+                "tooltips": {
+                    "activity": "गतिविधि फ़ीड",
+                    "kb": "ज्ञान आधार",
+                    "generator": "Work उत्पन्न करें, एक बार या निर्धारित समय पर",
+                    "deploy": "Work परिनियोजित करें"
+                }
             },
             "members": {
                 "title": "टीम सदस्य",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Ringkasan",
-                "activity": "Activity Feed",
+                "activity": "Aktivitas",
                 "items": "Item",
                 "generator": "Generator",
                 "schedule": "Jadwal",
@@ -1019,7 +1019,13 @@
                 "deploy": "Penerapan",
                 "members": "Anggota",
                 "settings": "Pengaturan",
-                "kb": "Knowledge Base"
+                "kb": "Basis Pengetahuan",
+                "tooltips": {
+                    "activity": "Umpan Aktivitas",
+                    "kb": "Basis Pengetahuan",
+                    "generator": "Buat Work, sekali atau terjadwal",
+                    "deploy": "Deploy Work"
+                }
             },
             "members": {
                 "title": "Anggota Tim",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Panoramica",
-                "activity": "Activity Feed",
+                "activity": "Attività",
                 "items": "Elementi",
                 "generator": "Generatore",
                 "schedule": "Programmazione",
@@ -1019,7 +1019,13 @@
                 "deploy": "Distribuzione",
                 "members": "Membri",
                 "settings": "Impostazioni",
-                "kb": "Knowledge Base"
+                "kb": "Base di conoscenza",
+                "tooltips": {
+                    "activity": "Feed attività",
+                    "kb": "Base di conoscenza",
+                    "generator": "Genera Work, una tantum o pianificato",
+                    "deploy": "Distribuisci Work"
+                }
             },
             "members": {
                 "title": "Membri del team",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "概要",
-                "activity": "Activity Feed",
+                "activity": "アクティビティ",
                 "items": "アイテム",
                 "generator": "ジェネレーター",
                 "schedule": "スケジュール",
@@ -1019,7 +1019,13 @@
                 "deploy": "デプロイ",
                 "members": "メンバー",
                 "settings": "設定",
-                "kb": "Knowledge Base"
+                "kb": "ナレッジベース",
+                "tooltips": {
+                    "activity": "アクティビティフィード",
+                    "kb": "ナレッジベース",
+                    "generator": "Work を 1 回またはスケジュールで生成",
+                    "deploy": "Work をデプロイ"
+                }
             },
             "members": {
                 "title": "チームメンバー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "개요",
-                "activity": "Activity Feed",
+                "activity": "활동",
                 "items": "항목",
                 "generator": "생성기",
                 "schedule": "스케줄",
@@ -1019,7 +1019,13 @@
                 "deploy": "배포",
                 "members": "멤버",
                 "settings": "설정",
-                "kb": "Knowledge Base"
+                "kb": "지식 베이스",
+                "tooltips": {
+                    "activity": "활동 피드",
+                    "kb": "지식 베이스",
+                    "generator": "Work를 일회성 또는 예약된 일정으로 생성",
+                    "deploy": "Work 배포"
+                }
             },
             "members": {
                 "title": "팀 멤버",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Overzicht",
-                "activity": "Activity Feed",
+                "activity": "Activiteit",
                 "items": "Items",
                 "generator": "Generator",
                 "schedule": "Planning",
@@ -1019,7 +1019,13 @@
                 "deploy": "Deployen",
                 "members": "Leden",
                 "settings": "Instellingen",
-                "kb": "Knowledge Base"
+                "kb": "Kennisbank",
+                "tooltips": {
+                    "activity": "Activiteitenfeed",
+                    "kb": "Kennisbank",
+                    "generator": "Work genereren — eenmalig of volgens planning",
+                    "deploy": "Work uitrollen"
+                }
             },
             "members": {
                 "title": "Teamleden",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Przegląd",
-                "activity": "Activity Feed",
+                "activity": "Aktywność",
                 "items": "Elementy",
                 "generator": "Generator",
                 "schedule": "Harmonogram",
@@ -1019,7 +1019,13 @@
                 "deploy": "Wdrożenie",
                 "members": "Członkowie",
                 "settings": "Ustawienia",
-                "kb": "Knowledge Base"
+                "kb": "Baza wiedzy",
+                "tooltips": {
+                    "activity": "Kanał aktywności",
+                    "kb": "Baza wiedzy",
+                    "generator": "Wygeneruj Work — jednorazowo lub według harmonogramu",
+                    "deploy": "Wdróż Work"
+                }
             },
             "members": {
                 "title": "Członkowie zespołu",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Visão Geral",
-                "activity": "Activity Feed",
+                "activity": "Atividade",
                 "items": "Itens",
                 "generator": "Gerador",
                 "schedule": "Agendamento",
@@ -1019,7 +1019,13 @@
                 "deploy": "Implantar",
                 "members": "Membros",
                 "settings": "Configurações",
-                "kb": "Knowledge Base"
+                "kb": "Base de conhecimento",
+                "tooltips": {
+                    "activity": "Feed de atividade",
+                    "kb": "Base de conhecimento",
+                    "generator": "Gerar Work, uma vez ou em agenda",
+                    "deploy": "Implantar Work"
+                }
             },
             "members": {
                 "title": "Membros da Equipe",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Обзор",
-                "activity": "Activity Feed",
+                "activity": "Активность",
                 "items": "Элементы",
                 "generator": "Генератор",
                 "schedule": "Расписание",
@@ -1019,7 +1019,13 @@
                 "deploy": "Развертывание",
                 "members": "Участники",
                 "settings": "Настройки",
-                "kb": "Knowledge Base"
+                "kb": "База знаний",
+                "tooltips": {
+                    "activity": "Лента активности",
+                    "kb": "База знаний",
+                    "generator": "Сгенерировать Work — разово или по расписанию",
+                    "deploy": "Развернуть Work"
+                }
             },
             "members": {
                 "title": "Участники команды",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "ภาพรวม",
-                "activity": "Activity Feed",
+                "activity": "กิจกรรม",
                 "items": "รายการ",
                 "generator": "เครื่องสร้าง",
                 "schedule": "กำหนดการ",
@@ -1019,7 +1019,13 @@
                 "deploy": "เผยแพร่",
                 "members": "สมาชิก",
                 "settings": "การตั้งค่า",
-                "kb": "Knowledge Base"
+                "kb": "ฐานความรู้",
+                "tooltips": {
+                    "activity": "ฟีดกิจกรรม",
+                    "kb": "ฐานความรู้",
+                    "generator": "สร้าง Work ครั้งเดียวหรือตามตารางเวลา",
+                    "deploy": "ปรับใช้ Work"
+                }
             },
             "members": {
                 "title": "สมาชิกทีม",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Genel Bakış",
-                "activity": "Activity Feed",
+                "activity": "Etkinlik",
                 "items": "Öğeler",
                 "generator": "Oluşturucu",
                 "schedule": "Program",
@@ -1019,7 +1019,13 @@
                 "deploy": "Dağıt",
                 "members": "Üyeler",
                 "settings": "Ayarlar",
-                "kb": "Knowledge Base"
+                "kb": "Bilgi Tabanı",
+                "tooltips": {
+                    "activity": "Etkinlik Akışı",
+                    "kb": "Bilgi Tabanı",
+                    "generator": "Work'i tek seferlik veya zamanlanmış üret",
+                    "deploy": "Work'i dağıt"
+                }
             },
             "members": {
                 "title": "Takım Üyeleri",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Огляд",
-                "activity": "Activity Feed",
+                "activity": "Активність",
                 "items": "Елементи",
                 "generator": "Генератор",
                 "schedule": "Розклад",
@@ -1019,7 +1019,13 @@
                 "deploy": "Розгортання",
                 "members": "Учасники",
                 "settings": "Налаштування",
-                "kb": "Knowledge Base"
+                "kb": "База знань",
+                "tooltips": {
+                    "activity": "Стрічка активності",
+                    "kb": "База знань",
+                    "generator": "Згенерувати Work — разово або за розкладом",
+                    "deploy": "Розгорнути Work"
+                }
             },
             "members": {
                 "title": "Учасники команди",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Tổng quan",
-                "activity": "Activity Feed",
+                "activity": "Hoạt động",
                 "items": "Mục",
                 "generator": "Trình tạo",
                 "schedule": "Lịch trình",
@@ -1019,7 +1019,13 @@
                 "deploy": "Triển khai",
                 "members": "Thành viên",
                 "settings": "Cài đặt",
-                "kb": "Knowledge Base"
+                "kb": "Cơ sở tri thức",
+                "tooltips": {
+                    "activity": "Bảng tin hoạt động",
+                    "kb": "Cơ sở tri thức",
+                    "generator": "Tạo Work một lần hoặc theo lịch",
+                    "deploy": "Triển khai Work"
+                }
             },
             "members": {
                 "title": "Thành viên đội ngũ",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "概览",
-                "activity": "Activity Feed",
+                "activity": "活动",
                 "items": "项目",
                 "generator": "生成器",
                 "schedule": "计划",
@@ -1019,7 +1019,13 @@
                 "deploy": "部署",
                 "members": "成员",
                 "settings": "设置",
-                "kb": "Knowledge Base"
+                "kb": "知识库",
+                "tooltips": {
+                    "activity": "活动动态",
+                    "kb": "知识库",
+                    "generator": "生成 Work，一次性或按计划",
+                    "deploy": "部署 Work"
+                }
             },
             "members": {
                 "title": "团队成员",

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -295,15 +295,19 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
             <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-border dark:divide-border-dark">
                     <thead className="bg-muted/50 dark:bg-muted/20">
+                        {/*
+                         * Column order (user-requested 2026-05-24):
+                         *   expander | DATE/TIME | WORK | TYPE | SUMMARY | STATUS
+                         * Status moves to the rightmost data column so the
+                         * scannable left-to-right reading order is
+                         * temporal-first ("when did it happen?"), then
+                         * subject ("which Work?"), then nature ("what kind
+                         * of event?"), then narrative ("what's the gist?"),
+                         * then state ("did it succeed?").
+                         */}
                         <tr>
                             <th scope="col" className="w-8 px-3 py-3">
                                 <span className="sr-only">{t('detail.expand')}</span>
-                            </th>
-                            <th
-                                scope="col"
-                                className="w-[9rem] whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark"
-                            >
-                                {t('columns.status')}
                             </th>
                             <th
                                 scope="col"
@@ -328,6 +332,12 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                 className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark"
                             >
                                 {t('columns.summary')}
+                            </th>
+                            <th
+                                scope="col"
+                                className="w-[9rem] whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark"
+                            >
+                                {t('columns.status')}
                             </th>
                         </tr>
                     </thead>
@@ -394,9 +404,11 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                                 )}
                                             </Tooltip>
                                         </td>
-                                        <td className="w-[9rem] whitespace-nowrap px-4 py-3 align-top">
-                                            <ActivityStatusBadge status={activity.status} />
-                                        </td>
+                                        {/*
+                                         * Cells reordered 2026-05-24 to match the
+                                         * new column header order:
+                                         *   expander | DATE/TIME | WORK | TYPE | SUMMARY | STATUS
+                                         */}
                                         <td className="px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
                                             <ActivityTimestamp
                                                 value={activity.createdAt}
@@ -445,6 +457,9 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                                     </div>
                                                 ) : null}
                                             </div>
+                                        </td>
+                                        <td className="w-[9rem] whitespace-nowrap px-4 py-3 align-top">
+                                            <ActivityStatusBadge status={activity.status} />
                                         </td>
                                     </tr>
                                     <tr

--- a/apps/web/src/components/works/detail/WorkTabs.tsx
+++ b/apps/web/src/components/works/detail/WorkTabs.tsx
@@ -14,6 +14,7 @@ interface WorkTabsProps {
 
 export function WorkTabs({ work }: WorkTabsProps) {
     const t = useTranslations('dashboard.workDetail.tabs');
+    const tTooltip = useTranslations('dashboard.workDetail.tabs.tooltips');
     const pathname = usePathname();
     const { config } = useWorkDetail();
     const permissions = useWorkPermissions();
@@ -21,6 +22,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
     const tabs = [
         {
             name: t('overview'),
+            tooltip: undefined as string | undefined,
             href: ROUTES.DASHBOARD_WORK(work.id),
             icon: (
                 <svg
@@ -41,6 +43,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('activity'),
+            tooltip: tTooltip('activity'),
             href: ROUTES.DASHBOARD_WORK_ACTIVITY(work.id),
             icon: (
                 <svg
@@ -61,6 +64,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('items'),
+            tooltip: undefined as string | undefined,
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/items`,
             icon: (
                 <svg
@@ -81,6 +85,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('kb'),
+            tooltip: tTooltip('kb'),
             href: ROUTES.DASHBOARD_WORK_KB(work.id),
             icon: (
                 <svg
@@ -101,6 +106,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('generator'),
+            tooltip: tTooltip('generator'),
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/generator`,
             visible: permissions.canGenerate,
             icon: (
@@ -122,6 +128,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('plugins'),
+            tooltip: undefined as string | undefined,
             href: ROUTES.DASHBOARD_WORK_PLUGINS(work.id),
             visible: permissions.canAccessSettings,
             icon: (
@@ -143,6 +150,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('deploy'),
+            tooltip: tTooltip('deploy'),
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/deploy`,
             visible: Boolean(config) && permissions.canDeploy,
             icon: (
@@ -164,6 +172,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('settings'),
+            tooltip: undefined as string | undefined,
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/settings`,
             visible: permissions.canAccessSettings,
             icon: (
@@ -199,6 +208,8 @@ export function WorkTabs({ work }: WorkTabsProps) {
                         <Link
                             key={tab.name}
                             href={tab.href}
+                            title={tab.tooltip}
+                            aria-label={tab.tooltip ? `${tab.name} — ${tab.tooltip}` : tab.name}
                             className={cn(
                                 'flex items-center gap-1.5 @sm/main:gap-2 py-3 @sm/main:py-4 px-3 @2xl/main:px-1 border-b-2 font-medium text-sm whitespace-nowrap transition-colors',
                                 tab.isActive


### PR DESCRIPTION
## Summary

Three operator-requested UX tweaks.

### 1) Work detail tabs — shorter labels + hover tooltips

| Tab        | Label  | Tooltip on hover                              |
|------------|--------|-----------------------------------------------|
| Activity   | Activity (was "Activity Feed") | "Activity Feed"                |
| KB         | KB     (was "Knowledge Base")  | "Knowledge Base"               |
| Generator  | Generator                      | "Generate Work, one time or on schedule" |
| Deploy     | Deploy                         | "Deploy Work"                  |

Implementation: \`WorkTabs.tsx\` renders \`title={tab.tooltip}\` (native browser tooltip — accessible, no new dependency, works on all 21 supported locales). \`aria-label\` includes both short label and full tooltip for screen readers. Other tabs (Overview, Items, Plugins, Settings) are untouched.

Tooltip strings live under \`dashboard.workDetail.tabs.tooltips.{activity,kb,generator,deploy}\` in all 21 locale files (en + 20 localized).

### 2) Activity page (sidebar "Activity") — column reorder

| Old order | New order |
|---|---|
| expander · STATUS · DATE/TIME · WORK · TYPE · SUMMARY | expander · DATE/TIME · WORK · TYPE · SUMMARY · STATUS |

Status moves to the rightmost data column so left-to-right reading is temporal-first ("when did it happen?") → subject ("which Work?") → nature ("what kind of event?") → narrative ("what's the gist?") → state ("did it succeed?").

Edit confined to \`ActivityTable.tsx\`: matching \`<th>\` and \`<td>\` blocks moved together so the table stays grid-aligned.

## Verified locally

- prettier@3.7.4 clean on all changed files
- apps/web \`tsc --noEmit\` clean
- No test fixtures asserted the old labels or column order — searched for \`"Activity Feed"\` / \`"Knowledge Base"\` / \`columns.status\` order in specs, none found

## Scope discipline

- Translations: localized into each of the 20 non-English locales (helper at \`C:/tmp/kb-tabs-labels-tooltips-i18n.py\`)
- No e2e selectors changed
- Route hrefs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive tooltips to work detail tabs for contextual guidance during navigation.

* **Improvements**
  * Streamlined tab label names for clearer, more intuitive navigation.
  * Reorganized activity table columns to improve data visibility and layout.
  * Updated localization across 21 languages with consistent, improved terminology and descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->