### PR TITLE
fix(agent): unbreak internal-cli CI — drop embedded quotes from Task.recurrenceTimezone default

### DIFF
--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -129,7 +129,17 @@ export class Task {
     @Column({ type: 'varchar', length: 200, nullable: true })
     recurrenceRule?: string | null;
 
-    @Column({ type: 'varchar', length: 64, nullable: true, default: "'UTC'" })
+    // `default: 'UTC'` (not `"'UTC'"`) — TypeORM auto-quotes string
+    // defaults for varchar columns, matching the convention used by
+    // every other string default in the entity layer (`'usd'`,
+    // `'pending'`, `'local'`, …). The previously-shipped embedded-
+    // quote form passed through Postgres correctly as `DEFAULT 'UTC'`
+    // but better-sqlite3's TypeORM driver emitted `DEFAULT UTC`
+    // (unquoted), so sqlite parsed `UTC` as an identifier and the
+    // CLI's `synchronize` step crashed with `near "UTC": syntax
+    // error`. That broke `apps/internal-cli`'s lint-and-test step on
+    // every PR open against `develop` since PR #1019.
+    @Column({ type: 'varchar', length: 64, nullable: true, default: 'UTC' })
     recurrenceTimezone?: string | null;
 
     @PortableDateColumn({ nullable: true })


### PR DESCRIPTION
## Summary

`packages/agent/src/entities/task.entity.ts` line 132 declared:

\`\`\`ts
@Column({ type: 'varchar', length: 64, nullable: true, default: \"'UTC'\" })
recurrenceTimezone?: string | null;
\`\`\`

The embedded single quotes were meant to emit a raw SQL \`DEFAULT 'UTC'\` expression. That round-trips fine through PostgreSQL but breaks better-sqlite3's TypeORM driver: when \`synchronize\` runs against sqlite (which is the path \`apps/internal-cli\`'s \`test:cli\` boot uses), the driver emits the bare \`DEFAULT UTC\` clause without re-quoting, and sqlite parses \`UTC\` as an identifier:

\`\`\`
SqliteError: near \"UTC\": syntax error
\`\`\`

## Impact

Every PR open against \`develop\` since PR [#1019](https://github.com/ever-works/ever-works/pull/1019) (Agents + Skills + Tasks) has failed the \`lint-and-test (22.x) / Test Internal CLI\` step with this error. \`develop\` itself has been red for the last 4 commits. [#1023](https://github.com/ever-works/ever-works/pull/1023) merged anyway; [#1024](https://github.com/ever-works/ever-works/pull/1024) still sits blocked on this.

## Fix

Match the convention every other string default in the entity layer already uses (\`default: 'usd'\`, \`'pending'\`, \`'local'\`, …) — pass the value unquoted and let TypeORM auto-quote it for the target dialect. Produces \`DEFAULT 'UTC'\` on both Postgres and sqlite, prod behaviour unchanged.

## Why the prior \"unbreak CI\" commits missed this

[\`aef0a7de\`](https://github.com/ever-works/ever-works/commit/aef0a7de) and [\`ddfb1b12\`](https://github.com/ever-works/ever-works/commit/ddfb1b12) swept \`type: 'timestamp'\` columns (Postgres-only type) — but the offender was a \`type: 'varchar'\` column with a bogus default expression. Different category of portability bug, didn't show up on the timestamp-type grep.

## Migration left as-is

\`1779978013000-CreateTasksTables.ts\` carries the same embedded-quote form, but only runs on Postgres in production (where \`DEFAULT 'UTC'\` is valid) and altering an already-applied migration would require a follow-up migration to ALTER the column default. Out of scope here — the entity fix alone unblocks the CI synchronize path without changing prod schema.

## Test plan

- [x] Agent typecheck + build clean
- [ ] CI: \`lint-and-test (22.x) / Test Internal CLI\` step goes green
- [ ] [#1024](https://github.com/ever-works/ever-works/pull/1024)'s CI re-runs cleanly after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database schema synchronization failures that caused crashes during internal CLI operations when processing recurring task timezone configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->