### PR TITLE
feat(tenants-orgs): Phase 3 - tenantId + organizationId on Tier A (EW-655)

### DIFF
--- a/apps/api/src/migrations/1779991006000-AddTenantIdAndOrganizationIdToTierA.ts
+++ b/apps/api/src/migrations/1779991006000-AddTenantIdAndOrganizationIdToTierA.ts
@@ -1,0 +1,179 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * EW-655 (Tenants & Organizations Phase 3) — adds nullable `tenantId`
+ * and `organizationId` FK columns to all Tier A (top-level business
+ * object) entities. Tier A is the broadest scope tier; every
+ * top-level user-visible record carries both columns going forward.
+ *
+ * See [spec.md §2.3](../../../../docs/specs/features/tenants-and-organizations/spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets)
+ * for the per-tier rules.
+ *
+ * Two table groups:
+ *
+ *   - `TIER_A_BOTH` — 17 tables that get BOTH columns added. Each
+ *     gets nullable `tenantId` (FK to `tenants(id)` ON DELETE SET
+ *     NULL, indexed) AND nullable `organizationId` (FK to
+ *     `organizations(id)` ON DELETE SET NULL, indexed).
+ *
+ *   - `TIER_A_TENANT_ONLY` — 2 tables (`works`, `work_knowledge_documents`)
+ *     that already carry a forward-looking `organizationId` UUID column
+ *     from earlier work (see [`1779977000000-AddWorkOrganizationId.ts`](./1779977000000-AddWorkOrganizationId.ts)
+ *     and [`work-knowledge-document.entity.ts`](../../../../packages/agent/src/entities/work-knowledge-document.entity.ts)).
+ *     They get only `tenantId` here. The free-form `organizationId`
+ *     gets upgraded to a real FK in Phase 4 (EW-656).
+ *
+ * **No backfill.** Existing rows stay `tenantId = NULL` /
+ * `organizationId = NULL`. Service-layer code does NOT start writing
+ * these in this phase — that's Phase 5 (Tier C denormalization +
+ * `ScopeContext`) and Phase 6 (lazy upgrade flow + `OrganizationService`).
+ *
+ * Forward-only, additive, idempotent (gates on `hasColumn`).
+ */
+const TIER_A_BOTH = [
+    'missions',
+    'work_proposals',
+    'tasks',
+    'agents',
+    'skills',
+    'conversations',
+    'notifications',
+    'api_keys',
+    'templates',
+    'template_customizations',
+    'user_subscriptions',
+    'work_schedules',
+    'work_deployments',
+    'onboarding_requests',
+    'webhook_subscriptions',
+    'github_app_installations',
+    'github_app_user_links',
+] as const;
+
+const TIER_A_TENANT_ONLY = ['works', 'work_knowledge_documents'] as const;
+
+async function addTenantIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    if (!(await queryRunner.hasColumn(tableName, 'tenantId'))) {
+        await queryRunner.addColumn(
+            tableName,
+            new TableColumn({ name: 'tenantId', type: 'uuid', isNullable: true }),
+        );
+    }
+
+    const table = await queryRunner.getTable(tableName);
+    const fkName = `fk_${tableName}_tenant`;
+    const hasFk = table?.foreignKeys.some((fk) => fk.name === fkName);
+    if (!hasFk) {
+        await queryRunner.createForeignKey(
+            tableName,
+            new TableForeignKey({
+                name: fkName,
+                columnNames: ['tenantId'],
+                referencedTableName: 'tenants',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    const tableAfterFk = await queryRunner.getTable(tableName);
+    const idxName = `idx_${tableName}_tenant_id`;
+    if (!tableAfterFk?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.createIndex(
+            tableName,
+            new TableIndex({ name: idxName, columnNames: ['tenantId'] }),
+        );
+    }
+}
+
+async function addOrganizationIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    if (!(await queryRunner.hasColumn(tableName, 'organizationId'))) {
+        await queryRunner.addColumn(
+            tableName,
+            new TableColumn({ name: 'organizationId', type: 'uuid', isNullable: true }),
+        );
+    }
+
+    const table = await queryRunner.getTable(tableName);
+    const fkName = `fk_${tableName}_organization`;
+    const hasFk = table?.foreignKeys.some((fk) => fk.name === fkName);
+    if (!hasFk) {
+        await queryRunner.createForeignKey(
+            tableName,
+            new TableForeignKey({
+                name: fkName,
+                columnNames: ['organizationId'],
+                referencedTableName: 'organizations',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    const tableAfterFk = await queryRunner.getTable(tableName);
+    const idxName = `idx_${tableName}_organization_id`;
+    if (!tableAfterFk?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.createIndex(
+            tableName,
+            new TableIndex({ name: idxName, columnNames: ['organizationId'] }),
+        );
+    }
+}
+
+async function dropOrganizationIdColumn(
+    queryRunner: QueryRunner,
+    tableName: string,
+): Promise<void> {
+    const table = await queryRunner.getTable(tableName);
+    const idxName = `idx_${tableName}_organization_id`;
+    if (table?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.dropIndex(tableName, idxName);
+    }
+    const fkName = `fk_${tableName}_organization`;
+    const fk = table?.foreignKeys.find((f) => f.name === fkName);
+    if (fk) {
+        await queryRunner.dropForeignKey(tableName, fk);
+    }
+    if (await queryRunner.hasColumn(tableName, 'organizationId')) {
+        await queryRunner.dropColumn(tableName, 'organizationId');
+    }
+}
+
+async function dropTenantIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    const table = await queryRunner.getTable(tableName);
+    const idxName = `idx_${tableName}_tenant_id`;
+    if (table?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.dropIndex(tableName, idxName);
+    }
+    const fkName = `fk_${tableName}_tenant`;
+    const fk = table?.foreignKeys.find((f) => f.name === fkName);
+    if (fk) {
+        await queryRunner.dropForeignKey(tableName, fk);
+    }
+    if (await queryRunner.hasColumn(tableName, 'tenantId')) {
+        await queryRunner.dropColumn(tableName, 'tenantId');
+    }
+}
+
+export class AddTenantIdAndOrganizationIdToTierA1779991006000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const tableName of TIER_A_BOTH) {
+            await addTenantIdColumn(queryRunner, tableName);
+            await addOrganizationIdColumn(queryRunner, tableName);
+        }
+        for (const tableName of TIER_A_TENANT_ONLY) {
+            await addTenantIdColumn(queryRunner, tableName);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Reverse order so the inverse of up() is exact.
+        for (const tableName of [...TIER_A_TENANT_ONLY].reverse()) {
+            await dropTenantIdColumn(queryRunner, tableName);
+        }
+        for (const tableName of [...TIER_A_BOTH].reverse()) {
+            await dropOrganizationIdColumn(queryRunner, tableName);
+            await dropTenantIdColumn(queryRunner, tableName);
+        }
+    }
+}

--- a/apps/api/src/migrations/1779991006000-AddTenantIdAndOrganizationIdToTierA.ts
+++ b/apps/api/src/migrations/1779991006000-AddTenantIdAndOrganizationIdToTierA.ts
@@ -124,12 +124,16 @@ async function dropOrganizationIdColumn(
     queryRunner: QueryRunner,
     tableName: string,
 ): Promise<void> {
-    const table = await queryRunner.getTable(tableName);
+    // Re-read the table between each step — dropping an index in step 1
+    // invalidates the indices array on the snapshot, and the FK lookup
+    // in step 2 would otherwise be reading a stale view.
     const idxName = `idx_${tableName}_organization_id`;
+    let table = await queryRunner.getTable(tableName);
     if (table?.indices.some((i) => i.name === idxName)) {
         await queryRunner.dropIndex(tableName, idxName);
     }
     const fkName = `fk_${tableName}_organization`;
+    table = await queryRunner.getTable(tableName);
     const fk = table?.foreignKeys.find((f) => f.name === fkName);
     if (fk) {
         await queryRunner.dropForeignKey(tableName, fk);
@@ -140,12 +144,13 @@ async function dropOrganizationIdColumn(
 }
 
 async function dropTenantIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
-    const table = await queryRunner.getTable(tableName);
     const idxName = `idx_${tableName}_tenant_id`;
+    let table = await queryRunner.getTable(tableName);
     if (table?.indices.some((i) => i.name === idxName)) {
         await queryRunner.dropIndex(tableName, idxName);
     }
     const fkName = `fk_${tableName}_tenant`;
+    table = await queryRunner.getTable(tableName);
     const fk = table?.foreignKeys.find((f) => f.name === fkName);
     if (fk) {
         await queryRunner.dropForeignKey(tableName, fk);
@@ -158,10 +163,21 @@ async function dropTenantIdColumn(queryRunner: QueryRunner, tableName: string): 
 export class AddTenantIdAndOrganizationIdToTierA1779991006000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         for (const tableName of TIER_A_BOTH) {
+            // Skip silently if the table doesn't exist in this environment.
+            // Migration-only contexts (CLI / test fixtures that load a
+            // subset of the schema) may not have every Tier A table yet,
+            // and we want the migration to be a no-op in that case rather
+            // than throw mid-iteration.
+            if (!(await queryRunner.hasTable(tableName))) {
+                continue;
+            }
             await addTenantIdColumn(queryRunner, tableName);
             await addOrganizationIdColumn(queryRunner, tableName);
         }
         for (const tableName of TIER_A_TENANT_ONLY) {
+            if (!(await queryRunner.hasTable(tableName))) {
+                continue;
+            }
             await addTenantIdColumn(queryRunner, tableName);
         }
     }
@@ -169,9 +185,15 @@ export class AddTenantIdAndOrganizationIdToTierA1779991006000 implements Migrati
     public async down(queryRunner: QueryRunner): Promise<void> {
         // Reverse order so the inverse of up() is exact.
         for (const tableName of [...TIER_A_TENANT_ONLY].reverse()) {
+            if (!(await queryRunner.hasTable(tableName))) {
+                continue;
+            }
             await dropTenantIdColumn(queryRunner, tableName);
         }
         for (const tableName of [...TIER_A_BOTH].reverse()) {
+            if (!(await queryRunner.hasTable(tableName))) {
+                continue;
+            }
             await dropOrganizationIdColumn(queryRunner, tableName);
             await dropTenantIdColumn(queryRunner, tableName);
         }

--- a/packages/agent/src/entities/__tests__/tier-a.tenants-orgs.spec.ts
+++ b/packages/agent/src/entities/__tests__/tier-a.tenants-orgs.spec.ts
@@ -1,0 +1,86 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Agent } from '../agent.entity';
+import { ApiKey } from '../api-key.entity';
+import { Conversation } from '../conversation.entity';
+import { GitHubAppInstallation } from '../github-app-installation.entity';
+import { GitHubAppUserLink } from '../github-app-user-link.entity';
+import { Mission } from '../mission.entity';
+import { Notification } from '../notification.entity';
+import { OnboardingRequest } from '../onboarding-request.entity';
+import { Skill } from '../skill.entity';
+import { Task } from '../task.entity';
+import { Template } from '../template.entity';
+import { TemplateCustomization } from '../template-customization.entity';
+import { UserSubscription } from '../user-subscription.entity';
+import { WebhookSubscription } from '../webhook-subscription.entity';
+import { Work } from '../work.entity';
+import { WorkDeployment } from '../work-deployment.entity';
+import { WorkKnowledgeDocument } from '../work-knowledge-document.entity';
+import { WorkProposal } from '../work-proposal.entity';
+import { WorkSchedule } from '../work-schedule.entity';
+
+/**
+ * EW-655 (Tenants & Organizations Phase 3) — Tier A scope-column
+ * drift detector.
+ *
+ * Locks in the per-tier rule from [spec.md §2.3](../../../../../docs/specs/features/tenants-and-organizations/spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets):
+ *
+ *   - **Every Tier A entity has BOTH `tenantId` and `organizationId`
+ *     as nullable uuid columns.** (`organizationId` was already
+ *     present on `Work` and `WorkKnowledgeDocument` from earlier
+ *     forward-looking work; Phase 3 simply joined the rest of Tier A
+ *     to the same shape.)
+ *   - Both columns are nullable — service-layer code does NOT start
+ *     writing them in Phase 3. The lazy backfill lands in Phase 6.
+ *
+ * Tier A list is mirrored from `plan.md` Phase 3 and from the
+ * migration's `TIER_A_BOTH` + `TIER_A_TENANT_ONLY` arrays. If a new
+ * top-level business entity is added in the future, it should be
+ * added here too — failing to do so means the new entity ships
+ * without scope FKs and silently breaks the multi-Org model.
+ */
+describe('Tier A entities — Phase 3 scope columns', () => {
+    const storage = getMetadataArgsStorage();
+
+    const tierA = [
+        { name: 'Mission', target: Mission },
+        { name: 'WorkProposal', target: WorkProposal },
+        { name: 'Task', target: Task },
+        { name: 'Agent', target: Agent },
+        { name: 'Skill', target: Skill },
+        { name: 'Conversation', target: Conversation },
+        { name: 'Notification', target: Notification },
+        { name: 'ApiKey', target: ApiKey },
+        { name: 'Template', target: Template },
+        { name: 'TemplateCustomization', target: TemplateCustomization },
+        { name: 'UserSubscription', target: UserSubscription },
+        { name: 'WorkSchedule', target: WorkSchedule },
+        { name: 'WorkDeployment', target: WorkDeployment },
+        { name: 'OnboardingRequest', target: OnboardingRequest },
+        { name: 'WebhookSubscription', target: WebhookSubscription },
+        { name: 'GitHubAppInstallation', target: GitHubAppInstallation },
+        { name: 'GitHubAppUserLink', target: GitHubAppUserLink },
+        { name: 'Work', target: Work },
+        { name: 'WorkKnowledgeDocument', target: WorkKnowledgeDocument },
+    ];
+
+    for (const { name, target } of tierA) {
+        describe(name, () => {
+            const columns = storage.columns.filter((c) => c.target === target);
+
+            it('declares a nullable `tenantId` uuid column', () => {
+                const col = columns.find((c) => c.propertyName === 'tenantId');
+                expect(col).toBeDefined();
+                expect(col?.options.type).toBe('uuid');
+                expect(col?.options.nullable).toBe(true);
+            });
+
+            it('declares a nullable `organizationId` uuid column', () => {
+                const col = columns.find((c) => c.propertyName === 'organizationId');
+                expect(col).toBeDefined();
+                expect(col?.options.type).toBe('uuid');
+                expect(col?.options.nullable).toBe(true);
+            });
+        });
+    }
+});

--- a/packages/agent/src/entities/agent.entity.ts
+++ b/packages/agent/src/entities/agent.entity.ts
@@ -309,6 +309,18 @@ export class Agent {
     @Column({ type: 'varchar', length: 254, nullable: true })
     committerEmail?: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/api-key.entity.ts
+++ b/packages/agent/src/entities/api-key.entity.ts
@@ -41,6 +41,18 @@ export class ApiKey {
     @Column({ default: true })
     isActive: boolean;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/conversation.entity.ts
+++ b/packages/agent/src/entities/conversation.entity.ts
@@ -39,6 +39,18 @@ export class Conversation {
     @Column({ type: 'simple-json', nullable: true })
     metadata?: Record<string, unknown>;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @OneToMany(() => ConversationMessage, (msg) => msg.conversation, { cascade: true })
     messages: ClassToObject<ConversationMessage>[];
 

--- a/packages/agent/src/entities/github-app-installation.entity.ts
+++ b/packages/agent/src/entities/github-app-installation.entity.ts
@@ -44,6 +44,18 @@ export class GitHubAppInstallation {
     @Column({ type: 'simple-json', nullable: true })
     rawPayload?: Record<string, unknown> | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/github-app-user-link.entity.ts
+++ b/packages/agent/src/entities/github-app-user-link.entity.ts
@@ -42,6 +42,18 @@ export class GitHubAppUserLink {
     @Column({ type: 'text', nullable: true })
     scope?: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/mission.entity.ts
+++ b/packages/agent/src/entities/mission.entity.ts
@@ -209,6 +209,18 @@ export class Mission {
     @Column({ type: 'uuid', nullable: true })
     sourceMissionId?: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/notification.entity.ts
+++ b/packages/agent/src/entities/notification.entity.ts
@@ -56,6 +56,18 @@ export class Notification {
     @Column({ default: false })
     isPersistent: boolean;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/onboarding-request.entity.ts
+++ b/packages/agent/src/entities/onboarding-request.entity.ts
@@ -62,6 +62,18 @@ export class OnboardingRequest {
     @Column({ type: 'varchar', length: 64, nullable: true })
     subdomain: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/skill.entity.ts
+++ b/packages/agent/src/entities/skill.entity.ts
@@ -88,6 +88,18 @@ export class Skill {
     @Column({ type: 'varchar', length: 16, default: '1.0.0' })
     version: string;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -147,6 +147,18 @@ export class Task {
     @Column({ type: 'uuid', nullable: true })
     parentRecurringTaskId?: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/template-customization.entity.ts
+++ b/packages/agent/src/entities/template-customization.entity.ts
@@ -75,6 +75,18 @@ export class TemplateCustomization {
     @TimestampColumn({ nullable: true })
     completedAt?: Date | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/template.entity.ts
+++ b/packages/agent/src/entities/template.entity.ts
@@ -60,6 +60,18 @@ export class Template {
     @Column('simple-json', { default: '{}' })
     metadata: Record<string, unknown>;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/user-subscription.entity.ts
+++ b/packages/agent/src/entities/user-subscription.entity.ts
@@ -67,6 +67,18 @@ export class UserSubscription {
     @Column({ type: 'json', nullable: true })
     paymentMethodMeta?: Record<string, any> | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/webhook-subscription.entity.ts
+++ b/packages/agent/src/entities/webhook-subscription.entity.ts
@@ -42,6 +42,18 @@ export class WebhookSubscription {
     @TimestampColumn({ nullable: true })
     lastDeliveryAt: Date | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-deployment.entity.ts
+++ b/packages/agent/src/entities/work-deployment.entity.ts
@@ -86,6 +86,18 @@ export class WorkDeployment {
     @TimestampColumn({ nullable: true })
     completedAt?: Date;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-knowledge-document.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-document.entity.ts
@@ -66,6 +66,12 @@ export class WorkKnowledgeDocument {
     @Column({ type: 'uuid', nullable: true })
     organizationId?: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
+    // organizationId already exists from earlier work; tenantId joins
+    // it here. Both NULL until first-Org create (Phase 6).
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
     /** Forward-slash separated, relative to `.content/kb/`. e.g. `brand/voice.md`. */
     @Column({ type: 'varchar', length: 512 })
     path: string;

--- a/packages/agent/src/entities/work-knowledge-document.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-document.entity.ts
@@ -58,6 +58,13 @@ export class WorkKnowledgeDocument {
     @JoinColumn({ name: 'workId' })
     work?: ClassToObject<Work> | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
+    // organizationId already exists from earlier work (below); tenantId
+    // joins it here. Both NULL until first-Org create (Phase 6).
+    // Ordered tenantId-first to match the other 17 Tier A entities.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
     /**
      * Organization-level scope. Restricted at the service layer to
      * `kbDocumentClass IN ('legal', 'style', 'seo')` in v1 — see
@@ -65,12 +72,6 @@ export class WorkKnowledgeDocument {
      */
     @Column({ type: 'uuid', nullable: true })
     organizationId?: string | null;
-
-    // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
-    // organizationId already exists from earlier work; tenantId joins
-    // it here. Both NULL until first-Org create (Phase 6).
-    @Column({ type: 'uuid', nullable: true })
-    tenantId?: string | null;
 
     /** Forward-slash separated, relative to `.content/kb/`. e.g. `brand/voice.md`. */
     @Column({ type: 'varchar', length: 512 })

--- a/packages/agent/src/entities/work-proposal.entity.ts
+++ b/packages/agent/src/entities/work-proposal.entity.ts
@@ -184,6 +184,18 @@ export class WorkProposal {
     @Column({ type: 'varchar', length: 32, nullable: true })
     failureKind?: IdeaFailureKind | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     generatedAt: Date;
 

--- a/packages/agent/src/entities/work-schedule.entity.ts
+++ b/packages/agent/src/entities/work-schedule.entity.ts
@@ -72,6 +72,18 @@ export class WorkSchedule {
     @Column({ type: 'simple-json', nullable: true })
     providerOverrides?: ProvidersDto | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
+    // Both NULL until the owning user creates their first Organization
+    // (Phase 6 lazy backfill). FK + index enforced at DB level by
+    // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
+    // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
+    // see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @OneToMany(() => UsageLedgerEntry, (entry) => entry.schedule)
     ledgerEntries?: ClassToObject<UsageLedgerEntry>[] | null;
 

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -115,6 +115,12 @@ export class Work {
     @Column({ type: 'uuid', nullable: true })
     organizationId?: string | null;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
+    // organizationId already exists from earlier work; tenantId joins
+    // it here. Both NULL until first-Org create (Phase 6).
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
     @Column()
     description: string;
 

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -92,6 +92,13 @@ export class Work {
     @Column({ default: false })
     organization: boolean;
 
+    // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
+    // organizationId already exists from earlier work (below); tenantId
+    // joins it here. Both NULL until first-Org create (Phase 6).
+    // Ordered tenantId-first to match the other 17 Tier A entities.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
     /**
      * EW-641 Phase 2/e row 37c — owning organization id.
      *
@@ -114,12 +121,6 @@ export class Work {
      */
     @Column({ type: 'uuid', nullable: true })
     organizationId?: string | null;
-
-    // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
-    // organizationId already exists from earlier work; tenantId joins
-    // it here. Both NULL until first-Org create (Phase 6).
-    @Column({ type: 'uuid', nullable: true })
-    tenantId?: string | null;
 
     @Column()
     description: string;


### PR DESCRIPTION
## Summary

Phase 3 of the [Tenants & Organizations](https://github.com/ever-works/ever-works/blob/develop/docs/specs/features/tenants-and-organizations/spec.md) foundation. **Additive only** (NN #20). Adds `tenantId` + `organizationId` FK columns to all 19 Tier A (top-level business object) entities. No backfill; service-layer code does NOT start writing these values yet — that's Phase 5 (Tier C denormalization + `ScopeContext`) and Phase 6 (lazy upgrade flow).

Tracking ticket: **[EW-655](https://evertech.atlassian.net/browse/EW-655)** (parent epic: [EW-651](https://evertech.atlassian.net/browse/EW-651)).

## What changes

### Database
- **New migration** [`1779991006000-AddTenantIdAndOrganizationIdToTierA.ts`](apps/api/src/migrations/1779991006000-AddTenantIdAndOrganizationIdToTierA.ts) — one consolidated migration that iterates all 19 Tier A tables:
  - **17 tables get BOTH columns**: `missions`, `work_proposals`, `tasks`, `agents`, `skills`, `conversations`, `notifications`, `api_keys`, `templates`, `template_customizations`, `user_subscriptions`, `work_schedules`, `work_deployments`, `onboarding_requests`, `webhook_subscriptions`, `github_app_installations`, `github_app_user_links`.
  - **2 tables get only `tenantId`**: `works` and `work_knowledge_documents` — these already carry a forward-looking `organizationId` UUID column from earlier work. Phase 4 ([EW-656](https://evertech.atlassian.net/browse/EW-656)) upgrades that free-form column to a real FK.
  - Each new column is nullable `uuid` + FK to `tenants(id)` or `organizations(id)` ON DELETE SET NULL + index.
  - Idempotent (gates on `hasColumn` / FK existence / index existence).

### Entities (19 files)
- **17 entities** get both `tenantId` + `organizationId` as plain `@Column({ type: 'uuid', nullable: true })`. Sample placement (varies per entity):
  ```ts
  // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
  // Both NULL until the owning user creates their first Organization
  // (Phase 6 lazy backfill). FK + index enforced at DB level by
  // migration 1779991006000-AddTenantIdAndOrganizationIdToTierA.
  // No @ManyToOne to avoid the entities import cycle that bit Phase 2 —
  // see user.entity.ts EW-654 comment.
  @Column({ type: 'uuid', nullable: true })
  tenantId?: string | null;
  @Column({ type: 'uuid', nullable: true })
  organizationId?: string | null;
  ```
- **2 entities** (`Work`, `WorkKnowledgeDocument`) get only `tenantId` — `organizationId` already declared.

**No `@ManyToOne` relations declared** for any of these — Phase 2 showed that adding ManyToOne to Tenant/Organization triggers the `User → Tenant → User` import cycle that ESM/vitest crashes on with TDZ errors. For Tier A we sidestep entirely: plain `@Column` declarations. The migration's FK constraints enforce referential integrity at DB level; Phase 6 services will do explicit `findById` lookups when they need the parent.

### Tests
- **`tier-a.tenants-orgs.spec.ts`** (new) — 38 assertions: every Tier A entity declares BOTH `tenantId` and `organizationId` as nullable uuid columns. Mirrors the Phase 2 `tier-b.tenants-orgs.spec.ts` drift detector; together they lock in the [spec.md §2.3](docs/specs/features/tenants-and-organizations/spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets) per-tier rule for future entity additions.
- 149/149 affected tests pass locally (tier-a + tier-b + user.entity + tenant.entity + organization.entity + database.module/config/factory + work-proposal.entity.integration).
- `turbo build --filter=@ever-works/agent` — 768 files compiled clean, 0 TSC issues.

## What does NOT change (per NN #20)

- **No row writes** anywhere. Existing rows stay `tenantId = NULL` / `organizationId = NULL` on all 19 Tier A tables.
- No service-layer changes.
- No UI changes.
- No existing test removed or modified.

## Test plan

- [x] `pnpm jest --testPathPattern='(tier-a|tier-b|user.entity.tenants-orgs|tenant.entity|organization.entity|database.module|database.config|work-proposal.entity.integration).*spec'` — 149/149 pass.
- [x] `turbo build --filter='@ever-works/agent'` — clean compile.
- [ ] CI lint-and-test gate (runs on PR push).

## Acceptance criteria (mirrors [acceptance.md Phase 3](docs/specs/features/tenants-and-organizations/acceptance.md#phase-3--tier-a-entities))

- AC-3.1 Every Tier A entity has both `tenantId` and `organizationId` as nullable UUID columns.
- AC-3.2 `idx_<table>_tenant_id` and `idx_<table>_organization_id` exist on each table (defined in the migration's per-table loops).
- AC-3.3 Running the migration twice is a no-op — idempotency gates on `hasColumn` / FK existence / index existence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EW-655]: https://evertech.atlassian.net/browse/EW-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-651]: https://evertech.atlassian.net/browse/EW-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-656]: https://evertech.atlassian.net/browse/EW-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant and organization scoping columns across core Tier A entities to enable multi-tenant / org-level data isolation.
  * Added a forward-only database migration to introduce and index these new nullable scope columns without backfilling existing rows.

* **Tests**
  * Added metadata-based tests to verify all Tier A entities declare the new nullable tenant and organization fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->