### PR TITLE
feat(tenants-orgs): Phase 1 - create tenants + organizations tables (EW-653)

### DIFF
--- a/apps/api/src/migrations/1779991002000-CreateTenantsTable.ts
+++ b/apps/api/src/migrations/1779991002000-CreateTenantsTable.ts
@@ -1,0 +1,119 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * EW-653 (Tenants & Organizations Phase 1) — creates the `tenants`
+ * table behind the new `Tenant` entity.
+ *
+ * Mirrors the entity 1:1:
+ *   - id (uuid, pk),
+ *   - ownerUserId (uuid, unique, FK → users.id, ON DELETE CASCADE),
+ *   - slug (varchar 64, unique),
+ *   - displayName (varchar 200),
+ *   - createdAt, updatedAt (timestamps).
+ *
+ * The unique constraint on `ownerUserId` enforces the v1 invariant
+ * "1 User : 1 Tenant". Dropping it later (if v1.1 wants
+ * multi-tenant-per-user) is additive and reversible — see
+ * [spec.md §7 v1.1 + open decisions](../../../../docs/specs/features/tenants-and-organizations/spec.md#7-open-decisions--out-of-scope-v11).
+ *
+ * **No rows are written** by this migration. The lazy-create flow in
+ * Phase 6 (EW-658) inserts the first Tenant row when a user creates
+ * their first Organization.
+ *
+ * Forward-only, additive, idempotent (gates on `hasTable`).
+ */
+export class CreateTenantsTable1779991002000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable('tenants'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'tenants',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            isGenerated: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: 'ownerUserId', type: 'uuid', isNullable: false },
+                        { name: 'slug', type: 'varchar', length: '64', isNullable: false },
+                        {
+                            name: 'displayName',
+                            type: 'varchar',
+                            length: '200',
+                            isNullable: false,
+                        },
+                        {
+                            name: 'createdAt',
+                            type: 'timestamp',
+                            default: 'now()',
+                            isNullable: false,
+                        },
+                        {
+                            name: 'updatedAt',
+                            type: 'timestamp',
+                            default: 'now()',
+                            isNullable: false,
+                        },
+                    ],
+                    foreignKeys: [
+                        {
+                            name: 'fk_tenants_owner_user',
+                            columnNames: ['ownerUserId'],
+                            referencedTableName: 'users',
+                            referencedColumnNames: ['id'],
+                            onDelete: 'CASCADE',
+                        },
+                    ],
+                }),
+                true,
+            );
+        }
+
+        const tenants = await queryRunner.getTable('tenants');
+
+        // Unique index on ownerUserId — enforces 1:1 User:Tenant in v1.
+        const hasOwnerIndex = tenants?.indices.some(
+            (i) => i.name === 'idx_tenants_owner_user_unique',
+        );
+        if (!hasOwnerIndex) {
+            await queryRunner.createIndex(
+                'tenants',
+                new TableIndex({
+                    name: 'idx_tenants_owner_user_unique',
+                    columnNames: ['ownerUserId'],
+                    isUnique: true,
+                }),
+            );
+        }
+
+        // Unique index on slug — required for the slug routing layer
+        // (Phase 7 / EW-659).
+        const hasSlugIndex = tenants?.indices.some((i) => i.name === 'idx_tenants_slug_unique');
+        if (!hasSlugIndex) {
+            await queryRunner.createIndex(
+                'tenants',
+                new TableIndex({
+                    name: 'idx_tenants_slug_unique',
+                    columnNames: ['slug'],
+                    isUnique: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const tenants = await queryRunner.getTable('tenants');
+        if (tenants?.indices.some((i) => i.name === 'idx_tenants_slug_unique')) {
+            await queryRunner.dropIndex('tenants', 'idx_tenants_slug_unique');
+        }
+        if (tenants?.indices.some((i) => i.name === 'idx_tenants_owner_user_unique')) {
+            await queryRunner.dropIndex('tenants', 'idx_tenants_owner_user_unique');
+        }
+        if (await queryRunner.hasTable('tenants')) {
+            await queryRunner.dropTable('tenants');
+        }
+    }
+}

--- a/apps/api/src/migrations/1779991003000-CreateOrganizationsTable.ts
+++ b/apps/api/src/migrations/1779991003000-CreateOrganizationsTable.ts
@@ -1,0 +1,155 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * EW-653 (Tenants & Organizations Phase 1) — creates the
+ * `organizations` table behind the new `Organization` entity.
+ *
+ * Mirrors the entity 1:1:
+ *   - id (uuid, pk),
+ *   - tenantId (uuid, FK → tenants.id, ON DELETE CASCADE),
+ *   - slug (varchar 64, unique globally),
+ *   - legalName (varchar 200, nullable),
+ *   - displayName (varchar 200),
+ *   - countryCode (varchar 2, nullable),
+ *   - registrationProvider (varchar 32, nullable — open string for
+ *     future providers; manual / stripe-atlas today),
+ *   - registrationStatus (varchar 16, default 'draft' — draft /
+ *     pending / registered),
+ *   - linkedWorkId (uuid, nullable — no FK to works yet because Work
+ *     already has organizationId going the other direction and a real
+ *     FK both ways risks a circular constraint at migration time),
+ *   - createdAt, updatedAt (timestamps).
+ *
+ * Indexes:
+ *   - UNIQUE on `slug` (matches the entity decorator).
+ *   - `idx_organizations_tenant_created` on `(tenantId, createdAt)`
+ *     for the WorkspaceSwitcher list query (Phase 8 / EW-660).
+ *
+ * **No rows are written.** Insertions happen via
+ * `OrganizationService.createOrganization` (Phase 6) and the Stripe
+ * Atlas completion handler (Phase 10).
+ *
+ * Note on cross-Org slug collisions vs `users.slug` and `tenants.slug`:
+ * those are NOT enforced at the DB level (different tables can't share
+ * a single UNIQUE constraint without a materialized view or trigger).
+ * The application-layer `UsernameAllocatorService.allocateSlug`
+ * (EW-652) guarantees no cross-table collision at write time. This is
+ * a deliberate trade — the DB enforces per-table uniqueness, the app
+ * enforces cross-table uniqueness.
+ *
+ * Forward-only, additive, idempotent.
+ */
+export class CreateOrganizationsTable1779991003000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable('organizations'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'organizations',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            isGenerated: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: 'tenantId', type: 'uuid', isNullable: false },
+                        { name: 'slug', type: 'varchar', length: '64', isNullable: false },
+                        {
+                            name: 'legalName',
+                            type: 'varchar',
+                            length: '200',
+                            isNullable: true,
+                        },
+                        {
+                            name: 'displayName',
+                            type: 'varchar',
+                            length: '200',
+                            isNullable: false,
+                        },
+                        { name: 'countryCode', type: 'varchar', length: '2', isNullable: true },
+                        {
+                            name: 'registrationProvider',
+                            type: 'varchar',
+                            length: '32',
+                            isNullable: true,
+                        },
+                        {
+                            name: 'registrationStatus',
+                            type: 'varchar',
+                            length: '16',
+                            isNullable: false,
+                            default: "'draft'",
+                        },
+                        { name: 'linkedWorkId', type: 'uuid', isNullable: true },
+                        {
+                            name: 'createdAt',
+                            type: 'timestamp',
+                            default: 'now()',
+                            isNullable: false,
+                        },
+                        {
+                            name: 'updatedAt',
+                            type: 'timestamp',
+                            default: 'now()',
+                            isNullable: false,
+                        },
+                    ],
+                    foreignKeys: [
+                        {
+                            name: 'fk_organizations_tenant',
+                            columnNames: ['tenantId'],
+                            referencedTableName: 'tenants',
+                            referencedColumnNames: ['id'],
+                            onDelete: 'CASCADE',
+                        },
+                    ],
+                }),
+                true,
+            );
+        }
+
+        const organizations = await queryRunner.getTable('organizations');
+
+        const hasSlugIndex = organizations?.indices.some(
+            (i) => i.name === 'idx_organizations_slug_unique',
+        );
+        if (!hasSlugIndex) {
+            await queryRunner.createIndex(
+                'organizations',
+                new TableIndex({
+                    name: 'idx_organizations_slug_unique',
+                    columnNames: ['slug'],
+                    isUnique: true,
+                }),
+            );
+        }
+
+        const hasTenantIndex = organizations?.indices.some(
+            (i) => i.name === 'idx_organizations_tenant_created',
+        );
+        if (!hasTenantIndex) {
+            await queryRunner.createIndex(
+                'organizations',
+                new TableIndex({
+                    name: 'idx_organizations_tenant_created',
+                    columnNames: ['tenantId', 'createdAt'],
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const organizations = await queryRunner.getTable('organizations');
+        if (organizations?.indices.some((i) => i.name === 'idx_organizations_tenant_created')) {
+            await queryRunner.dropIndex('organizations', 'idx_organizations_tenant_created');
+        }
+        if (organizations?.indices.some((i) => i.name === 'idx_organizations_slug_unique')) {
+            await queryRunner.dropIndex('organizations', 'idx_organizations_slug_unique');
+        }
+        if (await queryRunner.hasTable('organizations')) {
+            await queryRunner.dropTable('organizations');
+        }
+    }
+}

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -64,6 +64,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'Mission',
     'Notification',
     'OnboardingRequest',
+    'Organization',
     'PluginUsageEvent',
     'RefreshToken',
     // Skills family (PR #1019) ──
@@ -85,6 +86,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     // ──────────────────────────
     'Template',
     'TemplateCustomization',
+    'Tenant',
     'UsageLedgerEntry',
     'User',
     'UserSubscription',

--- a/packages/agent/src/database/_repository-inventory.ts
+++ b/packages/agent/src/database/_repository-inventory.ts
@@ -37,11 +37,13 @@ import { GitHubAppInstallationRepository } from './repositories/github-app-insta
 import { GitHubAppUserLinkRepository } from './repositories/github-app-user-link.repository';
 import { NotificationRepository } from './repositories/notification.repository';
 import { OnboardingRequestRepository } from './repositories/onboarding-request.repository';
+import { OrganizationRepository } from './repositories/organization.repository';
 import { PluginUsageRepository } from './repositories/plugin-usage.repository';
 import { RefreshTokenRepository } from './repositories/refresh-token.repository';
 import { SubscriptionPlanRepository } from './repositories/subscription-plan.repository';
 import { TemplateCustomizationRepository } from './repositories/template-customization.repository';
 import { TemplateRepository } from './repositories/template.repository';
+import { TenantRepository } from './repositories/tenant.repository';
 import { UsageLedgerRepository } from './repositories/usage-ledger.repository';
 import { UserRepository } from './repositories/user.repository';
 import { UserSubscriptionRepository } from './repositories/user-subscription.repository';
@@ -69,11 +71,13 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     GitHubAppUserLinkRepository,
     NotificationRepository,
     OnboardingRequestRepository,
+    OrganizationRepository,
     PluginUsageRepository,
     RefreshTokenRepository,
     SubscriptionPlanRepository,
     TemplateCustomizationRepository,
     TemplateRepository,
+    TenantRepository,
     UsageLedgerRepository,
     UserRepository,
     UserSubscriptionRepository,

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -46,6 +46,9 @@ import {
     WorkKnowledgeCitation,
     WorkKnowledgeChunk,
     Mission,
+    // Tenants & Organizations (EW-651 epic) — Phase 1 / EW-653
+    Tenant,
+    Organization,
     // Agents/Skills/Tasks (PR #1017 specs)
     Agent,
     AgentRun,
@@ -140,6 +143,9 @@ export const ENTITIES = [
     WorkAgentRunLog,
     // Missions / Ideas / Works (spec 2026-05-24, Phase 0 PR 0.2)
     Mission,
+    // Tenants & Organizations (EW-651 epic) — Phase 1 / EW-653
+    Tenant,
+    Organization,
     // Agents / Skills / Tasks (PR #1017 specs, Phase 1 + Phase 8)
     Agent,
     AgentRun,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -43,4 +43,7 @@ export * from './repositories/agent-membership.repository';
 // Agents/Skills/Tasks PR #1017 — Phase 8. Skill catalog repositories.
 export * from './repositories/skill.repository';
 export * from './repositories/skill-binding.repository';
+// Tenants & Organizations (EW-651 epic) — Phase 1 / EW-653.
+export * from './repositories/tenant.repository';
+export * from './repositories/organization.repository';
 export * from './database-init.service';

--- a/packages/agent/src/database/repositories/organization.repository.ts
+++ b/packages/agent/src/database/repositories/organization.repository.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Organization } from '../../entities/organization.entity';
+
+/**
+ * EW-653 (Tenants & Organizations Phase 1) — repository for the
+ * `organizations` table.
+ *
+ * Phase 1 lands the minimal lookup surface needed by the Phase 6
+ * service layer + the Phase 7 slug router:
+ *
+ *   - `findById` / `findBySlug` — single-row lookups.
+ *   - `findByTenantId` — switcher list query (ordered by createdAt
+ *     to match the `idx_organizations_tenant_created` index).
+ *   - `countByTenantId` — first-Org guard in `upgradeFromAccount`.
+ *   - `create` / `save` / `update` — write surface for
+ *     `OrganizationService.createOrganization` and the Stripe Atlas
+ *     completion handler (Phase 10).
+ */
+@Injectable()
+export class OrganizationRepository {
+    constructor(
+        @InjectRepository(Organization)
+        private readonly repository: Repository<Organization>,
+    ) {}
+
+    async findById(id: string): Promise<Organization | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    /**
+     * Slug lookup used by the slug routing middleware (Phase 7). Org
+     * resolution wins over User resolution per
+     * [spec.md §4.2](../../../../docs/specs/features/tenants-and-organizations/spec.md#42-slug-resolution).
+     */
+    async findBySlug(slug: string): Promise<Organization | null> {
+        return this.repository.findOne({ where: { slug } });
+    }
+
+    /**
+     * Used by the WorkspaceSwitcher (Phase 8) to list the user's Orgs.
+     * Ordered by `createdAt` ASC to match the
+     * `idx_organizations_tenant_created` composite index — newer Orgs
+     * naturally appear at the top of the popover.
+     */
+    async findByTenantId(tenantId: string): Promise<Organization[]> {
+        return this.repository.find({
+            where: { tenantId },
+            order: { createdAt: 'ASC' },
+        });
+    }
+
+    /**
+     * First-Org guard used by `upgradeFromAccount` (Phase 6). Returns
+     * the exact count so the caller can apply both the
+     * `count === 1 AND :organizationId === earliest` check from
+     * [plan.md Phase 6](../../../../docs/specs/features/tenants-and-organizations/plan.md#phase-6--lazy-upgrade-flow--organization-create-api).
+     */
+    async countByTenantId(tenantId: string): Promise<number> {
+        return this.repository.count({ where: { tenantId } });
+    }
+
+    /**
+     * Lookup the Work backing a registered Organization. Used by the
+     * Settings → Organization page (Phase 8) to render the "view the
+     * Company Work" link, and by the Stripe Atlas handler (Phase 10)
+     * to find the existing Org row when re-running registration.
+     */
+    async findByLinkedWorkId(workId: string): Promise<Organization | null> {
+        return this.repository.findOne({ where: { linkedWorkId: workId } });
+    }
+
+    async create(data: Partial<Organization>): Promise<Organization> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    async save(org: Organization): Promise<Organization> {
+        return this.repository.save(org);
+    }
+
+    async update(id: string, data: Partial<Organization>): Promise<void> {
+        await this.repository.update(id, data);
+    }
+}

--- a/packages/agent/src/database/repositories/organization.repository.ts
+++ b/packages/agent/src/database/repositories/organization.repository.ts
@@ -40,14 +40,16 @@ export class OrganizationRepository {
 
     /**
      * Used by the WorkspaceSwitcher (Phase 8) to list the user's Orgs.
-     * Ordered by `createdAt` ASC to match the
-     * `idx_organizations_tenant_created` composite index — newer Orgs
-     * naturally appear at the top of the popover.
+     * Ordered by `createdAt DESC` so the **most recently created Org
+     * appears at the top** of the popover — matches the spec's intent
+     * ([spec.md §5.5](../../../../docs/specs/features/tenants-and-organizations/spec.md#popover-contents)).
+     * The composite index `idx_organizations_tenant_created` covers
+     * both directions.
      */
     async findByTenantId(tenantId: string): Promise<Organization[]> {
         return this.repository.find({
             where: { tenantId },
-            order: { createdAt: 'ASC' },
+            order: { createdAt: 'DESC' },
         });
     }
 

--- a/packages/agent/src/database/repositories/tenant.repository.ts
+++ b/packages/agent/src/database/repositories/tenant.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tenant } from '../../entities/tenant.entity';
+
+/**
+ * EW-653 (Tenants & Organizations Phase 1) — repository for the
+ * `tenants` table.
+ *
+ * Mostly accessed indirectly via `User.tenantId` (Phase 2). The two
+ * direct lookups exposed today are used by the slug routing middleware
+ * (Phase 7) and by the lazy-create flow that the Organization-create
+ * endpoint runs on first-Org (Phase 6).
+ */
+@Injectable()
+export class TenantRepository {
+    constructor(
+        @InjectRepository(Tenant)
+        private readonly repository: Repository<Tenant>,
+    ) {}
+
+    async findById(id: string): Promise<Tenant | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    /**
+     * Used by `TenantBootstrapService.ensureTenant(userId)` to check
+     * whether the user already has a Tenant before lazy-creating one.
+     */
+    async findByOwnerUserId(ownerUserId: string): Promise<Tenant | null> {
+        return this.repository.findOne({ where: { ownerUserId } });
+    }
+
+    /**
+     * Used by the slug routing middleware (Phase 7) as part of the
+     * `users.slug → bare-Tenant` resolution path. Case-sensitive — the
+     * allocator guarantees slugs are always stored lowercase.
+     */
+    async findBySlug(slug: string): Promise<Tenant | null> {
+        return this.repository.findOne({ where: { slug } });
+    }
+
+    async create(data: Partial<Tenant>): Promise<Tenant> {
+        const entity = this.repository.create(data);
+        return this.repository.save(entity);
+    }
+
+    async save(tenant: Tenant): Promise<Tenant> {
+        return this.repository.save(tenant);
+    }
+}

--- a/packages/agent/src/entities/__tests__/organization.entity.spec.ts
+++ b/packages/agent/src/entities/__tests__/organization.entity.spec.ts
@@ -1,0 +1,72 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Organization } from '../organization.entity';
+
+/**
+ * EW-653 — shape tests for the `Organization` entity. See
+ * [spec.md §1.2](../../../../../docs/specs/features/tenants-and-organizations/spec.md#12-organization-user-facing--ui-label-varies)
+ * for the design.
+ */
+describe('Organization entity', () => {
+    const storage = getMetadataArgsStorage();
+    const table = storage.tables.find((t) => t.target === Organization);
+    const columns = storage.columns.filter((c) => c.target === Organization);
+    const indices = storage.indices.filter((i) => i.target === Organization);
+    const columnNames = columns.map((c) => c.propertyName);
+
+    it('maps to the `organizations` table', () => {
+        expect(table?.name).toBe('organizations');
+    });
+
+    it('declares the full Phase 1 column set', () => {
+        expect(columnNames).toEqual(
+            expect.arrayContaining([
+                'id',
+                'tenantId',
+                'slug',
+                'legalName',
+                'displayName',
+                'countryCode',
+                'registrationProvider',
+                'registrationStatus',
+                'linkedWorkId',
+                'createdAt',
+                'updatedAt',
+            ]),
+        );
+    });
+
+    it('marks slug as unique (globally across the table)', () => {
+        const slug = columns.find((c) => c.propertyName === 'slug');
+        expect(slug?.options.unique).toBe(true);
+    });
+
+    it('marks tenantId and displayName as NOT nullable', () => {
+        const tenant = columns.find((c) => c.propertyName === 'tenantId');
+        const display = columns.find((c) => c.propertyName === 'displayName');
+        expect(tenant?.options.nullable).not.toBe(true);
+        expect(display?.options.nullable).not.toBe(true);
+    });
+
+    it('marks legalName, countryCode, registrationProvider, linkedWorkId as nullable', () => {
+        for (const name of ['legalName', 'countryCode', 'registrationProvider', 'linkedWorkId']) {
+            const col = columns.find((c) => c.propertyName === name);
+            expect(col?.options.nullable).toBe(true);
+        }
+    });
+
+    it('defaults registrationStatus to "draft"', () => {
+        const status = columns.find((c) => c.propertyName === 'registrationStatus');
+        expect(status?.options.default).toBe('draft');
+    });
+
+    it('declares the (tenantId, createdAt) composite index for switcher list queries', () => {
+        const idx = indices.find((i) => i.name === 'idx_organizations_tenant_created');
+        expect(idx).toBeDefined();
+        expect(idx?.columns).toEqual(['tenantId', 'createdAt']);
+    });
+
+    it('declares countryCode column with a length constraint (driven by migration)', () => {
+        const cc = columns.find((c) => c.propertyName === 'countryCode');
+        expect(cc?.options.length).toBeDefined();
+    });
+});

--- a/packages/agent/src/entities/__tests__/tenant.entity.spec.ts
+++ b/packages/agent/src/entities/__tests__/tenant.entity.spec.ts
@@ -1,0 +1,52 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Tenant } from '../tenant.entity';
+
+/**
+ * EW-653 — shape tests for the `Tenant` entity. Mirrors the same
+ * metadata-graph approach used by `agent.entity.spec.ts` —
+ * no DataSource is spun up; we just assert the TypeORM decorator
+ * graph matches Phase 1 of the
+ * [Tenants & Organizations spec](../../../../../docs/specs/features/tenants-and-organizations/spec.md#11-tenant-internal-only-never-shown-in-ui).
+ */
+describe('Tenant entity', () => {
+    const storage = getMetadataArgsStorage();
+    const table = storage.tables.find((t) => t.target === Tenant);
+    const columns = storage.columns.filter((c) => c.target === Tenant);
+    const columnNames = columns.map((c) => c.propertyName);
+
+    it('maps to the `tenants` table', () => {
+        expect(table?.name).toBe('tenants');
+    });
+
+    it('declares all required columns', () => {
+        expect(columnNames).toEqual(
+            expect.arrayContaining([
+                'id',
+                'ownerUserId',
+                'slug',
+                'displayName',
+                'createdAt',
+                'updatedAt',
+            ]),
+        );
+    });
+
+    it('marks ownerUserId as unique (1:1 User:Tenant for v1)', () => {
+        const col = columns.find((c) => c.propertyName === 'ownerUserId');
+        expect(col?.options.unique).toBe(true);
+    });
+
+    it('marks ownerUserId and displayName as NOT nullable', () => {
+        const owner = columns.find((c) => c.propertyName === 'ownerUserId');
+        const display = columns.find((c) => c.propertyName === 'displayName');
+        expect(owner?.options.nullable).not.toBe(true);
+        expect(display?.options.nullable).not.toBe(true);
+    });
+
+    it('constrains slug column length (driven by migration)', () => {
+        // Don't pin the exact value — TypeORM normalizes `length` to either a
+        // number or string depending on dialect. Just assert it's set.
+        const slug = columns.find((c) => c.propertyName === 'slug');
+        expect(slug?.options.length).toBeDefined();
+    });
+});

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -36,6 +36,9 @@ export * from './webhook-subscription.entity';
 export * from './webhook-delivery.entity';
 export * from './work-proposal.entity';
 export * from './mission.entity';
+// Tenants & Organizations (EW-651 epic) — Phase 1 / EW-653.
+export * from './tenant.entity';
+export * from './organization.entity';
 export * from './work-agent-preference.entity';
 export * from './work-agent-goal.entity';
 export * from './work-agent-run.entity';

--- a/packages/agent/src/entities/organization.entity.ts
+++ b/packages/agent/src/entities/organization.entity.ts
@@ -1,0 +1,146 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { Tenant } from './tenant.entity';
+
+/**
+ * Provenance for the `Organization` row — how it came to exist.
+ *
+ * `manual`       — created via the Settings UI / API directly.
+ * `stripe-atlas` — created as a side-effect of a Work-of-type-Company
+ *                  reaching `registered` status (Phase 10 / EW-662).
+ *
+ * Open string column (not an enum at the DB level) so future providers
+ * (Firstbase, Doola, etc.) can extend without a schema change. Code
+ * pinning lands in `OrganizationService` (Phase 6).
+ */
+export type OrganizationRegistrationProvider = 'manual' | 'stripe-atlas' | (string & {});
+
+/**
+ * Lifecycle of the Organization's registration with its provider.
+ *
+ * `draft`      — record exists but provider work hasn't started.
+ * `pending`    — provider workflow in flight (e.g. Stripe Atlas
+ *                paperwork submitted, awaiting confirmation).
+ * `registered` — provider returned success; org is a real legal entity.
+ *
+ * Manual orgs ([spec.md §5.2 Settings path](../../../../docs/specs/features/tenants-and-organizations/spec.md#52-user-creates-their-first-organization))
+ * land directly in `registered`. Stripe-Atlas orgs traverse the full
+ * lifecycle.
+ */
+export type OrganizationRegistrationStatus = 'draft' | 'pending' | 'registered';
+
+/**
+ * EW-653 (Tenants & Organizations Phase 1) — user-facing scope inside a
+ * Tenant. See
+ * [spec.md §1.2](../../../../docs/specs/features/tenants-and-organizations/spec.md#12-organization-user-facing--ui-label-varies).
+ *
+ * **UI label varies by surface:**
+ * - "Organization" — Settings, WorkspaceSwitcher (EW-660 Phase 8).
+ * - "Company"      — `+ New` page chip + Stripe Atlas flow (EW-662 Phase 10).
+ *
+ * Same DB row either way. The wording-vs-DB split is intentional —
+ * "Company" reads naturally to founders, but "Organization" is the
+ * internal name across the API and DB.
+ *
+ * **Cardinality:** 1 Tenant : 0..N Organizations. Created via either:
+ *   1. `POST /api/organizations` from the Settings / Switcher modal
+ *      (Phase 6 / EW-658), or
+ *   2. A Work of type Company transitioning to `registered` status —
+ *      the Phase 10 wire-up creates the `Organization` row with
+ *      `linkedWorkId` pointing at the Work.
+ *
+ * **Slug:** globally unique across the `organizations` table.
+ * Cross-table collision against `users.slug` and `tenants.slug` is
+ * enforced by `UsernameAllocatorService.allocateSlug` (EW-652) at
+ * write time, not at DB level.
+ *
+ * Indexes:
+ * - UNIQUE on `slug` — required for the routing layer (Phase 7).
+ * - `idx_organizations_tenant_created` on `(tenantId, createdAt)` —
+ *   feeds the WorkspaceSwitcher's "list my Orgs" query, ordered by
+ *   creation time so newer Orgs naturally appear at the top.
+ */
+@Entity({ name: 'organizations' })
+@Index('idx_organizations_tenant_created', ['tenantId', 'createdAt'])
+export class Organization {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column('uuid')
+    tenantId: string;
+
+    @ManyToOne(() => Tenant, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'tenantId' })
+    tenant?: Tenant;
+
+    /**
+     * URL-safe slug. Globally unique across the `organizations` table.
+     * Used as the URL path segment by the slug routing layer (Phase 7 /
+     * EW-659): `/{slug}/missions/...`. Allocated by
+     * `UsernameAllocatorService` with cross-table collision checks
+     * against `users.slug` and `tenants.slug`.
+     */
+    @Column({ type: 'varchar', length: 64, unique: true })
+    slug: string;
+
+    /**
+     * Registered legal name (if applicable) — e.g. "Acme, Inc." for an
+     * Org backed by a Stripe Atlas registration. Nullable for
+     * unregistered Orgs (e.g. an unincorporated team's draft).
+     */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    legalName?: string | null;
+
+    /**
+     * Human-friendly name shown in the WorkspaceSwitcher and Settings.
+     * Falls back to `legalName` when present, otherwise prompts the
+     * user for a name at create time.
+     */
+    @Column({ type: 'varchar', length: 200 })
+    displayName: string;
+
+    /**
+     * ISO 3166-1 alpha-2 country code (e.g. "US", "DE"). Used by the
+     * Stripe Atlas integration to route to the right entity-formation
+     * pipeline. Nullable until a provider workflow specifies a
+     * jurisdiction.
+     */
+    @Column({ type: 'varchar', length: 2, nullable: true })
+    countryCode?: string | null;
+
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    registrationProvider?: OrganizationRegistrationProvider | null;
+
+    @Column({ type: 'varchar', length: 16, default: 'draft' })
+    registrationStatus: OrganizationRegistrationStatus;
+
+    /**
+     * Optional pointer back to the Work-of-type-Company that produced
+     * this Organization (Phase 10 wire-up). NULL for Orgs created
+     * directly via the Settings UI or `POST /api/organizations`.
+     *
+     * Stored here as a UUID without an FK constraint — `works.id` is a
+     * UUID column but adding the FK from the agent package would
+     * create a circular dependency between `Organization` and `Work`
+     * (Work already has `organizationId` going the other direction,
+     * which is upgraded to a real FK in Phase 4 / EW-656). The FK on
+     * THIS column can be added in a later phase if the constraint
+     * proves valuable; for now, the relationship is service-enforced.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    linkedWorkId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/tenant.entity.ts
+++ b/packages/agent/src/entities/tenant.entity.ts
@@ -1,0 +1,76 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    JoinColumn,
+    OneToOne,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+/**
+ * EW-653 (Tenants & Organizations Phase 1) — internal-only scope
+ * primitive. Every business-level row in the system eventually carries
+ * `tenantId` pointing here. See
+ * [spec.md §1.1](../../../../docs/specs/features/tenants-and-organizations/spec.md#11-tenant-internal-only-never-shown-in-ui)
+ * for the full design.
+ *
+ * **Never appears in the UI** — the user-facing concepts are
+ * `Organization` (settings, switcher) and `Company` (`+ New` chip,
+ * Stripe Atlas flow). Both map to `Organization` rows under the
+ * Tenant. The Tenant is the always-present default container.
+ *
+ * **Cardinality:** 1 User : 1 Tenant. The Tenant row is created
+ * lazily the first time the user creates an Organization (Phase 6 /
+ * EW-658). Existing users have `tenantId = NULL` on their `User` row
+ * and have no Tenant at all until that moment.
+ *
+ * **Slug:** mirrors `users.slug` at creation time so the bare-Tenant
+ * URL view (`/{userSlug}/missions/...`) resolves correctly. Globally
+ * unique within the `tenants` table; the `UsernameAllocatorService`
+ * (EW-652 Phase 0) also enforces no cross-table collision against
+ * `users.slug` and `organizations.slug` at write time.
+ */
+@Entity({ name: 'tenants' })
+export class Tenant {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /**
+     * FK back to the User that owns this Tenant. 1:1 for v1 — multi-
+     * tenant per user is a v1.1 consideration (would require dropping
+     * the UNIQUE constraint on this column). The reverse relation lives
+     * on the User entity as `tenantId` (added in Phase 2 / EW-654).
+     */
+    @Column('uuid', { unique: true })
+    ownerUserId: string;
+
+    @OneToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'ownerUserId' })
+    ownerUser?: User;
+
+    /**
+     * URL-safe slug. Mirrors `users.slug` for the bare-Tenant view's URL
+     * resolution. Globally unique across the `tenants` table; the
+     * cross-table collision check (vs `users.slug` and
+     * `organizations.slug`) is enforced by `UsernameAllocatorService`
+     * at write time, not at DB level.
+     */
+    @Column({ type: 'varchar', length: 64 })
+    slug: string;
+
+    /**
+     * Human-readable name surfaced internally (admin tooling, logs).
+     * Falls back to the owner's `username` at create time. Never shown
+     * to end users.
+     */
+    @Column({ type: 'varchar', length: 200 })
+    displayName: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/tenant.entity.ts
+++ b/packages/agent/src/entities/tenant.entity.ts
@@ -52,12 +52,15 @@ export class Tenant {
 
     /**
      * URL-safe slug. Mirrors `users.slug` for the bare-Tenant view's URL
-     * resolution. Globally unique across the `tenants` table; the
-     * cross-table collision check (vs `users.slug` and
-     * `organizations.slug`) is enforced by `UsernameAllocatorService`
-     * at write time, not at DB level.
+     * resolution. Globally unique across the `tenants` table (enforced
+     * by `idx_tenants_slug_unique` in the migration AND by `unique: true`
+     * here for synchronize-based contexts — the CLI/local SQLite path
+     * and in-memory integration tests build schemas from entity
+     * decorators, not migrations). The cross-table collision check
+     * (vs `users.slug` and `organizations.slug`) is enforced by
+     * `UsernameAllocatorService` at write time.
      */
-    @Column({ type: 'varchar', length: 64 })
+    @Column({ type: 'varchar', length: 64, unique: true })
     slug: string;
 
     /**


### PR DESCRIPTION
## Summary

Phase 1 of the [Tenants & Organizations](https://github.com/ever-works/ever-works/blob/develop/docs/specs/features/tenants-and-organizations/spec.md) foundation work. **Additive only** (NN #20). Lands the empty `tenants` + `organizations` tables, entities, and repositories. No row writes happen in this phase; insertions land in Phase 6 ([EW-658](https://evertech.atlassian.net/browse/EW-658)).

Tracking ticket: **[EW-653](https://evertech.atlassian.net/browse/EW-653)** (parent epic: [EW-651](https://evertech.atlassian.net/browse/EW-651)).

## What changes

### Database
- **New migration** [`1779991002000-CreateTenantsTable.ts`](apps/api/src/migrations/1779991002000-CreateTenantsTable.ts) — `tenants` table with FK to `users(id)` ON DELETE CASCADE, UNIQUE indexes on `ownerUserId` (enforces 1:1 User:Tenant in v1) and `slug`.
- **New migration** [`1779991003000-CreateOrganizationsTable.ts`](apps/api/src/migrations/1779991003000-CreateOrganizationsTable.ts) — `organizations` table with FK to `tenants(id)` ON DELETE CASCADE, UNIQUE on `slug` (globally), composite index on `(tenantId, createdAt)` for the WorkspaceSwitcher list query.

### Entities (`packages/agent/src/entities/`)
- **`tenant.entity.ts`** — internal-only scope, never shown in UI. Columns: `id`, `ownerUserId` (unique FK), `slug` (unique), `displayName`, timestamps.
- **`organization.entity.ts`** — user-facing scope inside a Tenant (labeled "Organization" in settings, "Company" in chips). Columns: `id`, `tenantId` (FK), `slug` (globally unique), `legalName`, `displayName`, `countryCode`, `registrationProvider`, `registrationStatus`, `linkedWorkId`, timestamps.

### Repositories (`packages/agent/src/database/repositories/`)
- **`tenant.repository.ts`** — `findById`, `findByOwnerUserId`, `findBySlug`, `create`, `save`.
- **`organization.repository.ts`** — `findById`, `findBySlug`, `findByTenantId` (switcher list), `countByTenantId` (first-Org guard for Phase 6's `upgradeFromAccount`), `findByLinkedWorkId`, `create`, `save`, `update`.

### Wiring (the EW-638 single-source-of-truth files)
- `entities/index.ts` — barrel exports both new entities.
- `database/index.ts` — barrel exports both new repositories.
- `database/_repository-inventory.ts` — adds `TenantRepository` + `OrganizationRepository` to `REPOSITORY_PROVIDERS`. Drift checker auto-picks them up.
- `database/_entity-names.ts` — adds `Tenant` + `Organization` to `AGENT_ENTITY_NAMES`.
- `database/database.config.ts` — adds both classes to the `ENTITIES` array fed to `TypeOrmModule.forFeature`.

## What does NOT change (per NN #20)

- No row writes anywhere. Both new tables ship empty on first deploy.
- No FK-back from existing tables to these new tables — that's Phase 2+ (tenantId on users + Tier B/A/C entities).
- No service/controller surface — the `OrganizationService` and the `POST /api/organizations` endpoints land in Phase 6.
- No UI changes.

## Test plan

- [x] `pnpm jest --testPathPattern='(tenant|organization).entity'` — 13/13 metadata-graph assertions pass.
- [x] `pnpm jest --testPathPattern='database.module.spec|database.config.spec'` — 53/53 drift-detector tests pass with the new entities + repositories listed.
- [x] Full agent test suite (273+ suites) passes.
- [x] `turbo build --filter=ever-works-api...` — clean compile, no TSC errors.

## Acceptance criteria (mirrors [acceptance.md Phase 1](docs/specs/features/tenants-and-organizations/acceptance.md#phase-1--tenants-and-organizations-tables))

- AC-1.1 Both tables exist; both indexes present.
- AC-1.2 `DELETE FROM tenants` cascades to delete child Organizations. (FK behaviour configured; runtime behaviour will be exercised in Phase 6 integration tests when rows actually exist.)
- AC-1.3 No row writes — confirmed (this PR adds no INSERT statements anywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EW-658]: https://evertech.atlassian.net/browse/EW-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-653]: https://evertech.atlassian.net/browse/EW-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-651]: https://evertech.atlassian.net/browse/EW-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced multi-tenant support with tenant ownership and unique slugs for tenant routing.
  * Added organizations within tenants, including registration status tracking and tenant-scoped ordering.

* **Tests**
  * Added validation tests for tenant and organization schemas and constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->