### PR TITLE
fix(web): Mission template id preservation + clarify ?prompt= comments

### DIFF
--- a/apps/web/src/components/agents/NewAgentDialog.tsx
+++ b/apps/web/src/components/agents/NewAgentDialog.tsx
@@ -106,8 +106,14 @@ export function NewAgentDialog({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [searchParams]);
 
-    // Pre-fill from `?prompt=` (global `/new` page hands off the
-    // user's free-text description as the Agent's name/title).
+    // Pre-fill from `?prompt=` — supports direct deep-link navigation
+    // to `/agents/new?prompt=…` (e.g. from external integrations or
+    // callers that still want to pre-populate the form via URL). Note:
+    // the global `/new` page no longer passes `?prompt=` for the Agent
+    // chip; it sends the prompt through the chat channel instead and
+    // routes here without a query string. This effect is a no-op on
+    // that path and only fires when something explicitly puts a
+    // `prompt` param in the URL.
     useEffect(() => {
         const promptParam = searchParams?.get('prompt');
         if (!promptParam) return;

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -21,6 +21,7 @@ import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
+import { createMissionAction } from '@/app/actions/dashboard/missions';
 
 /**
  * Unified `/new` page — single prompt input + chips for every
@@ -210,7 +211,33 @@ export function NewPageClient({
             toast.error(t('hints.minLength'));
             return;
         }
-        startSubmit(() => {
+        startSubmit(async () => {
+            // Special case: Mission with a template-id in scope.
+            // `/new?type=mission&template=<id>` comes from "Use this
+            // template" buttons elsewhere in the app and needs the
+            // template persisted as `missionTemplateRepo` on the new
+            // Mission. The chat AI doesn't yet have a template-aware
+            // Mission-creation tool, so dropping the id would silently
+            // lose the template link (Greptile P1 on PR #1038). Keep
+            // the legacy inline-create path here, then still open
+            // chat afterward so the user can keep iterating in
+            // conversation about the Mission we just created.
+            if (selectedChip === 'mission' && initialTemplateId) {
+                try {
+                    const mission = await createMissionAction({
+                        description,
+                        type: 'one-shot',
+                        missionTemplateRepo: initialTemplateId,
+                    });
+                    toast.success(t('toasts.missionCreated'));
+                    startFromPrompt(description, { intent: CHIP_INTENT_LABEL.mission });
+                    router.push(ROUTES.DASHBOARD_MISSION(mission.id));
+                } catch (err) {
+                    toast.error(err instanceof Error ? err.message : t('toasts.submitError'));
+                }
+                return;
+            }
+
             // Send the prompt into the chat AI so the user can keep
             // iterating in chat — replaces the old "submit + redirect
             // with the same prompt pre-filled" pattern. The chat AI's
@@ -247,10 +274,6 @@ export function NewPageClient({
                 return;
             }
         });
-        // initialTemplateId stays informational for now — Mission
-        // template-driven creation moves into the chat flow once the
-        // chat surface understands "use template <id>" intents.
-        void initialTemplateId;
     };
 
     // Per-chip placeholder cycle. New reference on each chip flip

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -219,9 +219,16 @@ export function NewPageClient({
             // Mission. The chat AI doesn't yet have a template-aware
             // Mission-creation tool, so dropping the id would silently
             // lose the template link (Greptile P1 on PR #1038). Keep
-            // the legacy inline-create path here, then still open
-            // chat afterward so the user can keep iterating in
-            // conversation about the Mission we just created.
+            // the legacy inline-create path here.
+            //
+            // Importantly, we DO NOT then send the same prompt into
+            // the chat AI: the chat has `createMission` registered as
+            // a tool and the system prompt instructs it to use tools
+            // for mutations (Codex P2), so re-sending "I want to
+            // create a Mission. <description>" would trigger a SECOND
+            // non-template Mission creation. Just open the panel so
+            // the user can iterate manually if they want, but don't
+            // dispatch a message.
             if (selectedChip === 'mission' && initialTemplateId) {
                 try {
                     const mission = await createMissionAction({
@@ -230,7 +237,7 @@ export function NewPageClient({
                         missionTemplateRepo: initialTemplateId,
                     });
                     toast.success(t('toasts.missionCreated'));
-                    startFromPrompt(description, { intent: CHIP_INTENT_LABEL.mission });
+                    setChatOpen?.(true);
                     router.push(ROUTES.DASHBOARD_MISSION(mission.id));
                 } catch (err) {
                     toast.error(err instanceof Error ? err.message : t('toasts.submitError'));

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('next-intl', () => ({
     useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
@@ -198,7 +198,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
     });
 
     describe('Mission template path (initialTemplateId set)', () => {
-        it('Submit with chip=mission + template inline-creates with missionTemplateRepo, opens chat, routes to the new Mission detail page', async () => {
+        it('Submit with chip=mission + template inline-creates with missionTemplateRepo, opens chat WITHOUT a message, routes to the new Mission detail page', async () => {
             createMissionMock.mockClear();
             startFromPromptMock.mockClear();
             routerPushMock.mockClear();
@@ -213,25 +213,25 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             fireEvent.change(getTextarea(container), {
                 target: { value: 'Starter Business — long enough to enable Submit' },
             });
-            fireEvent.click(getSubmit(container));
-            // Resolve the in-flight startSubmit → createMissionAction promise.
-            await Promise.resolve();
-            await Promise.resolve();
+            await act(async () => {
+                fireEvent.click(getSubmit(container));
+            });
             // The template path must persist the template id on the
             // new Mission — Greptile P1 on PR #1038 caught the
             // regression where this was silently dropped.
-            expect(createMissionMock).toHaveBeenCalledWith({
-                description: 'Starter Business — long enough to enable Submit',
-                type: 'one-shot',
-                missionTemplateRepo: 'starter-business',
-            });
-            // Chat still gets the prompt so the user can keep iterating.
-            expect(startFromPromptMock).toHaveBeenCalledWith(
-                'Starter Business — long enough to enable Submit',
-                { intent: 'Mission' },
+            await waitFor(() =>
+                expect(createMissionMock).toHaveBeenCalledWith({
+                    description: 'Starter Business — long enough to enable Submit',
+                    type: 'one-shot',
+                    missionTemplateRepo: 'starter-business',
+                }),
             );
+            // Codex P2: must NOT send the prompt into chat after the
+            // inline create — the chat AI's `createMission` tool would
+            // re-create the Mission as a second non-template row.
+            expect(startFromPromptMock).not.toHaveBeenCalled();
             // Canvas is the new Mission's detail page.
-            expect(routerPushMock).toHaveBeenCalledWith('/missions/m-tpl-new');
+            await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/missions/m-tpl-new'));
         });
 
         it('Submit with chip=mission WITHOUT a template falls through to the chat-only path (no inline create)', () => {

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -35,6 +35,11 @@ vi.mock('@/lib/hooks/use-chat-panel', () => ({
     useChatPanel: () => ({ open: false, setOpen: vi.fn() }),
 }));
 
+const createMissionMock = vi.fn();
+vi.mock('@/app/actions/dashboard/missions', () => ({
+    createMissionAction: (...args: unknown[]) => createMissionMock(...args),
+}));
+
 import { NewPageClient } from './NewPageClient';
 
 function getTextarea(container: HTMLElement): HTMLTextAreaElement {
@@ -190,5 +195,60 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
         );
         const textarea = getTextarea(container);
         expect(textarea.value).toBe(prefill);
+    });
+
+    describe('Mission template path (initialTemplateId set)', () => {
+        it('Submit with chip=mission + template inline-creates with missionTemplateRepo, opens chat, routes to the new Mission detail page', async () => {
+            createMissionMock.mockClear();
+            startFromPromptMock.mockClear();
+            routerPushMock.mockClear();
+            createMissionMock.mockResolvedValueOnce({ id: 'm-tpl-new', title: 'x' });
+            const { container } = render(
+                <NewPageClient
+                    initialType="mission"
+                    initialPrompt="Starter Business"
+                    initialTemplateId="starter-business"
+                />,
+            );
+            fireEvent.change(getTextarea(container), {
+                target: { value: 'Starter Business — long enough to enable Submit' },
+            });
+            fireEvent.click(getSubmit(container));
+            // Resolve the in-flight startSubmit → createMissionAction promise.
+            await Promise.resolve();
+            await Promise.resolve();
+            // The template path must persist the template id on the
+            // new Mission — Greptile P1 on PR #1038 caught the
+            // regression where this was silently dropped.
+            expect(createMissionMock).toHaveBeenCalledWith({
+                description: 'Starter Business — long enough to enable Submit',
+                type: 'one-shot',
+                missionTemplateRepo: 'starter-business',
+            });
+            // Chat still gets the prompt so the user can keep iterating.
+            expect(startFromPromptMock).toHaveBeenCalledWith(
+                'Starter Business — long enough to enable Submit',
+                { intent: 'Mission' },
+            );
+            // Canvas is the new Mission's detail page.
+            expect(routerPushMock).toHaveBeenCalledWith('/missions/m-tpl-new');
+        });
+
+        it('Submit with chip=mission WITHOUT a template falls through to the chat-only path (no inline create)', () => {
+            createMissionMock.mockClear();
+            startFromPromptMock.mockClear();
+            routerPushMock.mockClear();
+            const { container } = render(<NewPageClient initialType="mission" />);
+            fireEvent.change(getTextarea(container), {
+                target: { value: 'No template, just a typed mission goal' },
+            });
+            fireEvent.click(getSubmit(container));
+            expect(createMissionMock).not.toHaveBeenCalled();
+            expect(startFromPromptMock).toHaveBeenCalledWith(
+                'No template, just a typed mission goal',
+                { intent: 'Mission' },
+            );
+            expect(routerPushMock).toHaveBeenCalledWith('/missions');
+        });
     });
 });

--- a/apps/web/src/components/tasks/NewTaskForm.tsx
+++ b/apps/web/src/components/tasks/NewTaskForm.tsx
@@ -63,11 +63,16 @@ export function NewTaskForm({ createTask }: { createTask: CreateTaskFn }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [searchParams]);
 
-    // Pre-fill from `?prompt=` so the global `/new` page can hand off
-    // the user's free-text description into the Task form's title /
-    // description fields. The first line becomes the title and the
-    // remainder seeds the description, so a single-line prompt still
-    // lands cleanly without an empty description block.
+    // Pre-fill from `?prompt=` — supports direct deep-link navigation
+    // to `/tasks/new?prompt=…` (e.g. from external integrations or
+    // callers that still want to pre-populate the form via URL). Note:
+    // the global `/new` page no longer passes `?prompt=` for the Task
+    // chip; it sends the prompt through the chat channel instead and
+    // routes here without a query string. This effect is a no-op on
+    // that path and only fires when something explicitly puts a
+    // `prompt` param in the URL. The first line becomes the title and
+    // the remainder seeds the description, so a single-line prompt
+    // still lands cleanly without an empty description block.
     useEffect(() => {
         const promptParam = searchParams?.get('prompt');
         if (!promptParam) return;


### PR DESCRIPTION
## Summary

Addresses [Greptile's review findings on PR #1038](https://github.com/ever-works/ever-works/pull/1038) (the develop → stage cascade). Three issues, all surfaced by the bot pass after [#1034](https://github.com/ever-works/ever-works/pull/1034) landed on develop.

### 1. P1 — \`initialTemplateId\` silently dropped (`NewPageClient`)

Before the chat-driven rewrite, \`/new?type=mission&template=<id>\` ("Use this template" buttons elsewhere in the app) created the Mission inline with \`missionTemplateRepo\` set. After the rewrite, the template id was unceremoniously \`void\`'d, so the new Mission would lose its template link — and the corresponding chat-AI tool for template-aware Mission creation hasn't shipped yet.

**Fix:** keep the legacy inline \`createMissionAction\` path when \`initialTemplateId\` is in scope so the template is persisted, AND still open chat afterward so the user can keep iterating in conversation about the just-created Mission. Non-template Mission submits keep the chat-only path unchanged.

### 2. P2 — Stale \`?prompt=\` comment in \`NewAgentDialog.tsx\`

The comment claimed the global \`/new\` page hands off the prompt as a URL param. After the chat rewrite, \`/new\` no longer passes \`?prompt=\` for the Agent chip — it sends the prompt through the chat channel and routes here without a query string. The pre-fill path now only matters for direct deep-links from external integrations. Updated to reflect that.

### 3. P2 — Same stale comment in \`NewTaskForm.tsx\` for the Task chip

Updated identically.

### Tests

Added two unit tests covering the template path:
- inline-create + chat-open + Mission-detail-route happy path
- "no template" guard confirming the chat-only path is unchanged when no template id is in scope

13 tests total in the spec, all passing.

## Test plan

- [ ] CI green (\`tsc --noEmit\`, prettier, vitest, jest)
- [ ] Manual: open \`/new?type=mission&template=<some-template>\`, submit prompt — verify a new Mission is created with the template repo set, chat opens, redirect lands on the Mission detail page.
- [ ] Manual: open \`/new\` directly (no template), pick Mission chip, submit — verify chat opens and redirect lands on \`/missions\`, no inline create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mission creation with template support—when a mission template is selected, submitting creates the mission server-side, shows success feedback, opens chat, and redirects to the new mission page.

* **Tests**
  * Added unit tests covering mission-template creation paths and related routing/behavior.

* **Documentation**
  * Clarified comments about ?prompt= URL pre-fill behavior for agent and task creation forms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->