### PR TITLE
fix(web): polish Missions/Ideas/New/Templates UI

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -545,10 +545,18 @@
         "missionsPage": {
             "title": "Missions",
             "subtitle": "Long-running Goals that keep generating Ideas (and Works) for you. Open one to tune its cadence, cap, or auto-build behavior.",
-            "newMission": "+ New Mission",
+            "newMission": "New Mission",
+            "quickAdd": {
+                "label": "Start a new Mission",
+                "submitTitle": "Create Mission",
+                "minLength": "Description must be at least 10 characters.",
+                "created": "Mission created",
+                "error": "Couldn't create Mission. Please try again."
+            },
             "empty": {
                 "title": "No Missions yet.",
-                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting."
+                "subtitle": "Start one to give the agent a persistent Goal. Each Mission generates Ideas on a schedule (or one-shot), with its own outstanding-Ideas cap and auto-build setting.",
+                "openNew": "Open the unified creator"
             },
             "card": {
                 "scheduled": "Scheduled",
@@ -829,6 +837,7 @@
                 "label": "Add a new Idea",
                 "placeholder": "Describe an Idea — e.g. \"A curated list of the best AI coding agents released this year\"",
                 "submit": "Add",
+                "submitTitle": "Add Idea",
                 "minLength": "Description must be at least 10 characters."
             },
             "toggles": {
@@ -3262,8 +3271,8 @@
             }
         },
         "newPage": {
-            "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "title": "Start something new",
+            "subtitle": "Tell the agent what you want to build. Pick a kind below to bias the result, or jump into the manual flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",
@@ -3276,11 +3285,20 @@
                 "directory": "Directory",
                 "awesome-repo": "Awesome Repo"
             },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+            },
             "submit": "Create",
+            "submitTitle": "Create",
             "or": "or",
             "hints": {
-                "pickChip": "Pick a chip above to enable Create.",
-                "minLength": "Add a description (at least 10 characters) to enable Create."
+                "minLength": "Add a description (at least 10 characters) to start."
             },
             "toasts": {
                 "missionCreated": "Mission created",

--- a/apps/web/src/app/[locale]/(dashboard)/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/new/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { NewPageClient, type ChipType } from '@/components/new';
 import { templatesAPI } from '@/lib/api/templates';
+import { missionsAPI } from '@/lib/api/missions';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.newPage');
@@ -24,33 +25,42 @@ const VALID_CHIP_TYPES: ChipType[] = [
  * Reads an optional `?type=<chip>` query param to pre-select the
  * chip. PR Q's "+ New Mission" button on `/missions` passes
  * `type=mission`; PR DD's sidebar "+ New" repoint passes no
- * type. Unknown values are ignored — the page renders with no
- * chip preselected.
+ * type. When `?type=` is missing, the page picks a sensible
+ * default: **Mission** when the user hasn't created any yet
+ * (so first-time users land on the persistent-goal kind),
+ * otherwise **Idea** (the lighter weight one-shot path).
  *
  * Phase 8 PR Y — also reads an optional `?template=<id>` query
  * param. When set AND the resolved chip is `'mission'`, the
  * server fetches the Mission template's catalog row and forwards
  * its name + description so NewPageClient can pre-fill the
- * prompt. Unknown / non-mission templates are silently ignored
- * (the page renders empty just like before).
+ * prompt.
  */
 type SearchParams = Promise<{ type?: string; template?: string }>;
 
 export default async function NewPage({ searchParams }: { searchParams: SearchParams }) {
     const params = await searchParams;
     const raw = (params?.type ?? '').trim().toLowerCase();
-    const initialType: ChipType | null = (VALID_CHIP_TYPES as string[]).includes(raw)
+    const explicitType: ChipType | null = (VALID_CHIP_TYPES as string[]).includes(raw)
         ? (raw as ChipType)
         : null;
+
+    // Default-chip selection: only ask the API for the mission
+    // count when the URL didn't already nail down a chip — saves a
+    // round-trip on the common `/new?type=…` paths from /missions
+    // and template "Use this" buttons.
+    let initialType: ChipType = 'mission';
+    if (explicitType) {
+        initialType = explicitType;
+    } else {
+        const missions = await missionsAPI.list().catch(() => []);
+        initialType = missions.length > 0 ? 'idea' : 'mission';
+    }
 
     let initialPrompt: string | undefined;
     let initialTemplateId: string | undefined;
     const templateIdRaw = (params?.template ?? '').trim();
     if (initialType === 'mission' && templateIdRaw.length > 0) {
-        // Mission templates list is small (≤2 in v1) — a single
-        // fetch on render is fine; no need to look up by id
-        // separately. Defensive .catch(() => []) so a flaky API
-        // surfaces the empty form instead of 500ing the page.
         const list = await templatesAPI.list('mission').catch(() => ({
             templates: [] as Array<{ id: string; name: string; description?: string | null }>,
         }));

--- a/apps/web/src/app/[locale]/(dashboard)/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/templates/page.tsx
@@ -74,7 +74,14 @@ export default async function TemplatesPage({ searchParams }: { searchParams: Se
 
     return (
         <div className="w-full overflow-auto">
+            {/* `key={kind}` forces a fresh mount when the user flips
+                the Mission / Work / Website pill, so the catalog's
+                local state (`templates`, default id, filter mode)
+                re-initializes from the new server-fetched list.
+                Without it, the client-side useState keeps showing
+                the previous kind's templates after navigation. */}
             <TemplatesCatalog
+                key={kind}
                 kind={kind}
                 templates={templatesData.templates}
                 defaultTemplateId={templatesData.defaultTemplateId}

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -61,7 +61,10 @@ function useTypewriterPlaceholder(
             if (shown.length < target.length) {
                 timer = setTimeout(() => setShown(target.slice(0, shown.length + 1)), TYPE_MS);
             } else {
-                timer = setTimeout(() => setPhase('holding'), HOLD_TYPED_MS);
+                // Hand off to 'holding' immediately — that phase owns
+                // the full HOLD_TYPED_MS pause. Setting a HOLD_TYPED_MS
+                // here too would double-count the hold (3.6s total).
+                timer = setTimeout(() => setPhase('holding'), 0);
             }
         } else if (phase === 'holding') {
             timer = setTimeout(() => setPhase('erasing'), HOLD_TYPED_MS);
@@ -134,10 +137,13 @@ export function PromptComposer({
     const [focused, setFocused] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const trimmed = value.trim();
-    const tooLong = trimmed.length > maxLength;
-    const canSubmit = !disabled && !submitting && trimmed.length >= minLength && !tooLong;
+    // The textarea's native `maxLength={maxLength}` caps the raw value
+    // before we ever see it, so no `tooLong` guard is needed here —
+    // trimming can only shorten the string, never grow it past the cap.
+    const canSubmit = !disabled && !submitting && trimmed.length >= minLength;
 
-    const examples = placeholderExamples && placeholderExamples.length > 0 ? placeholderExamples : [];
+    const examples =
+        placeholderExamples && placeholderExamples.length > 0 ? placeholderExamples : [];
     const typed = useTypewriterPlaceholder(focused || value.length > 0, examples, placeholder);
     const effectivePlaceholder = examples.length > 0 ? typed : placeholder || '';
 

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { ArrowRight, Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Phase 9 — shared prompt composer used by `/missions`, `/ideas`,
+ * and `/new`. Modeled on the website's `LandingPromptForm` (see
+ * `Ever Works/Code/website/packages/web/components/global/
+ * LandingPromptForm.tsx`) so the dashboard's quick-add surfaces
+ * read the same way visitors first met the product:
+ *
+ *   - Rounded card, sits on the page's natural dark background
+ *     (no nested `bg-card` wrapper).
+ *   - Typewriter placeholder cycling through example briefs.
+ *   - Arrow submit button anchored bottom-right inside the card
+ *     (no separate "Add" / "Create" button beside the textarea).
+ *   - Enter submits; Shift+Enter inserts a newline.
+ *   - Optional `belowInput` slot for chip strips (used by `/new`).
+ */
+const TYPE_MS = 35;
+const ERASE_MS = 18;
+const HOLD_TYPED_MS = 1800;
+const HOLD_ERASED_MS = 350;
+
+function useTypewriterPlaceholder(
+    focused: boolean,
+    examples: ReadonlyArray<string>,
+    fallback?: string,
+): string {
+    const [index, setIndex] = useState(0);
+    const [shown, setShown] = useState('');
+    const [phase, setPhase] = useState<'typing' | 'holding' | 'erasing' | 'paused'>('typing');
+
+    // Reset whenever the examples array reference changes so a
+    // parent-controlled list swap (e.g. chip selection on /new)
+    // doesn't leave a half-erased stale string on screen.
+    useEffect(() => {
+        setIndex(0);
+        setShown('');
+        setPhase(focused ? 'paused' : 'typing');
+        // Only react to a *new* examples reference.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [examples]);
+
+    useEffect(() => {
+        if (focused) {
+            setPhase('paused');
+            return;
+        }
+        if (phase === 'paused') setPhase('typing');
+    }, [focused, phase]);
+
+    useEffect(() => {
+        if (focused) return;
+        if (!examples || examples.length === 0) return;
+        const target = examples[index % examples.length];
+        let timer: ReturnType<typeof setTimeout>;
+        if (phase === 'typing') {
+            if (shown.length < target.length) {
+                timer = setTimeout(() => setShown(target.slice(0, shown.length + 1)), TYPE_MS);
+            } else {
+                timer = setTimeout(() => setPhase('holding'), HOLD_TYPED_MS);
+            }
+        } else if (phase === 'holding') {
+            timer = setTimeout(() => setPhase('erasing'), HOLD_TYPED_MS);
+        } else if (phase === 'erasing') {
+            if (shown.length > 0) {
+                timer = setTimeout(() => setShown(shown.slice(0, -1)), ERASE_MS);
+            } else {
+                timer = setTimeout(() => {
+                    setIndex((i) => (i + 1) % examples.length);
+                    setPhase('typing');
+                }, HOLD_ERASED_MS);
+            }
+        }
+        return () => clearTimeout(timer);
+    }, [phase, shown, index, focused, examples]);
+
+    return shown || examples[0] || fallback || '';
+}
+
+export interface PromptComposerProps {
+    value: string;
+    onChange: (next: string) => void;
+    onSubmit: () => void;
+    /** Min chars required for submit to be enabled. Defaults to 10. */
+    minLength?: number;
+    /** Hard cap enforced by the textarea. Defaults to 5000. */
+    maxLength?: number;
+    /** Number of rows in the textarea. Defaults to 3. */
+    rows?: number;
+    submitting?: boolean;
+    /** Placeholder examples to cycle through. Falls back to the single `placeholder`. */
+    placeholderExamples?: ReadonlyArray<string>;
+    placeholder?: string;
+    /** Accessible label for the textarea. */
+    ariaLabel: string;
+    /** Optional content rendered BELOW the textarea inside the same card. */
+    belowInput?: ReactNode;
+    /** Optional id for the textarea so an external <label> can point at it. */
+    inputId?: string;
+    /** Stable hook for tests / instrumentation. */
+    testId?: string;
+    /** Submit button tooltip. */
+    submitTitle?: string;
+    className?: string;
+    /** Disable the input + submit entirely. */
+    disabled?: boolean;
+    /** Show the running character counter. Defaults to true. */
+    showCounter?: boolean;
+}
+
+export function PromptComposer({
+    value,
+    onChange,
+    onSubmit,
+    minLength = 10,
+    maxLength = 5000,
+    rows = 3,
+    submitting = false,
+    placeholderExamples,
+    placeholder,
+    ariaLabel,
+    belowInput,
+    inputId,
+    testId,
+    submitTitle,
+    className,
+    disabled = false,
+    showCounter = true,
+}: PromptComposerProps) {
+    const [focused, setFocused] = useState(false);
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const trimmed = value.trim();
+    const tooLong = trimmed.length > maxLength;
+    const canSubmit = !disabled && !submitting && trimmed.length >= minLength && !tooLong;
+
+    const examples = placeholderExamples && placeholderExamples.length > 0 ? placeholderExamples : [];
+    const typed = useTypewriterPlaceholder(focused || value.length > 0, examples, placeholder);
+    const effectivePlaceholder = examples.length > 0 ? typed : placeholder || '';
+
+    function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            if (canSubmit) onSubmit();
+        }
+    }
+
+    return (
+        <div
+            className={cn(
+                // Rounded composer card. No solid background — the page's
+                // dark surface shows through, matching the website's
+                // landing prompt. The subtle ring + border give it shape
+                // without making it feel like a separate panel.
+                'relative flex flex-col rounded-2xl border border-border/60 dark:border-white/10 bg-white/40 dark:bg-black/40 backdrop-blur',
+                'shadow-sm ring-1 ring-black/[0.02] dark:ring-white/[0.04]',
+                'transition focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/30',
+                submitting && 'opacity-70 pointer-events-none',
+                className,
+            )}
+        >
+            <textarea
+                ref={textareaRef}
+                id={inputId}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onKeyDown={onKeyDown}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+                placeholder={effectivePlaceholder}
+                maxLength={maxLength}
+                rows={rows}
+                disabled={disabled || submitting}
+                aria-label={ariaLabel}
+                data-testid={testId}
+                className="block w-full resize-none rounded-2xl bg-transparent px-5 pt-4 pb-2 text-base outline-none placeholder:text-text-muted dark:placeholder:text-text-muted-dark text-text dark:text-text-dark"
+            />
+
+            {belowInput ? <div className="px-4 pb-2">{belowInput}</div> : null}
+
+            <div className="flex items-center gap-2 px-3 pb-2">
+                <div className="ml-auto flex items-center gap-2">
+                    {showCounter ? (
+                        <span className="text-xs tabular-nums text-text-muted dark:text-text-muted-dark">
+                            {trimmed.length}/{maxLength}
+                        </span>
+                    ) : null}
+                    <button
+                        type="button"
+                        onClick={onSubmit}
+                        disabled={!canSubmit}
+                        title={submitTitle}
+                        aria-label={submitTitle || ariaLabel}
+                        data-testid={testId ? `${testId}-submit` : undefined}
+                        className={cn(
+                            'inline-flex items-center justify-center rounded-full p-2.5 shadow-md transition',
+                            'bg-primary text-white hover:bg-primary/90',
+                            'disabled:cursor-not-allowed disabled:opacity-40',
+                        )}
+                    >
+                        {submitting ? (
+                            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                            <ArrowRight className="size-4" aria-hidden="true" />
+                        )}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState, useTransition } from 'react';
-import { Lightbulb, Send, Settings as SettingsIcon } from 'lucide-react';
+import { Lightbulb, Settings as SettingsIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils/cn';
@@ -12,7 +12,7 @@ import {
 } from '@/app/actions/dashboard/work-proposals';
 import type { WorkProposal, WorkProposalStatus } from '@/lib/api/work-proposals';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { PromptComposer } from '@/components/common/PromptComposer';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -26,7 +26,7 @@ import { ROUTES } from '@/lib/constants';
 import { IdeaCard } from './IdeaCard';
 
 /**
- * Phase 5 PR N — Ideas catalog page client.
+ * Phase 5 PR N + UI polish — Ideas catalog page client.
  *
  * Renders the full list of the user's Ideas — drafted by auto-
  * generation, suggested by Discover, spawned from a Mission, and
@@ -34,42 +34,15 @@ import { IdeaCard } from './IdeaCard';
  * terminal statuses (ACCEPTED + DISMISSED, off by default) and a
  * filter-chip strip for narrowing to one specific status.
  *
- * Quick-add form at the top wires Phase 1 PR B's
- * `POST /me/work-proposals` (user-manual create) — first UI surface
- * for that endpoint. The created Idea is prepended to the local
- * state immediately (optimistic) so the user sees their typed
- * description show up as a PENDING card without round-tripping a
- * full re-fetch.
- *
- * Gears menu (Settings dropdown, top-right) deep-links to the
- * Phase 4 PR L / PR EE settings anchors so the user can jump from
- * "I want fewer auto-suggestions" → the cadence knob in a single
- * click.
- *
- * Each IdeaCard's Build CTA still routes to `/works/new?proposal=…`
- * for now (the existing Phase 0 flow). A future tick can swap that
- * for `buildIdeaAction` directly — but doing so here would change
- * IdeaCard's behavior for the dashboard preview block too, which
- * is out of PR N's scope.
+ * Quick-add at the top now uses the shared `PromptComposer`
+ * (same shape as the marketing site's landing prompt) so this
+ * page and `/missions` feel like the same primitive.
  */
 type Toggles = {
     showAccepted: boolean;
     showDismissed: boolean;
 };
 
-/**
- * Phase 5 PR P — pseudo-filter `'done'` is an alias for ACCEPTED
- * with two distinct behaviors:
- *   1. The Done chip is enabled regardless of the "Show accepted"
- *      toggle (it expresses "show my completed work" rather than
- *      "include the hidden accepted bucket in my browse view").
- *   2. While Done is active, ACCEPTED Ideas are visible even if
- *      the toggle is off — same data, different semantics.
- *
- * The chip lives at the FAR END of the filter strip with a
- * checkmark glyph to read as a celebratory/terminal state, not
- * just another filter.
- */
 type StatusFilter = 'all' | WorkProposalStatus | 'done';
 
 const ACTIONABLE_STATUSES: WorkProposalStatus[] = ['pending', 'queued', 'building', 'failed'];
@@ -83,6 +56,15 @@ const STATUS_FILTER_ORDER: StatusFilter[] = [
     'accepted',
     'dismissed',
     'done',
+];
+
+const IDEA_PLACEHOLDERS: ReadonlyArray<string> = [
+    'e.g. "A curated list of the best AI coding agents released this year"',
+    'e.g. "Landing page for my fintech startup with hero, pricing, and CTA"',
+    'e.g. "Awesome list: best React state-management libraries with benchmarks"',
+    'e.g. "Directory of MCP servers — capabilities, language, install command, source repo"',
+    'e.g. "Knowledge base for our open-source SDK with search and versioning"',
+    'e.g. "Blog about indie game development with categories for postmortems and tooling"',
 ];
 
 interface IdeasPageClientProps {
@@ -103,21 +85,12 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     const [isBuilding, startBuilding] = useTransition();
 
     const visibleIdeas = useMemo(() => {
-        // Phase 5 PR P — Done bypasses the showAccepted toggle.
-        // When Done is selected, the user is explicitly asking to
-        // see their completed Ideas — the toggle gate would be a
-        // mis-feature.
         const isDoneFilter = statusFilter === 'done';
         return ideas.filter((idea) => {
-            // Toggles gate the terminal-status surfaces — unless
-            // the Done filter is active (then accepted rows show
-            // regardless).
             if (idea.status === 'accepted' && !toggles.showAccepted && !isDoneFilter) {
                 return false;
             }
             if (idea.status === 'dismissed' && !toggles.showDismissed) return false;
-            // Filter chip narrows further. `'done'` is an alias
-            // for ACCEPTED.
             if (statusFilter === 'done' && idea.status !== 'accepted') return false;
             if (statusFilter !== 'all' && statusFilter !== 'done' && idea.status !== statusFilter) {
                 return false;
@@ -126,17 +99,12 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
         });
     }, [ideas, toggles, statusFilter]);
 
-    // Per-status counts for the filter-chip badges. Computed once
-    // per render against the full set so the toggles don't reduce
-    // the chip badges out from under the user.
     const counts = useMemo(() => {
         const map = new Map<StatusFilter, number>();
         map.set('all', ideas.length);
         for (const idea of ideas) {
             map.set(idea.status, (map.get(idea.status) ?? 0) + 1);
         }
-        // Phase 5 PR P — `done` chip aliases ACCEPTED; mirror the
-        // count so the badge is meaningful.
         map.set('done', map.get('accepted') ?? 0);
         return map;
     }, [ideas]);
@@ -160,21 +128,11 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     };
 
     const handleDismissed = (id: string) => {
-        // IdeaCard's own dismiss path already calls
-        // dismissProposalAction; we just mirror the local list so
-        // the card disappears from this page without a full re-fetch.
         setIdeas((prev) =>
             prev.map((idea) => (idea.id === id ? { ...idea, status: 'dismissed' as const } : idea)),
         );
     };
 
-    // Build-from-Idea handler (Phase 1 PR B `POST /me/work-proposals/:id/build`).
-    // Wired here as an explicit `Queue build` button on the FAILED
-    // and PENDING cards once we add a richer card variant. For now
-    // the existing IdeaCard's Build CTA preserves the legacy
-    // `/works/new?proposal=…` flow. This handler is exposed so a
-    // follow-up tick can swap one for the other without touching
-    // the IdeaCard component.
     const handleQueueBuild = (id: string) => {
         startBuilding(async () => {
             try {
@@ -186,30 +144,25 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
             }
         });
     };
-    // Suppress unused-var warning until a card variant calls it.
     void handleQueueBuild;
-
-    // Catch-all dismiss for the per-card handler in IdeaCard; we
-    // re-export a `silent` no-op when the user manually dismisses
-    // via the card's X button (handled inside IdeaCard already).
     void dismissProposalAction;
 
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
-            {/* Header */}
-            <div className="flex items-start justify-between gap-3 mb-6">
-                <div className="flex items-start gap-3">
-                    <div className="shrink-0 w-9 h-9 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
-                        <Lightbulb className="w-4 h-4 text-warning" />
-                    </div>
-                    <div>
-                        <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
-                            {t('title')}
-                        </h1>
-                        <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1 max-w-2xl">
-                            {t('subtitle')}
-                        </p>
-                    </div>
+            {/* Header — title + subtitle take the full row width and
+                the gears menu floats to the far right so the subtitle
+                isn't truncated next to it. */}
+            <div className="flex items-start gap-3 mb-6">
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
+                    <Lightbulb className="w-4 h-4 text-warning" />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
+                        {t('title')}
+                    </h1>
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1">
+                        {t('subtitle')}
+                    </p>
                 </div>
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -217,7 +170,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
                             type="button"
                             variant="secondary"
                             size="sm"
-                            className="gap-1.5"
+                            className="ml-auto shrink-0 gap-1.5"
                             aria-label={t('gears.menuLabel')}
                         >
                             <SettingsIcon className="w-4 h-4" />
@@ -274,34 +227,25 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
                 </DropdownMenu>
             </div>
 
-            {/* Quick add */}
-            <div className="mb-5 rounded-lg border border-border/60 dark:border-border-dark/60 bg-surface/40 dark:bg-surface-dark/30 p-3">
+            {/* Quick add — shared composer matches the marketing site. */}
+            <div className="mb-6">
                 <label
                     htmlFor="ideas-quick-add"
-                    className="text-xs font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark"
+                    className="block text-xs font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark mb-2"
                 >
                     {t('quickAdd.label')}
                 </label>
-                <div className="mt-2 flex flex-col gap-2 @3xl/main:flex-row @3xl/main:items-stretch">
-                    <Textarea
-                        id="ideas-quick-add"
-                        value={draft}
-                        onChange={(e) => setDraft(e.target.value)}
-                        rows={2}
-                        placeholder={t('quickAdd.placeholder')}
-                        className="min-h-20 flex-1 resize-none bg-card dark:bg-card-primary-dark"
-                    />
-                    <Button
-                        type="button"
-                        size="sm"
-                        className="gap-1.5 self-stretch @3xl/main:px-4"
-                        onClick={handleQuickAdd}
-                        disabled={isCreating || draft.trim().length < 10}
-                    >
-                        <Send className="w-3.5 h-3.5" />
-                        {t('quickAdd.submit')}
-                    </Button>
-                </div>
+                <PromptComposer
+                    inputId="ideas-quick-add"
+                    value={draft}
+                    onChange={setDraft}
+                    onSubmit={handleQuickAdd}
+                    submitting={isCreating}
+                    placeholderExamples={IDEA_PLACEHOLDERS}
+                    ariaLabel={t('quickAdd.label')}
+                    submitTitle={t('quickAdd.submitTitle')}
+                    testId="ideas-quick-add"
+                />
             </div>
 
             {/* Toggles + filter chips row */}
@@ -342,10 +286,6 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
                         const isActive = statusFilter === s;
                         const isTerminal = s === 'accepted' || s === 'dismissed';
                         const isDoneChip = s === 'done';
-                        // Phase 5 PR P — Done is enabled REGARDLESS of
-                        // the showAccepted toggle (different semantics:
-                        // "show me my completed work" vs. "include the
-                        // hidden accepted bucket in my browse view").
                         const isHidden =
                             (s === 'accepted' && !toggles.showAccepted) ||
                             (s === 'dismissed' && !toggles.showDismissed);
@@ -357,10 +297,6 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
                                 disabled={isHidden}
                                 className={cn(
                                     'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors',
-                                    // Done chip uses a success-tinted
-                                    // active/inactive palette so it
-                                    // reads as a celebratory terminal
-                                    // state, not just another filter.
                                     isDoneChip
                                         ? isActive
                                             ? 'bg-success text-white border-success'
@@ -427,11 +363,5 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     );
 }
 
-// Re-export the constant so spec-doc / a follow-up tick can
-// import it (e.g. dashboard preview wants the same default set).
 export { ACTIONABLE_STATUSES };
-
-// Re-export ROUTES alias so spec docs can deep-link to this page
-// without re-importing constants.ts. (Tiny: keeps PR N's surface
-// self-contained at a single import point.)
 export { ROUTES as IDEAS_PAGE_ROUTES };

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -133,6 +133,13 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
         );
     };
 
+    // Build-from-Idea handler (Phase 1 PR B `POST /me/work-proposals/:id/build`).
+    // Wired here as an explicit `Queue build` button on the FAILED
+    // and PENDING cards once we add a richer card variant. For now
+    // the existing IdeaCard's Build CTA preserves the legacy
+    // `/works/new?proposal=…` flow. This handler stays exposed so a
+    // follow-up tick can swap one for the other without touching
+    // the IdeaCard component.
     const handleQueueBuild = (id: string) => {
         startBuilding(async () => {
             try {
@@ -144,7 +151,12 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
             }
         });
     };
+    // Suppress unused-var warning until a card variant calls handleQueueBuild.
     void handleQueueBuild;
+
+    // Catch-all dismiss for the per-card handler in IdeaCard; we
+    // re-export a `silent` no-op when the user manually dismisses
+    // via the card's X button (handled inside IdeaCard already).
     void dismissProposalAction;
 
     return (

--- a/apps/web/src/components/ideas/IdeasPageClient.unit.spec.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.unit.spec.tsx
@@ -111,9 +111,23 @@ describe('IdeasPageClient (Phase 5 PR N)', () => {
             mkIdea({ id: 'b1', status: 'building' }),
             mkIdea({ id: 'a1', status: 'accepted' }),
         ];
-        const { container } = render(<IdeasPageClient initialIdeas={ideas} />);
-        // 8 chips total ('all' + 6 statuses + 'done' alias, Phase 5 PR P).
-        expect(container.querySelectorAll('button.rounded-full')).toHaveLength(8);
+        render(<IdeasPageClient initialIdeas={ideas} />);
+        // Locate filter chips via their i18n key text — the PromptComposer
+        // submit button is also `rounded-full` so we can't just count
+        // `button.rounded-full` anymore.
+        const filterChipKeys = [
+            'all',
+            'pending',
+            'queued',
+            'building',
+            'failed',
+            'accepted',
+            'dismissed',
+            'done',
+        ];
+        for (const key of filterChipKeys) {
+            expect(screen.getByText(`filters.${key}`)).toBeTruthy();
+        }
         // 'all' badge shows total count (5), pending shows (2).
         expect(screen.getByText('filters.all').parentElement?.textContent).toMatch(/5/);
         expect(screen.getByText('filters.pending').parentElement?.textContent).toMatch(/2/);
@@ -130,11 +144,16 @@ describe('IdeasPageClient (Phase 5 PR N)', () => {
         expect(screen.queryByText('Idea p1')).toBeNull();
     });
 
-    it('quick-add disabled until description >= 10 chars', () => {
-        render(<IdeasPageClient initialIdeas={[]} />);
-        const addBtn = screen.getByText('quickAdd.submit').closest('button')!;
+    it('quick-add submit disabled until description >= 10 chars', () => {
+        const { container } = render(<IdeasPageClient initialIdeas={[]} />);
+        const textarea = container.querySelector(
+            'textarea[data-testid="ideas-quick-add"]',
+        ) as HTMLTextAreaElement;
+        const addBtn = container.querySelector(
+            'button[data-testid="ideas-quick-add-submit"]',
+        ) as HTMLButtonElement;
+        expect(addBtn).toBeTruthy();
         expect(addBtn.disabled).toBe(true);
-        const textarea = screen.getByPlaceholderText('quickAdd.placeholder');
         fireEvent.change(textarea, { target: { value: 'too short' } });
         expect(addBtn.disabled).toBe(true);
         fireEvent.change(textarea, { target: { value: 'A long enough idea description' } });
@@ -145,12 +164,19 @@ describe('IdeasPageClient (Phase 5 PR N)', () => {
         createIdeaMock.mockClear();
         const newIdea = mkIdea({ id: 'new-1', status: 'pending' });
         createIdeaMock.mockResolvedValueOnce(newIdea);
-        render(<IdeasPageClient initialIdeas={[mkIdea({ id: 'old', status: 'pending' })]} />);
-        const textarea = screen.getByPlaceholderText('quickAdd.placeholder');
+        const { container } = render(
+            <IdeasPageClient initialIdeas={[mkIdea({ id: 'old', status: 'pending' })]} />,
+        );
+        const textarea = container.querySelector(
+            'textarea[data-testid="ideas-quick-add"]',
+        ) as HTMLTextAreaElement;
         fireEvent.change(textarea, {
             target: { value: 'My freshly typed Idea, longer than ten chars' },
         });
-        fireEvent.click(screen.getByText('quickAdd.submit'));
+        const addBtn = container.querySelector(
+            'button[data-testid="ideas-quick-add-submit"]',
+        ) as HTMLButtonElement;
+        fireEvent.click(addBtn);
         expect(createIdeaMock).toHaveBeenCalledWith({
             description: 'My freshly typed Idea, longer than ten chars',
         });

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -1,47 +1,111 @@
 'use client';
 
+import { useState, useTransition } from 'react';
 import { Target } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import { Link } from '@/i18n/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { PromptComposer } from '@/components/common/PromptComposer';
+import { createMissionAction } from '@/app/actions/dashboard/missions';
 import { MissionCard } from './MissionCard';
 import type { Mission } from '@/lib/api/missions';
 
 /**
- * Phase 6 PR Q — Missions catalog list client.
+ * Phase 6 PR Q + UI polish — Missions catalog list client.
  *
- * Spec: simple grid of MissionCards with creation routed through
- * the unified `/new?type=mission` flow. `/missions` deliberately
- * does NOT host its own quick-add form; empty accounts get one
- * focused CTA in the empty state instead of a duplicated header
- * and empty-state action.
+ * Spec: simple grid of MissionCards with a quick-add composer at
+ * the top so the user can describe a new Mission inline (mirrors
+ * `/ideas`, see [IdeasPageClient.tsx]). The composer matches the
+ * marketing site's landing prompt (typewriter placeholder, arrow
+ * submit inside the input) so first-time and returning users see
+ * the same shape.
+ *
+ * The sidebar's "+ New" still routes to `/new?type=mission` for
+ * the chip-aware unified entry point — this page hosts the
+ * Mission-only composer.
  */
+
+const MISSION_PLACEHOLDERS: ReadonlyArray<string> = [
+    'e.g. "Curate the best AI coding assistants and refresh the list weekly"',
+    'e.g. "Maintain a directory of remote-friendly climate-tech companies"',
+    'e.g. "Track new MCP servers shipped each week and tag the standout ones"',
+    'e.g. "Publish a fresh investor-targeted comparison of OSS observability tools every month"',
+    'e.g. "Keep an awesome-list of TypeScript ESLint rules in sync with the latest releases"',
+    'e.g. "Spin up a niche directory of Tailwind component libraries and refresh metadata"',
+];
+
 export function MissionsList({ missions }: { missions: Mission[] }) {
     const t = useTranslations('dashboard.missionsPage');
-    const newMissionLabel = t('newMission').replace(/^\+\s*/, '');
+    const router = useRouter();
+    const [draft, setDraft] = useState('');
+    const [submitting, startSubmit] = useTransition();
+
+    const submit = () => {
+        const description = draft.trim();
+        if (description.length < 10) {
+            toast.error(t('quickAdd.minLength'));
+            return;
+        }
+        startSubmit(async () => {
+            try {
+                const mission = await createMissionAction({
+                    description,
+                    type: 'one-shot',
+                });
+                toast.success(t('quickAdd.created'));
+                setDraft('');
+                // Route into the new Mission's detail page — this is
+                // the same destination `/new?type=mission` lands on,
+                // so the user gets the next-step affordances (tune
+                // cadence, cap, auto-build) immediately.
+                router.push(ROUTES.DASHBOARD_MISSION(mission.id));
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : t('quickAdd.error'));
+            }
+        });
+    };
 
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
             {/* Header */}
-            <div className="flex items-start justify-between gap-3 mb-6">
-                <div className="flex items-start gap-3">
-                    <div className="shrink-0 w-9 h-9 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
-                        <Target className="w-4 h-4 text-warning" />
-                    </div>
-                    <div>
-                        <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
-                            {t('title')}
-                        </h1>
-                        <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1 max-w-2xl">
-                            {t('subtitle')}
-                        </p>
-                    </div>
+            <div className="flex items-start gap-3 mb-6">
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
+                    <Target className="w-4 h-4 text-warning" />
                 </div>
-                {missions.length > 0 && (
-                    <Button asChild size="sm" className="gap-1.5 shrink-0">
-                        <Link href={`/new?type=mission`}>{newMissionLabel}</Link>
-                    </Button>
-                )}
+                <div className="min-w-0 flex-1">
+                    <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
+                        {t('title')}
+                    </h1>
+                    <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1">
+                        {t('subtitle')}
+                    </p>
+                </div>
+            </div>
+
+            {/* Quick-add composer — modeled on the marketing site's
+                landing prompt. Used by both empty and populated
+                states so the entry point doesn't move around as the
+                user's catalog grows. */}
+            <div className="mb-6">
+                <label
+                    htmlFor="missions-quick-add"
+                    className="block text-xs font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark mb-2"
+                >
+                    {t('quickAdd.label')}
+                </label>
+                <PromptComposer
+                    inputId="missions-quick-add"
+                    value={draft}
+                    onChange={setDraft}
+                    onSubmit={submit}
+                    submitting={submitting}
+                    placeholderExamples={MISSION_PLACEHOLDERS}
+                    ariaLabel={t('quickAdd.label')}
+                    submitTitle={t('quickAdd.submitTitle')}
+                    testId="missions-quick-add"
+                />
             </div>
 
             {/* List */}
@@ -56,8 +120,10 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
                     <p className="mx-auto mt-1 max-w-2xl text-xs text-text-muted dark:text-text-muted-dark">
                         {t('empty.subtitle')}
                     </p>
-                    <Button asChild size="sm" className="mt-4 gap-1.5">
-                        <Link href={`/new?type=mission`}>{newMissionLabel}</Link>
+                    {/* Secondary path: open the unified /new flow if the
+                        user wants the chip-aware composer instead. */}
+                    <Button asChild variant="ghost" size="sm" className="mt-4">
+                        <Link href={`/new?type=mission`}>{t('empty.openNew')}</Link>
                     </Button>
                 </div>
             ) : (

--- a/apps/web/src/components/missions/MissionsList.unit.spec.tsx
+++ b/apps/web/src/components/missions/MissionsList.unit.spec.tsx
@@ -17,7 +17,12 @@ vi.mock('@/i18n/navigation', () => ({
             {children}
         </a>
     ),
+    useRouter: () => ({ push: vi.fn() }),
 }));
+vi.mock('@/app/actions/dashboard/missions', () => ({
+    createMissionAction: vi.fn(),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 import { MissionsList } from './MissionsList';
 import type { Mission } from '@/lib/api/missions';
@@ -42,31 +47,32 @@ function mkMission(id: string, overrides: Partial<Mission> = {}): Mission {
     };
 }
 
-describe('MissionsList (Phase 6 PR Q)', () => {
+describe('MissionsList (Phase 6 PR Q + quick-add)', () => {
     it('renders header title + subtitle', () => {
         render(<MissionsList missions={[]} />);
         expect(screen.getByText('title')).toBeTruthy();
         expect(screen.getByText('subtitle')).toBeTruthy();
     });
 
-    it('renders the top-right "+ New Mission" button linking to /new?type=mission', () => {
+    it('renders the inline quick-add composer on the /missions page', () => {
         const { container } = render(<MissionsList missions={[]} />);
-        const newMissionLinks = Array.from(container.querySelectorAll('a[href]')).filter((a) =>
-            (a as HTMLAnchorElement).textContent?.includes('newMission'),
-        );
-        expect(newMissionLinks.length).toBeGreaterThan(0);
-        // All "+ New Mission" links point at /new?type=mission so Phase
-        // 6.5 PR CC2's `/new` page can read the type query param to
-        // pre-fill the chip selection.
-        for (const a of newMissionLinks) {
-            expect((a as HTMLAnchorElement).getAttribute('href')).toBe('/new?type=mission');
-        }
+        const textarea = container.querySelector('textarea');
+        expect(textarea).not.toBeNull();
+        // Label points at the quick-add input.
+        const label = container.querySelector('label[for="missions-quick-add"]');
+        expect(label).not.toBeNull();
     });
 
-    it('renders the empty-state surface when no Missions exist', () => {
-        render(<MissionsList missions={[]} />);
+    it('renders the empty-state surface when no Missions exist with a /new?type=mission escape hatch', () => {
+        const { container } = render(<MissionsList missions={[]} />);
         expect(screen.getByText('empty.title')).toBeTruthy();
         expect(screen.getByText('empty.subtitle')).toBeTruthy();
+        // The empty state still keeps a secondary link to /new for the
+        // chip-aware flow (sidebar's "+ New" target).
+        const openNewLinks = Array.from(container.querySelectorAll('a[href]')).filter(
+            (a) => (a as HTMLAnchorElement).getAttribute('href') === '/new?type=mission',
+        );
+        expect(openNewLinks.length).toBeGreaterThan(0);
     });
 
     it('renders one MissionCard per Mission and no empty-state when missions present', () => {
@@ -78,11 +84,9 @@ describe('MissionsList (Phase 6 PR Q)', () => {
         expect(screen.queryByText('empty.title')).toBeNull();
     });
 
-    it('NO large quick-add form is rendered (Phase 6.5 PR CC2 owns /new)', () => {
-        const { container } = render(<MissionsList missions={[]} />);
-        // Quick-add would be a textarea — the catalog page must not
-        // ship one per spec §5.5 PR Q. The /missions page is browse-
-        // and-detail; creation goes through /new.
-        expect(container.querySelector('textarea')).toBeNull();
+    it('keeps the quick-add composer visible after Missions exist (single entry point)', () => {
+        const missions = ['a'].map((id) => mkMission(id));
+        const { container } = render(<MissionsList missions={missions} />);
+        expect(container.querySelector('textarea')).not.toBeNull();
     });
 });

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import {
-    ArrowRight,
     BookOpen,
     Files,
     FolderInput,
@@ -16,7 +15,7 @@ import type { LucideIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { PromptComposer } from '@/components/common/PromptComposer';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
@@ -24,32 +23,19 @@ import { createMissionAction } from '@/app/actions/dashboard/missions';
 import { createIdeaAction } from '@/app/actions/dashboard/work-proposals';
 
 /**
- * Phase 6.5 PR CC2 — unified `/new` page.
+ * Phase 6.5 PR CC2 + UI polish — unified `/new` page.
  *
- * Single creation entry point spec §8b carves out. The chip strip
- * pre-narrows the kind of thing the user is creating; the prompt
- * Textarea collects their description; the reused
- * CreationBlockTrio (PR CC1) gives a fallback path for users who
- * want the per-mode flows directly.
+ * Single creation entry point per spec §8b. Composer matches the
+ * marketing site's landing prompt — a rounded card on the page's
+ * dark background with chips below the input and an arrow submit
+ * inside the composer. The previous "Create" button + chip hint
+ * are gone: a chip is always preselected (Mission for new users,
+ * Idea for users with existing Missions), so the "Pick a chip to
+ * enable Create" hint never served a purpose.
  *
- * Chip order is fixed per spec: Mission, Idea, Website, Landing
- * Page, Blog, Directory, Awesome Repo. The `type` query param
- * pre-selects a chip (e.g. `/new?type=mission` from the PR Q
- * "+ New Mission" button); default = no selection so the user
- * sees the full menu.
- *
- * Submit behavior (v1):
- *   - Mission → POST /me/missions (one-shot) + navigate to detail
- *   - Idea → POST /me/work-proposals + navigate to /ideas
- *   - Website/Landing Page/Blog/Directory/Awesome Repo → route to
- *     /works/new (the existing flow) with the prompt carried via
- *     a query param so the AI Creator pre-fills it
- *
- * AI Chat sidebar hide-until-submit: the layout-level chat panel
- * is OUT OF SCOPE for v1 — wiring "hide on /new" needs the
- * layout-client refactor a follow-up tick will pick up. For now
- * the page renders the form full-width; the chat panel still
- * appears in the right rail per the user's preference.
+ * Selecting a chip swaps the typewriter placeholder list AND
+ * surfaces a one-line description of what that kind is, so the
+ * user gets the same affordance the marketing site shows.
  */
 export type ChipType =
     | 'mission'
@@ -80,52 +66,84 @@ const CHIP_ICONS: Record<ChipType, LucideIcon> = {
     'awesome-repo': Star,
 };
 
+const PLACEHOLDERS_BY_CHIP: Record<ChipType, ReadonlyArray<string>> = {
+    mission: [
+        'e.g. "Curate the best AI coding assistants and refresh the list weekly"',
+        'e.g. "Maintain a directory of remote-friendly climate-tech companies"',
+        'e.g. "Track new MCP servers shipped each week and tag the standout ones"',
+        'e.g. "Publish a fresh investor-targeted comparison of OSS observability tools monthly"',
+        'e.g. "Keep an awesome-list of TypeScript ESLint rules in sync with the latest releases"',
+    ],
+    idea: [
+        'e.g. "A curated list of the best AI coding agents released this year"',
+        'e.g. "Awesome list: best React state-management libraries with benchmarks"',
+        'e.g. "Directory of MCP servers — capabilities, language, install command, source repo"',
+        'e.g. "Knowledge base for our open-source SDK with search and versioning"',
+        'e.g. "Blog about indie game development with categories for postmortems and tooling"',
+    ],
+    website: [
+        'e.g. "Modern website for a boutique design studio with case studies and a contact form"',
+        'e.g. "Marketing site for a B2B SaaS with pricing, integrations, and a documentation hub"',
+        'e.g. "Portfolio for a freelance photographer with galleries by genre and testimonials"',
+        'e.g. "Five-page site for my dentist practice with services, team, and online booking"',
+        'e.g. "Non-profit site with donation flow, programs, impact stats, and volunteer signup"',
+    ],
+    'landing-page': [
+        'e.g. "Waitlist landing page for an AI customer-support copilot with a hero demo and FAQ"',
+        'e.g. "Product launch page for noise-cancelling earbuds with specs, video, and pre-order CTA"',
+        'e.g. "Lead-magnet landing page for a free SaaS pricing benchmark report"',
+        'e.g. "Webinar registration page with speaker bios, agenda, and a countdown timer"',
+        'e.g. "Comparison landing page: us vs. <competitor> with feature matrix and migration guide"',
+    ],
+    blog: [
+        'e.g. "Personal blog about indie game development with postmortems and tooling tags"',
+        'e.g. "Engineering blog with RSS, code-highlighting, author pages, and OG previews"',
+        'e.g. "AI research summaries blog — daily 200-word paper rundowns with citations"',
+        'e.g. "Founder journal — weekly progress logs tagged for revenue, hiring, product"',
+        'e.g. "Recipe blog with structured data, ingredient scaler, and category filters"',
+    ],
+    directory: [
+        'e.g. "Directory of AI coding assistants with reviews, pricing tiers, and editor compatibility"',
+        'e.g. "Directory of agent skills for Claude Code — categories, install instructions, demos"',
+        'e.g. "Directory of remote-first companies with timezone overlap, perks, and stack tags"',
+        'e.g. "Directory of climate-tech startups by sub-sector with funding stage and team size"',
+        'e.g. "Directory of MCP servers — capabilities, language, install command, source repo"',
+    ],
+    'awesome-repo': [
+        'e.g. "Awesome list of React state-management libraries with benchmarks and trade-offs"',
+        'e.g. "Awesome list of TypeScript ESLint rules with examples and when-to-disable guidance"',
+        'e.g. "Awesome list of self-hostable open-source SaaS alternatives — categorized + docker-ready"',
+        'e.g. "Awesome list of agent frameworks (LangChain, AutoGen, CrewAI…) with pros/cons"',
+        'e.g. "Awesome list of free design resources for indie founders — icons, illustrations, fonts"',
+    ],
+};
+
 export interface NewPageClientProps {
     initialType?: ChipType | null;
-    /**
-     * Phase 8 PR Y — when the user lands here from a Mission
-     * Template's "Use this Template" button, the server page
-     * resolves the template + passes its name+description as
-     * the initial prompt. NewPageClient just renders it.
-     */
     initialPrompt?: string;
-    /**
-     * Phase 8 PR Y — id of the source template, forwarded to
-     * the Mission-create submit so the spawned Mission can be
-     * tagged with `missionTemplateRepo` for the back-link.
-     * Wired through `createMissionAction` when present.
-     */
     initialTemplateId?: string;
 }
 
 export function NewPageClient({
-    initialType = null,
+    initialType = 'mission',
     initialPrompt,
     initialTemplateId,
 }: NewPageClientProps) {
     const t = useTranslations('dashboard.newPage');
     const router = useRouter();
     const [prompt, setPrompt] = useState(initialPrompt ?? '');
-    const [selectedChip, setSelectedChip] = useState<ChipType | null>(initialType);
+    const [selectedChip, setSelectedChip] = useState<ChipType>(initialType ?? 'mission');
     const [submitting, startSubmit] = useTransition();
 
-    const canSubmit = selectedChip !== null && prompt.trim().length >= 10;
-
     const submit = () => {
-        if (!canSubmit || !selectedChip) return;
         const description = prompt.trim();
+        if (description.length < 10) {
+            toast.error(t('hints.minLength'));
+            return;
+        }
         startSubmit(async () => {
             try {
                 if (selectedChip === 'mission') {
-                    // Mission is a one-shot in v1; the user can flip
-                    // it to scheduled on the detail page (PR R).
-                    // Phase 8 PR Y — when the user landed via a
-                    // Mission Template's "Use this Template" button,
-                    // forward the template id as `missionTemplateRepo`
-                    // so the new Mission carries the back-link. The
-                    // field accepts a string identifier — PR JJ's
-                    // manifest service will resolve it to the actual
-                    // repo coords at scaffold time.
                     const mission = await createMissionAction({
                         description,
                         type: 'one-shot',
@@ -142,11 +160,7 @@ export function NewPageClient({
                     return;
                 }
                 // The remaining 5 chip types route into the existing
-                // /works/new flow; the `kind` query param hints
-                // the AI Creator at which Work shape to bias toward.
-                // The legacy page ignores unknown query params today,
-                // so this is forward-compatible — the wiring lands
-                // when the AI Creator reads `kind` (follow-up tick).
+                // /works/new flow.
                 const params = new URLSearchParams({
                     mode: 'ai',
                     kind: selectedChip,
@@ -159,6 +173,13 @@ export function NewPageClient({
         });
     };
 
+    // Per-chip placeholder cycle. New reference on each chip flip
+    // resets the typewriter inside PromptComposer.
+    const placeholderExamples = useMemo(
+        () => PLACEHOLDERS_BY_CHIP[selectedChip] ?? PLACEHOLDERS_BY_CHIP.mission,
+        [selectedChip],
+    );
+
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-6">
             <div>
@@ -168,73 +189,50 @@ export function NewPageClient({
                 </p>
             </div>
 
-            {/* Prompt + chip strip card */}
-            <div className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
-                <label
-                    htmlFor="new-prompt"
-                    className="text-xs uppercase tracking-wide text-text-muted dark:text-text-muted-dark"
-                >
-                    {t('promptLabel')}
-                </label>
-                <Textarea
-                    id="new-prompt"
-                    value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
-                    rows={5}
-                    placeholder={t('promptPlaceholder')}
-                    className="mt-2 text-base"
-                />
-                <div className="mt-3">
-                    <div className="text-xs uppercase tracking-wide text-text-muted dark:text-text-muted-dark mb-2">
-                        {t('chipLabel')}
+            {/* Composer with chips below — sits directly on the page's
+                dark background, no nested card wrapper. */}
+            <PromptComposer
+                inputId="new-prompt"
+                value={prompt}
+                onChange={setPrompt}
+                onSubmit={submit}
+                submitting={submitting}
+                placeholderExamples={placeholderExamples}
+                rows={5}
+                ariaLabel={t('promptLabel')}
+                submitTitle={t('submitTitle')}
+                testId="new-prompt"
+                belowInput={
+                    <div className="space-y-2">
+                        <div className="flex flex-wrap gap-2">
+                            {CHIP_ORDER.map((c) => {
+                                const Icon = CHIP_ICONS[c];
+                                const active = selectedChip === c;
+                                return (
+                                    <button
+                                        key={c}
+                                        type="button"
+                                        onClick={() => setSelectedChip(c)}
+                                        className={cn(
+                                            'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                            active
+                                                ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
+                                                : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
+                                        )}
+                                        aria-pressed={active}
+                                    >
+                                        <Icon className="w-3.5 h-3.5" />
+                                        {t(`chips.${c}`)}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t(`chipDescriptions.${selectedChip}`)}
+                        </p>
                     </div>
-                    <div className="flex flex-wrap gap-2">
-                        {CHIP_ORDER.map((c) => {
-                            const Icon = CHIP_ICONS[c];
-                            const active = selectedChip === c;
-                            return (
-                                <button
-                                    key={c}
-                                    type="button"
-                                    onClick={() => setSelectedChip(c)}
-                                    className={cn(
-                                        'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors',
-                                        active
-                                            ? 'bg-primary text-white border-primary'
-                                            : 'bg-card dark:bg-card-primary-dark border-border dark:border-border-dark text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
-                                    )}
-                                    aria-pressed={active}
-                                >
-                                    <Icon className="w-3.5 h-3.5" />
-                                    {t(`chips.${c}`)}
-                                </button>
-                            );
-                        })}
-                    </div>
-                </div>
-                <div className="mt-4 flex items-center justify-end gap-2">
-                    <Button
-                        type="button"
-                        size="sm"
-                        className="gap-1.5"
-                        onClick={submit}
-                        disabled={!canSubmit || submitting}
-                    >
-                        {t('submit')}
-                        <ArrowRight className="w-3.5 h-3.5" />
-                    </Button>
-                </div>
-                {selectedChip === null && (
-                    <p className="mt-2 text-xs text-text-muted dark:text-text-muted-dark">
-                        {t('hints.pickChip')}
-                    </p>
-                )}
-                {selectedChip !== null && prompt.trim().length < 10 && (
-                    <p className="mt-2 text-xs text-text-muted dark:text-text-muted-dark">
-                        {t('hints.minLength')}
-                    </p>
-                )}
-            </div>
+                }
+            />
 
             <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 dark:border-border-dark/60 bg-surface/60 dark:bg-surface-dark/60 px-4 py-3">
                 <p className="text-sm text-text-secondary dark:text-text-secondary-dark">

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -38,14 +38,24 @@ vi.mock('@/app/actions/dashboard/work-proposals', () => ({
 
 import { NewPageClient } from './NewPageClient';
 
-describe('NewPageClient (Phase 6.5 PR CC2)', () => {
+function getTextarea(container: HTMLElement): HTMLTextAreaElement {
+    const el = container.querySelector('textarea[data-testid="new-prompt"]');
+    if (!el) throw new Error('prompt textarea not found');
+    return el as HTMLTextAreaElement;
+}
+
+function getSubmit(container: HTMLElement): HTMLButtonElement {
+    const el = container.querySelector('button[data-testid="new-prompt-submit"]');
+    if (!el) throw new Error('submit button not found');
+    return el as HTMLButtonElement;
+}
+
+describe('NewPageClient (Phase 6.5 PR CC2 + UI polish)', () => {
     it('renders all 7 chips in the spec order: Mission, Idea, Website, Landing Page, Blog, Directory, Awesome Repo', () => {
         const { container } = render(<NewPageClient />);
         const chipButtons = Array.from(
             container.querySelectorAll('button[aria-pressed]'),
         ) as HTMLButtonElement[];
-        // 7 chips with aria-pressed (the chip strip uses aria-pressed
-        // for active state; CTA + trio buttons don't).
         expect(chipButtons).toHaveLength(7);
         const labels = chipButtons.map((b) => b.textContent?.trim());
         expect(labels).toEqual([
@@ -67,33 +77,41 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
         expect(mission.getAttribute('aria-pressed')).toBe('true');
     });
 
-    it('Submit button is disabled until BOTH a chip is selected AND the prompt is >= 10 chars', () => {
-        render(<NewPageClient />);
-        const submit = screen.getByText('dashboard.newPage.submit').closest('button')!;
+    it('defaults to Mission when no initialType is supplied', () => {
+        const { container } = render(<NewPageClient />);
+        const mission = Array.from(container.querySelectorAll('button[aria-pressed]')).find((b) =>
+            b.textContent?.includes('mission'),
+        ) as HTMLButtonElement;
+        expect(mission.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('Submit (arrow) is disabled until the prompt is >= 10 chars', () => {
+        const { container } = render(<NewPageClient initialType="idea" />);
+        const submit = getSubmit(container);
         expect(submit.disabled).toBe(true);
-        // Pick a chip — still disabled because prompt is empty.
-        fireEvent.click(screen.getByText('dashboard.newPage.chips.idea'));
-        expect(submit.disabled).toBe(true);
-        // Type something short — still disabled.
-        const textarea = screen.getByPlaceholderText('dashboard.newPage.promptPlaceholder');
+        const textarea = getTextarea(container);
         fireEvent.change(textarea, { target: { value: 'short' } });
         expect(submit.disabled).toBe(true);
-        // Type something long enough — enabled.
         fireEvent.change(textarea, {
             target: { value: 'A long enough idea description here' },
         });
         expect(submit.disabled).toBe(false);
     });
 
+    it('shows a one-line description for the currently selected chip', () => {
+        render(<NewPageClient initialType="mission" />);
+        expect(screen.getByText('dashboard.newPage.chipDescriptions.mission')).toBeTruthy();
+    });
+
     it('Submit with chip=mission calls createMissionAction and routes to the new Mission detail page', async () => {
         createMissionMock.mockClear();
         routerPushMock.mockClear();
         createMissionMock.mockResolvedValueOnce({ id: 'm-new', title: 'x' });
-        render(<NewPageClient initialType="mission" />);
-        fireEvent.change(screen.getByPlaceholderText('dashboard.newPage.promptPlaceholder'), {
+        const { container } = render(<NewPageClient initialType="mission" />);
+        fireEvent.change(getTextarea(container), {
             target: { value: 'Build the best cat business' },
         });
-        fireEvent.click(screen.getByText('dashboard.newPage.submit'));
+        fireEvent.click(getSubmit(container));
         await Promise.resolve();
         await Promise.resolve();
         expect(createMissionMock).toHaveBeenCalledWith({
@@ -107,11 +125,11 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
         createIdeaMock.mockClear();
         routerPushMock.mockClear();
         createIdeaMock.mockResolvedValueOnce({ id: 'i-new' });
-        render(<NewPageClient initialType="idea" />);
-        fireEvent.change(screen.getByPlaceholderText('dashboard.newPage.promptPlaceholder'), {
+        const { container } = render(<NewPageClient initialType="idea" />);
+        fireEvent.change(getTextarea(container), {
             target: { value: 'A curated list of AI coding agents' },
         });
-        fireEvent.click(screen.getByText('dashboard.newPage.submit'));
+        fireEvent.click(getSubmit(container));
         await Promise.resolve();
         await Promise.resolve();
         expect(createIdeaMock).toHaveBeenCalledWith({
@@ -122,50 +140,44 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
 
     it('Submit with chip=website routes to the Work wizard with mode + kind + prompt query params', () => {
         routerPushMock.mockClear();
-        render(<NewPageClient initialType="website" />);
-        fireEvent.change(screen.getByPlaceholderText('dashboard.newPage.promptPlaceholder'), {
+        const { container } = render(<NewPageClient initialType="website" />);
+        fireEvent.change(getTextarea(container), {
             target: { value: 'Landing page for my SaaS launch' },
         });
-        fireEvent.click(screen.getByText('dashboard.newPage.submit'));
+        fireEvent.click(getSubmit(container));
         expect(routerPushMock).toHaveBeenCalledTimes(1);
         const href = routerPushMock.mock.calls[0][0] as string;
         expect(href.startsWith('/works/new?')).toBe(true);
         expect(href).toContain('mode=ai');
         expect(href).toContain('kind=website');
-        // URLSearchParams encodes spaces as `+`, not `%20`.
         expect(href).toContain('prompt=Landing+page+for+my+SaaS+launch');
     });
 
     describe('Phase 8 PR Y — template prefill', () => {
         it('renders initialPrompt verbatim in the prompt textarea', () => {
-            // Real newlines (template string) so we test the realistic
-            // prefill the server page builds via `${name}\n\n${desc}`.
             const prefill = `Starter Business\n\nA blank-slate Mission for cats.`;
-            render(<NewPageClient initialType="mission" initialPrompt={prefill} />);
-            const textarea = screen.getByPlaceholderText(
-                'dashboard.newPage.promptPlaceholder',
-            ) as HTMLTextAreaElement;
+            const { container } = render(
+                <NewPageClient initialType="mission" initialPrompt={prefill} />,
+            );
+            const textarea = getTextarea(container);
             expect(textarea.value).toBe(prefill);
         });
 
         it('Submit forwards initialTemplateId as missionTemplateRepo for mission chip', async () => {
             createMissionMock.mockClear();
             createMissionMock.mockResolvedValueOnce({ id: 'm-new', title: 'x' });
-            render(
+            const { container } = render(
                 <NewPageClient
                     initialType="mission"
                     initialPrompt="Starter Business"
                     initialTemplateId="starter-business"
                 />,
             );
-            // Stretch the prompt past the 10-char minimum so Submit enables.
-            const textarea = screen.getByPlaceholderText(
-                'dashboard.newPage.promptPlaceholder',
-            ) as HTMLTextAreaElement;
+            const textarea = getTextarea(container);
             fireEvent.change(textarea, {
                 target: { value: 'Starter Business — long enough to enable Submit' },
             });
-            fireEvent.click(screen.getByText('dashboard.newPage.submit'));
+            fireEvent.click(getSubmit(container));
             await Promise.resolve();
             await Promise.resolve();
             expect(createMissionMock).toHaveBeenCalledWith(
@@ -180,11 +192,11 @@ describe('NewPageClient (Phase 6.5 PR CC2)', () => {
         it('Submit does NOT include missionTemplateRepo when no initialTemplateId', async () => {
             createMissionMock.mockClear();
             createMissionMock.mockResolvedValueOnce({ id: 'm-direct', title: 'x' });
-            render(<NewPageClient initialType="mission" />);
-            fireEvent.change(screen.getByPlaceholderText('dashboard.newPage.promptPlaceholder'), {
+            const { container } = render(<NewPageClient initialType="mission" />);
+            fireEvent.change(getTextarea(container), {
                 target: { value: 'No template, just a typed mission goal' },
             });
-            fireEvent.click(screen.getByText('dashboard.newPage.submit'));
+            fireEvent.click(getSubmit(container));
             await Promise.resolve();
             await Promise.resolve();
             const call = createMissionMock.mock.calls[0][0];

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -880,7 +880,7 @@ export function TemplatesCatalog({
     return (
         <div className="w-full">
             <div className="mb-8 flex flex-col gap-4 @lg/main:flex-row @lg/main:items-start @lg/main:justify-between">
-                <div>
+                <div className="min-w-0">
                     <h1 className="text-3xl font-bold text-text dark:text-text-dark">
                         {t('title')}
                     </h1>
@@ -895,23 +895,19 @@ export function TemplatesCatalog({
                     <KindSwitcher current={kind} />
                 </div>
 
-                <div className="flex flex-wrap items-center gap-2">
-                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-primary/10 text-primary border border-primary/20 max-w-[220px]">
+                {/* UI polish — Built-in / Custom counts are already
+                    rendered in the filter row below (with the same
+                    counts wired to the active filter), so we don't
+                    double-print them here. Only the Active-default
+                    chip remains in this header — it carries unique
+                    information (which template new Works start from)
+                    and the long template name fits comfortably on one
+                    line. */}
+                <div className="flex flex-wrap items-center gap-2 shrink-0">
+                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-primary/10 text-primary border border-primary/20 max-w-[260px]">
                         <Star className="w-3 h-3 fill-current shrink-0" />
                         <span className="truncate">
                             {activeDefaultTemplate?.name || t('stats.none')}
-                        </span>
-                    </span>
-                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs bg-surface dark:bg-white/5 text-text-secondary dark:text-text-secondary-dark border border-border dark:border-border-dark">
-                        {t('stats.builtInLabel')}
-                        <span className="font-semibold text-text dark:text-text-dark">
-                            {builtInCount}
-                        </span>
-                    </span>
-                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs bg-surface dark:bg-white/5 text-text-secondary dark:text-text-secondary-dark border border-border dark:border-border-dark">
-                        {t('stats.customLabel')}
-                        <span className="font-semibold text-text dark:text-text-dark">
-                            {customCount}
                         </span>
                     </span>
                 </div>


### PR DESCRIPTION
## Summary

Bundle of small UI polish fixes that landed together because they share a primitive — a shared `PromptComposer` modeled on the marketing site's landing prompt (typewriter placeholders, arrow submit inside the input). Used across the three creation surfaces so they read like the same product.

### `/missions` — duplicate "+" + inline composer
- The deployed page rendered **two** `+` signs (a `Plus` icon AND a translation string `"+ New Mission"`).
- Replaced the top-right button with an inline composer at the top of the page, matching `/ideas`.
- Empty-state surface keeps a secondary link to `/new?type=mission` so the sidebar's "+ New" still works.

### `/ideas` — composer + header alignment
- Swapped the boxy textarea + "Add" button for the shared composer.
- Header subtitle no longer fights with the settings icon: `flex-1` on the title block + `ml-auto` on the gears button floats it hard right and lets the subtitle use the full row width (issue #4).

### `/new` — match website design
- Composer sits on the page's **natural dark surface** (no nested `bg-card` wrapper — issue #3).
- Chips render below the input; each chip flip surfaces a one-line description of what that kind is (like the marketing site).
- **Mission** is the default chip when the user has no Missions yet; **Idea** is the default once any Mission exists.
- Removed the "Pick a chip to enable Create" hint and the visible Create button — the arrow inside the composer carries submit.

### `/templates` — header badges + kind switch
- Header no longer prints the Built-in/Custom badges. They were duplicated by the filter chips below (same counts) and prone to wrap onto two rows (issue #5).
- `key={kind}` on `TemplatesCatalog` forces a fresh mount when the Mission/Work/Website pill flips, so the client-side `templates` state actually re-initializes from the new server-fetched list (previously the catalog kept showing the old kind's templates after navigation).

## Files

- **New**: `apps/web/src/components/common/PromptComposer.tsx`
- **Edited**: `MissionsList.tsx`, `IdeasPageClient.tsx`, `NewPageClient.tsx`, `TemplatesCatalog.tsx`, `new/page.tsx`, `templates/page.tsx`, `en.json`
- **Test updates**: visible button labels are gone (the arrow icon carries submit), so tests now query the textarea + submit via `data-testid`.

## Test plan

- [x] `pnpm --filter ever-works-web test` — 569/569 passing.
- [x] `npx tsc --noEmit` clean across `apps/web` after `pnpm build:plugins`.
- [ ] Smoke check on `app.ever.works` preview:
  - [ ] `/missions` shows the composer; no double `+`.
  - [ ] `/ideas` settings icon is right-aligned, subtitle uses full row.
  - [ ] `/new` lands with Mission preselected (or Idea if the tenant already has missions); chip swap updates the description below.
  - [ ] `/templates` Mission/Work/Website pill actually swaps the catalog list now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick-add mission composer added to the Missions page
  * Animated typewriter-style placeholders for prompt inputs across creation flows

* **Improvements**
  * Updated UI copy across Missions, Ideas, and New Work flows for clearer guidance
  * Templates catalog reliably refreshes when switching template kinds

* **Tests**
  * Updated unit tests to align with revised UI and quick-add behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->