### PR TITLE
test(agent): pass domain in DeployReadyPoller spec to fix CI on develop

### DIFF
--- a/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
+++ b/packages/agent/src/services/__tests__/deploy-ready-poller.service.spec.ts
@@ -61,7 +61,7 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const httpFetch = jest.fn().mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
         const { service, workRepository, funnel } = buildService([work], httpFetch);
 
-        await service.pollOnce({ fetch: httpFetch, now: () => NOW });
+        await service.pollOnce({ fetch: httpFetch, now: () => NOW, domain: 'ever.works' });
 
         expect(workRepository.update).toHaveBeenCalledWith('w-2', { deploymentState: 'READY' });
         expect(funnel.emit).not.toHaveBeenCalled();
@@ -77,7 +77,11 @@ describe('DeployReadyPollerService.pollOnce', () => {
         const httpFetch = jest.fn().mockResolvedValue({ status: 503 }) as unknown as typeof fetch;
         const { service, workRepository, funnel } = buildService([work], httpFetch);
 
-        const summary = await service.pollOnce({ fetch: httpFetch, now: () => NOW });
+        const summary = await service.pollOnce({
+            fetch: httpFetch,
+            now: () => NOW,
+            domain: 'ever.works',
+        });
 
         expect(summary).toEqual({ scanned: 1, ready: 0, stillPending: 1, failed: 0 });
         expect(workRepository.update).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Port spec fix from PR #1035 (merged to `main`) to `develop`.
- Pass `domain: 'ever.works'` to `pollOnce()` in the two subsequent specs that were missing it.

## Background

PR #1031 made `DeployReadyPollerService.pollOnce()` throw when neither `options.domain` nor `EVER_WORKS_DOMAIN` is set. PR #1035 fixed the test on `main`, but the fix never propagated back to `develop` — so develop's CI is still red on the agent package.

This is a straight port of the same 8-line change.

## CI failure being fixed

[Run 26511767004](https://github.com/ever-works/ever-works/actions/runs/26511767004) — `@ever-works/agent#test` exits 1 with:

```
deploy-ready-poller: domain not configured — set EVER_WORKS_DOMAIN env or pass options.domain
```

on `DeployReadyPollerService.pollOnce › flips state to READY but skips emit when lastDeployCorrelationId is absent` and `leaves the row alone and counts stillPending when the health probe returns non-200`.

## Test plan

- [x] `cd packages/agent && npx jest deploy-ready-poller.service.spec.ts` → 3 passed, 0 failed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test cases to align with service method signature requirements.

**Note:** This release contains internal maintenance improvements only. No user-facing changes or new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->