### PR TITLE
feat: route unified creation flow to Work wizard with mode

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
@@ -115,7 +115,7 @@ export default function DashboardClient({
                             action={{
                                 label: t('works.empty.action'),
                                 onClick: () => {
-                                    router.push(ROUTES.DASHBOARD_WORKS_NEW);
+                                    router.push(ROUTES.DASHBOARD_NEW);
                                 },
                             }}
                         />

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils/cn';
 import { WorkAICreator } from '@/components/works/WorkAICreator';
 import { WorkManualForm } from '@/components/works/WorkManualForm';
 import { WorkImportForm } from '@/components/works/WorkImportForm';
-import { CreationBlockTrio } from '@/components/works/CreationBlockTrio';
+import { CreationBlockTrio, type CreationMode } from '@/components/works/CreationBlockTrio';
 import { GitProviderSelector } from './git-provider-selector';
 import { DeployProviderSelector, type DeployProvider } from './deploy-provider-selector';
 import { useTranslations } from 'next-intl';
@@ -22,6 +22,8 @@ interface NewWorkClientProps {
     defaultDeployProviderId: string | null;
     websiteTemplates: WebsiteTemplateOption[];
     proposal?: WorkProposal | null;
+    initialMode?: CreationMode | null;
+    initialPrompt?: string;
 }
 
 export default function NewWorkClient({
@@ -32,9 +34,11 @@ export default function NewWorkClient({
     defaultDeployProviderId,
     websiteTemplates,
     proposal,
+    initialMode = null,
+    initialPrompt,
 }: NewWorkClientProps) {
-    const [creationMode, setCreationMode] = useState<'ai' | 'manual' | 'import' | null>(
-        proposal ? 'ai' : null,
+    const [creationMode, setCreationMode] = useState<CreationMode | null>(
+        proposal ? 'ai' : initialMode,
     );
     const [selectedProviderId, setSelectedProviderId] = useState<string | null>(
         defaultProviderId || providers[0]?.provider.id || null,
@@ -153,6 +157,7 @@ export default function NewWorkClient({
                         deployProvider={selectedDeployProviderId || undefined}
                         websiteTemplates={websiteTemplates}
                         proposal={proposal ?? undefined}
+                        initialPrompt={initialPrompt}
                     />
                 )}
                 {creationMode === 'manual' && (
@@ -163,6 +168,7 @@ export default function NewWorkClient({
                         deployProvider={selectedDeployProviderId || undefined}
                         websiteTemplates={websiteTemplates}
                         proposal={proposal ?? undefined}
+                        initialDescription={initialPrompt}
                     />
                 )}
                 {creationMode === 'import' && (

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -14,6 +14,8 @@ import type { ProviderWithConnection } from './page';
 import type { WebsiteTemplateOption } from '@/lib/api/work';
 import type { WorkProposal } from '@/lib/api/work-proposals';
 
+type InitialWorkKind = 'website' | 'landing-page' | 'blog' | 'directory' | 'awesome-repo';
+
 interface NewWorkClientProps {
     user: AuthUser;
     providers: ProviderWithConnection[];
@@ -24,6 +26,7 @@ interface NewWorkClientProps {
     proposal?: WorkProposal | null;
     initialMode?: CreationMode | null;
     initialPrompt?: string;
+    initialKind?: InitialWorkKind | null;
 }
 
 export default function NewWorkClient({
@@ -36,6 +39,7 @@ export default function NewWorkClient({
     proposal,
     initialMode = null,
     initialPrompt,
+    initialKind = null,
 }: NewWorkClientProps) {
     const [creationMode, setCreationMode] = useState<CreationMode | null>(
         proposal ? 'ai' : initialMode,
@@ -158,6 +162,7 @@ export default function NewWorkClient({
                         websiteTemplates={websiteTemplates}
                         proposal={proposal ?? undefined}
                         initialPrompt={initialPrompt}
+                        initialKind={initialKind ?? undefined}
                     />
                 )}
                 {creationMode === 'manual' && (

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
@@ -32,6 +32,8 @@ interface NewWorkPageProps {
 }
 
 const VALID_CREATION_MODES: CreationMode[] = ['ai', 'manual', 'import'];
+const VALID_WORK_KINDS = ['website', 'landing-page', 'blog', 'directory', 'awesome-repo'] as const;
+type InitialWorkKind = (typeof VALID_WORK_KINDS)[number];
 
 export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
     const params = await searchParams;
@@ -42,6 +44,9 @@ export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
         : initialPrompt.length > 0
           ? 'ai'
           : null;
+    const initialKind = (VALID_WORK_KINDS as readonly string[]).includes(params.kind ?? '')
+        ? (params.kind as InitialWorkKind)
+        : null;
 
     if (!proposalId && !initialMode) {
         redirect(ROUTES.DASHBOARD_NEW);
@@ -131,6 +136,7 @@ export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
             proposal={proposal}
             initialMode={initialMode}
             initialPrompt={initialPrompt}
+            initialKind={initialKind}
         />
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
@@ -14,6 +14,8 @@ import NewWorkClient from './new-work-client';
 import type { DeployProvider } from './deploy-provider-selector';
 import { workProposalsAPI } from '@/lib/api/work-proposals';
 import type { WorkProposal } from '@/lib/api/work-proposals';
+import { ROUTES } from '@/lib/constants';
+import type { CreationMode } from '@/components/works/CreationBlockTrio';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('metadata.pages');
@@ -26,11 +28,24 @@ export interface ProviderWithConnection {
 }
 
 interface NewWorkPageProps {
-    searchParams: Promise<{ proposal?: string }>;
+    searchParams: Promise<{ proposal?: string; mode?: string; prompt?: string; kind?: string }>;
 }
 
+const VALID_CREATION_MODES: CreationMode[] = ['ai', 'manual', 'import'];
+
 export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
-    const { proposal: proposalId } = await searchParams;
+    const params = await searchParams;
+    const proposalId = params.proposal;
+    const initialPrompt = (params.prompt ?? '').trim().slice(0, 4000);
+    const initialMode = (VALID_CREATION_MODES as string[]).includes(params.mode ?? '')
+        ? (params.mode as CreationMode)
+        : initialPrompt.length > 0
+          ? 'ai'
+          : null;
+
+    if (!proposalId && !initialMode) {
+        redirect(ROUTES.DASHBOARD_NEW);
+    }
     const user = await getAuthFromCookie();
 
     // Defense: rendering with `user!` (non-null assertion) crashes the page
@@ -114,6 +129,8 @@ export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
             defaultDeployProviderId={defaultDeployProviderId}
             websiteTemplates={websiteTemplates}
             proposal={proposal}
+            initialMode={initialMode}
+            initialPrompt={initialPrompt}
         />
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/works/works-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/works-client.tsx
@@ -301,7 +301,7 @@ export default function WorksClient({ initialWorks, totalWorks, initialStats }: 
                 </div>
 
                 <Link
-                    href={ROUTES.DASHBOARD_WORKS_NEW}
+                    href={ROUTES.DASHBOARD_NEW}
                     className={cn(
                         'px-6 py-2 rounded-lg font-medium transition-colors inline-flex items-center gap-2',
                         'bg-black dark:bg-button-primary-dark hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark text-white dark:text-black rounded-sm',
@@ -433,7 +433,7 @@ export default function WorksClient({ initialWorks, totalWorks, initialStats }: 
                     action={{
                         label: t('empty.action'),
                         onClick: () => {
-                            router.push(ROUTES.DASHBOARD_WORKS_NEW);
+                            router.push(ROUTES.DASHBOARD_NEW);
                         },
                     }}
                 />

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -184,6 +184,17 @@ export async function createWork(data: CreateWorkDto) {
     }
 }
 
+const aiWorkKindSchema = z.enum(['website', 'landing-page', 'blog', 'directory', 'awesome-repo']);
+type AIWorkKind = z.infer<typeof aiWorkKindSchema>;
+
+const AI_WORK_KIND_PROMPT_LABELS: Record<AIWorkKind, string> = {
+    website: 'website',
+    'landing-page': 'landing page',
+    blog: 'blog',
+    directory: 'directory',
+    'awesome-repo': 'awesome repository list',
+};
+
 interface AIWorkOptions {
     name: string;
     prompt: string;
@@ -201,6 +212,7 @@ interface AIWorkOptions {
     };
     pluginConfig?: Record<string, unknown>;
     proposalId?: string;
+    workKind?: AIWorkKind;
 }
 
 export async function createWorkWithAI(request: AIWorkOptions) {
@@ -220,6 +232,7 @@ export async function createWorkWithAI(request: AIWorkOptions) {
             .pipe(z.string().max(100, t('name.maxLength'))),
         gitProvider: z.string().optional(),
         proposalId: z.string().uuid().optional(),
+        workKind: aiWorkKindSchema.optional(),
     });
 
     const createWorkSchema = await getCreateWorkSchema();
@@ -231,6 +244,7 @@ export async function createWorkWithAI(request: AIWorkOptions) {
             name: request.name,
             gitProvider: request.gitProvider,
             proposalId: request.proposalId,
+            workKind: request.workKind,
         });
         if (!validation.success) {
             return {
@@ -259,6 +273,9 @@ export async function createWorkWithAI(request: AIWorkOptions) {
         }
 
         const aiProvider = request.providers?.ai;
+        const generationPrompt = validation.data.workKind
+            ? `Create a ${AI_WORK_KIND_PROMPT_LABELS[validation.data.workKind]}.\n\n${validation.data.prompt}`
+            : validation.data.prompt;
         const defaultDetails = {
             name: validation.data.name,
             slug: slugify(validation.data.name),
@@ -272,7 +289,7 @@ export async function createWorkWithAI(request: AIWorkOptions) {
             workDetails = await workAPI
                 .generateDetails({
                     work_name: validation.data.name,
-                    prompt: validation.data.prompt,
+                    prompt: generationPrompt,
                     ai_provider: aiProvider,
                 })
                 .catch(() => defaultDetails);
@@ -308,7 +325,7 @@ export async function createWorkWithAI(request: AIWorkOptions) {
 
         await itemsGeneratorAPI.generate(work.id, {
             name: validation.data.name,
-            prompt: validation.data.prompt,
+            prompt: generationPrompt,
             providers: request.providers || undefined,
             pluginConfig: {
                 target_keywords: workDetails.keywords,

--- a/apps/web/src/components/dashboard/WorkProposalsSection.tsx
+++ b/apps/web/src/components/dashboard/WorkProposalsSection.tsx
@@ -236,18 +236,21 @@ export function WorkProposalsSection({
                     </h2>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                    {/* Phase 5 PR O — `+ Add` quick-add toggle */}
-                    <Button
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        className="gap-1.5"
-                        onClick={() => setQuickAddOpen((v) => !v)}
-                        aria-expanded={quickAddOpen}
-                    >
-                        <Plus className="w-3.5 h-3.5" />
-                        {tPage('quickAdd.submit')}
-                    </Button>
+                    {/* Phase 5 PR O — quick-add trigger. Hidden while the form is open
+                        so the header and form don't show duplicate Add controls. */}
+                    {!quickAddOpen && (
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="gap-1.5"
+                            onClick={() => setQuickAddOpen(true)}
+                            aria-expanded={quickAddOpen}
+                        >
+                            <Plus className="w-3.5 h-3.5" />
+                            {tPage('quickAdd.submit')}
+                        </Button>
+                    )}
 
                     {/* Phase 5 PR O — gears dropdown linking to settings anchors */}
                     <DropdownMenu>

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState, useTransition } from 'react';
-import { Lightbulb, Plus, Settings as SettingsIcon } from 'lucide-react';
+import { Lightbulb, Send, Settings as SettingsIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils/cn';
@@ -275,37 +275,37 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
             </div>
 
             {/* Quick add */}
-            <div className="mb-6 rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-4">
+            <div className="mb-5 rounded-lg border border-border/60 dark:border-border-dark/60 bg-surface/40 dark:bg-surface-dark/30 p-3">
                 <label
                     htmlFor="ideas-quick-add"
-                    className="text-xs uppercase tracking-wide text-text-muted dark:text-text-muted-dark"
+                    className="text-xs font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark"
                 >
                     {t('quickAdd.label')}
                 </label>
-                <div className="mt-2 flex flex-col gap-3 @3xl/main:flex-row @3xl/main:items-start">
+                <div className="mt-2 flex flex-col gap-2 @3xl/main:flex-row @3xl/main:items-stretch">
                     <Textarea
                         id="ideas-quick-add"
                         value={draft}
                         onChange={(e) => setDraft(e.target.value)}
-                        rows={3}
+                        rows={2}
                         placeholder={t('quickAdd.placeholder')}
-                        className="flex-1"
+                        className="min-h-20 flex-1 resize-none bg-card dark:bg-card-primary-dark"
                     />
                     <Button
                         type="button"
                         size="sm"
-                        className="gap-1.5 self-start @3xl/main:self-stretch @3xl/main:px-4"
+                        className="gap-1.5 self-stretch @3xl/main:px-4"
                         onClick={handleQuickAdd}
                         disabled={isCreating || draft.trim().length < 10}
                     >
-                        <Plus className="w-3.5 h-3.5" />
+                        <Send className="w-3.5 h-3.5" />
                         {t('quickAdd.submit')}
                     </Button>
                 </div>
             </div>
 
             {/* Toggles + filter chips row */}
-            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/50 dark:border-border-dark/50 bg-card/70 dark:bg-card-primary-dark/50 px-3 py-2">
                 <div className="flex flex-wrap items-center gap-3">
                     <label className="inline-flex items-center gap-2 text-sm text-text-secondary dark:text-text-secondary-dark cursor-pointer select-none">
                         <input
@@ -395,9 +395,14 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
 
             {/* Sorted list */}
             {visibleIdeas.length === 0 ? (
-                <div className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-6">
-                    <p className="text-sm text-text dark:text-text-dark">{t('empty.title')}</p>
-                    <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                <div className="rounded-lg border border-dashed border-border/70 dark:border-border-dark/70 bg-surface/40 dark:bg-surface-dark/30 p-8 text-center">
+                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-warning/20 bg-warning/10">
+                        <Lightbulb className="w-4 h-4 text-warning" />
+                    </div>
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('empty.title')}
+                    </p>
+                    <p className="mx-auto mt-1 max-w-xl text-xs text-text-muted dark:text-text-muted-dark">
                         {t('empty.subtitle')}
                     </p>
                 </div>

--- a/apps/web/src/components/missions/MissionDetailClient.tsx
+++ b/apps/web/src/components/missions/MissionDetailClient.tsx
@@ -313,12 +313,11 @@ export function MissionDetailClient({
                     </div>
 
                     {/* Action buttons */}
-                    <div className="flex flex-wrap items-center gap-2 shrink-0">
+                    <div className="flex flex-wrap items-center justify-end gap-2 shrink-0">
                         {canRunNow && (
                             <Button
                                 type="button"
                                 size="sm"
-                                variant="secondary"
                                 className="gap-1.5"
                                 onClick={runNow}
                                 disabled={pendingRunNow}
@@ -452,7 +451,7 @@ export function MissionDetailClient({
 
             {/* Guardrails section (placeholder for v1; sparse-override
                 editor lands in a follow-up tick). */}
-            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+            <section className="rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 p-4">
                 <h2 className="text-sm font-semibold text-text dark:text-text-dark mb-1">
                     {t('sections.guardrails')}
                 </h2>
@@ -474,7 +473,7 @@ export function MissionDetailClient({
                 before the data wires through, and the layout
                 doesn't reshuffle later. */}
             <div className="grid gap-6 @3xl/main:grid-cols-2">
-                <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+                <section className="rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 p-4">
                     <div className="flex items-center gap-2 mb-2">
                         <Activity className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
                         <h2 className="text-sm font-semibold text-text dark:text-text-dark">
@@ -485,7 +484,7 @@ export function MissionDetailClient({
                         {t('activity.empty')}
                     </p>
                 </section>
-                <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+                <section className="rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 p-4">
                     <div className="flex items-center gap-2 mb-3">
                         <BarChart3 className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
                         <h2 className="text-sm font-semibold text-text dark:text-text-dark">
@@ -511,7 +510,7 @@ export function MissionDetailClient({
             {/* Live runs section (Decision A15 — LIST shape, not single
                 run). v1 lists nothing because Mission ticks don't yet
                 produce queryable run records; PR J / PR GG wires it. */}
-            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+            <section className="rounded-lg border border-border/50 dark:border-border-dark/50 bg-surface/40 dark:bg-surface-dark/30 p-4">
                 <h2 className="text-sm font-semibold text-text dark:text-text-dark mb-2">
                     {t('sections.liveRuns')}
                 </h2>
@@ -521,7 +520,7 @@ export function MissionDetailClient({
             </section>
 
             {/* Ideas list section */}
-            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+            <section className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-4">
                 <h2 className="text-sm font-semibold text-text dark:text-text-dark mb-3">
                     {t('sections.ideas')} ({ideas.length})
                 </h2>
@@ -539,7 +538,7 @@ export function MissionDetailClient({
             </section>
 
             {/* Related Works section */}
-            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+            <section className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-4">
                 <h2 className="text-sm font-semibold text-text dark:text-text-dark mb-3">
                     {t('sections.relatedWorks')} ({acceptedWorkLinks.length})
                 </h2>
@@ -569,7 +568,7 @@ export function MissionDetailClient({
                 source Mission are NOT duplicated during Clone — this
                 panel surfaces them as read-only references. */}
             {mission.sourceMissionId && (
-                <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
+                <section className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-4">
                     <div className="flex items-center gap-2 mb-1">
                         <GitFork className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
                         <h2 className="text-sm font-semibold text-text dark:text-text-dark">

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plus, Target } from 'lucide-react';
+import { Target } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Link } from '@/i18n/navigation';
@@ -10,19 +10,15 @@ import type { Mission } from '@/lib/api/missions';
 /**
  * Phase 6 PR Q — Missions catalog list client.
  *
- * Spec: simple grid of MissionCards, top-right "+ New Mission"
- * button that routes to the unified `/new` (Phase 6.5 PR CC2) —
- * `/missions` deliberately does NOT host its own quick-add form.
- * Empty-state surface is a friendly nudge with the same CTA so
- * a brand-new account has a clear way in.
- *
- * Until Phase 6.5 lands, the "+ New Mission" button routes to
- * `/new?type=mission` as a forward-compatible pointer; the
- * `/new` page itself ships in PR CC2 and reads the `type` query
- * param to pre-fill its chip selection.
+ * Spec: simple grid of MissionCards with creation routed through
+ * the unified `/new?type=mission` flow. `/missions` deliberately
+ * does NOT host its own quick-add form; empty accounts get one
+ * focused CTA in the empty state instead of a duplicated header
+ * and empty-state action.
  */
 export function MissionsList({ missions }: { missions: Mission[] }) {
     const t = useTranslations('dashboard.missionsPage');
+    const newMissionLabel = t('newMission').replace(/^\+\s*/, '');
 
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
@@ -41,29 +37,28 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
                         </p>
                     </div>
                 </div>
-                <Button asChild size="sm" className="gap-1.5 shrink-0">
-                    <Link href={`/new?type=mission`}>
-                        <Plus className="w-3.5 h-3.5" />
-                        {t('newMission')}
-                    </Link>
-                </Button>
+                {missions.length > 0 && (
+                    <Button asChild size="sm" className="gap-1.5 shrink-0">
+                        <Link href={`/new?type=mission`}>{newMissionLabel}</Link>
+                    </Button>
+                )}
             </div>
 
             {/* List */}
             {missions.length === 0 ? (
-                <div className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-6">
-                    <p className="text-sm text-text dark:text-text-dark">{t('empty.title')}</p>
-                    <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1 max-w-2xl">
+                <div className="rounded-lg border border-dashed border-border/70 dark:border-border-dark/70 bg-surface/40 dark:bg-surface-dark/30 p-8 text-center">
+                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-warning/20 bg-warning/10">
+                        <Target className="w-4 h-4 text-warning" />
+                    </div>
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('empty.title')}
+                    </p>
+                    <p className="mx-auto mt-1 max-w-2xl text-xs text-text-muted dark:text-text-muted-dark">
                         {t('empty.subtitle')}
                     </p>
-                    <div className="mt-4">
-                        <Button asChild size="sm" className="gap-1.5">
-                            <Link href={`/new?type=mission`}>
-                                <Plus className="w-3.5 h-3.5" />
-                                {t('newMission')}
-                            </Link>
-                        </Button>
-                    </div>
+                    <Button asChild size="sm" className="mt-4 gap-1.5">
+                        <Link href={`/new?type=mission`}>{newMissionLabel}</Link>
+                    </Button>
                 </div>
             ) : (
                 <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-4">

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -139,6 +139,7 @@ export function NewPageClient({
                 // so this is forward-compatible — the wiring lands
                 // when the AI Creator reads `kind` (follow-up tick).
                 const params = new URLSearchParams({
+                    mode: 'ai',
                     kind: selectedChip,
                     prompt: description.slice(0, 4000),
                 });

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { BookOpen, Files, Globe, Lightbulb, Plus, Star, Target } from 'lucide-react';
+import {
+    ArrowRight,
+    BookOpen,
+    Files,
+    FolderInput,
+    Globe,
+    Lightbulb,
+    PenLine,
+    Star,
+    Target,
+} from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
@@ -10,7 +20,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
-import { CreationBlockTrio } from '@/components/works/CreationBlockTrio';
 import { createMissionAction } from '@/app/actions/dashboard/missions';
 import { createIdeaAction } from '@/app/actions/dashboard/work-proposals';
 
@@ -211,8 +220,8 @@ export function NewPageClient({
                         onClick={submit}
                         disabled={!canSubmit || submitting}
                     >
-                        <Plus className="w-3.5 h-3.5" />
                         {t('submit')}
+                        <ArrowRight className="w-3.5 h-3.5" />
                     </Button>
                 </div>
                 {selectedChip === null && (
@@ -227,30 +236,42 @@ export function NewPageClient({
                 )}
             </div>
 
-            {/* Or-divider + reused CreationBlockTrio in unified mode for
-                users who want the per-mode flows directly. PR CC1
-                already shipped the trio with the alternate label set. */}
-            <div className="flex items-center gap-3">
-                <div className="flex-1 h-px bg-border/60 dark:bg-border-dark/60" />
-                <span className="text-xs uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 dark:border-border-dark/60 bg-surface/60 dark:bg-surface-dark/60 px-4 py-3">
+                <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
                     {t('or')}
-                </span>
-                <div className="flex-1 h-px bg-border/60 dark:bg-border-dark/60" />
+                </p>
+                <div className="flex flex-wrap gap-2">
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={() => {
+                            const params = new URLSearchParams({ mode: 'manual' });
+                            if (prompt.trim().length > 0) {
+                                params.set('prompt', prompt.trim().slice(0, 4000));
+                            }
+                            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?${params.toString()}`);
+                        }}
+                    >
+                        <PenLine className="w-3.5 h-3.5" />
+                        {t('cards.manual.title')}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={() => {
+                            const params = new URLSearchParams({ mode: 'import' });
+                            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?${params.toString()}`);
+                        }}
+                    >
+                        <FolderInput className="w-3.5 h-3.5" />
+                        {t('cards.import.title')}
+                    </Button>
+                </div>
             </div>
-            <CreationBlockTrio
-                labelSet="unified"
-                onSelect={(mode) => {
-                    // The trio's mode → /works/new mapping mirrors the
-                    // existing per-mode AI/manual/import flow. Carries
-                    // the prompt forward if the user typed one but
-                    // hadn't yet picked a chip.
-                    const params = new URLSearchParams({ mode });
-                    if (prompt.trim().length > 0) {
-                        params.set('prompt', prompt.trim().slice(0, 4000));
-                    }
-                    router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?${params.toString()}`);
-                }}
-            />
         </div>
     );
 }

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -120,7 +120,7 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
         expect(routerPushMock).toHaveBeenCalledWith('/ideas');
     });
 
-    it('Submit with chip=website routes to /works/new with kind + prompt query params', () => {
+    it('Submit with chip=website routes to the Work wizard with mode + kind + prompt query params', () => {
         routerPushMock.mockClear();
         render(<NewPageClient initialType="website" />);
         fireEvent.change(screen.getByPlaceholderText('dashboard.newPage.promptPlaceholder'), {
@@ -130,6 +130,7 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
         expect(routerPushMock).toHaveBeenCalledTimes(1);
         const href = routerPushMock.mock.calls[0][0] as string;
         expect(href.startsWith('/works/new?')).toBe(true);
+        expect(href).toContain('mode=ai');
         expect(href).toContain('kind=website');
         // URLSearchParams encodes spaces as `+`, not `%20`.
         expect(href).toContain('prompt=Landing+page+for+my+SaaS+launch');

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -192,17 +192,10 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
         });
     });
 
-    it('CreationBlockTrio renders below the chip strip with labelSet="unified"', () => {
-        const { container } = render(<NewPageClient />);
-        // Unified label set: title key is "dashboard.newPage.cards.ai.title"
-        // (vs. legacy "dashboard.workCreation.ai.title").
-        expect(screen.getByText('dashboard.newPage.cards.ai.title')).toBeTruthy();
+    it('renders compact manual/import shortcuts instead of a second Work card chooser', () => {
+        render(<NewPageClient />);
+        expect(screen.queryByText('dashboard.newPage.cards.ai.title')).toBeNull();
         expect(screen.getByText('dashboard.newPage.cards.manual.title')).toBeTruthy();
         expect(screen.getByText('dashboard.newPage.cards.import.title')).toBeTruthy();
-        // Three mode-card buttons (no aria-pressed on these).
-        const modeButtons = Array.from(container.querySelectorAll('button:not([aria-pressed])'));
-        // At least 3 (Submit + 3 mode buttons). The Submit also lacks
-        // aria-pressed but is the only non-trio button.
-        expect(modeButtons.length).toBeGreaterThanOrEqual(4);
     });
 });

--- a/apps/web/src/components/not-found-content.tsx
+++ b/apps/web/src/components/not-found-content.tsx
@@ -1,4 +1,5 @@
-import Link from 'next/link';
+import { CircleAlert } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { GoBackButton } from '@/components/ui/go-back-button';
 
@@ -25,19 +26,7 @@ export function NotFoundContent({
                     </p>
                     <div className="absolute inset-0 flex items-center justify-center">
                         <div className="w-20 h-20 rounded-2xl bg-primary/10 flex items-center justify-center">
-                            <svg
-                                className="w-10 h-10 text-primary"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={1.5}
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
-                                />
-                            </svg>
+                            <CircleAlert className="w-10 h-10 text-primary" strokeWidth={1.5} />
                         </div>
                     </div>
                 </div>
@@ -48,7 +37,7 @@ export function NotFoundContent({
                 <p className="text-text-muted dark:text-text-muted-dark mb-8 leading-relaxed">
                     {description}
                 </p>
-                <div className="flex items-center justify-center gap-3">
+                <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
                     <Link
                         href={ROUTES.DASHBOARD}
                         className="inline-flex items-center justify-center px-6 py-2.5 rounded-lg font-medium transition-colors bg-primary text-white hover:bg-primary-hover"

--- a/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
@@ -104,7 +104,7 @@ export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkSte
                     </>
                 ) : (
                     <Link
-                        href={ROUTES.DASHBOARD_WORKS_NEW}
+                        href={ROUTES.DASHBOARD_NEW}
                         onClick={onLeave}
                         className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
                     >

--- a/apps/web/src/components/works/WorkAICreator.tsx
+++ b/apps/web/src/components/works/WorkAICreator.tsx
@@ -22,6 +22,8 @@ import type { GeneratorFormSchema } from '@/lib/api/types-only';
 import type { WebsiteTemplateOption } from '@/lib/api/work';
 import type { WorkProposal } from '@/lib/api/work-proposals';
 
+type InitialWorkKind = 'website' | 'landing-page' | 'blog' | 'directory' | 'awesome-repo';
+
 interface WorkAICreatorProps {
     gitProvider?: string;
     gitConnected?: boolean;
@@ -29,6 +31,7 @@ interface WorkAICreatorProps {
     websiteTemplates: WebsiteTemplateOption[];
     proposal?: WorkProposal;
     initialPrompt?: string;
+    initialKind?: InitialWorkKind;
 }
 
 export function WorkAICreator({
@@ -38,6 +41,7 @@ export function WorkAICreator({
     websiteTemplates,
     proposal,
     initialPrompt,
+    initialKind,
 }: WorkAICreatorProps) {
     const [prompt, setPrompt] = useState(proposal?.generatedPrompt ?? initialPrompt ?? '');
     const [workName, setWorkName] = useState(proposal?.title ?? '');
@@ -133,6 +137,7 @@ export function WorkAICreator({
                 pluginConfig: Object.keys(pluginConfig).length > 0 ? pluginConfig : undefined,
                 websiteTemplateId: websiteTemplateId || undefined,
                 proposalId: proposal?.id,
+                workKind: initialKind,
             });
 
             if (result.success) {

--- a/apps/web/src/components/works/WorkAICreator.tsx
+++ b/apps/web/src/components/works/WorkAICreator.tsx
@@ -28,6 +28,7 @@ interface WorkAICreatorProps {
     deployProvider?: string;
     websiteTemplates: WebsiteTemplateOption[];
     proposal?: WorkProposal;
+    initialPrompt?: string;
 }
 
 export function WorkAICreator({
@@ -36,8 +37,9 @@ export function WorkAICreator({
     deployProvider,
     websiteTemplates,
     proposal,
+    initialPrompt,
 }: WorkAICreatorProps) {
-    const [prompt, setPrompt] = useState(proposal?.generatedPrompt ?? '');
+    const [prompt, setPrompt] = useState(proposal?.generatedPrompt ?? initialPrompt ?? '');
     const [workName, setWorkName] = useState(proposal?.title ?? '');
     const [organization, setOrganization] = useState(false);
     const [owner, setOwner] = useState('');

--- a/apps/web/src/components/works/WorkList.tsx
+++ b/apps/web/src/components/works/WorkList.tsx
@@ -64,7 +64,7 @@ export function WorkList({
                     </h2>
 
                     <Link
-                        href={ROUTES.DASHBOARD_WORKS_NEW}
+                        href={ROUTES.DASHBOARD_NEW}
                         className={cn(
                             'px-4 py-2 rounded-lg font-medium transition-colors inline-flex items-center gap-2',
                             'bg-primary-500 hover:bg-primary-700 text-white',

--- a/apps/web/src/components/works/WorkManualForm.tsx
+++ b/apps/web/src/components/works/WorkManualForm.tsx
@@ -26,6 +26,7 @@ interface WorkManualFormProps {
     deployProvider?: string;
     websiteTemplates: WebsiteTemplateOption[];
     proposal?: WorkProposal;
+    initialDescription?: string;
 }
 
 export function WorkManualForm({
@@ -35,6 +36,7 @@ export function WorkManualForm({
     deployProvider,
     websiteTemplates,
     proposal,
+    initialDescription,
 }: WorkManualFormProps) {
     const [isPending, startTransition] = useTransition();
     const router = useRouter();
@@ -44,7 +46,7 @@ export function WorkManualForm({
     const [formData, setFormData] = useState<CreateWorkDto>({
         slug: proposal?.slugSuggestion ?? '',
         name: proposal?.title ?? '',
-        description: proposal?.description ?? '',
+        description: proposal?.description ?? initialDescription ?? '',
         organization: false,
         owner: '',
         websiteTemplateId: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-select creation mode and pre-fill work form fields (mode, prompt, kind) from URL/query parameters for quicker setup.

* **Behavior Changes**
  * Unified work-creation navigation: all “create” actions now route to the same new-work entry point.
  * Empty-state and quick-add actions updated to avoid duplicate controls and improve navigation.

* **Style**
  * UI/spacing/icon updates across onboarding, ideas, missions, dashboard and not-found screens for clearer layout.

* **Tests**
  * Unit tests updated to reflect new routing query parameters and revised UI shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->