### PR TITLE
perf: serve Work Overview & Generator from DB cache; defer Items + Comparisons to client

### DIFF
--- a/apps/api/src/migrations/1779990000000-AddWorkDataConfigCacheColumns.ts
+++ b/apps/api/src/migrations/1779990000000-AddWorkDataConfigCacheColumns.ts
@@ -1,0 +1,111 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds five denormalised cache columns to `works` so the Work Overview
+ * tab (and any other dashboard surface that needs counts/config) can
+ * render straight from Postgres without cloning the Work's data
+ * repository on every request.
+ *
+ * Background: prior to this migration, every `/works/[id]` page load
+ * called `DataGeneratorService.getConfig()` + `count()`, each of which
+ * invokes `gitFacade.cloneOrPull()` against the Work's data repo. A
+ * single Overview render therefore triggered 2–3 git clones (multi-MB,
+ * network-bound) — observed page loads were routinely 10–20 s.
+ *
+ * Source of truth is unchanged — `.works/works.yml` in the data repo
+ * is still authoritative. These columns are a read-side projection
+ * populated by:
+ *   1. The generator on every successful run
+ *      (`DataGeneratorService` final `updateWork` call), and
+ *   2. Lazy backfill in `WorkQueryService` — first time a Work is
+ *      read after this migration deploys, the service clones once,
+ *      populates the columns, and serves from DB on every subsequent
+ *      read.
+ *
+ * All columns are nullable so existing rows survive the deploy and
+ * lazy backfill can fill them in over time.
+ *
+ * Forward-only, additive. EW-Perf-Overview-DB.
+ */
+export class AddWorkDataConfigCacheColumns1779990000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const hasTable = await queryRunner.hasTable('works');
+        if (!hasTable) return;
+
+        if (!(await queryRunner.hasColumn('works', 'companyWebsite'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'companyWebsite',
+                    type: 'varchar',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasColumn('works', 'categoriesCount'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'categoriesCount',
+                    type: 'int',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasColumn('works', 'tagsCount'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'tagsCount',
+                    type: 'int',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasColumn('works', 'comparisonsCount'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'comparisonsCount',
+                    type: 'int',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasColumn('works', 'configCache'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'configCache',
+                    type: 'text',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const hasTable = await queryRunner.hasTable('works');
+        if (!hasTable) return;
+
+        if (await queryRunner.hasColumn('works', 'configCache')) {
+            await queryRunner.dropColumn('works', 'configCache');
+        }
+        if (await queryRunner.hasColumn('works', 'comparisonsCount')) {
+            await queryRunner.dropColumn('works', 'comparisonsCount');
+        }
+        if (await queryRunner.hasColumn('works', 'tagsCount')) {
+            await queryRunner.dropColumn('works', 'tagsCount');
+        }
+        if (await queryRunner.hasColumn('works', 'categoriesCount')) {
+            await queryRunner.dropColumn('works', 'categoriesCount');
+        }
+        if (await queryRunner.hasColumn('works', 'companyWebsite')) {
+            await queryRunner.dropColumn('works', 'companyWebsite');
+        }
+    }
+}

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1708,6 +1708,7 @@
                 "searchPlaceholder": "البحث عن عناصر...",
                 "allCategories": "جميع الفئات",
                 "showing": "عرض {current} من {total} عنصر",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "لا توجد عناصر تطابق معايير البحث الخاصة بك",
                 "source": "المصدر",
                 "viewOnWebsite": "عرض على الموقع",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1708,6 +1708,7 @@
                 "searchPlaceholder": "Търсене на елементи...",
                 "allCategories": "Всички категории",
                 "showing": "Показани са {current} от {total} елемента",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Няма елементи, които да съответстват на критериите за търсене",
                 "source": "Източник",
                 "viewOnWebsite": "Вижте на сайта",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1708,6 +1708,7 @@
                 "searchPlaceholder": "Einträge suchen…",
                 "allCategories": "Alle Kategorien",
                 "showing": "Zeige {current} von {total} Einträgen",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Keine Einträge entsprechen Ihren Suchkriterien",
                 "source": "Quelle",
                 "viewOnWebsite": "Auf Website ansehen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2047,6 +2047,7 @@
                 "searchPlaceholder": "Search items...",
                 "allCategories": "All Categories",
                 "showing": "Showing {current} of {total} items",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "No items match your search criteria",
                 "source": "Source",
                 "viewOnWebsite": "View on website",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1708,6 +1708,7 @@
                 "searchPlaceholder": "Buscar elementos...",
                 "allCategories": "Todas las categorías",
                 "showing": "Mostrando {current} de {total} elementos",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "No hay elementos que coincidan con tus criterios de búsqueda",
                 "source": "Fuente",
                 "viewOnWebsite": "Ver en el sitio web",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1708,6 +1708,7 @@
                 "searchPlaceholder": "Rechercher des éléments...",
                 "allCategories": "Toutes les catégories",
                 "showing": "Affichage de {current} sur {total} éléments",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Aucun élément ne correspond à vos critères de recherche",
                 "source": "Source",
                 "viewOnWebsite": "Voir sur le site web",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1708,6 +1708,7 @@
                 "searchPlaceholder": "חפש פריטים...",
                 "allCategories": "כל הקטגוריות",
                 "showing": "מציג {current} מתוך {total} פריטים",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "אין פריטים התואמים את קריטריוני החיפוש",
                 "source": "מקור",
                 "viewOnWebsite": "הצג באתר",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "आइटम खोजें...",
                 "allCategories": "सभी श्रेणियाँ",
                 "showing": "{total} में से {current} आइटम दिखा रहे हैं",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "आपके खोज मानदंड से मेल खाने वाले कोई आइटम नहीं",
                 "source": "स्रोत",
                 "viewOnWebsite": "वेबसाइट पर देखें",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Cari item...",
                 "allCategories": "Semua Kategori",
                 "showing": "Menampilkan {current} dari {total} item",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Tidak ada item yang cocok dengan kriteria pencarian Anda",
                 "source": "Sumber",
                 "viewOnWebsite": "Lihat di situs web",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Cerca elementi...",
                 "allCategories": "Tutte le Categorie",
                 "showing": "Visualizzazione di {current} su {total} elementi",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Nessun elemento corrisponde ai criteri di ricerca",
                 "source": "Sorgente",
                 "viewOnWebsite": "Visualizza sul sito web",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "項目を検索...",
                 "allCategories": "すべてのカテゴリ",
                 "showing": "{total} 項目中 {current} 項目を表示",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "検索条件に一致する項目がありません",
                 "source": "ソース",
                 "viewOnWebsite": "ウェブサイトで表示",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "항목 검색...",
                 "allCategories": "모든 카테고리",
                 "showing": "{total}개 항목 중 {current}개 표시 중",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "검색 조건에 맞는 항목이 없습니다",
                 "source": "소스",
                 "viewOnWebsite": "웹사이트에서 보기",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Zoek items…",
                 "allCategories": "Alle categorieën",
                 "showing": "Weergeven {current} van {total} items",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Geen items die overeenkomen met je zoekcriteria",
                 "source": "Bron",
                 "viewOnWebsite": "Bekijk op website",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Wyszukaj elementy...",
                 "allCategories": "Wszystkie kategorie",
                 "showing": "Wyświetlanie {current} z {total} elementów",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Brak elementów pasujących do kryteriów wyszukiwania",
                 "source": "Źródło",
                 "viewOnWebsite": "Zobacz na stronie",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Pesquisar itens...",
                 "allCategories": "Todas as Categorias",
                 "showing": "Mostrando {current} de {total} itens",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Nenhum item corresponde aos critérios de pesquisa",
                 "source": "Fonte",
                 "viewOnWebsite": "Ver no site",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Поиск элементов...",
                 "allCategories": "Все категории",
                 "showing": "Показаны {current} из {total} элементов",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Нет элементов, соответствующих критериям поиска",
                 "source": "Источник",
                 "viewOnWebsite": "Просмотреть на сайте",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "ค้นหารายการ...",
                 "allCategories": "ทุกหมวดหมู่",
                 "showing": "แสดง {current} จาก {total} รายการ",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "ไม่มีรายการที่ตรงกับเกณฑ์ค้นหา",
                 "source": "แหล่งที่มา",
                 "viewOnWebsite": "ดูในเว็บไซต์",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Öğe ara...",
                 "allCategories": "Tüm Kategoriler",
                 "showing": "{total} öğeden {current} tanesi gösteriliyor",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Arama kriterlerinize uyan öğe yok",
                 "source": "Kaynak",
                 "viewOnWebsite": "Web sitesinde görüntüle",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Пошук елементів...",
                 "allCategories": "Усі категорії",
                 "showing": "Показую {current} з {total} елементів",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Жоден елемент не відповідає критеріям пошуку",
                 "source": "Джерело",
                 "viewOnWebsite": "Переглянути на сайті",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1644,6 +1644,7 @@
                 "searchPlaceholder": "Tìm kiếm mục...",
                 "allCategories": "Tất Cả Danh Mục",
                 "showing": "Đang hiển thị {current} trong {total} mục",
+                "loadingFromRepo": "Please wait, we are loading your items from the data repository of this Work…",
                 "noMatch": "Không có mục nào khớp với tiêu chí tìm kiếm",
                 "source": "Nguồn",
                 "viewOnWebsite": "Xem trên trang web",

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/generator/comparisons/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/generator/comparisons/page.tsx
@@ -16,7 +16,6 @@ export default async function WorkComparisonsPage({ params }: Params) {
     const { id } = await params;
 
     let comparisons: ComparisonData[] = [];
-    let items: Array<{ slug: string; name: string; category: string | string[] }> = [];
     let websiteUrl: string | null = null;
 
     const defaultAiConfig = {
@@ -33,24 +32,21 @@ export default async function WorkComparisonsPage({ params }: Params) {
     let aiConfig = defaultAiConfig;
 
     try {
-        const [workRes, comparisonsRes, itemsRes, aiConfigRes] = await Promise.all([
+        // Items are intentionally dropped from this SSR call —
+        // `workAPI.getItems()` clones the data repo and was
+        // dominating the Comparisons tab's load time. The client
+        // fetches them lazily via `loadComparisonItems()` so the
+        // existing comparison cards + AI provider settings + tab
+        // chrome paint instantly.
+        const [workRes, comparisonsRes, aiConfigRes] = await Promise.all([
             workAPI.get(id).catch(() => null),
             workAPI.getComparisons(id).catch(() => []),
-            workAPI.getItems(id).catch(() => null),
             getComparisonAiConfig(id),
         ]);
 
         comparisons = comparisonsRes ?? [];
         aiConfig = aiConfigRes;
         websiteUrl = workRes?.work?.website ?? null;
-
-        if (itemsRes?.items) {
-            items = itemsRes.items.map((item) => ({
-                slug: item.slug ?? '',
-                name: item.name,
-                category: item.category as string | string[],
-            }));
-        }
     } catch (error) {
         console.error('Failed to fetch comparisons:', error);
     }
@@ -60,7 +56,6 @@ export default async function WorkComparisonsPage({ params }: Params) {
             workId={id}
             websiteUrl={websiteUrl}
             initialComparisons={comparisons}
-            items={items}
             availableProviders={aiConfig.availableProviders}
             initialAiConfig={aiConfig.currentConfig}
         />

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/generator/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/generator/page.tsx
@@ -42,18 +42,22 @@ export default async function WorkGeneratorPage({ params, searchParams }: Params
         return <GenerationProgress work={work} />;
     }
 
-    const [configRes, websiteTemplatesRes, pluginsRes] = await Promise.all([
-        workAPI.getConfig(id).catch(() => ({ config: undefined })),
+    // `config` comes from the cached `works.yml` payload on the
+    // Work entity (populated by `DataGeneratorService.refreshDataCache`),
+    // so the Generator tab opens without a git clone. The remaining
+    // two fetches are DB-only / cheap plugin metadata.
+    const [websiteTemplatesRes, pluginsRes] = await Promise.all([
         workAPI
             .getWebsiteTemplates()
             .catch((): { templates: WebsiteTemplateOption[] } => ({ templates: [] })),
         pluginsAPI.listForWork(id).catch((): { plugins: WorkPlugin[] } => ({ plugins: [] })),
     ]);
+
     return (
         <GeneratorForm
             workId={id}
             work={work}
-            config={configRes.config}
+            config={work.configCache ?? undefined}
             websiteTemplates={websiteTemplatesRes.templates}
             workPlugins={pluginsRes.plugins}
             startInProgressView={starting === '1'}

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/items/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/items/page.tsx
@@ -1,13 +1,7 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { workAPI } from '@/lib/api';
-import type {
-    ItemData,
-    Category,
-    Collection,
-    Tag,
-    SourceValidationSettingsDto,
-} from '@/lib/api/types-only';
+import type { SourceValidationSettingsDto } from '@/lib/api/types-only';
 import { ItemsPageClient } from '@/components/works/detail/items/ItemsPageClient';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -20,75 +14,24 @@ type Params = { params: Promise<{ id: string }> };
 export default async function WorkItemsPage({ params }: Params) {
     const { id } = await params;
 
-    let items: ItemData[] = [];
-    let categories: Category[] = [];
-    let tags: Tag[] = [];
-    let collections: Collection[] = [];
+    // Items + taxonomy are intentionally NOT fetched on the server
+    // any more — `workAPI.getItems()` and `workAPI.getCategoriesTags()`
+    // both trigger a `cloneOrPull()` of the data repo on the API
+    // side, which can take 10–20 s on large repos and previously
+    // blocked the whole route from rendering. They now load
+    // client-side from `loadItemsForList()` inside `ItemsPageClient`,
+    // so the page shell (title, tabs, search input, sticky actions)
+    // paints immediately and the rows fill in once the clone
+    // completes.
+    //
+    // `getSourceValidationSettings` stays in SSR — it's a cheap DB
+    // read, and the Source Health tab needs it on first paint.
     let sourceValidationSettings: SourceValidationSettingsDto | null = null;
-    let error: string | null = null;
-
     try {
-        // Fetch items and taxonomy data in parallel
-        const [itemsRes, taxonomyRes, sourceValidationRes] = await Promise.all([
-            workAPI.getItems(id).catch(() => ({ items: [] })),
-            workAPI
-                .getCategoriesTags(id)
-                .catch(() => ({ categories: [], tags: [], collections: [] })),
-            workAPI.getSourceValidationSettings(id).catch(() => null),
-        ]);
-        sourceValidationSettings = sourceValidationRes;
-
-        items = itemsRes.items || [];
-
-        // Convert string arrays to Category/Tag/Collection objects if needed
-        const rawCategories = taxonomyRes.categories || [];
-        const rawTags = taxonomyRes.tags || [];
-        const rawCollections = taxonomyRes.collections || [];
-
-        // Ensure categories have proper structure
-        categories = rawCategories.map((cat: string | Category) => {
-            if (typeof cat === 'string') {
-                return { id: cat, name: cat };
-            }
-            return cat;
-        });
-
-        // Ensure tags have proper structure
-        tags = rawTags.map((tag: string | Tag) => {
-            if (typeof tag === 'string') {
-                return { id: tag, name: tag };
-            }
-            return tag;
-        });
-
-        // Ensure collections have proper structure
-        collections = rawCollections.map((col: string | Collection) => {
-            if (typeof col === 'string') {
-                return { id: col, name: col };
-            }
-            return col;
-        });
+        sourceValidationSettings = await workAPI.getSourceValidationSettings(id).catch(() => null);
     } catch (err) {
-        console.error('Failed to fetch items:', err);
-        error = 'Failed to load items';
+        console.error('Failed to fetch source validation settings:', err);
     }
 
-    if (error) {
-        return (
-            <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-6">
-                <p className="text-red-800 dark:text-red-200">{error}</p>
-            </div>
-        );
-    }
-
-    return (
-        <ItemsPageClient
-            items={items}
-            workId={id}
-            categories={categories}
-            tags={tags}
-            collections={collections}
-            sourceValidationSettings={sourceValidationSettings}
-        />
-    );
+    return <ItemsPageClient workId={id} sourceValidationSettings={sourceValidationSettings} />;
 }

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/layout.tsx
@@ -38,13 +38,12 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
     let config = null;
 
     try {
-        const [res, configRes] = await Promise.all([
-            workAPI.get(id),
-            workAPI.getConfig(id).catch(() => ({ config: null })),
-        ]);
-
+        const res = await workAPI.get(id);
         work = res.work;
-        config = configRes.config;
+        // Sourced from the cached `works.yml` payload the API
+        // populated alongside the Work row. No extra git clone
+        // needed; see `DataGeneratorService.refreshDataCache`.
+        config = work.configCache ?? null;
 
         if (work) {
             // Fetch connection info and provider list in parallel

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/page.tsx
@@ -20,24 +20,21 @@ export default async function WorkOverviewPage({ params }: Params) {
     const { id } = await params;
 
     let work;
-    let config = null;
-    let countRes = { items: 0, categories: 0, tags: 0, comparisons: 0 };
 
     try {
-        const [workRes, configResult, countResult] = await Promise.all([
-            workAPI.get(id),
-            workAPI.getConfig(id).catch(() => ({ config: null })),
-            workAPI
-                .getCount(id)
-                .catch(() => ({ items: 0, categories: 0, tags: 0, comparisons: 0 })),
-        ]);
-
+        const workRes = await workAPI.get(id);
         work = workRes.work;
-        config = configResult.config;
-        countRes = countResult;
     } catch {
         notFound();
     }
+
+    // Counts + config come straight off the Work payload. The API
+    // populates `configCache` / `*Count` from the data repo at
+    // generator-completion time (and lazily backfills on first read
+    // for legacy Works), so the Overview tab no longer needs a
+    // per-render `cloneOrPull()` of the data repo. See
+    // `DataGeneratorService.refreshDataCache`.
+    const config = work.configCache ?? null;
 
     const showStatusCard =
         !work.generateStatus?.status ||
@@ -52,10 +49,10 @@ export default async function WorkOverviewPage({ params }: Params) {
             {showStatusCard && <WorkStatusCard work={work} />}
 
             <WorkStats
-                itemsCount={work.itemsCount || countRes.items}
-                categoriesCount={countRes.categories}
-                tagsCount={countRes.tags}
-                comparisonsCount={countRes.comparisons || 0}
+                itemsCount={work.itemsCount ?? 0}
+                categoriesCount={work.categoriesCount ?? 0}
+                tagsCount={work.tagsCount ?? 0}
+                comparisonsCount={work.comparisonsCount ?? 0}
                 work={work}
             />
 

--- a/apps/web/src/app/actions/dashboard/comparisons.ts
+++ b/apps/web/src/app/actions/dashboard/comparisons.ts
@@ -21,6 +21,39 @@ export async function listComparisons(workId: string) {
     }
 }
 
+export type ComparisonPairItem = {
+    slug: string;
+    name: string;
+    category: string | string[];
+};
+
+/**
+ * Server action used by `ComparisonsPageClient` to populate the
+ * Item A / Item B comboboxes (and gate the "Generate Next" button)
+ * client-side. Split off the SSR fetch so the rest of the
+ * Comparisons tab — comparison cards, AI provider settings, list
+ * controls — paints immediately while the items list (which still
+ * requires cloning the data repo) loads in the background.
+ */
+export async function loadComparisonItems(workId: string): Promise<ComparisonPairItem[]> {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const itemsRes = await workAPI.getItems(workId);
+        return (itemsRes?.items ?? []).map((item) => ({
+            slug: item.slug ?? '',
+            name: item.name,
+            category: item.category as string | string[],
+        }));
+    } catch (error) {
+        console.error('Load comparison items error:', error);
+        return [];
+    }
+}
+
 export async function getRemainingComparisonCount(workId: string) {
     const user = await getAuthFromCookie();
     if (!user) {

--- a/apps/web/src/app/actions/dashboard/items.ts
+++ b/apps/web/src/app/actions/dashboard/items.ts
@@ -35,9 +35,9 @@ export async function loadItemsForList(workId: string): Promise<LoadItemsForList
     const [itemsRes, taxonomyRes] = await Promise.all([
         workAPI.getItems(workId).catch(() => ({ items: [] as ItemData[] })),
         workAPI.getCategoriesTags(workId).catch(() => ({
-            categories: [] as string[],
-            tags: [] as string[],
-            collections: [] as string[],
+            categories: [] as Array<string | Category>,
+            tags: [] as Array<string | Tag>,
+            collections: [] as Array<string | Collection>,
         })),
     ]);
 

--- a/apps/web/src/app/actions/dashboard/items.ts
+++ b/apps/web/src/app/actions/dashboard/items.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { itemsGeneratorAPI, SubmitItemDto, UpdateItemDto } from '@/lib/api';
+import type { Category, Collection, ItemData, Tag } from '@/lib/api';
 import { screenshotAPI } from '@/lib/api';
 import { workAPI } from '@/lib/api';
 import { getAuthFromCookie } from '@/lib/auth';
@@ -9,6 +10,47 @@ import { ROUTES } from '@/lib/constants';
 import { revalidatePath } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 import { WorkScheduleCadence } from '@/lib/api/enums';
+
+export type LoadItemsForListResult = {
+    items: ItemData[];
+    categories: Category[];
+    tags: Tag[];
+    collections: Collection[];
+};
+
+/**
+ * Server action that fetches the items + taxonomy needed to populate
+ * the Items tab. Splits off the page's SSR data so the route shell
+ * (title, tabs, search input) renders instantly while this slow call
+ * — which still triggers a `cloneOrPull()` of the data repo on the
+ * API side, since items live as Markdown files in git — resolves in
+ * the background and the client swaps the skeletons for real rows.
+ */
+export async function loadItemsForList(workId: string): Promise<LoadItemsForListResult> {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const [itemsRes, taxonomyRes] = await Promise.all([
+        workAPI.getItems(workId).catch(() => ({ items: [] as ItemData[] })),
+        workAPI
+            .getCategoriesTags(workId)
+            .catch(() => ({ categories: [] as string[], tags: [] as string[], collections: [] as string[] })),
+    ]);
+
+    const normalize = <T extends { id: string; name: string }>(
+        raw: ReadonlyArray<string | T>,
+    ): T[] =>
+        raw.map((entry) => (typeof entry === 'string' ? ({ id: entry, name: entry } as T) : entry));
+
+    return {
+        items: itemsRes.items ?? [],
+        categories: normalize<Category>(taxonomyRes.categories ?? []),
+        tags: normalize<Tag>(taxonomyRes.tags ?? []),
+        collections: normalize<Collection>(taxonomyRes.collections ?? []),
+    };
+}
 
 export async function addItem(workId: string, data: SubmitItemDto) {
     const user = await getAuthFromCookie();

--- a/apps/web/src/app/actions/dashboard/items.ts
+++ b/apps/web/src/app/actions/dashboard/items.ts
@@ -34,9 +34,11 @@ export async function loadItemsForList(workId: string): Promise<LoadItemsForList
 
     const [itemsRes, taxonomyRes] = await Promise.all([
         workAPI.getItems(workId).catch(() => ({ items: [] as ItemData[] })),
-        workAPI
-            .getCategoriesTags(workId)
-            .catch(() => ({ categories: [] as string[], tags: [] as string[], collections: [] as string[] })),
+        workAPI.getCategoriesTags(workId).catch(() => ({
+            categories: [] as string[],
+            tags: [] as string[],
+            collections: [] as string[],
+        })),
     ]);
 
     const normalize = <T extends { id: string; name: string }>(

--- a/apps/web/src/components/works/detail/comparisons/ComparisonsPageClient.tsx
+++ b/apps/web/src/components/works/detail/comparisons/ComparisonsPageClient.tsx
@@ -46,6 +46,8 @@ import {
     saveComparisonAiConfig,
     getAiProviderModels,
     listComparisons,
+    loadComparisonItems,
+    type ComparisonPairItem,
 } from '@/app/actions/dashboard/comparisons';
 import { ComparisonGenerationProgress } from './ComparisonGenerationProgress';
 
@@ -53,7 +55,6 @@ interface ComparisonsPageClientProps {
     workId: string;
     websiteUrl: string | null;
     initialComparisons: ComparisonData[];
-    items: Array<{ slug: string; name: string; category: string | string[] }>;
     availableProviders: ProviderOption[];
     initialAiConfig: { provider: string | null; model: string | null; extendedAnalysis?: boolean };
 }
@@ -62,10 +63,31 @@ export function ComparisonsPageClient({
     workId,
     websiteUrl,
     initialComparisons,
-    items,
     availableProviders,
     initialAiConfig,
 }: ComparisonsPageClientProps) {
+    // Items power the manual pair-selector + the "Generate Next"
+    // enable check. They're fetched client-side because the API call
+    // clones the data repo and used to block the whole page from
+    // rendering. `null` = still loading; `[]` = loaded, none found.
+    const [items, setItems] = useState<ComparisonPairItem[] | null>(null);
+    useEffect(() => {
+        let cancelled = false;
+        loadComparisonItems(workId)
+            .then((result) => {
+                if (!cancelled) setItems(result);
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                console.error('Failed to load comparison items:', err);
+                setItems([]);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [workId]);
+    const itemsList: ComparisonPairItem[] = items ?? [];
+    const isLoadingItems = items === null;
     const t = useTranslations('dashboard.workDetail.comparisons');
     const [comparisons, setComparisons] = useState<ComparisonData[]>(initialComparisons);
     const [isPending, startTransition] = useTransition();
@@ -133,17 +155,17 @@ export function ComparisonsPageClient({
         };
     }, [initialAiConfig.provider]);
 
-    const selectedItemAObj = items.find((item) => item.slug === selectedItemA) ?? null;
-    const selectedItemBObj = items.find((item) => item.slug === selectedItemB) ?? null;
+    const selectedItemAObj = itemsList.find((item) => item.slug === selectedItemA) ?? null;
+    const selectedItemBObj = itemsList.find((item) => item.slug === selectedItemB) ?? null;
     const selectedProviderOption =
         availableProviders.find((provider) => provider.id === aiProvider) ?? null;
     const selectedProviderConfigured = selectedProviderOption?.configured ?? true;
 
-    const filteredItemsA = items
+    const filteredItemsA = itemsList
         .filter((item) => item.slug !== selectedItemB)
         .filter((item) => queryA === '' || item.name.toLowerCase().includes(queryA.toLowerCase()));
 
-    const filteredItemsB = items
+    const filteredItemsB = itemsList
         .filter((item) => item.slug !== selectedItemA)
         .filter((item) => queryB === '' || item.name.toLowerCase().includes(queryB.toLowerCase()));
 
@@ -336,7 +358,7 @@ export function ComparisonsPageClient({
                         variant="secondary"
                         size="sm"
                         onClick={() => setShowManualForm(!showManualForm)}
-                        disabled={isBusy || items.length < 2}
+                        disabled={isBusy || isLoadingItems || itemsList.length < 2}
                     >
                         {t('actions.compareItems')}
                     </Button>

--- a/apps/web/src/components/works/detail/items/ItemsListSkeleton.tsx
+++ b/apps/web/src/components/works/detail/items/ItemsListSkeleton.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Lightweight placeholder shown while `ItemsPageClient` fetches the
+ * Work's items + taxonomy from the API (which in turn clones the
+ * data repo). Keeps the page shell — title, tabs, search input,
+ * sticky actions — visible immediately so the user sees forward
+ * motion instead of a frozen route.
+ */
+export function ItemsListSkeleton({ rows = 8 }: { rows?: number }) {
+    return (
+        <div
+            className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+            aria-hidden="true"
+            data-testid="items-list-skeleton"
+        >
+            {Array.from({ length: rows }).map((_, i) => (
+                <div
+                    key={i}
+                    className={cn(
+                        'rounded-lg border border-border dark:border-border-dark',
+                        'bg-muted/30 dark:bg-muted/10 p-4 animate-pulse',
+                        'h-[160px] flex flex-col gap-3',
+                    )}
+                >
+                    <div className="h-4 w-2/3 rounded bg-muted/60 dark:bg-muted/30" />
+                    <div className="h-3 w-full rounded bg-muted/50 dark:bg-muted/20" />
+                    <div className="h-3 w-5/6 rounded bg-muted/50 dark:bg-muted/20" />
+                    <div className="mt-auto flex gap-2">
+                        <div className="h-5 w-14 rounded-full bg-muted/50 dark:bg-muted/20" />
+                        <div className="h-5 w-20 rounded-full bg-muted/40 dark:bg-muted/20" />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/items/ItemsPageClient.tsx
+++ b/apps/web/src/components/works/detail/items/ItemsPageClient.tsx
@@ -248,6 +248,7 @@ export function ItemsPageClient({ workId, sourceValidationSettings }: ItemsPageC
             )}
             {activeTab === 'items' &&
                 !isLoadingItems &&
+                !itemsLoadError &&
                 (items!.length === 0 ? (
                     <ItemsEmptyState workId={workId} />
                 ) : (
@@ -260,8 +261,18 @@ export function ItemsPageClient({ workId, sourceValidationSettings }: ItemsPageC
                 </div>
             )}
 
+            {/*
+             * `key={loaded?.workId ?? 'pending'}` forces a remount of
+             * each taxonomy tab when items finish loading. Without
+             * this, `CategoriesTab` / `TagsTab` / `CollectionsTab`
+             * each call `useState(initialX)` and snapshot the empty
+             * array on first render — they would never observe the
+             * real taxonomy when it arrives, leaving the tab stuck
+             * blank until the user navigated away and back.
+             */}
             {activeTab === 'categories' && (
                 <CategoriesTab
+                    key={loaded?.workId ?? 'pending'}
                     workId={workId}
                     initialCategories={initialCategories}
                     items={items ?? []}
@@ -271,6 +282,7 @@ export function ItemsPageClient({ workId, sourceValidationSettings }: ItemsPageC
 
             {activeTab === 'tags' && (
                 <TagsTab
+                    key={loaded?.workId ?? 'pending'}
                     workId={workId}
                     initialTags={initialTags}
                     items={items ?? []}
@@ -280,6 +292,7 @@ export function ItemsPageClient({ workId, sourceValidationSettings }: ItemsPageC
 
             {activeTab === 'collections' && (
                 <CollectionsTab
+                    key={loaded?.workId ?? 'pending'}
                     workId={workId}
                     initialCollections={initialCollections}
                     items={items ?? []}

--- a/apps/web/src/components/works/detail/items/ItemsPageClient.tsx
+++ b/apps/web/src/components/works/detail/items/ItemsPageClient.tsx
@@ -9,6 +9,7 @@ import {
     SourceValidationSettingsDto,
 } from '@/lib/api/types-only';
 import { ItemsList } from './ItemsList';
+import { ItemsListSkeleton } from './ItemsListSkeleton';
 import { AddItemModal } from './AddItemModal';
 import { ItemsExportButton } from './ItemsExportButton';
 import { ItemsImportButton } from './ItemsImportButton';
@@ -23,29 +24,18 @@ import { TagsTab } from './TagsTab';
 import { CollectionsTab } from './CollectionsTab';
 import { SourceValidationSettingsCard } from './SourceValidationSettingsCard';
 import { ItemsEmptyState } from './ItemsEmptyState';
-import { checkScreenshotAvailability } from '@/app/actions/dashboard/items';
+import { checkScreenshotAvailability, loadItemsForList } from '@/app/actions/dashboard/items';
 import { ItemsProvider } from './ItemsContext';
 import type { ProviderOption } from '@/lib/api/types-only';
 
 type TabType = 'items' | 'categories' | 'tags' | 'collections' | 'sourceHealth';
 
 interface ItemsPageClientProps {
-    items: ItemData[];
     workId: string;
-    categories?: Category[];
-    tags?: Tag[];
-    collections?: Collection[];
     sourceValidationSettings?: SourceValidationSettingsDto | null;
 }
 
-export function ItemsPageClient({
-    items,
-    workId,
-    categories: initialCategories = [],
-    tags: initialTags = [],
-    collections: initialCollections = [],
-    sourceValidationSettings,
-}: ItemsPageClientProps) {
+export function ItemsPageClient({ workId, sourceValidationSettings }: ItemsPageClientProps) {
     const t = useTranslations('dashboard.workDetail.items');
     const permissions = useWorkPermissions();
     const { work } = useWorkDetail();
@@ -58,6 +48,54 @@ export function ItemsPageClient({
     );
     const navRef = useRef<HTMLDivElement>(null);
     const [pillStyle, setPillStyle] = useState<{ left: number; width: number } | null>(null);
+
+    // Items + taxonomy are loaded lazily on mount so the page shell
+    // (title, tabs, search input, sticky actions) paints instantly
+    // while the API clones the data repo in the background. The
+    // result is keyed by `workId` so switching Works while a fetch
+    // is in flight still shows skeletons (instead of the previous
+    // Work's items) until the new fetch resolves — without needing
+    // a setState-in-effect reset.
+    type LoadedItems = {
+        workId: string;
+        items: ItemData[];
+        categories: Category[];
+        tags: Tag[];
+        collections: Collection[];
+        error: string | null;
+    };
+    const [loaded, setLoaded] = useState<LoadedItems | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        loadItemsForList(workId)
+            .then((result) => {
+                if (cancelled) return;
+                setLoaded({ workId, ...result, error: null });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                console.error('Failed to load items:', err);
+                setLoaded({
+                    workId,
+                    items: [],
+                    categories: [],
+                    tags: [],
+                    collections: [],
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [workId]);
+
+    const isLoadingItems = loaded?.workId !== workId;
+    const items: ItemData[] | null = isLoadingItems ? null : loaded!.items;
+    const initialCategories: Category[] = isLoadingItems ? [] : loaded!.categories;
+    const initialTags: Tag[] = isLoadingItems ? [] : loaded!.tags;
+    const initialCollections: Collection[] = isLoadingItems ? [] : loaded!.collections;
+    const itemsLoadError: string | null = isLoadingItems ? null : loaded!.error;
 
     useLayoutEffect(() => {
         const nav = navRef.current;
@@ -83,7 +121,7 @@ export function ItemsPageClient({
     // Get unique categories from existing items for the Add Item modal
     const categoryNames = Array.from(
         new Set(
-            items
+            (items ?? [])
                 .map((item) => getCategoryName(item.category))
                 .filter((category): category is string => Boolean(category)),
         ),
@@ -198,18 +236,35 @@ export function ItemsPageClient({
             </div>
 
             {/* Tab Content */}
+            {activeTab === 'items' && isLoadingItems && (
+                <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                        <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                            {t('loadingFromRepo')}
+                        </p>
+                    </div>
+                    <ItemsListSkeleton />
+                </div>
+            )}
             {activeTab === 'items' &&
-                (items.length === 0 ? (
+                !isLoadingItems &&
+                (items!.length === 0 ? (
                     <ItemsEmptyState workId={workId} />
                 ) : (
-                    <ItemsList items={items} addItemRef={addItemRef} />
+                    <ItemsList items={items!} addItemRef={addItemRef} />
                 ))}
+
+            {activeTab === 'items' && itemsLoadError && (
+                <div className="mt-4 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4">
+                    <p className="text-sm text-red-800 dark:text-red-200">{itemsLoadError}</p>
+                </div>
+            )}
 
             {activeTab === 'categories' && (
                 <CategoriesTab
                     workId={workId}
                     initialCategories={initialCategories}
-                    items={items}
+                    items={items ?? []}
                     canEdit={permissions.canEdit}
                 />
             )}
@@ -218,7 +273,7 @@ export function ItemsPageClient({
                 <TagsTab
                     workId={workId}
                     initialTags={initialTags}
-                    items={items}
+                    items={items ?? []}
                     canEdit={permissions.canEdit}
                 />
             )}
@@ -227,7 +282,7 @@ export function ItemsPageClient({
                 <CollectionsTab
                     workId={workId}
                     initialCollections={initialCollections}
-                    items={items}
+                    items={items ?? []}
                     canEdit={permissions.canEdit}
                 />
             )}

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { cache } from 'react';
 import { serverFetch, serverMutation } from './server-api';
 import {
     GenerateStatusType,
@@ -170,6 +171,13 @@ export interface Work {
     description: string;
     owner?: string;
     website?: string;
+    /**
+     * Cached `company_website` from `.works/works.yml`. Populated by
+     * the generator and the lazy backfill in `WorkQueryService` so
+     * the Overview tab can render straight from this `Work` payload
+     * without re-fetching the config from git.
+     */
+    companyWebsite?: string | null;
     organization: boolean;
     /**
      * EW-641 Phase 2/e row 37c — owning organization id (free-form UUID,
@@ -186,6 +194,23 @@ export interface Work {
     createdAt: string;
     updatedAt: string;
     itemsCount?: number;
+    /**
+     * Denormalised counts cached from the Work's data repo (see
+     * `companyWebsite` above). The Overview tab reads these instead
+     * of calling `/works/:id/count`, which previously cloned the
+     * repo on every page load.
+     */
+    categoriesCount?: number | null;
+    tagsCount?: number | null;
+    comparisonsCount?: number | null;
+    /**
+     * Cached `.works/works.yml` payload, shaped like {@link WorkConfig}.
+     * `null` only on a brand-new Work whose data repo has not yet
+     * been populated by the lazy backfill. Consumers should treat
+     * absent / null exactly the same as today's "config not yet
+     * available".
+     */
+    configCache?: WorkConfig | null;
     lastPullRequest?: { main?: PRUpdate; data?: PRUpdate };
     deploymentState?: GetProjectsReadyState;
     deploymentStartedAt?: string;
@@ -553,10 +578,19 @@ export const workAPI = {
         return serverFetch<WorkStatsResponse>(`/works/stats`);
     },
 
-    // Get a work by ID
-    get: async (id: string) => {
+    // Get a work by ID.
+    //
+    // Wrapped in React.cache so the per-request work fetch is
+    // deduplicated across the parent `/works/[id]/layout.tsx` and
+    // every nested `page.tsx` (Overview, Items, Generator, …)
+    // running in the same render. Without this, layout + page each
+    // fired their own HTTP request to /works/:id — and with the new
+    // lazy-backfill path on the API side, each unmemoised duplicate
+    // could re-trigger `refreshDataCache()` redundantly on the very
+    // first read.
+    get: cache(async (id: string) => {
         return serverFetch<APIResponse<{ work: Work }>>(`/works/${id}`);
-    },
+    }),
 
     getWebsiteTemplates: async () => {
         return serverFetch<APIResponse<{ templates: WebsiteTemplateOption[] }>>(

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -79,8 +79,14 @@ export class Work {
      * Cached `company_website` from `.works/works.yml`. See `configCache`
      * for the full design — populated by the generator and by the lazy
      * backfill path in `WorkQueryService`.
+     *
+     * `type: 'varchar'` is required for `string | null` unions —
+     * TypeORM's reflect-metadata fallback emits `Object` for the
+     * union, which better-sqlite3 (used in CLI tests) rejects with
+     * `DataTypeNotSupportedError`. Same pattern as `committerName`
+     * / `committerEmail` above. See develop commit f1ad254e.
      */
-    @Column({ nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     companyWebsite?: string | null;
 
     @Column({ default: false })

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -75,6 +75,14 @@ export class Work {
     @Column({ nullable: true })
     companyName: string;
 
+    /**
+     * Cached `company_website` from `.works/works.yml`. See `configCache`
+     * for the full design — populated by the generator and by the lazy
+     * backfill path in `WorkQueryService`.
+     */
+    @Column({ nullable: true })
+    companyWebsite?: string | null;
+
     @Column({ default: false })
     organization: boolean;
 
@@ -183,6 +191,36 @@ export class Work {
 
     @Column({ nullable: true })
     itemsCount?: number;
+
+    /**
+     * Denormalised counts cached from the Work's data repo, so the
+     * Overview tab can render without `gitFacade.cloneOrPull()`.
+     * Populated by the generator on every successful run and by the
+     * lazy backfill in `WorkQueryService` on first read after the
+     * caching migration deploys. Source of truth is still the
+     * `categories.yml` / `tags.yml` / comparisons listing in the repo.
+     */
+    @Column({ nullable: true })
+    categoriesCount?: number;
+
+    @Column({ nullable: true })
+    tagsCount?: number;
+
+    @Column({ nullable: true })
+    comparisonsCount?: number;
+
+    /**
+     * Cached `.works/works.yml` payload (the full `IDataConfig`) so
+     * tabs that need config fields — Overview, Generator, Settings,
+     * Deploy — can read straight from Postgres instead of cloning the
+     * data repo. Populated alongside the count columns above and
+     * refreshed whenever the generator (or the Settings save path)
+     * writes the YAML back to the repo. Stored as `text` + parsed at
+     * read time, matching the `simple-json` convention used elsewhere
+     * on this entity (`readmeConfig`, `kbConfig`, etc.).
+     */
+    @Column('simple-json', { nullable: true, name: 'configCache' })
+    configCache?: WorksConfigCache | null;
 
     // Git committer overrides at work level (optional — fallback to user/default)
     @Column({ type: 'varchar', nullable: true })
@@ -452,6 +490,20 @@ export interface MarkdownReadmeConfig {
     footer?: string;
     overwriteDefaultFooter?: boolean;
 }
+
+/**
+ * Cached copy of the parsed `.works/works.yml` (the IDataConfig
+ * shape returned by `DataRepository.getConfig()`). Mirrored from
+ * the data repo by the generator + the lazy backfill path so that
+ * dashboard tabs can render without cloning the data repo on every
+ * request. Loose `Record`-shape because (a) we don't query any
+ * fields inside it from SQL, and (b) we don't want the entity file
+ * to import from `agent/generators` (would create a cycle).
+ *
+ * Consumers that need a strongly-typed view should cast to
+ * `IDataConfig` from `@src/generators/data-generator`.
+ */
+export type WorksConfigCache = Record<string, unknown>;
 
 export type {
     ImportSourceType,

--- a/packages/agent/src/generators/data-generator/data-generator.service.ts
+++ b/packages/agent/src/generators/data-generator/data-generator.service.ts
@@ -66,6 +66,20 @@ export type GenerationStats = {
     changelog?: ReturnType<typeof buildWorkChangelog>;
 };
 
+/**
+ * Snapshot of the cache columns `refreshDataCache` populated on the
+ * Work row. Each field is `null` when the corresponding read off the
+ * data repo failed (e.g. missing YAML, transient git error).
+ */
+export type RefreshedDataCache = {
+    configCache: IDataConfig | null;
+    companyWebsite: string | null;
+    categoriesCount: number | null;
+    tagsCount: number | null;
+    comparisonsCount: number | null;
+    itemsCount: number | null;
+};
+
 const getWorkDefaultDataConfig = (work: Work): Partial<IDataConfig> => ({
     company_name: work.name || work.slug,
 });
@@ -600,6 +614,12 @@ export class DataGeneratorService {
                 itemsCount: pipelineResult.outputs.items.length + existingData.existingItems.length,
             });
 
+            // Refresh the denormalised cache columns (counts + parsed
+            // config) so the Overview / Generator dashboard tabs can
+            // render straight from Postgres on the next page load,
+            // without re-cloning the data repo we just pushed to.
+            await this.refreshDataCache(work, user);
+
             // Persist domain type if detected and not manually set
             if (pipelineResult.outputs.domainAnalysis && !work.domainTypeManuallySet) {
                 await this.workOperations.updateWork(work.id, {
@@ -983,6 +1003,79 @@ export class DataGeneratorService {
     }
 
     /**
+     * Repopulate the denormalised cache columns on `works` (counts +
+     * full parsed `.works/works.yml`) from the current state of the
+     * data repo. One clone, four parallel reads, one DB write.
+     *
+     * Called from:
+     *   - the generator's final step (after items push) so freshly
+     *     generated Works land with the cache primed,
+     *   - `updateWebsiteSettings` after a YAML edit is pushed so the
+     *     cache stays in sync with the just-saved config, and
+     *   - `WorkQueryService.getWork` as a lazy backfill when the
+     *     cache columns are still NULL on an existing Work.
+     *
+     * Errors are swallowed (logged) — the cache is best-effort and
+     * read paths must still tolerate NULL columns (e.g. a brand-new
+     * Work whose data repo doesn't exist yet, or a transient git
+     * outage). Returns `null` in that case.
+     */
+    async refreshDataCache(work: Work, user: User): Promise<RefreshedDataCache | null> {
+        try {
+            const data = await this.repositoryData(work, user);
+
+            const [configResult, categoriesResult, tagsResult, itemsResult, comparisonsResult] =
+                await Promise.allSettled([
+                    data.getConfig(),
+                    data.getCategories(),
+                    data.getTags(),
+                    data.countItems(),
+                    data.countComparisons(),
+                ]);
+
+            const configCache = configResult.status === 'fulfilled' ? configResult.value : null;
+            const categoriesCount =
+                categoriesResult.status === 'fulfilled' ? categoriesResult.value.length : null;
+            const tagsCount = tagsResult.status === 'fulfilled' ? tagsResult.value.length : null;
+            const itemsCount = itemsResult.status === 'fulfilled' ? itemsResult.value : null;
+            const comparisonsCount =
+                comparisonsResult.status === 'fulfilled' ? comparisonsResult.value : null;
+
+            const update: Partial<Work> = {};
+            if (configCache !== null) {
+                update.configCache = configCache as unknown as Work['configCache'];
+                if (typeof configCache.company_website === 'string') {
+                    update.companyWebsite = configCache.company_website;
+                }
+            }
+            if (categoriesCount !== null) update.categoriesCount = categoriesCount;
+            if (tagsCount !== null) update.tagsCount = tagsCount;
+            if (comparisonsCount !== null) update.comparisonsCount = comparisonsCount;
+            if (itemsCount !== null) update.itemsCount = itemsCount;
+
+            if (Object.keys(update).length > 0) {
+                await this.workOperations.updateWork(work.id, update);
+            }
+
+            return {
+                configCache: (update.configCache ?? null) as IDataConfig | null,
+                companyWebsite: update.companyWebsite ?? null,
+                categoriesCount: update.categoriesCount ?? null,
+                tagsCount: update.tagsCount ?? null,
+                comparisonsCount: update.comparisonsCount ?? null,
+                itemsCount: update.itemsCount ?? null,
+            };
+        } catch (error) {
+            this.logger.warn(
+                `Failed to refresh data cache for work ${work.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
+    }
+
+    /**
      * Returns a lightweight snapshot of the data repository for sync purposes.
      * Uses the shared repositoryData() helper to respect cloning/pulling patterns.
      */
@@ -1106,6 +1199,10 @@ export class DataGeneratorService {
         );
 
         this.logger.log(`Successfully updated website settings for work ${work.slug}`);
+
+        // Keep the denormalised cache (configCache, companyWebsite,
+        // counts) in sync with the YAML we just pushed.
+        await this.refreshDataCache(work, user);
     }
 
     private async repositoryData(work: Work, user: User) {
@@ -1852,6 +1949,10 @@ export class DataGeneratorService {
             await this.workOperations.updateWork(work.id, {
                 itemsCount: existingItems.length + newItemsCount,
             });
+
+            // Refresh the denormalised cache so the Overview / Generator
+            // tabs see the synced counts without re-cloning the repo.
+            await this.refreshDataCache(work, user);
 
             const stats: GenerationStats = {
                 newItemsCount,

--- a/packages/agent/src/services/work-import.service.ts
+++ b/packages/agent/src/services/work-import.service.ts
@@ -662,6 +662,13 @@ export class WorkImportService {
                 }),
             ]);
 
+            // Prime the denormalised cache columns (categoriesCount,
+            // tagsCount, comparisonsCount, configCache,
+            // companyWebsite) so the Overview tab can render straight
+            // from Postgres on the next page load instead of cloning
+            // the freshly-imported data repo. Best-effort.
+            await this.dataGenerator.refreshDataCache(work, user);
+
             await this.generationHistoryRepository.updateEntry(history.id, {
                 status: GenerateStatusType.GENERATED,
                 finishedAt: endTime,

--- a/packages/agent/src/services/work-query.service.ts
+++ b/packages/agent/src/services/work-query.service.ts
@@ -225,18 +225,20 @@ export class WorkQueryService {
 
     /**
      * Should we attempt a one-shot backfill of the data-cache columns
-     * on this read? True iff the work has been generated at least once
-     * (so the data repo plausibly exists) and the cache is still
-     * empty. After the first successful backfill, every column is
-     * populated and subsequent reads short-circuit.
+     * on this read? Gated on `configCache` alone, not on any of the
+     * count columns. Reason: `refreshDataCache` writes each column
+     * independently from its own `Promise.allSettled` slot — so if a
+     * single read (e.g. `countComparisons()` on a Work with no
+     * comparisons folder) consistently rejects, that one count stays
+     * NULL forever even after the rest are populated. Triggering on
+     * `configCache == null` instead means once the YAML snapshot has
+     * been written at least once, the page is unblocked regardless
+     * of which sibling reads failed — and a per-read failure can be
+     * retried by an explicit refresh path, not by silently
+     * re-cloning the repo on every page load.
      */
     private shouldBackfillDataCache(work: Work): boolean {
-        return (
-            work.configCache == null ||
-            work.categoriesCount == null ||
-            work.tagsCount == null ||
-            work.comparisonsCount == null
-        );
+        return work.configCache == null;
     }
 
     async workExists(slug: string, user: User) {

--- a/packages/agent/src/services/work-query.service.ts
+++ b/packages/agent/src/services/work-query.service.ts
@@ -173,6 +173,40 @@ export class WorkQueryService {
                 user,
             );
 
+            // Lazy backfill of the denormalised cache columns
+            // (configCache + counts). When a Work pre-dates the
+            // caching migration its cache is NULL on first read; we
+            // clone once here, populate, and serve straight from
+            // Postgres on every subsequent load. Strictly best-effort
+            // — `refreshDataCache` swallows errors so we never trade
+            // a working page for a transient git outage.
+            if (
+                this.shouldBackfillDataCache(work) &&
+                work.generateStatus?.status === GenerateStatusType.GENERATED
+            ) {
+                const refreshed = await this.dataGenerator.refreshDataCache(work, user);
+                if (refreshed) {
+                    if (refreshed.configCache !== null) {
+                        work.configCache = refreshed.configCache as Work['configCache'];
+                    }
+                    if (refreshed.companyWebsite !== null) {
+                        work.companyWebsite = refreshed.companyWebsite;
+                    }
+                    if (refreshed.categoriesCount !== null) {
+                        work.categoriesCount = refreshed.categoriesCount;
+                    }
+                    if (refreshed.tagsCount !== null) {
+                        work.tagsCount = refreshed.tagsCount;
+                    }
+                    if (refreshed.comparisonsCount !== null) {
+                        work.comparisonsCount = refreshed.comparisonsCount;
+                    }
+                    if (refreshed.itemsCount !== null) {
+                        work.itemsCount = refreshed.itemsCount;
+                    }
+                }
+            }
+
             // Return work with user's role
             const workWithRole: WorkWithRole = {
                 ...work,
@@ -187,6 +221,22 @@ export class WorkQueryService {
         } catch (error) {
             rethrowAsNormalized(error, this.logger, 'getting work');
         }
+    }
+
+    /**
+     * Should we attempt a one-shot backfill of the data-cache columns
+     * on this read? True iff the work has been generated at least once
+     * (so the data repo plausibly exists) and the cache is still
+     * empty. After the first successful backfill, every column is
+     * populated and subsequent reads short-circuit.
+     */
+    private shouldBackfillDataCache(work: Work): boolean {
+        return (
+            work.configCache == null ||
+            work.categoriesCount == null ||
+            work.tagsCount == null ||
+            work.comparisonsCount == null
+        );
     }
 
     async workExists(slug: string, user: User) {


### PR DESCRIPTION
## Summary

The Work detail page used to clone the data repo 2–3 times per server render via `workAPI.getConfig` + `workAPI.getCount` (plus `workAPI.getItems` from neighbouring sections), routinely costing 10–20s per dashboard navigation. This PR splits the dashboard into "DB-only" surfaces (no git) and "needs the repo" surfaces (clone, but deferred to the client with a skeleton).

### What's now DB-only (no git on read)
- **Overview tab** — counts + config served from new cache columns on `works`
- **Generator main tab** — config served from the same cache
- **`[id]/layout.tsx`** — drops `getConfig` (was running on every nested tab)

### What still needs the repo, but no longer blocks SSR
- **Items tab** — page shell paints instantly; `loadItemsForList` server action lazy-fetches into a skeleton + "Please wait, we are loading your items from the data repository of this Work…" message
- **Comparisons tab** — comparison cards + AI settings render immediately; `loadComparisonItems` lazy-loads the pair-selector

## How it works

1. **Migration** `1779990000000-AddWorkDataConfigCacheColumns` — adds 5 nullable columns to `works`: `companyWebsite`, `categoriesCount`, `tagsCount`, `comparisonsCount`, `configCache` (the parsed `.works/works.yml` payload).
2. **Write paths populate the cache**: `DataGeneratorService.refreshDataCache(work, user)` is called from the generator's final step, `updateWebsiteSettings`, the import flow, and the source-sync flow — every time we push to the data repo we also write the denormalised cache.
3. **Lazy backfill** in `WorkQueryService.getWork`: if a pre-migration Work has NULL cache columns AND has been generated at least once, the next read clones once + populates. One slow load per Work, then fast forever.
4. **React.cache** on `workAPI.get` so layout + page share one fetch (which means at most one lazy backfill trigger per render).

## Out of scope (deferred to follow-up)

These tabs have the same shape of issue (external API calls or git clones on SSR) and are independent of this PR — keeping the diff reviewable:

- **Plugins (per-work + per-user)** — defer per-plugin `getConnectionStatus` OAuth probes
- **Deploy** — defer Vercel/k8s capability + existing-deployment lookups
- **Schedule** — defer `getFormSchema` (plugin capability detection)

## Test plan

- [x] `packages/agent` typecheck: 0 issues
- [x] `apps/web` typecheck: 0 issues
- [x] `packages/agent` jest: 51 suites, 1182 tests pass
- [x] `apps/api` jest: 142/143 suites pass, 2359 tests pass (1 unrelated pre-existing failure in `deploy.e2e.spec.ts` re: missing `@ever-works/k8s-plugin`)
- [x] `apps/web` vitest: 64 suites, 567 tests pass
- [x] ESLint clean on all touched files
- [ ] Manual: open an existing Work's Overview tab — first load triggers lazy backfill (slow), subsequent loads sub-second
- [ ] Manual: open a freshly-generated Work — Overview opens fast immediately (cache primed by generator)
- [ ] Manual: open Items tab — page shell paints instantly; "loading from data repository" message appears; skeleton rows; then real items
- [ ] Manual: edit settings (Website Settings) — config in DB reflects change after save
- [ ] Manual: Comparisons tab — comparison cards visible immediately; "Compare Items" button disabled until items load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading state indicators for work items, displaying a skeleton loader and "loading from repository" message across all supported languages.

* **Performance**
  * Implemented data caching for work configurations and statistics, reducing redundant API requests and improving page load speed.
  * Optimized client-side data fetching to prevent duplicate HTTP calls during rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->