### PR TITLE
[EW-657] Phase 5a - Tier C scope columns + migration

### DIFF
--- a/apps/api/src/migrations/1779991009000-AddTenantIdAndOrganizationIdToTierC.ts
+++ b/apps/api/src/migrations/1779991009000-AddTenantIdAndOrganizationIdToTierC.ts
@@ -1,0 +1,202 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * EW-657 (Tenants & Organizations Phase 5a) — adds nullable
+ * `tenantId` and `organizationId` FK columns to all Tier C child
+ * tables. Mirrors the Tier A migration in
+ * [`1779991006000-AddTenantIdAndOrganizationIdToTierA.ts`](./1779991006000-AddTenantIdAndOrganizationIdToTierA.ts).
+ *
+ * See [spec.md §2.3](../../../../docs/specs/features/tenants-and-organizations/spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets)
+ * for the per-tier rules.
+ *
+ * Tier C are denormalized child rows of Tier A objects (e.g.,
+ * `task_assignees` is a child of `tasks`; `agent_runs` is a child of
+ * `agents`). Each Tier C row carries BOTH columns as a denormalized
+ * copy of its parent's scope. Per the design call recorded in the
+ * spec, the denormalization wins over a join because every read path
+ * already filters by scope; carrying the scope alongside avoids a
+ * Tier A lookup on every Tier C read.
+ *
+ * **No backfill.** Existing Tier C rows stay `tenantId = NULL` /
+ * `organizationId = NULL`. The service-layer code that starts writing
+ * these on insert lands in Phase 5b (EW-657 cont. — ScopeContext
+ * provider + service-layer wiring). The lazy backfill that promotes
+ * existing rows on the user's first-Org upgrade lands in Phase 6
+ * (EW-658).
+ *
+ * **No entity-level `@ManyToOne` to Tenant / Organization.** Same
+ * rationale as Phase 2's `User` entity (see EW-654 import-cycle
+ * comment on [`user.entity.ts`](../../../../packages/agent/src/entities/user.entity.ts)):
+ * Tier C entities are imported widely; adding `@ManyToOne(() => Tenant)`
+ * or `@ManyToOne(() => Organization)` would re-introduce the User →
+ * ... → Tier C → Tenant → User cycle that crashed ESM/vitest in
+ * Phase 2. The FK is enforced at DB level; service-layer code that
+ * needs the parent Tenant / Organization does explicit repository
+ * lookups.
+ *
+ * Forward-only, additive, idempotent (gates on `hasColumn` and
+ * `hasTable`).
+ */
+const TIER_C_TABLES = [
+    'conversation_messages',
+    'task_assignees',
+    'task_approvers',
+    'task_reviewers',
+    'task_watchers',
+    'task_blocks',
+    'task_chat_messages',
+    'task_kb_mentions',
+    'task_attachments',
+    'task_relations',
+    'agent_runs',
+    'agent_run_logs',
+    'agent_budgets',
+    'agent_memberships',
+    'skill_bindings',
+    'work_members',
+    'work_invitations',
+    'work_generation_history',
+    'work_knowledge_chunks',
+    'work_knowledge_citations',
+    'work_knowledge_tags',
+    'work_knowledge_uploads',
+    'webhook_deliveries',
+    'usage_ledger_entries',
+    'plugin_usage_events',
+    'activity_log',
+] as const;
+
+async function addTenantIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    if (!(await queryRunner.hasColumn(tableName, 'tenantId'))) {
+        await queryRunner.addColumn(
+            tableName,
+            new TableColumn({ name: 'tenantId', type: 'uuid', isNullable: true }),
+        );
+    }
+
+    const table = await queryRunner.getTable(tableName);
+    const fkName = `fk_${tableName}_tenant`;
+    const hasFk = table?.foreignKeys.some((fk) => fk.name === fkName);
+    if (!hasFk) {
+        await queryRunner.createForeignKey(
+            tableName,
+            new TableForeignKey({
+                name: fkName,
+                columnNames: ['tenantId'],
+                referencedTableName: 'tenants',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    const tableAfterFk = await queryRunner.getTable(tableName);
+    const idxName = `idx_${tableName}_tenant_id`;
+    if (!tableAfterFk?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.createIndex(
+            tableName,
+            new TableIndex({ name: idxName, columnNames: ['tenantId'] }),
+        );
+    }
+}
+
+async function addOrganizationIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    if (!(await queryRunner.hasColumn(tableName, 'organizationId'))) {
+        await queryRunner.addColumn(
+            tableName,
+            new TableColumn({ name: 'organizationId', type: 'uuid', isNullable: true }),
+        );
+    }
+
+    const table = await queryRunner.getTable(tableName);
+    const fkName = `fk_${tableName}_organization`;
+    const hasFk = table?.foreignKeys.some((fk) => fk.name === fkName);
+    if (!hasFk) {
+        await queryRunner.createForeignKey(
+            tableName,
+            new TableForeignKey({
+                name: fkName,
+                columnNames: ['organizationId'],
+                referencedTableName: 'organizations',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    const tableAfterFk = await queryRunner.getTable(tableName);
+    const idxName = `idx_${tableName}_organization_id`;
+    if (!tableAfterFk?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.createIndex(
+            tableName,
+            new TableIndex({ name: idxName, columnNames: ['organizationId'] }),
+        );
+    }
+}
+
+async function dropOrganizationIdColumn(
+    queryRunner: QueryRunner,
+    tableName: string,
+): Promise<void> {
+    // Re-read the table between each step — dropping an index in step 1
+    // invalidates the indices array on the snapshot, and the FK lookup
+    // in step 2 would otherwise be reading a stale view.
+    const idxName = `idx_${tableName}_organization_id`;
+    let table = await queryRunner.getTable(tableName);
+    if (table?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.dropIndex(tableName, idxName);
+    }
+    const fkName = `fk_${tableName}_organization`;
+    table = await queryRunner.getTable(tableName);
+    const fk = table?.foreignKeys.find((f) => f.name === fkName);
+    if (fk) {
+        await queryRunner.dropForeignKey(tableName, fk);
+    }
+    if (await queryRunner.hasColumn(tableName, 'organizationId')) {
+        await queryRunner.dropColumn(tableName, 'organizationId');
+    }
+}
+
+async function dropTenantIdColumn(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    const idxName = `idx_${tableName}_tenant_id`;
+    let table = await queryRunner.getTable(tableName);
+    if (table?.indices.some((i) => i.name === idxName)) {
+        await queryRunner.dropIndex(tableName, idxName);
+    }
+    const fkName = `fk_${tableName}_tenant`;
+    table = await queryRunner.getTable(tableName);
+    const fk = table?.foreignKeys.find((f) => f.name === fkName);
+    if (fk) {
+        await queryRunner.dropForeignKey(tableName, fk);
+    }
+    if (await queryRunner.hasColumn(tableName, 'tenantId')) {
+        await queryRunner.dropColumn(tableName, 'tenantId');
+    }
+}
+
+export class AddTenantIdAndOrganizationIdToTierC1779991009000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const tableName of TIER_C_TABLES) {
+            // Skip silently if the table doesn't exist in this environment.
+            // Migration-only contexts (CLI / test fixtures that load a
+            // subset of the schema) may not have every Tier C table yet,
+            // and we want the migration to be a no-op in that case rather
+            // than throw mid-iteration.
+            if (!(await queryRunner.hasTable(tableName))) {
+                continue;
+            }
+            await addTenantIdColumn(queryRunner, tableName);
+            await addOrganizationIdColumn(queryRunner, tableName);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const tableName of [...TIER_C_TABLES].reverse()) {
+            if (!(await queryRunner.hasTable(tableName))) {
+                continue;
+            }
+            await dropOrganizationIdColumn(queryRunner, tableName);
+            await dropTenantIdColumn(queryRunner, tableName);
+        }
+    }
+}

--- a/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
+++ b/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
@@ -1,0 +1,102 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { ActivityLog } from '../activity-log.entity';
+import { AgentBudget } from '../agent-budget.entity';
+import { AgentMembership } from '../agent-membership.entity';
+import { AgentRun } from '../agent-run.entity';
+import { AgentRunLog } from '../agent-run-log.entity';
+import { ConversationMessage } from '../conversation-message.entity';
+import { PluginUsageEvent } from '../plugin-usage-event.entity';
+import { SkillBinding } from '../skill-binding.entity';
+import { TaskApprover } from '../task-approver.entity';
+import { TaskAssignee } from '../task-assignee.entity';
+import { TaskAttachment } from '../task-attachment.entity';
+import { TaskBlock } from '../task-block.entity';
+import { TaskChatMessage } from '../task-chat-message.entity';
+import { TaskKbMention } from '../task-kb-mention.entity';
+import { TaskRelation } from '../task-relation.entity';
+import { TaskReviewer } from '../task-reviewer.entity';
+import { TaskWatcher } from '../task-watcher.entity';
+import { UsageLedgerEntry } from '../usage-ledger-entry.entity';
+import { WebhookDelivery } from '../webhook-delivery.entity';
+import { WorkGenerationHistory } from '../work-generation-history.entity';
+import { WorkInvitation } from '../work-invitation.entity';
+import { WorkKnowledgeChunk } from '../work-knowledge-chunk.entity';
+import { WorkKnowledgeCitation } from '../work-knowledge-citation.entity';
+import { WorkKnowledgeTag } from '../work-knowledge-tag.entity';
+import { WorkKnowledgeUpload } from '../work-knowledge-upload.entity';
+import { WorkMember } from '../work-member.entity';
+
+/**
+ * EW-657 (Tenants & Organizations Phase 5a) — Tier C scope-column
+ * drift detector.
+ *
+ * Locks in the per-tier rule from [spec.md §2.3](../../../../../docs/specs/features/tenants-and-organizations/spec.md#23-three-tiers-of-entities-which-columns-each-tier-gets):
+ *
+ *   - **Every Tier C entity has BOTH `tenantId` and `organizationId`
+ *     as nullable uuid columns.** Denormalized copies of the parent
+ *     Tier A's scope — see [plan.md Phase 5](../../../../../docs/specs/features/tenants-and-organizations/plan.md#phase-5--tier-c-children-denormalize-tenantid-and-organizationid).
+ *   - Both columns are nullable — service-layer code starts writing
+ *     them in Phase 5b (ScopeContext provider). Existing rows backfill
+ *     lazily on the user's first-Org upgrade (Phase 6).
+ *
+ * Tier C list is mirrored from `plan.md` Phase 5, `tasks.md` Phase 5,
+ * and the migration's `TIER_C_TABLES` array. If a new child entity is
+ * added in the future, it should be added here too — failing to do so
+ * means the new child ships without scope FKs and silently breaks the
+ * multi-Org model.
+ *
+ * Mirror of [`tier-a.tenants-orgs.spec.ts`](./tier-a.tenants-orgs.spec.ts) and
+ * [`tier-b.tenants-orgs.spec.ts`](./tier-b.tenants-orgs.spec.ts).
+ */
+describe('Tier C entities — Phase 5a scope columns', () => {
+    const storage = getMetadataArgsStorage();
+
+    const tierC = [
+        { name: 'ConversationMessage', target: ConversationMessage },
+        { name: 'TaskAssignee', target: TaskAssignee },
+        { name: 'TaskApprover', target: TaskApprover },
+        { name: 'TaskReviewer', target: TaskReviewer },
+        { name: 'TaskWatcher', target: TaskWatcher },
+        { name: 'TaskBlock', target: TaskBlock },
+        { name: 'TaskChatMessage', target: TaskChatMessage },
+        { name: 'TaskKbMention', target: TaskKbMention },
+        { name: 'TaskAttachment', target: TaskAttachment },
+        { name: 'TaskRelation', target: TaskRelation },
+        { name: 'AgentRun', target: AgentRun },
+        { name: 'AgentRunLog', target: AgentRunLog },
+        { name: 'AgentBudget', target: AgentBudget },
+        { name: 'AgentMembership', target: AgentMembership },
+        { name: 'SkillBinding', target: SkillBinding },
+        { name: 'WorkMember', target: WorkMember },
+        { name: 'WorkInvitation', target: WorkInvitation },
+        { name: 'WorkGenerationHistory', target: WorkGenerationHistory },
+        { name: 'WorkKnowledgeChunk', target: WorkKnowledgeChunk },
+        { name: 'WorkKnowledgeCitation', target: WorkKnowledgeCitation },
+        { name: 'WorkKnowledgeTag', target: WorkKnowledgeTag },
+        { name: 'WorkKnowledgeUpload', target: WorkKnowledgeUpload },
+        { name: 'WebhookDelivery', target: WebhookDelivery },
+        { name: 'UsageLedgerEntry', target: UsageLedgerEntry },
+        { name: 'PluginUsageEvent', target: PluginUsageEvent },
+        { name: 'ActivityLog', target: ActivityLog },
+    ];
+
+    for (const { name, target } of tierC) {
+        describe(name, () => {
+            const columns = storage.columns.filter((c) => c.target === target);
+
+            it('declares a nullable `tenantId` uuid column', () => {
+                const col = columns.find((c) => c.propertyName === 'tenantId');
+                expect(col).toBeDefined();
+                expect(col?.options.type).toBe('uuid');
+                expect(col?.options.nullable).toBe(true);
+            });
+
+            it('declares a nullable `organizationId` uuid column', () => {
+                const col = columns.find((c) => c.propertyName === 'organizationId');
+                expect(col).toBeDefined();
+                expect(col?.options.type).toBe('uuid');
+                expect(col?.options.nullable).toBe(true);
+            });
+        });
+    }
+});

--- a/packages/agent/src/entities/activity-log.entity.ts
+++ b/packages/agent/src/entities/activity-log.entity.ts
@@ -73,6 +73,14 @@ export class ActivityLog {
     @Column({ type: 'varchar', nullable: true })
     userAgent?: string;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/agent-budget.entity.ts
+++ b/packages/agent/src/entities/agent-budget.entity.ts
@@ -68,6 +68,14 @@ export class AgentBudget {
     @Column({ type: 'boolean', default: false })
     allowOverage: boolean;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/agent-membership.entity.ts
+++ b/packages/agent/src/entities/agent-membership.entity.ts
@@ -36,6 +36,14 @@ export class AgentMembership {
     @Column('uuid', { nullable: true })
     targetId?: string | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/agent-run-log.entity.ts
+++ b/packages/agent/src/entities/agent-run-log.entity.ts
@@ -33,6 +33,14 @@ export class AgentRunLog {
     @Column('simple-json', { nullable: true })
     metadata?: Record<string, unknown> | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -81,6 +81,14 @@ export class AgentRun {
     @Column('uuid', { nullable: true })
     chatMessageId?: string | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/conversation-message.entity.ts
+++ b/packages/agent/src/entities/conversation-message.entity.ts
@@ -42,6 +42,14 @@ export class ConversationMessage {
     @Column({ type: 'simple-json', nullable: true })
     usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/plugin-usage-event.entity.ts
+++ b/packages/agent/src/entities/plugin-usage-event.entity.ts
@@ -110,6 +110,14 @@ export class PluginUsageEvent {
     @Column({ type: 'uuid', nullable: true })
     ownerId?: string | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     occurredAt: Date;
 }

--- a/packages/agent/src/entities/skill-binding.entity.ts
+++ b/packages/agent/src/entities/skill-binding.entity.ts
@@ -66,6 +66,14 @@ export class SkillBinding {
     @Column({ type: 'int', default: 100 })
     priority: number;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-approver.entity.ts
+++ b/packages/agent/src/entities/task-approver.entity.ts
@@ -42,6 +42,14 @@ export class TaskApprover {
     @PortableDateColumn({ nullable: true })
     approvedAt?: Date | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-assignee.entity.ts
+++ b/packages/agent/src/entities/task-assignee.entity.ts
@@ -35,6 +35,14 @@ export class TaskAssignee {
     @Column({ type: 'uuid' })
     assigneeId: string;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-attachment.entity.ts
+++ b/packages/agent/src/entities/task-attachment.entity.ts
@@ -31,6 +31,14 @@ export class TaskAttachment {
     @Column({ type: 'uuid' })
     uploadId: string;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-block.entity.ts
+++ b/packages/agent/src/entities/task-block.entity.ts
@@ -31,6 +31,14 @@ export class TaskBlock {
     @Column({ type: 'uuid' })
     blockedByTaskId: string;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-chat-message.entity.ts
+++ b/packages/agent/src/entities/task-chat-message.entity.ts
@@ -59,6 +59,14 @@ export class TaskChatMessage {
     @PortableDateColumn({ nullable: true })
     editedAt?: Date | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/task-kb-mention.entity.ts
+++ b/packages/agent/src/entities/task-kb-mention.entity.ts
@@ -32,6 +32,14 @@ export class TaskKbMention {
     @Column({ type: 'uuid' })
     kbDocumentId: string;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-relation.entity.ts
+++ b/packages/agent/src/entities/task-relation.entity.ts
@@ -35,6 +35,14 @@ export class TaskRelation {
     @Column({ type: 'varchar', length: 16 })
     kind: TaskRelationKind;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-reviewer.entity.ts
+++ b/packages/agent/src/entities/task-reviewer.entity.ts
@@ -42,6 +42,14 @@ export class TaskReviewer {
     @PortableDateColumn({ nullable: true })
     reviewedAt?: Date | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task-watcher.entity.ts
+++ b/packages/agent/src/entities/task-watcher.entity.ts
@@ -36,6 +36,14 @@ export class TaskWatcher {
     @JoinColumn({ name: 'userId' })
     user?: User;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/usage-ledger-entry.entity.ts
+++ b/packages/agent/src/entities/usage-ledger-entry.entity.ts
@@ -106,6 +106,14 @@ export class UsageLedgerEntry {
     @Column({ type: 'uuid', nullable: true })
     ownerId?: string | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/webhook-delivery.entity.ts
+++ b/packages/agent/src/entities/webhook-delivery.entity.ts
@@ -96,6 +96,14 @@ export class WebhookDelivery {
     @TimestampColumn({ nullable: true })
     lastAttemptAt: Date | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-generation-history.entity.ts
+++ b/packages/agent/src/entities/work-generation-history.entity.ts
@@ -114,6 +114,14 @@ export class WorkGenerationHistory {
     @Column({ type: 'text', nullable: true })
     errorMessage?: string | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-invitation.entity.ts
+++ b/packages/agent/src/entities/work-invitation.entity.ts
@@ -78,6 +78,14 @@ export class WorkInvitation {
     @Column({ type: 'simple-json', nullable: true })
     metadata: WorkInvitationMetadata | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-knowledge-chunk.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-chunk.entity.ts
@@ -97,6 +97,14 @@ export class WorkKnowledgeChunk {
     @Column({ type: 'simple-json', nullable: true })
     metadata?: Record<string, unknown> | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/work-knowledge-citation.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-citation.entity.ts
@@ -71,6 +71,14 @@ export class WorkKnowledgeCitation {
     @Column({ type: 'float', nullable: true, name: 'relevance_score' })
     relevanceScore?: number | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/work-knowledge-tag.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-tag.entity.ts
@@ -54,6 +54,14 @@ export class WorkKnowledgeTag {
     @Column({ type: 'text', nullable: true })
     description?: string | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-knowledge-upload.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-upload.entity.ts
@@ -120,6 +120,14 @@ export class WorkKnowledgeUpload {
     @Column({ type: 'simple-json', nullable: true })
     metadata?: Record<string, unknown> | null;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/agent/src/entities/work-member.entity.ts
+++ b/packages/agent/src/entities/work-member.entity.ts
@@ -52,6 +52,14 @@ export class WorkMember {
     @JoinColumn({ name: 'invitedById' })
     invitedBy?: ClassToObject<User>;
 
+    // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
+    // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
     @CreateDateColumn()
     createdAt: Date;
 


### PR DESCRIPTION
## Summary

Phase 5a of the Tenants & Organizations rollout (EW-657, [plan.md Phase 5](https://github.com/ever-works/ever-works/blob/develop/docs/specs/features/tenants-and-organizations/plan.md#phase-5--tier-c-children-denormalize-tenantid-and-organizationid)). Adds nullable `tenantId` + `organizationId` FK columns to all 26 Tier C child tables — denormalized copies of the parent Tier A's scope.

This is the **mechanical half** of Phase 5. The service-layer wiring (ScopeContext request-scoped provider + ~20-30 service files) is intentionally split out as a follow-up PR (Phase 5b) for reviewability.

## What changes

- **1 migration** — `1779991009000-AddTenantIdAndOrganizationIdToTierC.ts` — iterates 26 tables, adds both FK columns + indexes. Same `hasTable`-guarded helper pattern as Phase 3 (PR #1049). Forward-only, additive, idempotent.
- **26 entity files** — each declares `@Column({ type: 'uuid', nullable: true }) tenantId/organizationId` (tenantId first per Phase 3 P2 field-order rule). **No `@ManyToOne`** — cycle-avoidance, matching the EW-654 resolution on [user.entity.ts](https://github.com/ever-works/ever-works/blob/develop/packages/agent/src/entities/user.entity.ts).
- **1 drift-detector spec** — `tier-c.tenants-orgs.spec.ts` mirroring the tier-a/tier-b specs. 52 assertions (26 entities × 2 columns).

## Out of scope

- **Phase 5b (next PR)**: ScopeContext provider + service-layer wiring. New Tier C rows still get NULL scope after this PR lands.
- **Phase 6 (EW-658)**: lazy backfill on first-Org upgrade.

## Tier C tables touched (26)

`conversation_messages`; `task_assignees`, `task_approvers`, `task_reviewers`, `task_watchers`, `task_blocks`, `task_chat_messages`, `task_kb_mentions`, `task_attachments`, `task_relations`; `agent_runs`, `agent_run_logs`, `agent_budgets`, `agent_memberships`; `skill_bindings`; `work_members`, `work_invitations`, `work_generation_history`; `work_knowledge_chunks`, `work_knowledge_citations`, `work_knowledge_tags`, `work_knowledge_uploads`; `webhook_deliveries`, `usage_ledger_entries`, `plugin_usage_events`, `activity_log`.

## Test plan

- [x] `tier-c.tenants-orgs.spec.ts` passes (52/52)
- [x] Full agent suite: 279/279 suites, 5543 tests pass
- [x] `pnpm -F ever-works-api build` clean (0 TSC issues, 437 files via SWC)
- [x] `pnpm format:check` clean
- [ ] CI: lint-and-test (22.x)
- [ ] Codex + Greptile + CodeRabbit reviews clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced system architecture to support improved tenant and organization scoping across multiple entities, enabling better multi-tenant operations and data isolation for organizations using the platform.

* **Tests**
  * Added validation tests to verify tenant and organization scoping functionality across system entities.

* **Chores**
  * Updated database schema to add tenant and organization identifiers to core system tables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->