### PR TITLE
fix(api): wire SkillsModule + DatabaseModule into AgentsModule

### DIFF
--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -37,6 +37,16 @@ import {
     AiFacadeService,
     GitFacadeService,
 } from '@ever-works/agent/facades';
+// FU-2 — `AgentsController` injects `SkillBindingRepository` (for the
+// `GET /api/agents/:id/skills` rollup) and `PluginUsageRepository` (for
+// the `GET /api/agents/:id/budget` rollup). Their providers live in
+// the agent-side `SkillsModule` / `DatabaseModule` — neither is
+// re-exported by `AgentAgentsModule`, so we must import them directly
+// here for Nest to resolve the controller's constructor args. Same
+// posture as api-side `TasksModule` importing `DatabaseModule` for
+// `PluginUsageRepository`.
+import { SkillsModule as AgentSkillsModule } from '@ever-works/agent/skills';
+import { DatabaseModule } from '@ever-works/agent/database';
 import { AuthModule } from '../auth/auth.module';
 import { AgentsController } from './agents.controller';
 
@@ -73,7 +83,14 @@ import { AgentsController } from './agents.controller';
 // every unit test passing.
 @Global()
 @Module({
-    imports: [AgentAgentsModule, TasksDomainModule, FacadesModule, AuthModule],
+    imports: [
+        AgentAgentsModule,
+        AgentSkillsModule,
+        DatabaseModule,
+        TasksDomainModule,
+        FacadesModule,
+        AuthModule,
+    ],
     controllers: [AgentsController],
     providers: [
         {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
 			"fast-uri@<=3.1.1": ">=3.1.2",
 			"@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": ">=7.29.4",
 			"langsmith@<0.6.0": ">=0.6.0",
-			"fast-xml-builder@<=1.1.6": ">=1.1.7"
+			"fast-xml-builder@<=1.1.6": ">=1.1.7",
+			"tmp@<0.2.6": ">=0.2.6"
 		}
 	},
 	"prettier": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': '>=7.29.4'
   langsmith@<0.6.0: '>=0.6.0'
   fast-xml-builder@<=1.1.6: '>=1.1.7'
+  tmp@<0.2.6: '>=0.2.6'
 
 importers:
 
@@ -17688,8 +17689,8 @@ packages:
     resolution: {integrity: sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -30704,7 +30705,7 @@ snapshots:
       jszip: 3.10.1
       readable-stream: 3.6.2
       saxes: 5.0.1
-      tmp: 0.2.5
+      tmp: 0.2.6
       unzipper: 0.10.14
       uuid: 8.3.2
 
@@ -38224,7 +38225,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.24
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
## Summary

E2E was failing on `develop` → `stage` → `main` because the API crashed on boot:

```
Nest can't resolve dependencies of the AgentsController
(AgentsService, AgentFileService, AgentExportService,
 AgentScheduleDispatcherService, AgentRunRepository, ?,
 PluginUsageRepository, ...).
Please make sure that the argument SkillBindingRepository
at index [5] is available in the AgentsModule module.
```

PR #1021 (FU-2 — 6 new runtime endpoints) added `SkillBindingRepository` (for `GET /api/agents/:id/skills`) and `PluginUsageRepository` (for `GET /api/agents/:id/budget`) to [`AgentsController`'s constructor](apps/api/src/agents/agents.controller.ts), but the api-side [`AgentsModule`](apps/api/src/agents/agents.module.ts) was never updated to import the modules that provide them. The agent-side `AgentsModule` imports `SkillsModule` for its own internal use but does not re-export it, so the providers aren't visible to api-side consumers.

**Fix:** import `AgentSkillsModule` (from `@ever-works/agent/skills`) and `DatabaseModule` (from `@ever-works/agent/database`) directly into the api-side `AgentsModule`. Same posture as api-side `TasksModule` which already imports `DatabaseModule` for `PluginUsageRepository`.

## Failing runs that motivated this

- E2E Tests (#26481062364): https://github.com/ever-works/ever-works/actions/runs/26481062364 — fixed by this PR
- Build/Publish CLIs (#26481062365): https://github.com/ever-works/ever-works/actions/runs/26481062365 — separate issue, not in scope here: `"The job was not started because an Actions budget is preventing further use."` (GitHub Actions billing cap; needs operator action in repo Settings → Billing, not a code fix)

## Test plan

- [ ] CI `e2e (22.x)` job passes — API boots without `UnknownDependenciesException`
- [ ] CI `e2e-prod-build (22.x)` job passes — `next start` + API boot under prod build
- [ ] No regression in api unit tests (`apps/api/src/agents/agents.controller.runtime.spec.ts` mocks the imports, so this change is transparent to it)
- [ ] `GET /api/agents/:id/skills` and `GET /api/agents/:id/budget` resolve their repositories at runtime (covered by E2E API boot succeeding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved dependency resolution issues in the agents module, enabling proper initialization and integration of skill management and database components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->