### PR TITLE
chore(release): cascade KB hotfixes develop → stage (#1004-#1007)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "نظرة عامة",
-                "activity": "Activity Feed",
+                "activity": "النشاط",
                 "items": "العناصر",
                 "generator": "مولد",
                 "schedule": "جدولة",
@@ -1146,7 +1146,13 @@
                 "deploy": "نشر",
                 "members": "الأعضاء",
                 "settings": "الإعدادات",
-                "kb": "Knowledge Base"
+                "kb": "قاعدة المعرفة",
+                "tooltips": {
+                    "activity": "موجز النشاط",
+                    "kb": "قاعدة المعرفة",
+                    "generator": "توليد الـWork مرة واحدة أو وفق جدول",
+                    "deploy": "نشر الـWork"
+                }
             },
             "members": {
                 "title": "أعضاء الفريق",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "Преглед",
-                "activity": "Activity Feed",
+                "activity": "Активност",
                 "items": "Елементи",
                 "generator": "Генератор",
                 "schedule": "График",
@@ -1146,7 +1146,13 @@
                 "deploy": "Разполагане",
                 "members": "Членове",
                 "settings": "Настройки",
-                "kb": "Knowledge Base"
+                "kb": "База знания",
+                "tooltips": {
+                    "activity": "Поток на активността",
+                    "kb": "База знания",
+                    "generator": "Генериране на Work — еднократно или по график",
+                    "deploy": "Разгръщане на Work"
+                }
             },
             "members": {
                 "title": "Членове на екипа",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "Übersicht",
-                "activity": "Activity Feed",
+                "activity": "Aktivität",
                 "items": "Elemente",
                 "generator": "Generator",
                 "schedule": "Zeitplan",
@@ -1146,7 +1146,13 @@
                 "deploy": "Bereitstellen",
                 "members": "Mitglieder",
                 "settings": "Einstellungen",
-                "kb": "Knowledge Base"
+                "kb": "Wissensdatenbank",
+                "tooltips": {
+                    "activity": "Aktivitäts-Feed",
+                    "kb": "Wissensdatenbank",
+                    "generator": "Work generieren – einmalig oder nach Zeitplan",
+                    "deploy": "Work bereitstellen"
+                }
             },
             "members": {
                 "title": "Teammitglieder",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1164,7 +1164,7 @@
             },
             "tabs": {
                 "overview": "Overview",
-                "activity": "Activity Feed",
+                "activity": "Activity",
                 "items": "Items",
                 "generator": "Generator",
                 "schedule": "Schedule",
@@ -1174,7 +1174,13 @@
                 "deploy": "Deploy",
                 "members": "Members",
                 "settings": "Settings",
-                "kb": "Knowledge Base"
+                "kb": "KB",
+                "tooltips": {
+                    "activity": "Activity Feed",
+                    "kb": "Knowledge Base",
+                    "generator": "Generate Work, one time or on schedule",
+                    "deploy": "Deploy Work"
+                }
             },
             "members": {
                 "title": "Team Members",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "Resumen",
-                "activity": "Activity Feed",
+                "activity": "Actividad",
                 "items": "Elementos",
                 "generator": "Generador",
                 "schedule": "Programación",
@@ -1146,7 +1146,13 @@
                 "deploy": "Implementar",
                 "members": "Miembros",
                 "settings": "Configuración",
-                "kb": "Knowledge Base"
+                "kb": "Base de conocimiento",
+                "tooltips": {
+                    "activity": "Feed de actividad",
+                    "kb": "Base de conocimiento",
+                    "generator": "Generar Work, una vez o según programación",
+                    "deploy": "Desplegar Work"
+                }
             },
             "members": {
                 "title": "Miembros del equipo",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1163,7 +1163,7 @@
             },
             "tabs": {
                 "overview": "Aperçu",
-                "activity": "Activity Feed",
+                "activity": "Activité",
                 "items": "Éléments",
                 "generator": "Générateur",
                 "schedule": "Programmation",
@@ -1173,7 +1173,13 @@
                 "deploy": "Déploiement",
                 "members": "Membres",
                 "settings": "Paramètres",
-                "kb": "Knowledge Base"
+                "kb": "Base de connaissances",
+                "tooltips": {
+                    "activity": "Fil d'activité",
+                    "kb": "Base de connaissances",
+                    "generator": "Générer le Work, ponctuellement ou planifié",
+                    "deploy": "Déployer le Work"
+                }
             },
             "members": {
                 "title": "Membres de l'équipe",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1136,7 +1136,7 @@
             },
             "tabs": {
                 "overview": "סקירה כללית",
-                "activity": "Activity Feed",
+                "activity": "פעילות",
                 "items": "פריטים",
                 "generator": "מחולל",
                 "schedule": "לוח זמנים",
@@ -1146,7 +1146,13 @@
                 "deploy": "פריסה",
                 "members": "חברים",
                 "settings": "הגדרות",
-                "kb": "Knowledge Base"
+                "kb": "מאגר ידע",
+                "tooltips": {
+                    "activity": "פיד פעילות",
+                    "kb": "מאגר ידע",
+                    "generator": "צור Work, חד-פעמי או על פי לוח זמנים",
+                    "deploy": "פרוס Work"
+                }
             },
             "members": {
                 "title": "חברי צוות",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "अवलोकन",
-                "activity": "Activity Feed",
+                "activity": "गतिविधि",
                 "items": "आइटम",
                 "generator": "जनरेटर",
                 "schedule": "अनुसूची",
@@ -1019,7 +1019,13 @@
                 "deploy": "तैनाती",
                 "members": "सदस्य",
                 "settings": "सेटिंग्स",
-                "kb": "Knowledge Base"
+                "kb": "ज्ञान आधार",
+                "tooltips": {
+                    "activity": "गतिविधि फ़ीड",
+                    "kb": "ज्ञान आधार",
+                    "generator": "Work उत्पन्न करें, एक बार या निर्धारित समय पर",
+                    "deploy": "Work परिनियोजित करें"
+                }
             },
             "members": {
                 "title": "टीम सदस्य",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Ringkasan",
-                "activity": "Activity Feed",
+                "activity": "Aktivitas",
                 "items": "Item",
                 "generator": "Generator",
                 "schedule": "Jadwal",
@@ -1019,7 +1019,13 @@
                 "deploy": "Penerapan",
                 "members": "Anggota",
                 "settings": "Pengaturan",
-                "kb": "Knowledge Base"
+                "kb": "Basis Pengetahuan",
+                "tooltips": {
+                    "activity": "Umpan Aktivitas",
+                    "kb": "Basis Pengetahuan",
+                    "generator": "Buat Work, sekali atau terjadwal",
+                    "deploy": "Deploy Work"
+                }
             },
             "members": {
                 "title": "Anggota Tim",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Panoramica",
-                "activity": "Activity Feed",
+                "activity": "Attività",
                 "items": "Elementi",
                 "generator": "Generatore",
                 "schedule": "Programmazione",
@@ -1019,7 +1019,13 @@
                 "deploy": "Distribuzione",
                 "members": "Membri",
                 "settings": "Impostazioni",
-                "kb": "Knowledge Base"
+                "kb": "Base di conoscenza",
+                "tooltips": {
+                    "activity": "Feed attività",
+                    "kb": "Base di conoscenza",
+                    "generator": "Genera Work, una tantum o pianificato",
+                    "deploy": "Distribuisci Work"
+                }
             },
             "members": {
                 "title": "Membri del team",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "概要",
-                "activity": "Activity Feed",
+                "activity": "アクティビティ",
                 "items": "アイテム",
                 "generator": "ジェネレーター",
                 "schedule": "スケジュール",
@@ -1019,7 +1019,13 @@
                 "deploy": "デプロイ",
                 "members": "メンバー",
                 "settings": "設定",
-                "kb": "Knowledge Base"
+                "kb": "ナレッジベース",
+                "tooltips": {
+                    "activity": "アクティビティフィード",
+                    "kb": "ナレッジベース",
+                    "generator": "Work を 1 回またはスケジュールで生成",
+                    "deploy": "Work をデプロイ"
+                }
             },
             "members": {
                 "title": "チームメンバー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "개요",
-                "activity": "Activity Feed",
+                "activity": "활동",
                 "items": "항목",
                 "generator": "생성기",
                 "schedule": "스케줄",
@@ -1019,7 +1019,13 @@
                 "deploy": "배포",
                 "members": "멤버",
                 "settings": "설정",
-                "kb": "Knowledge Base"
+                "kb": "지식 베이스",
+                "tooltips": {
+                    "activity": "활동 피드",
+                    "kb": "지식 베이스",
+                    "generator": "Work를 일회성 또는 예약된 일정으로 생성",
+                    "deploy": "Work 배포"
+                }
             },
             "members": {
                 "title": "팀 멤버",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Overzicht",
-                "activity": "Activity Feed",
+                "activity": "Activiteit",
                 "items": "Items",
                 "generator": "Generator",
                 "schedule": "Planning",
@@ -1019,7 +1019,13 @@
                 "deploy": "Deployen",
                 "members": "Leden",
                 "settings": "Instellingen",
-                "kb": "Knowledge Base"
+                "kb": "Kennisbank",
+                "tooltips": {
+                    "activity": "Activiteitenfeed",
+                    "kb": "Kennisbank",
+                    "generator": "Work genereren — eenmalig of volgens planning",
+                    "deploy": "Work uitrollen"
+                }
             },
             "members": {
                 "title": "Teamleden",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Przegląd",
-                "activity": "Activity Feed",
+                "activity": "Aktywność",
                 "items": "Elementy",
                 "generator": "Generator",
                 "schedule": "Harmonogram",
@@ -1019,7 +1019,13 @@
                 "deploy": "Wdrożenie",
                 "members": "Członkowie",
                 "settings": "Ustawienia",
-                "kb": "Knowledge Base"
+                "kb": "Baza wiedzy",
+                "tooltips": {
+                    "activity": "Kanał aktywności",
+                    "kb": "Baza wiedzy",
+                    "generator": "Wygeneruj Work — jednorazowo lub według harmonogramu",
+                    "deploy": "Wdróż Work"
+                }
             },
             "members": {
                 "title": "Członkowie zespołu",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Visão Geral",
-                "activity": "Activity Feed",
+                "activity": "Atividade",
                 "items": "Itens",
                 "generator": "Gerador",
                 "schedule": "Agendamento",
@@ -1019,7 +1019,13 @@
                 "deploy": "Implantar",
                 "members": "Membros",
                 "settings": "Configurações",
-                "kb": "Knowledge Base"
+                "kb": "Base de conhecimento",
+                "tooltips": {
+                    "activity": "Feed de atividade",
+                    "kb": "Base de conhecimento",
+                    "generator": "Gerar Work, uma vez ou em agenda",
+                    "deploy": "Implantar Work"
+                }
             },
             "members": {
                 "title": "Membros da Equipe",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Обзор",
-                "activity": "Activity Feed",
+                "activity": "Активность",
                 "items": "Элементы",
                 "generator": "Генератор",
                 "schedule": "Расписание",
@@ -1019,7 +1019,13 @@
                 "deploy": "Развертывание",
                 "members": "Участники",
                 "settings": "Настройки",
-                "kb": "Knowledge Base"
+                "kb": "База знаний",
+                "tooltips": {
+                    "activity": "Лента активности",
+                    "kb": "База знаний",
+                    "generator": "Сгенерировать Work — разово или по расписанию",
+                    "deploy": "Развернуть Work"
+                }
             },
             "members": {
                 "title": "Участники команды",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "ภาพรวม",
-                "activity": "Activity Feed",
+                "activity": "กิจกรรม",
                 "items": "รายการ",
                 "generator": "เครื่องสร้าง",
                 "schedule": "กำหนดการ",
@@ -1019,7 +1019,13 @@
                 "deploy": "เผยแพร่",
                 "members": "สมาชิก",
                 "settings": "การตั้งค่า",
-                "kb": "Knowledge Base"
+                "kb": "ฐานความรู้",
+                "tooltips": {
+                    "activity": "ฟีดกิจกรรม",
+                    "kb": "ฐานความรู้",
+                    "generator": "สร้าง Work ครั้งเดียวหรือตามตารางเวลา",
+                    "deploy": "ปรับใช้ Work"
+                }
             },
             "members": {
                 "title": "สมาชิกทีม",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Genel Bakış",
-                "activity": "Activity Feed",
+                "activity": "Etkinlik",
                 "items": "Öğeler",
                 "generator": "Oluşturucu",
                 "schedule": "Program",
@@ -1019,7 +1019,13 @@
                 "deploy": "Dağıt",
                 "members": "Üyeler",
                 "settings": "Ayarlar",
-                "kb": "Knowledge Base"
+                "kb": "Bilgi Tabanı",
+                "tooltips": {
+                    "activity": "Etkinlik Akışı",
+                    "kb": "Bilgi Tabanı",
+                    "generator": "Work'i tek seferlik veya zamanlanmış üret",
+                    "deploy": "Work'i dağıt"
+                }
             },
             "members": {
                 "title": "Takım Üyeleri",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Огляд",
-                "activity": "Activity Feed",
+                "activity": "Активність",
                 "items": "Елементи",
                 "generator": "Генератор",
                 "schedule": "Розклад",
@@ -1019,7 +1019,13 @@
                 "deploy": "Розгортання",
                 "members": "Учасники",
                 "settings": "Налаштування",
-                "kb": "Knowledge Base"
+                "kb": "База знань",
+                "tooltips": {
+                    "activity": "Стрічка активності",
+                    "kb": "База знань",
+                    "generator": "Згенерувати Work — разово або за розкладом",
+                    "deploy": "Розгорнути Work"
+                }
             },
             "members": {
                 "title": "Учасники команди",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "Tổng quan",
-                "activity": "Activity Feed",
+                "activity": "Hoạt động",
                 "items": "Mục",
                 "generator": "Trình tạo",
                 "schedule": "Lịch trình",
@@ -1019,7 +1019,13 @@
                 "deploy": "Triển khai",
                 "members": "Thành viên",
                 "settings": "Cài đặt",
-                "kb": "Knowledge Base"
+                "kb": "Cơ sở tri thức",
+                "tooltips": {
+                    "activity": "Bảng tin hoạt động",
+                    "kb": "Cơ sở tri thức",
+                    "generator": "Tạo Work một lần hoặc theo lịch",
+                    "deploy": "Triển khai Work"
+                }
             },
             "members": {
                 "title": "Thành viên đội ngũ",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1009,7 +1009,7 @@
             },
             "tabs": {
                 "overview": "概览",
-                "activity": "Activity Feed",
+                "activity": "活动",
                 "items": "项目",
                 "generator": "生成器",
                 "schedule": "计划",
@@ -1019,7 +1019,13 @@
                 "deploy": "部署",
                 "members": "成员",
                 "settings": "设置",
-                "kb": "Knowledge Base"
+                "kb": "知识库",
+                "tooltips": {
+                    "activity": "活动动态",
+                    "kb": "知识库",
+                    "generator": "生成 Work，一次性或按计划",
+                    "deploy": "部署 Work"
+                }
             },
             "members": {
                 "title": "团队成员",

--- a/apps/web/src/components/activity-log/ActivityTable.tsx
+++ b/apps/web/src/components/activity-log/ActivityTable.tsx
@@ -295,15 +295,19 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
             <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-border dark:divide-border-dark">
                     <thead className="bg-muted/50 dark:bg-muted/20">
+                        {/*
+                         * Column order (user-requested 2026-05-24):
+                         *   expander | DATE/TIME | WORK | TYPE | SUMMARY | STATUS
+                         * Status moves to the rightmost data column so the
+                         * scannable left-to-right reading order is
+                         * temporal-first ("when did it happen?"), then
+                         * subject ("which Work?"), then nature ("what kind
+                         * of event?"), then narrative ("what's the gist?"),
+                         * then state ("did it succeed?").
+                         */}
                         <tr>
                             <th scope="col" className="w-8 px-3 py-3">
                                 <span className="sr-only">{t('detail.expand')}</span>
-                            </th>
-                            <th
-                                scope="col"
-                                className="w-[9rem] whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark"
-                            >
-                                {t('columns.status')}
                             </th>
                             <th
                                 scope="col"
@@ -328,6 +332,12 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                 className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark"
                             >
                                 {t('columns.summary')}
+                            </th>
+                            <th
+                                scope="col"
+                                className="w-[9rem] whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark"
+                            >
+                                {t('columns.status')}
                             </th>
                         </tr>
                     </thead>
@@ -394,9 +404,11 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                                 )}
                                             </Tooltip>
                                         </td>
-                                        <td className="w-[9rem] whitespace-nowrap px-4 py-3 align-top">
-                                            <ActivityStatusBadge status={activity.status} />
-                                        </td>
+                                        {/*
+                                         * Cells reordered 2026-05-24 to match the
+                                         * new column header order:
+                                         *   expander | DATE/TIME | WORK | TYPE | SUMMARY | STATUS
+                                         */}
                                         <td className="px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
                                             <ActivityTimestamp
                                                 value={activity.createdAt}
@@ -445,6 +457,9 @@ export function ActivityTable({ activities, loading, onStopRequested }: Activity
                                                     </div>
                                                 ) : null}
                                             </div>
+                                        </td>
+                                        <td className="w-[9rem] whitespace-nowrap px-4 py-3 align-top">
+                                            <ActivityStatusBadge status={activity.status} />
                                         </td>
                                     </tr>
                                     <tr

--- a/apps/web/src/components/works/detail/WorkTabs.tsx
+++ b/apps/web/src/components/works/detail/WorkTabs.tsx
@@ -14,6 +14,7 @@ interface WorkTabsProps {
 
 export function WorkTabs({ work }: WorkTabsProps) {
     const t = useTranslations('dashboard.workDetail.tabs');
+    const tTooltip = useTranslations('dashboard.workDetail.tabs.tooltips');
     const pathname = usePathname();
     const { config } = useWorkDetail();
     const permissions = useWorkPermissions();
@@ -21,6 +22,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
     const tabs = [
         {
             name: t('overview'),
+            tooltip: undefined as string | undefined,
             href: ROUTES.DASHBOARD_WORK(work.id),
             icon: (
                 <svg
@@ -41,6 +43,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('activity'),
+            tooltip: tTooltip('activity'),
             href: ROUTES.DASHBOARD_WORK_ACTIVITY(work.id),
             icon: (
                 <svg
@@ -61,6 +64,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('items'),
+            tooltip: undefined as string | undefined,
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/items`,
             icon: (
                 <svg
@@ -81,6 +85,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('kb'),
+            tooltip: tTooltip('kb'),
             href: ROUTES.DASHBOARD_WORK_KB(work.id),
             icon: (
                 <svg
@@ -101,6 +106,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('generator'),
+            tooltip: tTooltip('generator'),
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/generator`,
             visible: permissions.canGenerate,
             icon: (
@@ -122,6 +128,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('plugins'),
+            tooltip: undefined as string | undefined,
             href: ROUTES.DASHBOARD_WORK_PLUGINS(work.id),
             visible: permissions.canAccessSettings,
             icon: (
@@ -143,6 +150,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('deploy'),
+            tooltip: tTooltip('deploy'),
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/deploy`,
             visible: Boolean(config) && permissions.canDeploy,
             icon: (
@@ -164,6 +172,7 @@ export function WorkTabs({ work }: WorkTabsProps) {
         },
         {
             name: t('settings'),
+            tooltip: undefined as string | undefined,
             href: `${ROUTES.DASHBOARD_WORK(work.id)}/settings`,
             visible: permissions.canAccessSettings,
             icon: (
@@ -199,6 +208,8 @@ export function WorkTabs({ work }: WorkTabsProps) {
                         <Link
                             key={tab.name}
                             href={tab.href}
+                            title={tab.tooltip}
+                            aria-label={tab.tooltip ? `${tab.name} — ${tab.tooltip}` : tab.name}
                             className={cn(
                                 'flex items-center gap-1.5 @sm/main:gap-2 py-3 @sm/main:py-4 px-3 @2xl/main:px-1 border-b-2 font-medium text-sm whitespace-nowrap transition-colors',
                                 tab.isActive

--- a/apps/web/src/components/works/detail/kb/KbClassifyModal.tsx
+++ b/apps/web/src/components/works/detail/kb/KbClassifyModal.tsx
@@ -193,7 +193,17 @@ export function KbClassifyModal({
             <div
                 className={cn(
                     'w-full max-w-xl rounded-lg border border-border dark:border-border-dark',
-                    'bg-card dark:bg-card-primary-dark p-5 shadow-xl',
+                    // EW-639 dark-theme fix: `--color-card-primary-dark`
+                    // resolves to `#ffffff08` (a 3% translucent overlay,
+                    // intended for cards that sit on top of solid page
+                    // chrome). Using it as the modal panel background
+                    // made the dialog see-through in dark mode — the
+                    // page content behind the `bg-black/40` overlay
+                    // bled through. `bg-card-dark` (#1e293b, solid
+                    // slate) matches the elevated-surface convention
+                    // used by the shadcn `DialogContent` primitive
+                    // elsewhere in the app.
+                    'bg-card dark:bg-card-dark p-5 shadow-xl',
                     'flex flex-col gap-4',
                 )}
             >

--- a/apps/web/src/components/works/detail/kb/KbHistoryDialog.tsx
+++ b/apps/web/src/components/works/detail/kb/KbHistoryDialog.tsx
@@ -127,7 +127,11 @@ export function KbHistoryDialog({ workId, docId, path, open, onClose }: KbHistor
             <div
                 className={cn(
                     'w-full max-w-xl rounded-lg border shadow-2xl',
-                    'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                    // EW-639 dark-theme fix: see KbClassifyModal for context.
+                    // `card-primary-dark` is intentionally translucent
+                    // (#ffffff08) — wrong for a modal panel. `card-dark`
+                    // (#1e293b) is the solid elevated-surface convention.
+                    'border-border bg-card dark:border-border-dark dark:bg-card-dark',
                     'flex flex-col gap-2 p-4',
                 )}
             >

--- a/apps/web/src/components/works/detail/kb/KbSearchPalette.tsx
+++ b/apps/web/src/components/works/detail/kb/KbSearchPalette.tsx
@@ -221,7 +221,11 @@ export function KbSearchPalette({
                     <div
                         className={cn(
                             'w-full max-w-xl rounded-lg border shadow-2xl',
-                            'border-border bg-card dark:border-border-dark dark:bg-card-primary-dark',
+                            // EW-639 dark-theme fix: see KbClassifyModal /
+                            // KbHistoryDialog. `card-primary-dark` is
+                            // translucent — wrong for a modal panel. Use
+                            // `card-dark` for solid elevated-surface.
+                            'border-border bg-card dark:border-border-dark dark:bg-card-dark',
                         )}
                     >
                         <input

--- a/packages/agent/src/entities/_types.ts
+++ b/packages/agent/src/entities/_types.ts
@@ -1,14 +1,41 @@
-import { Column } from 'typeorm';
+import { Column, type ColumnOptions } from 'typeorm';
 
-export const TimestampColumn = ({ nullable = false }: { nullable?: boolean } = {}) => {
-    return Column({
+/**
+ * Portable epoch-millis timestamp column. Stores as `bigint` (works
+ * cross-DB; raw `Date` defaults to TIMESTAMP WITH TIME ZONE on
+ * Postgres and INTEGER on SQLite, breaking parity). The transformer
+ * turns the stored value back into a `Date` at read time so callers
+ * see a normal `Date` either way.
+ *
+ * `name` override: TypeORM defaults the column name to the property
+ * name verbatim, which means `extractionStartedAt` (camelCase) on
+ * the entity tries to read column `"extractionStartedAt"` from
+ * Postgres. If the migration created the column as
+ * `extraction_started_at` (snake_case — the convention used by every
+ * other `name:`-overridden column in the same entities), the query
+ * fails with `column ... does not exist`. The fix landed in EW-639
+ * after the 500 surfaced on the KB upload path in production: pass
+ * the explicit snake_case column name from the call site.
+ */
+export const TimestampColumn = ({
+    nullable = false,
+    name,
+}: { nullable?: boolean; name?: string } = {}) => {
+    // DTS-emit gotcha (CLAUDE.md): conditional spreads like
+    // `...(name && { name })` produce `string | false` and break
+    // declaration generation. Build the options imperatively.
+    const opts: ColumnOptions = {
         type: 'bigint',
         nullable,
         transformer: {
             to: (value?: Date) => (value ? value.getTime() : null),
             from: (value?: string | number) => (value ? new Date(Number(value)) : null),
         },
-    });
+    };
+    if (name) {
+        opts.name = name;
+    }
+    return Column(opts);
 };
 
 export const PortableDateColumn = ({ nullable = false }: { nullable?: boolean } = {}) => {

--- a/packages/agent/src/entities/work-knowledge-document.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-document.entity.ts
@@ -150,7 +150,11 @@ export class WorkKnowledgeDocument {
     @JoinColumn({ name: 'updated_by_id' })
     updatedBy?: ClassToObject<User> | null;
 
-    @TimestampColumn({ nullable: true })
+    // EW-639 prod-hotfix: the 1779971 migration creates this column as
+    // snake_case `last_indexed_at`; same camelCase/snake_case mismatch
+    // class as the upload entity's `extractionStartedAt`. Pass the
+    // explicit `name:` so TypeORM emits the right column in SELECTs.
+    @TimestampColumn({ nullable: true, name: 'last_indexed_at' })
     lastIndexedAt?: Date | null;
 
     @Column({ type: 'varchar', length: 40, nullable: true, name: 'last_commit_sha' })

--- a/packages/agent/src/entities/work-knowledge-upload.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-upload.entity.ts
@@ -80,10 +80,18 @@ export class WorkKnowledgeUpload {
     @Column({ type: 'text', nullable: true, name: 'extraction_error' })
     extractionError?: string | null;
 
-    @TimestampColumn({ nullable: true })
+    // EW-639 prod-hotfix: the 1779972 migration creates these columns
+    // as snake_case `extraction_started_at` / `extraction_finished_at`;
+    // without an explicit `name:` override TypeORM defaulted to the
+    // camelCase property name and Postgres rejected every upload with
+    // `QueryFailedError: column WorkKnowledgeUpload.extractionStartedAt
+    // does not exist`. Pass the snake_case names explicitly to match
+    // the migration. Same fix lands on `lastIndexedAt` over in the
+    // sibling `work-knowledge-document.entity.ts`.
+    @TimestampColumn({ nullable: true, name: 'extraction_started_at' })
     extractionStartedAt?: Date | null;
 
-    @TimestampColumn({ nullable: true })
+    @TimestampColumn({ nullable: true, name: 'extraction_finished_at' })
     extractionFinishedAt?: Date | null;
 
     /** The KB document this upload was extracted into, if any. */

--- a/packages/agent/src/services/knowledge-base.module.spec.ts
+++ b/packages/agent/src/services/knowledge-base.module.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * EW-639 Phase 2/e (post-cascade fix) — DI smoke test for KnowledgeBaseModule.
+ *
+ * `KnowledgeBaseService` injects `@Optional()` references to several
+ * services owned by sibling modules (notably `ActivityLogService`). When
+ * an owning module isn't imported here, those `@Optional()` resolutions
+ * silently land as `undefined` and the affected code paths short-circuit
+ * — the API still boots, but features like the upload activity-log
+ * sequence stop emitting rows.
+ *
+ * This spec pins the module's *static* metadata (the decorator's
+ * `imports` array). A future cleanup that removes one of these imports
+ * trips the assertion immediately rather than failing 30s later in an
+ * e2e poll loop.
+ *
+ * Pattern mirrors `pipeline.module.spec.ts` (row 33c) — the heavy
+ * runtime trees (TypeORM, plugin services that import ESM-only
+ * `p-map`, etc.) are mocked out at module scope so
+ * `Reflect.getMetadata('imports', KnowledgeBaseModule)` returns the
+ * real array without forcing those trees to load under Jest's CJS
+ * transformer.
+ */
+
+jest.mock('@nestjs/typeorm', () => ({
+    TypeOrmModule: { forFeature: () => class TypeOrmFeatureStub {} },
+    InjectRepository: () => () => undefined,
+    InjectDataSource: () => () => undefined,
+}));
+jest.mock('../database/database.module', () => ({
+    DatabaseModule: class DatabaseModule {},
+}));
+jest.mock('../facades/facades.module', () => ({
+    FacadesModule: class FacadesModule {},
+}));
+jest.mock('../activity-log/activity-log.module', () => ({
+    ActivityLogModule: class ActivityLogModule {},
+}));
+
+// Provider classes — replace with empty shells so the metadata still
+// records the right class identities without dragging in the full
+// implementations (most of which import TypeORM `@InjectRepository` etc.).
+jest.mock('../database/repositories/work-knowledge-document.repository', () => ({
+    WorkKnowledgeDocumentRepository: class {},
+}));
+jest.mock('../database/repositories/work-knowledge-upload.repository', () => ({
+    WorkKnowledgeUploadRepository: class {},
+}));
+jest.mock('../database/repositories/work-knowledge-tag.repository', () => ({
+    WorkKnowledgeTagRepository: class {},
+}));
+jest.mock('../database/repositories/work-knowledge-citation.repository', () => ({
+    WorkKnowledgeCitationRepository: class {},
+}));
+jest.mock('../database/repositories/work-knowledge-chunk.repository', () => ({
+    WorkKnowledgeChunkRepository: class {},
+}));
+jest.mock('./knowledge-base.service', () => ({ KnowledgeBaseService: class {} }));
+jest.mock('./knowledge-base-git-mirror.service', () => ({
+    KnowledgeBaseGitMirrorService: class {},
+}));
+jest.mock('./knowledge-base-buffer-extractor.service', () => ({
+    KnowledgeBaseBufferExtractorService: class {},
+}));
+jest.mock('./kb-mention-resolver.service', () => ({ KbMentionResolverService: class {} }));
+jest.mock('./kb-agent-tools.service', () => ({ KbAgentToolsService: class {} }));
+jest.mock('./kb-tools-facade.adapter', () => ({ KbToolsFacadeAdapter: class {} }));
+jest.mock('./work-ownership.service', () => ({ WorkOwnershipService: class {} }));
+
+import 'reflect-metadata';
+import { KnowledgeBaseModule } from './knowledge-base.module';
+import { ActivityLogModule } from '../activity-log/activity-log.module';
+import { DatabaseModule } from '../database/database.module';
+import { FacadesModule } from '../facades/facades.module';
+
+describe('KnowledgeBaseModule — static metadata', () => {
+    const imports = Reflect.getMetadata('imports', KnowledgeBaseModule) as unknown[];
+
+    it('declares its expected non-TypeORM imports', () => {
+        // The TypeORM forFeature import is a dynamic shell from the
+        // jest.mock above — we only assert the named module imports
+        // here. The static module imports are what the @Module
+        // decorator records and what determines DI scope.
+        expect(imports).toContain(DatabaseModule);
+        expect(imports).toContain(FacadesModule);
+        expect(imports).toContain(ActivityLogModule);
+    });
+
+    it('imports ActivityLogModule so KnowledgeBaseService.activityLog actually resolves at runtime', () => {
+        // EW-639 regression guard. Removing this import doesn't break
+        // API boot — it makes every `recordUploadActivity` call early-
+        // return because `@Optional() activityLog` lands as undefined.
+        // The 3 KB e2e specs (kb-activity-log, kb-dedup, kb-extraction-
+        // retry) that poll the activity-log endpoint for KB rows time
+        // out after 30s. Lock this import in.
+        expect(imports).toContain(ActivityLogModule);
+    });
+});

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { DatabaseModule } from '../database/database.module';
 import { FacadesModule } from '../facades/facades.module';
 import {
@@ -42,6 +43,17 @@ import { WorkOwnershipService } from './work-ownership.service';
  * imports only `DatabaseModule + UsageModule + BudgetsModule`, none of
  * which depend on KB.
  *
+ * EW-639 Phase 2/e (post-cascade fix) — `ActivityLogModule` is imported
+ * for the same DI-walkback reason. `KnowledgeBaseService.recordUploadActivity`
+ * injects `@Optional() activityLog?: ActivityLogService` and silently
+ * early-returns when it's undefined. Without this import the API boots
+ * fine but no `kb_upload_created` / `kb_upload_extracted` /
+ * `kb_document_created` / `kb_upload_deduped` / `kb_upload_extraction_skipped`
+ * rows are ever written, which manifests as 3 of the 4 KB e2e specs
+ * timing out polling for activity rows that never arrive (kb-activity-log,
+ * kb-dedup, kb-extraction-retry). `ActivityLogModule` imports only
+ * `DatabaseModule`, no circular dep.
+ *
  * Entities registered:
  *  - WorkKnowledgeDocument
  *  - WorkKnowledgeUpload
@@ -54,6 +66,7 @@ import { WorkOwnershipService } from './work-ownership.service';
     imports: [
         DatabaseModule,
         FacadesModule,
+        ActivityLogModule,
         TypeOrmModule.forFeature([
             WorkKnowledgeDocument,
             WorkKnowledgeUpload,


### PR DESCRIPTION
## Summary

Cascade of 4 production hotfixes to stage. All four landed CI-green on develop with operator-approved expedited merge.

| PR | Issue |
|---|---|
| #1004 | \`ActivityLogModule\` DI miss — KB activity rows were silently dropped (3 e2e specs red) |
| #1005 | KB modal panels (\`KbClassifyModal\` / \`KbHistoryDialog\` / \`KbSearchPalette\`) rendered transparent on dark theme |
| #1006 | **Upload 500** — TimestampColumn camelCase / DB snake_case mismatch caused \`QueryFailedError: column WorkKnowledgeUpload.extractionStartedAt does not exist\` |
| #1007 | UX polish — short tab labels (Activity / KB) + hover tooltips + Activity-page column reorder |

All four PRs CI-green individually before merge. Merging stage→main next once stage CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)