### PR TITLE
test(e2e): fix locale-prefix URL waits for PR #1052

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -43,10 +43,15 @@ test.describe('Registration', () => {
         // Submit
         await page.locator('button[type="submit"]').click();
 
-        // Should redirect to dashboard (any /en path that isn't an auth page)
-        await page.waitForURL(/\/en(\/(?!login|register|forgot|reset|email|auth)|$|\?)/, {
-            timeout: 120_000,
-        });
+        // Should redirect to dashboard. Accept both legacy `/en/<path>`
+        // and the canonical unprefixed `/<path>` introduced by PR #1052
+        // (`localePrefix: 'never'`). Anchored at the protocol+host
+        // boundary so the auth-page exclusion lookahead fires against
+        // the actual pathname.
+        await page.waitForURL(
+            /^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset|email|auth)|$|\?)/,
+            { timeout: 120_000 },
+        );
         await expect(page).not.toHaveURL(/\/register/);
     });
 

--- a/apps/web/e2e/dashboard-comprehensive.spec.ts
+++ b/apps/web/e2e/dashboard-comprehensive.spec.ts
@@ -54,20 +54,23 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         });
     }
 
-    test('sidebar shows "Works" nav item with /en/works href', async ({ page }) => {
+    test('sidebar shows "Works" nav item with /works href', async ({ page }) => {
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const worksLink = page.locator('a[href="/en/works"]').first();
-        await expect(worksLink, 'sidebar /en/works link present').toBeVisible({ timeout: 10_000 });
+        // PR #1052 dropped the URL-level locale prefix — match both the
+        // canonical `/works` and the legacy `/en/works` so this stays
+        // green across the cutover.
+        const worksLink = page.locator('a[href="/works"], a[href="/en/works"]').first();
+        await expect(worksLink, 'sidebar Works link present').toBeVisible({ timeout: 10_000 });
     });
 
     test('sidebar "New Work" CTA is present', async ({ page }) => {
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const newWorkLink = page.locator('a[href="/en/works/new"]').first();
-        await expect(newWorkLink, 'sidebar /en/works/new CTA present').toBeVisible({
+        const newWorkLink = page.locator('a[href="/works/new"], a[href="/en/works/new"]').first();
+        await expect(newWorkLink, 'sidebar New Work CTA present').toBeVisible({
             timeout: 10_000,
         });
     });
@@ -137,21 +140,24 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
-        const worksLink = page.locator('a[href="/en/works"]').first();
+        // PR #1052 dropped the URL-level locale prefix, so sidebar
+        // links render as `/works` (not `/en/works`). Match both shapes
+        // so this spec stays green across the cutover.
+        const worksLink = page.locator('a[href="/works"], a[href="/en/works"]').first();
         await expect(worksLink).toBeVisible({ timeout: 10_000 });
         await worksLink.click();
-        await page.waitForURL(/\/en\/works(\?|$|\/)/, { timeout: 30_000 });
-        expect(page.url()).toMatch(/\/en\/works/);
+        await page.waitForURL(/(?:\/en)?\/works(\?|$|\/)/, { timeout: 30_000 });
+        expect(page.url()).toMatch(/(?:\/en)?\/works/);
     });
 
-    test('clicking sidebar "New Work" link navigates to /en/works/new', async ({ page }) => {
+    test('clicking sidebar "New Work" link navigates to /works/new', async ({ page }) => {
         test.setTimeout(60_000);
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
-        const newWorkLink = page.locator('a[href="/en/works/new"]').first();
+        const newWorkLink = page.locator('a[href="/works/new"], a[href="/en/works/new"]').first();
         await expect(newWorkLink).toBeVisible({ timeout: 10_000 });
         await newWorkLink.click();
-        await page.waitForURL(/\/en\/works\/new/, { timeout: 30_000 });
+        await page.waitForURL(/(?:\/en)?\/works\/new/, { timeout: 30_000 });
     });
 });

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -44,12 +44,18 @@ setup('authenticate', async ({ page, baseURL }) => {
     await page.locator('input[name="password"]').fill(TEST_USER.password);
     await page.locator('button[type="submit"]').click();
 
-    // Wait for successful redirect to dashboard. The regex matches `/en`, `/en/`,
-    // `/en?...`, or `/en/<dashboard-path>` — but NOT `/en/login` or other auth pages
-    // (so we don't accidentally consider the still-on-login state as success).
-    await page.waitForURL(/\/en(\/(?!login|register|forgot|reset|email|auth)|$|\?)/, {
-        timeout: 120_000,
-    });
+    // Wait for successful redirect to dashboard. After PR #1052 dropped
+    // the URL-level locale prefix (`localePrefix: 'never'`), the legacy
+    // `/en/...` paths still 307-redirect to the unprefixed equivalents,
+    // so this regex accepts BOTH shapes — `/en/<path>` for any test that
+    // happens to land mid-redirect, and the canonical unprefixed
+    // `/<path>` for everything else. We anchor at the protocol+host
+    // boundary so the path-specific lookahead actually fires against
+    // the URL pathname, not a stray substring.
+    await page.waitForURL(
+        /^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset|email|auth)|$|\?)/,
+        { timeout: 120_000 },
+    );
 
     // Verify we're authenticated
     await expect(page).not.toHaveURL(/\/login/);

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -18,10 +18,12 @@ export async function registerViaUI(
 
     await page.locator('button[type="submit"]').click();
 
-    // Wait for redirect to dashboard
-    await page.waitForURL(/\/en(\/(?!login|register|forgot|reset|email|auth)|$|\?)/, {
-        timeout: 30_000,
-    });
+    // Wait for redirect to dashboard. Matches both legacy `/en/<path>`
+    // and the canonical unprefixed `/<path>` shape (PR #1052).
+    await page.waitForURL(
+        /^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset|email|auth)|$|\?)/,
+        { timeout: 30_000 },
+    );
 }
 
 /**
@@ -36,10 +38,12 @@ export async function loginViaUI(page: Page, credentials: { email: string; passw
 
     await page.locator('button[type="submit"]').click();
 
-    // Wait for redirect to dashboard
-    await page.waitForURL(/\/en(\/(?!login|register|forgot|reset|email|auth)|$|\?)/, {
-        timeout: 30_000,
-    });
+    // Wait for redirect to dashboard. Matches both legacy `/en/<path>`
+    // and the canonical unprefixed `/<path>` shape (PR #1052).
+    await page.waitForURL(
+        /^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset|email|auth)|$|\?)/,
+        { timeout: 30_000 },
+    );
 }
 
 /**

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -58,15 +58,21 @@ test.describe('Public pages', () => {
 });
 
 test.describe('Locale routing', () => {
-    test('should redirect root to default locale', async ({ page }) => {
+    test('root URL stays unprefixed', async ({ page }) => {
+        // PR #1052 switched `localePrefix` from `'always'` to `'never'`.
+        // `/` no longer redirects to `/en/` — it renders the canonical
+        // unprefixed home directly.
         await page.goto('/');
-
-        // Should redirect to /en/ or another locale
-        await page.waitForURL(/\/[a-z]{2}\//, { timeout: 10_000 });
+        await expect(page).toHaveURL(
+            /\/(?!en|fr|de|es|pt|nl|it|ja|zh|ar|he|ru|tr|sv|pl|uk|vi|id|hi|fa|bg|fi|no)/,
+        );
     });
 
-    test('should load pages with explicit locale prefix', async ({ page }) => {
+    test('legacy /en/<path> URLs redirect to the unprefixed equivalent', async ({ page }) => {
+        // Old `/en/login` bookmarks should 307-redirect to `/login` and
+        // seed the NEXT_LOCALE cookie (proxy.ts handles this).
         await page.goto('/en/login');
-        await expect(page).toHaveURL(/\/en\/login/);
+        await expect(page).toHaveURL(/\/login/);
+        await expect(page).not.toHaveURL(/\/en\/login/);
     });
 });

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -61,10 +61,18 @@ test.describe('Locale routing', () => {
     test('root URL stays unprefixed', async ({ page }) => {
         // PR #1052 switched `localePrefix` from `'always'` to `'never'`.
         // `/` no longer redirects to `/en/` — it renders the canonical
-        // unprefixed home directly.
+        // unprefixed home directly. Assert that the URL does NOT contain
+        // a `/<locale>/` segment anywhere; an unprefixed URL like
+        // `http://host:port/` (or `/?<query>`) passes.
+        //
+        // Greptile P1: an earlier draft used a negative lookahead
+        // (`/\/(?!en|...)/ `) which is vacuously satisfied by the `/`
+        // inside `http://` — every URL passed. The negated `toHaveURL`
+        // shape below tests the substring directly, so it can actually
+        // fail when a locale prefix sneaks back in.
         await page.goto('/');
-        await expect(page).toHaveURL(
-            /\/(?!en|fr|de|es|pt|nl|it|ja|zh|ar|he|ru|tr|sv|pl|uk|vi|id|hi|fa|bg|fi|no)/,
+        await expect(page).not.toHaveURL(
+            /\/(?:en|fr|de|es|pt|nl|it|ja|zh|ar|he|ru|tr|sv|pl|uk|vi|id|hi|fa|bg|fi|no)(?:\/|$|\?|#)/,
         );
     });
 

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -15,10 +15,13 @@ test.describe('Onboarding — dismissal persists', () => {
 
         // The "Welcome" / onboarding modal would block all clicks. Verify
         // we can still click a sidebar link.
-        const worksLink = page.locator('a[href="/en/works"]').first();
+        // PR #1052 dropped the URL-level locale prefix, so the sidebar
+        // href renders as `/works` (not `/en/works`). Accept both
+        // during the rollout.
+        const worksLink = page.locator('a[href="/works"], a[href="/en/works"]').first();
         await expect(worksLink).toBeVisible({ timeout: 10_000 });
         await worksLink.click();
-        await page.waitForURL(/\/en\/works(\?|\/|$)/, { timeout: 30_000 });
+        await page.waitForURL(/(?:\/en)?\/works(\?|\/|$)/, { timeout: 30_000 });
     });
 
     test('localStorage contains the dismissed onboarding state', async ({ page }) => {

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -34,10 +34,12 @@ test.describe('Complete user journey', () => {
         await page.locator('#terms').check();
         await page.locator('button[type="submit"]').click();
 
-        // Should arrive at dashboard (any /en path that isn't an auth page)
-        await page.waitForURL(/\/en(\/(?!login|register|forgot|reset|email|auth)|$|\?)/, {
-            timeout: 60_000,
-        });
+        // Should arrive at dashboard. Match both legacy `/en/<path>`
+        // and the canonical unprefixed `/<path>` shape (PR #1052).
+        await page.waitForURL(
+            /^https?:\/\/[^/]+(?:\/en)?(\/(?!login|register|forgot|reset|email|auth)|$|\?)/,
+            { timeout: 60_000 },
+        );
 
         // ---- Step 2: Navigate to create work ----
         // Pre-dismiss the onboarding wizard so the modal doesn't intercept clicks.

--- a/apps/web/e2e/works-detail.spec.ts
+++ b/apps/web/e2e/works-detail.spec.ts
@@ -79,7 +79,7 @@ test.describe('Works list page — interactive surface', () => {
         const newWorkLink = page.locator('a[href$="/works/new"], a[href*="/works/new?"]').first();
         await expect(newWorkLink).toBeVisible({ timeout: 10_000 });
         await newWorkLink.click();
-        await page.waitForURL(/\/en\/works\/new/, { timeout: 30_000 });
+        await page.waitForURL(/(?:\/en)?\/works\/new/, { timeout: 30_000 });
     });
 });
 


### PR DESCRIPTION
## Summary

[PR #1052](https://github.com/ever-works/ever-works/pull/1052) switched next-intl from \`localePrefix: 'always'\` to \`'never'\` and added a 307 legacy redirect from \`/<locale>/<path>\` to \`/<path>\`. The E2E specs were missed in that change — they still \`waitForURL(/\/en(\/...)/)\` and look for \`a[href=\"/en/works\"]\` sidebar links, both stale under the new URL scheme.

That is the entire E2E failure on the open stage→main cascade ([PR #1057](https://github.com/ever-works/ever-works/pull/1057), see [actions run 26540373216](https://github.com/ever-works/ever-works/actions/runs/26540373216)):

- \`[setup] › global-setup.ts:authenticate\` — 120s timeout waiting for \`/en/...\` that never appears.
- \`[chromium-no-auth] › auth.spec.ts › Registration\` — same regex, same timeout.

## Changes

- \`global-setup.ts\`, \`auth.spec.ts\`, \`helpers/auth.ts\`, \`user-journey.spec.ts\` — \`waitForURL\` regexes accept both \`/en/<path>\` and unprefixed \`/<path>\`. Anchored at the protocol+host boundary so the auth-page-exclusion lookahead fires against the actual pathname.
- \`dashboard-comprehensive.spec.ts\`, \`onboarding.spec.ts\`, \`works-detail.spec.ts\` — sidebar \`a[href=\"/en/works\"]\` locators expanded to also match \`/works\`.
- \`navigation.spec.ts\` — \`Locale routing\` block updated to assert the new behavior (root stays unprefixed; legacy \`/en/<path>\` redirects to \`/<path>\`). The previous assertions tested the old \`localePrefix: 'always'\` behavior.

## Not in this PR

\`POST /api/auth/register\` returned **HTTP 422 \"Failed to create user\"** in the same stage→main run, hitting the \`conversations\` spec via \`registerUserViaAPI\`. That looks like a Tenants/Orgs migration follow-up (PR #1046/#1049/#1051 series) and needs its own investigation. Tracked as a separate item.

## Test plan

- [ ] Lightweight CI passes (lint + unit tests).
- [ ] After merge, the next \`stage → main\` cascade re-runs E2E; \`global-setup\` and the Registration spec should pass on first try.
- [ ] If the \`conversations\` 422 reappears, that is the next blocker — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site routes now render without locale prefixes by default (e.g., /works instead of /en/works) for cleaner URLs.
  * Legacy locale-prefixed URLs remain supported for backward compatibility.

* **Bug Fixes**
  * Improved post-auth and navigation redirect handling so login, registration, and bookmarked legacy links reliably land on the correct unprefixed pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->