### PR TITLE
test(agent): pass domain in DeployReadyPoller spec to fix CI

### DIFF
--- a/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
+++ b/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
@@ -77,7 +77,11 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const httpFetch = jest.fn().mockResolvedValue({ status: 503 }) as unknown as typeof fetch;
         const { service, workRepository, funnel } = buildService([work], httpFetch);
 
-        const summary = await service.pollOnce({ fetch: httpFetch, now: () => NOW, domain: 'ever.works' });
+        const summary = await service.pollOnce({
+            fetch: httpFetch,
+            now: () => NOW,
+            domain: 'ever.works',
+        });
 
         expect(summary).toEqual({ scanned: 1, ready: 0, stillPending: 1, failed: 0 });
         expect(workRepository.update).not.toHaveBeenCalled();

--- a/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
+++ b/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
@@ -61,7 +61,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const httpFetch = jest.fn().mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
         const { service, workRepository, funnel } = buildService([work], httpFetch);
 
-        await service.pollOnce({ fetch: httpFetch, now: () => NOW });
+        await service.pollOnce({ fetch: httpFetch, now: () => NOW, domain: 'ever.works' });
 
         expect(workRepository.update).toHaveBeenCalledWith('w-2', { deploymentState: 'READY' });
         expect(funnel.emit).not.toHaveBeenCalled();
@@ -77,7 +77,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const httpFetch = jest.fn().mockResolvedValue({ status: 503 }) as unknown as typeof fetch;
         const { service, workRepository, funnel } = buildService([work], httpFetch);
 
-        const summary = await service.pollOnce({ fetch: httpFetch, now: () => NOW });
+        const summary = await service.pollOnce({ fetch: httpFetch, now: () => NOW, domain: 'ever.works' });
 
         expect(summary).toEqual({ scanned: 1, ready: 0, stillPending: 1, failed: 0 });
         expect(workRepository.update).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Pass `domain: 'ever.works'` in the two `pollOnce` calls in `deploy-ready-poller.service.spec.ts` that were missing it.
- Fixes the `lint-and-test (22.x)` failure introduced on `main` after [PR #1031](https://github.com/ever-works/ever-works/pull/1031) hardened `DeployReadyPollerService.pollOnce()` to throw when neither `options.domain` nor `EVER_WORKS_DOMAIN` is set (greptile P2: prevents a misconfigured staging from probing the production hostname pattern and reporting false-positive READY states).

The first test in the spec already passed `domain: 'ever.works'`; the two later cases didn't, so on CI (no `EVER_WORKS_DOMAIN` env) they now throw with `deploy-ready-poller: domain not configured`. Mirrors the existing pattern in the happy-path test rather than mutating `process.env`.

Failing run: https://github.com/ever-works/ever-works/actions/runs/26509142259/job/78069188834

## Test plan

- [x] `cd packages/agent && npx jest src/services/__tests__/deploy-ready-poller.service.spec.ts` — 3/3 pass locally
- [ ] CI `lint-and-test (22.x)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)