### PR TITLE
[EW-660] Phase 8 - WorkspaceSwitcher UI

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4825,5 +4825,13 @@
             "private": "خاص",
             "public": "عام"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4825,5 +4825,13 @@
             "private": "Частен",
             "public": "Публичен"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4825,5 +4825,13 @@
             "private": "Privat",
             "public": "Öffentlich"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4644,5 +4644,13 @@
             "private": "Private",
             "public": "Public"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4825,5 +4825,13 @@
             "private": "Privado",
             "public": "Público"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4825,5 +4825,13 @@
             "private": "Privé",
             "public": "Public"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4825,5 +4825,13 @@
             "private": "פרטי",
             "public": "ציבורי"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4889,5 +4889,13 @@
             "private": "निजी",
             "public": "सार्वजनिक"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4889,5 +4889,13 @@
             "private": "Pribadi",
             "public": "Publik"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4889,5 +4889,13 @@
             "private": "Privato",
             "public": "Pubblico"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4889,5 +4889,13 @@
             "private": "非公開",
             "public": "公開"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4889,5 +4889,13 @@
             "private": "비공개",
             "public": "공개"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4889,5 +4889,13 @@
             "private": "Privé",
             "public": "Openbaar"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4889,5 +4889,13 @@
             "private": "Prywatny",
             "public": "Publiczny"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4889,5 +4889,13 @@
             "private": "Privado",
             "public": "Público"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4889,5 +4889,13 @@
             "private": "Приватный",
             "public": "Публичный"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4889,5 +4889,13 @@
             "private": "ส่วนตัว",
             "public": "สาธารณะ"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4889,5 +4889,13 @@
             "private": "Özel",
             "public": "Genel"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4889,5 +4889,13 @@
             "private": "Приватний",
             "public": "Публічний"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4889,5 +4889,13 @@
             "private": "Riêng tư",
             "public": "Công khai"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4889,5 +4889,13 @@
             "private": "私有",
             "public": "公开"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — web BFF proxy for
+ * `GET /api/organizations`.
+ *
+ * Forwards to the NestJS API at `${API_URL}/organizations` with the
+ * user's auth token attached as a Bearer header (the encrypted
+ * `auth_token` cookie is decrypted here, NEVER shipped to the browser).
+ *
+ * Returns the upstream `OrganizationResponse[]` payload as-is. On 401
+ * or upstream error we fall through to `{ status }` so the client-side
+ * `useOrganizations()` hook can surface a sensible `error` value without
+ * mistaking the auth-failure for an empty-orgs list.
+ */
+export async function GET(_request: NextRequest) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+
+    try {
+        const upstream = await fetch(`${API_URL}/organizations`, {
+            method: 'GET',
+            headers,
+            cache: 'no-store',
+        });
+        if (!upstream.ok) {
+            return NextResponse.json(
+                { error: 'Failed to fetch organizations' },
+                { status: upstream.status || 500 },
+            );
+        }
+        const body = await upstream.json();
+        return NextResponse.json(body, { status: 200 });
+    } catch (error) {
+        console.error('Failed to proxy /api/organizations:', error);
+        return NextResponse.json({ error: 'Failed to fetch organizations' }, { status: 500 });
+    }
+}

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -39,7 +39,8 @@ import {
     DropdownMenuSeparator,
     DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu';
-import { LogoEverWork, FaviconEverWork } from '../logos';
+import { FaviconEverWork } from '../logos';
+import { WorkspaceSwitcher } from '../layout/WorkspaceSwitcher';
 import { useWorkDetail } from '../works/detail/WorkDetailContext';
 import { ChatPanelExpandButton } from '@/components/ai/ChatPanel';
 import { SidebarActivityIndicator } from './SidebarActivityIndicator';
@@ -151,12 +152,24 @@ export function DashboardSidebar({
                     )}
                 >
                     <div className="w-full relative">
+                        {/*
+                            EW-660 (Tenants & Organizations Phase 8) —
+                            the expanded sidebar swaps `<LogoEverWork>`
+                            for `<WorkspaceSwitcher>`, which itself
+                            renders the unmodified logo when the user
+                            has zero Organizations (NN #20 — extension,
+                            not replacement). The collapsed sidebar
+                            keeps the bare favicon: there's no room for
+                            a chip+chevron at 16px column width, and
+                            users in that mode already expand the
+                            sidebar before reaching for the switcher.
+                        */}
                         <div className={cn('flex items-center -ml-2')}>
-                            <FaviconEverWork
-                                config={config}
-                                className={cn(isCollapsed ? 'w-11 ml-[5px]' : 'w-12')}
-                            />
-                            <LogoEverWork config={config} className={cn(isCollapsed && 'hidden')} />
+                            {isCollapsed ? (
+                                <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
+                            ) : (
+                                <WorkspaceSwitcher config={config} logoClassName="" />
+                            )}
                         </div>
                         <div
                             className={cn(

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Building2, Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { useRouter } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { useActiveScope } from '@/lib/hooks/use-active-scope';
+import { LogoEverWork } from '../logos';
+import type { WorkConfig } from '@/lib/api';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+interface WorkspaceSwitcherProps {
+    /** Site config passed through to the empty-state `<LogoEverWork>`. */
+    config?: WorkConfig | null;
+    /** Tailwind class for the empty-state logo. Lets the sidebar size it. */
+    logoClassName?: string;
+}
+
+function pickInitial(org: OrganizationResponse): string {
+    const source = org.displayName ?? org.slug ?? '';
+    return source.charAt(0).toUpperCase() || '?';
+}
+
+function pickLabel(org: OrganizationResponse): string {
+    return org.displayName ?? org.slug;
+}
+
+/**
+ * Avatar circle for an Organization. Mimics shadcn `sidebar-07`
+ * TeamSwitcher's visual: a colored square with the first initial.
+ * `Building2` is used as a fallback when the initial would be empty.
+ */
+function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' }) {
+    const initial = pickInitial(org);
+    return (
+        <div
+            className={cn(
+                'shrink-0 inline-flex items-center justify-center rounded-md',
+                'bg-surface-tertiary dark:bg-surface-tertiary-dark',
+                'text-text dark:text-text-dark',
+                'font-semibold',
+                size === 'sm' ? 'w-7 h-7 text-xs' : 'w-5 h-5 text-[10px]',
+            )}
+            aria-hidden="true"
+        >
+            {initial || <Building2 className="w-3.5 h-3.5" strokeWidth={1.5} />}
+        </div>
+    );
+}
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — top-of-sidebar component
+ * showing the active Organization (or the bare Ever Works logo when
+ * the user has zero Orgs) with a popover to switch between Orgs.
+ *
+ * Behavior matrix:
+ *
+ * | Org count | Trigger UI                       | Popover                   |
+ * |-----------|----------------------------------|---------------------------|
+ * | 0         | `<LogoEverWork />` unmodified    | none (no chevron)         |
+ * | 1+        | Chip: [avatar] [name] [chevron]  | List of orgs + create row |
+ *
+ * The empty-state branch renders `<LogoEverWork />` AS-IS so the
+ * sidebar visuals for the no-org majority of users stay pixel-identical
+ * (NN #20 — extension, not replacement).
+ *
+ * Clicking an Org row navigates to `/{org.slug}/dashboard`. Clicking
+ * "+ Create Organization" is a stub for Phase 9 — it `console.log`s
+ * and the modal lands in EW-661.
+ */
+export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
+    const t = useTranslations('organizations.switcher');
+    const router = useRouter();
+    const { organizations, isLoading } = useOrganizations();
+    const { activeOrganization } = useActiveScope();
+
+    // Empty state: no orgs yet → render the existing logo unmodified.
+    // We intentionally treat `isLoading` as empty for the initial
+    // render so we don't flash a "Loading…" chip in the most common
+    // case (zero orgs). Once the fetch resolves and orgs > 0, the
+    // chip appears.
+    if (!isLoading && organizations.length === 0) {
+        return <LogoEverWork config={config} className={logoClassName} />;
+    }
+
+    // Loading state, but only on the very first fetch when we don't
+    // yet know whether the user has orgs. Render a minimal skeleton
+    // (same width as the chip) so layout doesn't jump.
+    if (isLoading && organizations.length === 0) {
+        return (
+            <div
+                className={cn(
+                    'flex items-center gap-2 px-2 py-1.5 rounded-md',
+                    'text-text-muted dark:text-text-muted-dark',
+                    'text-sm',
+                )}
+                aria-busy="true"
+            >
+                <span className="w-7 h-7 rounded-md bg-surface-tertiary/60 dark:bg-surface-tertiary-dark/60 animate-pulse" />
+                <span className="truncate">{t('loading')}</span>
+            </div>
+        );
+    }
+
+    // Active state: 1+ orgs. Pick the trigger label — if we know the
+    // active Org from the URL slug, use it; otherwise fall back to the
+    // first org in the list so the chip never shows up empty.
+    const triggerOrg = activeOrganization ?? organizations[0];
+
+    const handleSelectOrg = (org: OrganizationResponse) => {
+        router.push(`/${org.slug}/dashboard`);
+    };
+
+    const handleCreateOrg = () => {
+        // Phase 9 — EW-661 lands the modal. For now we log so the
+        // wiring point is explicit and easy to grep for during the
+        // next PR.
+        console.log('TODO Phase 9: open CreateOrganizationModal');
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                className={cn(
+                    'w-full rounded-md transition-colors cursor-pointer',
+                    'focus:outline-none focus-visible:outline-none',
+                    'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
+                    'px-2 py-1.5',
+                )}
+            >
+                <div className="flex items-center gap-2 w-full">
+                    <OrgAvatar org={triggerOrg} />
+                    <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                        {pickLabel(triggerOrg)}
+                    </span>
+                    <ChevronsUpDown
+                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                        strokeWidth={1.5}
+                        aria-hidden="true"
+                    />
+                </div>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="start" className="w-60">
+                <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
+                {organizations.map((org) => {
+                    const isActive = activeOrganization?.id === org.id;
+                    return (
+                        <DropdownMenuItem
+                            key={org.id}
+                            onClick={() => handleSelectOrg(org)}
+                            className="cursor-pointer"
+                        >
+                            <div className="flex items-center gap-2 w-full">
+                                <OrgAvatar org={org} size="xs" />
+                                <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                    {pickLabel(org)}
+                                </span>
+                                {isActive && (
+                                    <Check
+                                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                        strokeWidth={1.5}
+                                        aria-label="Active organization"
+                                    />
+                                )}
+                            </div>
+                        </DropdownMenuItem>
+                    );
+                })}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
+                    <div className="flex items-center gap-2 w-full">
+                        <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">
+                            <Plus
+                                className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
+                                strokeWidth={1.5}
+                            />
+                        </span>
+                        <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                            {t('createNew')}
+                        </span>
+                    </div>
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+// next-intl — return the key path verbatim so assertions can match
+// against the namespaced keys (we don't care about translated copy
+// here, only structure).
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+// next/navigation — `useParams()` returns the URL slug. We mock it
+// per-test via `paramsMock`.
+const paramsMock = vi.fn<() => { slug?: string }>();
+paramsMock.mockReturnValue({});
+vi.mock('next/navigation', () => ({
+    useParams: () => paramsMock(),
+}));
+
+// i18n navigation — `useRouter().push()` for the switch-on-click flow.
+const routerPushMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href: string }) => (
+        <a {...rest}>{children}</a>
+    ),
+    useRouter: () => ({ push: routerPushMock }),
+}));
+
+// Mock the LogoEverWork to a simple sentinel — we don't want to render
+// the real Next.js Image (jsdom) and we want a stable test selector
+// for the empty-state assertion.
+vi.mock('../logos', () => ({
+    LogoEverWork: () => <div data-testid="logo-everwork">LogoEverWork</div>,
+}));
+
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+function makeOrg(overrides: Partial<OrganizationResponse> = {}): OrganizationResponse {
+    return {
+        id: `o-${Math.random().toString(36).slice(2, 8)}`,
+        tenantId: 't-1',
+        slug: 'acme',
+        legalName: null,
+        displayName: 'Acme Inc',
+        countryCode: null,
+        registrationProvider: null,
+        registrationStatus: null,
+        linkedWorkId: null,
+        createdAt: '2026-05-28T00:00:00.000Z',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        routerPushMock.mockReset();
+        paramsMock.mockReset().mockReturnValue({});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Empty state: `organizations.length === 0` → falls back to the
+     * unmodified `<LogoEverWork>` (NN #20 — extension, not replacement).
+     * No popover trigger should be present.
+     */
+    it('renders the LogoEverWork (no popover trigger) when the user has zero organizations', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        const { container } = render(<WorkspaceSwitcher />);
+
+        expect(screen.getByTestId('logo-everwork')).toBeInTheDocument();
+        // No popover-trigger button — the empty state is the bare logo.
+        expect(container.querySelector('[role="button"]')).toBeNull();
+        // And the chevron icon — used as the trigger affordance — is
+        // absent.
+        expect(container.querySelectorAll('svg').length).toBe(0);
+    });
+
+    /**
+     * Active state with 1 org: the chip renders with the org's display
+     * name AND a trigger affordance (chevron icon).
+     */
+    it('renders the chip with the org name and a popover trigger when the user has 1 organization', () => {
+        const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher />);
+
+        // Chip text shows the display name.
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
+        // The logo from the empty-state branch should NOT render.
+        expect(screen.queryByTestId('logo-everwork')).toBeNull();
+    });
+
+    /**
+     * 3 orgs — when the popover opens, all three list rows are
+     * present. We assert against the DOM (text content) rather than
+     * driving headlessui's actual open animation, since the items are
+     * rendered into the menu's items container regardless of open
+     * state at the JSX level.
+     */
+    it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
+        const orgs = [
+            makeOrg({ id: 'o-1', slug: 'acme', displayName: 'Acme Inc' }),
+            makeOrg({ id: 'o-2', slug: 'globex', displayName: 'Globex LLC' }),
+            makeOrg({ id: 'o-3', slug: 'initech', displayName: 'Initech' }),
+        ];
+        __seedOrganizationsStoreForTests({
+            data: orgs,
+            isLoading: false,
+            error: null,
+        });
+
+        // Force the popover to open by clicking the trigger. Headless UI's
+        // MenuButton handles the click; the items mount on open.
+        render(<WorkspaceSwitcher />);
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+
+        // All three display names appear in the rendered tree (some
+        // also in the trigger chip — assert >= 1 for each).
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Globex LLC').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Initech').length).toBeGreaterThanOrEqual(1);
+
+        // The "+ Create Organization" row uses the i18n key
+        // `organizations.switcher.createNew` (our mock returns the key
+        // verbatim).
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Falls back to the org's slug when `displayName` is null — slug is
+     * NOT NULL on the DB row, so this is the right fallback shape.
+     */
+    it('uses the org slug as the chip label when displayName is null', () => {
+        const org = makeOrg({ displayName: null, slug: 'fallback-org' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher />);
+
+        expect(screen.getAllByText('fallback-org').length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/apps/web/src/lib/hooks/use-active-scope.ts
+++ b/apps/web/src/lib/hooks/use-active-scope.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { useOrganizations } from './use-organizations';
+
+export interface UseActiveScopeResult {
+    /**
+     * The slug from the URL — `/[slug]/...`. Returns `null` when the
+     * route doesn't carry a slug (e.g. bare `/dashboard`,
+     * `/[userSlug]/dashboard` before Phase 7 web-side wiring lands, or
+     * when navigating outside the slug-prefixed routes entirely).
+     */
+    slug: string | null;
+    /**
+     * The Organization whose `slug` matches the URL slug. `null` when
+     * the user is in bare-Tenant scope, when the URL doesn't carry an
+     * org slug, or when the slug exists but isn't in the user's
+     * fetched org list (defensive fallback — shouldn't normally happen
+     * because the API only returns orgs the user can see).
+     */
+    activeOrganization: OrganizationResponse | null;
+}
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — derives the user's active
+ * Organization from the URL slug. Reads `useParams()` from the App
+ * Router (Phase 7's `[slug]` segment, when it lands web-side) and
+ * cross-references it against `useOrganizations()`.
+ *
+ * Today most users have zero organizations and bare-Tenant routes don't
+ * carry a slug, so this hook will return `{ slug: null,
+ * activeOrganization: null }` for them — the WorkspaceSwitcher uses
+ * that signal plus `organizations.length === 0` to render the
+ * empty-state logo.
+ */
+export function useActiveScope(): UseActiveScopeResult {
+    const params = useParams<{ slug?: string | string[] }>();
+    const { organizations } = useOrganizations();
+
+    const rawSlug = params?.slug;
+    const slug = Array.isArray(rawSlug) ? (rawSlug[0] ?? null) : (rawSlug ?? null);
+
+    const activeOrganization = slug
+        ? (organizations.find((org) => org.slug === slug) ?? null)
+        : null;
+
+    return { slug, activeOrganization };
+}

--- a/apps/web/src/lib/hooks/use-organizations.ts
+++ b/apps/web/src/lib/hooks/use-organizations.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
 /**
@@ -38,7 +38,11 @@ let store: OrganizationsStore = {
     isLoading: true,
     error: null,
 };
-const listeners = new Set<Listener>();
+// `let` rather than `const` because the underlying Set is mutated via
+// add/delete/clear throughout the module. Team convention (Greptile P2,
+// ref: ever-co/ever-gauzy#8961) prefers `let` for conceptually-mutable
+// container vars even when the binding itself isn't reassigned.
+let listeners = new Set<Listener>();
 let inFlight: Promise<void> | null = null;
 let hasFetchedAtLeastOnce = false;
 

--- a/apps/web/src/lib/hooks/use-organizations.ts
+++ b/apps/web/src/lib/hooks/use-organizations.ts
@@ -1,0 +1,154 @@
+'use client';
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — client-side hook fetching
+ * `GET /api/organizations` (proxied by `apps/web/src/app/api/organizations/route.ts`).
+ *
+ * The spec called for an SWR hook, but SWR is not a dependency of
+ * `apps/web` (verified against `package.json`) and Phase 8 explicitly
+ * forbids adding new deps. We implement the same surface — cache shared
+ * across components, `mutate()` to revalidate — with a module-level
+ * store + `useSyncExternalStore`, matching the pattern already used by
+ * `use-dashboard-current-work.tsx`.
+ *
+ * Surface:
+ *   - `organizations` — `OrganizationResponse[]` (defaults to `[]` until
+ *     the first successful fetch, NOT `undefined`, so the empty-state
+ *     check `organizations.length === 0` works on the very first render
+ *     without a flash of the active-state chip).
+ *   - `isLoading` — `true` until the first fetch resolves (success or
+ *     error).
+ *   - `error` — `Error | null`. `null` when the last fetch succeeded.
+ *   - `mutate()` — re-runs the fetch and updates all subscribers.
+ */
+
+type Listener = () => void;
+
+interface OrganizationsStore {
+    data: OrganizationResponse[];
+    isLoading: boolean;
+    error: Error | null;
+}
+
+let store: OrganizationsStore = {
+    data: [],
+    isLoading: true,
+    error: null,
+};
+const listeners = new Set<Listener>();
+let inFlight: Promise<void> | null = null;
+let hasFetchedAtLeastOnce = false;
+
+function emit() {
+    for (const listener of listeners) {
+        listener();
+    }
+}
+
+function setStore(next: Partial<OrganizationsStore>) {
+    store = { ...store, ...next };
+    emit();
+}
+
+function subscribe(listener: Listener) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+function getSnapshot() {
+    return store;
+}
+
+function getServerSnapshot() {
+    return store;
+}
+
+async function fetchOrganizations(): Promise<void> {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+        try {
+            const response = await fetch('/api/organizations', {
+                method: 'GET',
+                credentials: 'include',
+                cache: 'no-store',
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to fetch organizations (${response.status})`);
+            }
+            const body = (await response.json()) as OrganizationResponse[];
+            const data = Array.isArray(body) ? body : [];
+            setStore({ data, isLoading: false, error: null });
+        } catch (err) {
+            // Keep `data` so a transient failure doesn't blow away the
+            // user's current org list mid-session (extension, not
+            // replacement — NN #20).
+            setStore({
+                isLoading: false,
+                error: err instanceof Error ? err : new Error('Unknown error'),
+            });
+        } finally {
+            hasFetchedAtLeastOnce = true;
+            inFlight = null;
+        }
+    })();
+    return inFlight;
+}
+
+export interface UseOrganizationsResult {
+    organizations: OrganizationResponse[];
+    isLoading: boolean;
+    error: Error | null;
+    mutate: () => Promise<void>;
+}
+
+export function useOrganizations(): UseOrganizationsResult {
+    const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+    useEffect(() => {
+        if (!hasFetchedAtLeastOnce) {
+            void fetchOrganizations();
+        }
+    }, []);
+
+    const mutate = useCallback(() => fetchOrganizations(), []);
+
+    return {
+        organizations: snapshot.data,
+        isLoading: snapshot.isLoading,
+        error: snapshot.error,
+        mutate,
+    };
+}
+
+/**
+ * Test-only helper. Resets the module-level cache between unit tests so
+ * one test's fetched data doesn't bleed into the next. Not exported from
+ * any barrel — import the hook module directly.
+ */
+export function __resetOrganizationsStoreForTests() {
+    store = { data: [], isLoading: true, error: null };
+    inFlight = null;
+    hasFetchedAtLeastOnce = false;
+    listeners.clear();
+}
+
+/**
+ * Test-only helper. Lets a unit test pre-seed the store without going
+ * through a real fetch — useful when asserting purely visual states
+ * (empty / 1 org / 3 orgs).
+ */
+export function __seedOrganizationsStoreForTests(next: Partial<OrganizationsStore>) {
+    store = { ...store, ...next };
+    hasFetchedAtLeastOnce = true;
+    emit();
+}
+
+// Tiny stand-in to silence TS "unused" complaints from default state
+// shape exports; consumers that need a placeholder Loading view rely on
+// `isLoading`.
+export type { OrganizationsStore };


### PR DESCRIPTION
## Summary

Ships the user-facing `<WorkspaceSwitcher>` that lives at the top of the dashboard sidebar — the visual surface that appears once a user has 1+ Organizations under their Tenant.

- **Empty-state fallback to logo** — when the user has zero Organizations (the majority of users today), the component renders `<LogoEverWork />` unmodified: no chevron, no popover trigger. This is the NN #20 "extension, not replacement" rule. The sidebar is visually identical to what shipped before for the no-org case.
- **Active state** — chip with `[avatar] [displayName ?? slug] [chevron]`. Opens a DropdownMenu popover with the Org list (active row gets a check icon) + a `+ Create Organization` footer row. Clicking an Org navigates to `/{slug}/dashboard`.
- **"+ Create Organization" is a Phase 9 stub** — `console.log('TODO Phase 9: open CreateOrganizationModal')` for now. The modal lands in EW-661.
- **Other locales fall back to en** — per the spec, all 20 non-English locales get the same English copy for the four new keys (`organizations.switcher.{heading,createNew,bareTenant,loading}`) rather than a half-translation. The existing `translate:messages` script can fill them in a follow-up PR.

## Files

### New

- `apps/web/src/app/api/organizations/route.ts` — BFF proxy forwarding `GET /api/organizations` to the NestJS API with the encrypted auth cookie decrypted into a Bearer header.
- `apps/web/src/lib/hooks/use-organizations.ts` — client hook over the proxy. Built on `useSyncExternalStore` + module-level store; the spec called for SWR but SWR is not a dependency of `apps/web` and the task forbids adding new ones.
- `apps/web/src/lib/hooks/use-active-scope.ts` — derives the active Organization from `useParams().slug` + the fetched org list.
- `apps/web/src/components/layout/WorkspaceSwitcher.tsx` — the visual.
- `apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx` — Vitest unit tests (4 cases).

### Modified

- `apps/web/src/components/dashboard/DashboardSidebar.tsx` — expanded sidebar now renders `<WorkspaceSwitcher>` instead of `<LogoEverWork>`. Collapsed sidebar still shows the favicon.
- `apps/web/messages/*.json` — new `organizations.switcher.*` namespace in all 21 locales.

## Test plan

- [x] `pnpm -F ever-works-web type-check` clean.
- [x] `pnpm -F ever-works-web build` clean (`/api/organizations` listed in the route manifest).
- [x] `pnpm -F ever-works-web test` — 578/578 passing, including 4 new WorkspaceSwitcher cases.
- [x] `pnpm format:check` clean.
- [ ] Manual smoke (post-merge, in real environment):
  - [ ] Zero-org user — sidebar shows unmodified Ever Works logo.
  - [ ] 1+ org user — chip appears, popover lists orgs, clicking an org navigates to `/{slug}/dashboard`.
  - [ ] "+ Create Organization" logs the TODO message (no crash, no modal yet).

Refs: EW-660 · plan.md Phase 8 · spec.md §5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization switcher to the dashboard sidebar for switching between workspaces.
  * Added new API endpoint to fetch available organizations with authentication.
  * Added organization display names and creation UI in switcher menu.

* **Documentation**
  * Added internationalization strings for organization switcher across 21 languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->