### PR TITLE
perf(plugins): drop connectionStatus from list response; add lazy /plugins/:id/connection-status

### DIFF
--- a/apps/api/src/plugins/plugins.controller.ts
+++ b/apps/api/src/plugins/plugins.controller.ts
@@ -111,7 +111,9 @@ export class PluginsController {
     async getPluginConnectionStatus(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('pluginId') pluginId: string,
-    ): Promise<{ connectionStatus: Awaited<ReturnType<PluginOperationsService['getPluginConnectionStatus']>> }> {
+    ): Promise<{
+        connectionStatus: Awaited<ReturnType<PluginOperationsService['getPluginConnectionStatus']>>;
+    }> {
         const connectionStatus = await this.pluginsService.getPluginConnectionStatus(
             pluginId,
             auth.userId,

--- a/apps/api/src/plugins/plugins.controller.ts
+++ b/apps/api/src/plugins/plugins.controller.ts
@@ -98,6 +98,27 @@ export class PluginsController {
         return this.pluginsService.listPluginModels(pluginId, auth.userId);
     }
 
+    @Get('plugins/:pluginId/connection-status')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Probe a single plugin connection status on demand',
+        description:
+            'Returns the same `PluginConnectionStatus` shape the list endpoint used to embed eagerly per plugin. Use this from settings drawers / "test connection" buttons so the list endpoint can stay fast (the list response no longer fans out to every external provider on every page load).',
+    })
+    @ApiParam({ name: 'pluginId', description: 'Plugin ID' })
+    @ApiResponse({ status: 200, description: 'Plugin connection status' })
+    @ApiResponse({ status: 404, description: 'Plugin not found' })
+    async getPluginConnectionStatus(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('pluginId') pluginId: string,
+    ): Promise<{ connectionStatus: Awaited<ReturnType<PluginOperationsService['getPluginConnectionStatus']>> }> {
+        const connectionStatus = await this.pluginsService.getPluginConnectionStatus(
+            pluginId,
+            auth.userId,
+        );
+        return { connectionStatus };
+    }
+
     @Get('plugins/:pluginId')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({

--- a/apps/web/src/lib/api/plugins.ts
+++ b/apps/web/src/lib/api/plugins.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { serverFetch, serverMutation } from './server-api';
 import type {
+    PluginConnectionStatus,
     PluginResponse,
     UserPluginResponse,
     WorkPluginResponse,
@@ -13,6 +14,7 @@ import type {
 
 // Re-export types from @ever-works/plugin/api for consistency
 export type {
+    PluginConnectionStatus,
     PluginSettingsSchemaProperty,
     PluginSettingsSchema,
     PluginCategory,
@@ -84,6 +86,23 @@ export const pluginsAPI = {
             return await serverFetch<any[]>(`/plugins/${pluginId}/models`);
         } catch {
             return [];
+        }
+    },
+
+    /**
+     * Probe one plugin's connection status on demand. Returns the
+     * same shape the list endpoint used to embed per-plugin
+     * eagerly — call this from settings drawers or a "test
+     * connection" button so the list response itself can stay fast.
+     */
+    getConnectionStatus: async (pluginId: string): Promise<PluginConnectionStatus | null> => {
+        try {
+            const response = await serverFetch<{
+                connectionStatus: PluginConnectionStatus | null | undefined;
+            }>(`/plugins/${pluginId}/connection-status`);
+            return response.connectionStatus ?? null;
+        } catch {
+            return null;
         }
     },
 

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -1286,39 +1286,38 @@ export class PluginOperationsService {
     ): Promise<UserPluginResponse> {
         const response = this.toUserPluginResponse(registered, userPlugin);
 
-        // Resolve the user-scope settings ONCE and feed both display +
-        // model-summary projections off the same payload. The old
-        // implementation called `settingsService.getResolvedSettings`
-        // twice (in `getResolvedDisplaySettings` AND
-        // `getProviderModelSummaries`), doubling the per-plugin DB
-        // round-trip on every list response.
+        // Fan out the two independent reads in parallel:
+        //   (1) resolve the user-scope settings (used for the display
+        //       + model-summary projections); skipped entirely if the
+        //       plugin has no schema AND isn't an AI provider.
+        //   (2) probe the connection status — only on opt-in
+        //       (detail endpoint + post-mutation responses); the
+        //       LIST path skips this so the dashboard doesn't fan
+        //       out to ~39 external providers per page load.
+        //
+        // The previous shape ran (1) and (2) sequentially when both
+        // were needed, regressing detail-endpoint latency from
+        // `max(T_resolve, T_probe)` to `T_resolve + T_probe`. Putting
+        // them back inside a single `Promise.all` restores the
+        // original concurrency on the opt-in path while preserving
+        // the list-path savings (the probe is `Promise.resolve(undefined)`
+        // when `includeConnectionStatus` is false, so no extra work).
         const schema = registered.plugin.settingsSchema;
-        const resolved =
-            schema?.properties || this.hasAiProviderCapability(registered)
-                ? await this.settingsService.getResolvedSettings(registered.plugin.id, { userId })
-                : undefined;
+        const needsResolved = !!schema?.properties || this.hasAiProviderCapability(registered);
+        const resolvedP = needsResolved
+            ? this.settingsService.getResolvedSettings(registered.plugin.id, { userId })
+            : Promise.resolve(undefined);
+        const connectionStatusP = options.includeConnectionStatus
+            ? this.getConnectionStatus(registered, userId)
+            : Promise.resolve(undefined);
+
+        const [resolved, connectionStatus] = await Promise.all([resolvedP, connectionStatusP]);
 
         const resolvedSettings = resolved
             ? this.projectDisplaySettings(registered, resolved)
             : undefined;
         const models = resolved
             ? this.projectProviderModelSummaries(registered, resolved)
-            : undefined;
-
-        // `connectionStatus` is the expensive bit — it fans out to
-        // external providers (Anthropic, OpenAI, Tavily, GitHub
-        // OAuth, …) per plugin and can dominate dashboard latency
-        // when computed for the full ~39-plugin list on every page
-        // load. The web UI has no list-page surface for this field
-        // (no "Connected / Not configured" badge on any list page),
-        // so list callers default to opting out. Detail endpoints +
-        // post-mutation responses (enable / disable / settings
-        // update) opt in so a saved-token confirmation can still
-        // come back fresh, and the new
-        // `GET /plugins/:pluginId/connection-status` endpoint serves
-        // any explicit on-demand probe (e.g. settings drawer).
-        const connectionStatus = options.includeConnectionStatus
-            ? await this.getConnectionStatus(registered, userId)
             : undefined;
 
         if (!resolvedSettings && !connectionStatus && !models) {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -15,6 +15,7 @@ import {
     type JsonSchema,
     type DeviceAuthStatus,
     type PluginManifest,
+    type ResolvedSettings,
     isDeviceAuthProvider,
     toPluginSettingsSchemaProperty,
     PLUGIN_CAPABILITIES,
@@ -353,7 +354,9 @@ export class PluginOperationsService {
             where: { userId, pluginId },
         });
 
-        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId);
+        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId, {
+            includeConnectionStatus: true,
+        });
     }
 
     async getPluginDeviceAuthStatus(pluginId: string, userId: string): Promise<DeviceAuthStatus> {
@@ -446,7 +449,9 @@ export class PluginOperationsService {
         await this.userPluginRepository.save(userPlugin);
         this.logger.log(`Plugin "${pluginId}" enabled for user "${userId}"`);
 
-        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId);
+        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId, {
+            includeConnectionStatus: true,
+        });
     }
 
     /**
@@ -502,7 +507,9 @@ export class PluginOperationsService {
 
         this.logger.log(`Plugin "${pluginId}" disabled for user "${userId}"`);
 
-        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId);
+        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId, {
+            includeConnectionStatus: true,
+        });
     }
 
     /**
@@ -588,7 +595,9 @@ export class PluginOperationsService {
         await this.userPluginRepository.save(userPlugin);
         this.logger.log(`Plugin "${pluginId}" settings updated for user "${userId}"`);
 
-        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId);
+        return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId, {
+            includeConnectionStatus: true,
+        });
     }
 
     /**
@@ -1273,13 +1282,44 @@ export class PluginOperationsService {
         registered: RegisteredPlugin,
         userPlugin: UserPluginEntity | null | undefined,
         userId: string,
+        options: { includeConnectionStatus?: boolean } = {},
     ): Promise<UserPluginResponse> {
         const response = this.toUserPluginResponse(registered, userPlugin);
-        const [resolvedSettings, connectionStatus, models] = await Promise.all([
-            this.getResolvedDisplaySettings(registered, userId),
-            this.getConnectionStatus(registered, userId),
-            this.getProviderModelSummaries(registered, { userId }),
-        ]);
+
+        // Resolve the user-scope settings ONCE and feed both display +
+        // model-summary projections off the same payload. The old
+        // implementation called `settingsService.getResolvedSettings`
+        // twice (in `getResolvedDisplaySettings` AND
+        // `getProviderModelSummaries`), doubling the per-plugin DB
+        // round-trip on every list response.
+        const schema = registered.plugin.settingsSchema;
+        const resolved =
+            schema?.properties || this.hasAiProviderCapability(registered)
+                ? await this.settingsService.getResolvedSettings(registered.plugin.id, { userId })
+                : undefined;
+
+        const resolvedSettings = resolved
+            ? this.projectDisplaySettings(registered, resolved)
+            : undefined;
+        const models = resolved
+            ? this.projectProviderModelSummaries(registered, resolved)
+            : undefined;
+
+        // `connectionStatus` is the expensive bit — it fans out to
+        // external providers (Anthropic, OpenAI, Tavily, GitHub
+        // OAuth, …) per plugin and can dominate dashboard latency
+        // when computed for the full ~39-plugin list on every page
+        // load. The web UI has no list-page surface for this field
+        // (no "Connected / Not configured" badge on any list page),
+        // so list callers default to opting out. Detail endpoints +
+        // post-mutation responses (enable / disable / settings
+        // update) opt in so a saved-token confirmation can still
+        // come back fresh, and the new
+        // `GET /plugins/:pluginId/connection-status` endpoint serves
+        // any explicit on-demand probe (e.g. settings drawer).
+        const connectionStatus = options.includeConnectionStatus
+            ? await this.getConnectionStatus(registered, userId)
+            : undefined;
 
         if (!resolvedSettings && !connectionStatus && !models) {
             return response;
@@ -1291,6 +1331,28 @@ export class PluginOperationsService {
             connectionStatus,
             models,
         };
+    }
+
+    private hasAiProviderCapability(registered: RegisteredPlugin): boolean {
+        return registered.plugin.capabilities.includes(PLUGIN_CAPABILITIES.AI_PROVIDER);
+    }
+
+    /**
+     * Public entry point for the new
+     * `GET /plugins/:pluginId/connection-status` endpoint. Runs the
+     * same probe `toUserPluginResponseWithResolvedSettings` used to
+     * run eagerly for every plugin in the list response, but only
+     * for the one plugin the caller asks about.
+     */
+    async getPluginConnectionStatus(
+        pluginId: string,
+        userId: string,
+    ): Promise<PluginConnectionStatus | undefined> {
+        const registered = this.pluginRegistryService.get(pluginId);
+        if (!registered) {
+            throw new NotFoundException(`Plugin "${pluginId}" not found`);
+        }
+        return this.getConnectionStatus(registered, userId);
     }
 
     private async getConnectionStatus(
@@ -1403,6 +1465,26 @@ export class PluginOperationsService {
             userId,
         });
 
+        return this.projectDisplaySettings(registered, resolved);
+    }
+
+    /**
+     * Pure projection from already-resolved settings to the visible
+     * "display settings" shape returned on the list response. Same
+     * masking + filtering rules as `getResolvedDisplaySettings` but
+     * synchronous and takes the resolve result as a parameter, so
+     * the list path can resolve once and share between
+     * `projectProviderModelSummaries` and this.
+     */
+    private projectDisplaySettings(
+        registered: RegisteredPlugin,
+        resolved: ResolvedSettings,
+    ): Record<string, unknown> | undefined {
+        const schema = registered.plugin.settingsSchema;
+        if (!schema?.properties) {
+            return undefined;
+        }
+
         const displaySettings: Record<string, unknown> = {};
 
         for (const [key, propSchema] of Object.entries(schema.properties)) {
@@ -1472,7 +1554,7 @@ export class PluginOperationsService {
         registered: RegisteredPlugin,
         options: { userId: string; workId?: string },
     ): Promise<WorkPluginResponse['models']> {
-        if (!registered.plugin.capabilities.includes(PLUGIN_CAPABILITIES.AI_PROVIDER)) {
+        if (!this.hasAiProviderCapability(registered)) {
             return undefined;
         }
 
@@ -1481,6 +1563,22 @@ export class PluginOperationsService {
             workId: options.workId,
         });
 
+        return buildProviderModelSummaries(registered.plugin.settingsSchema, resolved);
+    }
+
+    /**
+     * Pure projection from already-resolved settings to the
+     * provider-model summary used on the list response. Exists so
+     * the list path can resolve user-scope settings once and feed
+     * both `projectDisplaySettings` + this without re-querying.
+     */
+    private projectProviderModelSummaries(
+        registered: RegisteredPlugin,
+        resolved: ResolvedSettings,
+    ): WorkPluginResponse['models'] {
+        if (!this.hasAiProviderCapability(registered)) {
+            return undefined;
+        }
         return buildProviderModelSummaries(registered.plugin.settingsSchema, resolved);
     }
 


### PR DESCRIPTION
## Summary

The platform's plugin list endpoint used to compute `connectionStatus` for every registered plugin on every page load. That meant up to ~117 external HTTP calls per dashboard navigation (Anthropic, OpenAI, Tavily, GitHub OAuth, device-auth probes…) — and the dashboard layout calls `pluginsAPI.list()` on every page, so the latency compounded across the whole dashboard.

An audit of `apps/web/src/**` confirmed `connectionStatus` has **zero visible UI surface** on any list page — no badge, no chip, no icon. Even the onboarding step reads its connection state from separate OAuth / device-auth capability endpoints, not from `plugin.connectionStatus`. Pure dead weight on the list response.

## Changes

- **`PluginOperationsService.toUserPluginResponseWithResolvedSettings`** now accepts `{ includeConnectionStatus?: boolean }`. List callers default to `false` and skip the external fan-out entirely. Detail + post-mutation callers (`getPlugin`, `enablePluginForUser`, `disablePluginForUser`, `updateUserPluginSettings`) opt in so a fresh status still comes back the moment a user pastes a token.
- Same method now resolves user-scope settings ONCE per plugin and feeds both the display projection and the AI-model summary from the same payload — eliminating the duplicate `settingsService.getResolvedSettings` round-trip the previous code did inside `getResolvedDisplaySettings` and `getProviderModelSummaries` (option 4 from the spec).
- New endpoint **`GET /api/plugins/:pluginId/connection-status`** — same `PluginConnectionStatus` shape, single plugin, on demand. Settings drawers / "Test connection" buttons should call this.
- New web client method **`pluginsAPI.getConnectionStatus(pluginId)`**.

## Out of scope (deferred)

- `toWorkPluginResponse` (per-work plugins) does NOT compute `connectionStatus` and so is unaffected here. It does have its own duplicated `getResolvedSettings` calls (different `includeSecrets` flag) — separate follow-up.
- No new schema (option 2 — caching `lastConnectionStatus` on `UserPluginEntity`) because the audit showed no UI consumer exists to render even a stale cached value. We don't need to cache what isn't displayed.
- Option 3 (skip checks for non-installed plugins) becomes moot once option 1 drops the field from list responses entirely.

Pairs with [#1023](https://github.com/ever-works/ever-works/pull/1023) (Work Overview / Items / Comparisons perf), but touches different files entirely.

## Test plan

- [x] `packages/agent` typecheck: 0 issues
- [x] `apps/web` typecheck: 0 issues
- [x] `packages/agent` jest: 273 suites, 5424 pass (2 skipped)
- [x] `apps/api` jest: 142/143 suites pass, 2359 pass (1 unrelated pre-existing failure)
- [x] ESLint clean on `apps/web/src/lib/api/plugins.ts`
- [ ] Manual: open `/settings/plugins` — page renders without delay; no per-plugin external probe in server logs
- [ ] Manual: open a single plugin detail (`/plugins/[id]`) — `connectionStatus` still populated (opt-in path)
- [ ] Manual: enable a plugin with valid credentials — response includes `connectionStatus.connected = true`
- [ ] Manual: hit `GET /api/plugins/openai/connection-status` directly — returns `{ connectionStatus: {...} }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve a plugin's connection status so users can verify a plugin is connected and operational.
  * Added a client-side API method to fetch a plugin's connection status for real-time visibility in the UI.

* **Performance**
  * Reduced unnecessary work when listing plugins by computing connection status only when explicitly requested, improving responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->