### PR TITLE
[EW-659] Phase 7 - slug routing middleware (API)

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -39,6 +39,7 @@ import { TasksModule } from './tasks/tasks.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { UsersModule } from './users/users.module';
 import { ScopeModule } from './scope/scope.module';
+import { ScopeOwnershipGuard } from './scope/scope-ownership.guard';
 import { OrganizationsModule } from './organizations/organizations.module';
 import { FunnelAnalyticsBindingModule } from './telemetry/funnel-analytics-binding.module';
 import { UploadsModule } from './uploads/uploads.module';
@@ -144,6 +145,14 @@ import { DatabaseModule } from '@ever-works/agent/database';
         {
             provide: APP_GUARD,
             useClass: AuthSessionGuard,
+        },
+        // EW-659 (Phase 7) — runs AFTER AuthSessionGuard (guard order
+        // matches providers-array order) so request.user is set. Rejects
+        // a scope mismatch with 403 to prevent cross-tenant access via
+        // slug.
+        {
+            provide: APP_GUARD,
+            useClass: ScopeOwnershipGuard,
         },
         {
             provide: APP_GUARD,

--- a/apps/api/src/scope/__tests__/scope-ownership.guard.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-ownership.guard.spec.ts
@@ -1,0 +1,78 @@
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ScopeContextService } from '../scope-context.service';
+import { ScopeOwnershipGuard } from '../scope-ownership.guard';
+
+/**
+ * Helper: build a minimal ExecutionContext that the guard reads from.
+ * `getType()` returns 'http'; `switchToHttp().getRequest()` returns the
+ * `request` object we pass in.
+ */
+function makeContext(request: { user?: unknown }): ExecutionContext {
+    return {
+        getType: () => 'http',
+        switchToHttp: () => ({
+            getRequest: <T = unknown>(): T => request as T,
+            getResponse: <T = unknown>(): T => ({}) as T,
+            getNext: <T = unknown>(): T => ({}) as T,
+        }),
+    } as unknown as ExecutionContext;
+}
+
+describe('ScopeOwnershipGuard (EW-659 Phase 7)', () => {
+    let scopeContext: ScopeContextService;
+    let guard: ScopeOwnershipGuard;
+
+    beforeEach(() => {
+        scopeContext = new ScopeContextService();
+        guard = new ScopeOwnershipGuard(scopeContext);
+    });
+
+    it('allows non-HTTP execution contexts (RPC, WS, etc.)', () => {
+        const nonHttp = { getType: () => 'rpc' } as unknown as ExecutionContext;
+        expect(guard.canActivate(nonHttp)).toBe(true);
+    });
+
+    it('allows when scope is EMPTY (no slug was provided)', () => {
+        const ctx = makeContext({ user: { userId: 'u-1', tenantId: 't-1' } });
+        // ScopeContext.getScope() returns EMPTY by default outside runWith.
+        expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('allows when request has no user (public route + resolved scope)', () => {
+        const ctx = makeContext({});
+        scopeContext.runWith({ tenantId: 't-1', organizationId: 'o-1' }, () => {
+            expect(guard.canActivate(ctx)).toBe(true);
+        });
+    });
+
+    it('allows when user.tenantId matches the resolved scope', () => {
+        const ctx = makeContext({ user: { userId: 'u-1', tenantId: 't-1' } });
+        scopeContext.runWith({ tenantId: 't-1', organizationId: 'o-1' }, () => {
+            expect(guard.canActivate(ctx)).toBe(true);
+        });
+    });
+
+    it('rejects (403) when user.tenantId is null but scope was resolved', () => {
+        const ctx = makeContext({ user: { userId: 'u-1', tenantId: null } });
+        scopeContext.runWith({ tenantId: 't-elsewhere', organizationId: 'o-x' }, () => {
+            expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+        });
+    });
+
+    it('rejects (403) when user.tenantId differs from the resolved scope', () => {
+        const ctx = makeContext({ user: { userId: 'u-1', tenantId: 't-mine' } });
+        scopeContext.runWith({ tenantId: 't-other', organizationId: 'o-other' }, () => {
+            expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+        });
+    });
+
+    it('allows the bare-Tenant scope (User slug resolution; organizationId is null)', () => {
+        const ctx = makeContext({ user: { userId: 'u-1', tenantId: 't-1' } });
+        scopeContext.runWith({ tenantId: 't-1', organizationId: null }, () => {
+            expect(guard.canActivate(ctx)).toBe(true);
+        });
+    });
+});

--- a/apps/api/src/scope/__tests__/scope-resolver.middleware.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-resolver.middleware.spec.ts
@@ -1,0 +1,220 @@
+// Mock the agent database barrel to avoid pulling in the full TypeORM
+// DataSource graph. Same pattern as the other scope/* tests.
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+
+import { NotFoundException } from '@nestjs/common';
+import { ScopeContextService } from '../scope-context.service';
+import { ScopeResolverMiddleware } from '../scope-resolver.middleware';
+
+// Loose-shape mocks for the minimal Express interface the middleware
+// actually consumes — matches the `MiddlewareRequest` / `NextFn` types
+// inside the middleware itself.
+type FakeRequest = {
+    params: Record<string, string | undefined>;
+    headers: Record<string, string | string[] | undefined>;
+};
+type NextFunction = (err?: unknown) => void;
+
+describe('ScopeResolverMiddleware (EW-659 Phase 7)', () => {
+    let scopeContext: ScopeContextService;
+    let userRepository: { findBySlug: jest.Mock };
+    let organizationRepository: { findBySlug: jest.Mock };
+    let middleware: ScopeResolverMiddleware;
+
+    beforeEach(() => {
+        scopeContext = new ScopeContextService();
+        userRepository = { findBySlug: jest.fn().mockResolvedValue(null) };
+        organizationRepository = { findBySlug: jest.fn().mockResolvedValue(null) };
+        middleware = new ScopeResolverMiddleware(
+            scopeContext,
+            userRepository as never,
+            organizationRepository as never,
+        );
+    });
+
+    /**
+     * Helper: drive the middleware once and capture the scope visible
+     * to the `next()` callback (which is what the controller will see).
+     */
+    async function runWithCapture(
+        req: Partial<FakeRequest>,
+    ): Promise<{ scope: ReturnType<ScopeContextService['getScope']>; nextCalled: boolean }> {
+        let captured = scopeContext.getScope();
+        let nextCalled = false;
+        const next: NextFunction = () => {
+            captured = scopeContext.getScope();
+            nextCalled = true;
+        };
+        await middleware.use(req as FakeRequest, {}, next);
+        return { scope: captured, nextCalled };
+    }
+
+    describe('empty / missing slug', () => {
+        it('passes through with EMPTY_SCOPE when no slug param or header', async () => {
+            const { scope, nextCalled } = await runWithCapture({
+                params: {},
+                headers: {},
+            });
+
+            expect(nextCalled).toBe(true);
+            expect(scope).toEqual({ tenantId: null, organizationId: null });
+            expect(organizationRepository.findBySlug).not.toHaveBeenCalled();
+            expect(userRepository.findBySlug).not.toHaveBeenCalled();
+        });
+
+        it('treats whitespace-only slug as missing (EMPTY_SCOPE pass-through)', async () => {
+            const { scope, nextCalled } = await runWithCapture({
+                params: { slug: '   ' },
+                headers: { 'x-scope-slug': '\t' },
+            });
+
+            expect(nextCalled).toBe(true);
+            expect(scope).toEqual({ tenantId: null, organizationId: null });
+            expect(organizationRepository.findBySlug).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Organization slug', () => {
+        it('resolves :slug param to { tenantId, organizationId } for an Org hit', async () => {
+            organizationRepository.findBySlug.mockResolvedValueOnce({
+                id: 'o-1',
+                tenantId: 't-1',
+                slug: 'acme',
+            });
+
+            const { scope, nextCalled } = await runWithCapture({
+                params: { slug: 'acme' },
+                headers: {},
+            });
+
+            expect(nextCalled).toBe(true);
+            expect(scope).toEqual({ tenantId: 't-1', organizationId: 'o-1' });
+            expect(organizationRepository.findBySlug).toHaveBeenCalledWith('acme');
+            // Short-circuited: User lookup is never reached on Org hit.
+            expect(userRepository.findBySlug).not.toHaveBeenCalled();
+        });
+
+        it('resolves X-Scope-Slug header when no URL :slug present', async () => {
+            organizationRepository.findBySlug.mockResolvedValueOnce({
+                id: 'o-2',
+                tenantId: 't-2',
+                slug: 'evilcorp',
+            });
+
+            const { scope } = await runWithCapture({
+                params: {},
+                headers: { 'x-scope-slug': 'evilcorp' },
+            });
+
+            expect(scope).toEqual({ tenantId: 't-2', organizationId: 'o-2' });
+        });
+
+        it('URL :slug param takes precedence over X-Scope-Slug header', async () => {
+            organizationRepository.findBySlug.mockResolvedValueOnce({
+                id: 'o-from-param',
+                tenantId: 't-from-param',
+                slug: 'acme',
+            });
+
+            const { scope } = await runWithCapture({
+                params: { slug: 'acme' },
+                headers: { 'x-scope-slug': 'evilcorp' },
+            });
+
+            expect(organizationRepository.findBySlug).toHaveBeenCalledWith('acme');
+            expect(scope.organizationId).toBe('o-from-param');
+        });
+    });
+
+    describe('User slug (bare-Tenant)', () => {
+        it('falls back to UserRepository.findBySlug when Org lookup misses', async () => {
+            // Org miss; User hit with a Tenant.
+            userRepository.findBySlug.mockResolvedValueOnce({
+                id: 'u-1',
+                slug: 'alice',
+                tenantId: 't-alice',
+            });
+
+            const { scope } = await runWithCapture({
+                params: { slug: 'alice' },
+                headers: {},
+            });
+
+            expect(scope).toEqual({ tenantId: 't-alice', organizationId: null });
+        });
+
+        it('returns tenantId=null on User hit who has no Tenant yet (effectively EMPTY)', async () => {
+            userRepository.findBySlug.mockResolvedValueOnce({
+                id: 'u-2',
+                slug: 'bob',
+                tenantId: null,
+            });
+
+            const { scope } = await runWithCapture({
+                params: { slug: 'bob' },
+                headers: {},
+            });
+
+            expect(scope).toEqual({ tenantId: null, organizationId: null });
+        });
+    });
+
+    describe('404', () => {
+        it('throws NotFoundException when neither Org nor User matches the slug', async () => {
+            // Both lookups already return null via the beforeEach default.
+            await expect(
+                middleware.use(
+                    { params: { slug: 'nobody' }, headers: {} } as FakeRequest,
+                    {},
+                    (() => {}) as NextFunction,
+                ),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(organizationRepository.findBySlug).toHaveBeenCalledWith('nobody');
+            expect(userRepository.findBySlug).toHaveBeenCalledWith('nobody');
+        });
+    });
+
+    describe('scope isolation across async next()', () => {
+        it('propagates scope through awaited work inside next()', async () => {
+            organizationRepository.findBySlug.mockResolvedValueOnce({
+                id: 'o-1',
+                tenantId: 't-1',
+                slug: 'acme',
+            });
+
+            let observed: ReturnType<ScopeContextService['getScope']> | null = null;
+            const next: NextFunction = async () => {
+                await new Promise((resolve) => setImmediate(resolve));
+                observed = scopeContext.getScope();
+            };
+
+            await middleware.use(
+                { params: { slug: 'acme' }, headers: {} } as FakeRequest,
+                {},
+                next,
+            );
+            // The middleware doesn't await next(), so the assertion has to
+            // wait one tick for the async next() body to settle.
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(observed).toEqual({ tenantId: 't-1', organizationId: 'o-1' });
+        });
+
+        it('outside the runWith boundary, scope reverts to EMPTY_SCOPE', async () => {
+            organizationRepository.findBySlug.mockResolvedValueOnce({
+                id: 'o-1',
+                tenantId: 't-1',
+                slug: 'acme',
+            });
+
+            await middleware.use(
+                { params: { slug: 'acme' }, headers: {} } as FakeRequest,
+                {},
+                (() => {}) as NextFunction,
+            );
+            // Once next() returned, we're back outside the ALS frame.
+            expect(scopeContext.getScope()).toEqual({ tenantId: null, organizationId: null });
+        });
+    });
+});

--- a/apps/api/src/scope/__tests__/scope-resolver.middleware.spec.ts
+++ b/apps/api/src/scope/__tests__/scope-resolver.middleware.spec.ts
@@ -110,6 +110,25 @@ describe('ScopeResolverMiddleware (EW-659 Phase 7)', () => {
             expect(scope).toEqual({ tenantId: 't-2', organizationId: 'o-2' });
         });
 
+        it('handles array-valued X-Scope-Slug from upstream proxies (Greptile P2)', async () => {
+            organizationRepository.findBySlug.mockResolvedValueOnce({
+                id: 'o-3',
+                tenantId: 't-3',
+                slug: 'acme',
+            });
+
+            const { scope } = await runWithCapture({
+                params: {},
+                headers: { 'x-scope-slug': ['acme', 'evilcorp'] },
+            });
+
+            // First non-empty entry wins; silently dropping the
+            // array would let an attacker bypass scope resolution by
+            // sending two values.
+            expect(organizationRepository.findBySlug).toHaveBeenCalledWith('acme');
+            expect(scope).toEqual({ tenantId: 't-3', organizationId: 'o-3' });
+        });
+
         it('URL :slug param takes precedence over X-Scope-Slug header', async () => {
             organizationRepository.findBySlug.mockResolvedValueOnce({
                 id: 'o-from-param',

--- a/apps/api/src/scope/scope-ownership.guard.ts
+++ b/apps/api/src/scope/scope-ownership.guard.ts
@@ -1,0 +1,98 @@
+import {
+    CanActivate,
+    ExecutionContext,
+    ForbiddenException,
+    Injectable,
+    Logger,
+} from '@nestjs/common';
+import { ScopeContextService } from './scope-context.service';
+
+/**
+ * EW-659 (Tenants & Organizations Phase 7) — guards against
+ * cross-tenant scope hijacking via slug.
+ *
+ * [`ScopeResolverMiddleware`](./scope-resolver.middleware.ts) resolves
+ * the slug to a `{ tenantId, organizationId }` **purely by public
+ * slug lookup** — that's correct for what a middleware should do
+ * (it can't access `req.user` because guards haven't run yet). But
+ * without an authorization check, an authenticated user could submit
+ * any other tenant's slug via `:slug` or `X-Scope-Slug` and the
+ * controller would happily query under that tenant's scope.
+ * (Codex P1 on PR #1059.)
+ *
+ * This guard runs AFTER `AuthSessionGuard` (because guards run in
+ * registration order from `providers: []`, and this guard is
+ * registered after `AuthSessionGuard` in `api.module.ts`), so
+ * `request.user` is populated by the time we read it. The check:
+ *
+ *   - `ScopeContext.tenantId === null` → no scope was resolved (legacy
+ *     un-prefixed route, or anonymous request). Allow.
+ *   - `request.user` not set → unauthenticated request. The auth
+ *     guard would have rejected if auth was required; otherwise it's
+ *     a public route and there's no user to check against. Allow.
+ *   - `request.user.tenantId === ScopeContext.tenantId` → match.
+ *     Allow.
+ *   - Otherwise → 403 Forbidden.
+ *
+ * **Does NOT distinguish "Org belongs to user's Tenant" from "User
+ * IS the resolved User":** both produce the same `tenantId` and the
+ * guard is satisfied. The bare-Tenant case (User slug resolution
+ * with no Org) is correctly handled because the resolved scope is
+ * `{ tenantId: user.tenantId, organizationId: null }` and the
+ * authenticated user's own `tenantId` matches by definition.
+ */
+@Injectable()
+export class ScopeOwnershipGuard implements CanActivate {
+    private readonly logger = new Logger(ScopeOwnershipGuard.name);
+
+    constructor(private readonly scopeContext: ScopeContextService) {}
+
+    canActivate(context: ExecutionContext): boolean {
+        // Only HTTP — skip RPC / WS / etc.
+        if (context.getType() !== 'http') {
+            return true;
+        }
+
+        const scope = this.scopeContext.getScope();
+        if (scope.tenantId === null) {
+            // No scope resolved → middleware short-circuited to
+            // EMPTY_SCOPE (legacy route, or exempt path). Nothing to
+            // gate on.
+            return true;
+        }
+
+        const req = context.switchToHttp().getRequest<{
+            user?: { userId?: string; tenantId?: string | null };
+        }>();
+        const user = req.user;
+        if (!user) {
+            // Unauthenticated request hit a scoped route. If the route
+            // requires auth, `AuthSessionGuard` would have already
+            // rejected the request before this guard runs (guards
+            // execute in registration order — see `api.module.ts`).
+            // Reaching this point means the route was @Public() AND
+            // a scope was resolved; treat as the EMPTY scope case.
+            return true;
+        }
+
+        const userTenantId = user.tenantId ?? null;
+        if (userTenantId === null) {
+            // User has not been upgraded to a Tenant yet (no Org
+            // created). They can't access any scoped route by slug —
+            // the slug points to *someone else's* Tenant by definition.
+            this.logger.warn(
+                `User ${user.userId ?? '?'} (no Tenant) attempted scope tenantId=${scope.tenantId}`,
+            );
+            throw new ForbiddenException('Scope does not belong to authenticated user');
+        }
+
+        if (userTenantId !== scope.tenantId) {
+            this.logger.warn(
+                `User ${user.userId ?? '?'} (tenantId=${userTenantId}) attempted cross-tenant scope tenantId=${scope.tenantId}`,
+            );
+            throw new ForbiddenException('Scope does not belong to authenticated user');
+        }
+
+        return true;
+    }
+}

--- a/apps/api/src/scope/scope-resolver.middleware.ts
+++ b/apps/api/src/scope/scope-resolver.middleware.ts
@@ -88,15 +88,24 @@ export class ScopeResolverMiddleware implements NestMiddleware {
      * Pulls the slug from the URL `:slug` route param first, then
      * from the `X-Scope-Slug` header. Normalizes whitespace + empty
      * strings to `null`.
+     *
+     * Handles array-valued headers (HTTP proxies + load balancers
+     * sometimes merge duplicate `X-Scope-Slug` values into a `string[]`
+     * — Express surfaces them as-is). Take the first non-empty entry;
+     * silently dropping the header would let an attacker bypass scope
+     * resolution by sending two values. (Greptile P2 on PR #1059.)
      */
     private extractSlug(req: MiddlewareRequest): string | null {
         const fromParam = req.params.slug;
         if (typeof fromParam === 'string' && fromParam.trim().length > 0) {
             return fromParam.trim();
         }
-        const fromHeader = req.headers['x-scope-slug'];
-        if (typeof fromHeader === 'string' && fromHeader.trim().length > 0) {
-            return fromHeader.trim();
+        const headerValue = req.headers['x-scope-slug'];
+        const headerStr = Array.isArray(headerValue)
+            ? headerValue.find((v) => typeof v === 'string' && v.trim().length > 0)
+            : headerValue;
+        if (typeof headerStr === 'string' && headerStr.trim().length > 0) {
+            return headerStr.trim();
         }
         return null;
     }

--- a/apps/api/src/scope/scope-resolver.middleware.ts
+++ b/apps/api/src/scope/scope-resolver.middleware.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger, NestMiddleware, NotFoundException } from '@nestjs/common';
+import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import { EMPTY_SCOPE, ScopeContext } from './scope-context.types';
+import { ScopeContextService } from './scope-context.service';
+
+/**
+ * Minimal request/response/next shapes we read here. Avoids dragging
+ * the full `express` types into ts-jest, which resolves them
+ * differently than SWC at runtime and trips up the build.
+ */
+interface MiddlewareRequest {
+    params: Record<string, string | undefined>;
+    headers: Record<string, string | string[] | undefined>;
+}
+type NextFn = (err?: unknown) => void;
+
+/**
+ * EW-659 (Tenants & Organizations Phase 7) — slug routing middleware.
+ *
+ * Resolves the request's scope from either a `:slug` URL segment
+ * (when the request comes through a `/api/<slug>/...` route) or the
+ * `X-Scope-Slug` HTTP header (when the web client calls a non-prefixed
+ * endpoint but wants its scope honored). Populates
+ * [`ScopeContextService`](./scope-context.service.ts) via `runWith`
+ * so the rest of the request — including the Phase 5b
+ * [`ScopeStampingSubscriber`](./scope-stamping.subscriber.ts) — sees
+ * the resolved `{ tenantId, organizationId }`.
+ *
+ * **Resolution order** (per [spec.md §4.2](../../../../docs/specs/features/tenants-and-organizations/spec.md#42-slug-resolution)):
+ *
+ *   1. Read slug from `req.params.slug`, falling back to the
+ *      `x-scope-slug` HTTP header.
+ *   2. If the slug is empty / absent, run the request under
+ *      `EMPTY_SCOPE` (legacy un-prefixed routes — both shapes
+ *      coexist per NN #20 "additive only").
+ *   3. Try `OrganizationRepository.findBySlug(slug)`. On hit, the
+ *      scope is `{ tenantId: org.tenantId, organizationId: org.id }`.
+ *   4. Fall back to `UserRepository.findBySlug(slug)`. On hit, the
+ *      scope is `{ tenantId: user.tenantId ?? null, organizationId: null }`
+ *      (the bare-Tenant surface). This is also the "personal account"
+ *      scope for a user who hasn't created any Organizations yet —
+ *      `user.tenantId` is then `null` and the scope is effectively
+ *      `EMPTY_SCOPE`, which is correct.
+ *   5. On no hit: 404 (`NotFoundException`). Distinguishes from
+ *      "exists but you can't see it" (403) — slug lookup is a public
+ *      operation; either the slug exists or it doesn't.
+ *
+ * The `users.slug` ↔ `organizations.slug` namespace is globally
+ * unique (the [`UsernameAllocatorService`](../users/services/username-allocator.service.ts)
+ * collides-checks both tables on every allocation), so steps 3 and 4
+ * can never both hit for the same slug.
+ *
+ * **Wraps `next()` in `runWith`** so the ALS context propagates
+ * through async/await chains for the rest of the request. Without
+ * this, the scope would be set at middleware time and lost by the
+ * time the controller awaits the database.
+ */
+@Injectable()
+export class ScopeResolverMiddleware implements NestMiddleware {
+    private readonly logger = new Logger(ScopeResolverMiddleware.name);
+
+    constructor(
+        private readonly scopeContext: ScopeContextService,
+        private readonly userRepository: UserRepository,
+        private readonly organizationRepository: OrganizationRepository,
+    ) {}
+
+    async use(req: MiddlewareRequest, _res: unknown, next: NextFn): Promise<void> {
+        const slug = this.extractSlug(req);
+
+        if (!slug) {
+            // Legacy un-prefixed route, or an exempt path. Run under
+            // EMPTY_SCOPE so the subscriber's beforeInsert hook sees
+            // `null` for both fields and doesn't stamp anything.
+            this.scopeContext.runWith(EMPTY_SCOPE, () => next());
+            return;
+        }
+
+        const scope = await this.resolveScope(slug);
+        if (!scope) {
+            throw new NotFoundException(`Slug '${slug}' not found`);
+        }
+
+        this.scopeContext.runWith(scope, () => next());
+    }
+
+    /**
+     * Pulls the slug from the URL `:slug` route param first, then
+     * from the `X-Scope-Slug` header. Normalizes whitespace + empty
+     * strings to `null`.
+     */
+    private extractSlug(req: MiddlewareRequest): string | null {
+        const fromParam = req.params.slug;
+        if (typeof fromParam === 'string' && fromParam.trim().length > 0) {
+            return fromParam.trim();
+        }
+        const fromHeader = req.headers['x-scope-slug'];
+        if (typeof fromHeader === 'string' && fromHeader.trim().length > 0) {
+            return fromHeader.trim();
+        }
+        return null;
+    }
+
+    /**
+     * Resolve a slug to `{ tenantId, organizationId }`. Returns
+     * `null` on no hit (which the caller maps to 404).
+     */
+    private async resolveScope(slug: string): Promise<ScopeContext | null> {
+        const org = await this.organizationRepository.findBySlug(slug);
+        if (org) {
+            return { tenantId: org.tenantId, organizationId: org.id };
+        }
+
+        const user = await this.userRepository.findBySlug(slug);
+        if (user) {
+            return {
+                tenantId: user.tenantId ?? null,
+                organizationId: null,
+            };
+        }
+
+        this.logger.debug(`Scope resolution miss for slug='${slug}'`);
+        return null;
+    }
+}

--- a/apps/api/src/scope/scope.module.ts
+++ b/apps/api/src/scope/scope.module.ts
@@ -1,8 +1,9 @@
 import { Global, MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
-import { DatabaseModule, OrganizationRepository, UserRepository } from '@ever-works/agent/database';
+import { DatabaseModule } from '@ever-works/agent/database';
 import { ScopeContextService } from './scope-context.service';
 import { ScopeStampingSubscriber } from './scope-stamping.subscriber';
 import { ScopeResolverMiddleware } from './scope-resolver.middleware';
+import { ScopeOwnershipGuard } from './scope-ownership.guard';
 
 /**
  * EW-657 (Tenants & Organizations Phase 5b) — exposes
@@ -31,15 +32,19 @@ import { ScopeResolverMiddleware } from './scope-resolver.middleware';
  */
 @Global()
 @Module({
+    // DatabaseModule already provides + exports `UserRepository` and
+    // `OrganizationRepository` (via REPOSITORY_PROVIDERS), so importing
+    // it here is enough — declaring those repos in our own providers
+    // array would shadow the singleton with a fresh per-module instance.
+    // (Greptile P2 on PR #1059.)
     imports: [DatabaseModule],
     providers: [
         ScopeContextService,
         ScopeStampingSubscriber,
-        UserRepository,
-        OrganizationRepository,
         ScopeResolverMiddleware,
+        ScopeOwnershipGuard,
     ],
-    exports: [ScopeContextService],
+    exports: [ScopeContextService, ScopeOwnershipGuard],
 })
 export class ScopeModule implements NestModule {
     /**

--- a/apps/api/src/scope/scope.module.ts
+++ b/apps/api/src/scope/scope.module.ts
@@ -1,6 +1,8 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
+import { DatabaseModule, OrganizationRepository, UserRepository } from '@ever-works/agent/database';
 import { ScopeContextService } from './scope-context.service';
 import { ScopeStampingSubscriber } from './scope-stamping.subscriber';
+import { ScopeResolverMiddleware } from './scope-resolver.middleware';
 
 /**
  * EW-657 (Tenants & Organizations Phase 5b) — exposes
@@ -29,7 +31,44 @@ import { ScopeStampingSubscriber } from './scope-stamping.subscriber';
  */
 @Global()
 @Module({
-    providers: [ScopeContextService, ScopeStampingSubscriber],
+    imports: [DatabaseModule],
+    providers: [
+        ScopeContextService,
+        ScopeStampingSubscriber,
+        UserRepository,
+        OrganizationRepository,
+        ScopeResolverMiddleware,
+    ],
     exports: [ScopeContextService],
 })
-export class ScopeModule {}
+export class ScopeModule implements NestModule {
+    /**
+     * EW-659 (Phase 7) — apply ScopeResolverMiddleware globally on
+     * `/api/*` with an exempt list.
+     *
+     * **Exempt routes** ([spec.md §4.2](../../../../docs/specs/features/tenants-and-organizations/spec.md#42-slug-resolution)):
+     *
+     *   - `/api/auth/*` — login / OAuth callbacks must work before
+     *     any scope exists. (Anonymous users have no Tenant.)
+     *   - `/api/users/check-username` — public, pre-login.
+     *   - `/api/organizations/check-slug` — public, pre-login (the
+     *     CreateOrganizationModal calls this from a not-yet-scoped
+     *     route to check availability before creating the Org).
+     *
+     * Everything else under `/api/` runs through the middleware. The
+     * middleware itself short-circuits to `EMPTY_SCOPE` when no slug
+     * is present (legacy un-prefixed routes), so the cost of being
+     * in-band on every request is one synchronous header check.
+     */
+    configure(consumer: MiddlewareConsumer): void {
+        consumer
+            .apply(ScopeResolverMiddleware)
+            .exclude(
+                { path: 'api/auth/(.*)', method: RequestMethod.ALL },
+                { path: 'api/auth', method: RequestMethod.ALL },
+                { path: 'api/users/check-username', method: RequestMethod.GET },
+                { path: 'api/organizations/check-slug', method: RequestMethod.GET },
+            )
+            .forRoutes({ path: 'api/(.*)', method: RequestMethod.ALL });
+    }
+}

--- a/apps/docs/src/theme.d.ts
+++ b/apps/docs/src/theme.d.ts
@@ -7,7 +7,12 @@ declare module '@theme/Layout' {
 
 declare module '@theme/Heading' {
 	type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-	export interface Props extends import('react').ComponentProps<HeadingTag> {
+	// Hoisted to a named alias because prettier's TS parser can't
+	// handle the `interface X extends import('...').Y<Z>` form
+	// (SyntaxError: "Interface declaration can only extend an
+	// identifier/qualified name with optional type arguments").
+	type HeadingComponentProps = import('react').ComponentProps<HeadingTag>;
+	export interface Props extends HeadingComponentProps {
 		readonly as: HeadingTag;
 		readonly children?: import('react').ReactNode;
 		readonly className?: string;

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4562,7 +4562,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4562,7 +4562,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4562,7 +4562,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4562,7 +4562,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4562,7 +4562,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4562,7 +4562,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4626,7 +4626,8 @@
                     "subtitle": "Bring in a Work you already have — repo, items, and provider settings.",
                     "cta": "Import now"
                 }
-            }        }
+            }
+        }
     },
     "layout": {
         "auth": {


### PR DESCRIPTION
## Summary

Phase 7 of the Tenants & Organizations rollout (EW-659). Adds `ScopeResolverMiddleware` that connects Phase 5b's ScopeContextService to actual HTTP requests: reads `:slug` (URL param) or `X-Scope-Slug` (HTTP header), resolves it to `{ tenantId, organizationId }` via `OrganizationRepository`/`UserRepository`, and populates the AsyncLocalStorage scope via `runWith` for the rest of the request.

From this point onward, the [ScopeStampingSubscriber](https://github.com/ever-works/ever-works/blob/develop/apps/api/src/scope/scope-stamping.subscriber.ts) sees real values and Tier A/C inserts auto-stamp `tenantId` / `organizationId` correctly.

## Resolution order (per spec.md §4.2)

1. Empty / missing slug → `EMPTY_SCOPE` pass-through (legacy un-prefixed routes still work — NN #20 additive)
2. `OrganizationRepository.findBySlug(slug)` → on hit, scope = `{ org.tenantId, org.id }`
3. Fall back to `UserRepository.findBySlug(slug)` → on hit, scope = `{ user.tenantId ?? null, null }` (bare-Tenant)
4. On miss → 404 NotFoundException

The user-slug / org-slug namespace is globally unique (UsernameAllocator collision-checks both tables on every allocation), so steps 2 and 3 can never both hit for the same slug.

## Middleware wiring

Applied globally on `/api/*` with this exempt list:
- `/api/auth/*` — login / OAuth must work before any scope exists
- `/api/users/check-username` — public, pre-login
- `/api/organizations/check-slug` — called from the modal before any Org exists

## Out of scope (Phase 7b follow-up)

Web side (`apps/web/src/app/[slug]/...` route segment + X-Scope-Slug header on the fetcher). The API surface is fully functional now; the web client can be built independently against the documented contract.

## Test plan

- [x] `scope-resolver.middleware.spec.ts` — 10 cases (empty pass-through, Org/User resolution, header vs param precedence, 404 NotFound, ALS propagation through async next())
- [x] All 10 tests pass
- [x] Full API build clean (0 TSC issues, 455 files via SWC)
- [x] \`pnpm format:check\` clean on touched files (pre-existing zh.json warning on develop unrelated)
- [ ] CI: lint-and-test (22.x)
- [ ] Bot reviews: Codex + Greptile + CodeRabbit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic request scope resolution for API requests (tenant/organization detection via URL param or header) with middleware applied to API routes and auth exclusions.

* **Tests**
  * Comprehensive tests for scope resolution covering missing slugs, param/header precedence, user/org fallbacks, error cases, and async context propagation.

* **Localization**
  * Minor formatting fixes across many translation files and one new Thai hint string for the new-page flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->