### PR TITLE
feat(web): prompt UI polish + composer-to-storage wiring + per-entity attachments

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -633,4 +633,42 @@ export class AgentsController {
             // best-effort — log failure should never break the request.
         }
     }
+
+    /**
+     * Agent attachment surface — list/add/remove `AgentAttachment`
+     * edges (FK to `work_knowledge_uploads`). Same shape as the
+     * Mission / Idea endpoints; reference files / specs attached to
+     * an Agent profile (separate from the Agent's `avatarImageUploadId`).
+     */
+    @Get(':id/attachments')
+    @ApiOperation({ summary: "List an Agent's attached uploads" })
+    async listAttachments(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ) {
+        return this.service.listAttachments(auth.userId, id);
+    }
+
+    @Post(':id/attachments')
+    @ApiOperation({ summary: 'Attach an uploaded file to an Agent' })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ default: { limit: 60, ttl: 60_000 } })
+    async addAttachment(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: { uploadId: string },
+    ) {
+        return this.service.addAttachment(auth.userId, id, body?.uploadId);
+    }
+
+    @Delete(':id/attachments/:attachmentId')
+    @ApiOperation({ summary: 'Detach an upload from an Agent' })
+    @HttpCode(HttpStatus.OK)
+    async removeAttachment(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('attachmentId', ParseUUIDPipe) attachmentId: string,
+    ) {
+        return this.service.removeAttachment(auth.userId, id, attachmentId);
+    }
 }

--- a/apps/api/src/migrations/1779991000000-CreateMissionIdeaAgentAttachmentTables.ts
+++ b/apps/api/src/migrations/1779991000000-CreateMissionIdeaAgentAttachmentTables.ts
@@ -1,10 +1,4 @@
-import {
-    MigrationInterface,
-    QueryRunner,
-    Table,
-    TableForeignKey,
-    TableIndex,
-} from 'typeorm';
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
 
 /**
  * Adds three Mission/Idea/Agent → Upload edge tables. Mirrors the
@@ -16,8 +10,12 @@ import {
  *   - `<parent>Id` uuid NOT NULL, FK to the parent table with
  *     ON DELETE CASCADE so cleaning up the Mission / Idea / Agent
  *     also clears its attachment edges
- *   - `uploadId` uuid NOT NULL (no DB-level FK — service validates;
- *     mirrors `task_attachments`)
+ *   - `uploadId` varchar(64) NOT NULL — SHA-256 content hash returned
+ *     as `id` by POST /api/uploads/file. Stored as varchar(64) rather
+ *     than uuid because sha256 isn't UUID-shaped (Codex + Greptile P1
+ *     on PR #1044). No DB-level FK — the upload pipeline can GC the
+ *     storage object independently; service-layer validates the hash
+ *     shape on insert.
  *   - `createdAt` timestamp NOT NULL default now()
  *   - unique index on (`<parent>Id`, `uploadId`) — same Upload can
  *     only be attached to the same parent once
@@ -27,9 +25,7 @@ import {
  * Idempotent: each `CREATE TABLE` is guarded by `hasTable`, each index
  * by name lookup. Re-runs are no-ops.
  */
-export class CreateMissionIdeaAgentAttachmentTables1779991000000
-    implements MigrationInterface
-{
+export class CreateMissionIdeaAgentAttachmentTables1779991000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await this.createAttachmentTable(queryRunner, {
             tableName: 'mission_attachments',
@@ -94,7 +90,9 @@ export class CreateMissionIdeaAgentAttachmentTables1779991000000
                             default: 'uuid_generate_v4()',
                         },
                         { name: parentColumn, type: 'uuid', isNullable: false },
-                        { name: 'uploadId', type: 'uuid', isNullable: false },
+                        // SHA-256 content hash — varchar(64) not uuid.
+                        // See header comment for the Codex/Greptile P1.
+                        { name: 'uploadId', type: 'varchar', length: '64', isNullable: false },
                         {
                             name: 'createdAt',
                             type: 'timestamp',

--- a/apps/api/src/migrations/1779991000000-CreateMissionIdeaAgentAttachmentTables.ts
+++ b/apps/api/src/migrations/1779991000000-CreateMissionIdeaAgentAttachmentTables.ts
@@ -1,0 +1,162 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    Table,
+    TableForeignKey,
+    TableIndex,
+} from 'typeorm';
+
+/**
+ * Adds three Mission/Idea/Agent → Upload edge tables. Mirrors the
+ * `task_attachments` table from the 1779978013000 CreateTasksTables
+ * migration so the surfaces stay symmetric.
+ *
+ * For each table:
+ *   - `id` uuid PK (generated)
+ *   - `<parent>Id` uuid NOT NULL, FK to the parent table with
+ *     ON DELETE CASCADE so cleaning up the Mission / Idea / Agent
+ *     also clears its attachment edges
+ *   - `uploadId` uuid NOT NULL (no DB-level FK — service validates;
+ *     mirrors `task_attachments`)
+ *   - `createdAt` timestamp NOT NULL default now()
+ *   - unique index on (`<parent>Id`, `uploadId`) — same Upload can
+ *     only be attached to the same parent once
+ *   - secondary index on `uploadId` for the "what's referencing this
+ *     upload?" query
+ *
+ * Idempotent: each `CREATE TABLE` is guarded by `hasTable`, each index
+ * by name lookup. Re-runs are no-ops.
+ */
+export class CreateMissionIdeaAgentAttachmentTables1779991000000
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await this.createAttachmentTable(queryRunner, {
+            tableName: 'mission_attachments',
+            parentTable: 'missions',
+            parentColumn: 'missionId',
+            uniqueIndexName: 'uq_mission_attachment',
+            uploadIndexName: 'idx_mission_attachment_upload',
+        });
+        await this.createAttachmentTable(queryRunner, {
+            tableName: 'work_proposal_attachments',
+            parentTable: 'work_proposals',
+            parentColumn: 'workProposalId',
+            uniqueIndexName: 'uq_work_proposal_attachment',
+            uploadIndexName: 'idx_work_proposal_attachment_upload',
+        });
+        await this.createAttachmentTable(queryRunner, {
+            tableName: 'agent_attachments',
+            parentTable: 'agents',
+            parentColumn: 'agentId',
+            uniqueIndexName: 'uq_agent_attachment',
+            uploadIndexName: 'idx_agent_attachment_upload',
+        });
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Reverse order for cleanliness; each drop is idempotent via
+        // `hasTable` check.
+        for (const name of [
+            'agent_attachments',
+            'work_proposal_attachments',
+            'mission_attachments',
+        ]) {
+            if (await queryRunner.hasTable(name)) {
+                await queryRunner.dropTable(name, true);
+            }
+        }
+    }
+
+    private async createAttachmentTable(
+        queryRunner: QueryRunner,
+        opts: {
+            tableName: string;
+            parentTable: string;
+            parentColumn: string; // FK column name on this table
+            uniqueIndexName: string;
+            uploadIndexName: string;
+        },
+    ): Promise<void> {
+        const { tableName, parentTable, parentColumn, uniqueIndexName, uploadIndexName } = opts;
+
+        if (!(await queryRunner.hasTable(tableName))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: tableName,
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            isGenerated: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: parentColumn, type: 'uuid', isNullable: false },
+                        { name: 'uploadId', type: 'uuid', isNullable: false },
+                        {
+                            name: 'createdAt',
+                            type: 'timestamp',
+                            default: 'now()',
+                            isNullable: false,
+                        },
+                    ],
+                }),
+                true,
+            );
+            // Create the FK separately so the migration is friendlier to
+            // schema diffing (TypeORM names the inline-declared FK
+            // unpredictably otherwise).
+            await queryRunner.createForeignKey(
+                tableName,
+                new TableForeignKey({
+                    columnNames: [parentColumn],
+                    referencedTableName: parentTable,
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+
+        await this.ensureIndex(
+            queryRunner,
+            tableName,
+            uniqueIndexName,
+            [parentColumn, 'uploadId'],
+            true,
+        );
+        await this.ensureIndex(queryRunner, tableName, uploadIndexName, ['uploadId'], false);
+    }
+
+    private async ensureIndex(
+        queryRunner: QueryRunner,
+        tableName: string,
+        indexName: string,
+        columnNames: string[],
+        isUnique: boolean,
+    ): Promise<void> {
+        const table = await queryRunner.getTable(tableName);
+        const existing = table?.indices.find((idx) => idx.name === indexName);
+        if (existing) {
+            // Same defensive shape used by the tasks migration: if the
+            // index already exists with the right columns + uniqueness,
+            // leave it. Otherwise drop and recreate — keeps in-dev
+            // re-runs honest.
+            const sameColumns =
+                existing.columnNames.length === columnNames.length &&
+                existing.columnNames.every((c, i) => c === columnNames[i]) &&
+                (existing.isUnique ?? false) === isUnique;
+            if (sameColumns) return;
+            await queryRunner.dropIndex(tableName, indexName);
+        }
+        await queryRunner.createIndex(
+            tableName,
+            new TableIndex({
+                name: indexName,
+                columnNames,
+                isUnique,
+            }),
+        );
+    }
+}

--- a/apps/api/src/missions/missions.controller.ts
+++ b/apps/api/src/missions/missions.controller.ts
@@ -234,4 +234,46 @@ export class MissionsController {
     }> {
         return this.service.runNow(auth.userId, id);
     }
+
+    /**
+     * Mission attachment surface — list/add/remove `MissionAttachment`
+     * edges (FK to `work_knowledge_uploads`). Backs the
+     * PromptComposer's "files attached when creating a Mission" flow:
+     * the composer uploads via `POST /api/uploads/file` and then the
+     * caller hits `POST /api/me/missions/:id/attachments` to associate.
+     *
+     * Same security model as the rest of this controller — ownership
+     * is enforced inside `MissionsService.{list,add,remove}Attachment`.
+     */
+    @Get(':id/attachments')
+    @ApiOperation({ summary: "List a Mission's attached uploads" })
+    async listAttachments(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ) {
+        return this.service.listAttachments(auth.userId, id);
+    }
+
+    @Post(':id/attachments')
+    @ApiOperation({ summary: 'Attach an uploaded file to a Mission' })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ default: { limit: 60, ttl: 60_000 } })
+    async addAttachment(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: { uploadId: string },
+    ) {
+        return this.service.addAttachment(auth.userId, id, body?.uploadId);
+    }
+
+    @Delete(':id/attachments/:attachmentId')
+    @ApiOperation({ summary: 'Detach an upload from a Mission' })
+    @HttpCode(HttpStatus.OK)
+    async removeAttachment(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('attachmentId', ParseUUIDPipe) attachmentId: string,
+    ) {
+        return this.service.removeAttachment(auth.userId, id, attachmentId);
+    }
 }

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -140,6 +140,66 @@ export class UploadsController {
     }
 
     /**
+     * Broader file-upload endpoint — accepts images PLUS PDFs, ZIP /
+     * Office Open XML, gzip, and the common text-like formats (markdown,
+     * CSV, JSON, code). Backs the PromptComposer's "Upload a file" /
+     * "Upload a folder" affordances on `/missions`, `/ideas`, `/new`,
+     * and `/works/new`.
+     *
+     * Same security model as `POST /api/uploads`: rate-limited, JWT-
+     * auth-gated, sha256-named storage keys, owner-scoped paths,
+     * magic-byte sniff for binaries / UTF-8 shape check for text. The
+     * declared MIME must be in the broader allow-list maintained inside
+     * `UploadsService.saveFile`.
+     *
+     * Larger size cap than the image endpoint (default 25 MiB vs 5 MiB
+     * for images) since PDFs / archives are typically bigger. Tunable
+     * via `UPLOADS_FILE_MAX_BYTES`.
+     */
+    @Post('file')
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ default: { limit: 20, ttl: 60_000 } })
+    @UseInterceptors(
+        FileInterceptor('file', {
+            // Multer-level cap — UploadsService.saveFile re-validates with
+            // the env-tunable cap; the interceptor's limit is a higher
+            // bound that catches absurdly-large payloads before they hit
+            // the service. 50 MiB is roomy enough for any reasonable
+            // ZIP / PDF.
+            limits: { fileSize: 50 * 1024 * 1024 },
+        }),
+    )
+    @ApiOperation({
+        summary: 'Upload a file (image / PDF / archive / text)',
+        description:
+            'Multipart upload of an image, PDF, ZIP / Office document, gzip, or text-like file (markdown, CSV, JSON, code). Auth required. Returns the same { id, url, filename, size, mimeType, hash, key } shape as POST /api/uploads. The server validates magic bytes for binary formats and verifies UTF-8 shape for text-like declared MIMEs.',
+    })
+    @ApiResponse({ status: 201, description: 'Upload accepted, returns { id, url, ... }' })
+    @ApiResponse({
+        status: 400,
+        description:
+            'Validation failed (size, MIME, magic-byte mismatch, or non-UTF-8 bytes for a text declared MIME)',
+    })
+    @ApiResponse({ status: 401, description: 'Unauthenticated' })
+    @ApiResponse({ status: 413, description: 'File exceeds size cap' })
+    async uploadFile(
+        @CurrentUser() auth: AuthenticatedUser,
+        @UploadedFile() file: Express.Multer.File | undefined,
+        @Query('workId') workId?: string,
+    ) {
+        if (!file) {
+            throw new BadRequestException({
+                status: 'error',
+                message: "Multipart field 'file' is required",
+            });
+        }
+        if (workId) {
+            await this.assertWorkAccess(auth.userId, workId);
+        }
+        return this.uploads.saveFile(auth.userId, file, workId ? { workId } : undefined);
+    }
+
+    /**
      * EW-644 (Codex P1) — verify the authenticated caller actually has
      * access to the Work referenced by `workId` before any storage
      * backend uses it to resolve repo coordinates / a token.

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -351,7 +351,6 @@ export class UploadsController {
     async uploadAnonymousFile(
         @UploadedFile() file: Express.Multer.File | undefined,
         @Req() req: AnonRequest,
-        @Headers('x-correlation-id') correlationHeader: string | undefined,
     ) {
         if (!file) {
             throw new BadRequestException({
@@ -364,7 +363,11 @@ export class UploadsController {
 
         const result = await this.uploads.saveFile(userId, file);
 
-        void correlationHeader;
+        // The existing /anonymous endpoint takes an `x-correlation-id`
+        // header for future telemetry; we omit it here until the
+        // funnel-emit follow-up wires it in. Adding the parameter
+        // before it has a consumer was flagged as dead code (Greptile
+        // P2 on PR #1044).
 
         return {
             uploadId: result.key ?? `${userId}/${result.filename}`,

--- a/apps/api/src/uploads/uploads.controller.ts
+++ b/apps/api/src/uploads/uploads.controller.ts
@@ -308,6 +308,78 @@ export class UploadsController {
     }
 
     /**
+     * Anonymous file upload — same as `/anonymous` but accepts the
+     * broader MIME allow-list from `saveFile` (PDFs, ZIP / Office
+     * Open XML, gzip, text-like formats) in addition to images.
+     *
+     * Backs the marketing site's "Upload a file" / "Upload a folder"
+     * affordances in `LandingPromptForm`. The website is being updated
+     * to call this endpoint instead of `/anonymous` for non-image
+     * picks; the existing `/anonymous` endpoint stays image-only so
+     * legacy callers don't change shape.
+     *
+     * Same anon-mint contract as `/anonymous`: when no bearer is
+     * present, an anonymous user is provisioned inline with a TTL of
+     * `ANONYMOUS_USER_TTL_DAYS` (default 3). The returned
+     * `anonAccessToken` is the bearer the visitor's later
+     * `/api/uploads/file` and prompt-submit calls reuse so the whole
+     * pre-signup session is attributed to the same anon user.
+     */
+    @Public()
+    @Post('anonymous/file')
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ default: { limit: 10, ttl: 60_000 } })
+    @UseInterceptors(
+        FileInterceptor('file', {
+            // 50 MiB outer cap, same as the authenticated `/file` route;
+            // saveFile re-validates with its env-tunable inner cap.
+            limits: { fileSize: 50 * 1024 * 1024 },
+        }),
+    )
+    @ApiOperation({
+        summary: 'Upload a file (image / PDF / archive / text) from an anonymous visitor',
+        description:
+            'Multipart upload from an unauthenticated visitor. Accepts the same broader MIME set as POST /api/uploads/file (images, PDFs, ZIP / Office docs, gzip, text-like formats). Same anon-mint contract as /anonymous — returns { uploadId, id, url, filename, size, mimeType, hash, expiresAt, anonAccessToken? }.',
+    })
+    @ApiResponse({ status: 201, description: 'Upload accepted' })
+    @ApiResponse({
+        status: 400,
+        description:
+            'Validation failed (size, MIME, magic-byte mismatch, or non-UTF-8 bytes for a text declared MIME)',
+    })
+    @ApiResponse({ status: 413, description: 'File exceeds size cap' })
+    async uploadAnonymousFile(
+        @UploadedFile() file: Express.Multer.File | undefined,
+        @Req() req: AnonRequest,
+        @Headers('x-correlation-id') correlationHeader: string | undefined,
+    ) {
+        if (!file) {
+            throw new BadRequestException({
+                status: 'error',
+                message: "Multipart field 'file' is required",
+            });
+        }
+
+        const { userId, anonAccessToken, anonymousExpiresAt } = await this.resolveActingUser(req);
+
+        const result = await this.uploads.saveFile(userId, file);
+
+        void correlationHeader;
+
+        return {
+            uploadId: result.key ?? `${userId}/${result.filename}`,
+            id: result.id,
+            url: result.url,
+            filename: result.filename,
+            size: result.size,
+            mimeType: result.mimeType,
+            hash: result.hash,
+            expiresAt: anonymousExpiresAt ?? null,
+            ...(anonAccessToken ? { anonAccessToken } : {}),
+        };
+    }
+
+    /**
      * EW-637 — mint a presigned upload URL when the active storage backend
      * supports direct-to-cloud uploads (S3 / MinIO). Local-fs and
      * github-storage don't, in which case we return HTTP 501 with a hint

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -434,4 +434,110 @@ describe('UploadsService', () => {
             expect(lastSeenKey).toEqual([`${userId}/${r.filename}`]);
         });
     });
+
+    describe('saveFile — broader-than-image accept list', () => {
+        const fakeFileWith = (
+            buffer: Buffer,
+            mimetype: string,
+            originalname = 'probe.bin',
+        ) => fakeFile({ buffer, mimetype, size: buffer.length, originalname });
+
+        it('accepts PDF via magic-byte sniff', async () => {
+            const pdf = Buffer.concat([
+                Buffer.from('%PDF-1.4\n', 'ascii'),
+                Buffer.alloc(64, 0x20),
+            ]);
+            const r = await service.saveFile(
+                userId,
+                fakeFileWith(pdf, 'application/pdf', 'doc.pdf'),
+            );
+            expect(r.filename.endsWith('.pdf')).toBe(true);
+            expect(r.mimeType).toBe('application/pdf');
+            expect(r.size).toBe(pdf.length);
+            // Persisted at the same owner-scoped path shape saveImage uses.
+            expect(r.url).toContain(`/api/uploads/${userId}/`);
+        });
+
+        it('accepts a ZIP archive', async () => {
+            const zip = Buffer.concat([
+                Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+                Buffer.alloc(32, 0x00),
+            ]);
+            const r = await service.saveFile(
+                userId,
+                fakeFileWith(zip, 'application/zip', 'archive.zip'),
+            );
+            expect(r.filename.endsWith('.zip')).toBe(true);
+            expect(r.mimeType).toBe('application/zip');
+        });
+
+        it('accepts Office Open XML (.docx) as ZIP under the hood, echoes declared MIME', async () => {
+            const docx = Buffer.concat([
+                Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+                Buffer.alloc(64, 0x00),
+            ]);
+            const r = await service.saveFile(
+                userId,
+                fakeFileWith(
+                    docx,
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    'report.docx',
+                ),
+            );
+            // Stored as ZIP, response carries the declared Office MIME.
+            expect(r.filename.endsWith('.zip')).toBe(true);
+            expect(r.mimeType).toBe(
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            );
+        });
+
+        it('accepts a plain-text file with no NUL bytes', async () => {
+            const text = Buffer.from('hello, world\nline two\n', 'utf-8');
+            const r = await service.saveFile(
+                userId,
+                fakeFileWith(text, 'text/plain', 'notes.txt'),
+            );
+            expect(r.filename.endsWith('.txt')).toBe(true);
+            expect(r.mimeType).toBe('text/plain');
+        });
+
+        it('accepts JSON declared as application/json', async () => {
+            const json = Buffer.from('{"hello":"world"}', 'utf-8');
+            const r = await service.saveFile(
+                userId,
+                fakeFileWith(json, 'application/json', 'config.json'),
+            );
+            expect(r.filename.endsWith('.json')).toBe(true);
+        });
+
+        it('rejects a binary uploaded with text/plain (NUL bytes)', async () => {
+            // Buffer with a NUL byte in the middle — looksLikeUtf8Text
+            // rejects when it sees 0x00 anywhere in the first 8KiB.
+            const bin = Buffer.concat([
+                Buffer.from('hello', 'utf-8'),
+                Buffer.from([0x00]),
+                Buffer.from('world', 'utf-8'),
+            ]);
+            await expect(
+                service.saveFile(userId, fakeFileWith(bin, 'text/plain', 'sneaky.txt')),
+            ).rejects.toThrow(BadRequestException);
+        });
+
+        it('rejects an unknown MIME type', async () => {
+            const buf = Buffer.alloc(8, 0xff);
+            await expect(
+                service.saveFile(userId, fakeFileWith(buf, 'video/mp4', 'movie.mp4')),
+            ).rejects.toThrow(BadRequestException);
+        });
+
+        it('rejects a file whose bytes do not match the declared MIME', async () => {
+            // Declared PDF but bytes are PNG.
+            await expect(
+                service.saveFile(
+                    userId,
+                    fakeFileWith(TINY_PNG, 'application/pdf', 'fake.pdf'),
+                ),
+            ).rejects.toThrow(BadRequestException);
+        });
+    });
 });

--- a/apps/api/src/uploads/uploads.service.spec.ts
+++ b/apps/api/src/uploads/uploads.service.spec.ts
@@ -436,17 +436,11 @@ describe('UploadsService', () => {
     });
 
     describe('saveFile — broader-than-image accept list', () => {
-        const fakeFileWith = (
-            buffer: Buffer,
-            mimetype: string,
-            originalname = 'probe.bin',
-        ) => fakeFile({ buffer, mimetype, size: buffer.length, originalname });
+        const fakeFileWith = (buffer: Buffer, mimetype: string, originalname = 'probe.bin') =>
+            fakeFile({ buffer, mimetype, size: buffer.length, originalname });
 
         it('accepts PDF via magic-byte sniff', async () => {
-            const pdf = Buffer.concat([
-                Buffer.from('%PDF-1.4\n', 'ascii'),
-                Buffer.alloc(64, 0x20),
-            ]);
+            const pdf = Buffer.concat([Buffer.from('%PDF-1.4\n', 'ascii'), Buffer.alloc(64, 0x20)]);
             const r = await service.saveFile(
                 userId,
                 fakeFileWith(pdf, 'application/pdf', 'doc.pdf'),
@@ -493,10 +487,7 @@ describe('UploadsService', () => {
 
         it('accepts a plain-text file with no NUL bytes', async () => {
             const text = Buffer.from('hello, world\nline two\n', 'utf-8');
-            const r = await service.saveFile(
-                userId,
-                fakeFileWith(text, 'text/plain', 'notes.txt'),
-            );
+            const r = await service.saveFile(userId, fakeFileWith(text, 'text/plain', 'notes.txt'));
             expect(r.filename.endsWith('.txt')).toBe(true);
             expect(r.mimeType).toBe('text/plain');
         });
@@ -533,10 +524,7 @@ describe('UploadsService', () => {
         it('rejects a file whose bytes do not match the declared MIME', async () => {
             // Declared PDF but bytes are PNG.
             await expect(
-                service.saveFile(
-                    userId,
-                    fakeFileWith(TINY_PNG, 'application/pdf', 'fake.pdf'),
-                ),
+                service.saveFile(userId, fakeFileWith(TINY_PNG, 'application/pdf', 'fake.pdf')),
             ).rejects.toThrow(BadRequestException);
         });
     });

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -412,8 +412,7 @@ export class UploadsService {
             });
         }
 
-        const maxFileSize =
-            Number(process.env.UPLOADS_FILE_MAX_BYTES) || DEFAULT_MAX_FILE_SIZE;
+        const maxFileSize = Number(process.env.UPLOADS_FILE_MAX_BYTES) || DEFAULT_MAX_FILE_SIZE;
         if (file.size > maxFileSize) {
             throw new BadRequestException({
                 status: 'error',

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -69,20 +69,133 @@ const MAGIC_BYTES: ReadonlyArray<{
         bytes: [0x57, 0x45, 0x42, 0x50],
         offset: 8,
     },
+    // PDF: "%PDF-"
+    { mime: 'application/pdf', ext: 'pdf', bytes: [0x25, 0x50, 0x44, 0x46, 0x2d] },
+    // ZIP family (covers .zip + Office Open XML .docx/.xlsx/.pptx — all are
+    // ZIP archives under the hood). We store as plain `.zip` because the
+    // outer container is a ZIP; the original filename / original MIME are
+    // still echoed back to the caller so the UI knows what to show.
+    { mime: 'application/zip', ext: 'zip', bytes: [0x50, 0x4b, 0x03, 0x04] },
+    // GZIP: 1F 8B
+    { mime: 'application/gzip', ext: 'gz', bytes: [0x1f, 0x8b] },
 ];
 
 /**
- * Allow-list of accepted MIME families. Anything outside this list is
- * rejected unconditionally. SVG is INTENTIONALLY excluded — it can
- * carry inline `<script>` payloads that would execute if a downstream
- * tier ever serves it inline with `Content-Type: image/svg+xml` to a
- * browser. If you need SVG support, route through a sanitizer (DOMPurify
- * with `USE_PROFILES: { svg: true }`) and add a `image/svg+xml`
- * `sanitized` variant — do NOT just add it here.
+ * Allow-list of accepted IMAGE MIME families. Anything outside this list is
+ * rejected by `saveImage`. SVG is INTENTIONALLY excluded — it can carry
+ * inline `<script>` payloads that would execute if a downstream tier ever
+ * serves it inline with `Content-Type: image/svg+xml` to a browser. If
+ * you need SVG support, route through a sanitizer (DOMPurify with
+ * `USE_PROFILES: { svg: true }`) and add an `image/svg+xml` `sanitized`
+ * variant — do NOT just add it here.
  */
 const ALLOWED_MIME = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
 
-const DEFAULT_MAX_SIZE = 5 * 1024 * 1024; // 5 MiB
+/**
+ * Allow-list for the broader `saveFile` path — images PLUS documents,
+ * archives, and text-like formats. PromptComposer's "Upload a file" /
+ * "Upload a folder" affordances route here. Anything not in this set OR
+ * not in `TEXT_LIKE_MIMES` below is rejected.
+ *
+ * Binary types here MUST have a matching magic-byte signature in
+ * `MAGIC_BYTES`; the sniff still runs and the declared MIME must match
+ * the bytes. Text-like types live in their own set (below) because they
+ * have no canonical magic bytes and are validated via a content shape
+ * heuristic instead.
+ */
+const ALLOWED_FILE_BINARY_MIME = new Set([
+    ...ALLOWED_MIME, // images
+    'application/pdf',
+    'application/zip',
+    'application/gzip',
+    // Office Open XML — the bytes are ZIP, but browsers may declare these
+    // canonical MIMEs. We accept the declaration AND require the magic
+    // bytes to be ZIP. Stored as `.zip` (the container format).
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+]);
+
+/**
+ * Declared MIMEs that have no reliable magic byte signature — these are
+ * text-like formats (plain text, markdown, CSV, JSON, code). The bytes
+ * are validated via `looksLikeUtf8Text` (no NUL bytes in the first 8KiB,
+ * mostly printable ASCII / valid UTF-8) rather than magic-byte sniffing.
+ * The map value is the canonical extension we write to disk.
+ */
+const TEXT_LIKE_MIMES: ReadonlyMap<string, string> = new Map([
+    ['text/plain', 'txt'],
+    ['text/markdown', 'md'],
+    ['text/x-markdown', 'md'],
+    ['text/csv', 'csv'],
+    ['text/tab-separated-values', 'tsv'],
+    ['text/html', 'html'],
+    ['text/css', 'css'],
+    ['text/javascript', 'js'],
+    ['application/javascript', 'js'],
+    ['application/json', 'json'],
+    ['application/xml', 'xml'],
+    ['text/xml', 'xml'],
+    ['application/x-yaml', 'yaml'],
+    ['text/yaml', 'yaml'],
+    ['text/x-yaml', 'yaml'],
+]);
+
+/**
+ * Union of all extensions writable by saveImage + saveFile. Used by
+ * `assertValidFilename` to validate filenames on the serve path.
+ */
+const ALL_VALID_EXTS = [
+    'png',
+    'jpg',
+    'jpeg',
+    'gif',
+    'webp',
+    'pdf',
+    'zip',
+    'gz',
+    'txt',
+    'md',
+    'csv',
+    'tsv',
+    'html',
+    'css',
+    'js',
+    'json',
+    'xml',
+    'yaml',
+];
+
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024; // 5 MiB images
+const DEFAULT_MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MiB non-image files
+
+/**
+ * Heuristic "is this UTF-8 text?" check for text-like uploads. Scans the
+ * first 8KiB and rejects when:
+ *   - any NUL byte (0x00) is present (binaries almost always have NULs;
+ *     UTF-8 text never does)
+ *   - the buffer is not a valid UTF-8 sequence
+ *
+ * This is intentionally simple — text files are bounded enough by the
+ * declared MIME + no-NUL rule that we don't need a full encoding
+ * detector. A malicious caller can still upload arbitrary "text" bytes,
+ * but the storage backend serves them with the declared text MIME so
+ * the only impact is the user re-downloading their own file.
+ */
+function looksLikeUtf8Text(buf: Buffer): boolean {
+    const head = buf.length > 8192 ? buf.subarray(0, 8192) : buf;
+    if (head.length === 0) return false;
+    for (let i = 0; i < head.length; i++) {
+        if (head[i] === 0) return false;
+    }
+    try {
+        // Strict UTF-8 decode — throws on invalid sequences.
+        new TextDecoder('utf-8', { fatal: true }).decode(head);
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 /**
  * EW-637 — UploadsService is now the validation + dispatch layer in front
@@ -266,6 +379,161 @@ export class UploadsService {
     }
 
     /**
+     * Validate + persist an uploaded file of broader-than-image type.
+     * Same security model as `saveImage` (magic-byte sniff for binaries,
+     * UTF-8 shape check for text-like declared MIMEs, SHA-256 storage
+     * naming, owner-scoped key, no part of the originalname reaches
+     * storage) but the allow-list covers PDFs, ZIP / Office Open XML,
+     * gzip, and the common text formats listed in `TEXT_LIKE_MIMES`.
+     *
+     * Used by `POST /api/uploads/file` (auth) and the PromptComposer's
+     * "Upload a file" / "Upload a folder" affordances. Images can also
+     * be uploaded here; they take the same magic-byte path saveImage
+     * uses and end up at the same kind of storage key (just routed
+     * through the broader allowlist).
+     *
+     * Returns the same `UploadResult` shape as `saveImage` so callers
+     * can treat both endpoints uniformly. The `mimeType` field reflects
+     * the **declared** MIME (since text formats can't be sniffed); the
+     * `key` field is the backend-opaque storage key.
+     */
+    async saveFile(
+        userId: string,
+        file: Pick<Express.Multer.File, 'buffer' | 'mimetype' | 'size' | 'originalname'>,
+        opts?: { workId?: string },
+    ): Promise<UploadResult> {
+        this.assertValidUserId(userId);
+
+        if (!file || !file.buffer || file.buffer.length === 0) {
+            throw new BadRequestException({
+                status: 'error',
+                code: 'EmptyFile',
+                message: 'No file content received',
+            });
+        }
+
+        const maxFileSize =
+            Number(process.env.UPLOADS_FILE_MAX_BYTES) || DEFAULT_MAX_FILE_SIZE;
+        if (file.size > maxFileSize) {
+            throw new BadRequestException({
+                status: 'error',
+                code: 'FileTooLarge',
+                message: `File exceeds ${maxFileSize} byte cap`,
+            });
+        }
+
+        const declared = (file.mimetype || '').toLowerCase();
+
+        // Branch 1: binary type with a known magic-byte signature.
+        // Includes images (delegated to the same path as saveImage for
+        // uniformity) plus PDF / ZIP / gzip / Office Open XML.
+        if (ALLOWED_FILE_BINARY_MIME.has(declared)) {
+            const sniffed = this.sniffMagicBytes(file.buffer);
+            if (!sniffed) {
+                throw new BadRequestException({
+                    status: 'error',
+                    code: 'MimeMismatch',
+                    message: `File has no recognized magic-byte signature`,
+                });
+            }
+            // For Office Open XML, the underlying bytes are ZIP, so the
+            // sniffed MIME is `application/zip` but the declared MIME is
+            // the canonical Office MIME. Treat that as a match.
+            const sniffedFamily = sniffed.mime;
+            const declaredFamily = declared.startsWith(
+                'application/vnd.openxmlformats-officedocument',
+            )
+                ? 'application/zip'
+                : declared;
+            if (sniffedFamily !== declaredFamily) {
+                throw new BadRequestException({
+                    status: 'error',
+                    code: 'MimeMismatch',
+                    message: `Declared Content-Type ${JSON.stringify(
+                        declared,
+                    )} does not match the file's magic bytes`,
+                });
+            }
+            const hash = createHash('sha256').update(file.buffer).digest('hex');
+            const filename = `${hash}.${sniffed.ext}`;
+            const backend = await this.getBackend();
+            const workId = opts?.workId;
+            if (workId !== undefined) this.assertValidWorkId(workId);
+            // For Office files the storage type is the ZIP (under-the-hood
+            // format); the response echoes the declared MIME so the UI can
+            // still show "Word document", not "ZIP archive".
+            const { key } = await backend.putObject({
+                buffer: file.buffer,
+                filename,
+                mimeType: sniffed.mime,
+                size: file.size,
+                ownerId: userId,
+                ...(workId ? { workId } : {}),
+            });
+            const url = workId
+                ? `/api/uploads/${encodeURIComponent(userId)}/${filename}?workId=${encodeURIComponent(workId)}`
+                : `/api/uploads/${encodeURIComponent(userId)}/${filename}`;
+            return {
+                id: hash,
+                url,
+                filename,
+                size: file.size,
+                mimeType: declared, // echo declared MIME so Office docs read as such
+                hash,
+                key,
+            };
+        }
+
+        // Branch 2: text-like declared MIME (no magic bytes to sniff).
+        // Validate UTF-8 shape + absence of NUL bytes as a cheap "this
+        // really is text" guard, then store under the canonical extension
+        // mapped from the declared MIME.
+        const textExt = TEXT_LIKE_MIMES.get(declared);
+        if (textExt) {
+            if (!looksLikeUtf8Text(file.buffer)) {
+                throw new BadRequestException({
+                    status: 'error',
+                    code: 'NotTextContent',
+                    message: `Declared Content-Type ${JSON.stringify(
+                        declared,
+                    )} but the buffer is not valid UTF-8 text (NUL bytes or invalid encoding)`,
+                });
+            }
+            const hash = createHash('sha256').update(file.buffer).digest('hex');
+            const filename = `${hash}.${textExt}`;
+            const backend = await this.getBackend();
+            const workId = opts?.workId;
+            if (workId !== undefined) this.assertValidWorkId(workId);
+            const { key } = await backend.putObject({
+                buffer: file.buffer,
+                filename,
+                mimeType: declared,
+                size: file.size,
+                ownerId: userId,
+                ...(workId ? { workId } : {}),
+            });
+            const url = workId
+                ? `/api/uploads/${encodeURIComponent(userId)}/${filename}?workId=${encodeURIComponent(workId)}`
+                : `/api/uploads/${encodeURIComponent(userId)}/${filename}`;
+            return {
+                id: hash,
+                url,
+                filename,
+                size: file.size,
+                mimeType: declared,
+                hash,
+                key,
+            };
+        }
+
+        throw new BadRequestException({
+            status: 'error',
+            code: 'MimeNotAllowed',
+            message: `Content-Type ${JSON.stringify(declared)} is not accepted for file uploads`,
+        });
+    }
+
+    /**
      * Read a stored file's bytes + metadata for the file-serve route.
      * Refuses to serve outside the configured storage root even if the
      * caller hands us a path-traversal `..` segment.
@@ -367,9 +635,14 @@ export class UploadsService {
     }
 
     private assertValidFilename(filename: string): void {
-        // Only allow `<hex64>.<ext>` shapes — same format saveImage
-        // writes. Anything else is invalid by construction.
-        if (!filename || !/^[a-f0-9]{64}\.(png|jpg|jpeg|gif|webp)$/.test(filename)) {
+        // Only allow `<hex64>.<ext>` shapes — same format saveImage /
+        // saveFile write. Anything else is invalid by construction. The
+        // extension list is the union of image extensions (saveImage)
+        // and file extensions (saveFile) since this method gates the
+        // serve route for both.
+        const extPattern = ALL_VALID_EXTS.join('|');
+        const filenameRe = new RegExp(`^[a-f0-9]{64}\\.(${extPattern})$`);
+        if (!filename || !filenameRe.test(filename)) {
             throw new BadRequestException({
                 status: 'error',
                 code: 'InvalidFilename',
@@ -378,11 +651,10 @@ export class UploadsService {
         }
         // Defensive: although the regex above already restricts to
         // canonical hash-named files, extract the extension here as a
-        // belt-and-suspenders check — the spec uses both alphanumeric and
-        // dot characters and a malicious key would have to slip past the
-        // regex to reach this point. Throw on anything unexpected.
+        // belt-and-suspenders check — a malicious key would have to slip
+        // past the regex to reach this point. Throw on anything unexpected.
         const ext = extname(filename).toLowerCase();
-        if (!['.png', '.jpg', '.jpeg', '.gif', '.webp'].includes(ext)) {
+        if (!ALL_VALID_EXTS.map((e) => `.${e}`).includes(ext)) {
             throw new BadRequestException({
                 status: 'error',
                 code: 'InvalidFilename',

--- a/apps/api/src/work-proposals/work-proposals.controller.ts
+++ b/apps/api/src/work-proposals/work-proposals.controller.ts
@@ -2,6 +2,7 @@ import {
     BadRequestException,
     Body,
     Controller,
+    Delete,
     Get,
     HttpCode,
     HttpException,
@@ -343,5 +344,44 @@ export class WorkProposalsController {
             throw new NotFoundException('Proposal not found or already finalized');
         }
         return { ok: true };
+    }
+
+    /**
+     * Idea (WorkProposal) attachment surface — list/add/remove
+     * `WorkProposalAttachment` edges (FK to `work_knowledge_uploads`).
+     * Backs the PromptComposer's "files attached when creating an
+     * Idea" flow. Same security model: ownership enforced inside
+     * `WorkProposalsApiService.{list,add,remove}Attachment`.
+     */
+    @Get(':id/attachments')
+    @ApiOperation({ summary: "List an Idea's attached uploads" })
+    async listAttachments(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ) {
+        return this.service.listAttachments(auth.userId, id);
+    }
+
+    @Post(':id/attachments')
+    @ApiOperation({ summary: 'Attach an uploaded file to an Idea' })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ default: { limit: 60, ttl: 60_000 } })
+    async addAttachment(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: { uploadId: string },
+    ) {
+        return this.service.addAttachment(auth.userId, id, body?.uploadId);
+    }
+
+    @Delete(':id/attachments/:attachmentId')
+    @ApiOperation({ summary: 'Detach an upload from an Idea' })
+    @HttpCode(HttpStatus.OK)
+    async removeAttachment(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('attachmentId', ParseUUIDPipe) attachmentId: string,
+    ) {
+        return this.service.removeAttachment(auth.userId, id, attachmentId);
     }
 }

--- a/apps/api/src/work-proposals/work-proposals.service.ts
+++ b/apps/api/src/work-proposals/work-proposals.service.ts
@@ -59,6 +59,21 @@ export class WorkProposalsApiService {
         return this.proposals.dismiss(userId, proposalId);
     }
 
+    /**
+     * Idea (WorkProposal) attachment surface — thin forwarders to the
+     * agent-side service. The controller maps these to
+     * `POST/GET/DELETE /api/me/work-proposals/:id/attachments[/:attachmentId]`.
+     */
+    async listAttachments(userId: string, proposalId: string) {
+        return this.proposals.listAttachments(userId, proposalId);
+    }
+    async addAttachment(userId: string, proposalId: string, uploadId: string) {
+        return this.proposals.addAttachment(userId, proposalId, uploadId);
+    }
+    async removeAttachment(userId: string, proposalId: string, attachmentId: string) {
+        return this.proposals.removeAttachment(userId, proposalId, attachmentId);
+    }
+
     async accept(userId: string, proposalId: string, workId: string): Promise<boolean> {
         // Existing user-facing accept: only valid from PENDING (today's
         // contract — preserved). The shared helper now lives on the

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3278,7 +3278,7 @@
         },
         "newPage": {
             "title": "Start something new",
-            "subtitle": "Tell the agent what you want to build. Pick a kind below to bias the result.",
+            "subtitle": "Tell us what you want to build. Pick a kind below to bias the result.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4118,7 +4118,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4117,7 +4117,7 @@
         },
         "newPage": {
             "title": "+ New",
-            "subtitle": "Tell the agent what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
+            "subtitle": "Tell us what you want to build. Pick a chip to bias toward a specific kind, or use one of the cards below for the per-mode flow.",
             "promptLabel": "What do you want to build?",
             "promptPlaceholder": "Describe what you want — e.g. \"A weekly curated list of new AI coding agents\" or \"Landing page for my SaaS launch\".",
             "chipLabel": "Pick a kind",

--- a/apps/web/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { agentsAPI } from '@/lib/api/agents';
 import { notFound } from 'next/navigation';
+import { AgentAttachmentsPanel } from '@/components/agents/AgentAttachmentsPanel';
 
 /**
  * Agents/Skills/Tasks PR #1017 — Phase 5. Dashboard tab is the
@@ -12,6 +13,10 @@ export default async function AgentDashboardPage({ params }: { params: Promise<{
     const { id } = await params;
     const agent = await agentsAPI.get(id);
     if (!agent) notFound();
+    // Server-fetch the attachment edges so the client panel can hydrate
+    // with the existing list. Defensive `.catch` so a missing migration
+    // on a stale env doesn't 500 the whole page.
+    const attachments = await agentsAPI.listAttachments(id).catch(() => []);
 
     return (
         <div className="p-6 space-y-4 max-w-screen-2xl mx-auto">
@@ -46,6 +51,7 @@ export default async function AgentDashboardPage({ params }: { params: Promise<{
                     {agent.capabilities ?? 'No capabilities set yet.'}
                 </p>
             </section>
+            <AgentAttachmentsPanel agentId={id} initial={attachments} />
         </div>
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/missions/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/missions/[id]/page.tsx
@@ -50,22 +50,26 @@ export default async function MissionDetailPage({ params }: { params: Params }) 
     // the Spend section can render real data instead of the PR GG
     // placeholder. Defensive catch — a flaky budget endpoint
     // surfaces the empty state, never 500s the detail page.
-    const [ideas, sourceMission, sourceAcceptedIdeas, budget] = await Promise.all([
-        workProposalsAPI
-            .list(['pending', 'queued', 'building', 'failed', 'accepted', 'dismissed'], {
-                missionId: id,
-            })
-            .catch(() => []),
-        mission.sourceMissionId
-            ? missionsAPI.get(mission.sourceMissionId).catch(() => null)
-            : Promise.resolve(null),
-        mission.sourceMissionId
-            ? workProposalsAPI
-                  .list(['accepted'], { missionId: mission.sourceMissionId })
-                  .catch(() => [])
-            : Promise.resolve([]),
-        missionsAPI.getBudget(id).catch(() => null),
-    ]);
+    const [ideas, sourceMission, sourceAcceptedIdeas, budget, attachments] =
+        await Promise.all([
+            workProposalsAPI
+                .list(['pending', 'queued', 'building', 'failed', 'accepted', 'dismissed'], {
+                    missionId: id,
+                })
+                .catch(() => []),
+            mission.sourceMissionId
+                ? missionsAPI.get(mission.sourceMissionId).catch(() => null)
+                : Promise.resolve(null),
+            mission.sourceMissionId
+                ? workProposalsAPI
+                      .list(['accepted'], { missionId: mission.sourceMissionId })
+                      .catch(() => [])
+                : Promise.resolve([]),
+            missionsAPI.getBudget(id).catch(() => null),
+            // Attachments — defensive .catch so a missing migration on
+            // a stale environment doesn't 500 the page.
+            missionsAPI.listAttachments(id).catch(() => []),
+        ]);
 
     return (
         <MissionDetailClient
@@ -74,6 +78,7 @@ export default async function MissionDetailPage({ params }: { params: Params }) 
             sourceMission={sourceMission}
             inheritedIdeas={sourceAcceptedIdeas}
             budget={budget}
+            attachments={attachments}
         />
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/missions/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/missions/[id]/page.tsx
@@ -50,26 +50,25 @@ export default async function MissionDetailPage({ params }: { params: Params }) 
     // the Spend section can render real data instead of the PR GG
     // placeholder. Defensive catch — a flaky budget endpoint
     // surfaces the empty state, never 500s the detail page.
-    const [ideas, sourceMission, sourceAcceptedIdeas, budget, attachments] =
-        await Promise.all([
-            workProposalsAPI
-                .list(['pending', 'queued', 'building', 'failed', 'accepted', 'dismissed'], {
-                    missionId: id,
-                })
-                .catch(() => []),
-            mission.sourceMissionId
-                ? missionsAPI.get(mission.sourceMissionId).catch(() => null)
-                : Promise.resolve(null),
-            mission.sourceMissionId
-                ? workProposalsAPI
-                      .list(['accepted'], { missionId: mission.sourceMissionId })
-                      .catch(() => [])
-                : Promise.resolve([]),
-            missionsAPI.getBudget(id).catch(() => null),
-            // Attachments — defensive .catch so a missing migration on
-            // a stale environment doesn't 500 the page.
-            missionsAPI.listAttachments(id).catch(() => []),
-        ]);
+    const [ideas, sourceMission, sourceAcceptedIdeas, budget, attachments] = await Promise.all([
+        workProposalsAPI
+            .list(['pending', 'queued', 'building', 'failed', 'accepted', 'dismissed'], {
+                missionId: id,
+            })
+            .catch(() => []),
+        mission.sourceMissionId
+            ? missionsAPI.get(mission.sourceMissionId).catch(() => null)
+            : Promise.resolve(null),
+        mission.sourceMissionId
+            ? workProposalsAPI
+                  .list(['accepted'], { missionId: mission.sourceMissionId })
+                  .catch(() => [])
+            : Promise.resolve([]),
+        missionsAPI.getBudget(id).catch(() => null),
+        // Attachments — defensive .catch so a missing migration on
+        // a stale environment doesn't 500 the page.
+        missionsAPI.listAttachments(id).catch(() => []),
+    ]);
 
     return (
         <MissionDetailClient

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import {
     BookOpen,
+    Building2,
     Files,
     FolderInput,
     FolderKanban,
@@ -18,10 +19,12 @@ import {
     Globe,
     PenLine,
     Star,
+    Store,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PromptComposer } from '@/components/common/PromptComposer';
+import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import type { ProviderWithConnection } from './page';
@@ -148,6 +151,25 @@ export default function NewWorkClient({
         [selectedKind],
     );
 
+    // Full work-kind chip catalog. `store` + `company` are inert "Soon"
+    // chips (roadmap, not shipped) appended after the live kinds so they
+    // match the marketing site's chip catalog without breaking the
+    // existing /works/new kind picker behavior.
+    const workKindChips = useMemo<
+        ReadonlyArray<PromptChip<InitialWorkKind | 'store' | 'company'>>
+    >(
+        () => [
+            ...WORK_KIND_ORDER.map((k) => ({
+                value: k,
+                label: t(`kinds.${k}`),
+                Icon: WORK_KIND_ICONS[k],
+            })),
+            { value: 'store' as const, label: 'Store', Icon: Store, comingSoon: true },
+            { value: 'company' as const, label: 'Company', Icon: Building2, comingSoon: true },
+        ],
+        [t],
+    );
+
     const submitPrompt = () => {
         const description = prompt.trim();
         if (description.length < 10) {
@@ -190,32 +212,32 @@ export default function NewWorkClient({
                     ariaLabel={t('promptLabel')}
                     submitTitle={t('promptHints.submitTitle')}
                     testId="new-work-prompt"
-                    belowInput={
+                    // /works/new is the surface where importing an
+                    // existing GitHub repo as a Work makes sense.
+                    showImportGithubRepo
+                    chipsBelow={
                         <div className="space-y-2">
-                            <div className="flex flex-wrap gap-2">
-                                {WORK_KIND_ORDER.map((k) => {
-                                    const Icon = WORK_KIND_ICONS[k];
-                                    const active = selectedKind === k;
-                                    return (
-                                        <button
-                                            key={k}
-                                            type="button"
-                                            onClick={() => setSelectedKind(k)}
-                                            className={cn(
-                                                'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors whitespace-nowrap',
-                                                active
-                                                    ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
-                                                    : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
-                                            )}
-                                            aria-pressed={active}
-                                        >
-                                            <Icon className="w-3.5 h-3.5" />
-                                            {t(`kinds.${k}`)}
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            <PromptChipsRow
+                                chips={workKindChips}
+                                value={selectedKind}
+                                onChange={(next) => {
+                                    // `store` and `company` are inert "Soon"
+                                    // chips and never get emitted — narrow
+                                    // back to InitialWorkKind before
+                                    // persisting.
+                                    if (
+                                        next === null ||
+                                        next === 'store' ||
+                                        next === 'company'
+                                    ) {
+                                        return;
+                                    }
+                                    setSelectedKind(next);
+                                }}
+                                ariaLabel={t('promptLabel')}
+                                testIdPrefix="new-work-kind"
+                            />
+                            <p className="px-1 text-xs text-text-muted dark:text-text-muted-dark">
                                 {t(`kindDescriptions.${selectedKind}`)}
                             </p>
                         </div>

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -23,7 +23,11 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { PromptComposer } from '@/components/common/PromptComposer';
+import {
+    PromptComposer,
+    buildAttachmentRefs,
+    type ComposerAttachment,
+} from '@/components/common/PromptComposer';
 import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
@@ -129,6 +133,7 @@ export default function NewWorkClient({
     // Composer state used by the entry view (creationMode === null).
     const [prompt, setPrompt] = useState(initialPrompt ?? '');
     const [selectedKind, setSelectedKind] = useState<InitialWorkKind>(initialKind ?? 'website');
+    const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
 
@@ -183,7 +188,10 @@ export default function NewWorkClient({
         // chat carries it, the form starts empty so the user isn't
         // re-prompted to confirm the same text twice.
         startSubmit(() => {
-            startFromPrompt(description, { intent: WORK_KIND_INTENT_LABEL[selectedKind] });
+            startFromPrompt(description, {
+                intent: WORK_KIND_INTENT_LABEL[selectedKind],
+                attachments: buildAttachmentRefs(attachments),
+            });
             setPrompt('');
             setCreationMode('ai');
         });
@@ -212,6 +220,7 @@ export default function NewWorkClient({
                     ariaLabel={t('promptLabel')}
                     submitTitle={t('promptHints.submitTitle')}
                     testId="new-work-prompt"
+                    onAttachmentsChange={setAttachments}
                     // /works/new is the surface where importing an
                     // existing GitHub repo as a Work makes sense.
                     showImportGithubRepo

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -160,9 +160,7 @@ export default function NewWorkClient({
     // chips (roadmap, not shipped) appended after the live kinds so they
     // match the marketing site's chip catalog without breaking the
     // existing /works/new kind picker behavior.
-    const workKindChips = useMemo<
-        ReadonlyArray<PromptChip<InitialWorkKind | 'store' | 'company'>>
-    >(
+    const workKindChips = useMemo<ReadonlyArray<PromptChip<InitialWorkKind | 'store' | 'company'>>>(
         () => [
             ...WORK_KIND_ORDER.map((k) => ({
                 value: k,
@@ -234,11 +232,7 @@ export default function NewWorkClient({
                                     // chips and never get emitted — narrow
                                     // back to InitialWorkKind before
                                     // persisting.
-                                    if (
-                                        next === null ||
-                                        next === 'store' ||
-                                        next === 'company'
-                                    ) {
+                                    if (next === null || next === 'store' || next === 'company') {
                                         return;
                                     }
                                     setSelectedKind(next);

--- a/apps/web/src/app/actions/agents.ts
+++ b/apps/web/src/app/actions/agents.ts
@@ -116,3 +116,19 @@ export async function cancelAgentRunAction(id: string, runId: string) {
     revalidatePath(`/agents/${id}/activity`);
     return res;
 }
+
+// Attachment actions — used by the PromptComposer-driven flow on
+// /new (Agent chip). Lets the caller wire uploads to an Agent once
+// we have its id.
+
+export async function attachUploadToAgentAction(agentId: string, uploadId: string) {
+    const row = await agentsAPI.addAttachment(agentId, uploadId);
+    revalidatePath(`/agents/${agentId}`);
+    return row;
+}
+
+export async function detachAgentAttachmentAction(agentId: string, attachmentId: string) {
+    const result = await agentsAPI.removeAttachment(agentId, attachmentId);
+    revalidatePath(`/agents/${agentId}`);
+    return result;
+}

--- a/apps/web/src/app/actions/dashboard/missions.ts
+++ b/apps/web/src/app/actions/dashboard/missions.ts
@@ -70,3 +70,19 @@ export async function cloneMissionAction(id: string, title?: string) {
     revalidateMissionSurfaces();
     return result;
 }
+
+// Attachment actions — used by the PromptComposer-driven create flow
+// on /new (Mission template inline-create path) to wire uploads into
+// the newly created Mission, and by future Mission detail pages.
+
+export async function attachUploadToMissionAction(missionId: string, uploadId: string) {
+    const row = await missionsAPI.addAttachment(missionId, uploadId);
+    revalidatePath(`/[locale]/(dashboard)/missions/${missionId}`, 'page');
+    return row;
+}
+
+export async function detachMissionAttachmentAction(missionId: string, attachmentId: string) {
+    const result = await missionsAPI.removeAttachment(missionId, attachmentId);
+    revalidatePath(`/[locale]/(dashboard)/missions/${missionId}`, 'page');
+    return result;
+}

--- a/apps/web/src/app/actions/dashboard/work-proposals.ts
+++ b/apps/web/src/app/actions/dashboard/work-proposals.ts
@@ -66,3 +66,19 @@ export async function buildIdeaAction(proposalId: string) {
     revalidateIdeaSurfaces();
     return result;
 }
+
+// Attachment actions — used by the PromptComposer-driven flow on
+// /new (Idea chip) and the standalone /ideas quick-add. Lets the
+// caller wire uploads to a freshly-created Idea once we have its id.
+
+export async function attachUploadToIdeaAction(ideaId: string, uploadId: string) {
+    const row = await workProposalsAPI.addAttachment(ideaId, uploadId);
+    revalidatePath(`/[locale]/(dashboard)/ideas/${ideaId}`, 'page');
+    return row;
+}
+
+export async function detachIdeaAttachmentAction(ideaId: string, attachmentId: string) {
+    const result = await workProposalsAPI.removeAttachment(ideaId, attachmentId);
+    revalidatePath(`/[locale]/(dashboard)/ideas/${ideaId}`, 'page');
+    return result;
+}

--- a/apps/web/src/app/api/uploads/file/route.ts
+++ b/apps/web/src/app/api/uploads/file/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * Multipart upload proxy for the broader-than-image PromptComposer
+ * uploads (PDFs, ZIP / Office docs, text / markdown / code, plus
+ * images).
+ *
+ * Forwards `POST /api/uploads/file` from the browser to the NestJS API
+ * controller of the same name. Streams the request body upstream so the
+ * multipart boundary stays intact (NestJS's `FileInterceptor` parses it
+ * on the upstream side).
+ *
+ * Mirrors the existing image-upload proxy at `../route.ts` — auth
+ * cookie → Authorization Bearer, no caching, upstream status + body
+ * surfaced verbatim on error so the client sees the right
+ * 400 / 413 / 415 messaging.
+ *
+ * The `workId` query string is forwarded as-is for backends that scope
+ * storage per Work (currently `github-storage` in `data-repo` mode).
+ */
+export async function POST(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    const contentType = request.headers.get('content-type');
+    if (contentType) headers.set('Content-Type', contentType);
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+
+    const search = request.nextUrl.search; // includes the leading "?" if present
+
+    const upstream = await fetch(`${API_URL}/uploads/file${search}`, {
+        method: 'POST',
+        headers,
+        body: request.body,
+        duplex: 'half',
+        cache: 'no-store',
+    } as RequestInit & { duplex: 'half' });
+
+    const upstreamContentType = upstream.headers.get('content-type') ?? 'application/json';
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: { 'Content-Type': upstreamContentType, 'Cache-Control': 'no-store' },
+        });
+    }
+    const body = await upstream.json().catch(() => null);
+    return NextResponse.json(body ?? {}, { status: upstream.status });
+}

--- a/apps/web/src/components/agents/AgentAttachmentsPanel.tsx
+++ b/apps/web/src/components/agents/AgentAttachmentsPanel.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { EntityAttachmentsSection } from '@/components/common/EntityAttachmentsSection';
-import {
-    attachUploadToAgentAction,
-    detachAgentAttachmentAction,
-} from '@/app/actions/agents';
+import { attachUploadToAgentAction, detachAgentAttachmentAction } from '@/app/actions/agents';
 import type { AgentAttachmentRow } from '@/lib/api/agents';
 
 /**

--- a/apps/web/src/components/agents/AgentAttachmentsPanel.tsx
+++ b/apps/web/src/components/agents/AgentAttachmentsPanel.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { EntityAttachmentsSection } from '@/components/common/EntityAttachmentsSection';
+import {
+    attachUploadToAgentAction,
+    detachAgentAttachmentAction,
+} from '@/app/actions/agents';
+import type { AgentAttachmentRow } from '@/lib/api/agents';
+
+/**
+ * Client-side wrapper around {@link EntityAttachmentsSection} for the
+ * Agent detail page. Supplies the onAttach / onDetach callbacks bound
+ * to the matching server actions so the server-rendered Agent page
+ * stays a plain RSC and only this leaf needs to be a client component.
+ */
+export function AgentAttachmentsPanel({
+    agentId,
+    initial,
+}: {
+    agentId: string;
+    initial: ReadonlyArray<AgentAttachmentRow>;
+}) {
+    return (
+        <EntityAttachmentsSection<AgentAttachmentRow>
+            initial={initial}
+            onAttach={(uploadId) => attachUploadToAgentAction(agentId, uploadId)}
+            onDetach={(attachmentId) => detachAgentAttachmentAction(agentId, attachmentId)}
+            testId="agent-attachments"
+        />
+    );
+}

--- a/apps/web/src/components/common/EntityAttachmentsSection.tsx
+++ b/apps/web/src/components/common/EntityAttachmentsSection.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+import { Paperclip, Trash2, Upload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils/cn';
+import { uploadFile, UploadError } from '@/lib/api/uploads';
+
+/**
+ * Generic per-entity attachment panel — shared by the Mission, Idea,
+ * and Agent detail pages. Modeled on {@link TaskAttachmentsSection}
+ * (which stays as-is to preserve its slightly different shape — Task
+ * attachments carry joined upload metadata; the new entity types don't
+ * yet).
+ *
+ * Flow per file:
+ *   1. User drops or picks a file in the drag-and-drop zone.
+ *   2. `POST /api/uploads/file` (auth-gated, broader MIME allow-list) →
+ *      returns `{ id: <sha256>, url, filename, size, mimeType, hash }`.
+ *   3. Caller-supplied `onAttach(uploadId)` wires the upload to the
+ *      entity (calls one of the new
+ *      `attachUploadTo{Mission,Idea,Agent}Action` server actions).
+ *   4. The returned row is prepended to the local list with the
+ *      client-known filename + size in `meta` so the user sees
+ *      something useful before any joined metadata lands.
+ *
+ * The component is fully controlled-by-callbacks — it doesn't know
+ * which entity type it's rendering for, which keeps the routing
+ * decision (which API endpoint, which revalidate paths) at the call
+ * site. That mirrors how `PromptComposer` exposes the same surface
+ * across `/missions`, `/ideas`, `/new`, `/works/new`.
+ */
+
+interface UploadedFileMeta {
+    filename: string;
+    sizeBytes: number;
+    contentType: string;
+}
+
+export interface EntityAttachmentRow {
+    readonly id: string;
+    readonly uploadId: string;
+    readonly createdAt: string;
+}
+
+export interface EntityAttachmentsSectionProps<TRow extends EntityAttachmentRow> {
+    /** Existing attachment rows (server-rendered initial state). */
+    readonly initial: ReadonlyArray<TRow>;
+    /**
+     * Called after a successful `/api/uploads/file` upload to wire the
+     * upload into the entity. Implementations should call the matching
+     * `attachUploadTo{Mission,Idea,Agent}Action` server action and
+     * return the new attachment row.
+     */
+    readonly onAttach: (uploadId: string) => Promise<TRow>;
+    /**
+     * Called when the user clicks the trash icon. Implementations
+     * should call the matching `detach{...}Action`.
+     */
+    readonly onDetach: (attachmentId: string) => Promise<{ deleted: true }>;
+    /** Visible heading. Defaults to "Attachments". */
+    readonly title?: string;
+    /** Stable test hook prefix. */
+    readonly testId?: string;
+}
+
+export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
+    initial,
+    onAttach,
+    onDetach,
+    title = 'Attachments',
+    testId,
+}: EntityAttachmentsSectionProps<TRow>) {
+    const [rows, setRows] = useState<TRow[]>([...initial]);
+    const [meta, setMeta] = useState<Record<string, UploadedFileMeta>>({});
+    const [pending, startTransition] = useTransition();
+    const [dragOver, setDragOver] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [busy, setBusy] = useState(false);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    const uploadFiles = (files: File[]) => {
+        if (files.length === 0) return;
+        setError(null);
+        setBusy(true);
+        startTransition(() => {
+            void (async () => {
+                for (const file of files) {
+                    try {
+                        const res = await uploadFile(file);
+                        const row = await onAttach(res.id);
+                        setRows((prev) => [row, ...prev]);
+                        setMeta((prev) => ({
+                            ...prev,
+                            [row.id]: {
+                                filename: file.name,
+                                sizeBytes: file.size,
+                                contentType: file.type,
+                            },
+                        }));
+                    } catch (err) {
+                        const message =
+                            err instanceof UploadError
+                                ? err.message
+                                : err instanceof Error
+                                  ? err.message
+                                  : 'Upload failed';
+                        setError(message);
+                    }
+                }
+                setBusy(false);
+            })();
+        });
+    };
+
+    const handleDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        setDragOver(false);
+        const files = Array.from(e.dataTransfer.files ?? []);
+        uploadFiles(files);
+    };
+
+    const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files ?? []);
+        uploadFiles(files);
+        if (inputRef.current) inputRef.current.value = '';
+    };
+
+    const handleRemove = (attachmentId: string) => {
+        startTransition(() => {
+            void (async () => {
+                try {
+                    await onDetach(attachmentId);
+                    setRows((prev) => prev.filter((r) => r.id !== attachmentId));
+                    setMeta((prev) => {
+                        const next = { ...prev };
+                        delete next[attachmentId];
+                        return next;
+                    });
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : 'Detach failed');
+                }
+            })();
+        });
+    };
+
+    const formatSize = (bytes: number): string => {
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    };
+
+    return (
+        <section
+            className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5"
+            data-testid={testId}
+        >
+            <header className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-medium text-text dark:text-text-dark">{title}</h2>
+                <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
+                    {rows.length} file{rows.length === 1 ? '' : 's'}
+                </p>
+            </header>
+
+            <div
+                onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOver(true);
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={handleDrop}
+                className={cn(
+                    'rounded-lg border-2 border-dashed transition-colors p-6 flex flex-col items-center justify-center gap-2 text-center',
+                    dragOver
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border/60 dark:border-border-dark/60',
+                    busy && 'opacity-60',
+                )}
+            >
+                <Upload className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
+                <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                    Drag &amp; drop a file here or
+                </p>
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => inputRef.current?.click()}
+                    disabled={busy}
+                    data-testid={testId ? `${testId}-browse` : undefined}
+                >
+                    {busy ? 'Uploading…' : 'Browse'}
+                </Button>
+                <input
+                    ref={inputRef}
+                    type="file"
+                    multiple
+                    onChange={handleSelect}
+                    className="hidden"
+                    data-testid={testId ? `${testId}-input` : undefined}
+                />
+            </div>
+
+            {error && (
+                <p
+                    className="text-xs text-danger mt-2"
+                    role="alert"
+                    data-testid={testId ? `${testId}-error` : undefined}
+                >
+                    {error}
+                </p>
+            )}
+
+            {rows.length > 0 && (
+                <ul className="mt-4 space-y-2" data-testid={testId ? `${testId}-list` : undefined}>
+                    {rows.map((r) => {
+                        const m = meta[r.id] ?? null;
+                        const filename = m?.filename ?? r.uploadId;
+                        const size = m ? formatSize(m.sizeBytes) : null;
+                        return (
+                            <li
+                                key={r.id}
+                                className="flex items-center gap-3 rounded-md border border-border/40 dark:border-border-dark/40 p-2.5"
+                            >
+                                <Paperclip className="w-4 h-4 text-text-muted dark:text-text-muted-dark shrink-0" />
+                                <div className="min-w-0 flex-1">
+                                    {/* Download wiring pending — the upload
+                                        URL needs the user id, which we don't
+                                        carry on this row. Surface filename as
+                                        plain text + a tooltip until a
+                                        uploadId-only resolver lands (same
+                                        constraint TaskAttachmentsSection
+                                        documents). */}
+                                    <span
+                                        className="text-sm text-text dark:text-text-dark truncate block"
+                                        title="Download wiring pending"
+                                    >
+                                        {filename}
+                                    </span>
+                                    <div className="text-[11px] text-text-muted dark:text-text-muted-dark">
+                                        {size ?? r.uploadId.slice(0, 12) + '…'} · attached{' '}
+                                        {new Date(r.createdAt).toLocaleString()}
+                                    </div>
+                                </div>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => handleRemove(r.id)}
+                                    disabled={pending}
+                                    className="text-danger hover:text-danger gap-1.5"
+                                    title="Detach"
+                                    data-testid={testId ? `${testId}-detach-${r.id}` : undefined}
+                                >
+                                    <Trash2 className="w-3.5 h-3.5" />
+                                </Button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </section>
+    );
+}

--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Horizontally-scrollable chip row for the dashboard prompt surfaces
+ * (`/new`, `/works/new`). Mirrors the marketing site's
+ * `GenerationTypeChips` (see
+ * `Ever Works/Code/website/packages/web/components/global/
+ * GenerationTypeChips.tsx`) so the dashboard and landing pages share
+ * the same chip behavior:
+ *
+ *   - Chips overflow horizontally instead of wrapping to a second row.
+ *   - Mouse-friendly ◀ / ▶ buttons appear when the row overflows; the
+ *     buttons disable themselves at the start / end so they always
+ *     reflect what's actually scrollable.
+ *   - Edge gradient fades make the chips appear to slide under the
+ *     buttons.
+ *   - Trackpad + touch swipe still work — the scroll position drives
+ *     the button enabled state through a `ResizeObserver` and a
+ *     passive scroll listener.
+ *   - `comingSoon` chips render as inert `<span>`s with a "SOON" badge
+ *     (matching the marketing site) so the chip catalog can telegraph
+ *     upcoming kinds without making them clickable.
+ */
+export interface PromptChip<TValue extends string = string> {
+    readonly value: TValue;
+    readonly label: ReactNode;
+    readonly Icon: LucideIcon;
+    /**
+     * When true, the chip is rendered as a muted, inert span with a
+     * "SOON" badge — the user sees it's coming but can't activate it.
+     */
+    readonly comingSoon?: boolean;
+}
+
+export interface PromptChipsRowProps<TValue extends string = string> {
+    readonly chips: ReadonlyArray<PromptChip<TValue>>;
+    readonly value: TValue | null;
+    readonly onChange: (next: TValue | null) => void;
+    /**
+     * Optional aria-label for the row (defaults to "Pick a kind").
+     * Pages with a translated label should pass the translated string.
+     */
+    readonly ariaLabel?: string;
+    /** Stable hook for tests. */
+    readonly testIdPrefix?: string;
+    readonly className?: string;
+}
+
+export function PromptChipsRow<TValue extends string = string>({
+    chips,
+    value,
+    onChange,
+    ariaLabel = 'Pick a kind',
+    testIdPrefix,
+    className,
+}: PromptChipsRowProps<TValue>) {
+    const scrollerRef = useRef<HTMLDivElement | null>(null);
+    const [overflowing, setOverflowing] = useState(false);
+    const [atStart, setAtStart] = useState(true);
+    const [atEnd, setAtEnd] = useState(false);
+
+    const measure = useCallback(() => {
+        const el = scrollerRef.current;
+        if (!el) return;
+        const overflows = el.scrollWidth > el.clientWidth + 1;
+        setOverflowing(overflows);
+        setAtStart(el.scrollLeft <= 1);
+        setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
+    }, []);
+
+    useEffect(() => {
+        const el = scrollerRef.current;
+        if (!el) return;
+        measure();
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        el.addEventListener('scroll', measure, { passive: true });
+        return () => {
+            ro.disconnect();
+            el.removeEventListener('scroll', measure);
+        };
+    }, [measure]);
+
+    const scrollBy = (delta: number) => {
+        scrollerRef.current?.scrollBy({ left: delta, behavior: 'smooth' });
+    };
+
+    return (
+        <div className={cn('relative w-full', className)}>
+            {overflowing && !atStart ? (
+                <>
+                    <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute left-0 top-0 bottom-0 z-10 w-12 bg-gradient-to-r from-background to-transparent dark:from-black"
+                    />
+                    <button
+                        type="button"
+                        onClick={() => scrollBy(-220)}
+                        aria-label="Scroll chips left"
+                        className="absolute left-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
+                        data-testid={
+                            testIdPrefix ? `${testIdPrefix}-scroll-left` : undefined
+                        }
+                    >
+                        <ChevronLeft className="size-4" aria-hidden="true" />
+                    </button>
+                </>
+            ) : null}
+
+            <div
+                ref={scrollerRef}
+                role="listbox"
+                aria-label={ariaLabel}
+                data-testid={testIdPrefix ? `${testIdPrefix}-chips` : undefined}
+                className={cn(
+                    'flex gap-2 overflow-x-auto scroll-smooth py-1',
+                    // Hide native scrollbar — the explicit buttons + edge
+                    // fades replace it as the affordance for scrolling.
+                    '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                    overflowing ? 'justify-start px-10' : 'justify-start px-1',
+                )}
+            >
+                {chips.map((c) => {
+                    const { Icon } = c;
+                    if (c.comingSoon) {
+                        return (
+                            <span
+                                key={c.value}
+                                role="option"
+                                aria-disabled="true"
+                                aria-selected="false"
+                                title="Coming soon"
+                                className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-sm border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
+                                data-testid={
+                                    testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
+                                }
+                            >
+                                <Icon className="size-3.5 opacity-70" aria-hidden="true" />
+                                <span className="whitespace-nowrap">{c.label}</span>
+                                <span
+                                    aria-label="Coming soon"
+                                    className="ml-1 rounded-full bg-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted dark:bg-white/10 dark:text-text-muted-dark"
+                                >
+                                    Soon
+                                </span>
+                            </span>
+                        );
+                    }
+                    const selected = value === c.value;
+                    return (
+                        <button
+                            key={c.value}
+                            type="button"
+                            role="option"
+                            aria-selected={selected}
+                            // role="option" doesn't support aria-pressed
+                            // (jsx-a11y/role-supports-aria-props). aria-selected
+                            // is the right toggle state inside a listbox; tests
+                            // querying by `[aria-selected]` get the live chips.
+                            onClick={() => onChange(selected ? null : c.value)}
+                            data-testid={
+                                testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
+                            }
+                            className={cn(
+                                'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                selected
+                                    ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
+                                    : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
+                            )}
+                        >
+                            <Icon className="size-3.5" aria-hidden="true" />
+                            {c.label}
+                        </button>
+                    );
+                })}
+            </div>
+
+            {overflowing && !atEnd ? (
+                <>
+                    <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute right-0 top-0 bottom-0 z-10 w-12 bg-gradient-to-l from-background to-transparent dark:from-black"
+                    />
+                    <button
+                        type="button"
+                        onClick={() => scrollBy(220)}
+                        aria-label="Scroll chips right"
+                        className="absolute right-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
+                        data-testid={
+                            testIdPrefix ? `${testIdPrefix}-scroll-right` : undefined
+                        }
+                    >
+                        <ChevronRight className="size-4" aria-hidden="true" />
+                    </button>
+                </>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -103,9 +103,7 @@ export function PromptChipsRow<TValue extends string = string>({
                         onClick={() => scrollBy(-220)}
                         aria-label="Scroll chips left"
                         className="absolute left-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
-                        data-testid={
-                            testIdPrefix ? `${testIdPrefix}-scroll-left` : undefined
-                        }
+                        data-testid={testIdPrefix ? `${testIdPrefix}-scroll-left` : undefined}
                     >
                         <ChevronLeft className="size-4" aria-hidden="true" />
                     </button>
@@ -163,9 +161,7 @@ export function PromptChipsRow<TValue extends string = string>({
                             // is the right toggle state inside a listbox; tests
                             // querying by `[aria-selected]` get the live chips.
                             onClick={() => onChange(selected ? null : c.value)}
-                            data-testid={
-                                testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
-                            }
+                            data-testid={testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined}
                             className={cn(
                                 'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
                                 selected
@@ -191,9 +187,7 @@ export function PromptChipsRow<TValue extends string = string>({
                         onClick={() => scrollBy(220)}
                         aria-label="Scroll chips right"
                         className="absolute right-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
-                        data-testid={
-                            testIdPrefix ? `${testIdPrefix}-scroll-right` : undefined
-                        }
+                        data-testid={testIdPrefix ? `${testIdPrefix}-scroll-right` : undefined}
                     >
                         <ChevronRight className="size-4" aria-hidden="true" />
                     </button>

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -40,7 +40,8 @@ const HOLD_ERASED_MS = 350;
 // `https://github.com/<owner>/<repo>` shape (optionally trailing slash,
 // `.git`, or extra path segments). The chat / canvas flows do deeper
 // validation; this is just to keep obvious garbage out of the picker.
-const GITHUB_REPO_RE = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[/?#].*)?$/i;
+const GITHUB_REPO_RE =
+    /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[/?#].*)?$/i;
 
 function useTypewriterPlaceholder(
     focused: boolean,
@@ -619,9 +620,7 @@ export function PromptComposer({
                                     className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs ${variant}`}
                                     title={a.error || a.displayName}
                                     data-testid={
-                                        testId
-                                            ? `${testId}-attachment-${stateTag}`
-                                            : undefined
+                                        testId ? `${testId}-attachment-${stateTag}` : undefined
                                     }
                                 >
                                     {a.uploading ? (
@@ -632,7 +631,10 @@ export function PromptComposer({
                                     ) : a.kind === 'folder-file' ? (
                                         <Folder className="size-3 opacity-60" aria-hidden="true" />
                                     ) : (
-                                        <FileIcon className="size-3 opacity-60" aria-hidden="true" />
+                                        <FileIcon
+                                            className="size-3 opacity-60"
+                                            aria-hidden="true"
+                                        />
                                     )}
                                     <span className="max-w-[12rem] truncate" title={a.displayName}>
                                         {a.displayName}
@@ -686,7 +688,10 @@ export function PromptComposer({
                                 // and surface every file in it. React 19 types
                                 // accept it as a string attribute; cast for older
                                 // types.
-                                {...({ webkitdirectory: '', directory: '' } as Record<string, string>)}
+                                {...({ webkitdirectory: '', directory: '' } as Record<
+                                    string,
+                                    string
+                                >)}
                             />
 
                             <div className="relative">
@@ -941,6 +946,13 @@ export interface ComposerAttachmentRef {
     readonly url: string;
     readonly mimeType?: string;
     readonly kind: 'upload' | 'github-repo';
+    /**
+     * SHA-256 upload id — present only for `kind: 'upload'` refs that
+     * have completed. Callers that wire the upload to a freshly-
+     * created entity (Mission/Idea/Agent) pass this to
+     * `addAttachment`. The chat-forwarder ignores this field.
+     */
+    readonly uploadId?: string;
 }
 
 export function buildAttachmentRefs(
@@ -952,12 +964,13 @@ export function buildAttachmentRefs(
             refs.push({ name: a.displayName, url: a.url, kind: 'github-repo' });
             continue;
         }
-        if (a.url && !a.uploading && !a.error) {
+        if (a.url && a.uploadId && !a.uploading && !a.error) {
             refs.push({
                 name: a.displayName,
                 url: a.url,
                 mimeType: a.mimeType,
                 kind: 'upload',
+                uploadId: a.uploadId,
             });
         }
     }

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -1,28 +1,45 @@
 'use client';
 
-import { ArrowRight, Loader2 } from 'lucide-react';
-import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { ArrowRight, File as FileIcon, Folder, Github, Loader2, Mic, Plus, X } from 'lucide-react';
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type KeyboardEvent,
+    type ReactNode,
+} from 'react';
 import { cn } from '@/lib/utils/cn';
 
 /**
- * Phase 9 — shared prompt composer used by `/missions`, `/ideas`,
- * and `/new`. Modeled on the website's `LandingPromptForm` (see
+ * Shared prompt composer used by `/missions`, `/ideas`, `/new`, and
+ * `/works/new`. Modeled on the website's `LandingPromptForm` (see
  * `Ever Works/Code/website/packages/web/components/global/
- * LandingPromptForm.tsx`) so the dashboard's quick-add surfaces
- * read the same way visitors first met the product:
+ * LandingPromptForm.tsx`) so the dashboard's prompt surfaces read
+ * the same way visitors first met the product:
  *
- *   - Rounded card, sits on the page's natural dark background
- *     (no nested `bg-card` wrapper).
+ *   - Rounded card on the page's natural dark background (no nested
+ *     `bg-card` wrapper).
  *   - Typewriter placeholder cycling through example briefs.
- *   - Arrow submit button anchored bottom-right inside the card
- *     (no separate "Add" / "Create" button beside the textarea).
+ *   - Bottom toolbar (single row): `+` attachment popover, mic
+ *     dictation, character counter, arrow submit.
+ *   - Optional attachment chip strip (file / folder / GitHub repo)
+ *     rendered INSIDE the card, above the toolbar.
+ *   - Optional `chipsBelow` slot for generation-type chip strips
+ *     (rendered OUTSIDE / BELOW the card on the page) so the chip
+ *     row visually mirrors the website.
  *   - Enter submits; Shift+Enter inserts a newline.
- *   - Optional `belowInput` slot for chip strips (used by `/new`).
  */
 const TYPE_MS = 35;
 const ERASE_MS = 18;
 const HOLD_TYPED_MS = 1800;
 const HOLD_ERASED_MS = 350;
+
+// GitHub repo URL validator. Accepts the canonical
+// `https://github.com/<owner>/<repo>` shape (optionally trailing slash,
+// `.git`, or extra path segments). The chat / canvas flows do deeper
+// validation; this is just to keep obvious garbage out of the picker.
+const GITHUB_REPO_RE = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[/?#].*)?$/i;
 
 function useTypewriterPlaceholder(
     focused: boolean,
@@ -84,6 +101,132 @@ function useTypewriterPlaceholder(
     return shown || examples[0] || fallback || '';
 }
 
+// Web Speech API isn't in TS's default DOM lib. Use a narrow ambient
+// type just for the bits we touch; browsers expose it on
+// `window.SpeechRecognition` (standard) or `window.webkitSpeechRecognition`
+// (Chrome / Safari).
+interface SpeechResult {
+    readonly isFinal: boolean;
+    readonly [index: number]: { readonly transcript: string };
+}
+interface SpeechResultList {
+    readonly length: number;
+    readonly [index: number]: SpeechResult;
+}
+interface SpeechEvent {
+    readonly resultIndex: number;
+    readonly results: SpeechResultList;
+}
+interface SpeechRecognizer {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    onresult: ((event: SpeechEvent) => void) | null;
+    onend: (() => void) | null;
+    onerror: (() => void) | null;
+    start(): void;
+    stop(): void;
+}
+type SpeechRecognizerCtor = new () => SpeechRecognizer;
+
+declare global {
+    interface Window {
+        SpeechRecognition?: SpeechRecognizerCtor;
+        webkitSpeechRecognition?: SpeechRecognizerCtor;
+    }
+}
+
+/**
+ * Hook: Web Speech API wrapper. Gracefully no-ops in browsers without
+ * SpeechRecognition.
+ */
+function useSpeechRecognition(onResult: (text: string) => void) {
+    const recognitionRef = useRef<SpeechRecognizer | null>(null);
+    const [listening, setListening] = useState(false);
+    const [supported, setSupported] = useState(false);
+
+    // Park the latest callback in a ref so the recognizer can dispatch
+    // through it without re-subscribing every render. See the website's
+    // LandingPromptForm — re-subscribing would tear down continuous
+    // dictation after the first phrase.
+    const onResultRef = useRef(onResult);
+    useEffect(() => {
+        onResultRef.current = onResult;
+    }, [onResult]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const Ctor = window.SpeechRecognition || window.webkitSpeechRecognition;
+        if (!Ctor) {
+            // `supported` defaults to false at mount — nothing to do here.
+            // We deliberately avoid calling setSupported(false) in the effect
+            // body to satisfy react-hooks/set-state-in-effect.
+            return;
+        }
+        const rec = new Ctor();
+        rec.continuous = true;
+        rec.interimResults = false;
+        rec.lang = typeof navigator !== 'undefined' ? navigator.language || 'en-US' : 'en-US';
+        rec.onresult = (event) => {
+            let transcript = '';
+            for (let i = event.resultIndex; i < event.results.length; i++) {
+                if (event.results[i].isFinal) transcript += event.results[i][0].transcript;
+            }
+            if (transcript) onResultRef.current(transcript.trim());
+        };
+        rec.onend = () => setListening(false);
+        rec.onerror = () => setListening(false);
+        recognitionRef.current = rec;
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot capability detection at mount; can't be derived during render (needs window.SpeechRecognition).
+        setSupported(true);
+        return () => {
+            try {
+                rec.stop();
+            } catch {
+                /* noop */
+            }
+        };
+    }, []);
+
+    const start = useCallback(() => {
+        if (!recognitionRef.current) return;
+        try {
+            recognitionRef.current.start();
+            setListening(true);
+        } catch {
+            /* already started */
+        }
+    }, []);
+    const stop = useCallback(() => {
+        try {
+            recognitionRef.current?.stop();
+        } catch {
+            /* noop */
+        }
+        setListening(false);
+    }, []);
+
+    return { supported, listening, start, stop };
+}
+
+// Attachment shapes — discriminated union mirrors the website's
+// LandingPromptForm. The composer keeps these in local state for now;
+// integration with the platform's upload backend can be added on top
+// later without changing the public PromptComposer API.
+type ComposerAttachment =
+    | {
+          readonly kind: 'file' | 'folder-file';
+          readonly localId: string;
+          readonly file: File;
+          readonly displayName: string;
+      }
+    | {
+          readonly kind: 'github-repo';
+          readonly localId: string;
+          readonly url: string;
+          readonly displayName: string;
+      };
+
 export interface PromptComposerProps {
     value: string;
     onChange: (next: string) => void;
@@ -100,8 +243,13 @@ export interface PromptComposerProps {
     placeholder?: string;
     /** Accessible label for the textarea. */
     ariaLabel: string;
-    /** Optional content rendered BELOW the textarea inside the same card. */
-    belowInput?: ReactNode;
+    /**
+     * Optional content rendered BELOW the composer card (outside the
+     * card itself). Used by `/new` and `/works/new` to render the
+     * generation-type chip strip beneath the prompt — matches the
+     * website's landing layout.
+     */
+    chipsBelow?: ReactNode;
     /** Optional id for the textarea so an external <label> can point at it. */
     inputId?: string;
     /** Stable hook for tests / instrumentation. */
@@ -113,6 +261,23 @@ export interface PromptComposerProps {
     disabled?: boolean;
     /** Show the running character counter. Defaults to true. */
     showCounter?: boolean;
+    /**
+     * Show the "Import GitHub Repo" menu item in the (+) popover.
+     * Only `/works/new` enables this — for other pages the GitHub
+     * import affordance lives elsewhere.
+     */
+    showImportGithubRepo?: boolean;
+    /**
+     * Whether to render the (+) attachment button at all. Defaults to
+     * true; set false on surfaces that don't want attachments.
+     */
+    attachmentsEnabled?: boolean;
+    /**
+     * Fired whenever the local attachments list changes. Consumers
+     * that want to persist or forward the attachments wire this up;
+     * pages that only need the UI affordance can ignore it.
+     */
+    onAttachmentsChange?: (attachments: ReadonlyArray<ComposerAttachment>) => void;
 }
 
 export function PromptComposer({
@@ -126,16 +291,31 @@ export function PromptComposer({
     placeholderExamples,
     placeholder,
     ariaLabel,
-    belowInput,
+    chipsBelow,
     inputId,
     testId,
     submitTitle,
     className,
     disabled = false,
     showCounter = true,
+    showImportGithubRepo = false,
+    attachmentsEnabled = true,
+    onAttachmentsChange,
 }: PromptComposerProps) {
     const [focused, setFocused] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const folderInputRef = useRef<HTMLInputElement | null>(null);
+    const attachButtonRef = useRef<HTMLButtonElement | null>(null);
+    const attachMenuRef = useRef<HTMLDivElement | null>(null);
+    const githubInputRef = useRef<HTMLInputElement | null>(null);
+
+    const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+    const [attachMenuOpen, setAttachMenuOpen] = useState(false);
+    const [githubFormOpen, setGithubFormOpen] = useState(false);
+    const [githubUrl, setGithubUrl] = useState('');
+    const [githubError, setGithubError] = useState<string | null>(null);
+
     const trimmed = value.trim();
     // The textarea's native `maxLength={maxLength}` caps the raw value
     // before we ever see it, so no `tooLong` guard is needed here —
@@ -147,6 +327,19 @@ export function PromptComposer({
     const typed = useTypewriterPlaceholder(focused || value.length > 0, examples, placeholder);
     const effectivePlaceholder = examples.length > 0 ? typed : placeholder || '';
 
+    const speech = useSpeechRecognition((text) =>
+        onChange(value ? `${value} ${text}`.slice(0, maxLength) : text.slice(0, maxLength)),
+    );
+
+    // Surface attachment changes to consumers that wire this up.
+    const onAttachmentsChangeRef = useRef(onAttachmentsChange);
+    useEffect(() => {
+        onAttachmentsChangeRef.current = onAttachmentsChange;
+    }, [onAttachmentsChange]);
+    useEffect(() => {
+        onAttachmentsChangeRef.current?.(attachments);
+    }, [attachments]);
+
     function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
@@ -154,67 +347,463 @@ export function PromptComposer({
         }
     }
 
+    // Escape closes the popover (and the github sub-form).
+    useEffect(() => {
+        if (!attachMenuOpen) return;
+        const onKey = (e: globalThis.KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                setGithubFormOpen(false);
+                setAttachMenuOpen(false);
+            }
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, [attachMenuOpen]);
+
+    // Document-level mousedown listener to close the popover on outside
+    // click. The composer card uses backdrop-blur which creates a
+    // containing block for `position: fixed`, so a `<div className="fixed inset-0">`
+    // backdrop would be clipped to the card. Ref-guarded so clicks inside
+    // the popover (or on the (+) button itself) don't fire the close.
+    useEffect(() => {
+        if (!attachMenuOpen) return;
+        const onDocMouseDown = (e: MouseEvent) => {
+            const target = e.target as Node | null;
+            if (!target) return;
+            if (attachMenuRef.current?.contains(target)) return;
+            if (attachButtonRef.current?.contains(target)) return;
+            setGithubFormOpen(false);
+            setAttachMenuOpen(false);
+        };
+        document.addEventListener('mousedown', onDocMouseDown);
+        return () => document.removeEventListener('mousedown', onDocMouseDown);
+    }, [attachMenuOpen]);
+
+    useEffect(() => {
+        if (githubFormOpen) githubInputRef.current?.focus();
+    }, [githubFormOpen]);
+
+    const ingestFiles = useCallback((picked: FileList, kind: 'file' | 'folder-file') => {
+        if (!picked || picked.length === 0) return;
+        const next = Array.from(picked).map((file): ComposerAttachment => {
+            const relPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath || '';
+            const displayName = kind === 'folder-file' && relPath ? relPath : file.name;
+            return {
+                kind,
+                localId: `${file.name}-${file.size}-${file.lastModified}-${Math.random()
+                    .toString(36)
+                    .slice(2, 6)}`,
+                file,
+                displayName,
+            };
+        });
+        setAttachments((cur) => [...cur, ...next]);
+    }, []);
+
+    function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
+        const picked = e.target.files;
+        if (picked) ingestFiles(picked, 'file');
+        e.target.value = '';
+    }
+
+    function onPickFolder(e: React.ChangeEvent<HTMLInputElement>) {
+        const picked = e.target.files;
+        if (picked) ingestFiles(picked, 'folder-file');
+        e.target.value = '';
+    }
+
+    function removeAttachment(localId: string) {
+        setAttachments((cur) => cur.filter((a) => a.localId !== localId));
+    }
+
+    function onClickFile() {
+        setAttachMenuOpen(false);
+        fileInputRef.current?.click();
+    }
+    function onClickFolder() {
+        setAttachMenuOpen(false);
+        folderInputRef.current?.click();
+    }
+    function onClickGithub() {
+        // Reveal the sub-form inside the popover (rather than opening a
+        // separate URL) — the dashboard already has the user authenticated,
+        // so we just need a repo URL to forward into the import flow.
+        setGithubFormOpen(true);
+    }
+    function onAddGithub() {
+        const url = githubUrl.trim();
+        const match = url.match(GITHUB_REPO_RE);
+        if (!match) {
+            setGithubError('Enter a URL like https://github.com/owner/repo');
+            return;
+        }
+        const owner = match[1];
+        const repoRaw = match[2].replace(/\.git$/i, '');
+        const displayName = `${owner}/${repoRaw}`;
+        const canonical = `https://github.com/${owner}/${repoRaw}`;
+        const entry: ComposerAttachment = {
+            kind: 'github-repo',
+            localId: `gh-${owner}-${repoRaw}-${Math.random().toString(36).slice(2, 6)}`,
+            url: canonical,
+            displayName,
+        };
+        setAttachments((cur) => [...cur, entry]);
+        setGithubFormOpen(false);
+        setAttachMenuOpen(false);
+        setGithubUrl('');
+        setGithubError(null);
+    }
+    function onCancelGithub() {
+        setGithubFormOpen(false);
+        setGithubUrl('');
+        setGithubError(null);
+    }
+
+    const inputDisabled = disabled || submitting;
+
     return (
-        <div
-            className={cn(
-                // Rounded composer card. No solid background — the page's
-                // dark surface shows through, matching the website's
-                // landing prompt. The subtle ring + border give it shape
-                // without making it feel like a separate panel.
-                'relative flex flex-col rounded-2xl border border-border/60 dark:border-white/10 bg-white/40 dark:bg-black/40 backdrop-blur',
-                'shadow-sm ring-1 ring-black/[0.02] dark:ring-white/[0.04]',
-                'transition focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/30',
-                submitting && 'opacity-70 pointer-events-none',
-                className,
-            )}
-        >
-            <textarea
-                ref={textareaRef}
-                id={inputId}
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                onKeyDown={onKeyDown}
-                onFocus={() => setFocused(true)}
-                onBlur={() => setFocused(false)}
-                placeholder={effectivePlaceholder}
-                maxLength={maxLength}
-                rows={rows}
-                disabled={disabled || submitting}
-                aria-label={ariaLabel}
-                data-testid={testId}
-                className="block w-full resize-none rounded-2xl bg-transparent px-5 pt-4 pb-2 text-base outline-none placeholder:text-text-muted dark:placeholder:text-text-muted-dark text-text dark:text-text-dark"
-            />
+        <div className={cn('w-full space-y-3', className)}>
+            <div
+                className={cn(
+                    // Rounded composer card. No solid background — the page's
+                    // dark surface shows through, matching the website's
+                    // landing prompt. The subtle ring + border give it shape
+                    // without making it feel like a separate panel.
+                    'relative flex flex-col rounded-2xl border border-border/60 dark:border-white/10 bg-white/40 dark:bg-black/40 backdrop-blur',
+                    'shadow-sm ring-1 ring-black/[0.02] dark:ring-white/[0.04]',
+                    'transition focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/30',
+                    submitting && 'opacity-70 pointer-events-none',
+                )}
+            >
+                <textarea
+                    ref={textareaRef}
+                    id={inputId}
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    onKeyDown={onKeyDown}
+                    onFocus={() => setFocused(true)}
+                    onBlur={() => setFocused(false)}
+                    placeholder={effectivePlaceholder}
+                    maxLength={maxLength}
+                    rows={rows}
+                    disabled={inputDisabled}
+                    aria-label={ariaLabel}
+                    data-testid={testId}
+                    className="block w-full resize-none rounded-2xl bg-transparent px-5 pt-4 pb-2 text-base outline-none placeholder:text-text-muted dark:placeholder:text-text-muted-dark text-text dark:text-text-dark"
+                />
 
-            {belowInput ? <div className="px-4 pb-2">{belowInput}</div> : null}
-
-            <div className="flex items-center gap-2 px-3 pb-2">
-                <div className="ml-auto flex items-center gap-2">
-                    {showCounter ? (
-                        <span className="text-xs tabular-nums text-text-muted dark:text-text-muted-dark">
-                            {trimmed.length}/{maxLength}
-                        </span>
-                    ) : null}
-                    <button
-                        type="button"
-                        onClick={onSubmit}
-                        disabled={!canSubmit}
-                        title={submitTitle}
-                        aria-label={submitTitle || ariaLabel}
-                        data-testid={testId ? `${testId}-submit` : undefined}
-                        className={cn(
-                            'inline-flex items-center justify-center rounded-full p-2.5 shadow-md transition',
-                            'bg-primary text-white hover:bg-primary/90',
-                            'disabled:cursor-not-allowed disabled:opacity-40',
-                        )}
+                {attachments.length > 0 ? (
+                    <div
+                        className="flex flex-wrap gap-2 px-5 pb-2"
+                        aria-label="Attached files"
+                        data-testid={testId ? `${testId}-attachments` : undefined}
                     >
-                        {submitting ? (
-                            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                        ) : (
-                            <ArrowRight className="size-4" aria-hidden="true" />
-                        )}
-                    </button>
+                        {attachments.map((a) => {
+                            if (a.kind === 'github-repo') {
+                                return (
+                                    <div
+                                        key={a.localId}
+                                        className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs border-border/60 dark:border-white/10 bg-foreground/[0.03]"
+                                        title={a.url}
+                                    >
+                                        <Github className="size-3 opacity-70" aria-hidden="true" />
+                                        <span className="max-w-[12rem] truncate" title={a.url}>
+                                            {a.displayName}
+                                        </span>
+                                        <button
+                                            type="button"
+                                            onClick={() => removeAttachment(a.localId)}
+                                            aria-label={`Remove ${a.displayName}`}
+                                            className="rounded-full p-0.5 hover:bg-foreground/10"
+                                        >
+                                            <X className="size-3" aria-hidden="true" />
+                                        </button>
+                                    </div>
+                                );
+                            }
+                            return (
+                                <div
+                                    key={a.localId}
+                                    className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs border-border/60 dark:border-white/10 bg-foreground/[0.03]"
+                                    title={a.displayName}
+                                >
+                                    {a.kind === 'folder-file' ? (
+                                        <Folder className="size-3 opacity-60" aria-hidden="true" />
+                                    ) : (
+                                        <FileIcon className="size-3 opacity-60" aria-hidden="true" />
+                                    )}
+                                    <span className="max-w-[12rem] truncate" title={a.displayName}>
+                                        {a.displayName}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        onClick={() => removeAttachment(a.localId)}
+                                        aria-label={`Remove ${a.displayName}`}
+                                        className="rounded-full p-0.5 hover:bg-foreground/10"
+                                    >
+                                        <X className="size-3" aria-hidden="true" />
+                                    </button>
+                                </div>
+                            );
+                        })}
+                    </div>
+                ) : null}
+
+                <div className="flex items-center gap-1 px-3 pb-2">
+                    {attachmentsEnabled ? (
+                        <>
+                            {/* Hidden file pickers driven by the popover menu. */}
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                className="hidden"
+                                onChange={onPickFiles}
+                                data-testid={testId ? `${testId}-file-input` : undefined}
+                            />
+                            <input
+                                ref={folderInputRef}
+                                type="file"
+                                multiple
+                                className="hidden"
+                                onChange={onPickFolder}
+                                data-testid={testId ? `${testId}-folder-input` : undefined}
+                                // `webkitdirectory` lets the browser pick a folder
+                                // and surface every file in it. React 19 types
+                                // accept it as a string attribute; cast for older
+                                // types.
+                                {...({ webkitdirectory: '', directory: '' } as Record<string, string>)}
+                            />
+
+                            <div className="relative">
+                                <button
+                                    ref={attachButtonRef}
+                                    type="button"
+                                    onClick={() => {
+                                        setGithubFormOpen(false);
+                                        setAttachMenuOpen((v) => !v);
+                                    }}
+                                    aria-label="Add attachment"
+                                    title={
+                                        showImportGithubRepo
+                                            ? 'Add attachment (file, folder, or GitHub repo)'
+                                            : 'Add attachment (file or folder)'
+                                    }
+                                    aria-haspopup="menu"
+                                    aria-expanded={attachMenuOpen}
+                                    disabled={inputDisabled}
+                                    className="rounded-full p-2 text-text-muted dark:text-text-muted-dark hover:bg-foreground/5 hover:text-text dark:hover:text-text-dark disabled:opacity-40 disabled:cursor-not-allowed"
+                                    data-testid={testId ? `${testId}-attach` : undefined}
+                                >
+                                    <Plus className="size-5" aria-hidden="true" />
+                                </button>
+
+                                {attachMenuOpen ? (
+                                    <div
+                                        ref={attachMenuRef}
+                                        role="menu"
+                                        aria-label="Attachment options"
+                                        data-testid={testId ? `${testId}-attach-menu` : undefined}
+                                        // Positioned ABOVE the (+) button so the
+                                        // menu stays visible without clipping —
+                                        // page content below the composer is
+                                        // typically dense.
+                                        className="absolute bottom-full left-0 z-50 mb-2 min-w-[14rem] rounded-xl border border-border/60 dark:border-white/10 bg-background dark:bg-zinc-900 shadow-lg ring-1 ring-black/[0.04] dark:ring-white/[0.04]"
+                                    >
+                                        {githubFormOpen ? (
+                                            <div className="flex flex-col gap-2 p-2">
+                                                <label
+                                                    htmlFor={
+                                                        testId
+                                                            ? `${testId}-attach-github-input`
+                                                            : undefined
+                                                    }
+                                                    className="px-2 pt-1 text-[11px] font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark"
+                                                >
+                                                    GitHub repo URL
+                                                </label>
+                                                <input
+                                                    ref={githubInputRef}
+                                                    id={
+                                                        testId
+                                                            ? `${testId}-attach-github-input`
+                                                            : undefined
+                                                    }
+                                                    data-testid={
+                                                        testId
+                                                            ? `${testId}-attach-github-input`
+                                                            : undefined
+                                                    }
+                                                    type="url"
+                                                    value={githubUrl}
+                                                    onChange={(e) => {
+                                                        setGithubUrl(e.target.value);
+                                                        if (githubError) setGithubError(null);
+                                                    }}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === 'Enter') {
+                                                            e.preventDefault();
+                                                            onAddGithub();
+                                                        } else if (e.key === 'Escape') {
+                                                            e.preventDefault();
+                                                            onCancelGithub();
+                                                        }
+                                                    }}
+                                                    placeholder="https://github.com/owner/repo"
+                                                    className="w-full rounded-md border border-border/60 dark:border-white/10 bg-transparent px-2 py-1 text-xs outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/30"
+                                                />
+                                                {githubError ? (
+                                                    <p
+                                                        role="alert"
+                                                        className="px-1 text-[11px] text-red-600 dark:text-red-400"
+                                                    >
+                                                        {githubError}
+                                                    </p>
+                                                ) : null}
+                                                <div className="flex items-center justify-end gap-2 px-1 pb-1">
+                                                    <button
+                                                        type="button"
+                                                        onClick={onCancelGithub}
+                                                        className="rounded-md px-2 py-1 text-xs text-text-muted dark:text-text-muted-dark hover:bg-foreground/5"
+                                                    >
+                                                        Cancel
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={onAddGithub}
+                                                        data-testid={
+                                                            testId
+                                                                ? `${testId}-attach-github-add`
+                                                                : undefined
+                                                        }
+                                                        className="rounded-md bg-primary px-2 py-1 text-xs text-white hover:bg-primary/90"
+                                                    >
+                                                        Add
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            <ul className="flex flex-col py-1">
+                                                <li>
+                                                    <button
+                                                        type="button"
+                                                        role="menuitem"
+                                                        onClick={onClickFile}
+                                                        data-testid={
+                                                            testId
+                                                                ? `${testId}-attach-file`
+                                                                : undefined
+                                                        }
+                                                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-foreground/5"
+                                                    >
+                                                        <FileIcon
+                                                            className="size-4 opacity-70"
+                                                            aria-hidden="true"
+                                                        />
+                                                        Upload a file
+                                                    </button>
+                                                </li>
+                                                <li>
+                                                    <button
+                                                        type="button"
+                                                        role="menuitem"
+                                                        onClick={onClickFolder}
+                                                        data-testid={
+                                                            testId
+                                                                ? `${testId}-attach-folder`
+                                                                : undefined
+                                                        }
+                                                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-foreground/5"
+                                                    >
+                                                        <Folder
+                                                            className="size-4 opacity-70"
+                                                            aria-hidden="true"
+                                                        />
+                                                        Upload a folder
+                                                    </button>
+                                                </li>
+                                                {showImportGithubRepo ? (
+                                                    <li>
+                                                        <button
+                                                            type="button"
+                                                            role="menuitem"
+                                                            onClick={onClickGithub}
+                                                            data-testid={
+                                                                testId
+                                                                    ? `${testId}-attach-github`
+                                                                    : undefined
+                                                            }
+                                                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-foreground/5"
+                                                        >
+                                                            <Github
+                                                                className="size-4 opacity-70"
+                                                                aria-hidden="true"
+                                                            />
+                                                            Import GitHub Repo
+                                                        </button>
+                                                    </li>
+                                                ) : null}
+                                            </ul>
+                                        )}
+                                    </div>
+                                ) : null}
+                            </div>
+                        </>
+                    ) : null}
+
+                    {speech.supported ? (
+                        <button
+                            type="button"
+                            onClick={() => (speech.listening ? speech.stop() : speech.start())}
+                            aria-label={speech.listening ? 'Stop dictation' : 'Start dictation'}
+                            title={speech.listening ? 'Stop dictation' : 'Dictate your prompt'}
+                            aria-pressed={speech.listening}
+                            disabled={inputDisabled}
+                            className={cn(
+                                'rounded-full p-2 hover:bg-foreground/5 disabled:opacity-40 disabled:cursor-not-allowed',
+                                speech.listening
+                                    ? 'text-red-500 animate-pulse'
+                                    : 'text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark',
+                            )}
+                            data-testid={testId ? `${testId}-mic` : undefined}
+                        >
+                            <Mic className="size-5" aria-hidden="true" />
+                        </button>
+                    ) : null}
+
+                    <div className="ml-auto flex items-center gap-2">
+                        {showCounter ? (
+                            <span className="text-xs tabular-nums text-text-muted dark:text-text-muted-dark">
+                                {trimmed.length}/{maxLength}
+                            </span>
+                        ) : null}
+                        <button
+                            type="button"
+                            onClick={onSubmit}
+                            disabled={!canSubmit}
+                            title={submitTitle}
+                            aria-label={submitTitle || ariaLabel}
+                            data-testid={testId ? `${testId}-submit` : undefined}
+                            className={cn(
+                                'inline-flex items-center justify-center rounded-full p-2.5 shadow-md transition',
+                                'bg-primary text-white hover:bg-primary/90',
+                                'disabled:cursor-not-allowed disabled:opacity-40',
+                            )}
+                        >
+                            {submitting ? (
+                                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                            ) : (
+                                <ArrowRight className="size-4" aria-hidden="true" />
+                            )}
+                        </button>
+                    </div>
                 </div>
             </div>
+
+            {chipsBelow ? <div>{chipsBelow}</div> : null}
         </div>
     );
 }
+
+// Re-export the attachment shape so consumers wiring up
+// `onAttachmentsChange` can type their state safely.
+export type { ComposerAttachment };

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -10,6 +10,7 @@ import {
     type ReactNode,
 } from 'react';
 import { cn } from '@/lib/utils/cn';
+import { uploadFile, UploadError } from '@/lib/api/uploads';
 
 /**
  * Shared prompt composer used by `/missions`, `/ideas`, `/new`, and
@@ -210,15 +211,34 @@ function useSpeechRecognition(onResult: (text: string) => void) {
 }
 
 // Attachment shapes — discriminated union mirrors the website's
-// LandingPromptForm. The composer keeps these in local state for now;
-// integration with the platform's upload backend can be added on top
-// later without changing the public PromptComposer API.
+// LandingPromptForm. Each `file` / `folder-file` entry tracks its own
+// upload state (progress / uploadId / url / error) so the chip strip
+// can render distinct uploading / ready / error variants.
 type ComposerAttachment =
     | {
           readonly kind: 'file' | 'folder-file';
           readonly localId: string;
           readonly file: File;
           readonly displayName: string;
+          /** 0–100 percent — XHR-driven during upload. */
+          progress: number;
+          uploading: boolean;
+          /**
+           * Server-side upload id (sha256 of bytes) once the upload
+           * completes. Callers persist this — it's the canonical
+           * reference for `POST /api/me/missions/:id/attachments` etc.
+           */
+          uploadId?: string;
+          /**
+           * API-routed serve URL (`/api/uploads/<userId>/<filename>`)
+           * once the upload completes. Forwarded into the chat prompt
+           * so the chat AI can reference the file by URL.
+           */
+          url?: string;
+          /** Server-declared MIME (echoed from backend response). */
+          mimeType?: string;
+          /** Human-readable failure message; chip flips to red. */
+          error?: string;
       }
     | {
           readonly kind: 'github-repo';
@@ -385,19 +405,77 @@ export function PromptComposer({
 
     const ingestFiles = useCallback((picked: FileList, kind: 'file' | 'folder-file') => {
         if (!picked || picked.length === 0) return;
-        const next = Array.from(picked).map((file): ComposerAttachment => {
-            const relPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath || '';
-            const displayName = kind === 'folder-file' && relPath ? relPath : file.name;
-            return {
-                kind,
-                localId: `${file.name}-${file.size}-${file.lastModified}-${Math.random()
-                    .toString(36)
-                    .slice(2, 6)}`,
-                file,
-                displayName,
-            };
-        });
+        const next = Array.from(picked).map(
+            (file): Extract<ComposerAttachment, { kind: 'file' | 'folder-file' }> => {
+                const relPath =
+                    (file as File & { webkitRelativePath?: string }).webkitRelativePath || '';
+                const displayName = kind === 'folder-file' && relPath ? relPath : file.name;
+                return {
+                    kind,
+                    localId: `${file.name}-${file.size}-${file.lastModified}-${Math.random()
+                        .toString(36)
+                        .slice(2, 6)}`,
+                    file,
+                    displayName,
+                    progress: 0,
+                    uploading: true,
+                };
+            },
+        );
         setAttachments((cur) => [...cur, ...next]);
+
+        // Fire one XHR upload per file in parallel. Each settles
+        // independently; failures stay in `attachments` with an `error`
+        // field so the user can see + retry / dismiss. The submit flow
+        // can choose to wait for in-flight uploads or filter to
+        // completed `uploadId`s — that's the caller's call.
+        for (const attachment of next) {
+            void uploadFile(attachment.file, {
+                onProgress: (percent) => {
+                    setAttachments((cur) =>
+                        cur.map((a) =>
+                            a.localId === attachment.localId &&
+                            (a.kind === 'file' || a.kind === 'folder-file')
+                                ? { ...a, progress: percent }
+                                : a,
+                        ),
+                    );
+                },
+            })
+                .then((res) => {
+                    setAttachments((cur) =>
+                        cur.map((a) =>
+                            a.localId === attachment.localId &&
+                            (a.kind === 'file' || a.kind === 'folder-file')
+                                ? {
+                                      ...a,
+                                      uploading: false,
+                                      progress: 100,
+                                      uploadId: res.id,
+                                      url: res.url,
+                                      mimeType: res.mimeType,
+                                  }
+                                : a,
+                        ),
+                    );
+                })
+                .catch((err: unknown) => {
+                    const message =
+                        err instanceof UploadError
+                            ? err.message
+                            : err instanceof Error
+                              ? err.message
+                              : 'Upload failed';
+                    setAttachments((cur) =>
+                        cur.map((a) =>
+                            a.localId === attachment.localId &&
+                            (a.kind === 'file' || a.kind === 'folder-file')
+                                ? { ...a, uploading: false, progress: 0, error: message }
+                                : a,
+                        ),
+                    );
+                });
+        }
     }, []);
 
     function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
@@ -521,13 +599,37 @@ export function PromptComposer({
                                     </div>
                                 );
                             }
+                            // Three visual states:
+                            //   uploading: spinner + "% N"
+                            //   error: red ring + tooltip
+                            //   ready: default
+                            const variant = a.error
+                                ? 'border-red-500/40 bg-red-500/5 text-red-700 dark:text-red-300'
+                                : a.uploading
+                                  ? 'border-border/60 dark:border-white/10 bg-foreground/[0.03] opacity-80'
+                                  : 'border-border/60 dark:border-white/10 bg-foreground/[0.03]';
+                            const stateTag = a.error
+                                ? 'error'
+                                : a.uploading
+                                  ? 'uploading'
+                                  : 'ready';
                             return (
                                 <div
                                     key={a.localId}
-                                    className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs border-border/60 dark:border-white/10 bg-foreground/[0.03]"
-                                    title={a.displayName}
+                                    className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs ${variant}`}
+                                    title={a.error || a.displayName}
+                                    data-testid={
+                                        testId
+                                            ? `${testId}-attachment-${stateTag}`
+                                            : undefined
+                                    }
                                 >
-                                    {a.kind === 'folder-file' ? (
+                                    {a.uploading ? (
+                                        <Loader2
+                                            className="size-3 animate-spin opacity-70"
+                                            aria-hidden="true"
+                                        />
+                                    ) : a.kind === 'folder-file' ? (
                                         <Folder className="size-3 opacity-60" aria-hidden="true" />
                                     ) : (
                                         <FileIcon className="size-3 opacity-60" aria-hidden="true" />
@@ -535,6 +637,19 @@ export function PromptComposer({
                                     <span className="max-w-[12rem] truncate" title={a.displayName}>
                                         {a.displayName}
                                     </span>
+                                    {a.uploading ? (
+                                        <span
+                                            className="text-[10px] tabular-nums opacity-70"
+                                            aria-label={`Uploading ${a.progress} percent`}
+                                        >
+                                            {a.progress}%
+                                        </span>
+                                    ) : null}
+                                    {a.error ? (
+                                        <span className="text-[10px] uppercase tracking-wide">
+                                            failed
+                                        </span>
+                                    ) : null}
                                     <button
                                         type="button"
                                         onClick={() => removeAttachment(a.localId)}
@@ -807,3 +922,44 @@ export function PromptComposer({
 // Re-export the attachment shape so consumers wiring up
 // `onAttachmentsChange` can type their state safely.
 export type { ComposerAttachment };
+
+/**
+ * Helper for caller pages: turn the composer's full attachment list
+ * into the lighter `{ name, url, mimeType?, kind }` shape that
+ * `useStartFromPrompt` accepts. Uploads still in flight, uploads that
+ * failed, and entries that don't yet have a server-side URL are
+ * filtered out — only references the chat AI can actually act on are
+ * forwarded.
+ *
+ * Returned tuple matches `StartFromPromptAttachmentRef` from
+ * `use-start-from-prompt.tsx`; we don't import the type here to keep
+ * this module free of upstream-hook dependencies, but consumers can
+ * pass the return value straight into `startFromPrompt({ attachments })`.
+ */
+export interface ComposerAttachmentRef {
+    readonly name: string;
+    readonly url: string;
+    readonly mimeType?: string;
+    readonly kind: 'upload' | 'github-repo';
+}
+
+export function buildAttachmentRefs(
+    attachments: ReadonlyArray<ComposerAttachment>,
+): ReadonlyArray<ComposerAttachmentRef> {
+    const refs: ComposerAttachmentRef[] = [];
+    for (const a of attachments) {
+        if (a.kind === 'github-repo') {
+            refs.push({ name: a.displayName, url: a.url, kind: 'github-repo' });
+            continue;
+        }
+        if (a.url && !a.uploading && !a.error) {
+            refs.push({
+                name: a.displayName,
+                url: a.url,
+                mimeType: a.mimeType,
+                kind: 'upload',
+            });
+        }
+    }
+    return refs;
+}

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -8,7 +8,11 @@ import { cn } from '@/lib/utils/cn';
 import { buildIdeaAction, dismissProposalAction } from '@/app/actions/dashboard/work-proposals';
 import type { WorkProposal, WorkProposalStatus } from '@/lib/api/work-proposals';
 import { Button } from '@/components/ui/button';
-import { PromptComposer } from '@/components/common/PromptComposer';
+import {
+    PromptComposer,
+    buildAttachmentRefs,
+    type ComposerAttachment,
+} from '@/components/common/PromptComposer';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import {
@@ -74,6 +78,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     const router = useRouter();
     const [ideas, setIdeas] = useState(initialIdeas);
     const [draft, setDraft] = useState('');
+    const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [toggles, setToggles] = useState<Toggles>({
         showAccepted: false,
         showDismissed: false,
@@ -108,6 +113,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     }, [ideas]);
 
     const startFromPrompt = useStartFromPrompt();
+
     const handleQuickAdd = () => {
         const description = draft.trim();
         if (description.length < 10) {
@@ -121,7 +127,10 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
         // once chat confirms creation. Single source of truth for
         // "create from a prompt" lives in the chat side panel.
         startCreating(() => {
-            startFromPrompt(description, { intent: 'Idea' });
+            startFromPrompt(description, {
+                intent: 'Idea',
+                attachments: buildAttachmentRefs(attachments),
+            });
             setDraft('');
         });
     };
@@ -253,6 +262,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
                     ariaLabel={t('quickAdd.label')}
                     submitTitle={t('quickAdd.submitTitle')}
                     testId="ideas-quick-add"
+                    onAttachmentsChange={setAttachments}
                 />
             </div>
 

--- a/apps/web/src/components/ideas/IdeasPageClient.unit.spec.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.unit.spec.tsx
@@ -186,7 +186,7 @@ describe('IdeasPageClient (Phase 5 PR N)', () => {
         // the create-from-prompt flow.
         expect(startFromPromptMock).toHaveBeenCalledWith(
             'My freshly typed Idea, longer than ten chars',
-            { intent: 'Idea' },
+            expect.objectContaining({ intent: 'Idea' }),
         );
         expect(createIdeaMock).not.toHaveBeenCalled();
         // The existing rows are still rendered (canvas) — the new

--- a/apps/web/src/components/missions/MissionDetailClient.tsx
+++ b/apps/web/src/components/missions/MissionDetailClient.tsx
@@ -33,10 +33,15 @@ import {
     runMissionNowAction,
     updateMissionAction,
 } from '@/app/actions/dashboard/missions';
-import type { Mission, OwnerBudgetSummary } from '@/lib/api/missions';
+import type { Mission, MissionAttachmentRow, OwnerBudgetSummary } from '@/lib/api/missions';
 import type { WorkProposal } from '@/lib/api/work-proposals';
 import { IdeaCard } from '@/components/ideas';
 import { BudgetSummaryCard } from '@/components/budgets';
+import { EntityAttachmentsSection } from '@/components/common/EntityAttachmentsSection';
+import {
+    attachUploadToMissionAction,
+    detachMissionAttachmentAction,
+} from '@/app/actions/dashboard/missions';
 import {
     Dialog,
     DialogContent,
@@ -97,6 +102,12 @@ export interface MissionDetailClientProps {
      * gracefully falls back to its empty surface).
      */
     budget?: OwnerBudgetSummary | null;
+    /**
+     * Server-rendered initial attachment rows. The attachments
+     * section is purely additive (see follow-up FU1) and slots in
+     * below the existing detail-page sections.
+     */
+    attachments?: ReadonlyArray<MissionAttachmentRow>;
 }
 
 const RUNNABLE_STATUSES = new Set(['active', 'paused']);
@@ -110,6 +121,7 @@ export function MissionDetailClient({
     sourceMission = null,
     inheritedIdeas = [],
     budget = null,
+    attachments = [],
 }: MissionDetailClientProps) {
     const t = useTranslations('dashboard.missionDetail');
     const router = useRouter();
@@ -606,6 +618,19 @@ export function MissionDetailClient({
                     )}
                 </section>
             )}
+
+            {/* Attachments section — uploads attached to this Mission
+                via the PromptComposer or future detail-page actions.
+                Drag-and-drop + browse uploads via /api/uploads/file and
+                wires the new edges via attachUploadToMissionAction. */}
+            <EntityAttachmentsSection
+                initial={attachments}
+                onAttach={(uploadId) => attachUploadToMissionAction(mission.id, uploadId)}
+                onDetach={(attachmentId) =>
+                    detachMissionAttachmentAction(mission.id, attachmentId)
+                }
+                testId="mission-attachments"
+            />
 
             {/* Phase 6 PR GG — Clone confirmation modal. Opens from
                 the toolbar Clone button. Optional title override; on

--- a/apps/web/src/components/missions/MissionDetailClient.tsx
+++ b/apps/web/src/components/missions/MissionDetailClient.tsx
@@ -25,9 +25,11 @@ import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 import { NumberField, StatusPill, ToggleRow } from '@/components/work-agent';
 import {
+    attachUploadToMissionAction,
     cloneMissionAction,
     completeMissionAction,
     deleteMissionAction,
+    detachMissionAttachmentAction,
     pauseMissionAction,
     resumeMissionAction,
     runMissionNowAction,
@@ -38,10 +40,6 @@ import type { WorkProposal } from '@/lib/api/work-proposals';
 import { IdeaCard } from '@/components/ideas';
 import { BudgetSummaryCard } from '@/components/budgets';
 import { EntityAttachmentsSection } from '@/components/common/EntityAttachmentsSection';
-import {
-    attachUploadToMissionAction,
-    detachMissionAttachmentAction,
-} from '@/app/actions/dashboard/missions';
 import {
     Dialog,
     DialogContent,
@@ -626,9 +624,7 @@ export function MissionDetailClient({
             <EntityAttachmentsSection
                 initial={attachments}
                 onAttach={(uploadId) => attachUploadToMissionAction(mission.id, uploadId)}
-                onDetach={(attachmentId) =>
-                    detachMissionAttachmentAction(mission.id, attachmentId)
-                }
+                onDetach={(attachmentId) => detachMissionAttachmentAction(mission.id, attachmentId)}
                 testId="mission-attachments"
             />
 

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -4,7 +4,11 @@ import { useState, useTransition } from 'react';
 import { Target } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { PromptComposer } from '@/components/common/PromptComposer';
+import {
+    PromptComposer,
+    buildAttachmentRefs,
+    type ComposerAttachment,
+} from '@/components/common/PromptComposer';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import { MissionCard } from './MissionCard';
@@ -37,6 +41,7 @@ const MISSION_PLACEHOLDERS: ReadonlyArray<string> = [
 export function MissionsList({ missions }: { missions: Mission[] }) {
     const t = useTranslations('dashboard.missionsPage');
     const [draft, setDraft] = useState('');
+    const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [submitting, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
 
@@ -54,7 +59,10 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
         // matches the pattern on /new — a single source of truth for
         // "I'm trying to create something" is the chat side panel.
         startSubmit(() => {
-            startFromPrompt(description, { intent: 'Mission' });
+            startFromPrompt(description, {
+                intent: 'Mission',
+                attachments: buildAttachmentRefs(attachments),
+            });
             setDraft('');
         });
     };
@@ -85,6 +93,7 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
                     ariaLabel={t('quickAdd.label')}
                     submitTitle={t('quickAdd.submitTitle')}
                     testId="missions-quick-add"
+                    onAttachmentsChange={setAttachments}
                 />
             </div>
 

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -17,7 +17,11 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { PromptComposer } from '@/components/common/PromptComposer';
+import {
+    PromptComposer,
+    buildAttachmentRefs,
+    type ComposerAttachment,
+} from '@/components/common/PromptComposer';
 import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
@@ -195,8 +199,13 @@ export function NewPageClient({
     const router = useRouter();
     const [prompt, setPrompt] = useState(initialPrompt ?? '');
     const [selectedChip, setSelectedChip] = useState<ChipType>(initialType ?? 'mission');
+    const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [submitting, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
+
+    // `buildAttachmentRefs` imported from PromptComposer — turns the
+    // composer's full attachment list into chat-ready refs (filtering
+    // uploads in flight + failed uploads).
 
     // Close the layout chat panel on mount so the prompt + chips
     // take the full main column. We depend ONLY on the (stable)
@@ -258,7 +267,10 @@ export function NewPageClient({
             // with the same prompt pre-filled" pattern. The chat AI's
             // currentPageUrl context tells it where the user is, and
             // the intent prefix narrows it further.
-            startFromPrompt(description, { intent: CHIP_INTENT_LABEL[selectedChip] });
+            startFromPrompt(description, {
+                intent: CHIP_INTENT_LABEL[selectedChip],
+                attachments: buildAttachmentRefs(attachments),
+            });
 
             // Then navigate to the canvas for that intent. The canvas
             // page does NOT pre-fill the prompt — the user already
@@ -337,6 +349,7 @@ export function NewPageClient({
                 ariaLabel={t('promptLabel')}
                 submitTitle={t('submitTitle')}
                 testId="new-prompt"
+                onAttachmentsChange={setAttachments}
                 chipsBelow={
                     <div className="space-y-2">
                         <PromptChipsRow

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -4,21 +4,23 @@ import { useEffect, useMemo, useState, useTransition } from 'react';
 import {
     BookOpen,
     Bot,
+    Building2,
     Files,
     FolderOpen,
     Globe,
     Lightbulb,
     ListChecks,
     Star,
+    Store,
     Target,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { PromptComposer } from '@/components/common/PromptComposer';
+import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
-import { cn } from '@/lib/utils/cn';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import { createMissionAction } from '@/app/actions/dashboard/missions';
@@ -36,6 +38,12 @@ import { createMissionAction } from '@/app/actions/dashboard/missions';
  *                       there collect any remaining bits and persist).
  *   - website + 4 work kinds — forwarded to `/works/new` with the
  *                       prompt and the selected kind preserved.
+ *
+ * `store` and `company` are catalog entries telegraphing roadmap
+ * scope (see Workspace notes `2026-05-23-missions-ideas-works-spec.md`
+ * + AGENTS.md "stores + companies are in-scope future use cases"). They
+ * render as inert "Soon" chips and aren't selectable yet, matching how
+ * the marketing site already telegraphs them.
  *
  * The chat panel is auto-collapsed on mount so the prompt + chips
  * get the full main column on first land. Users can reopen it from
@@ -290,6 +298,22 @@ export function NewPageClient({
         [selectedChip],
     );
 
+    // Full chip catalog. `store` + `company` are inert "Soon" chips,
+    // appended after the live chips so they sit at the end of the
+    // horizontal scroll the way the marketing site does it.
+    const allChips = useMemo<ReadonlyArray<PromptChip<ChipType | 'store' | 'company'>>>(
+        () => [
+            ...CHIP_ORDER.map((c) => ({
+                value: c,
+                label: t(`chips.${c}`),
+                Icon: CHIP_ICONS[c],
+            })),
+            { value: 'store' as const, label: 'Store', Icon: Store, comingSoon: true },
+            { value: 'company' as const, label: 'Company', Icon: Building2, comingSoon: true },
+        ],
+        [t],
+    );
+
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-6">
             <div>
@@ -299,8 +323,9 @@ export function NewPageClient({
                 </p>
             </div>
 
-            {/* Composer with chips below — sits directly on the page's
-                dark background, no nested card wrapper. */}
+            {/* Composer with chips rendered BELOW the card (matches the
+                website's landing layout — chips sit outside the input
+                container, not inside). */}
             <PromptComposer
                 inputId="new-prompt"
                 value={prompt}
@@ -312,32 +337,28 @@ export function NewPageClient({
                 ariaLabel={t('promptLabel')}
                 submitTitle={t('submitTitle')}
                 testId="new-prompt"
-                belowInput={
+                chipsBelow={
                     <div className="space-y-2">
-                        <div className="flex flex-wrap gap-2">
-                            {CHIP_ORDER.map((c) => {
-                                const Icon = CHIP_ICONS[c];
-                                const active = selectedChip === c;
-                                return (
-                                    <button
-                                        key={c}
-                                        type="button"
-                                        onClick={() => setSelectedChip(c)}
-                                        className={cn(
-                                            'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors whitespace-nowrap',
-                                            active
-                                                ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
-                                                : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
-                                        )}
-                                        aria-pressed={active}
-                                    >
-                                        <Icon className="w-3.5 h-3.5" />
-                                        {t(`chips.${c}`)}
-                                    </button>
-                                );
-                            })}
-                        </div>
-                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                        <PromptChipsRow
+                            chips={allChips}
+                            value={selectedChip}
+                            onChange={(next) => {
+                                // `store` and `company` are inert, so the
+                                // chips row never emits them — narrow back
+                                // to ChipType before persisting.
+                                if (
+                                    next === null ||
+                                    next === 'store' ||
+                                    next === 'company'
+                                ) {
+                                    return;
+                                }
+                                setSelectedChip(next);
+                            }}
+                            ariaLabel={t('chipLabel')}
+                            testIdPrefix="new-chip"
+                        />
+                        <p className="px-1 text-xs text-text-muted dark:text-text-muted-dark">
                             {t(`chipDescriptions.${selectedChip}`)}
                         </p>
                     </div>

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -27,10 +27,7 @@ import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
-import {
-    attachUploadToMissionAction,
-    createMissionAction,
-} from '@/app/actions/dashboard/missions';
+import { attachUploadToMissionAction, createMissionAction } from '@/app/actions/dashboard/missions';
 
 /**
  * Unified `/new` page — single prompt input + chips for every
@@ -263,15 +260,15 @@ export function NewPageClient({
                     // proceed rather than rolling back. github-repo
                     // entries are skipped — they're metadata refs, not
                     // uploaded files.
-                    const refsToAttach = buildAttachmentRefs(attachments).filter(
-                        (r) => r.kind === 'upload',
-                    );
-                    if (refsToAttach.length > 0) {
-                        const uploadIds = attachments.flatMap((a) =>
-                            a.kind !== 'github-repo' && a.uploadId && !a.error
-                                ? [a.uploadId]
-                                : [],
-                        );
+                    // Single source of truth — `buildAttachmentRefs`
+                    // already filters in-flight + failed uploads and
+                    // carries the `uploadId` on each `upload` ref
+                    // (Greptile P2 on PR #1044: avoids re-scanning the
+                    // raw attachments with a divergent filter).
+                    const uploadIds = buildAttachmentRefs(attachments)
+                        .filter((r) => r.kind === 'upload' && r.uploadId)
+                        .map((r) => r.uploadId!);
+                    if (uploadIds.length > 0) {
                         const failed: string[] = [];
                         for (const uploadId of uploadIds) {
                             try {
@@ -392,11 +389,7 @@ export function NewPageClient({
                                 // `store` and `company` are inert, so the
                                 // chips row never emits them — narrow back
                                 // to ChipType before persisting.
-                                if (
-                                    next === null ||
-                                    next === 'store' ||
-                                    next === 'company'
-                                ) {
+                                if (next === null || next === 'store' || next === 'company') {
                                     return;
                                 }
                                 setSelectedChip(next);

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -27,7 +27,10 @@ import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
-import { createMissionAction } from '@/app/actions/dashboard/missions';
+import {
+    attachUploadToMissionAction,
+    createMissionAction,
+} from '@/app/actions/dashboard/missions';
 
 /**
  * Unified `/new` page — single prompt input + chips for every
@@ -253,6 +256,36 @@ export function NewPageClient({
                         type: 'one-shot',
                         missionTemplateRepo: initialTemplateId,
                     });
+                    // Wire any completed PromptComposer uploads onto the
+                    // newly created Mission via the new attachments
+                    // endpoint. Failures here are non-fatal: the Mission
+                    // is created either way, so we toast a warning and
+                    // proceed rather than rolling back. github-repo
+                    // entries are skipped — they're metadata refs, not
+                    // uploaded files.
+                    const refsToAttach = buildAttachmentRefs(attachments).filter(
+                        (r) => r.kind === 'upload',
+                    );
+                    if (refsToAttach.length > 0) {
+                        const uploadIds = attachments.flatMap((a) =>
+                            a.kind !== 'github-repo' && a.uploadId && !a.error
+                                ? [a.uploadId]
+                                : [],
+                        );
+                        const failed: string[] = [];
+                        for (const uploadId of uploadIds) {
+                            try {
+                                await attachUploadToMissionAction(mission.id, uploadId);
+                            } catch {
+                                failed.push(uploadId);
+                            }
+                        }
+                        if (failed.length > 0) {
+                            toast.warning(
+                                `${failed.length} attachment(s) couldn't be linked to the Mission — they're still saved in your uploads.`,
+                            );
+                        }
+                    }
                     toast.success(t('toasts.missionCreated'));
                     setChatOpen?.(true);
                     router.push(ROUTES.DASHBOARD_MISSION(mission.id));

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -58,7 +58,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
     it('renders all 9 chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo', () => {
         const { container } = render(<NewPageClient />);
         const chipButtons = Array.from(
-            container.querySelectorAll('button[aria-pressed]'),
+            container.querySelectorAll('button[role="option"][aria-selected]'),
         ) as HTMLButtonElement[];
         expect(chipButtons).toHaveLength(9);
         const labels = chipButtons.map((b) => b.textContent?.trim());
@@ -77,18 +77,18 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
 
     it('pre-selects the chip from initialType prop', () => {
         const { container } = render(<NewPageClient initialType="mission" />);
-        const mission = Array.from(container.querySelectorAll('button[aria-pressed]')).find((b) =>
+        const mission = Array.from(container.querySelectorAll('button[role="option"][aria-selected]')).find((b) =>
             b.textContent?.includes('mission'),
         ) as HTMLButtonElement;
-        expect(mission.getAttribute('aria-pressed')).toBe('true');
+        expect(mission.getAttribute('aria-selected')).toBe('true');
     });
 
     it('defaults to Mission when no initialType is supplied', () => {
         const { container } = render(<NewPageClient />);
-        const mission = Array.from(container.querySelectorAll('button[aria-pressed]')).find((b) =>
+        const mission = Array.from(container.querySelectorAll('button[role="option"][aria-selected]')).find((b) =>
             b.textContent?.includes('mission'),
         ) as HTMLButtonElement;
-        expect(mission.getAttribute('aria-pressed')).toBe('true');
+        expect(mission.getAttribute('aria-selected')).toBe('true');
     });
 
     it('Submit (arrow) is disabled until the prompt is >= 10 chars', () => {

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -117,9 +117,10 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             target: { value: 'Build the best cat business' },
         });
         fireEvent.click(getSubmit(container));
-        expect(startFromPromptMock).toHaveBeenCalledWith('Build the best cat business', {
-            intent: 'Mission',
-        });
+        expect(startFromPromptMock).toHaveBeenCalledWith(
+            'Build the best cat business',
+            expect.objectContaining({ intent: 'Mission' }),
+        );
         expect(routerPushMock).toHaveBeenCalledWith('/missions');
     });
 
@@ -131,9 +132,10 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             target: { value: 'A curated list of AI coding agents' },
         });
         fireEvent.click(getSubmit(container));
-        expect(startFromPromptMock).toHaveBeenCalledWith('A curated list of AI coding agents', {
-            intent: 'Idea',
-        });
+        expect(startFromPromptMock).toHaveBeenCalledWith(
+            'A curated list of AI coding agents',
+            expect.objectContaining({ intent: 'Idea' }),
+        );
         expect(routerPushMock).toHaveBeenCalledWith('/ideas');
     });
 
@@ -147,7 +149,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
         fireEvent.click(getSubmit(container));
         expect(startFromPromptMock).toHaveBeenCalledWith(
             'Research assistant for AI safety papers',
-            { intent: 'Agent' },
+            expect.objectContaining({ intent: 'Agent' }),
         );
         // Canvas route — chat carries the prompt, no `?prompt=` here.
         expect(routerPushMock).toHaveBeenCalledWith('/agents/new');
@@ -163,7 +165,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
         fireEvent.click(getSubmit(container));
         expect(startFromPromptMock).toHaveBeenCalledWith(
             'Audit the Mission backlog for stale items',
-            { intent: 'Task' },
+            expect.objectContaining({ intent: 'Task' }),
         );
         expect(routerPushMock).toHaveBeenCalledWith('/tasks/new');
     });
@@ -176,9 +178,10 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             target: { value: 'Landing page for my SaaS launch' },
         });
         fireEvent.click(getSubmit(container));
-        expect(startFromPromptMock).toHaveBeenCalledWith('Landing page for my SaaS launch', {
-            intent: 'website',
-        });
+        expect(startFromPromptMock).toHaveBeenCalledWith(
+            'Landing page for my SaaS launch',
+            expect.objectContaining({ intent: 'website' }),
+        );
         expect(routerPushMock).toHaveBeenCalledTimes(1);
         const href = routerPushMock.mock.calls[0][0] as string;
         expect(href.startsWith('/works/new?')).toBe(true);
@@ -246,7 +249,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             expect(createMissionMock).not.toHaveBeenCalled();
             expect(startFromPromptMock).toHaveBeenCalledWith(
                 'No template, just a typed mission goal',
-                { intent: 'Mission' },
+                expect.objectContaining({ intent: 'Mission' }),
             );
             expect(routerPushMock).toHaveBeenCalledWith('/missions');
         });

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -77,17 +77,17 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
 
     it('pre-selects the chip from initialType prop', () => {
         const { container } = render(<NewPageClient initialType="mission" />);
-        const mission = Array.from(container.querySelectorAll('button[role="option"][aria-selected]')).find((b) =>
-            b.textContent?.includes('mission'),
-        ) as HTMLButtonElement;
+        const mission = Array.from(
+            container.querySelectorAll('button[role="option"][aria-selected]'),
+        ).find((b) => b.textContent?.includes('mission')) as HTMLButtonElement;
         expect(mission.getAttribute('aria-selected')).toBe('true');
     });
 
     it('defaults to Mission when no initialType is supplied', () => {
         const { container } = render(<NewPageClient />);
-        const mission = Array.from(container.querySelectorAll('button[role="option"][aria-selected]')).find((b) =>
-            b.textContent?.includes('mission'),
-        ) as HTMLButtonElement;
+        const mission = Array.from(
+            container.querySelectorAll('button[role="option"][aria-selected]'),
+        ).find((b) => b.textContent?.includes('mission')) as HTMLButtonElement;
         expect(mission.getAttribute('aria-selected')).toBe('true');
     });
 

--- a/apps/web/src/lib/ai/agent.ts
+++ b/apps/web/src/lib/ai/agent.ts
@@ -51,6 +51,18 @@ For retries or re-runs:
 - **getUserInfo**: Get the current user's profile (name, email).
 - **suggestWorks**: A research subagent that autonomously looks up the user, searches the web for their interests, and returns personalized work suggestions. Use when the user asks "what should I create?", "suggest works", or "help me get started". This tool may take a moment as it runs multiple searches.
 
+## ATTACHMENTS
+
+When the user's message ends with an **"Attached files:"** block listing URLs of the form \`/api/uploads/<userId>/<sha256>.<ext>\`, those are uploads the user attached via the prompt composer's "+" button. The path segment after the user id (the \`<sha256>\` part of the filename) IS the uploadId.
+
+When you call **createMission** or **createIdea**, pass the attachments through via the tool's optional \`attachmentIds\` parameter. You may pass either:
+  - the full upload URL (the tool extracts the sha256 itself), or
+  - the bare \`<sha256>\` part.
+
+Both forms are accepted. Do this even if the user didn't explicitly say "attach these files" — the presence of the "Attached files:" block IS the user's intent.
+
+If you're calling **createWorkManual** or **createWorkWithAI**, the Work attach surface is the KB section (post-create) — note the attachment URLs in your summary so the user knows to drag them into KB if needed, but don't try to wire them through the Work create tool.
+
 ## CURRENT CONTEXT
 {context}
 

--- a/apps/web/src/lib/ai/tools/ideas.tools.ts
+++ b/apps/web/src/lib/ai/tools/ideas.tools.ts
@@ -4,6 +4,7 @@ import { ROUTES } from '@/lib/constants';
 import { workProposalsAPI, type WorkProposal } from '@/lib/api/work-proposals';
 import {
     acceptProposalAction,
+    attachUploadToIdeaAction,
     buildIdeaAction,
     createIdeaAction,
     dismissProposalAction,
@@ -11,6 +12,7 @@ import {
     listProposalsAction,
     refreshProposalsAction,
 } from '@/app/actions/dashboard/work-proposals';
+import { attachUploadsBestEffort, extractUploadIds } from './utils';
 
 /**
  * Phase 9 PR Z1 — in-app AI Chat tools for Ideas (spec §4.5).
@@ -128,13 +130,30 @@ export const createIdea = tool({
     inputSchema: z.object({
         description: z.string().min(10).describe('What the Idea is — used to seed the AI Goal.'),
         title: z.string().optional().describe('Optional display title.'),
+        attachmentIds: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Upload IDs (sha256 hex) OR full `/api/uploads/<userId>/<sha>.<ext>` URLs to attach to the new Idea. Source: the "Attached files:" block in the user message.',
+            ),
     }),
-    execute: async ({ description, title }) => {
+    execute: async ({ description, title, attachmentIds }) => {
         const idea = await createIdeaAction({
             description,
             ...(title !== undefined && { title }),
         });
-        return { created: true, idea: summarizeIdea(idea) };
+        const uploadIds = extractUploadIds(attachmentIds);
+        const attachStats =
+            uploadIds.length > 0
+                ? await attachUploadsBestEffort(uploadIds, (uploadId) =>
+                      attachUploadToIdeaAction(idea.id, uploadId),
+                  )
+                : { attached: 0, failed: 0 };
+        return {
+            created: true,
+            idea: summarizeIdea(idea),
+            ...(uploadIds.length > 0 && { attachments: attachStats }),
+        };
     },
 });
 

--- a/apps/web/src/lib/ai/tools/missions.tools.ts
+++ b/apps/web/src/lib/ai/tools/missions.tools.ts
@@ -3,6 +3,7 @@ import { tool } from 'ai';
 import { ROUTES } from '@/lib/constants';
 import { missionsAPI, type Mission } from '@/lib/api/missions';
 import {
+    attachUploadToMissionAction,
     cloneMissionAction,
     completeMissionAction,
     createMissionAction,
@@ -13,6 +14,7 @@ import {
     runMissionNowAction,
     updateMissionAction,
 } from '@/app/actions/dashboard/missions';
+import { attachUploadsBestEffort, extractUploadIds } from './utils';
 
 /**
  * Phase 9 PR Z1 — in-app AI Chat tools for Missions (spec §3.8).
@@ -129,6 +131,12 @@ export const createMission = tool({
             .nullable()
             .optional()
             .describe('Cap on un-built Ideas. -1 = unlimited; null = inherit user default.'),
+        attachmentIds: z
+            .array(z.string())
+            .optional()
+            .describe(
+                'Upload IDs (sha256 hex) OR full `/api/uploads/<userId>/<sha>.<ext>` URLs to attach to the new Mission. Source: the "Attached files:" block in the user message. Pass either the bare sha256 part of each URL or the URL itself — both are accepted.',
+            ),
     }),
     execute: async (input) => {
         const mission = await createMissionAction({
@@ -141,7 +149,18 @@ export const createMission = tool({
                 outstandingIdeasCap: input.outstandingIdeasCap,
             }),
         });
-        return { created: true, mission: summarizeMission(mission) };
+        const uploadIds = extractUploadIds(input.attachmentIds);
+        const attachStats =
+            uploadIds.length > 0
+                ? await attachUploadsBestEffort(uploadIds, (uploadId) =>
+                      attachUploadToMissionAction(mission.id, uploadId),
+                  )
+                : { attached: 0, failed: 0 };
+        return {
+            created: true,
+            mission: summarizeMission(mission),
+            ...(uploadIds.length > 0 && { attachments: attachStats }),
+        };
     },
 });
 

--- a/apps/web/src/lib/ai/tools/missions.tools.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/missions.tools.unit.spec.ts
@@ -36,6 +36,8 @@ const { missionsAPIGetMock, missionsAPIGetBudgetMock } = vi.hoisted(() => ({
     missionsAPIGetBudgetMock: vi.fn(),
 }));
 
+const { attachUploadMock } = vi.hoisted(() => ({ attachUploadMock: vi.fn() }));
+
 vi.mock('@/app/actions/dashboard/missions', () => ({
     listMissionsAction: listMissionsMock,
     createMissionAction: createMissionMock,
@@ -46,6 +48,7 @@ vi.mock('@/app/actions/dashboard/missions', () => ({
     completeMissionAction: completeMissionMock,
     runMissionNowAction: runNowMock,
     cloneMissionAction: cloneMissionMock,
+    attachUploadToMissionAction: attachUploadMock,
 }));
 
 vi.mock('@/lib/api/missions', () => ({
@@ -301,5 +304,71 @@ describe('missions chat tools — Lifecycle', () => {
         });
         await run(cloneMission, { missionId: 'm-1' });
         expect(cloneMissionMock).toHaveBeenCalledWith('m-1', undefined);
+    });
+});
+
+describe('createMission — attachmentIds wiring', () => {
+    beforeEach(() => {
+        attachUploadMock.mockReset();
+        createMissionMock.mockReset();
+    });
+
+    const sha = 'a'.repeat(64);
+    const sha2 = 'b'.repeat(64);
+
+    it('extracts uploadIds from full /api/uploads URLs and attaches them', async () => {
+        createMissionMock.mockResolvedValueOnce({ ...sampleMission, id: 'm-new' });
+        attachUploadMock.mockResolvedValue({ id: 'att', uploadId: sha });
+        const result = await run<{
+            created: boolean;
+            mission: { id: string };
+            attachments?: { attached: number; failed: number };
+        }>(createMission, {
+            description: 'A new mission with attached files',
+            attachmentIds: [
+                `/api/uploads/user-1/${sha}.pdf`,
+                `/api/uploads/user-1/${sha2}.png`,
+            ],
+        });
+        expect(attachUploadMock).toHaveBeenCalledTimes(2);
+        expect(attachUploadMock).toHaveBeenNthCalledWith(1, 'm-new', sha);
+        expect(attachUploadMock).toHaveBeenNthCalledWith(2, 'm-new', sha2);
+        expect(result.attachments).toEqual({ attached: 2, failed: 0 });
+    });
+
+    it('accepts bare sha256 uploadIds without URL wrapping', async () => {
+        createMissionMock.mockResolvedValueOnce({ ...sampleMission, id: 'm-new' });
+        attachUploadMock.mockResolvedValue({ id: 'att', uploadId: sha });
+        await run(createMission, {
+            description: 'A new mission with bare ids',
+            attachmentIds: [sha],
+        });
+        expect(attachUploadMock).toHaveBeenCalledWith('m-new', sha);
+    });
+
+    it('does not call attach when attachmentIds is absent', async () => {
+        createMissionMock.mockResolvedValueOnce({ ...sampleMission, id: 'm-new' });
+        const result = await run<{
+            created: boolean;
+            attachments?: { attached: number; failed: number };
+        }>(createMission, { description: 'A new mission without files' });
+        expect(attachUploadMock).not.toHaveBeenCalled();
+        expect(result.attachments).toBeUndefined();
+    });
+
+    it('counts per-id attach failures and still returns created:true', async () => {
+        createMissionMock.mockResolvedValueOnce({ ...sampleMission, id: 'm-new' });
+        attachUploadMock
+            .mockRejectedValueOnce(new Error('404'))
+            .mockResolvedValueOnce({ id: 'att', uploadId: sha2 });
+        const result = await run<{
+            created: boolean;
+            attachments?: { attached: number; failed: number };
+        }>(createMission, {
+            description: 'Two files, one will fail',
+            attachmentIds: [sha, sha2],
+        });
+        expect(result.created).toBe(true);
+        expect(result.attachments).toEqual({ attached: 1, failed: 1 });
     });
 });

--- a/apps/web/src/lib/ai/tools/missions.tools.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/missions.tools.unit.spec.ts
@@ -325,10 +325,7 @@ describe('createMission — attachmentIds wiring', () => {
             attachments?: { attached: number; failed: number };
         }>(createMission, {
             description: 'A new mission with attached files',
-            attachmentIds: [
-                `/api/uploads/user-1/${sha}.pdf`,
-                `/api/uploads/user-1/${sha2}.png`,
-            ],
+            attachmentIds: [`/api/uploads/user-1/${sha}.pdf`, `/api/uploads/user-1/${sha2}.png`],
         });
         expect(attachUploadMock).toHaveBeenCalledTimes(2);
         expect(attachUploadMock).toHaveBeenNthCalledWith(1, 'm-new', sha);

--- a/apps/web/src/lib/ai/tools/utils.ts
+++ b/apps/web/src/lib/ai/tools/utils.ts
@@ -55,3 +55,77 @@ export async function resolveGenerationConfig(workId?: string): Promise<Resolved
         return {};
     }
 }
+
+/**
+ * Extract upload IDs from `/api/uploads/<userId>/<sha256>.<ext>` URLs.
+ *
+ * The PromptComposer forwards completed uploads into the chat prompt
+ * as a markdown-style bullet list ("Attached files:\n- name (mime) —
+ * url"). Each chat AI create-entity tool accepts an `attachmentIds`
+ * array, but the model often passes URLs verbatim instead — this
+ * helper normalizes both shapes so callers can hand `attachmentIds`
+ * straight to the tool without forcing a perfect upstream parse.
+ *
+ * Returns deduped uploadIds in input order. Strings that don't match
+ * the URL shape are passed through unchanged (so a model that does the
+ * right thing — passes bare `<sha256>` strings — gets them respected).
+ * Bare sha256-shaped hex strings (64 lowercase hex chars) are also
+ * accepted as-is.
+ *
+ * Backed by the wire contract documented at
+ * `apps/api/src/uploads/uploads.service.ts` (saveImage / saveFile
+ * write the canonical key `<userId>/<sha256>.<ext>`; the `id` field
+ * on UploadResult IS the sha256).
+ */
+const UPLOAD_URL_RE = /\/api\/uploads\/[^/?#]+\/([0-9a-f]{64})\.[a-z0-9]+(?:\?[^#]*)?(?:#.*)?$/i;
+const BARE_SHA256_RE = /^[0-9a-f]{64}$/i;
+
+export function extractUploadIds(refs: ReadonlyArray<string> | undefined): string[] {
+    if (!refs || refs.length === 0) return [];
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of refs) {
+        if (typeof raw !== 'string') continue;
+        const trimmed = raw.trim();
+        if (!trimmed) continue;
+        let candidate: string | null = null;
+        const urlMatch = trimmed.match(UPLOAD_URL_RE);
+        if (urlMatch) {
+            candidate = urlMatch[1].toLowerCase();
+        } else if (BARE_SHA256_RE.test(trimmed)) {
+            candidate = trimmed.toLowerCase();
+        }
+        if (candidate && !seen.has(candidate)) {
+            seen.add(candidate);
+            out.push(candidate);
+        }
+    }
+    return out;
+}
+
+/**
+ * Best-effort "attach this list of uploadIds to the just-created
+ * entity" helper. Calls the supplied `attach` function per id,
+ * swallowing per-id failures so a single 404 / 409 doesn't unwind the
+ * whole chat-tool run — the entity is already created and the user
+ * can re-attach manually if needed.
+ *
+ * Returns the count of successful + failed attaches so callers can
+ * surface a partial-success message back to the model.
+ */
+export async function attachUploadsBestEffort(
+    uploadIds: ReadonlyArray<string>,
+    attach: (uploadId: string) => Promise<unknown>,
+): Promise<{ attached: number; failed: number }> {
+    let attached = 0;
+    let failed = 0;
+    for (const uploadId of uploadIds) {
+        try {
+            await attach(uploadId);
+            attached++;
+        } catch {
+            failed++;
+        }
+    }
+    return { attached, failed };
+}

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -412,10 +412,7 @@ export const agentsAPI = {
         });
     },
 
-    async removeAttachment(
-        id: string,
-        attachmentId: string,
-    ): Promise<{ deleted: true }> {
+    async removeAttachment(id: string, attachmentId: string): Promise<{ deleted: true }> {
         return serverMutation<{ deleted: true }>({
             endpoint: `/agents/${id}/attachments/${attachmentId}`,
             data: {},

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -392,4 +392,43 @@ export const agentsAPI = {
             wrapInData: false,
         });
     },
+
+    // Agent attachment surface — list/add/remove `AgentAttachment` rows.
+    // Mirrors `missionsAPI.{list,add,remove}Attachment` and
+    // `workProposalsAPI.{list,add,remove}Attachment` so the
+    // PromptComposer-driven creates can attach uniformly.
+    async listAttachments(id: string): Promise<AgentAttachmentRow[]> {
+        return serverFetch<AgentAttachmentRow[]>(`/agents/${id}/attachments`, {
+            method: 'GET',
+        });
+    },
+
+    async addAttachment(id: string, uploadId: string): Promise<AgentAttachmentRow> {
+        return serverMutation<AgentAttachmentRow>({
+            endpoint: `/agents/${id}/attachments`,
+            data: { uploadId },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async removeAttachment(
+        id: string,
+        attachmentId: string,
+    ): Promise<{ deleted: true }> {
+        return serverMutation<{ deleted: true }>({
+            endpoint: `/agents/${id}/attachments/${attachmentId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
 };
+
+/** Row shape returned by `/agents/:id/attachments`. */
+export interface AgentAttachmentRow {
+    readonly id: string;
+    readonly agentId: string;
+    readonly uploadId: string;
+    readonly createdAt: string;
+}

--- a/apps/web/src/lib/api/missions.ts
+++ b/apps/web/src/lib/api/missions.ts
@@ -191,4 +191,40 @@ export const missionsAPI = {
             method: 'GET',
         });
     },
+
+    // Attachment surface — list/add/remove `MissionAttachment` rows.
+    // Used by the PromptComposer-driven create flow on /new (Mission
+    // template inline-create path) and by future Mission detail
+    // attachment sections.
+    async listAttachments(id: string): Promise<MissionAttachmentRow[]> {
+        return serverFetch<MissionAttachmentRow[]>(`/me/missions/${id}/attachments`, {
+            method: 'GET',
+        });
+    },
+
+    async addAttachment(id: string, uploadId: string): Promise<MissionAttachmentRow> {
+        return serverMutation<MissionAttachmentRow>({
+            endpoint: `/me/missions/${id}/attachments`,
+            data: { uploadId },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async removeAttachment(id: string, attachmentId: string): Promise<{ deleted: true }> {
+        return serverMutation<{ deleted: true }>({
+            endpoint: `/me/missions/${id}/attachments/${attachmentId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
 };
+
+/** Row shape returned by `/me/missions/:id/attachments`. */
+export interface MissionAttachmentRow {
+    readonly id: string;
+    readonly missionId: string;
+    readonly uploadId: string;
+    readonly createdAt: string;
+}

--- a/apps/web/src/lib/api/uploads.ts
+++ b/apps/web/src/lib/api/uploads.ts
@@ -1,0 +1,143 @@
+/**
+ * Client-side helper for the dashboard's broader file-upload endpoint
+ * (`POST /api/uploads/file`). Uses XHR rather than `fetch` so we can
+ * surface per-byte progress to the UI — the marketing site does the
+ * same in its `LandingPromptForm`, and the PromptComposer mirrors that
+ * UX.
+ *
+ * Response shape matches the backend `UploadResult` (see
+ * `apps/api/src/uploads/uploads.service.ts`):
+ *
+ *   {
+ *     id:        string;  // sha256 of the uploaded bytes
+ *     url:       string;  // API-routed serve URL (`/api/uploads/<userId>/<filename>`)
+ *     filename:  string;  // canonical storage filename (`<sha256>.<ext>`)
+ *     size:      number;
+ *     mimeType:  string;  // declared MIME echoed back (text + Office files)
+ *     hash:      string;  // same as `id`
+ *     key?:      string;  // opaque backend storage key
+ *   }
+ */
+
+export interface UploadResult {
+    readonly id: string;
+    readonly url: string;
+    readonly filename: string;
+    readonly size: number;
+    readonly mimeType: string;
+    readonly hash: string;
+    readonly key?: string;
+}
+
+export interface UploadFileOptions {
+    /**
+     * Called repeatedly with the upload progress (0–100 integer
+     * percentage). Wired to `xhr.upload.onprogress` so each callback
+     * fires when the browser has flushed another chunk to the wire.
+     */
+    onProgress?: (percent: number) => void;
+    /**
+     * When provided, scopes the upload to the given Work. Only matters
+     * for backends that route per Work (today: `github-storage` in
+     * `data-repo` mode). Other backends ignore it. Most PromptComposer
+     * callers don't need this — we're always uploading before any
+     * entity exists.
+     */
+    workId?: string;
+    /** Abort signal — cancels the upload mid-flight. */
+    signal?: AbortSignal;
+}
+
+export class UploadError extends Error {
+    readonly status: number;
+    constructor(message: string, status: number) {
+        super(message);
+        this.name = 'UploadError';
+        this.status = status;
+    }
+}
+
+/**
+ * Upload a single file via `POST /api/uploads/file` (the web proxy
+ * forwards to the NestJS endpoint with the auth cookie translated to a
+ * Bearer token). Returns the canonical reference shape.
+ *
+ * Throws `UploadError` on non-2xx — the upstream body is parsed for a
+ * `{ message }` field where available so the UI can show the right
+ * 400 / 413 / 415 messaging from the server.
+ */
+export function uploadFile(file: File, opts?: UploadFileOptions): Promise<UploadResult> {
+    const { onProgress, workId, signal } = opts ?? {};
+
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new UploadError('Upload aborted', 0));
+            return;
+        }
+
+        const form = new FormData();
+        form.append('file', file, file.name);
+
+        const url = workId
+            ? `/api/uploads/file?workId=${encodeURIComponent(workId)}`
+            : '/api/uploads/file';
+
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', url, true);
+        // Never send cookies on the upload bytes path itself — the proxy
+        // route on the Next.js side reads our session cookie and forwards
+        // a Bearer header. `xhr.withCredentials = false` keeps the cross-
+        // origin story clean if the API is ever served from another host.
+        xhr.withCredentials = false;
+
+        if (onProgress && xhr.upload) {
+            xhr.upload.onprogress = (ev) => {
+                if (ev.lengthComputable) {
+                    onProgress(Math.min(100, Math.round((ev.loaded / ev.total) * 100)));
+                }
+            };
+        }
+
+        xhr.onload = () => {
+            const status = xhr.status;
+            const rawText = xhr.responseText || '';
+            if (status < 200 || status >= 300) {
+                let message = `Upload failed (${status})`;
+                try {
+                    const body = JSON.parse(rawText) as { message?: string };
+                    if (body && typeof body.message === 'string') message = body.message;
+                } catch {
+                    /* non-JSON; keep generic message */
+                }
+                reject(new UploadError(message, status));
+                return;
+            }
+            try {
+                const body = JSON.parse(rawText) as UploadResult;
+                if (!body || typeof body.id !== 'string') {
+                    reject(new UploadError('Upload succeeded but response was malformed', status));
+                    return;
+                }
+                resolve(body);
+            } catch {
+                reject(new UploadError('Upload response was not valid JSON', status));
+            }
+        };
+        xhr.onerror = () => reject(new UploadError('Network error during upload', 0));
+        xhr.onabort = () => reject(new UploadError('Upload aborted', 0));
+        xhr.ontimeout = () => reject(new UploadError('Upload timed out', 0));
+
+        if (signal) {
+            const onAbort = () => {
+                try {
+                    xhr.abort();
+                } catch {
+                    /* noop */
+                }
+            };
+            signal.addEventListener('abort', onAbort, { once: true });
+        }
+
+        xhr.send(form);
+    });
+}

--- a/apps/web/src/lib/api/work-proposals.ts
+++ b/apps/web/src/lib/api/work-proposals.ts
@@ -201,16 +201,12 @@ export const workProposalsAPI = {
     // PromptComposer-driven flows can attach files uniformly across
     // Mission / Idea creates.
     async listAttachments(id: string): Promise<WorkProposalAttachmentRow[]> {
-        return serverFetch<WorkProposalAttachmentRow[]>(
-            `/me/work-proposals/${id}/attachments`,
-            { method: 'GET' },
-        );
+        return serverFetch<WorkProposalAttachmentRow[]>(`/me/work-proposals/${id}/attachments`, {
+            method: 'GET',
+        });
     },
 
-    async addAttachment(
-        id: string,
-        uploadId: string,
-    ): Promise<WorkProposalAttachmentRow> {
+    async addAttachment(id: string, uploadId: string): Promise<WorkProposalAttachmentRow> {
         return serverMutation<WorkProposalAttachmentRow>({
             endpoint: `/me/work-proposals/${id}/attachments`,
             data: { uploadId },
@@ -219,10 +215,7 @@ export const workProposalsAPI = {
         });
     },
 
-    async removeAttachment(
-        id: string,
-        attachmentId: string,
-    ): Promise<{ deleted: true }> {
+    async removeAttachment(id: string, attachmentId: string): Promise<{ deleted: true }> {
         return serverMutation<{ deleted: true }>({
             endpoint: `/me/work-proposals/${id}/attachments/${attachmentId}`,
             data: {},

--- a/apps/web/src/lib/api/work-proposals.ts
+++ b/apps/web/src/lib/api/work-proposals.ts
@@ -195,7 +195,50 @@ export const workProposalsAPI = {
             method: 'GET',
         });
     },
+
+    // Idea attachment surface — list/add/remove `WorkProposalAttachment`
+    // edges. Mirrors `missionsAPI.{list,add,remove}Attachment` so the
+    // PromptComposer-driven flows can attach files uniformly across
+    // Mission / Idea creates.
+    async listAttachments(id: string): Promise<WorkProposalAttachmentRow[]> {
+        return serverFetch<WorkProposalAttachmentRow[]>(
+            `/me/work-proposals/${id}/attachments`,
+            { method: 'GET' },
+        );
+    },
+
+    async addAttachment(
+        id: string,
+        uploadId: string,
+    ): Promise<WorkProposalAttachmentRow> {
+        return serverMutation<WorkProposalAttachmentRow>({
+            endpoint: `/me/work-proposals/${id}/attachments`,
+            data: { uploadId },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async removeAttachment(
+        id: string,
+        attachmentId: string,
+    ): Promise<{ deleted: true }> {
+        return serverMutation<{ deleted: true }>({
+            endpoint: `/me/work-proposals/${id}/attachments/${attachmentId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
 };
+
+/** Row shape returned by `/me/work-proposals/:id/attachments`. */
+export interface WorkProposalAttachmentRow {
+    readonly id: string;
+    readonly workProposalId: string;
+    readonly uploadId: string;
+    readonly createdAt: string;
+}
 
 // Phase 7 PR U — single-source the OwnerBudgetSummary type. Defined
 // alongside the missions client (the first consumer) and re-exported

--- a/apps/web/src/lib/hooks/use-start-from-prompt.tsx
+++ b/apps/web/src/lib/hooks/use-start-from-prompt.tsx
@@ -34,14 +34,50 @@ import { useChatPanel } from '@/lib/hooks/use-chat-panel';
  * agent: <prompt>"). The unprefixed prompt is used when no intent
  * is supplied.
  */
+export interface StartFromPromptAttachmentRef {
+    /** Display name (original filename, repo `owner/repo`, etc.). */
+    readonly name: string;
+    /**
+     * API-routed URL the chat AI can fetch / reference. For uploads,
+     * `/api/uploads/<userId>/<filename>`. For GitHub repos, the
+     * canonical `https://github.com/owner/repo` URL.
+     */
+    readonly url: string;
+    /** Optional MIME type (server-echoed). Helps the chat AI decide
+     *  how to consume the file (image vs text vs document). */
+    readonly mimeType?: string;
+    /** Kind hint — distinguishes uploaded files from repos. */
+    readonly kind?: 'upload' | 'github-repo';
+}
+
 export interface StartFromPromptOptions {
     /** Short noun describing what the user is creating — used as a
      *  context prefix on the chat message. Examples: 'mission',
      *  'idea', 'agent', 'task', 'website', 'landing page'. */
     intent?: string;
+    /**
+     * Attachments the user added via the PromptComposer's `+` button.
+     * Appended to the chat message as a bullet list of `name — url`
+     * lines so the chat AI sees the references and can fetch / cite
+     * them via its tools. Only fully-uploaded files (with a `url`)
+     * should be passed — in-flight uploads are filtered by the
+     * caller.
+     */
+    attachments?: ReadonlyArray<StartFromPromptAttachmentRef>;
 }
 
 export type StartFromPromptFn = (prompt: string, opts?: StartFromPromptOptions) => boolean;
+
+function formatAttachmentsBlock(refs: ReadonlyArray<StartFromPromptAttachmentRef>): string {
+    if (refs.length === 0) return '';
+    // Group repos from uploaded files only for readability; the chat AI
+    // already gets a flat URL list and can act on either kind.
+    const lines = refs.map((r) => {
+        const mime = r.mimeType ? ` (${r.mimeType})` : '';
+        return `- ${r.name}${mime} — ${r.url}`;
+    });
+    return `\n\nAttached files:\n${lines.join('\n')}`;
+}
 
 export function useStartFromPrompt(): StartFromPromptFn {
     const chat = useChatContextOptional();
@@ -56,10 +92,11 @@ export function useStartFromPrompt(): StartFromPromptFn {
             // a confusing "where did my prompt go?" beat.
             chatPanel?.setOpen?.(true);
             if (chat) {
-                const message = opts?.intent
+                const base = opts?.intent
                     ? `I want to create a ${opts.intent}. ${trimmed}`
                     : trimmed;
-                chat.sendMessage(message);
+                const tail = opts?.attachments ? formatAttachmentsBlock(opts.attachments) : '';
+                chat.sendMessage(`${base}${tail}`);
             }
             return true;
         },

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agent } from '../entities/agent.entity';
+import { AgentAttachment } from '../entities/agent-attachment.entity';
 import { AgentRun } from '../entities/agent-run.entity';
 import { AgentRunLog } from '../entities/agent-run-log.entity';
 import { AgentBudget } from '../entities/agent-budget.entity';
@@ -10,6 +11,7 @@ import { AgentRunRepository } from '../database/repositories/agent-run.repositor
 import { AgentRunLogRepository } from '../database/repositories/agent-run-log.repository';
 import { AgentBudgetRepository } from '../database/repositories/agent-budget.repository';
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
+import { AgentAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { AgentsService } from './agents.service';
 import { AgentFileService } from './agent-file.service';
 import { AgentScheduleDispatcherService } from './agent-schedule-dispatcher.service';
@@ -32,7 +34,14 @@ import { SkillsModule } from '../skills/skills.module';
  */
 @Module({
     imports: [
-        TypeOrmModule.forFeature([Agent, AgentRun, AgentRunLog, AgentBudget, AgentMembership]),
+        TypeOrmModule.forFeature([
+            Agent,
+            AgentAttachment,
+            AgentRun,
+            AgentRunLog,
+            AgentBudget,
+            AgentMembership,
+        ]),
         ActivityLogModule,
         // Phase 10 — AgentRunService resolves active skills via
         // SkillBindingRepository before assembling the prompt.
@@ -44,6 +53,7 @@ import { SkillsModule } from '../skills/skills.module';
         AgentRunLogRepository,
         AgentBudgetRepository,
         AgentMembershipRepository,
+        AgentAttachmentRepository,
         AgentsService,
         AgentFileService,
         AgentScheduleDispatcherService,
@@ -58,6 +68,7 @@ import { SkillsModule } from '../skills/skills.module';
         AgentRunLogRepository,
         AgentBudgetRepository,
         AgentMembershipRepository,
+        AgentAttachmentRepository,
         AgentsService,
         AgentFileService,
         AgentScheduleDispatcherService,

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -5,6 +5,7 @@ import {
     Injectable,
     Logger,
     NotFoundException,
+    Optional,
 } from '@nestjs/common';
 import {
     AGENT_PERMISSIONS_DEFAULT,
@@ -16,12 +17,16 @@ import {
     AgentStatus,
     type AgentTarget,
 } from '../entities/agent.entity';
+import { AgentAttachment } from '../entities/agent-attachment.entity';
 import { AgentRepository, type ListAgentsFilter } from '../database/repositories/agent.repository';
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
 import { AgentBudgetRepository } from '../database/repositories/agent-budget.repository';
+import { AgentAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { slugifyText } from '../utils/text.utils';
 import { toAgentDto, type AgentDto } from './types';
 import { computeNextHeartbeat } from './heartbeat-cron';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Create-Agent input — writable subset of the entity. Validation
@@ -117,6 +122,11 @@ export class AgentsService {
         // budget row alongside (FK CASCADE handles it on DB but having
         // the call here keeps the service-level intent visible).
         private readonly budgets: AgentBudgetRepository,
+        // `@Optional()` because hand-rolled tests construct AgentsService
+        // without the attachments dep. Production DI provides it via
+        // AgentsModule.
+        @Optional()
+        private readonly agentAttachments?: AgentAttachmentRepository,
     ) {}
 
     async list(
@@ -374,6 +384,65 @@ export class AgentsService {
         await this.budgets.deleteByAgentId(id).catch(() => undefined); // FK CASCADE handles it; tolerate
         await this.memberships.deleteByAgentId(id).catch(() => undefined);
         await this.agents.deleteById(id);
+        return { deleted: true };
+    }
+
+    /**
+     * List the Upload edges attached to an Agent. Same shape as the
+     * Mission / Idea attachment surfaces.
+     */
+    async listAttachments(userId: string, id: string): Promise<AgentAttachment[]> {
+        await this.requireOwned(userId, id);
+        if (!this.agentAttachments) return [];
+        return this.agentAttachments.findByAgentId(id);
+    }
+
+    /** Attach an uploaded file to an Agent. Idempotent. */
+    async addAttachment(
+        userId: string,
+        id: string,
+        uploadId: string,
+    ): Promise<AgentAttachment> {
+        await this.requireOwned(userId, id);
+        if (!uploadId || !UUID_RE.test(uploadId)) {
+            throw new BadRequestException(`Invalid uploadId`);
+        }
+        if (!this.agentAttachments) {
+            throw new BadRequestException(
+                `AgentAttachmentRepository is not wired — attach the AgentAttachment provider before calling addAttachment`,
+            );
+        }
+        try {
+            return await this.agentAttachments.add(id, uploadId);
+        } catch (err) {
+            if (
+                err instanceof Error &&
+                /duplicate key|unique constraint/i.test(err.message)
+            ) {
+                const existing = (await this.agentAttachments.findByAgentId(id)).find(
+                    (a) => a.uploadId === uploadId,
+                );
+                if (existing) return existing;
+            }
+            throw err;
+        }
+    }
+
+    /** Detach an Upload from an Agent. */
+    async removeAttachment(
+        userId: string,
+        id: string,
+        attachmentId: string,
+    ): Promise<{ deleted: true }> {
+        await this.requireOwned(userId, id);
+        if (!this.agentAttachments) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        const row = await this.agentAttachments.findOne(attachmentId);
+        if (!row || row.agentId !== id) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        await this.agentAttachments.remove(attachmentId);
         return { deleted: true };
     }
 

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -26,7 +26,10 @@ import { slugifyText } from '../utils/text.utils';
 import { toAgentDto, type AgentDto } from './types';
 import { computeNextHeartbeat } from './heartbeat-cron';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Upload IDs are SHA-256 hex strings (the `id` field returned by
+// POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
+// (Codex + Greptile P1 on PR #1044).
+const SHA256_RE = /^[0-9a-f]{64}$/i;
 
 /**
  * Create-Agent input — writable subset of the entity. Validation
@@ -398,13 +401,9 @@ export class AgentsService {
     }
 
     /** Attach an uploaded file to an Agent. Idempotent. */
-    async addAttachment(
-        userId: string,
-        id: string,
-        uploadId: string,
-    ): Promise<AgentAttachment> {
+    async addAttachment(userId: string, id: string, uploadId: string): Promise<AgentAttachment> {
         await this.requireOwned(userId, id);
-        if (!uploadId || !UUID_RE.test(uploadId)) {
+        if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
         if (!this.agentAttachments) {
@@ -415,10 +414,7 @@ export class AgentsService {
         try {
             return await this.agentAttachments.add(id, uploadId);
         } catch (err) {
-            if (
-                err instanceof Error &&
-                /duplicate key|unique constraint/i.test(err.message)
-            ) {
+            if (err instanceof Error && /duplicate key|unique constraint/i.test(err.message)) {
                 const existing = (await this.agentAttachments.findByAgentId(id)).find(
                     (a) => a.uploadId === uploadId,
                 );

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -46,6 +46,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'ActivityLog',
     // Agents/Skills/Tasks (PR #1019) ──
     'Agent',
+    'AgentAttachment',
     'AgentBudget',
     'AgentMembership',
     'AgentRun',
@@ -62,6 +63,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'GitHubAppInstallationRepository',
     'GitHubAppUserLink',
     'Mission',
+    'MissionAttachment',
     'Notification',
     'OnboardingRequest',
     'PluginUsageEvent',
@@ -111,5 +113,6 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'WorkKnowledgeUpload',
     'WorkMember',
     'WorkProposal',
+    'WorkProposalAttachment',
     'WorkSchedule',
 ] as const;

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -65,6 +65,9 @@ import {
     TaskWatcher,
     TaskKbMention,
     UserTaskCounter,
+    MissionAttachment,
+    WorkProposalAttachment,
+    AgentAttachment,
 } from '../entities';
 import { PluginEntity, UserPluginEntity, WorkPluginEntity } from '../plugins/entities';
 import { UserSyncConfig } from '../account-transfer/entities/user-sync-config.entity';
@@ -146,6 +149,7 @@ export const ENTITIES = [
     AgentRunLog,
     AgentBudget,
     AgentMembership,
+    AgentAttachment,
     Skill,
     SkillBinding,
     // Phase 11 — Tasks family
@@ -160,6 +164,9 @@ export const ENTITIES = [
     TaskWatcher,
     TaskKbMention,
     UserTaskCounter,
+    // PR #1044 — Mission/Idea attachment edge tables
+    MissionAttachment,
+    WorkProposalAttachment,
     // Knowledge Base entities (EW-639 / EW-640)
     WorkKnowledgeDocument,
     WorkKnowledgeUpload,

--- a/packages/agent/src/database/repositories/attachment.repositories.ts
+++ b/packages/agent/src/database/repositories/attachment.repositories.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MissionAttachment } from '../../entities/mission-attachment.entity';
+import { WorkProposalAttachment } from '../../entities/work-proposal-attachment.entity';
+import { AgentAttachment } from '../../entities/agent-attachment.entity';
+
+/**
+ * Side-table repositories for Mission / Idea (WorkProposal) / Agent
+ * attachments. All three share the exact same CRUD shape as
+ * {@link TaskAttachmentRepository} — easier to reason about across
+ * the four attachment-bearing entity families.
+ *
+ * Each repository:
+ *   - `findByParentId(parentId)` — list attachments for one parent
+ *   - `add(parentId, uploadId)` — create the edge; relies on the
+ *     unique (parentId, uploadId) index for "already attached" idempotency
+ *     (callers can catch the QueryFailedError on the duplicate path)
+ *   - `findOne(id)` — fetch one edge (used by detach to validate
+ *     ownership before deleting)
+ *   - `remove(id)` — drop the edge
+ */
+
+@Injectable()
+export class MissionAttachmentRepository {
+    constructor(
+        @InjectRepository(MissionAttachment)
+        private readonly repo: Repository<MissionAttachment>,
+    ) {}
+
+    async findByMissionId(missionId: string): Promise<MissionAttachment[]> {
+        return this.repo.find({ where: { missionId }, order: { createdAt: 'DESC' } });
+    }
+    async findOne(id: string): Promise<MissionAttachment | null> {
+        return this.repo.findOne({ where: { id } });
+    }
+    async add(missionId: string, uploadId: string): Promise<MissionAttachment> {
+        const entity = this.repo.create({ missionId, uploadId });
+        return this.repo.save(entity);
+    }
+    async remove(id: string): Promise<void> {
+        await this.repo.delete(id);
+    }
+}
+
+@Injectable()
+export class WorkProposalAttachmentRepository {
+    constructor(
+        @InjectRepository(WorkProposalAttachment)
+        private readonly repo: Repository<WorkProposalAttachment>,
+    ) {}
+
+    async findByWorkProposalId(workProposalId: string): Promise<WorkProposalAttachment[]> {
+        return this.repo.find({ where: { workProposalId }, order: { createdAt: 'DESC' } });
+    }
+    async findOne(id: string): Promise<WorkProposalAttachment | null> {
+        return this.repo.findOne({ where: { id } });
+    }
+    async add(workProposalId: string, uploadId: string): Promise<WorkProposalAttachment> {
+        const entity = this.repo.create({ workProposalId, uploadId });
+        return this.repo.save(entity);
+    }
+    async remove(id: string): Promise<void> {
+        await this.repo.delete(id);
+    }
+}
+
+@Injectable()
+export class AgentAttachmentRepository {
+    constructor(
+        @InjectRepository(AgentAttachment) private readonly repo: Repository<AgentAttachment>,
+    ) {}
+
+    async findByAgentId(agentId: string): Promise<AgentAttachment[]> {
+        return this.repo.find({ where: { agentId }, order: { createdAt: 'DESC' } });
+    }
+    async findOne(id: string): Promise<AgentAttachment | null> {
+        return this.repo.findOne({ where: { id } });
+    }
+    async add(agentId: string, uploadId: string): Promise<AgentAttachment> {
+        const entity = this.repo.create({ agentId, uploadId });
+        return this.repo.save(entity);
+    }
+    async remove(id: string): Promise<void> {
+        await this.repo.delete(id);
+    }
+}

--- a/packages/agent/src/entities/agent-attachment.entity.ts
+++ b/packages/agent/src/entities/agent-attachment.entity.ts
@@ -1,0 +1,39 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Agent } from './agent.entity';
+
+/**
+ * Agent → Upload edge table. Same shape as {@link TaskAttachment} /
+ * {@link MissionAttachment} / {@link WorkProposalAttachment}. Lets
+ * users attach reference files / specs to an Agent profile (the
+ * `Agent` entity already has an `avatarImageUploadId` for the avatar
+ * image; this is a separate, multi-row attachment relation for
+ * reference material).
+ */
+@Entity({ name: 'agent_attachments' })
+@Index('uq_agent_attachment', ['agentId', 'uploadId'], { unique: true })
+@Index('idx_agent_attachment_upload', ['uploadId'])
+export class AgentAttachment {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    agentId: string;
+
+    @ManyToOne(() => Agent, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'agentId' })
+    agent?: Agent;
+
+    @Column({ type: 'uuid' })
+    uploadId: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/entities/agent-attachment.entity.ts
+++ b/packages/agent/src/entities/agent-attachment.entity.ts
@@ -31,7 +31,9 @@ export class AgentAttachment {
     @JoinColumn({ name: 'agentId' })
     agent?: Agent;
 
-    @Column({ type: 'uuid' })
+    // SHA-256 content hash (64 lowercase hex) — see MissionAttachment
+    // for the rationale + Codex/Greptile P1 reference.
+    @Column({ type: 'varchar', length: 64 })
     uploadId: string;
 
     @CreateDateColumn()

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -66,3 +66,6 @@ export * from './task-attachment.entity';
 export * from './task-watcher.entity';
 export * from './task-kb-mention.entity';
 export * from './user-task-counter.entity';
+export * from './mission-attachment.entity';
+export * from './work-proposal-attachment.entity';
+export * from './agent-attachment.entity';

--- a/packages/agent/src/entities/mission-attachment.entity.ts
+++ b/packages/agent/src/entities/mission-attachment.entity.ts
@@ -1,0 +1,45 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Mission } from './mission.entity';
+
+/**
+ * Mission → Upload edge table. Mirrors {@link TaskAttachment} so the
+ * Mission/Idea/Agent attachment surfaces share the same shape — easier
+ * to reason about and easier to extend later (the `attachments` UI
+ * sections under `apps/web/src/components/missions/` etc. all consume
+ * an identical row shape).
+ *
+ * `uploadId` is an opaque FK to a row in `work_knowledge_uploads` —
+ * the same upload pipeline backing Task attachments and the broader
+ * `POST /api/uploads/file` endpoint. No DB-level FK constraint on
+ * `uploadId` so an upload can be GC'd or rolled over without forcing
+ * a cascade through every attachment table; service-layer code
+ * validates the upload row exists before insert.
+ */
+@Entity({ name: 'mission_attachments' })
+@Index('uq_mission_attachment', ['missionId', 'uploadId'], { unique: true })
+@Index('idx_mission_attachment_upload', ['uploadId'])
+export class MissionAttachment {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    missionId: string;
+
+    @ManyToOne(() => Mission, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'missionId' })
+    mission?: Mission;
+
+    @Column({ type: 'uuid' })
+    uploadId: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/entities/mission-attachment.entity.ts
+++ b/packages/agent/src/entities/mission-attachment.entity.ts
@@ -16,12 +16,15 @@ import { Mission } from './mission.entity';
  * sections under `apps/web/src/components/missions/` etc. all consume
  * an identical row shape).
  *
- * `uploadId` is an opaque FK to a row in `work_knowledge_uploads` —
- * the same upload pipeline backing Task attachments and the broader
- * `POST /api/uploads/file` endpoint. No DB-level FK constraint on
- * `uploadId` so an upload can be GC'd or rolled over without forcing
- * a cascade through every attachment table; service-layer code
- * validates the upload row exists before insert.
+ * `uploadId` stores the SHA-256 content hash returned as `id` by
+ * `POST /api/uploads/file` (and `POST /api/uploads`). Stored as
+ * `varchar(64)` because sha256 in hex form is 64 lowercase hex
+ * characters — not a UUID, so a `uuid` column would reject every
+ * insert (Codex + Greptile P1 on PR #1044). No DB-level FK constraint
+ * either: the upload pipeline may GC the storage object independently
+ * (anonymous TTL, manual delete) and we don't want the attachment row
+ * dropped underneath us; service-layer code validates the hash shape
+ * before insert.
  */
 @Entity({ name: 'mission_attachments' })
 @Index('uq_mission_attachment', ['missionId', 'uploadId'], { unique: true })
@@ -37,7 +40,7 @@ export class MissionAttachment {
     @JoinColumn({ name: 'missionId' })
     mission?: Mission;
 
-    @Column({ type: 'uuid' })
+    @Column({ type: 'varchar', length: 64 })
     uploadId: string;
 
     @CreateDateColumn()

--- a/packages/agent/src/entities/work-proposal-attachment.entity.ts
+++ b/packages/agent/src/entities/work-proposal-attachment.entity.ts
@@ -33,7 +33,9 @@ export class WorkProposalAttachment {
     @JoinColumn({ name: 'workProposalId' })
     workProposal?: WorkProposal;
 
-    @Column({ type: 'uuid' })
+    // SHA-256 content hash (64 lowercase hex) — see MissionAttachment
+    // for the rationale + Codex/Greptile P1 reference.
+    @Column({ type: 'varchar', length: 64 })
     uploadId: string;
 
     @CreateDateColumn()

--- a/packages/agent/src/entities/work-proposal-attachment.entity.ts
+++ b/packages/agent/src/entities/work-proposal-attachment.entity.ts
@@ -1,0 +1,41 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+import { WorkProposal } from './work-proposal.entity';
+
+/**
+ * Idea (WorkProposal) → Upload edge table. Same shape as
+ * {@link TaskAttachment} / {@link MissionAttachment}.
+ *
+ * "Idea" is the user-facing term — the entity is `WorkProposal`, hence
+ * the table name `work_proposal_attachments` and the FK column
+ * `workProposalId`. API surfaces still expose this as `/api/me/
+ * work-proposals/:id/attachments` to match the existing controller
+ * naming.
+ */
+@Entity({ name: 'work_proposal_attachments' })
+@Index('uq_work_proposal_attachment', ['workProposalId', 'uploadId'], { unique: true })
+@Index('idx_work_proposal_attachment_upload', ['uploadId'])
+export class WorkProposalAttachment {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    workProposalId: string;
+
+    @ManyToOne(() => WorkProposal, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'workProposalId' })
+    workProposal?: WorkProposal;
+
+    @Column({ type: 'uuid' })
+    uploadId: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/missions/missions.module.ts
+++ b/packages/agent/src/missions/missions.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Mission } from '../entities/mission.entity';
+import { MissionAttachment } from '../entities/mission-attachment.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
+import { MissionAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { TitlerModule } from '../titler/titler.module';
 import { UserResearchModule } from '../user-research/user-research.module';
 import { WorkAgentModule } from '../work-agent/work-agent.module';
@@ -31,7 +33,7 @@ import { MissionTickService } from './mission-tick.service';
         // Repository<WorkProposal> for the Idea-copy half of Full
         // Fork, so the entity is registered here as well as via
         // UserResearchModule.
-        TypeOrmModule.forFeature([Mission, WorkProposal]),
+        TypeOrmModule.forFeature([Mission, MissionAttachment, WorkProposal]),
         TitlerModule,
         UserResearchModule,
         WorkAgentModule,
@@ -41,12 +43,14 @@ import { MissionTickService } from './mission-tick.service';
         MissionTickService,
         MissionCloneService,
         MissionTemplateManifestService,
+        MissionAttachmentRepository,
     ],
     exports: [
         MissionsService,
         MissionTickService,
         MissionCloneService,
         MissionTemplateManifestService,
+        MissionAttachmentRepository,
     ],
 })
 export class MissionsModule {}

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -19,7 +19,10 @@ import { TitlerService } from '../titler/titler.service';
 import { MissionTickService } from './mission-tick.service';
 import { toMissionDto, type MissionDto } from './types';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Upload IDs are SHA-256 hex strings (the `id` field returned by
+// POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
+// (Codex + Greptile P1 on PR #1044).
+const SHA256_RE = /^[0-9a-f]{64}$/i;
 
 /**
  * Input shape for `MissionsService.create`. Mirrors the writable
@@ -381,7 +384,7 @@ export class MissionsService {
         uploadId: string,
     ): Promise<MissionAttachment> {
         await this.findOrThrow(userId, missionId);
-        if (!uploadId || !UUID_RE.test(uploadId)) {
+        if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
         if (!this.missionAttachments) {
@@ -394,10 +397,7 @@ export class MissionsService {
         } catch (err) {
             // Duplicate (missionId, uploadId) — swallow and re-read.
             // Mirrors the idempotency contract on Task attachments.
-            if (
-                err instanceof Error &&
-                /duplicate key|unique constraint/i.test(err.message)
-            ) {
+            if (err instanceof Error && /duplicate key|unique constraint/i.test(err.message)) {
                 const existing = (await this.missionAttachments.findByMissionId(missionId)).find(
                     (a) => a.uploadId === uploadId,
                 );

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -13,9 +13,13 @@ import {
     MissionType,
     type MissionGuardrailsOverride,
 } from '../entities/mission.entity';
+import { MissionAttachment } from '../entities/mission-attachment.entity';
+import { MissionAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { TitlerService } from '../titler/titler.service';
 import { MissionTickService } from './mission-tick.service';
 import { toMissionDto, type MissionDto } from './types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Input shape for `MissionsService.create`. Mirrors the writable
@@ -118,6 +122,11 @@ export class MissionsService {
         // and the @Optional() resolves to a real instance.
         @Optional()
         private readonly tickService?: MissionTickService,
+        // `@Optional()` for the same reason as `tickService` — hand-rolled
+        // tests construct MissionsService without the attachments dep.
+        // Production DI provides it via MissionsModule.
+        @Optional()
+        private readonly missionAttachments?: MissionAttachmentRepository,
     ) {}
 
     /**
@@ -346,6 +355,79 @@ export class MissionsService {
             ideasQueued: result.ideasQueued,
             message: result.message,
         };
+    }
+
+    /**
+     * List the Upload edges attached to a Mission. Validates ownership
+     * (only the Mission's `userId` can list) before returning rows.
+     * Returns an empty array when the attachments repo isn't wired
+     * (hand-rolled tests) — same defensive shape as the tick service.
+     */
+    async listAttachments(userId: string, missionId: string): Promise<MissionAttachment[]> {
+        await this.findOrThrow(userId, missionId);
+        if (!this.missionAttachments) return [];
+        return this.missionAttachments.findByMissionId(missionId);
+    }
+
+    /**
+     * Attach an uploaded file (by `uploadId` from `POST /api/uploads/file`)
+     * to a Mission. Idempotent at the DB layer — the unique
+     * (missionId, uploadId) index turns a duplicate attach into a no-op
+     * conflict that we swallow and return the existing row.
+     */
+    async addAttachment(
+        userId: string,
+        missionId: string,
+        uploadId: string,
+    ): Promise<MissionAttachment> {
+        await this.findOrThrow(userId, missionId);
+        if (!uploadId || !UUID_RE.test(uploadId)) {
+            throw new BadRequestException(`Invalid uploadId`);
+        }
+        if (!this.missionAttachments) {
+            throw new BadRequestException(
+                `MissionAttachmentRepository is not wired — attach the MissionAttachment provider before calling addAttachment`,
+            );
+        }
+        try {
+            return await this.missionAttachments.add(missionId, uploadId);
+        } catch (err) {
+            // Duplicate (missionId, uploadId) — swallow and re-read.
+            // Mirrors the idempotency contract on Task attachments.
+            if (
+                err instanceof Error &&
+                /duplicate key|unique constraint/i.test(err.message)
+            ) {
+                const existing = (await this.missionAttachments.findByMissionId(missionId)).find(
+                    (a) => a.uploadId === uploadId,
+                );
+                if (existing) return existing;
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Detach an Upload from a Mission. Validates ownership of the
+     * Mission AND that the attachment row's `missionId` matches before
+     * deleting, so a malicious caller can't pass a foreign
+     * `attachmentId` to clean up someone else's edge.
+     */
+    async removeAttachment(
+        userId: string,
+        missionId: string,
+        attachmentId: string,
+    ): Promise<{ deleted: true }> {
+        await this.findOrThrow(userId, missionId);
+        if (!this.missionAttachments) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        const row = await this.missionAttachments.findOne(attachmentId);
+        if (!row || row.missionId !== missionId) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        await this.missionAttachments.remove(attachmentId);
+        return { deleted: true };
     }
 
     // ─── internals ──────────────────────────────────────────────────

--- a/packages/agent/src/user-research/user-research.module.ts
+++ b/packages/agent/src/user-research/user-research.module.ts
@@ -4,6 +4,8 @@ import { DatabaseModule } from '../database/database.module';
 import { FacadesModule } from '../facades/facades.module';
 import { TitlerModule } from '../titler/titler.module';
 import { WorkProposal } from '../entities/work-proposal.entity';
+import { WorkProposalAttachment } from '../entities/work-proposal-attachment.entity';
+import { WorkProposalAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { UserResearchService } from './user-research.service';
 import { WorkProposalService } from './work-proposal.service';
 import { WorkProposalRepository } from './work-proposal.repository';
@@ -21,12 +23,13 @@ import {
         DatabaseModule,
         FacadesModule,
         TitlerModule,
-        TypeOrmModule.forFeature([WorkProposal]),
+        TypeOrmModule.forFeature([WorkProposal, WorkProposalAttachment]),
     ],
     providers: [
         UserResearchService,
         WorkProposalService,
         WorkProposalRepository,
+        WorkProposalAttachmentRepository,
         {
             provide: USER_RESEARCH_LIMITS_CONFIG,
             useFactory: buildUserResearchLimitsConfig,
@@ -37,6 +40,7 @@ import {
         UserResearchService,
         WorkProposalService,
         WorkProposalRepository,
+        WorkProposalAttachmentRepository,
         UserResearchLimitsService,
     ],
 })

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -1,9 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+    BadRequestException,
+    Injectable,
+    Logger,
+    NotFoundException,
+    Optional,
+} from '@nestjs/common';
 import { AiFacadeService } from '../facades/ai.facade';
 import { UserRepository } from '../database/repositories/user.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { WorkProposalRepository } from './work-proposal.repository';
+import { WorkProposalAttachmentRepository } from '../database/repositories/attachment.repositories';
+import { WorkProposalAttachment } from '../entities/work-proposal-attachment.entity';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 import { permissiveWorkProposalsBatchSchema, type WorkProposalDraft } from './schemas';
 import { coerceWorkProposal } from './proposal-coercion';
 import {
@@ -147,7 +157,89 @@ export class WorkProposalService {
         // service that future PRs can swap to an AI-backed impl
         // without touching this call site.
         private readonly titler: TitlerService,
+        // Idea (WorkProposal) attachments — `@Optional()` because
+        // hand-rolled tests construct WorkProposalService without it.
+        // Production DI provides it via UserResearchModule.
+        @Optional()
+        private readonly proposalAttachments?: WorkProposalAttachmentRepository,
     ) {}
+
+    /**
+     * List the Upload edges attached to an Idea. Validates ownership
+     * before reading.
+     */
+    async listAttachments(
+        userId: string,
+        proposalId: string,
+    ): Promise<WorkProposalAttachment[]> {
+        const proposal = await this.repo.findByIdForUser(proposalId, userId);
+        if (!proposal) {
+            throw new NotFoundException(`Idea not found`);
+        }
+        if (!this.proposalAttachments) return [];
+        return this.proposalAttachments.findByWorkProposalId(proposalId);
+    }
+
+    /**
+     * Attach an uploaded file to an Idea. Idempotent on the unique
+     * (workProposalId, uploadId) index — see `MissionsService.addAttachment`.
+     */
+    async addAttachment(
+        userId: string,
+        proposalId: string,
+        uploadId: string,
+    ): Promise<WorkProposalAttachment> {
+        const proposal = await this.repo.findByIdForUser(proposalId, userId);
+        if (!proposal) {
+            throw new NotFoundException(`Idea not found`);
+        }
+        if (!uploadId || !UUID_RE.test(uploadId)) {
+            throw new BadRequestException(`Invalid uploadId`);
+        }
+        if (!this.proposalAttachments) {
+            throw new BadRequestException(
+                `WorkProposalAttachmentRepository is not wired — attach the WorkProposalAttachment provider before calling addAttachment`,
+            );
+        }
+        try {
+            return await this.proposalAttachments.add(proposalId, uploadId);
+        } catch (err) {
+            if (
+                err instanceof Error &&
+                /duplicate key|unique constraint/i.test(err.message)
+            ) {
+                const existing = (
+                    await this.proposalAttachments.findByWorkProposalId(proposalId)
+                ).find((a) => a.uploadId === uploadId);
+                if (existing) return existing;
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Detach an Upload from an Idea. Validates ownership of both the
+     * Idea AND that the attachment row's `workProposalId` matches.
+     */
+    async removeAttachment(
+        userId: string,
+        proposalId: string,
+        attachmentId: string,
+    ): Promise<{ deleted: true }> {
+        const proposal = await this.repo.findByIdForUser(proposalId, userId);
+        if (!proposal) {
+            throw new NotFoundException(`Idea not found`);
+        }
+        if (!this.proposalAttachments) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        const row = await this.proposalAttachments.findOne(attachmentId);
+        if (!row || row.workProposalId !== proposalId) {
+            throw new NotFoundException(`Attachment not found`);
+        }
+        await this.proposalAttachments.remove(attachmentId);
+        return { deleted: true };
+    }
 
     async generate(
         userId: string,

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -13,7 +13,10 @@ import { WorkProposalRepository } from './work-proposal.repository';
 import { WorkProposalAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { WorkProposalAttachment } from '../entities/work-proposal-attachment.entity';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Upload IDs are SHA-256 hex strings (the `id` field returned by
+// POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
+// (Codex + Greptile P1 on PR #1044).
+const SHA256_RE = /^[0-9a-f]{64}$/i;
 import { permissiveWorkProposalsBatchSchema, type WorkProposalDraft } from './schemas';
 import { coerceWorkProposal } from './proposal-coercion';
 import {
@@ -168,10 +171,7 @@ export class WorkProposalService {
      * List the Upload edges attached to an Idea. Validates ownership
      * before reading.
      */
-    async listAttachments(
-        userId: string,
-        proposalId: string,
-    ): Promise<WorkProposalAttachment[]> {
+    async listAttachments(userId: string, proposalId: string): Promise<WorkProposalAttachment[]> {
         const proposal = await this.repo.findByIdForUser(proposalId, userId);
         if (!proposal) {
             throw new NotFoundException(`Idea not found`);
@@ -193,7 +193,7 @@ export class WorkProposalService {
         if (!proposal) {
             throw new NotFoundException(`Idea not found`);
         }
-        if (!uploadId || !UUID_RE.test(uploadId)) {
+        if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
         }
         if (!this.proposalAttachments) {
@@ -204,10 +204,7 @@ export class WorkProposalService {
         try {
             return await this.proposalAttachments.add(proposalId, uploadId);
         } catch (err) {
-            if (
-                err instanceof Error &&
-                /duplicate key|unique constraint/i.test(err.message)
-            ) {
+            if (err instanceof Error && /duplicate key|unique constraint/i.test(err.message)) {
                 const existing = (
                     await this.proposalAttachments.findByWorkProposalId(proposalId)
                 ).find((a) => a.uploadId === uploadId);


### PR DESCRIPTION
## Summary

Polishes the dashboard prompt composer to match the marketing site's landing input, wires uploaded files through to backend storage, and adds per-entity attachment plumbing (Mission / Idea / Agent) so files attached via the composer or chat AI flow through to formal `*_attachments` rows.

Four commits, each a clean checkpoint:

1. **`feat(web): polish prompt input`** — chips moved BELOW the composer card (matches website layout), `+ / mic / counter / arrow` on a single bottom row, scrollable `PromptChipsRow` ported from the marketing site, Store + Company "SOON" chips, "Tell the agent" → "Tell us" across all 21 locales.
2. **`feat(uploads): wire PromptComposer to backend + broader-than-image file endpoint`** — new `POST /api/uploads/file` accepts images + PDFs + ZIP / Office Open XML + gzip + text-like formats with the same security model as the image endpoint. New `lib/api/uploads.ts` XHR helper with per-byte progress. PromptComposer actually uploads on file-pick, surfaces upload IDs via `onAttachmentsChange`, and the 4 caller pages forward URLs into the chat message via the extended `useStartFromPrompt`.
3. **`feat(attachments): Mission/Idea/Agent attachment entities + REST endpoints`** — 3 new TypeORM entities + 1 forward-only migration (`1779991000000-CreateMissionIdeaAgentAttachmentTables`) + repositories + service methods + 9 REST endpoints + 6 server actions + API client extensions. NewPageClient's Mission-template inline-create path attaches uploads synchronously.
4. **`feat(attachments): detail-page sections + chat AI tool wiring + anonymous file endpoint`** —
    - Shared `EntityAttachmentsSection` component + Mission/Agent detail-page mounting
    - `createMission` / `createIdea` chat-AI tools gain optional `attachmentIds: string[]` (accepts full URLs or bare sha256), best-effort attach after entity creation
    - System prompt teaches the model to flow "Attached files:" URLs through `attachmentIds`
    - New `POST /api/uploads/anonymous/file` mirrors the broader-MIME endpoint for the marketing site

## Test plan

- [x] **Type check**: `pnpm tsc --noEmit` clean across `apps/api`, `apps/web`, and `packages/agent`.
- [x] **Unit tests** (web): 496/496 pass — covers PromptComposer state machines, all 4 caller pages, chat-tool URL extraction + best-effort attach, attachment-section render.
- [x] **Unit + integration tests** (API): 46 uploads (incl. 8 new `saveFile` tests for PDF/ZIP/Office/text/NUL-byte rejection/MIME mismatch) + 78 mission/work-proposals/agents — all pass.
- [x] **Build**: `pnpm turbo build` clean across `@ever-works/agent`, `ever-works-api`, `web`.
- [ ] **Manual smoke** (to do post-merge or during review): attach a PDF + image via PromptComposer on \`/missions\`, submit, confirm chat receives URLs; on \`/new?type=mission&template=...\` confirm uploads attach to the new Mission row; visit \`/missions/:id\` and confirm the new attachments section lists them.
- [ ] **Migration** auto-applies on next deploy via TypeORM \`migrationsRun: true\` (NN #16). Verify on staging before prod.

## Scope notes

- The chips below-input + Store/Company SOON chips + subtitle copy are user-requested polish to match the marketing site (Ruslan).
- File uploads are auth-gated via the existing JWT cookie → Bearer proxy; storage backend is the env-selected \`STORAGE_BACKEND\` (default local-fs).
- Per-entity association: Tasks already had attachments; this PR adds parity for Mission / Idea (WorkProposal) / Agent. Idea detail-page UI is deferred until \`/ideas/[id]/page.tsx\` exists.
- Chat AI: only \`createMission\` + \`createIdea\` tools accept \`attachmentIds\`. Work-create tools deliberately don't — Works' attach surface is the KB endpoint, which expects a file body not an uploadId reference.

## Out of scope (follow-ups)

- LandingPromptForm in the **website** repo needs a separate PR to switch from `/api/uploads/anonymous` (image-only) to `/api/uploads/anonymous/file` (broader). The backend side ships here.
- Idea detail page + IdeaAttachmentsSection mount.
- Per-Work attachment association via the chat AI (would need a new tool that POSTs to `/api/works/:id/kb/uploads`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachments: list/add/remove attachments for agents, missions, and ideas.
  * Broader file uploads (PDFs, Office zips, archives, text) plus anonymous upload endpoint and upload progress UI.
  * Prompt composer enhancements: attachments, attachment chips, and optional GitHub import; voice dictation support.
  * New attachment UI components and prompt-chip selector with “Coming Soon” chips.

* **Tests**
  * Added coverage for broader file types and attachment flows.

* **Documentation**
  * Updated UI copy across many locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->