### PR TITLE
docs(specs): add Tenants and Organizations feature spec

### DIFF
--- a/docs/specs/features/tenants-and-organizations/acceptance.md
+++ b/docs/specs/features/tenants-and-organizations/acceptance.md
@@ -1,0 +1,225 @@
+# Tenants & Organizations — Acceptance Criteria
+
+**Status:** Draft v1 · **Date:** 2026-05-27
+**Spec:** [spec.md](spec.md) · **Plan:** [plan.md](plan.md) · **Tasks:** [tasks.md](tasks.md)
+
+This file describes the **observable behavior** required for each phase to be considered complete. Implementation details are in plan/tasks; this file is the user-and-reviewer-visible contract.
+
+---
+
+## Phase 0 — Username uniqueness contract
+
+### AC-0.1 — DB-enforced uniqueness
+- Two attempts to `INSERT INTO users (username) VALUES ('ever')` (case-equivalent — `EVER`, `Ever`, `ever`) from any code path fail with a UNIQUE violation. Postgres + SQLite both enforce.
+
+### AC-0.2 — Slug column present
+- Every user row has a non-null `slug` column populated with the URL-safe form of `username`. The slug is also case-insensitively unique.
+
+### AC-0.3 — Programmatic collision flow
+- An OAuth signup whose suggested username already exists produces a User with `username = '<suggested>-2'` (next free integer). No error surfaced to the user.
+
+### AC-0.4 — Interactive collision flow
+- `GET /api/users/check-username?value=ever` for an existing `ever` user returns `{ available: false, suggestion: 'ever-2' }`.
+- `GET /api/users/check-username?value=verynewname` returns `{ available: true }`.
+
+### AC-0.5 — No regressions
+- Existing 26 agent test suites + 719 tests pass. Existing auth flows (login, GitHub App, anonymous claim) succeed.
+
+---
+
+## Phase 1 — `tenants` and `organizations` tables
+
+### AC-1.1 — Tables exist
+- After migration: `SELECT * FROM tenants` and `SELECT * FROM organizations` succeed and return zero rows.
+- Both tables have the indexes specified in [spec.md §1.1 / §1.2](spec.md#1-the-two-concepts).
+
+### AC-1.2 — FK + cascade behavior
+- `DELETE FROM tenants WHERE id = X` cascades to delete every Organization with `tenantId = X`.
+- `DELETE FROM works WHERE id = X` sets `organizations.linkedWorkId = NULL` for any Org pointing at it.
+
+### AC-1.3 — No row writes
+- Phase 1 does not insert any row anywhere. No existing user gains a `tenantId`.
+
+---
+
+## Phase 2 — `tenantId` on `users` + Tier B
+
+### AC-2.1 — Columns present
+- `users.tenantId`, `auth_accounts.tenantId`, etc. all exist as nullable UUID columns.
+
+### AC-2.2 — No backfill
+- All existing rows have `tenantId IS NULL`.
+
+### AC-2.3 — No write-path change
+- Creating a new User via any existing signup path still produces `tenantId = NULL` (no Tenant exists yet for them).
+
+---
+
+## Phase 3 — Tier A entities
+
+### AC-3.1 — Columns present
+- Every Tier A entity has both `tenantId` and `organizationId` as nullable UUID columns.
+
+### AC-3.2 — Indexes present
+- `idx_<table>_tenant_id` and `idx_<table>_organization_id` exist on each table per [spec.md §2.3](spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets).
+
+### AC-3.3 — Idempotent migrations
+- Running each migration twice does not error (matches the existing `hasColumn` guard pattern).
+
+---
+
+## Phase 4 — FK upgrade for pre-existing `organizationId`
+
+### AC-4.1 — FK enforced
+- `INSERT INTO works (..., organizationId)` with a UUID not in `organizations.id` fails with FK violation.
+- Same for `work_knowledge_documents`.
+
+### AC-4.2 — Cascade behavior
+- `DELETE FROM organizations WHERE id = X` sets `works.organizationId = NULL` and `work_knowledge_documents.organizationId = NULL` for matching rows.
+
+---
+
+## Phase 5 — Tier C denormalization
+
+### AC-5.1 — Columns present
+- All Tier C entities have `tenantId` (nullable) and, where parent has it, `organizationId` (nullable).
+
+### AC-5.2 — Service propagation
+- After Phase 5, creating any Tier C row via the affected services (with an actor whose User has a `tenantId` set) results in the row having `tenantId` populated to match.
+- If the actor's User has `tenantId = NULL`, the row has `tenantId = NULL` (no change from pre-Phase-5 behavior).
+
+### AC-5.3 — Audit script clean
+- An audit query `SELECT COUNT(*) FROM <tier_c_table> WHERE tenantId IS NULL AND <parent_fk> IN (SELECT id FROM <parent> WHERE tenantId IS NOT NULL)` returns 0 for every Tier C table.
+
+---
+
+## Phase 6 — Lazy upgrade + Org-create API
+
+### AC-6.1 — First Organization creates a Tenant
+- User Alice has `tenantId = NULL` initially.
+- `POST /api/organizations { "name": "Acme Inc" }` succeeds; response includes the new Organization.
+- After the call: Alice has `tenantId = <new>`, exactly one Tenant row exists for her, one Organization row exists with `tenantId = Alice.tenantId`.
+
+### AC-6.2 — Second Organization reuses the Tenant
+- Alice creates `Globex LLC` via the same endpoint. After the call: exactly one Tenant row for Alice, two Organization rows, both with the same `tenantId`.
+
+### AC-6.3 — Upgrade-from-account moves rows
+- Alice has 5 Missions, 3 Works, 12 Tasks all with `organizationId IS NULL` (currently in her Tenant root).
+- `POST /api/organizations/:id/upgrade-from-account` moves all 20 rows: their `organizationId` is now the upgraded Org's id.
+- Re-running the same endpoint a second time is a no-op (idempotent).
+
+### AC-6.4 — Slug uniqueness across tables
+- `GET /api/organizations/check-slug?value=alice` returns `{ available: false }` if Alice's `users.slug` is `alice`.
+- Creating an Org with a slug that collides with an existing `users.slug` or `organizations.slug` either fails with a clear 409 (interactive flow) or auto-suffixes (programmatic flow).
+
+### AC-6.5 — Tenant ownership enforced
+- Bob attempts `POST /api/organizations/<aliceOrgId>/upgrade-from-account`. Server returns 404 (not 403 — see [spec.md §4.3](spec.md#43-authorization)).
+
+---
+
+## Phase 7 — Slug routing
+
+### AC-7.1 — Slug routes resolve
+- `GET /api/missions` on Alice's session with `X-Scope-Slug: alice` returns Alice's bare-Tenant Missions.
+- `GET /api/missions` with `X-Scope-Slug: acme-inc` returns only Acme Inc's Missions.
+- `GET /api/missions` with `X-Scope-Slug: notarealsulug` returns 404.
+
+### AC-7.2 — Org takes precedence on collision (defensive)
+- A degenerate test setup with `users.slug = 'acme'` and `organizations.slug = 'acme'` (which shouldn't be possible thanks to the allocator) resolves to the Organization. *(This is a defensive check; the allocator prevents this case at write time.)*
+
+### AC-7.3 — Web app routes work
+- Navigating to `/alice/missions` shows Alice's bare-Tenant data.
+- Navigating to `/acme-inc/missions` shows Acme Inc's data only.
+- Bookmarks to the existing un-prefixed URLs (`/missions`) still work for the lifetime of v1.
+
+---
+
+## Phase 8 — WorkspaceSwitcher UI
+
+### AC-8.1 — Empty state shows the Ever Works logo
+- A user with zero Organizations sees the existing Ever Works logo in the top-left sidebar slot. No chevron, no popover trigger, no visual hint that switching is possible.
+
+### AC-8.2 — Active state shows the switcher chip
+- A user with 1+ Organizations sees a chip displaying the currently active scope (Org logo + name OR user's display name if on bare Tenant) and a small chevron icon.
+
+### AC-8.3 — Popover lists Organizations
+- Clicking the chip opens a popover with heading "**Organizations**" (NOT "Workspaces", NOT "Tenants" — verified in i18n).
+- The currently active scope has a check icon.
+- Footer item "+ Create Organization" is present.
+
+### AC-8.4 — Switching navigates and persists
+- Clicking a different Organization navigates the user to `/{newOrgSlug}/dashboard` and persists `users.lastScopeOrganizationId`. The next session login lands on the same scope.
+
+---
+
+## Phase 9 — CreateOrganizationModal + upgrade-vs-new dialog
+
+### AC-9.1 — First-Org dialog defaults to Upgrade
+- When the user creates their FIRST Organization, the upgrade-vs-new dialog appears with "Upgrade current account" pre-selected and focused.
+
+### AC-9.2 — Upgrade choice moves all existing items
+- After confirming "Upgrade", every Tier A/B/C row owned by the user gets its `organizationId` set to the new Org. The new Org scope now shows the user's pre-existing items.
+
+### AC-9.3 — Empty choice leaves bare Tenant intact
+- After confirming "Create with empty data", the new Org scope is empty; the bare-Tenant scope still shows the user's pre-existing items.
+
+### AC-9.4 — Subsequent Orgs skip the dialog
+- When the user creates a SECOND (or later) Organization, no upgrade-vs-new dialog is shown. The Org is created empty.
+
+### AC-9.5 — Slug live-check
+- The modal shows a live slug suggestion (debounced) and disables submit until the slug is available.
+
+---
+
+## Phase 10 — Company chip + Work→Org wire-up
+
+### AC-10.1 — Chip present and ordered
+- The `+ New` page shows the chips in the order: `Mission · Idea · Website · Landing Page · Store · Blog · Directory · Awesome Repo · Knowledge Base · Company`.
+
+### AC-10.2 — Company chip routes to Register Company flow
+- Selecting the Company chip + submitting the prompt opens the Register Company flow (UI copy uses "**Register Company**", not "Create Organization").
+
+### AC-10.3 — Registered Company creates an Organization
+- When a Work of type Company is marked `registered`, an Organization row is created with `legalName`, `countryCode`, `registrationProvider`, `registrationStatus = 'registered'`, `linkedWorkId = work.id`.
+
+### AC-10.4 — Work stays in place
+- The Work that triggered the registration stays in its original scope (no relocation). It does, however, gain `organizationId = newOrg.id` so it's also visible in the new Org's scope.
+
+### AC-10.5 — First-Org upgrade dialog triggers (if applicable)
+- If this is the user's FIRST Organization (regardless of whether it came from manual create or Stripe-Atlas), the upgrade-vs-new dialog appears with the same defaults.
+
+---
+
+## Cross-cutting acceptance
+
+### AC-X.1 — No live data corruption
+- Running the full migration set on a snapshot of staging data leaves all existing tests green and no orphan rows.
+
+### AC-X.2 — Reversibility
+- Every migration's `down()` method runs cleanly in reverse order. (Not a routine operation, but the safety valve.)
+
+### AC-X.3 — CI gates
+- Lightweight CI (typecheck, lint, agent test suite) is green on every PR.
+- Medium + heavy CI (E2E, Lighthouse, k8s-e2e) is green on the `develop → stage` and `stage → main` cascade PRs.
+
+### AC-X.4 — No NN violations
+- No PR removes existing UI strings or surfaces (NN #20).
+- Every PR with an entity change ships the migration in the same PR (NN #16).
+- No PR force-pushes or pushes directly to `main`/`master`/`stage` (NN #21).
+
+### AC-X.5 — Documentation up-to-date
+- [spec.md](spec.md) reflects any deviation discovered during implementation (treated as additive amendments — never silent reshapes).
+- [tasks.md](tasks.md) checkboxes are ticked as each item lands.
+- The companion Workspace note [2026-05-27-tenants-and-organizations-spec.md](../../../../../../Workspace/knowledge/notes/2026-05-27-tenants-and-organizations-spec.md) is kept in sync.
+
+---
+
+## Definition of Done (overall)
+
+The Tenants & Organizations feature is **done** when:
+
+1. All 10 phases land on `develop` and cascade to `stage` and `main` per NN #21.
+2. Every Acceptance Criterion above is observably true on `stage`.
+3. The Workspace companion note links to the Epic in JIRA and back to this spec.
+4. The implementation prompt (for fresh agents) in the conversation history has been superseded (or marked as completed in JIRA).
+5. The Missions/Ideas/Works spec ([2026-05-24-missions-ideas-works-spec.md](../../../../../../Workspace/knowledge/notes/2026-05-24-missions-ideas-works-spec.md)) is cross-referenced from this spec, and vice versa.

--- a/docs/specs/features/tenants-and-organizations/plan.md
+++ b/docs/specs/features/tenants-and-organizations/plan.md
@@ -1,0 +1,344 @@
+# Tenants & Organizations — Implementation Plan
+
+**Status:** Draft v1 · **Owner:** Engineering · **Date:** 2026-05-27
+**Spec:** [spec.md](spec.md) · **Tasks:** [tasks.md](tasks.md) · **Acceptance:** [acceptance.md](acceptance.md)
+
+> This plan is **additive**. Every step adds a column, a table, an endpoint, or a UI surface. Nothing existing is removed, renamed, or refactored. Existing users keep working without any data migration applied to them — they simply have `tenantId = NULL` until they create their first Organization.
+
+The plan is **10 phases**. Each phase is a JIRA Story (Story keys assigned at ticket creation — see [tasks.md](tasks.md) for the linkage). Each phase ships as one PR against `develop` unless noted.
+
+---
+
+## Phase 0 — Username uniqueness contract (foundation)
+
+**Goal:** Make `users.username` uniqueness an enforced DB-level contract before anything else relies on it for slug routing.
+
+**Changes:**
+
+1. New TypeORM migration: `AddUniqueIndexToUsername`.
+   - Pre-check: `SELECT username, COUNT(*) FROM users GROUP BY username HAVING COUNT(*) > 1` — fail the migration loudly with a clear message if any duplicates exist (operator decides resolution). No live users yet, so we expect zero.
+   - Add a UNIQUE index on `lower(username)` (Postgres expression index for case-insensitive uniqueness).
+   - SQLite fallback: plain UNIQUE on the raw column (covers the better-sqlite3 internal-cli test driver — see [`database-migrations.md`](../../architecture/database-migrations.md)).
+2. New TypeORM migration: `AddSlugToUsers`.
+   - Add nullable `slug` varchar column.
+   - Backfill `slug` from `username` (URL-normalize per [spec.md §3.3](spec.md#33-url-safety)) for every existing user.
+   - Add UNIQUE index on `lower(slug)`.
+   - Flip column to NOT NULL after backfill.
+3. New service: `apps/api/src/users/username-allocator.service.ts`.
+   - Public method `allocateUsername(base: string): Promise<string>` — runs the existing suffix-on-collision loop in one place. Replace the inline loop in `github-app-onboarding.service.ts:223-229` with a call to this service.
+   - Public method `allocateSlug(base: string, ownerTable: 'users' | 'organizations'): Promise<string>` — same loop, checks both `users.slug` and `organizations.slug` for collisions. Used by the eventual Org-create path too.
+4. New API endpoint: `GET /api/users/check-username?value=<string>`.
+   - Public (`@Public()`).
+   - Throttled.
+   - Returns `{ available: boolean, suggestion?: string }`.
+   - Used by interactive UI signup / settings forms.
+5. Update entity: `user.entity.ts` — add `unique: true` to `@Column()` for `username`; add `@Column({ unique: true }) slug: string;` (matches migration).
+
+**Out of scope this phase:** any Tenant / Organization tables; any UI changes; any other entity changes.
+
+**Tests:**
+- Unit: `UsernameAllocatorService` handles collisions deterministically.
+- Integration: `GET /check-username` returns suggestions and matches subsequent create behavior.
+- Migration: dry-run on a snapshot — no duplicates, clean apply.
+
+---
+
+## Phase 1 — Create `tenants` and `organizations` tables
+
+**Goal:** Land the two new tables. Empty on first deploy. No rows are written by this phase.
+
+**Changes:**
+
+1. New entity: `packages/agent/src/entities/tenant.entity.ts`.
+   - Columns per [spec.md §1.1](spec.md#11-tenant-internal-only-never-shown-in-ui).
+   - Unique index on `ownerUserId`.
+   - Unique index on `lower(slug)`.
+2. New entity: `packages/agent/src/entities/organization.entity.ts`.
+   - Columns per [spec.md §1.2](spec.md#12-organization-user-facing--ui-label-varies).
+   - FK `tenantId` → `tenants(id)` ON DELETE CASCADE.
+   - FK `linkedWorkId` → `works(id)` ON DELETE SET NULL.
+   - Unique index on `lower(slug)` — globally unique across the table.
+   - Composite index on `(tenantId, createdAt)` for switcher list queries.
+3. New repository: `TenantRepository`, `OrganizationRepository` (under `packages/agent/src/database/`).
+4. New TypeORM migration: `CreateTenantsTable`.
+5. New TypeORM migration: `CreateOrganizationsTable`.
+6. Register both entities in `packages/agent/src/entities/index.ts` and the appropriate ORM module.
+
+**Out of scope this phase:** any FK-back from existing tables to these new tables (that's Phase 2+). No backfill. No API endpoints yet.
+
+**Tests:**
+- Schema test: both tables exist, indexes are present, FKs cascade correctly.
+- Entity test (alongside existing `work.entity.spec.ts` pattern): constructor + ClassToObject round-trip.
+
+---
+
+## Phase 2 — Add `tenantId` to `users`; add `tenantId` to Tier B entities
+
+**Goal:** Wire the User → Tenant FK and add `tenantId` to all auth-scoped Tier B entities (`tenantId` only — no `organizationId` for these).
+
+**Changes:**
+
+1. New TypeORM migration: `AddTenantIdToUsers`.
+   - Add nullable `tenantId uuid` column to `users`.
+   - Add FK to `tenants(id)` ON DELETE SET NULL.
+   - Add index.
+   - **No backfill.** Existing users stay `tenantId = NULL`.
+2. New TypeORM migration: `AddTenantIdToTierBEntities`.
+   - Adds nullable `tenantId uuid` column + FK + index to each of:
+     - `auth_accounts`
+     - `auth_sessions`
+     - `auth_verifications`
+     - `refresh_tokens`
+     - `user_template_preferences`
+     - `user_task_counters`
+   - **No backfill.** Existing rows stay `tenantId = NULL`.
+3. Update entities to add the column (`@ManyToOne(() => Tenant, { nullable: true })`).
+
+**Out of scope this phase:** writing `tenantId` on new inserts (that's Phase 5 — only after Tenant rows exist, which only happens after the lazy upgrade flow lands). Until then, `tenantId` stays NULL on all new auth rows too.
+
+---
+
+## Phase 3 — Add `tenantId` + `organizationId` to Tier A entities
+
+**Goal:** Add both columns to all top-level business entities.
+
+**Changes:**
+
+1. One TypeORM migration per entity (following the [`1779977000000-AddWorkOrganizationId.ts`](../../../../apps/api/src/migrations/1779977000000-AddWorkOrganizationId.ts) template):
+   - `missions` — add both `tenantId` + `organizationId`, both nullable, both indexed.
+   - `work_proposals` (Ideas) — add both.
+   - `tasks` — add both.
+   - `agents` — add both.
+   - `skills` — add both.
+   - `conversations` — add both.
+   - `notifications` — add both.
+   - `api_keys` — add both.
+   - `templates` — add both.
+   - `template_customizations` — add both.
+   - `user_subscriptions` — add both.
+   - `work_schedules` — add both.
+   - `work_deployments` — add both.
+   - `onboarding_requests` — add both.
+   - `webhook_subscriptions` — add both.
+   - `github_app_installations` — add both.
+   - `github_app_user_links` — add both.
+   - `works` — add `tenantId` only (`organizationId` already exists; upgrade to FK in Phase 4).
+   - `work_knowledge_documents` — add `tenantId` only (`organizationId` already exists; upgrade to FK in Phase 4).
+2. For each: update the corresponding entity file to declare the columns.
+3. **No backfill** in any of these migrations. Existing rows stay NULL.
+
+**PR scope guidance:** these can all ship in one PR (additive, low risk), or be split into 2–3 PRs grouped by domain (auth/work/agent/task/etc.) if the diff is too big for review. Editor's choice.
+
+**Tests:**
+- Per-entity migration test: apply + re-apply is idempotent (matches the existing `hasColumn` guard pattern).
+- Entity test: new columns are nullable, optional in `ClassToObject`.
+
+---
+
+## Phase 4 — Upgrade existing free-form `organizationId` columns to FK
+
+**Goal:** Now that `organizations(id)` exists, fix the existing forward-looking columns.
+
+**Changes:**
+
+1. New TypeORM migration: `UpgradeWorkOrganizationIdToFk`.
+   - Pre-check: count rows where `organizationId IS NOT NULL` (expect 0 — we haven't created any Orgs in DB yet).
+   - If any non-NULL orphan UUIDs exist (no matching `organizations.id`), NULL them out with a logged warning.
+   - Add FK constraint `works.organizationId` → `organizations(id)` ON DELETE SET NULL.
+2. New TypeORM migration: `UpgradeWorkKnowledgeDocumentOrganizationIdToFk` — same pattern.
+3. Update `work.entity.ts` and `work-knowledge-document.entity.ts` to declare the relation (`@ManyToOne(() => Organization, ...)`).
+
+---
+
+## Phase 5 — Tier C children: denormalize `tenantId` (and `organizationId`)
+
+**Goal:** Add denormalized scope columns to all Tier C children (per user-confirmed decision in [spec.md §2.3](spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets)).
+
+**Changes:**
+
+1. One TypeORM migration (or batch — same rationale as Phase 3 splitting):
+   - For each Tier C entity, add nullable `tenantId uuid` + FK + index.
+   - For Tier C entities whose parent is a Tier A object that *also* has `organizationId`, add nullable `organizationId uuid` + FK + index.
+   - **Tier C list:** `conversation_messages`, `task_assignees`, `task_approvers`, `task_reviewers`, `task_watchers`, `task_blocks`, `task_chat_messages`, `task_kb_mentions`, `task_attachments`, `task_relations`, `agent_runs`, `agent_run_logs`, `agent_budgets`, `agent_memberships`, `skill_bindings`, `work_members`, `work_invitations`, `work_generation_history`, `work_knowledge_chunks`, `work_knowledge_citations`, `work_knowledge_tags`, `work_knowledge_uploads`, `webhook_deliveries`, `usage_ledger_entries`, `plugin_usage_events`, `activity_log`.
+2. Update each entity to declare the columns.
+3. **Service-layer change:** every create path that writes a Tier C row must set `tenantId` and `organizationId` (if the parent has one) from the currently active scope context. This is the largest code change in this phase — ~20–30 services touched.
+   - Introduce a `ScopeContext` (request-scoped NestJS provider) carrying `{ tenantId: string | null, organizationId: string | null }`. Resolver middleware (Phase 7) populates it.
+   - Update every `Repository.create()` / `Repository.save()` call site for Tier C rows to consume `ScopeContext`.
+   - For background jobs / agent ticks / scheduled tasks: extract scope from the parent entity being processed and propagate.
+4. **No backfill** in this phase. Existing Tier C rows stay NULL. Backfilled on the user's first-Org-upgrade (Phase 6).
+
+**Risk:** missed service paths leave new rows with `NULL` scope. Mitigation: add a test that asserts new rows created via every service have `tenantId` set when the actor has a Tenant. Lint rule + code review.
+
+---
+
+## Phase 6 — Lazy upgrade flow + Organization-create API
+
+**Goal:** Implement the §5.2 / §5.3 flow — server-side creation of Tenants and Organizations + backfill.
+
+**Changes:**
+
+1. New API endpoints:
+   - `POST /api/organizations` — body `{ name, slug? }`. Creates Organization. If user has no Tenant, creates Tenant lazily. Returns the Organization row + scope info.
+   - `POST /api/organizations/:id/upgrade-from-account` — moves the user's existing Tier A/B/C rows from Tenant-root into this Organization. Idempotent (only runnable once per user, and only on their first Org).
+   - `GET /api/organizations` — list all Orgs for the current user's Tenant.
+   - `GET /api/organizations/:slug` — fetch one by slug (used by the slug resolver middleware).
+   - `PATCH /api/organizations/:id` — update displayName, legalName, etc.
+   - `GET /api/organizations/check-slug?value=<string>` — uniqueness check across `users.slug` + `organizations.slug`.
+2. New service: `apps/api/src/organizations/organization.service.ts`.
+   - `createOrganization(userId, name, slug?)`:
+     1. Lazy-create Tenant if `user.tenantId IS NULL`.
+     2. Allocate slug via `UsernameAllocatorService.allocateSlug(name, 'organizations')`.
+     3. Insert Organization row.
+     4. If `users.lastScopeOrganizationId IS NULL` and this is the user's first Org, store the new Org id on `users.lastScopeOrganizationId` so the next login lands there.
+   - `upgradeFromAccount(userId, organizationId)`:
+     1. Verify ownership (user owns Tenant; Org belongs to that Tenant).
+     2. Verify Org's tenantId matches user's tenantId.
+     3. UPDATE every Tier A/B/C row where `userId = X AND tenantId = (user's tenant) AND organizationId IS NULL` → set `organizationId = X`.
+     4. This is a transaction; the table list is enumerated in code (one UPDATE per table, all under one DB transaction). On Postgres, set `SET LOCAL statement_timeout = '30s'` for safety.
+3. New service: `apps/api/src/scope/scope-context.service.ts` — the request-scoped provider from Phase 5.
+4. New service: `apps/api/src/scope/tenant-bootstrap.service.ts` — `ensureTenant(userId): Promise<Tenant>`. Lazy creation logic in one place.
+
+**Tests:**
+- Unit: `OrganizationService.createOrganization` handles no-Tenant, has-Tenant, slug-collision, name-empty cases.
+- Integration: `POST /api/organizations` end-to-end against an in-memory DB.
+- Integration: `upgrade-from-account` moves expected rows, leaves nothing behind, second call is a no-op.
+
+---
+
+## Phase 7 — Slug routing middleware + scope context propagation
+
+**Goal:** Make `/{slug}/...` route shapes work on the API and the web app.
+
+**Changes:**
+
+1. **API (NestJS):**
+   - New middleware: `apps/api/src/scope/scope-resolver.middleware.ts`. Reads `:slug` (or `X-Scope-Slug` header for fetch-from-web-client requests), resolves to `{ tenantId, organizationId | null }`, populates `ScopeContext`. 404s on no hit.
+   - Apply globally on `/api/*` routes that are scope-sensitive (most of them — exempt list: `/api/auth/*`, `/api/users/check-username`, `/api/organizations/check-slug`).
+2. **Web (Next.js App Router):**
+   - New segment: `apps/web/src/app/[slug]/...` — mirrors the existing dashboard tree.
+   - Slug validated server-side in the layout; on 404, renders a not-found page.
+   - Client-side fetcher adds `X-Scope-Slug` header so the API sees the same scope on every call.
+3. **Legacy routes** (un-prefixed) — keep them. They resolve to the bare Tenant context for the session's user. Both shapes coexist (additive — NN #20).
+
+**Test surface:**
+- E2E: `/{username}/missions` renders the same data as the legacy `/missions` for a user with no Org.
+- E2E: `/{orgSlug}/missions` renders only that Org's data; switching the slug in the URL switches the data.
+- 404 path: `/notarealsulug/missions` returns 404, not 403, not 500.
+
+---
+
+## Phase 8 — WorkspaceSwitcher UI (sidebar-07 reskin)
+
+**Goal:** Ship the user-facing switcher.
+
+**Changes:**
+
+1. New component: `apps/web/src/components/layout/WorkspaceSwitcher.tsx`.
+   - Base: shadcn [`sidebar-07`](https://ui.shadcn.com/blocks#sidebar-07) `TeamSwitcher`, renamed and re-skinned.
+   - Reads `organizations` from a SWR hook (`useOrganizations()`) backed by `GET /api/organizations`.
+   - Empty state: if `organizations.length === 0`, render the existing `<EverWorksLogo />` component unmodified (no chevron, no popover trigger).
+   - Active state: render the switcher chip with avatar + display name + chevron.
+   - Popover heading: `"Organizations"` (i18n key TBD — `organizations.switcher.heading`).
+   - List item: avatar + display name + check icon for currently active.
+   - Footer item: `+ Create Organization` → opens `<CreateOrganizationModal />` (Phase 9).
+2. Wire `<WorkspaceSwitcher />` into the existing sidebar layout, replacing the standalone `<EverWorksLogo />` placement. The logo placement keeps showing the logo when zero Orgs exist; it just becomes a switcher chip when 1+ exist.
+3. State sync on switch:
+   - Clicking an Org row in the popover → POST `/api/users/me/scope` (or PATCH the user row) to persist `lastScopeOrganizationId`; navigate to `/{newSlug}/dashboard`.
+   - Clicking the bare-Tenant row (if listed per [spec.md §5.5 option b](spec.md#popover-contents)) → same, with `organizationId = null`; navigate to `/{userSlug}/dashboard`.
+
+**Out of scope this phase:** the Create Organization modal itself (Phase 9 — but Phase 8 still ships the entry point that triggers it; the modal can be a stub for the first PR if the team prefers to ship in two PRs).
+
+---
+
+## Phase 9 — CreateOrganizationModal + upgrade-vs-new dialog
+
+**Goal:** Ship the modal flow from [spec.md §5.2](spec.md#52-user-creates-their-first-organization).
+
+**Changes:**
+
+1. New component: `apps/web/src/components/organizations/CreateOrganizationModal.tsx`.
+   - Single input: `Name`.
+   - Live slug preview (debounced `GET /api/organizations/check-slug?value=<derivedSlug>`).
+   - Submit → POST `/api/organizations` → returns the new Org.
+2. New component: `apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx`.
+   - Renders *only* if this is the user's first Organization (gate: `(await GET /api/organizations).length === 1`).
+   - Two options:
+     - **Upgrade current account** (default, pre-selected, focused).
+     - **Create with empty data**.
+   - Confirm → if "Upgrade", POST `/api/organizations/:id/upgrade-from-account`. If "Empty", do nothing (the Org was already created, it just stays empty).
+   - In both branches: navigate to `/{newOrgSlug}/dashboard` and refresh state.
+3. Subsequent Org creates (when the user already has 1+ Orgs) skip the dialog entirely — just create + navigate.
+
+**Tests:**
+- Unit: `UpgradeOrCreateDialog` defaults to "Upgrade".
+- E2E (Playwright): full flow — open switcher, create Org, choose Upgrade, verify existing items show up in new scope.
+
+---
+
+## Phase 10 — Company chip on `+ New` page + Work-of-type-Company → Org wire-up
+
+**Goal:** Make the "Register Company" path (Stripe Atlas etc.) create an Organization on success.
+
+**Changes:**
+
+1. Add `Company` to the chip list on the `+ New` page (per [spec.md §6.3](spec.md#63--new-page--company-chip)). Order: `Mission · Idea · Website · Landing Page · Store · Blog · Directory · Awesome Repo · Knowledge Base · Company`. (Note: `Store` and `Company` were already coming-soon chips in earlier copy — they become real here.)
+2. New Work template/type: `Company`. Plumbing follows existing template/type patterns (`Templates` + `WorkType`).
+3. New service hook: when a Work of type Company transitions to "registered" status (provider callback or manual marking), the system:
+   - Creates an Organization row with `legalName`, `countryCode`, `registrationProvider`, `registrationStatus = 'registered'`, `linkedWorkId = work.id`.
+   - Sets `tenantId` to the user's Tenant (lazy-create Tenant if needed).
+   - Triggers the `UpgradeOrCreateDialog` flow client-side on the next page load (or via a notification → action handler).
+4. The Work itself stays in its original scope. It just gains `organizationId = newOrg.id` so it's visible in the new Org's scope as well as wherever it was created.
+
+---
+
+## Cross-cutting concerns
+
+### Database safety
+
+- All migrations are forward-only and additive (NN #16).
+- No DROP / ALTER TYPE / data deletion anywhere.
+- Pre-checks at the top of each migration to detect impossible states (e.g. duplicate usernames, orphan `organizationId` UUIDs); fail loud rather than silently corrupting.
+- Every PR with a TypeORM entity change ships the corresponding migration in the same PR (NN #16).
+
+### Tests
+
+Each phase ships with:
+- Migration tests (apply + revert idempotency).
+- Entity tests (round-trip, ClassToObject).
+- Service unit tests for new business logic.
+- Integration tests for new API endpoints.
+- E2E tests for new user-facing flows (Phases 7–10).
+
+The bar: existing 26 agent test suites + 719 tests all keep passing. New phases add their own suites alongside.
+
+### Rollout
+
+- **No feature flag needed for v1.** The columns are added but unused on existing data; the switcher is gated by `organizations.length === 0` (no UI change for users who don't have Orgs). Forward-looking and safe.
+- Deploy in phase order. Each phase is a separately mergeable PR. The full work spans Phases 0 → 10.
+
+### CI / release gates
+
+Refer to [`CI_RELEASE_GATES.md`](../../../../../../Workspace/knowledge/runbooks/CI_RELEASE_GATES.md):
+- Lightweight CI runs on every PR + release-branch push (typecheck, lint, agent test suite).
+- Medium/heavy CI runs on `stage`/`main` pushes only.
+- All 10 phase PRs follow the standard `develop → stage → main` cascade (NN #21).
+
+---
+
+## Sequencing summary
+
+| Phase | Title | Depends on | PR target |
+|---|---|---|---|
+| 0 | Username uniqueness contract | — | `develop` |
+| 1 | Create `tenants` + `organizations` tables | 0 | `develop` |
+| 2 | `tenantId` on users + Tier B | 1 | `develop` |
+| 3 | `tenantId` + `organizationId` on Tier A | 1 | `develop` |
+| 4 | Upgrade existing free-form `organizationId` to FK | 1, 3 | `develop` |
+| 5 | Tier C denormalization | 1, 3 | `develop` |
+| 6 | Lazy upgrade flow + Organization-create API | 2, 3, 4, 5 | `develop` |
+| 7 | Slug routing middleware | 6 | `develop` |
+| 8 | WorkspaceSwitcher UI | 6, 7 | `develop` |
+| 9 | CreateOrganizationModal + upgrade-vs-new dialog | 6, 7, 8 | `develop` |
+| 10 | Company chip + Work→Org wire-up | 6, 7 | `develop` |
+
+Phases 3, 4, 5 can run in parallel after Phase 1. Phases 8, 9, 10 can run in parallel after Phases 6–7. Otherwise, sequential.

--- a/docs/specs/features/tenants-and-organizations/spec.md
+++ b/docs/specs/features/tenants-and-organizations/spec.md
@@ -1,0 +1,405 @@
+# Tenants & Organizations — Product Spec
+
+**Status:** Draft v1 · **Owner:** Product (Ruslan) · **Date:** 2026-05-27
+**Audience:** Product, Engineering (backend + frontend + AI), Design
+**Internal codename:** "Workspace foundation"
+**Related code today:**
+- `users` entity, `apps/api/src/auth/*`, `apps/api/src/onboarding/*`
+- `users.username` referenced by `github-app-onboarding.service.ts:223-229` (existing suffix-on-collision pattern) and `onboarding-account.adapter.ts:138-145` (asserted DB UNIQUE constraint)
+- `Work.organizationId` already exists as forward-looking nullable UUID column ([`work.entity.ts:96-116`](../../../../packages/agent/src/entities/work.entity.ts), migration [`1779977000000-AddWorkOrganizationId.ts`](../../../../apps/api/src/migrations/1779977000000-AddWorkOrganizationId.ts))
+- `WorkKnowledgeDocument.organizationId` already exists with the same forward-looking treatment ([`work-knowledge-document.entity.ts:62-67`](../../../../packages/agent/src/entities/work-knowledge-document.entity.ts))
+- Spec §7.6 (referenced in `work.entity.ts` comments) anticipated this entity
+
+> **Scope of this document:** product behavior — concepts, relationships, UX, UI, flows, states, naming. Implementation details are referenced where they constrain behavior. The phased execution plan lives in the sibling [plan.md](plan.md); the task checklist in [tasks.md](tasks.md); acceptance criteria in [acceptance.md](acceptance.md).
+>
+> **Hard rule (NN #20 — additive by default):** Nothing currently shipping is removed or rewritten. Every column added is nullable on insert and additive to existing tables. Every UI surface is layered on top of existing UI. Existing users keep working with zero migration: they have no Tenant and no Organization until they explicitly create one.
+
+---
+
+## 0. TL;DR
+
+We introduce two new internal entities — **Tenant** and **Organization** — to give every user a scope they own and an optional sub-scope (or several sub-scopes) for registered companies.
+
+```
+User  ─1───1─►  Tenant  ─1───N─►  Organization
+                                       │
+                                       └─◄── (one Work of type Company can back each Org)
+```
+
+- **Tenant** — fully internal concept. Never appears in the UI. One per user, created on demand the first time the user creates an Organization. The default scope for everything the user owns.
+- **Organization** — user-facing. UI label varies by context: in settings and switcher it reads "Organization"; in the new-item chips and Stripe-Atlas registration flow it reads "Company". Same row in DB either way. A Tenant can have zero, one, or many Organizations.
+- **Switcher** — a small icon at the top-left of the sidebar (where the Ever Works logo lives today). Hidden while the user has zero Organizations; appears with chevron + Org logo/name once one exists. Cycles between the user's Organizations.
+- **URL slug** — `user.username` (URL-safe form) when the user has no Org active; `organization.slug` when an Org is active. Same path shape: `/{slug}/missions/...`.
+
+Existing users: no Tenant row, no Organization row, no `tenantId` set on their existing entities. Everything keeps working. The moment they create their first Organization and choose "**upgrade current account**", a Tenant is created for them, the Organization is linked to it, and their existing rows are backfilled with `tenantId` (and, for rows they want under the Org, `organizationId`).
+
+---
+
+## 1. The Two Concepts
+
+### 1.1 Tenant (internal-only, NEVER shown in UI)
+
+A **Tenant** is the user's private account scope. It is the always-present default container for everything the user creates.
+
+- **Cardinality:** 1 User : 1 Tenant. The User table gains a nullable `tenantId` FK column. A Tenant row is created the first time the user creates an Organization (lazy creation — see §5.1).
+- **UI visibility:** none. The word "Tenant" never appears in any user-facing string. It is a backend / DB concept only. The user sees their account name (handle) or their Organization name, never the Tenant.
+- **Why this exists:** every row in the system needs to know *which user's scope* it belongs to. Putting `userId` on every row works only as long as we assume 1:1 user:scope; the Tenant abstraction lets us evolve that later (e.g. shared workspaces, agency client scopes) without re-plumbing every entity.
+- **Properties:**
+  - `id` (uuid)
+  - `ownerUserId` (uuid, unique, FK to `users.id`)
+  - `slug` (varchar, mirrors `users.username` for routing; unique)
+  - `displayName` (varchar; falls back to username)
+  - `createdAt`, `updatedAt`
+
+### 1.2 Organization (user-facing — UI label varies)
+
+An **Organization** is a sub-scope inside the Tenant — typically representing a registered legal entity (a Company), but it could also be an unincorporated team, a brand, a side project, anything the user wants to keep isolated from their main account.
+
+- **Cardinality:** 1 Tenant : 0..N Organizations. A Tenant can have many Organizations. Each Organization belongs to exactly one Tenant.
+- **UI labels (same DB row, different wording per surface):**
+  - **"Organization"** — in the switcher popover heading, in the Settings → Organization page, anywhere the user is managing scope.
+  - **"Company"** — in the `+ New` page chips ("Mission · Idea · Website · Landing Page · Store · Blog · Directory · Awesome Repo · Company"), in Stripe Atlas registration copy, in the Work-of-type-Company flow.
+  - When a Work of type Company is created and succeeds (e.g. Stripe Atlas registration completes), a corresponding Organization row is created (or linked) — see §5.4.
+- **Properties:**
+  - `id` (uuid)
+  - `tenantId` (uuid, FK to `tenants.id`)
+  - `slug` (varchar, **globally unique** — coexists with `users.slug` in the URL namespace, see §6.2)
+  - `legalName` (varchar; the registered name if it's a real Company)
+  - `displayName` (varchar; what shows in the switcher chip)
+  - `countryCode` (varchar(2), nullable)
+  - `registrationProvider` (varchar, nullable: `'stripe-atlas' | 'manual' | …`)
+  - `registrationStatus` (varchar: `'draft' | 'pending' | 'registered'`)
+  - `linkedWorkId` (uuid, nullable, FK to `works.id`) — the Work of type Company that backs this Organization, if any
+  - `createdAt`, `updatedAt`
+- **Logo / avatar:** v1 uses a deterministic generated avatar from the slug initials (no upload). v1.1 may add upload to the Settings → Organization page.
+
+### 1.3 "Company" vs "Organization" — display wording
+
+The user explicitly chose: **DB always says `organizations` / `organizationId`; UI says "Company" wherever it reads more naturally to a founder.**
+
+| UI surface | Wording |
+|---|---|
+| `+ New` page chips | **Company** (alongside Mission, Idea, Website, etc.) |
+| Stripe Atlas registration flow | **Register Company** |
+| Settings page section | **Organization** |
+| Switcher popover heading | **Organizations** |
+| Switch chip in sidebar | display name of the selected Organization (no label prefix) |
+| API endpoints | `/api/organizations` (technical name; not user-visible) |
+| DB columns | `organizationId` |
+
+This is a wording-only choice; no two entities, no two tables, no two API surfaces.
+
+---
+
+## 2. Relationships & Scoping Rules
+
+### 2.1 Relationship diagram
+
+```mermaid
+flowchart LR
+    U[User] -- "1:1 (lazy)" --> T[Tenant]
+    T -- "1:N" --> O1[Organization A]
+    T -- "1:N" --> O2[Organization B]
+    O1 -. "0:1 backed by" .-> WC[Work of type Company]
+    O2 -. "0:1 backed by" .-> WC2[Work of type Company]
+    T --> M1[Missions / Ideas / Works / ...]
+    O1 --> M2[Missions / Ideas / Works / ...]
+    O2 --> M3[Missions / Ideas / Works / ...]
+```
+
+### 2.2 Scoping rules for entities
+
+Every business-level entity gains two new columns:
+
+- `tenantId` — required (NOT NULL) **after** the user's first Organization create (which triggers Tenant creation). Until then, existing rows have `NULL` — see §5.1 lazy backfill. New rows on a user who already has a Tenant are written with `tenantId` set on insert.
+- `organizationId` — always nullable. NULL means "belongs directly to the Tenant, not to any specific Organization." Set means "scoped to this Organization."
+
+A row's effective scope:
+- `organizationId IS NOT NULL` → scoped to that Organization. The switcher must be on that Organization to see it.
+- `organizationId IS NULL AND tenantId IS NOT NULL` → scoped to the Tenant root. Visible when no Organization is selected (i.e. the bare account view).
+- `tenantId IS NULL` → legacy / pre-Tenant row. Visible in the bare account view of its owning user.
+
+### 2.3 Three tiers of entities (which columns each tier gets)
+
+#### Tier A — top-level business objects (both `tenantId` + `organizationId`)
+- `Mission`, `Work`*, `Task`, `Agent`, `Skill`, `WorkProposal` (Ideas), `Conversation`, `Notification`, `ApiKey`, `Template`, `TemplateCustomization`, `UserSubscription`, `WorkSchedule`, `WorkDeployment`, `OnboardingRequest`, `WorkKnowledgeDocument`*, `WebhookSubscription`, `GithubAppInstallation`, `GithubAppUserLink`
+- (*) `Work.organizationId` and `WorkKnowledgeDocument.organizationId` already exist as free-form UUID columns; they get upgraded to FK referencing `organizations.id` in this work. `tenantId` is added fresh.
+
+#### Tier B — user-scoped but org-irrelevant (`tenantId` only)
+- `AuthAccount`, `AuthSession`, `AuthVerification`, `RefreshToken`, `UserTemplatePreference`, `UserTaskCounter`
+- No `organizationId` — these are user-identity records, never scoped to a sub-org.
+
+#### Tier C — children that denormalize `tenantId` (and `organizationId` where applicable) — per user decision
+- `ConversationMessage`, `TaskAssignee`, `TaskApprover`, `TaskReviewer`, `TaskWatcher`, `TaskBlock`, `TaskChatMessage`, `TaskKbMention`, `TaskAttachment`, `TaskRelation`, `AgentRun`, `AgentRunLog`, `AgentBudget`, `AgentMembership`, `SkillBinding`, `WorkMember`, `WorkInvitation`, `WorkGenerationHistory`, `WorkKnowledgeChunk`, `WorkKnowledgeCitation`, `WorkKnowledgeTag`, `WorkKnowledgeUpload`, `WebhookDelivery`, `UsageLedgerEntry`, `PluginUsageEvent`, `ActivityLog`
+- These rows denormalize `tenantId` for cheap scoping/RLS-style queries without joins.
+- For `organizationId`: denormalize when the parent has it (most do — TaskAssignee inherits from Task, etc.).
+- Service-layer responsibility: every create path sets `tenantId` (and `organizationId` if parent has one) on insert. No backfill needed for new installs; lazy backfill on first-Org-upgrade for the user's existing rows (§5.1).
+
+#### Tier D — global / system (neither column)
+- `SubscriptionPlan` (global catalog), `Cache` (system-level).
+
+### 2.4 What an Organization "owns"
+
+The user explicitly said: *"each company might have own Works (e.g. few websites, apps etc) and also Agents and also Tasks associated with such company and Human employees etc."*
+
+So an Organization can directly own:
+- Missions, Ideas, Works, Tasks, Agents, Skills (Tier A: any of these can carry `organizationId = thisOrg.id`)
+- Knowledge documents (KB org-overlay)
+- Human members (via `WorkMember` denormalized with `organizationId` — though full org-membership management is v1.1)
+
+A Mission scoped to an Organization spawns Ideas scoped to the same Organization, which become Works scoped to the same Organization. The fan-out preserves scope automatically because every child inherits `organizationId` from its parent at create time.
+
+---
+
+## 3. Username — Uniqueness and URL Safety
+
+Today's state (verified 2026-05-27):
+- `user.entity.ts:40` declares `@Column()` with no `unique: true`.
+- `github-app-onboarding.service.ts:223-229` runs a suffix-on-collision loop using `userRepository.findByUsername`.
+- `onboarding-account.adapter.ts:140-145` *asserts* a DB UNIQUE constraint exists, but no migration adds one and TypeORM's auto-sync may have created it inconsistently across environments.
+
+This spec fixes the contract:
+
+### 3.1 Database
+
+Add a UNIQUE index on `users.username` (case-insensitive on Postgres via `lower(username)` expression index). Migration is straightforward — no live users with duplicates to resolve because the platform is not yet live. The migration adds a one-time guard: if duplicates exist, the migration *fails loudly* with a clear message; operator decides resolution.
+
+Also add `users.slug` — a URL-safe denormalized form of username (lowercase ASCII, hyphens). Maintained on insert and on every username update via a service-layer hook. Unique index on `users.slug` (case-insensitive equivalent on Postgres).
+
+### 3.2 Two flows for collisions
+
+| Flow | Trigger | Behavior |
+|---|---|---|
+| **Programmatic** | OAuth callback, GitHub App install, social-auth registration, anonymous claim, any code path where the user is not interactively picking a username | Existing `findByUsername` + suffix loop (extract into shared `UsernameAllocatorService`). User never sees a "taken" error — they get `ever`, `ever-2`, `ever-3` automatically. |
+| **Interactive UI** | Username field on a signup or settings form | Debounced `GET /api/users/check-username?value=...` returns `{ available: boolean, suggestion?: string }`. On collision, surface "username taken — suggested: `ever-2`" with the suggestion pre-filled in the input. User accepts or types another. The form blocks submit until the value is `available`. |
+
+### 3.3 URL safety
+
+`users.slug` is the URL-safe form. Generated from `username` via:
+1. Lowercase.
+2. Replace any non-`[a-z0-9-]` with `-`.
+3. Collapse runs of `-` to a single `-`.
+4. Strip leading/trailing `-`.
+5. If empty after normalization (degenerate username), fall back to `u-{first-8-chars-of-uuid}`.
+6. If the result collides with an existing `users.slug` OR `organizations.slug`, append `-2`, `-3`, … (same suffix loop as username).
+
+The slug only changes when the username changes (and the slug recomputation goes through the same allocator, so it never collides). **No `slug_redirects` table** (user-confirmed: not needed; rename history is out of scope).
+
+---
+
+## 4. URL Routing
+
+### 4.1 Path shape
+
+```
+/{slug}/missions/...
+/{slug}/works/...
+/{slug}/tasks/...
+/{slug}/agents/...
+/{slug}/settings/...
+```
+
+Always a slug at the front. No "implicit" personal URLs without a slug.
+
+### 4.2 Slug resolution
+
+Middleware on every request:
+1. Read `:slug` from the URL.
+2. Look up in `organizations.slug` first.
+   - Hit → context is the Organization (resolves `tenantId` via the row's FK). All queries downstream are scoped `WHERE tenantId = X AND (organizationId = Y OR includeUnscoped)`.
+3. If no hit, look up in `users.slug`.
+   - Hit → context is the bare Tenant of that user. All queries downstream are scoped `WHERE tenantId = X AND organizationId IS NULL`.
+4. No hit → 404.
+
+Why Organization first: a user with username `acme` and an Organization with slug `acme` is a collision the slug allocator prevents at write time, but defensive precedence is "Org wins" because Orgs are explicitly created.
+
+### 4.3 Authorization
+
+The slug only tells us *which scope the request is viewing*. The authn layer separately verifies the requesting user is the owner of the Tenant (today, 1:1 user:Tenant). For Organizations, the requesting user must be the owner of the Tenant the Org belongs to (today; org-membership management with multiple human members is v1.1).
+
+A request to `/acme-inc/missions/...` by a user who doesn't own the underlying Tenant returns **404** (not 403, to avoid leaking existence). Same as GitHub's behavior for private org URLs.
+
+### 4.4 What about existing URLs?
+
+Today's URLs (`/missions/...` with no slug, scoped via session) keep working for the lifetime of v1 alongside the new slug-prefixed routes. New surfaces (Switcher, Org create, settings) always use the slug-prefixed routes. Migration from old to new is gradual; no hard cutover. **(NN #20 — additive.)**
+
+---
+
+## 5. Flows
+
+### 5.1 User signup (no change to UX, no Tenant created)
+
+1. User signs up via any existing path (email/password, OAuth, anonymous claim, GitHub App).
+2. `User` row created as today. `tenantId` is **NULL**.
+3. No `Tenant` row created. No `Organization` row created.
+4. User lands in the dashboard. Sidebar shows the Ever Works logo at top-left (no chevron, no switcher).
+5. Everything the user creates from here is `tenantId = NULL, organizationId = NULL`. Existing behavior — nothing changes.
+
+> **Rationale (user-confirmed):** *"we are NOT live yet, so we don't need any backfill. For existing users, it all should keep working as they will not have Orgs yet."*
+
+### 5.2 User creates their FIRST Organization
+
+This is the inflection point. User clicks "**+ Create Organization**" (the only option in the empty-state switcher popover when zero Orgs exist) OR creates a Work of type Company (§5.4).
+
+**Step 1 — modal: "Create Organization":**
+- Input: `Name` (required) — used to derive `slug` and `displayName`.
+- Auto-suggested slug shown live as user types (debounced collision check vs `users.slug` + `organizations.slug`).
+- Submit → server validates, creates Organization in pending state.
+
+**Step 2 — dialog: "Upgrade current account, or create new Organization?"**
+
+> **Default option: Upgrade current account.** (User-confirmed.)
+>
+> Copy (suggested — refine in implementation):
+> - **Upgrade current account** *(default, pre-selected)*
+>   > "All your existing missions, ideas, works, and other items become part of **{Org name}**. You won't have a separate personal account anymore."
+> - **Create with empty data**
+>   > "Start **{Org name}** fresh. Your existing items stay on your personal account, separate from the new Organization."
+
+**Step 3a — "Upgrade current account" branch:**
+1. Server creates the Tenant row for this user (lazy creation): `INSERT INTO tenants(ownerUserId, slug, displayName) VALUES (user.id, user.slug, user.username)`.
+2. Sets `users.tenantId = newTenant.id`.
+3. Sets `organizations.tenantId = newTenant.id`.
+4. **Lazy backfill:** for every Tier A, B, C entity owned by this user, UPDATE rows to set `tenantId = newTenant.id` AND `organizationId = newOrg.id` (i.e. move all existing items into the new Org).
+5. Switcher in UI updates to show the Org chip; URL slug changes from `user.slug` to `org.slug`; client navigates to the Org's dashboard.
+
+**Step 3b — "Create with empty data" branch:**
+1. Server creates the Tenant row (lazy, same as 3a step 1).
+2. Sets `users.tenantId = newTenant.id`.
+3. Sets `organizations.tenantId = newTenant.id`.
+4. **Backfills the user's existing rows with `tenantId` only** (not `organizationId`). They stay at the Tenant root.
+5. The Org is created empty. Switching to it shows zero items. The bare-Tenant view (clicking the user-named entry in the switcher) still shows the user's existing items.
+
+> **Crucial detail:** in both branches we backfill `tenantId` on existing rows at this moment. Before this moment, those rows had `tenantId = NULL`. After this moment, the user has a real Tenant and every one of their rows knows about it.
+
+### 5.3 User creates a SECOND (or third, …) Organization
+
+Same as §5.2 but:
+- Tenant already exists; reuse it.
+- "Upgrade current account" option is NOT shown (only the user's first Org gets that option). Subsequent Orgs always start empty.
+- Step 2 dialog is replaced with a single confirm: "Create Organization **{Org name}**" → confirm.
+
+### 5.4 User registers a Company via a Work of type Company
+
+This is the Stripe-Atlas (or similar) path. UI label is **"Register Company"** (not "Create Organization") even though the underlying outcome is the same — an Organization row is created.
+
+1. User goes to `+ New`, picks the **Company** chip, fills in the prompt and details.
+2. A Work of type Company is created in the user's current scope (Tenant root, or the currently-selected Organization — though typically users register a Company from their bare Tenant view).
+3. Stripe Atlas (or the chosen registration provider) runs.
+4. On success:
+   - An `Organization` row is created with `legalName`, `countryCode`, `registrationProvider`, `registrationStatus = 'registered'`.
+   - The Work's `id` is recorded on `organizations.linkedWorkId`.
+   - User is presented with the same Step 2 dialog from §5.2 (**upgrade current account, or create empty**), with the same "upgrade" default.
+5. The Work itself stays where it was created (no relocation — user explicitly rejected the move-the-Work behavior). It carries `organizationId = newOrg.id` so it's now visible in the Org scope as well.
+
+> **User-confirmed quote:** *"I don't want this [relocation]. If user want to register a company he do it and we create Company 'Work' item (repo) etc inside his current Workspace! It's just workspace itself instead of show his personal details will be tied to the company that operates."*
+
+### 5.5 Switcher behavior
+
+The switcher icon lives at the top-left of the sidebar — the slot where the Ever Works logo currently shows.
+
+#### Empty state (zero Organizations)
+
+- The slot continues to show the **Ever Works logo** exactly as today.
+- **No chevron**, no popover trigger. The user sees no UI hint that switching is possible — because it isn't, yet.
+
+#### Active state (1+ Organizations)
+
+- The slot shows the **currently active Organization** (logo/initial avatar + display name).
+- A small chevron (`⇅` icon, vertical) appears to the right.
+- Clicking opens a popover (shadcn `<Command>` inside `<Popover>` — see [sidebar-07 TeamSwitcher](https://ui.shadcn.com/blocks#sidebar-07) component).
+
+#### Popover contents
+
+```
+┌─────────────────────────────────┐
+│ Organizations                   │  ← heading
+├─────────────────────────────────┤
+│ [Avatar] Acme Inc          ✓   │  ← currently active
+│ [Avatar] Globex LLC             │
+├─────────────────────────────────┤
+│  +  Create Organization         │
+└─────────────────────────────────┘
+```
+
+- Heading is **"Organizations"** (NOT "Workspaces", NOT "Tenants").
+- Currently active row has a check icon.
+- Clicking a different Org → switches scope, navigates to that Org's dashboard, URL slug changes.
+- "+ Create Organization" → opens the modal from §5.2.
+
+#### Where is the bare-Tenant view?
+
+When the user has 1+ Organizations and is currently viewing the bare Tenant (their pre-Org items), the switcher chip shows the **user's display name** (their username, or whatever non-Org label fits) and the popover lists Organizations below it. Bare Tenant is implicit (not labeled "Personal" — user-confirmed).
+
+Two design options to surface bare Tenant in the popover:
+
+- **(a)** Don't list it — clicking the user-name chip at top toggles between "back to my account" and the currently-active Org. *Simpler, slightly less discoverable.*
+- **(b)** List the bare Tenant as the first row, labeled with the user's display name (e.g. "ever"). *More uniform with the Org rows.*
+
+**Recommendation:** **(b)** — uniform list, no special case. Each row in the popover is just a scope; the bare Tenant is "the scope without an Org filter applied."
+
+### 5.6 Default Organization on next login
+
+The most recently active scope is persisted on the User row (e.g. `users.lastScopeOrganizationId: uuid | null`, where `null` means bare Tenant). On the next login, the user lands in that scope.
+
+---
+
+## 6. UI Implementation Notes
+
+### 6.1 Switcher component
+
+- Reuse shadcn [sidebar-07](https://ui.shadcn.com/blocks#sidebar-07) `TeamSwitcher` component as the base; rename to `WorkspaceSwitcher` (internal name) and re-label the popover heading to "Organizations".
+- Empty state (zero Orgs): render the existing Ever Works logo component as-is. Wrap the logo in a conditional: if `organizations.length === 0 && !isLoading`, just render the logo. Otherwise, render the switcher.
+- Active state: avatar = `Organization.displayName.charAt(0)` deterministic-color background, OR a future uploaded logo (v1.1).
+
+### 6.2 Routes
+
+- New routes (App Router): `apps/web/src/app/[slug]/` — accepts the slug param, validates via middleware, sets a request-scoped scope context.
+- Old routes (`apps/web/src/app/(dashboard)/...`) — keep working for sessions where slug routing is not yet rolled out.
+- Both can coexist; the slug-prefixed routes are the new canonical, the un-prefixed routes are the legacy aliases.
+
+### 6.3 `+ New` page — Company chip
+
+Add **Company** to the chips on the unified `+ New` page (§4.0 of the [Missions/Ideas/Works spec](../../../../../../Workspace/knowledge/notes/2026-05-24-missions-ideas-works-spec.md)). Order: `Mission · Idea · Website · Landing Page · Store · Blog · Directory · Awesome Repo · Knowledge Base · Company`. Picking the Company chip routes the submit into the Register-Company flow (§5.4).
+
+> The user-facing chip is labeled "Company", but downstream entities are Organization rows. The wording-vs-DB split (§1.3) holds.
+
+### 6.4 Settings → Organization page (new)
+
+A new page at `/{slug}/settings/organization` (only present when the active scope is an Organization). Surfaces:
+- `displayName`, `legalName`, `countryCode`, `slug` (with collision check on save), avatar/logo (v1.1).
+- Registration provider + status (read-only if `'registered'`).
+- Link to the Work that backs this Org (`organizations.linkedWorkId`) — opens the Work detail in Canvas.
+
+Members management (inviting other humans into the Org) is **v1.1** (deferred — user said earlier *"so let's not go into it today"*). For v1, the Tenant owner is the sole member of every Org in their Tenant.
+
+### 6.5 Existing pages — no copy changes
+
+Per NN #20, no existing UI string changes. The only UI additions are:
+- Switcher slot (replaces visual of the Ever Works logo only once user has 1+ Org).
+- `Company` chip on `+ New` page (added to the existing chip list).
+- Settings → Organization sub-page (new sub-route only).
+- Create Organization modal + post-create dialog (new modals, surfaced by the Switcher's "+ Create Organization" entry).
+
+---
+
+## 7. Open Decisions & Out-of-Scope (v1.1+)
+
+- **Multi-tenant per user** — today, 1 User : 1 Tenant. If someone wants truly isolated separate accounts (different billing, different members, different Stripe customers), that becomes 1 User : N Tenants. Trivial schema change (drop the unique on `tenants.ownerUserId`); flagged as v1.1 if demand emerges.
+- **Org-membership (inviting other humans into an Org)** — deferred to v1.1. v1 ships with the Tenant owner as sole member of every Org. The existing `WorkMember` / `WorkInvitation` Work-scoped invitations keep working; an Org-scoped equivalent (`OrganizationMember` / `OrganizationInvitation`) lands in v1.1.
+- **Holdco / subsidiaries (Org-inside-Org)** — explicitly out of scope. Decision recorded in earlier brainstorm: keep strictly two levels (Tenant → Organization).
+- **Slug rename history / redirects** — explicitly out of scope. User said no slug_redirects table.
+- **Org logo upload** — v1.1. v1 uses deterministic generated avatars.
+
+---
+
+## 8. Cross-References
+
+- Implementation plan: [plan.md](plan.md)
+- Task checklist: [tasks.md](tasks.md)
+- Acceptance criteria: [acceptance.md](acceptance.md)
+- Companion Workspace note: [`Workspace/knowledge/notes/2026-05-27-tenants-and-organizations-spec.md`](../../../../../../Workspace/knowledge/notes/2026-05-27-tenants-and-organizations-spec.md)
+- Related product spec: [Missions → Ideas → Works](../../../../../../Workspace/knowledge/notes/2026-05-24-missions-ideas-works-spec.md)
+- Existing forward-looking columns: [`work.entity.ts`](../../../../packages/agent/src/entities/work.entity.ts) `organizationId`, [`work-knowledge-document.entity.ts`](../../../../packages/agent/src/entities/work-knowledge-document.entity.ts) `organizationId`
+- Existing username pattern: [`github-app-onboarding.service.ts`](../../../../apps/api/src/integrations/github-app/github-app-onboarding.service.ts) lines 223-229
+- shadcn switcher reference: <https://ui.shadcn.com/blocks#sidebar-07>

--- a/docs/specs/features/tenants-and-organizations/tasks.md
+++ b/docs/specs/features/tenants-and-organizations/tasks.md
@@ -1,0 +1,265 @@
+# Tenants & Organizations — Task Checklist
+
+**Status:** Draft v1 · **Date:** 2026-05-27
+**Spec:** [spec.md](spec.md) · **Plan:** [plan.md](plan.md) · **Acceptance:** [acceptance.md](acceptance.md)
+
+This file is the granular checklist agents and reviewers tick off as work lands. JIRA Epic + Story keys are added once the tickets exist (see "JIRA linkage" at the bottom).
+
+---
+
+## Phase 0 — Username uniqueness contract
+
+### Database
+- [ ] Migration `AddUniqueIndexToUsername` — pre-check duplicates, add `lower(username)` UNIQUE expression index (Postgres) / UNIQUE on raw column (SQLite).
+- [ ] Migration `AddSlugToUsers` — add nullable `slug`, backfill from `username` via URL-normalize, add UNIQUE expression index on `lower(slug)`, flip NOT NULL.
+
+### Entities
+- [ ] `user.entity.ts` — `username` gets `unique: true`; add `@Column({ unique: true }) slug: string`.
+
+### Services
+- [ ] New `apps/api/src/users/username-allocator.service.ts` exporting `allocateUsername(base)` and `allocateSlug(base, ownerTable)`.
+- [ ] Replace inline loop in `apps/api/src/integrations/github-app/github-app-onboarding.service.ts:223-229` with `UsernameAllocatorService.allocateUsername(base)`.
+
+### API
+- [ ] `GET /api/users/check-username?value=<string>` — public, throttled, returns `{ available, suggestion? }`.
+
+### Tests
+- [ ] `username-allocator.service.spec.ts` — collision suffixing, idempotency, normalization edge cases.
+- [ ] `users.check-username.controller.spec.ts` — happy path + collision suggestion.
+- [ ] Migration test for both migrations (apply + revert).
+
+---
+
+## Phase 1 — Create `tenants` and `organizations` tables
+
+### Database
+- [ ] Migration `CreateTenantsTable`.
+- [ ] Migration `CreateOrganizationsTable`.
+
+### Entities
+- [ ] `packages/agent/src/entities/tenant.entity.ts`.
+- [ ] `packages/agent/src/entities/organization.entity.ts`.
+- [ ] Register in `packages/agent/src/entities/index.ts`.
+
+### Repositories
+- [ ] `TenantRepository` (under `packages/agent/src/database/`).
+- [ ] `OrganizationRepository`.
+
+### Tests
+- [ ] Migration tests.
+- [ ] `tenant.entity.spec.ts` — round-trip + ClassToObject.
+- [ ] `organization.entity.spec.ts` — round-trip + ClassToObject + FK cascades.
+
+---
+
+## Phase 2 — `tenantId` on `users` and Tier B entities
+
+### Database
+- [ ] Migration `AddTenantIdToUsers` — nullable, FK + index, **no backfill**.
+- [ ] Migration `AddTenantIdToTierB` — same shape, applied to: `auth_accounts`, `auth_sessions`, `auth_verifications`, `refresh_tokens`, `user_template_preferences`, `user_task_counters`.
+
+### Entities
+- [ ] `user.entity.ts` — add `@ManyToOne(() => Tenant, { nullable: true })`.
+- [ ] Six Tier B entities — same.
+
+---
+
+## Phase 3 — Tier A entities (both columns)
+
+For each of the entities below, do all four sub-tasks (migration, entity, repo, test). One PR per group is fine; or batch by domain if review-friendly.
+
+- [ ] `missions` — `tenantId` + `organizationId`, both nullable, both FK + index.
+- [ ] `work_proposals` (Ideas) — both.
+- [ ] `tasks` — both.
+- [ ] `agents` — both.
+- [ ] `skills` — both.
+- [ ] `conversations` — both.
+- [ ] `notifications` — both.
+- [ ] `api_keys` — both.
+- [ ] `templates` — both.
+- [ ] `template_customizations` — both.
+- [ ] `user_subscriptions` — both.
+- [ ] `work_schedules` — both.
+- [ ] `work_deployments` — both.
+- [ ] `onboarding_requests` — both.
+- [ ] `webhook_subscriptions` — both.
+- [ ] `github_app_installations` — both.
+- [ ] `github_app_user_links` — both.
+- [ ] `works` — **only `tenantId`** (organizationId already exists; FK upgrade is Phase 4).
+- [ ] `work_knowledge_documents` — **only `tenantId`** (same reason).
+
+Tests:
+- [ ] One migration test per entity (idempotency).
+- [ ] Entity spec updated for each (column nullable, ClassToObject round-trip).
+
+---
+
+## Phase 4 — FK upgrade for pre-existing `organizationId` columns
+
+- [ ] Migration `UpgradeWorkOrganizationIdToFk` — orphan-UUID null-out + add FK + index already exists (verify).
+- [ ] Migration `UpgradeWorkKnowledgeDocumentOrganizationIdToFk` — same.
+- [ ] Entity update — `work.entity.ts` and `work-knowledge-document.entity.ts` declare `@ManyToOne(() => Organization, ...)`.
+
+---
+
+## Phase 5 — Tier C children (denormalized scope)
+
+For each Tier C entity below: migration adds `tenantId` (always) + `organizationId` (if parent has it). Service-layer create paths updated to set both.
+
+- [ ] `conversation_messages` — both.
+- [ ] `task_assignees`, `task_approvers`, `task_reviewers`, `task_watchers`, `task_blocks`, `task_chat_messages`, `task_kb_mentions`, `task_attachments`, `task_relations` — both.
+- [ ] `agent_runs`, `agent_run_logs`, `agent_budgets`, `agent_memberships` — both.
+- [ ] `skill_bindings` — both.
+- [ ] `work_members`, `work_invitations`, `work_generation_history` — both.
+- [ ] `work_knowledge_chunks`, `work_knowledge_citations`, `work_knowledge_tags`, `work_knowledge_uploads` — both.
+- [ ] `webhook_deliveries`, `usage_ledger_entries`, `plugin_usage_events`, `activity_log` — both.
+
+Service updates:
+- [ ] New `ScopeContext` request-scoped provider (`apps/api/src/scope/scope-context.service.ts`).
+- [ ] Walk through every Tier C row creation path; set `tenantId` + `organizationId` from `ScopeContext`.
+- [ ] Background-job / agent-tick / scheduled-task paths: extract scope from the parent entity being processed.
+
+Tests:
+- [ ] Per-entity migration test.
+- [ ] Service-level: assert new rows have `tenantId` set when the actor has a Tenant.
+- [ ] Integration tests for the affected services to verify scope propagation.
+
+---
+
+## Phase 6 — Lazy upgrade flow + Org-create API
+
+### API endpoints
+- [ ] `POST /api/organizations` — create Org, lazy-create Tenant if needed.
+- [ ] `POST /api/organizations/:id/upgrade-from-account` — backfill existing rows.
+- [ ] `GET /api/organizations` — list for current user's Tenant.
+- [ ] `GET /api/organizations/:slug` — fetch by slug.
+- [ ] `PATCH /api/organizations/:id` — update Org metadata.
+- [ ] `GET /api/organizations/check-slug?value=<string>` — slug availability.
+
+### Services
+- [ ] `apps/api/src/organizations/organization.service.ts`:
+  - [ ] `createOrganization(userId, name, slug?)`.
+  - [ ] `upgradeFromAccount(userId, organizationId)` — transactional, idempotent.
+- [ ] `apps/api/src/scope/tenant-bootstrap.service.ts` — `ensureTenant(userId)`.
+
+### DTOs / contracts
+- [ ] Add `CreateOrganizationDto`, `UpdateOrganizationDto`, `OrganizationResponseDto` to `packages/contracts/api`.
+- [ ] OpenAPI annotations on every endpoint so the MCP server picks them up.
+
+### Tests
+- [ ] `organization.service.spec.ts` — all branches.
+- [ ] `organization.controller.spec.ts` — all endpoints.
+- [ ] Integration test for `upgrade-from-account` flow end-to-end.
+
+---
+
+## Phase 7 — Slug routing middleware
+
+### API
+- [ ] `apps/api/src/scope/scope-resolver.middleware.ts` — reads `:slug` param or `X-Scope-Slug` header.
+- [ ] Apply middleware globally on `/api/*` with exempt list (`/api/auth/*`, `/api/users/check-username`, `/api/organizations/check-slug`).
+
+### Web (Next.js)
+- [ ] New segment `apps/web/src/app/[slug]/` mirroring the existing dashboard tree.
+- [ ] Layout-level slug validation + redirect to user's default scope on root path.
+- [ ] Client fetcher passes `X-Scope-Slug` on every API call from a scoped page.
+
+### Tests
+- [ ] Middleware unit test — all branches (Org hit, User hit, 404).
+- [ ] E2E: `/{username}/missions` vs `/{orgSlug}/missions` show correct data sets.
+- [ ] E2E: 404 on bad slug.
+
+---
+
+## Phase 8 — WorkspaceSwitcher UI
+
+### Components
+- [ ] `apps/web/src/components/layout/WorkspaceSwitcher.tsx` (reskin of shadcn sidebar-07 TeamSwitcher).
+- [ ] `apps/web/src/hooks/useOrganizations.ts` (SWR over `GET /api/organizations`).
+- [ ] `apps/web/src/hooks/useActiveScope.ts` (current scope from URL slug).
+
+### Wiring
+- [ ] Replace standalone Ever Works logo placement in sidebar with `<WorkspaceSwitcher />`.
+- [ ] Empty state path: render `<EverWorksLogo />` unmodified when `organizations.length === 0`.
+
+### i18n
+- [ ] Add new keys: `organizations.switcher.heading` ("Organizations"), `organizations.switcher.createNew` ("Create Organization"), `organizations.switcher.bareTenant` ("My account" or fallback to username). Update all locales (NN-equivalent: don't half-translate).
+
+### Tests
+- [ ] Unit: empty state renders logo only.
+- [ ] Unit: active state renders chip + chevron + popover with correct items.
+- [ ] Playwright: clicking another Org in popover navigates to its slug.
+
+---
+
+## Phase 9 — CreateOrganizationModal + upgrade-vs-new dialog
+
+### Components
+- [ ] `apps/web/src/components/organizations/CreateOrganizationModal.tsx` — single-name form, live slug preview, submit.
+- [ ] `apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx` — first-Org-only, defaults to Upgrade.
+
+### Wiring
+- [ ] Switcher's "+ Create Organization" item opens the modal.
+- [ ] On modal submit (server returns the new Org), if it's the user's first Org → open the dialog; else → just navigate.
+
+### i18n
+- [ ] Modal copy: name field label, slug preview, submit button.
+- [ ] Dialog copy: "Upgrade current account" (default) and "Create with empty data" descriptions per [spec.md §5.2](spec.md#52-user-creates-their-first-organization). Refine final wording with Product/Design.
+
+### Tests
+- [ ] Unit: dialog default focus is on "Upgrade".
+- [ ] Playwright: full flow — open switcher → create Org → choose Upgrade → existing items appear in new scope.
+- [ ] Playwright: full flow — choose Empty → new scope is empty; bare-Tenant scope still has the user's items.
+
+---
+
+## Phase 10 — Company chip on `+ New` + Work-of-type-Company → Org wire-up
+
+### `+ New` page
+- [ ] Add `Company` to the chip array in order specified in [spec.md §6.3](spec.md#63--new-page--company-chip).
+- [ ] Picking the `Company` chip routes the submit into the Register-Company sub-flow.
+
+### Work type "Company"
+- [ ] New template / WorkType `Company` plumbed through existing template/type patterns.
+- [ ] Registration provider integration (Stripe Atlas — out of scope to *implement* if no SDK yet; the WorkType + manual-completion path is enough for v1).
+
+### Wire-up
+- [ ] On Company Work transitioning to `registered` status:
+  - [ ] Lazy-create Tenant if needed.
+  - [ ] Create Organization row with `legalName`, `countryCode`, `registrationProvider`, `registrationStatus='registered'`, `linkedWorkId=work.id`.
+  - [ ] Trigger client-side `UpgradeOrCreateDialog` (via in-app notification → action) if this is the user's first Org.
+
+### Tests
+- [ ] E2E: pick Company chip → fill details → mark registered → Organization appears in switcher → user is offered the upgrade dialog.
+
+---
+
+## Cross-cutting
+
+- [ ] Update `apps/docs/` user-facing documentation: Organizations & scopes.
+- [ ] Update `apps/web/src/components/onboarding/*` if the onboarding wizard references the future Org flow.
+- [ ] No changes to existing UI strings other than additions (per NN #20).
+- [ ] Every entity touched gets a migration in the same PR (NN #16).
+- [ ] Every PR drives to a clean review state (NN #14) and green CI (NN #19).
+- [ ] All PRs target `develop`; never `main`/`master`/`stage` directly (NN #21).
+
+---
+
+## JIRA linkage
+
+JIRA Epic and per-phase Stories are created alongside this spec. Once created, update this section with the keys:
+
+- **Epic:** `EW-???` — Tenants & Organizations
+  - Phase 0: `EW-???`
+  - Phase 1: `EW-???`
+  - Phase 2: `EW-???`
+  - Phase 3: `EW-???`
+  - Phase 4: `EW-???`
+  - Phase 5: `EW-???`
+  - Phase 6: `EW-???`
+  - Phase 7: `EW-???`
+  - Phase 8: `EW-???`
+  - Phase 9: `EW-???`
+  - Phase 10: `EW-???`
+
+(See [JIRA_ATLASSIAN_MCP.md](../../../../../../Workspace/knowledge/runbooks/JIRA_ATLASSIAN_MCP.md) for ticket-management commands.)

--- a/docs/specs/features/tenants-and-organizations/tasks.md
+++ b/docs/specs/features/tenants-and-organizations/tasks.md
@@ -247,19 +247,19 @@ Tests:
 
 ## JIRA linkage
 
-JIRA Epic and per-phase Stories are created alongside this spec. Once created, update this section with the keys:
+JIRA Epic and per-phase Stories live in the `EW` project at <https://evertech.atlassian.net>:
 
-- **Epic:** `EW-???` — Tenants & Organizations
-  - Phase 0: `EW-???`
-  - Phase 1: `EW-???`
-  - Phase 2: `EW-???`
-  - Phase 3: `EW-???`
-  - Phase 4: `EW-???`
-  - Phase 5: `EW-???`
-  - Phase 6: `EW-???`
-  - Phase 7: `EW-???`
-  - Phase 8: `EW-???`
-  - Phase 9: `EW-???`
-  - Phase 10: `EW-???`
+- **Epic:** [EW-651](https://evertech.atlassian.net/browse/EW-651) — Tenants & Organizations
+  - Phase 0 — Username uniqueness contract: [EW-652](https://evertech.atlassian.net/browse/EW-652)
+  - Phase 1 — Create tenants + organizations tables: [EW-653](https://evertech.atlassian.net/browse/EW-653)
+  - Phase 2 — `tenantId` on users + Tier B: [EW-654](https://evertech.atlassian.net/browse/EW-654)
+  - Phase 3 — `tenantId` + `organizationId` on Tier A: [EW-655](https://evertech.atlassian.net/browse/EW-655)
+  - Phase 4 — Upgrade free-form `organizationId` to FK: [EW-656](https://evertech.atlassian.net/browse/EW-656)
+  - Phase 5 — Tier C denormalization: [EW-657](https://evertech.atlassian.net/browse/EW-657)
+  - Phase 6 — Lazy upgrade flow + Org-create API: [EW-658](https://evertech.atlassian.net/browse/EW-658)
+  - Phase 7 — Slug routing middleware: [EW-659](https://evertech.atlassian.net/browse/EW-659)
+  - Phase 8 — WorkspaceSwitcher UI: [EW-660](https://evertech.atlassian.net/browse/EW-660)
+  - Phase 9 — CreateOrganizationModal + upgrade-vs-new dialog: [EW-661](https://evertech.atlassian.net/browse/EW-661)
+  - Phase 10 — Company chip + Work→Org wire-up: [EW-662](https://evertech.atlassian.net/browse/EW-662)
 
 (See [JIRA_ATLASSIAN_MCP.md](../../../../../../Workspace/knowledge/runbooks/JIRA_ATLASSIAN_MCP.md) for ticket-management commands.)


### PR DESCRIPTION
## Summary

- Adds `docs/specs/features/tenants-and-organizations/{spec,plan,tasks,acceptance}.md` — a 4-document feature spec for a new multi-Organization scoping foundation, captured during the 2026-05-27 brainstorm with the operator.
- **Docs only** — no code changes, no migrations, no entity changes. This PR ships the design; implementation lands in follow-up PRs that map 1:1 to the 10 phases in `plan.md`.
- Follows the house spec pattern (`spec.md` / `plan.md` / `tasks.md` / `acceptance.md`) used under `docs/specs/features/`.
- Mirrors a short companion note in the Workspace repo at `knowledge/notes/2026-05-27-tenants-and-organizations-spec.md`.

## Highlights of the design

- **Tenant** = internal-only concept, 1:1 with User, lazy-created on first Org. Never appears in UI.
- **Organization** = user-facing scope, 0..N per Tenant. Displayed as "Organization" in settings/switcher and "Company" in the new-item chips and Stripe Atlas flow — same row in DB.
- **No backfill on existing users** — platform isn't live yet. Tenant + scope columns stay NULL until the user creates their first Organization, at which point we lazy-create the Tenant and optionally backfill `organizationId` if they pick "upgrade current account" — the default.
- **URL slug** — `users.slug` for bare Tenant view, `organizations.slug` for Org view. Always slug-prefixed: `/{slug}/...`.
- **WorkspaceSwitcher** — shadcn sidebar-07 reskin; empty state shows the existing Ever Works logo unchanged; popover heading reads "Organizations", never "Workspaces" or "Tenants".

## Test plan

- [ ] Review `spec.md` for completeness vs the 2026-05-27 brainstorm — 10 user-confirmed design calls captured.
- [ ] Review `plan.md` for phase ordering + dependencies.
- [ ] Confirm `tasks.md` checklist matches the level of granularity engineering expects.
- [ ] Confirm `acceptance.md` ACs are observable / testable.
- [ ] Cross-link to the separately-created JIRA Epic in EW project once the keys exist; update `tasks.md` JIRA section.

Docs-only PR; no automated tests added, no migrations applied. CI runs lint/typecheck of the docs site `apps/docs` if it picks them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Tenants & Organizations docs: product specification, implementation plan, phase-by-phase tasks, and acceptance criteria covering tenant/org concepts, rollout phases, slug routing/precedence, upgrade-vs-new organization flows, workspace switcher and create/upgrade UI expectations, data integrity/migration gates, and a Definition of Done checklist for the upcoming workspace scoping rollout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->