### PR TITLE
feat(web): dashboard polish — unified 8-tile stats, consistent section headers, Works composer

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -572,14 +572,14 @@
         },
         "agentsPage": {
             "title": "Agents",
-            "subtitle": "Your AI teammates. Each one carries a soul (who they are), instructions, and a budget — and acts on Missions, Works, or your whole tenant.",
+            "subtitle": "Your AI teammates. Each one carries a soul (who they are), instructions, and a budget — and acts on Missions, Works, or your whole Workspace.",
             "newAgent": "New Agent",
             "empty": {
                 "title": "No Agents yet.",
-                "subtitle": "Create your first Agent to delegate recurring work. Tenant-scope Agents act across your whole account; Mission- or Work-scoped ones stay focused on a single target."
+                "subtitle": "Create your first Agent to delegate recurring work. Workspace-scope Agents act across your whole account; Mission- or Work-scoped ones stay focused on a single target."
             },
             "card": {
-                "scopeTenant": "Tenant",
+                "scopeTenant": "Workspace",
                 "scopeMission": "Mission",
                 "scopeWork": "Work",
                 "scopeIdea": "Idea",
@@ -607,7 +607,7 @@
                 "step2Title": "Name your Agent",
                 "nameLabel": "Name",
                 "namePlaceholder": "e.g. CEO, Reviewer, Content Drafter",
-                "scopeTenantDesc": "Acts on your whole tenant",
+                "scopeTenantDesc": "Acts on your whole Workspace",
                 "scopeMissionDesc": "Locked to one Mission",
                 "scopeWorkDesc": "Locked to one Work",
                 "scopeIdeaDesc": "Locked to one Idea",
@@ -719,7 +719,7 @@
                 "mission": "Mission",
                 "idea": "Idea",
                 "work": "Work",
-                "tenant": "Tenant"
+                "tenant": "Workspace"
             }
         },
         "templatesPage": {
@@ -1477,6 +1477,11 @@
             "totalItems": "Total Items",
             "activeWebsites": "Active Websites",
             "monthSpend": "Month Spend",
+            "agents": "Agents",
+            "agentsActive": "{count} active",
+            "tasksInFlight": "Tasks in flight",
+            "tasksBlocked": "{count} blocked",
+            "tasksNoBlockers": "no blockers",
             "fromLastMonth": "from last month"
         },
         "adminUsage": {
@@ -3296,7 +3301,7 @@
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
                 "idea": "A one-shot brief the agent turns into a Work plan you can build.",
-                "agent": "An AI teammate that acts across Missions, Works, or your whole tenant.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
                 "task": "A trackable item assigned to a person or an Agent.",
                 "website": "A multi-page site for a business, service, or brand — generated content + code.",
                 "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
@@ -130,42 +130,50 @@ export default function DashboardClient({
 
             <div className="grid grid-cols-1 @3xl/main:grid-cols-3 gap-8 mt-8">
                 <div className="@3xl/main:col-span-3">
-                    {hasWorks ? (
-                        <>
-                            <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
-                                <div className="flex items-center gap-2 min-w-0">
-                                    <div className="shrink-0 w-9 h-9 rounded-lg bg-accent-indigo/10 border border-accent-indigo/20 flex items-center justify-center">
-                                        <FolderKanban className="w-4 h-4 text-accent-indigo" />
-                                    </div>
-                                    <h2 className="text-xl font-semibold text-text dark:text-text-dark truncate">
-                                        {t('works.recent')}
-                                    </h2>
-                                </div>
-                                <div className="flex flex-nowrap items-center gap-2 shrink-0">
-                                    <Link
-                                        href={ROUTES.DASHBOARD_WORKS_NEW}
-                                        className={cn(
-                                            'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap',
-                                            'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark',
-                                            'text-text-secondary dark:text-text-secondary-dark',
-                                            'hover:border-primary/40 hover:text-primary',
-                                        )}
-                                    >
-                                        <Plus className="w-3.5 h-3.5" />
-                                        Add
-                                    </Link>
-                                    {totalWorks > 5 && (
-                                        <Link
-                                            href={ROUTES.DASHBOARD_WORKS}
-                                            className="text-sm font-medium text-primary hover:underline whitespace-nowrap"
-                                        >
-                                            {t('works.viewAll', { count: totalWorks })}
-                                        </Link>
-                                    )}
-                                </div>
+                    {/* Dashboard polish (2026-05-27) — header is always
+                        rendered (outside the `hasWorks ?` branch) so the
+                        `+ Add` button stays visible for users with zero
+                        Works, matching every other section on the page.
+                        `+ Add` routes to `/new?type=website` (the
+                        unified chip entry point with a Work shape pre-
+                        selected) so the user lands in a Work-creation
+                        surface — `/works/new` without `mode` or
+                        `proposal` redirects back to `/new` and would
+                        otherwise default to Mission/Idea. */}
+                    <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
+                        <div className="flex items-center gap-2 min-w-0">
+                            <div className="shrink-0 w-9 h-9 rounded-lg bg-accent-indigo/10 border border-accent-indigo/20 flex items-center justify-center">
+                                <FolderKanban className="w-4 h-4 text-accent-indigo" />
                             </div>
-                            <WorkList initialWorks={initialWorks} showLimit={GET_WORK_LIST_LIMIT} />
-                        </>
+                            <h2 className="text-xl font-semibold text-text dark:text-text-dark truncate">
+                                {t('works.recent')}
+                            </h2>
+                        </div>
+                        <div className="flex flex-nowrap items-center gap-2 shrink-0">
+                            <Link
+                                href="/new?type=website"
+                                className={cn(
+                                    'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap',
+                                    'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark',
+                                    'text-text-secondary dark:text-text-secondary-dark',
+                                    'hover:border-primary/40 hover:text-primary',
+                                )}
+                            >
+                                <Plus className="w-3.5 h-3.5" />
+                                Add
+                            </Link>
+                            {totalWorks > 5 && (
+                                <Link
+                                    href={ROUTES.DASHBOARD_WORKS}
+                                    className="text-sm font-medium text-primary hover:underline whitespace-nowrap"
+                                >
+                                    {t('works.viewAll', { count: totalWorks })}
+                                </Link>
+                            )}
+                        </div>
+                    </div>
+                    {hasWorks ? (
+                        <WorkList initialWorks={initialWorks} showLimit={GET_WORK_LIST_LIMIT} />
                     ) : (
                         <EmptyState
                             title={t('works.empty.title')}
@@ -173,7 +181,7 @@ export default function DashboardClient({
                             action={{
                                 label: t('works.empty.action'),
                                 onClick: () => {
-                                    router.push(ROUTES.DASHBOARD_NEW);
+                                    router.push('/new?type=website');
                                 },
                             }}
                         />

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/dashboard-client.tsx
@@ -9,15 +9,15 @@ import { EmptyState } from '@/components/common/EmptyState';
 import { GET_WORK_LIST_LIMIT, ROUTES } from '@/lib/constants';
 import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
-import { FolderKanban } from 'lucide-react';
+import { FolderKanban, Plus } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
 import type { Work } from '@/lib/api';
 import type { WorkProposal } from '@/lib/api/work-proposals';
 import type { Mission } from '@/lib/api/missions';
-// Phase 18.1 — Dashboard grid mount.
-import { AgentsCountTile } from '@/components/dashboard/AgentsCountTile';
-import { TasksInProgressTile } from '@/components/dashboard/TasksInProgressTile';
 import { RecentTasks } from '@/components/dashboard/RecentTasks';
+import { AgentsPreviewSection } from '@/components/dashboard/AgentsPreviewSection';
 import type { Task } from '@/lib/api/tasks';
+import type { Agent } from '@/lib/api/agents';
 
 interface DashboardClientProps {
     user: AuthUser;
@@ -43,12 +43,20 @@ interface DashboardClientProps {
      * default to 0 so the props remain backwards-compatible if a
      * page-level fetch fails — the tiles just show zeros instead of
      * disappearing.
+     *
+     * Dashboard polish (2026-05-27) — Agents + Tasks counts now feed
+     * the unified StatsOverview grid; the separate two-tile row from
+     * Phase 18.1 was removed. The counts themselves are still passed
+     * through unchanged.
      */
     agentsTotal?: number;
     agentsActive?: number;
     tasksInProgress?: number;
     tasksBlocked?: number;
     initialRecentTasks?: Task[];
+    /** Dashboard polish (2026-05-27) — recent Agents for the new
+     *  Agents preview section that sits below Tasks. */
+    initialAgents?: Agent[];
 }
 
 export default function DashboardClient({
@@ -72,6 +80,7 @@ export default function DashboardClient({
     tasksInProgress = 0,
     tasksBlocked = 0,
     initialRecentTasks = [],
+    initialAgents = [],
 }: DashboardClientProps) {
     const router = useRouter();
     const t = useTranslations('dashboard');
@@ -88,6 +97,10 @@ export default function DashboardClient({
                 </p>
             </div>
 
+            {/* Dashboard polish (2026-05-27) — single grid of 8 tiles.
+                Agents + Tasks-in-flight moved into StatsOverview so the
+                whole strip collapses to one row when the chat panel is
+                hidden (`@7xl/main:grid-cols-8`). */}
             <StatsOverview
                 totalMissions={totalMissions}
                 totalIdeas={totalIdeas}
@@ -96,17 +109,11 @@ export default function DashboardClient({
                 activeWebsites={activeWebsites}
                 monthSpendCents={monthSpendCents}
                 monthSpendCurrency={monthSpendCurrency}
+                agentsTotal={agentsTotal}
+                agentsActive={agentsActive}
+                tasksInProgress={tasksInProgress}
+                tasksBlocked={tasksBlocked}
             />
-
-            {/* Phase 18.1 — Agents/Skills/Tasks tiles. Sit between the
-                StatsOverview row and the Missions preview so the home
-                page reads: stats → AST tiles → Missions → Works.
-                Counts come from `meta.total` of the page-level
-                list({limit:1}) fetches (cheap). */}
-            <div className="grid grid-cols-1 @md/main:grid-cols-2 gap-4 mt-6">
-                <AgentsCountTile total={agentsTotal} active={agentsActive} />
-                <TasksInProgressTile inProgress={tasksInProgress} blocked={tasksBlocked} />
-            </div>
 
             {/* Phase 6 PR S — Missions preview ABOVE Ideas so the home
                 page reads Missions → Ideas → Works in the same
@@ -125,7 +132,7 @@ export default function DashboardClient({
                 <div className="@3xl/main:col-span-3">
                     {hasWorks ? (
                         <>
-                            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                            <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
                                 <div className="flex items-center gap-2 min-w-0">
                                     <div className="shrink-0 w-9 h-9 rounded-lg bg-accent-indigo/10 border border-accent-indigo/20 flex items-center justify-center">
                                         <FolderKanban className="w-4 h-4 text-accent-indigo" />
@@ -134,14 +141,28 @@ export default function DashboardClient({
                                         {t('works.recent')}
                                     </h2>
                                 </div>
-                                {totalWorks > 5 && (
+                                <div className="flex flex-nowrap items-center gap-2 shrink-0">
                                     <Link
-                                        href={ROUTES.DASHBOARD_WORKS}
-                                        className="text-sm text-primary hover:text-primary-hover transition-colors whitespace-nowrap"
+                                        href={ROUTES.DASHBOARD_WORKS_NEW}
+                                        className={cn(
+                                            'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap',
+                                            'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark',
+                                            'text-text-secondary dark:text-text-secondary-dark',
+                                            'hover:border-primary/40 hover:text-primary',
+                                        )}
                                     >
-                                        {t('works.viewAll', { count: totalWorks })}
+                                        <Plus className="w-3.5 h-3.5" />
+                                        Add
                                     </Link>
-                                )}
+                                    {totalWorks > 5 && (
+                                        <Link
+                                            href={ROUTES.DASHBOARD_WORKS}
+                                            className="text-sm font-medium text-primary hover:underline whitespace-nowrap"
+                                        >
+                                            {t('works.viewAll', { count: totalWorks })}
+                                        </Link>
+                                    )}
+                                </div>
                             </div>
                             <WorkList initialWorks={initialWorks} showLimit={GET_WORK_LIST_LIMIT} />
                         </>
@@ -160,15 +181,18 @@ export default function DashboardClient({
                 </div>
             </div>
 
-            {/* Phase 18.2 — Recent Tasks block sits directly below
-                Recent Works per spec §18.2. Hidden when there are
-                no in-flight Tasks AND no Works (empty new-user state
-                already has its own empty CTA from EmptyState above). */}
-            {(initialRecentTasks.length > 0 || hasWorks) && (
-                <div className="mt-8">
-                    <RecentTasks tasks={initialRecentTasks} />
-                </div>
-            )}
+            {/* Phase 18.2 — Tasks block sits directly below Recent
+                Works. Dashboard polish (2026-05-27) — always render
+                so the dashboard reads Missions → Ideas → Works →
+                Tasks → Agents in a consistent strip even on a
+                brand-new account; the section's own empty state
+                handles the "no Tasks yet" copy. */}
+            <RecentTasks tasks={initialRecentTasks} total={tasksInProgress} />
+
+            {/* Dashboard polish (2026-05-27) — Agents preview below
+                Tasks. Same shape as the other sections so the user
+                sees the same icon-title-actions-grid rhythm. */}
+            <AgentsPreviewSection agents={initialAgents} totalAgents={agentsTotal} />
         </div>
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/(home)/page.tsx
@@ -42,6 +42,7 @@ export default async function Dashboard({ searchParams }: DashboardPageProps) {
         tasksInProgress,
         tasksBlocked,
         recentTasks,
+        recentAgents,
     ] = await Promise.all([
         searchParams,
         getAuthFromCookie(),
@@ -80,6 +81,13 @@ export default async function Dashboard({ searchParams }: DashboardPageProps) {
         tasksAPI
             .list({ status: ['todo', 'in_progress', 'in_review', 'blocked'] as any, limit: 5 })
             .catch(() => ({ data: [], meta: { total: 0, limit: 5, offset: 0 } })),
+        // Dashboard polish (2026-05-27) — recent Agents for the new
+        // preview section below Tasks. Same shape as `missions`:
+        // server-fetched up-front so the section can render without
+        // a client-side round-trip.
+        agentsAPI
+            .list({ limit: 3 })
+            .catch(() => ({ data: [], meta: { total: 0, limit: 3, offset: 0 } })),
     ]);
 
     const totalWorks = statsResponse.success ? statsResponse.totalWorks : worksResponse.total;
@@ -107,6 +115,7 @@ export default async function Dashboard({ searchParams }: DashboardPageProps) {
             tasksInProgress={tasksInProgress.meta.total}
             tasksBlocked={tasksBlocked.meta.total}
             initialRecentTasks={recentTasks.data ?? []}
+            initialAgents={recentAgents.data ?? []}
         />
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/works/works-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/works-client.tsx
@@ -5,10 +5,11 @@ import { useSearchParams } from 'next/navigation';
 import { Work } from '@/lib/api/work';
 import { WorkList } from '@/components/works/WorkList';
 import { WorksKanbanView } from '@/components/works/WorksKanbanView';
+import { WorksCreateComposer } from '@/components/works/WorksCreateComposer';
 import { ViewModeSwitch, type ViewMode } from '@/components/works/ViewModeSwitch';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ROUTES } from '@/lib/constants';
-import { Link, useRouter } from '@/i18n/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { getWorks } from '@/app/actions/dashboard/works';
 import { getWorkStats } from '@/app/actions/dashboard/works';
 import { cn } from '@/lib/utils/cn';
@@ -264,58 +265,47 @@ export default function WorksClient({ initialWorks, totalWorks, initialStats }: 
                 }
             />
 
-            {/* Search and Actions Bar */}
-            <div className="flex flex-col @sm/main:flex-row gap-4 mb-8">
-                <div className="flex-1">
-                    <div className="relative">
-                        <input
-                            ref={searchInputRef}
-                            type="text"
-                            placeholder={t('search')}
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            className={cn(
-                                'w-full px-4 py-2 pl-10 rounded-lg',
-                                'bg-surface dark:bg-surface-dark',
-                                'border border-border dark:border-border-dark',
-                                'text-text dark:text-text-dark',
-                                'placeholder:text-text-muted dark:placeholder:text-text-muted-dark',
-                                'focus:outline-none focus:ring-2 focus:ring-primary',
-                            )}
-                        />
-                        <svg
-                            className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted dark:text-text-muted-dark"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                            />
-                        </svg>
-                    </div>
-                </div>
+            {/* Dashboard polish (2026-05-27) — top-of-page composer
+                with Work chips + Manual/Import buttons. Replaces the
+                old "+ New Work" button next to the search input: the
+                composer is the entry point and the two buttons cover
+                the manual/import flows that previously lived behind
+                that single CTA. Same shape as `/missions` and
+                `/ideas`. */}
+            <WorksCreateComposer />
 
-                <Link
-                    href={ROUTES.DASHBOARD_NEW}
-                    className={cn(
-                        'px-6 py-2 rounded-lg font-medium transition-colors inline-flex items-center gap-2',
-                        'bg-black dark:bg-button-primary-dark hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark text-white dark:text-black rounded-sm',
-                    )}
-                >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {/* Search bar */}
+            <div className="mb-8">
+                <div className="relative">
+                    <input
+                        ref={searchInputRef}
+                        type="text"
+                        placeholder={t('search')}
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className={cn(
+                            'w-full px-4 py-2 pl-10 rounded-lg',
+                            'bg-surface dark:bg-surface-dark',
+                            'border border-border dark:border-border-dark',
+                            'text-text dark:text-text-dark',
+                            'placeholder:text-text-muted dark:placeholder:text-text-muted-dark',
+                            'focus:outline-none focus:ring-2 focus:ring-primary',
+                        )}
+                    />
+                    <svg
+                        className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted dark:text-text-muted-dark"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
                         <path
                             strokeLinecap="round"
                             strokeLinejoin="round"
                             strokeWidth={2}
-                            d="M12 4v16m8-8H4"
+                            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
                         />
                     </svg>
-                    {t('create')}
-                </Link>
+                </div>
             </div>
 
             {/* Work Count + View Mode Switch */}

--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -116,11 +116,25 @@ export function PromptChipsRow<TValue extends string = string>({
                 aria-label={ariaLabel}
                 data-testid={testIdPrefix ? `${testIdPrefix}-chips` : undefined}
                 className={cn(
-                    'flex gap-2 overflow-x-auto scroll-smooth py-1',
-                    // Hide native scrollbar — the explicit buttons + edge
-                    // fades replace it as the affordance for scrolling.
-                    '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-                    overflowing ? 'justify-start px-10' : 'justify-start px-1',
+                    'flex gap-2 overflow-x-auto overscroll-x-contain scroll-smooth py-1',
+                    // Hide native scrollbar across browsers (Firefox uses
+                    // `scrollbar-width`, WebKit/Chromium uses the
+                    // `::-webkit-scrollbar` pseudo). Without both, some
+                    // users still see a horizontal scrollbar even though
+                    // the explicit ◀ / ▶ buttons are the intended
+                    // affordance.
+                    '[scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
+                    // Asymmetric padding — only reserve room for an arrow
+                    // button on the side that's currently showing one.
+                    // Without this, the first chip ("Mission") looked like
+                    // it had stray left padding when the row was scrolled
+                    // to the start: the left button was hidden but the
+                    // padding was still applied.
+                    !overflowing && 'px-1',
+                    overflowing && !atStart && 'pl-10',
+                    overflowing && atStart && 'pl-1',
+                    overflowing && !atEnd && 'pr-10',
+                    overflowing && atEnd && 'pr-1',
                 )}
             >
                 {chips.map((c) => {

--- a/apps/web/src/components/dashboard/AgentsPreviewSection.tsx
+++ b/apps/web/src/components/dashboard/AgentsPreviewSection.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { Bot, Plus } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import type { Agent } from '@/lib/api/agents';
+
+/**
+ * Dashboard polish (2026-05-27) — Agents preview block. Sits below
+ * the Tasks section on the home page so the dashboard now reads:
+ *   Missions → Ideas → Works → Tasks → Agents.
+ *
+ * Mirrors `MissionsPreviewSection`: header with icon tile + title +
+ * `+ Add` + `View all (N) →`, body is a 3-up grid of compact Agent
+ * cards. Avatar/status/scope chips reuse the same vocabulary as
+ * `AgentCard` so the preview reads as a prefix of `/agents`.
+ *
+ * Defensive: degrades to a small "Create an Agent" empty state so a
+ * fresh account doesn't see a shouty empty grid.
+ */
+const PREVIEW_LIMIT = 3;
+
+interface AgentsPreviewSectionProps {
+    agents: Agent[];
+    totalAgents: number;
+}
+
+export function AgentsPreviewSection({ agents, totalAgents }: AgentsPreviewSectionProps) {
+    const previewAgents = agents.slice(0, PREVIEW_LIMIT);
+    return (
+        <section className="mt-8" aria-labelledby="agents-preview-heading">
+            <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
+                <div className="flex items-center gap-2 min-w-0">
+                    <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                        <Bot className="w-4 h-4 text-primary" />
+                    </div>
+                    <h2
+                        id="agents-preview-heading"
+                        className="text-xl font-semibold text-text dark:text-text-dark truncate"
+                    >
+                        Agents
+                    </h2>
+                </div>
+                <div className="flex flex-nowrap items-center gap-2 shrink-0">
+                    <Link
+                        href={ROUTES.DASHBOARD_AGENT_NEW}
+                        className={cn(
+                            'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap',
+                            'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark',
+                            'text-text-secondary dark:text-text-secondary-dark',
+                            'hover:border-primary/40 hover:text-primary',
+                        )}
+                    >
+                        <Plus className="w-3.5 h-3.5" />
+                        Add
+                    </Link>
+                    {totalAgents > 0 && (
+                        <Link
+                            href={ROUTES.DASHBOARD_AGENTS}
+                            className="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1 whitespace-nowrap"
+                        >
+                            View all ({totalAgents}) →
+                        </Link>
+                    )}
+                </div>
+            </div>
+
+            {previewAgents.length === 0 ? (
+                <div className="rounded-lg p-5 bg-card dark:bg-card-primary-dark/70 border border-card-border dark:border-white/9 text-sm text-text-secondary dark:text-text-secondary-dark">
+                    <p>No Agents yet.</p>
+                    <p className="mt-1 text-xs">
+                        <Link
+                            href={ROUTES.DASHBOARD_AGENT_NEW}
+                            className="text-primary hover:underline"
+                        >
+                            Create your first Agent
+                        </Link>{' '}
+                        to delegate recurring work.
+                    </p>
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-4">
+                    {previewAgents.map((a) => (
+                        <AgentPreviewCard key={a.id} agent={a} />
+                    ))}
+                </div>
+            )}
+        </section>
+    );
+}
+
+const STATUS_TONES: Record<Agent['status'], string> = {
+    draft: 'bg-text-muted/10 text-text-muted',
+    active: 'bg-success/10 text-success',
+    paused: 'bg-warning/10 text-warning',
+    running: 'bg-info/10 text-info',
+    error: 'bg-danger/10 text-danger',
+    archived: 'bg-text-muted/10 text-text-muted',
+};
+
+const SCOPE_LABELS: Record<Agent['scope'], string> = {
+    tenant: 'Workspace',
+    mission: 'Mission',
+    work: 'Work',
+    idea: 'Idea',
+};
+
+function AgentPreviewCard({ agent }: { agent: Agent }) {
+    const initials =
+        agent.name
+            .split(/\s+/)
+            .map((p) => p.charAt(0))
+            .join('')
+            .slice(0, 2)
+            .toUpperCase() || 'A';
+    return (
+        <Link
+            href={ROUTES.DASHBOARD_AGENT(agent.id)}
+            className={cn(
+                'group relative flex min-h-[8rem] flex-col overflow-hidden rounded-lg p-4 shadow-xs',
+                'bg-card dark:bg-card-primary-dark/70',
+                'border border-card-border dark:border-white/9',
+                'hover:border-primary-500/50 dark:hover:border-white/20',
+                'transition-colors no-underline',
+            )}
+        >
+            <div className="flex items-start gap-2 min-w-0">
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                    {agent.avatarMode === 'initials' ? (
+                        <span className="text-xs font-semibold text-primary">{initials}</span>
+                    ) : (
+                        <Bot className="w-4 h-4 text-primary" />
+                    )}
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                        <h3 className="text-sm font-semibold text-text dark:text-text-dark truncate">
+                            {agent.name}
+                        </h3>
+                        <span
+                            className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${STATUS_TONES[agent.status]}`}
+                        >
+                            {agent.status}
+                        </span>
+                    </div>
+                    {agent.title ? (
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1 truncate">
+                            {agent.title}
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-3 text-[11px] text-text-secondary dark:text-text-secondary-dark">
+                <span className="px-1.5 py-0.5 rounded bg-surface-secondary dark:bg-surface-secondary-dark">
+                    {SCOPE_LABELS[agent.scope]}
+                </span>
+                {agent.heartbeatCadence ? (
+                    <span className="truncate">every {agent.heartbeatCadence}</span>
+                ) : null}
+            </div>
+        </Link>
+    );
+}

--- a/apps/web/src/components/dashboard/AgentsPreviewSection.tsx
+++ b/apps/web/src/components/dashboard/AgentsPreviewSection.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Bot, Plus } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';

--- a/apps/web/src/components/dashboard/RecentTasks.tsx
+++ b/apps/web/src/components/dashboard/RecentTasks.tsx
@@ -1,6 +1,7 @@
-import { ListChecks } from 'lucide-react';
+import { ListChecks, Plus } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
 import type { Task, TaskStatus, TaskPriority } from '@/lib/api/tasks';
 
 const STATUS_TONES: Record<TaskStatus, string> = {
@@ -22,79 +23,95 @@ const PRIORITY_TONES: Record<TaskPriority, string> = {
 };
 
 /**
- * Agents/Skills/Tasks PR #1017 — Phase 18.2. Dashboard "Recent
- * Tasks" block. Server-fetches the user's 5 most-recent in-flight
- * Tasks (ordered by `updatedAt DESC`) and renders a compact list
- * with the same priority/status chip vocabulary used in /tasks.
- * Designed to sit directly below "Recent Works" per spec §18.2.
+ * Agents/Skills/Tasks PR #1017 — Phase 18.2. Dashboard "Tasks"
+ * block. Server-fetches the user's 5 most-recent in-flight Tasks
+ * (ordered by `updatedAt DESC`) and renders a compact list with
+ * the same priority/status chip vocabulary used in /tasks.
+ * Designed to sit directly below "Recent Works".
+ *
+ * Dashboard polish (2026-05-27) — header now matches Missions /
+ * Ideas / Works sections: large icon tile, `text-xl` title,
+ * `+ Add` button and `View all (N) →` link in a single non-wrapping
+ * row on the right.
  */
-export function RecentTasks({ tasks }: { tasks: Task[] }) {
-    if (tasks.length === 0) {
-        return (
-            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
-                <div className="flex items-center justify-between mb-3">
-                    <h2 className="text-sm font-medium text-text dark:text-text-dark flex items-center gap-2">
-                        <ListChecks className="w-4 h-4 text-info" />
-                        Recent Tasks
-                    </h2>
-                    <Link
-                        href={ROUTES.DASHBOARD_TASKS}
-                        className="text-xs text-text-muted hover:text-primary"
-                    >
-                        View all →
-                    </Link>
-                </div>
-                <p className="text-xs text-text-muted dark:text-text-muted-dark">
-                    No Tasks yet. Create one to start tracking work.
-                </p>
-            </section>
-        );
-    }
+export function RecentTasks({ tasks, total }: { tasks: Task[]; total?: number }) {
+    const totalCount = total ?? tasks.length;
     return (
-        <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
-            <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-medium text-text dark:text-text-dark flex items-center gap-2">
-                    <ListChecks className="w-4 h-4 text-info" />
-                    Recent Tasks
-                </h2>
-                <Link
-                    href={ROUTES.DASHBOARD_TASKS}
-                    className="text-xs text-text-muted hover:text-primary"
-                >
-                    View all →
-                </Link>
-            </div>
-            <ul className="divide-y divide-border/40 dark:divide-border-dark/40">
-                {tasks.map((t) => (
-                    <li key={t.id} className="py-2 first:pt-0 last:pb-0">
+        <section className="mt-8" aria-labelledby="recent-tasks-heading">
+            <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
+                <div className="flex items-center gap-2 min-w-0">
+                    <div className="shrink-0 w-9 h-9 rounded-lg bg-info/10 border border-info/20 flex items-center justify-center">
+                        <ListChecks className="w-4 h-4 text-info" />
+                    </div>
+                    <h2
+                        id="recent-tasks-heading"
+                        className="text-xl font-semibold text-text dark:text-text-dark truncate"
+                    >
+                        Tasks
+                    </h2>
+                </div>
+                <div className="flex flex-nowrap items-center gap-2 shrink-0">
+                    <Link
+                        href={ROUTES.DASHBOARD_TASK_NEW}
+                        className={cn(
+                            'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap',
+                            'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark',
+                            'text-text-secondary dark:text-text-secondary-dark',
+                            'hover:border-primary/40 hover:text-primary',
+                        )}
+                    >
+                        <Plus className="w-3.5 h-3.5" />
+                        Add
+                    </Link>
+                    {totalCount > 0 && (
                         <Link
-                            href={ROUTES.DASHBOARD_TASK(t.id)}
-                            className="flex items-center justify-between gap-3 hover:text-primary"
+                            href={ROUTES.DASHBOARD_TASKS}
+                            className="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1 whitespace-nowrap"
                         >
-                            <div className="min-w-0 flex-1 flex items-center gap-2">
-                                <span className="text-[10px] font-mono text-text-muted shrink-0">
-                                    {t.slug}
-                                </span>
-                                <span className="text-sm text-text dark:text-text-dark truncate">
-                                    {t.title}
-                                </span>
-                            </div>
-                            <div className="flex items-center gap-2 shrink-0">
-                                <span
-                                    className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${PRIORITY_TONES[t.priority]}`}
-                                >
-                                    {t.priority}
-                                </span>
-                                <span
-                                    className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${STATUS_TONES[t.status]}`}
-                                >
-                                    {t.status.replace('_', ' ')}
-                                </span>
-                            </div>
+                            View all ({totalCount}) →
                         </Link>
-                    </li>
-                ))}
-            </ul>
+                    )}
+                </div>
+            </div>
+
+            {tasks.length === 0 ? (
+                <div className="rounded-lg p-5 bg-card dark:bg-card-primary-dark/70 border border-card-border dark:border-white/9 text-sm text-text-secondary dark:text-text-secondary-dark">
+                    <p>No Tasks yet.</p>
+                    <p className="mt-1 text-xs">Create one to start tracking work.</p>
+                </div>
+            ) : (
+                <ul className="rounded-lg bg-card dark:bg-card-primary-dark/70 border border-card-border dark:border-white/9 divide-y divide-border/40 dark:divide-border-dark/40">
+                    {tasks.map((t) => (
+                        <li key={t.id} className="px-4 py-2.5">
+                            <Link
+                                href={ROUTES.DASHBOARD_TASK(t.id)}
+                                className="flex items-center justify-between gap-3 hover:text-primary"
+                            >
+                                <div className="min-w-0 flex-1 flex items-center gap-2">
+                                    <span className="text-[10px] font-mono text-text-muted shrink-0">
+                                        {t.slug}
+                                    </span>
+                                    <span className="text-sm text-text dark:text-text-dark truncate">
+                                        {t.title}
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-2 shrink-0">
+                                    <span
+                                        className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${PRIORITY_TONES[t.priority]}`}
+                                    >
+                                        {t.priority}
+                                    </span>
+                                    <span
+                                        className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${STATUS_TONES[t.status]}`}
+                                    >
+                                        {t.status.replace('_', ' ')}
+                                    </span>
+                                </div>
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            )}
         </section>
     );
 }

--- a/apps/web/src/components/dashboard/StatsOverview.tsx
+++ b/apps/web/src/components/dashboard/StatsOverview.tsx
@@ -3,15 +3,18 @@
 import { cn } from '@/lib/utils/cn';
 import { useTranslations } from 'next-intl';
 import {
+    Bot,
     FolderClosed,
-    ListTodo,
     Globe,
-    Target,
     Lightbulb,
+    ListChecks,
+    ListTodo,
+    Target,
     Wallet,
     type LucideIcon,
 } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
 
 interface StatsOverviewProps {
     totalWorks?: number;
@@ -21,12 +24,18 @@ interface StatsOverviewProps {
      * Phase 2 PR F — Missions/Ideas/Works v6 spec §5.1.
      * Dashboard tiles, rendered in this order (LEFT to RIGHT):
      *   [Missions] [Ideas] [Works] [Items] [Sites] [Month Spend]
+     *   [Agents] [Tasks in flight]
      * Each defaults to 0 so existing call sites that haven't been
      * updated still render (showing 0 instead of crashing).
      *
      * Phase 7 PR II added the 6th `Month Spend` tile, which is a
      * Link clicking through to `/settings/work-agent#account-budgets`
      * so the user can adjust the account-wide cap in one place.
+     *
+     * Dashboard polish (2026-05-27) — Agents + Tasks-in-flight folded
+     * into the same grid as the other 6 so all 8 share a single row
+     * when the chat panel is collapsed (`@7xl/main` and up). Replaces
+     * the previous Phase 18.1 standalone tile row.
      */
     totalMissions?: number;
     totalIdeas?: number;
@@ -34,6 +43,10 @@ interface StatsOverviewProps {
     monthSpendCents?: number;
     /** Phase 7 PR II — currency for monthSpendCents (default 'usd'). */
     monthSpendCurrency?: string;
+    agentsTotal?: number;
+    agentsActive?: number;
+    tasksInProgress?: number;
+    tasksBlocked?: number;
 }
 
 function formatMoney(cents: number, currency: string): string {
@@ -56,6 +69,10 @@ export function StatsOverview({
     totalIdeas = 0,
     monthSpendCents = 0,
     monthSpendCurrency = 'usd',
+    agentsTotal = 0,
+    agentsActive = 0,
+    tasksInProgress = 0,
+    tasksBlocked = 0,
 }: StatsOverviewProps) {
     const t = useTranslations('dashboard.stats');
 
@@ -67,10 +84,11 @@ export function StatsOverview({
         changeType: 'positive' | 'negative' | 'neutral';
         iconColor?: string;
         dotColor?: string;
-        /** Phase 7 PR II — when set, the tile renders as a Link. */
+        /** When set, the tile renders as a Link. */
         href?: string;
+        /** Optional secondary line under the title (e.g. "2 active"). */
+        sublabel?: string;
     }> = [
-        // Phase 2 PR F — new tiles FIRST, in spec §5.1 order.
         {
             title: t('totalMissions'),
             value: totalMissions,
@@ -79,6 +97,7 @@ export function StatsOverview({
             dotColor: 'bg-amber-500',
             change: '+0%',
             changeType: 'neutral',
+            href: ROUTES.DASHBOARD_MISSIONS,
         },
         {
             title: t('totalIdeas'),
@@ -88,6 +107,7 @@ export function StatsOverview({
             dotColor: 'bg-yellow-500',
             change: '+0%',
             changeType: 'neutral',
+            href: ROUTES.DASHBOARD_IDEAS,
         },
         {
             title: t('totalWorks'),
@@ -97,6 +117,7 @@ export function StatsOverview({
             dotColor: 'bg-blue-500',
             change: '+12%',
             changeType: 'positive',
+            href: ROUTES.DASHBOARD_WORKS,
         },
         {
             title: t('totalItems'),
@@ -116,9 +137,6 @@ export function StatsOverview({
             change: '0%',
             changeType: 'neutral',
         },
-        // Phase 7 PR II — Month Spend (6th tile). Clicks through to
-        // /settings/work-agent#account-budgets so the user can
-        // adjust the cap from the same row that shows the spend.
         {
             title: t('monthSpend'),
             value: formatMoney(monthSpendCents, monthSpendCurrency),
@@ -129,27 +147,54 @@ export function StatsOverview({
             changeType: 'neutral',
             href: '/settings/work-agent#account-budgets',
         },
+        {
+            title: t('agents'),
+            value: agentsTotal,
+            icon: Bot,
+            iconColor: 'text-primary',
+            dotColor: 'bg-primary',
+            change: '+0%',
+            changeType: 'neutral',
+            href: ROUTES.DASHBOARD_AGENTS,
+            sublabel: t('agentsActive', { count: agentsActive }),
+        },
+        {
+            title: t('tasksInFlight'),
+            value: tasksInProgress,
+            icon: ListChecks,
+            iconColor: 'text-info',
+            dotColor: 'bg-info',
+            change: '+0%',
+            changeType: 'neutral',
+            href: ROUTES.DASHBOARD_TASKS,
+            sublabel:
+                tasksBlocked > 0
+                    ? t('tasksBlocked', { count: tasksBlocked })
+                    : t('tasksNoBlockers'),
+        },
     ];
 
     return (
-        // 6 tiles, sized to collapse cleanly with the chat panel.
-        // When chat is open the main column is roughly @3xl-ish → show
-        // 4 per row (2 rows of stats). When chat is collapsed the main
-        // column opens up past @5xl → show all 6 in a single row.
-        // Smaller breakpoints wrap gracefully to 2 then 1 per row.
-        <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-4 @5xl/main:grid-cols-6 gap-4">
+        // 8 tiles. Grid shapes itself to the available width:
+        //   1 col on the narrowest viewport.
+        //   2 cols starting at @lg.
+        //   4 cols starting at @3xl — typical width when the chat
+        //     panel is open (two rows of four).
+        //   8 cols starting at @7xl — the chat panel is collapsed
+        //     and the main column has room for a single row of eight.
+        <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-4 @7xl/main:grid-cols-8 gap-4">
             {statCards.map((stat) => {
                 const tileBody = (
                     <div
                         className={cn(
-                            'group relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
+                            'group relative rounded-md p-1 transition-shadow duration-200 overflow-hidden h-full',
                             'border border-card-border dark:border-border-dark',
                             stat.href && 'hover:border-primary-500/50 dark:hover:border-white/20',
                         )}
                     >
                         <div
                             className={cn(
-                                'group relative rounded-sm p-5 transition-shadow duration-200 overflow-hidden',
+                                'group relative rounded-sm p-5 transition-shadow duration-200 overflow-hidden h-full',
                                 'bg-card dark:bg-surface-secondary-dark',
                                 'border border-card-border dark:border-border-dark',
                             )}
@@ -175,10 +220,15 @@ export function StatsOverview({
                             </div>
                             <div className="mt-1 flex items-center space-x-2">
                                 <div className={cn('w-1 h-1 rounded-full mt-0.5', stat.dotColor)} />
-                                <p className="text-xs text-gray-500 dark:text-text-muted-dark">
+                                <p className="text-xs text-gray-500 dark:text-text-muted-dark truncate">
                                     {stat.title}
                                 </p>
                             </div>
+                            {stat.sublabel ? (
+                                <p className="mt-1 ml-3 text-[11px] text-text-muted dark:text-text-muted-dark truncate">
+                                    {stat.sublabel}
+                                </p>
+                            ) : null}
                             <div className="mt-4 items-center hidden">
                                 <span
                                     className={cn(

--- a/apps/web/src/components/dashboard/WorkProposalsSection.tsx
+++ b/apps/web/src/components/dashboard/WorkProposalsSection.tsx
@@ -223,7 +223,7 @@ export function WorkProposalsSection({
 
     return (
         <section className="mt-8" aria-labelledby="work-proposals-heading">
-            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
                 <div className="flex items-center gap-2 min-w-0">
                     <div className="shrink-0 w-9 h-9 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
                         <Lightbulb className="w-4 h-4 text-warning" />
@@ -235,9 +235,17 @@ export function WorkProposalsSection({
                         {username ? t('header.titleWithName', { username }) : t('header.title')}
                     </h2>
                 </div>
-                <div className="flex flex-wrap items-center gap-2">
+                {/* Dashboard polish (2026-05-27) — actions stay on a
+                    single row (`flex-nowrap`) instead of stacking
+                    vertically when the chat panel narrows the column.
+                    `shrink-0` keeps each control measured so the title
+                    truncates first. */}
+                <div className="flex flex-nowrap items-center gap-2 shrink-0">
                     {/* Phase 5 PR O — quick-add trigger. Hidden while the form is open
-                        so the header and form don't show duplicate Add controls. */}
+                        so the header and form don't show duplicate Add controls.
+                        Dashboard polish (2026-05-27) — label collapses to icon-
+                        only below `@xl/main` so the action row fits one line
+                        when the chat panel is open. */}
                     {!quickAddOpen && (
                         <Button
                             type="button"
@@ -246,9 +254,13 @@ export function WorkProposalsSection({
                             className="gap-1.5"
                             onClick={() => setQuickAddOpen(true)}
                             aria-expanded={quickAddOpen}
+                            aria-label={tPage('quickAdd.submit')}
+                            title={tPage('quickAdd.submit')}
                         >
                             <Plus className="w-3.5 h-3.5" />
-                            {tPage('quickAdd.submit')}
+                            <span className="hidden @xl/main:inline">
+                                {tPage('quickAdd.submit')}
+                            </span>
                         </Button>
                     )}
 
@@ -316,12 +328,19 @@ export function WorkProposalsSection({
                         </DropdownMenuContent>
                     </DropdownMenu>
 
-                    {/* Existing Suggest more button (keeps prior PR-E label). */}
+                    {/* Existing Suggest more button (keeps prior PR-E label).
+                        Dashboard polish (2026-05-27) — label is hidden
+                        below `@xl/main` so the row stays one line when
+                        the chat panel is open. The icon alone still
+                        conveys "refresh" and the title attribute carries
+                        the accessible label. */}
                     {showRefreshButton && (
                         <button
                             type="button"
                             onClick={handleRefresh}
                             disabled={pendingRefresh || researching}
+                            title={t('actions.refresh')}
+                            aria-label={t('actions.refresh')}
                             className="inline-flex items-center gap-1.5 text-sm text-text-secondary dark:text-text-secondary-dark hover:text-text dark:hover:text-text-dark transition-colors disabled:opacity-50 whitespace-nowrap"
                         >
                             {pendingRefresh || researching ? (
@@ -329,7 +348,7 @@ export function WorkProposalsSection({
                             ) : (
                                 <RefreshCw className="w-4 h-4" />
                             )}
-                            {t('actions.refresh')}
+                            <span className="hidden @xl/main:inline">{t('actions.refresh')}</span>
                         </button>
                     )}
 

--- a/apps/web/src/components/missions/MissionsPreviewSection.tsx
+++ b/apps/web/src/components/missions/MissionsPreviewSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { CalendarClock, Target } from 'lucide-react';
+import { CalendarClock, Plus, Target } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
@@ -69,7 +69,7 @@ export function MissionsPreviewSection({ missions, allIdeas }: MissionsPreviewSe
 
     return (
         <section className="mt-8" aria-labelledby="missions-preview-heading">
-            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <div className="flex flex-nowrap items-center justify-between gap-3 mb-4">
                 <div className="flex items-center gap-2 min-w-0">
                     <div className="shrink-0 w-9 h-9 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
                         <Target className="w-4 h-4 text-warning" />
@@ -81,14 +81,32 @@ export function MissionsPreviewSection({ missions, allIdeas }: MissionsPreviewSe
                         {t('title')}
                     </h2>
                 </div>
-                {totalMissions > 0 && (
+                {/* Dashboard polish (2026-05-27) — `+ Add` button on
+                    every dashboard section so the UI is symmetrical
+                    (Missions / Ideas / Works / Tasks / Agents all
+                    surface their own create entry point). */}
+                <div className="flex flex-nowrap items-center gap-2 shrink-0">
                     <Link
-                        href={ROUTES.DASHBOARD_MISSIONS}
-                        className="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1 whitespace-nowrap"
+                        href="/new?type=mission"
+                        className={cn(
+                            'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap',
+                            'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark',
+                            'text-text-secondary dark:text-text-secondary-dark',
+                            'hover:border-primary/40 hover:text-primary',
+                        )}
                     >
-                        {t('viewAll', { n: totalMissions })}
+                        <Plus className="w-3.5 h-3.5" />
+                        Add
                     </Link>
-                )}
+                    {totalMissions > 0 && (
+                        <Link
+                            href={ROUTES.DASHBOARD_MISSIONS}
+                            className="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1 whitespace-nowrap"
+                        >
+                            {t('viewAll', { n: totalMissions })}
+                        </Link>
+                    )}
+                </div>
             </div>
 
             {previewMissions.length === 0 ? (

--- a/apps/web/src/components/skills/SkillDetailClient.tsx
+++ b/apps/web/src/components/skills/SkillDetailClient.tsx
@@ -243,7 +243,7 @@ function BindingsPanel({
                         onChange={(e) => setTargetType(e.target.value as SkillBindingTargetType)}
                         className="rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-2 h-8 text-xs"
                     >
-                        <option value="tenant">tenant</option>
+                        <option value="tenant">workspace</option>
                         <option value="agent">agent</option>
                         <option value="work">work</option>
                         <option value="mission">mission</option>
@@ -252,7 +252,9 @@ function BindingsPanel({
                 </div>
                 <div>
                     <label className="block text-[10px] text-text-muted mb-1">
-                        {targetType === 'tenant' ? 'Target (auto-filled)' : `Pick a ${targetType}`}
+                        {targetType === 'tenant'
+                            ? 'Target (auto-filled)'
+                            : `Pick a ${targetType}`}
                     </label>
                     <SkillBindingTargetPicker
                         targetType={targetType}

--- a/apps/web/src/components/skills/SkillDetailClient.tsx
+++ b/apps/web/src/components/skills/SkillDetailClient.tsx
@@ -252,9 +252,7 @@ function BindingsPanel({
                 </div>
                 <div>
                     <label className="block text-[10px] text-text-muted mb-1">
-                        {targetType === 'tenant'
-                            ? 'Target (auto-filled)'
-                            : `Pick a ${targetType}`}
+                        {targetType === 'tenant' ? 'Target (auto-filled)' : `Pick a ${targetType}`}
                     </label>
                     <SkillBindingTargetPicker
                         targetType={targetType}

--- a/apps/web/src/components/works/WorksCreateComposer.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { BookOpen, Files, FolderInput, FolderOpen, Globe, PenLine, Star } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { PromptComposer } from '@/components/common/PromptComposer';
+import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
+import { Button } from '@/components/ui/button';
+import { useRouter } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
+
+/**
+ * Dashboard polish (2026-05-27) — Work-specific composer mounted at
+ * the top of `/works`. Same shape as `MissionsList` (PromptComposer +
+ * chips) and the entry view of `/works/new`, but routes the submit
+ * into the existing `/works/new?mode=ai&kind=…` flow instead of
+ * persisting inline.
+ *
+ * Mirrors `NewPageClient` / `NewWorkClient` deliberately:
+ *   - The same Work kinds (no Mission/Idea — this is /works).
+ *   - The same icons and placeholder examples per kind.
+ *   - The same two affordances below the input: "Create Work
+ *     Manually" → `/works/new?mode=manual`, "Import Existing Work"
+ *     → `/works/new?mode=import`. We do NOT introduce a second
+ *     creation surface — the canvas pages are the same.
+ */
+type InitialWorkKind = 'website' | 'landing-page' | 'blog' | 'directory' | 'awesome-repo';
+
+const WORK_KIND_ORDER: InitialWorkKind[] = [
+    'website',
+    'landing-page',
+    'blog',
+    'directory',
+    'awesome-repo',
+];
+
+const WORK_KIND_ICONS: Record<InitialWorkKind, LucideIcon> = {
+    website: Globe,
+    'landing-page': Files,
+    blog: BookOpen,
+    directory: FolderOpen,
+    'awesome-repo': Star,
+};
+
+const PLACEHOLDERS_BY_KIND: Record<InitialWorkKind, ReadonlyArray<string>> = {
+    website: [
+        'e.g. "Modern website for a boutique design studio with case studies and a contact form"',
+        'e.g. "Marketing site for a B2B SaaS with pricing, integrations, and a documentation hub"',
+        'e.g. "Portfolio for a freelance photographer with galleries by genre and testimonials"',
+        'e.g. "Five-page site for my dentist practice with services, team, and online booking"',
+    ],
+    'landing-page': [
+        'e.g. "Waitlist landing page for an AI customer-support copilot with a hero demo and FAQ"',
+        'e.g. "Product launch page for noise-cancelling earbuds with specs, video, and pre-order CTA"',
+        'e.g. "Lead-magnet landing page for a free SaaS pricing benchmark report"',
+        'e.g. "Webinar registration page with speaker bios, agenda, and a countdown timer"',
+    ],
+    blog: [
+        'e.g. "Personal blog about indie game development with postmortems and tooling tags"',
+        'e.g. "Engineering blog with RSS, code-highlighting, author pages, and OG previews"',
+        'e.g. "AI research summaries blog — daily 200-word paper rundowns with citations"',
+        'e.g. "Founder journal — weekly progress logs tagged for revenue, hiring, product"',
+    ],
+    directory: [
+        'e.g. "Directory of AI coding assistants with reviews, pricing tiers, and editor compatibility"',
+        'e.g. "Directory of agent skills for Claude Code — categories, install instructions, demos"',
+        'e.g. "Directory of remote-first companies with timezone overlap, perks, and stack tags"',
+        'e.g. "Directory of climate-tech startups by sub-sector with funding stage and team size"',
+    ],
+    'awesome-repo': [
+        'e.g. "Awesome list of React state-management libraries with benchmarks and trade-offs"',
+        'e.g. "Awesome list of TypeScript ESLint rules with examples and when-to-disable guidance"',
+        'e.g. "Awesome list of self-hostable open-source SaaS alternatives — categorized + docker-ready"',
+        'e.g. "Awesome list of agent frameworks (LangChain, AutoGen, CrewAI…) with pros/cons"',
+    ],
+};
+
+const KIND_INTENT_LABEL: Record<InitialWorkKind, string> = {
+    website: 'website',
+    'landing-page': 'landing page',
+    blog: 'blog',
+    directory: 'directory',
+    'awesome-repo': 'awesome list repo',
+};
+
+export function WorksCreateComposer() {
+    const t = useTranslations('dashboard.workCreation');
+    const router = useRouter();
+    const [prompt, setPrompt] = useState('');
+    const [selectedKind, setSelectedKind] = useState<InitialWorkKind>('website');
+    const [submitting, startSubmit] = useTransition();
+    const startFromPrompt = useStartFromPrompt();
+
+    const placeholderExamples = useMemo(
+        () => PLACEHOLDERS_BY_KIND[selectedKind] ?? PLACEHOLDERS_BY_KIND.website,
+        [selectedKind],
+    );
+
+    const chips: ReadonlyArray<PromptChip<InitialWorkKind>> = useMemo(
+        () =>
+            WORK_KIND_ORDER.map((k) => ({
+                value: k,
+                label: t(`kinds.${k}`),
+                Icon: WORK_KIND_ICONS[k],
+            })),
+        [t],
+    );
+
+    const submit = () => {
+        const description = prompt.trim();
+        if (description.length < 10) {
+            toast.error(t('promptHints.minLength'));
+            return;
+        }
+        startSubmit(() => {
+            // Send the prompt into chat so the AI can iterate while the
+            // user lands on the AI form. `/works/new?mode=ai&kind=…`
+            // skips the entry view and renders the form directly.
+            startFromPrompt(description, { intent: KIND_INTENT_LABEL[selectedKind] });
+            const params = new URLSearchParams({ mode: 'ai', kind: selectedKind });
+            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?${params.toString()}`);
+        });
+    };
+
+    return (
+        <div className="mb-8 space-y-3">
+            <PromptComposer
+                inputId="works-quick-add"
+                value={prompt}
+                onChange={setPrompt}
+                onSubmit={submit}
+                submitting={submitting}
+                placeholderExamples={placeholderExamples}
+                rows={4}
+                ariaLabel={t('promptLabel')}
+                submitTitle={t('promptHints.submitTitle')}
+                testId="works-quick-add"
+                chipsBelow={
+                    <div className="space-y-2">
+                        <PromptChipsRow<InitialWorkKind>
+                            chips={chips}
+                            value={selectedKind}
+                            onChange={(v) => v && setSelectedKind(v)}
+                            ariaLabel={t('promptLabel')}
+                            testIdPrefix="works-quick-add"
+                        />
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark px-1">
+                            {t(`kindDescriptions.${selectedKind}`)}
+                        </p>
+                    </div>
+                }
+            />
+
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 dark:border-border-dark/60 bg-surface/60 dark:bg-surface-dark/60 px-4 py-3">
+                <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                    {t('or')}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={() =>
+                            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?mode=manual`)
+                        }
+                    >
+                        <PenLine className="w-3.5 h-3.5" />
+                        {t('buttons.manual')}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={() =>
+                            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?mode=import`)
+                        }
+                    >
+                        <FolderInput className="w-3.5 h-3.5" />
+                        {t('buttons.import')}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/WorksCreateComposer.tsx
+++ b/apps/web/src/components/works/WorksCreateComposer.tsx
@@ -164,9 +164,7 @@ export function WorksCreateComposer() {
                         variant="secondary"
                         size="sm"
                         className="gap-1.5"
-                        onClick={() =>
-                            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?mode=manual`)
-                        }
+                        onClick={() => router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?mode=manual`)}
                     >
                         <PenLine className="w-3.5 h-3.5" />
                         {t('buttons.manual')}
@@ -176,9 +174,7 @@ export function WorksCreateComposer() {
                         variant="secondary"
                         size="sm"
                         className="gap-1.5"
-                        onClick={() =>
-                            router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?mode=import`)
-                        }
+                        onClick={() => router.push(`${ROUTES.DASHBOARD_WORKS_NEW}?mode=import`)}
                     >
                         <FolderInput className="w-3.5 h-3.5" />
                         {t('buttons.import')}


### PR DESCRIPTION
## Summary

UI polish pass on the dashboard, `/new`, and `/works` pages based on operator feedback (8 items).

### Stats row (issue #3)
- `StatsOverview` now renders all 8 tiles (Missions, Ideas, Works, Items, Sites, Month Spend, Agents, Tasks in flight) in a single grid: 1 / 2 / 4 / 8 cols across breakpoints. Chat panel open → 4 per row; chat collapsed (`@7xl/main`) → all 8 in one row.
- Standalone Phase 18.1 `AgentsCountTile` / `TasksInProgressTile` row is gone (data folded into the unified grid). The component files are still on disk for any external importers.

### Section headers — Missions / Ideas / Works / Tasks / Agents (issues #1, #2, #4, #5)
- All five sections now share the same `icon + title + + Add + View all (N) →` row, `flex-nowrap` so they stay on one line when the chat panel narrows the column.
- Ideas section labels (`Suggest more`, `Add`) collapse to icon-only below `@xl/main`; `title` + `aria-label` preserve the accessible name.
- New `RecentTasks` shape mirrors the other sections (large icon tile, `text-xl` title, `+ Add`, `View all (N)`). Always rendered so the dashboard reads `Missions → Ideas → Works → Tasks → Agents` on every state.
- New `AgentsPreviewSection` below Tasks — grid of up to 3 Agent preview cards (status pill, scope, heartbeat cadence), empty-state CTA, server-fetched via `agentsAPI.list({ limit: 3 })`.

### Prompt chip row (issue #6)
- `PromptChipsRow` left/right padding is now asymmetric: padding is only reserved on the side currently showing a scroll arrow. Fixes the \"weird left padding on the Mission chip\" when the row is at scroll-start.
- Scrollbar fully hidden across browsers — `[-ms-overflow-style:none]` added alongside the existing rules. `overscroll-x-contain` prevents chip swipes from triggering page back/forward gestures.

### \"Tenant\" → \"Workspace\" (issue #7)
- User-visible \"Tenant\" labels replaced with \"Workspace\" in en.json + `SkillDetailClient` option label.
- Internal `'tenant'` enum values left as-is so API contracts and existing data continue to work.

### /works composer (issue #8)
- `/works` (list view) now leads with `WorksCreateComposer` — PromptComposer + Work kind chips + the same Manual / Import buttons that live on `/works/new`. Submit routes through `/works/new?mode=ai&kind=<kind>` so the canvas pages remain the single source of truth.
- Old \"+ New Work\" button next to the search input is removed (the composer + Manual/Import buttons replace it).

## Test plan

- [ ] `/` — confirm stats tiles fit 8-per-row when chat panel is closed and 4-per-row when open.
- [ ] `/` — confirm every section header (Missions / Ideas / Works / Tasks / Agents) shows `+ Add` and `View all (N) →` on a single non-wrapping row, including when the chat panel is open.
- [ ] `/` — `Recent Tasks` section uses the new header style and renders even with zero Tasks.
- [ ] `/` — `Agents` section appears below Tasks with up to 3 preview cards or an empty-state CTA.
- [ ] `/new` — first chip (Mission) sits flush against the left edge when the row hasn't scrolled (no stray 40px gap).
- [ ] `/new` — chip row scrollbar is hidden; only the ◀/▶ arrows are visible when overflow.
- [ ] `/agents` and `/skills` — \"Workspace\" reads everywhere the UI previously said \"Tenant\".
- [ ] `/works` — composer at the top: typing a prompt + picking a chip + submit routes to `/works/new?mode=ai&kind=<kind>` with the prompt sent to chat.
- [ ] `/works` — `Create Work Manually` button → `/works/new?mode=manual`; `Import Existing Work` → `/works/new?mode=import`.
- [ ] No \"+ New Work\" button next to the search input on `/works`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agents preview section to dashboard showing up to 3 agents with quick-add option
  * Added quick-add work creation composer with prompt-based and manual entry modes

* **UI Improvements**
  * Dashboard layout refreshed with expanded stats overview showing agent and task metrics
  * Terminology updated from "Tenant" to "Workspace" throughout UI
  * Enhanced responsive design for dashboard header actions and controls
  * Improved empty states with clearer call-to-action links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->