### PR TITLE
[EW-661] Phase 9 - Create Organization modal + upgrade dialog

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4651,6 +4651,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/src/app/api/organizations/[id]/upgrade-from-account/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/upgrade-from-account/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
+ * `POST /api/organizations/:id/upgrade-from-account`.
+ *
+ * Triggered from the `UpgradeOrCreateDialog` after the user creates
+ * their first Organization and picks "Move existing items". The upstream
+ * service enforces the first-Org guard (spec §5.2) and may return 409
+ * with `UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS` — we pass that body
+ * through verbatim so the dialog can surface the right copy.
+ */
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    if (!id) {
+        return NextResponse.json({ error: 'Missing organization id' }, { status: 400 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    try {
+        const upstream = await fetch(
+            `${API_URL}/organizations/${encodeURIComponent(id)}/upgrade-from-account`,
+            {
+                method: 'POST',
+                headers,
+                cache: 'no-store',
+            },
+        );
+        const text = await upstream.text();
+        const payload = text ? safeParse(text) : null;
+        if (!upstream.ok) {
+            return NextResponse.json(payload ?? { error: 'Failed to upgrade from account' }, {
+                status: upstream.status || 500,
+            });
+        }
+        return NextResponse.json(payload, { status: 200 });
+    } catch (error) {
+        console.error('Failed to proxy POST /api/organizations/:id/upgrade-from-account:', error);
+        return NextResponse.json({ error: 'Failed to upgrade from account' }, { status: 500 });
+    }
+}
+
+function safeParse(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/app/api/organizations/check-slug/route.ts
+++ b/apps/web/src/app/api/organizations/check-slug/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
+ * `GET /api/organizations/check-slug?value=<name>`.
+ *
+ * Mirrors the shape of `apps/web/src/app/api/organizations/route.ts` so
+ * the client-side CreateOrganizationModal can hit a same-origin URL. The
+ * upstream endpoint is `@Public()` + throttled, so this proxy does NOT
+ * attach the auth cookie — but we keep the proxy in place anyway for two
+ * reasons:
+ *
+ *  1. The browser never needs to know `API_URL` (kept server-side only).
+ *  2. Future hardening (e.g. CSRF, rate-limit by user) can land here
+ *     without touching the modal.
+ */
+export async function GET(request: NextRequest) {
+    const value = request.nextUrl.searchParams.get('value');
+    if (!value || value.length === 0) {
+        return NextResponse.json(
+            { error: 'Missing required `value` query parameter' },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const upstream = await fetch(
+            `${API_URL}/organizations/check-slug?value=${encodeURIComponent(value)}`,
+            {
+                method: 'GET',
+                cache: 'no-store',
+            },
+        );
+        if (!upstream.ok) {
+            return NextResponse.json(
+                { error: 'Failed to check slug availability' },
+                { status: upstream.status || 500 },
+            );
+        }
+        const body = await upstream.json();
+        return NextResponse.json(body, { status: 200 });
+    } catch (error) {
+        console.error('Failed to proxy /api/organizations/check-slug:', error);
+        return NextResponse.json({ error: 'Failed to check slug availability' }, { status: 500 });
+    }
+}

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -43,3 +43,63 @@ export async function GET(_request: NextRequest) {
         return NextResponse.json({ error: 'Failed to fetch organizations' }, { status: 500 });
     }
 }
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
+ * `POST /api/organizations`.
+ *
+ * Forwards the JSON body (`{ name, slug? }`) verbatim to the NestJS API
+ * with the user's bearer token attached. Returns the new
+ * `OrganizationResponse` payload as-is so the client-side
+ * `CreateOrganizationModal` can read `slug` to navigate, and `id` to
+ * call the follow-up `upgrade-from-account` endpoint.
+ *
+ * Error status codes from the upstream are passed through (e.g. 409
+ * slug-conflict, 400 validation failure) so the modal can render the
+ * right copy.
+ */
+export async function POST(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    try {
+        const upstream = await fetch(`${API_URL}/organizations`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            cache: 'no-store',
+        });
+        const text = await upstream.text();
+        const payload = text ? safeParse(text) : null;
+        if (!upstream.ok) {
+            return NextResponse.json(payload ?? { error: 'Failed to create organization' }, {
+                status: upstream.status || 500,
+            });
+        }
+        return NextResponse.json(payload, { status: 201 });
+    } catch (error) {
+        console.error('Failed to proxy POST /api/organizations:', error);
+        return NextResponse.json({ error: 'Failed to create organization' }, { status: 500 });
+    }
+}
+
+function safeParse(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Building2, Check, ChevronsUpDown, Plus } from 'lucide-react';
 import { useRouter } from '@/i18n/navigation';
@@ -15,6 +16,7 @@ import {
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { useActiveScope } from '@/lib/hooks/use-active-scope';
 import { LogoEverWork } from '../logos';
+import { CreateOrganizationModal } from '../organizations/CreateOrganizationModal';
 import type { WorkConfig } from '@/lib/api';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
@@ -82,6 +84,11 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
     const { activeOrganization } = useActiveScope();
+    // Phase 9 — EW-661 — lifts the create-Org modal state into the
+    // switcher. `+ Create Organization` opens it; on success the modal
+    // routes to `/{slug}/dashboard` and (if first Org) chains into the
+    // upgrade-or-empty dialog.
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
 
     // Empty state: no orgs yet → render the existing logo unmodified.
     // We intentionally treat `isLoading` as empty for the initial
@@ -121,75 +128,75 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
     };
 
     const handleCreateOrg = () => {
-        // Phase 9 — EW-661 lands the modal. For now we log so the
-        // wiring point is explicit and easy to grep for during the
-        // next PR.
-        console.log('TODO Phase 9: open CreateOrganizationModal');
+        setIsCreateOpen(true);
     };
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger
-                className={cn(
-                    'w-full rounded-md transition-colors cursor-pointer',
-                    'focus:outline-none focus-visible:outline-none',
-                    'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                    'px-2 py-1.5',
-                )}
-            >
-                <div className="flex items-center gap-2 w-full">
-                    <OrgAvatar org={triggerOrg} />
-                    <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                        {pickLabel(triggerOrg)}
-                    </span>
-                    <ChevronsUpDown
-                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                        strokeWidth={1.5}
-                        aria-hidden="true"
-                    />
-                </div>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="start" className="w-60">
-                <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
-                {organizations.map((org) => {
-                    const isActive = activeOrganization?.id === org.id;
-                    return (
-                        <DropdownMenuItem
-                            key={org.id}
-                            onClick={() => handleSelectOrg(org)}
-                            className="cursor-pointer"
-                        >
-                            <div className="flex items-center gap-2 w-full">
-                                <OrgAvatar org={org} size="xs" />
-                                <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
-                                    {pickLabel(org)}
-                                </span>
-                                {isActive && (
-                                    <Check
-                                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                                        strokeWidth={1.5}
-                                        aria-label="Active organization"
-                                    />
-                                )}
-                            </div>
-                        </DropdownMenuItem>
-                    );
-                })}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    className={cn(
+                        'w-full rounded-md transition-colors cursor-pointer',
+                        'focus:outline-none focus-visible:outline-none',
+                        'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
+                        'px-2 py-1.5',
+                    )}
+                >
                     <div className="flex items-center gap-2 w-full">
-                        <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">
-                            <Plus
-                                className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
-                                strokeWidth={1.5}
-                            />
+                        <OrgAvatar org={triggerOrg} />
+                        <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                            {pickLabel(triggerOrg)}
                         </span>
-                        <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
-                            {t('createNew')}
-                        </span>
+                        <ChevronsUpDown
+                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                            strokeWidth={1.5}
+                            aria-hidden="true"
+                        />
                     </div>
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="bottom" align="start" className="w-60">
+                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
+                    {organizations.map((org) => {
+                        const isActive = activeOrganization?.id === org.id;
+                        return (
+                            <DropdownMenuItem
+                                key={org.id}
+                                onClick={() => handleSelectOrg(org)}
+                                className="cursor-pointer"
+                            >
+                                <div className="flex items-center gap-2 w-full">
+                                    <OrgAvatar org={org} size="xs" />
+                                    <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                        {pickLabel(org)}
+                                    </span>
+                                    {isActive && (
+                                        <Check
+                                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                            strokeWidth={1.5}
+                                            aria-label="Active organization"
+                                        />
+                                    )}
+                                </div>
+                            </DropdownMenuItem>
+                        );
+                    })}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
+                        <div className="flex items-center gap-2 w-full">
+                            <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">
+                                <Plus
+                                    className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
+                                    strokeWidth={1.5}
+                                />
+                            </span>
+                            <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                {t('createNew')}
+                            </span>
+                        </div>
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+            <CreateOrganizationModal open={isCreateOpen} onOpenChange={setIsCreateOpen} />
+        </>
     );
 }

--- a/apps/web/src/components/organizations/CreateFirstOrgBanner.tsx
+++ b/apps/web/src/components/organizations/CreateFirstOrgBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Building2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { CreateOrganizationModal } from './CreateOrganizationModal';
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — Settings → Account banner
+ * surfacing the "Create your first Organization" CTA per spec §5.5
+ * (empty-state entry points list).
+ *
+ * Renders ONLY when `organizations.length === 0` (and we're not still
+ * doing the initial fetch). Once the user has at least one Org the
+ * banner quietly disappears.
+ *
+ * Drop this at the top of any settings/account-style page — currently
+ * wired into `<ProfileSettings>`.
+ */
+export function CreateFirstOrgBanner() {
+    const t = useTranslations('organizations.banner');
+    const { organizations, isLoading } = useOrganizations();
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    // Hide while we're loading the first fetch — prevents a flash of the
+    // banner for users who already have an Org. Once the request
+    // resolves, show iff they have zero.
+    if (isLoading || organizations.length > 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <div className="flex items-start gap-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                <div className="shrink-0 w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                    <Building2 className="w-5 h-5 text-primary" />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('title')}
+                    </p>
+                    <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('description')}
+                    </p>
+                </div>
+                <Button size="sm" onClick={() => setIsModalOpen(true)}>
+                    {t('cta')}
+                </Button>
+            </div>
+            <CreateOrganizationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
+        </>
+    );
+}

--- a/apps/web/src/components/organizations/CreateFirstOrgBanner.tsx
+++ b/apps/web/src/components/organizations/CreateFirstOrgBanner.tsx
@@ -24,31 +24,35 @@ export function CreateFirstOrgBanner() {
     const { organizations, isLoading } = useOrganizations();
     const [isModalOpen, setIsModalOpen] = useState(false);
 
-    // Hide while we're loading the first fetch — prevents a flash of the
-    // banner for users who already have an Org. Once the request
-    // resolves, show iff they have zero.
-    if (isLoading || organizations.length > 0) {
-        return null;
-    }
+    // Hide the banner UI while loading or once at least one Org
+    // exists, BUT keep the modal mounted unconditionally so the
+    // post-create upgrade dialog has a place to render. If the modal
+    // shared this guard, creating-the-first-Org would flip
+    // `organizations.length` to 1 and immediately unmount the modal
+    // before the UpgradeOrCreateDialog could appear. (Codex P1 on PR
+    // #1063.)
+    const shouldShowBanner = !isLoading && organizations.length === 0;
 
     return (
         <>
-            <div className="flex items-start gap-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
-                <div className="shrink-0 w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                    <Building2 className="w-5 h-5 text-primary" />
+            {shouldShowBanner && (
+                <div className="flex items-start gap-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                    <div className="shrink-0 w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                        <Building2 className="w-5 h-5 text-primary" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-text dark:text-text-dark">
+                            {t('title')}
+                        </p>
+                        <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+                            {t('description')}
+                        </p>
+                    </div>
+                    <Button size="sm" onClick={() => setIsModalOpen(true)}>
+                        {t('cta')}
+                    </Button>
                 </div>
-                <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-text dark:text-text-dark">
-                        {t('title')}
-                    </p>
-                    <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
-                        {t('description')}
-                    </p>
-                </div>
-                <Button size="sm" onClick={() => setIsModalOpen(true)}>
-                    {t('cta')}
-                </Button>
-            </div>
+            )}
             <CreateOrganizationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
         </>
     );

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import type {
+    CheckSlugAvailabilityResponse,
+    OrganizationResponse,
+} from '@ever-works/contracts/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { useRouter } from '@/i18n/navigation';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+
+/**
+ * Mirror of `User.deriveSlugIfMissing` (and the server-side
+ * `UsernameAllocatorService.normalize`) so the live preview matches
+ * what the server would allocate when the user submits. We deliberately
+ * do NOT call out to the API on every keystroke for normalization —
+ * only the availability check is debounced and remote.
+ */
+function normalizeSlugPreview(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+const DEBOUNCE_MS = 300;
+const MAX_NAME_LENGTH = 200;
+
+export interface CreateOrganizationModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+type SlugStatus =
+    | { kind: 'idle' }
+    | { kind: 'checking' }
+    | { kind: 'available'; normalized: string }
+    | { kind: 'taken'; normalized: string; suggestion?: string }
+    | { kind: 'error'; message: string };
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — first half of the
+ * create-Org flow from spec §5.2.
+ *
+ * Form contract:
+ *   - Single input `Name` (required, 1-200 chars).
+ *   - Live, debounced slug-availability check against
+ *     `GET /api/organizations/check-slug?value=<name>` shows
+ *     "Available" / "Taken (try: acme-2)" hints.
+ *   - Submit → `POST /api/organizations` with `{ name }`. The server
+ *     allocates the slug + creates the lazy Tenant.
+ *
+ * Post-submit branching:
+ *   - First Org (organizations.length === 0 before submit) → hands off
+ *     to `<UpgradeOrCreateDialog>` so the user can choose the upgrade
+ *     vs empty branch.
+ *   - 2nd+ Org → close modal and navigate to `/{slug}/dashboard`
+ *     directly. Subsequent Orgs skip the upgrade dialog entirely
+ *     (spec §5.3).
+ *
+ * Wires into `useOrganizations().mutate()` on success so the
+ * `<WorkspaceSwitcher>` populates without a full page reload.
+ */
+export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizationModalProps) {
+    const t = useTranslations('organizations.create');
+    const router = useRouter();
+    const { organizations, mutate } = useOrganizations();
+
+    const [name, setName] = useState('');
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const [slugStatus, setSlugStatus] = useState<SlugStatus>({ kind: 'idle' });
+    const [createdOrg, setCreatedOrg] = useState<OrganizationResponse | null>(null);
+    const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
+    /**
+     * Captures whether THIS submission is the user's first Org. Read
+     * once at submit-time so the post-mutate `organizations.length`
+     * can't flip the decision underneath us (post-mutate it's 1).
+     */
+    const wasFirstOrgRef = useRef(false);
+
+    const slugPreview = useMemo(() => normalizeSlugPreview(name.trim()), [name]);
+
+    // Reset state whenever the modal is closed so reopening starts fresh.
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setSubmitError(null);
+            setSlugStatus({ kind: 'idle' });
+            setCreatedOrg(null);
+            setShowUpgradeDialog(false);
+        }
+    }, [open]);
+
+    // Debounced slug-availability check. Each keystroke resets the
+    // 300ms timer; the request only fires once typing pauses.
+    useEffect(() => {
+        if (!open) return;
+        const trimmed = name.trim();
+        if (trimmed.length === 0) {
+            setSlugStatus({ kind: 'idle' });
+            return;
+        }
+        setSlugStatus({ kind: 'checking' });
+        const controller = new AbortController();
+        const timer = setTimeout(() => {
+            void (async () => {
+                try {
+                    const res = await fetch(
+                        `/api/organizations/check-slug?value=${encodeURIComponent(trimmed)}`,
+                        {
+                            method: 'GET',
+                            signal: controller.signal,
+                            cache: 'no-store',
+                        },
+                    );
+                    if (!res.ok) {
+                        setSlugStatus({ kind: 'error', message: `HTTP ${res.status}` });
+                        return;
+                    }
+                    const body = (await res.json()) as CheckSlugAvailabilityResponse;
+                    if (body.available) {
+                        setSlugStatus({ kind: 'available', normalized: body.normalized });
+                    } else {
+                        setSlugStatus({
+                            kind: 'taken',
+                            normalized: body.normalized,
+                            suggestion: body.suggestion,
+                        });
+                    }
+                } catch (err) {
+                    if ((err as { name?: string })?.name === 'AbortError') return;
+                    setSlugStatus({
+                        kind: 'error',
+                        message: err instanceof Error ? err.message : 'Network error',
+                    });
+                }
+            })();
+        }, DEBOUNCE_MS);
+        return () => {
+            controller.abort();
+            clearTimeout(timer);
+        };
+    }, [name, open]);
+
+    const handleSubmit = useCallback(() => {
+        const trimmed = name.trim();
+        if (trimmed.length === 0) {
+            setSubmitError(t('errors.nameRequired'));
+            return;
+        }
+        if (trimmed.length > MAX_NAME_LENGTH) {
+            setSubmitError(t('errors.nameTooLong'));
+            return;
+        }
+        setSubmitError(null);
+        wasFirstOrgRef.current = organizations.length === 0;
+        startTransition(() => {
+            void (async () => {
+                try {
+                    const res = await fetch('/api/organizations', {
+                        method: 'POST',
+                        credentials: 'include',
+                        cache: 'no-store',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ name: trimmed }),
+                    });
+                    if (!res.ok) {
+                        const body = await res
+                            .json()
+                            .catch(() => ({ error: 'Failed to create Organization' }));
+                        setSubmitError(
+                            (body as { message?: string; error?: string }).message ??
+                                (body as { error?: string }).error ??
+                                t('errors.generic'),
+                        );
+                        return;
+                    }
+                    const org = (await res.json()) as OrganizationResponse;
+                    // Refresh the org list so the switcher updates and
+                    // subsequent first-Org checks aren't fooled.
+                    await mutate();
+                    if (wasFirstOrgRef.current) {
+                        // Keep the parent modal mounted but hidden behind
+                        // the upgrade dialog so the user can't backtrack
+                        // into a half-finished form.
+                        setCreatedOrg(org);
+                        setShowUpgradeDialog(true);
+                    } else {
+                        onOpenChange(false);
+                        router.push(`/${org.slug}/dashboard`);
+                    }
+                } catch (err) {
+                    setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
+                }
+            })();
+        });
+    }, [name, organizations.length, mutate, onOpenChange, router, t]);
+
+    const handleUpgradeDialogClose = useCallback(
+        (didUpgrade: boolean) => {
+            setShowUpgradeDialog(false);
+            const target = createdOrg;
+            // Reset modal state then close the outer dialog. Navigation
+            // happens after close so a route change doesn't fight the
+            // transition.
+            setCreatedOrg(null);
+            onOpenChange(false);
+            if (target) {
+                router.push(`/${target.slug}/dashboard`);
+                // Pull the freshly-upgraded org list (tenantId is now set
+                // on the user, so subsequent fetches reflect that).
+                if (didUpgrade) void mutate();
+            }
+        },
+        [createdOrg, mutate, onOpenChange, router],
+    );
+
+    // Hide the modal panel while the upgrade dialog is visible so the
+    // user only sees one surface at a time. The Dialog `open` prop stays
+    // true so the create-modal state isn't reset mid-flow.
+    const showCreatePanel = !showUpgradeDialog;
+
+    return (
+        <>
+            <Dialog open={open} onOpenChange={onOpenChange}>
+                {showCreatePanel && (
+                    <DialogContent className="max-w-md">
+                        <DialogClose onClose={() => onOpenChange(false)} />
+                        <DialogHeader>
+                            <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                                {t('title')}
+                            </DialogTitle>
+                            <DialogDescription>{t('description')}</DialogDescription>
+                        </DialogHeader>
+
+                        <div className="space-y-4">
+                            <Input
+                                label={t('nameLabel')}
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                placeholder={t('namePlaceholder')}
+                                maxLength={MAX_NAME_LENGTH}
+                                autoFocus
+                                disabled={pending}
+                                error={submitError ?? undefined}
+                            />
+
+                            <SlugPreview
+                                preview={slugPreview}
+                                status={slugStatus}
+                                t={t}
+                                hasName={name.trim().length > 0}
+                            />
+                        </div>
+
+                        <DialogFooter>
+                            <Button
+                                variant="ghost"
+                                onClick={() => onOpenChange(false)}
+                                disabled={pending}
+                            >
+                                {t('cancel')}
+                            </Button>
+                            <Button
+                                onClick={handleSubmit}
+                                loading={pending}
+                                disabled={pending || name.trim().length === 0}
+                            >
+                                {t('submit')}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                )}
+            </Dialog>
+
+            {createdOrg && (
+                <UpgradeOrCreateDialog
+                    open={showUpgradeDialog}
+                    organization={createdOrg}
+                    onClose={handleUpgradeDialogClose}
+                />
+            )}
+        </>
+    );
+}
+
+function SlugPreview({
+    preview,
+    status,
+    t,
+    hasName,
+}: {
+    preview: string;
+    status: SlugStatus;
+    t: ReturnType<typeof useTranslations>;
+    hasName: boolean;
+}) {
+    if (!hasName) {
+        return null;
+    }
+    return (
+        <div className="text-xs text-text-muted dark:text-text-muted-dark">
+            <div>
+                <span className="font-medium text-text-secondary dark:text-text-secondary-dark">
+                    {t('slugPreview')}
+                </span>{' '}
+                <span
+                    className="font-mono text-text dark:text-text-dark"
+                    data-testid="slug-preview-value"
+                >
+                    {preview || '—'}
+                </span>
+            </div>
+            <div className="mt-1" data-testid="slug-status">
+                {status.kind === 'checking' && <span>{t('slugChecking')}</span>}
+                {status.kind === 'available' && (
+                    <span className="text-success">{t('slugAvailable')}</span>
+                )}
+                {status.kind === 'taken' && (
+                    <span className="text-warning">
+                        {status.suggestion
+                            ? t('slugTaken', { suggestion: status.suggestion })
+                            : t('slugTakenNoSuggestion')}
+                    </span>
+                )}
+                {status.kind === 'error' && (
+                    <span className="text-text-muted dark:text-text-muted-dark">
+                        {t('slugCheckError')}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -192,7 +192,19 @@ export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizati
                     const org = (await res.json()) as OrganizationResponse;
                     // Refresh the org list so the switcher updates and
                     // subsequent first-Org checks aren't fooled.
-                    await mutate();
+                    //
+                    // **Best-effort**: the POST already succeeded; the Org
+                    // exists. A transient 500/401/network failure on the
+                    // follow-up GET /api/organizations must NOT surface as
+                    // a creation error — otherwise the user retries and
+                    // we end up with duplicate Orgs. (Codex P2 on PR
+                    // #1063.) The switcher will pick up the new Org on
+                    // its next natural refresh.
+                    try {
+                        await mutate();
+                    } catch {
+                        // Swallow — see comment above.
+                    }
                     if (wasFirstOrgRef.current) {
                         // Keep the parent modal mounted but hidden behind
                         // the upgrade dialog so the user can't backtrack

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+// next-intl — return the key plus any `{var}` interpolations so the
+// assertions match against the namespaced keys without coupling to
+// translated copy.
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string, args?: Record<string, string | number>) => {
+        const path = `${ns}.${key}`;
+        if (!args) return path;
+        const interp = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${path} ${interp}`;
+    },
+}));
+
+const routerPushMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    // `Button` imports `Link` from this module; export a passthrough.
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+    useRouter: () => ({
+        push: routerPushMock,
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+    getPathname: ({ href }: { href: string }) => href,
+}));
+
+// next-intl `Dialog` uses Headless UI's Transition.show — render the
+// real dialog so we can drive the form. No additional mock needed.
+
+import { CreateOrganizationModal } from './CreateOrganizationModal';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+function org(overrides: Partial<OrganizationResponse> = {}): OrganizationResponse {
+    return {
+        id: 'o-new',
+        tenantId: 't-1',
+        slug: 'acme',
+        legalName: null,
+        displayName: 'Acme Inc',
+        countryCode: null,
+        registrationProvider: null,
+        registrationStatus: null,
+        linkedWorkId: null,
+        createdAt: '2026-05-28T00:00:00.000Z',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('CreateOrganizationModal — EW-661 Phase 9', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        routerPushMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Submitting with an empty name surfaces the inline validation error
+     * and does NOT fire the POST.
+     */
+    it('shows an inline error when submit is attempted with an empty name', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        const onOpenChange = vi.fn();
+        render(<CreateOrganizationModal open={true} onOpenChange={onOpenChange} />);
+
+        // The Create button is disabled while the name is empty — but
+        // we exercise the validation path by typing whitespace and
+        // submitting. (Whitespace-only is also invalid.)
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+        fireEvent.change(input, { target: { value: '   ' } });
+        const submit = screen.getByText('organizations.create.submit');
+        expect((submit as HTMLButtonElement).disabled).toBe(true);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Valid submission triggers `POST /api/organizations` with the
+     * trimmed name and (for non-first-Org) navigates to the new dashboard.
+     */
+    it('calls POST /api/organizations with the name and navigates after success (2nd Org skips upgrade dialog)', async () => {
+        __seedOrganizationsStoreForTests({
+            data: [org({ id: 'o-existing' })], // 1 existing = not first Org
+            isLoading: false,
+            error: null,
+        });
+        const newOrg = org({ id: 'o-new', slug: 'globex', displayName: 'Globex LLC' });
+        const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u.includes('/api/organizations/check-slug')) {
+                return new Response(JSON.stringify({ available: true, normalized: 'globex' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), {
+                    status: 201,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations') {
+                return new Response(JSON.stringify([newOrg]), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            throw new Error(`Unexpected fetch: ${u}`);
+        });
+
+        const onOpenChange = vi.fn();
+        render(<CreateOrganizationModal open={true} onOpenChange={onOpenChange} />);
+
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+        fireEvent.change(input, { target: { value: 'Globex LLC' } });
+
+        const submit = screen.getByText('organizations.create.submit');
+        fireEvent.click(submit);
+
+        await waitFor(() => {
+            // Modal closed.
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+            // Navigated to the new Org's dashboard.
+            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+        });
+
+        // POST request body carried the trimmed name.
+        const postCall = fetchMock.mock.calls.find(
+            ([url, init]) =>
+                String(url) === '/api/organizations' &&
+                (init as RequestInit | undefined)?.method === 'POST',
+        );
+        expect(postCall).toBeDefined();
+        const body = JSON.parse((postCall![1] as RequestInit).body as string);
+        expect(body).toEqual({ name: 'Globex LLC' });
+    });
+
+    /**
+     * As the user types, the slug preview updates live (no debounce —
+     * pure local string normalization). Mirror of the API normalizer.
+     */
+    it('renders a live slug preview that mirrors the server-side normalization', () => {
+        render(<CreateOrganizationModal open={true} onOpenChange={vi.fn()} />);
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+
+        // Pre-type: preview not shown yet.
+        expect(screen.queryByTestId('slug-preview-value')).toBeNull();
+
+        fireEvent.change(input, { target: { value: 'Acme Inc.' } });
+        expect(screen.getByTestId('slug-preview-value').textContent).toBe('acme-inc');
+
+        fireEvent.change(input, { target: { value: 'Globex Co/Ltd' } });
+        expect(screen.getByTestId('slug-preview-value').textContent).toBe('globex-co-ltd');
+    });
+
+    /**
+     * Submitting with zero existing Orgs → hands off to the upgrade
+     * dialog (rendered conditionally, so the create panel hides).
+     */
+    it('chains into the UpgradeOrCreateDialog when this is the user first Org', async () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        const newOrg = org({ id: 'o-first', slug: 'first-org', displayName: 'First Org' });
+        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u.includes('/api/organizations/check-slug')) {
+                return new Response(JSON.stringify({ available: true, normalized: 'first-org' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            return new Response(JSON.stringify([newOrg]), { status: 200 });
+        });
+
+        render(<CreateOrganizationModal open={true} onOpenChange={vi.fn()} />);
+
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+        fireEvent.change(input, { target: { value: 'First Org' } });
+
+        const submit = screen.getByText('organizations.create.submit');
+        fireEvent.click(submit);
+
+        await waitFor(() => {
+            // Upgrade dialog mounts.
+            expect(screen.getByText('organizations.upgrade.title')).toBeInTheDocument();
+            // Create panel hides (the Create submit button is no longer present).
+            expect(screen.queryByText('organizations.create.submit')).toBeNull();
+        });
+        // No navigation yet — that happens after upgrade choice.
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useRef, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS } from '@ever-works/contracts/api';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+
+type UpgradeChoice = 'upgrade' | 'empty';
+
+export interface UpgradeOrCreateDialogProps {
+    open: boolean;
+    organization: OrganizationResponse;
+    /**
+     * Fired when the dialog finishes (either branch completes, or the
+     * user cancels). `didUpgrade=true` means the upgrade API call ran
+     * and succeeded — the caller may want to refresh data tied to the
+     * promoted Tenant.
+     */
+    onClose: (didUpgrade: boolean) => void;
+}
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — second half of the
+ * create-Org flow from spec §5.2 step 2. Only renders for the user's
+ * FIRST Organization.
+ *
+ * Two radio choices:
+ *
+ *  - **Upgrade** (default, focused) → calls
+ *    `POST /api/organizations/:id/upgrade-from-account`, which sets
+ *    `organizationId = newOrg.id` on the user's existing Tier A + Tier
+ *    C rows. After it resolves we navigate the parent (via `onClose`)
+ *    to the new Org's dashboard.
+ *  - **Empty** → no API call. The new Org is already empty; the user's
+ *    existing rows stay in the bare-Tenant scope. We just close + let
+ *    the parent navigate.
+ *
+ * Handles 409 `UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS` gracefully —
+ * shouldn't happen here (this is first-Org only) but if a race lets it
+ * through we surface a generic "not available" message rather than
+ * silently failing.
+ */
+export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOrCreateDialogProps) {
+    const t = useTranslations('organizations.upgrade');
+    const [choice, setChoice] = useState<UpgradeChoice>('upgrade');
+    const [error, setError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const upgradeRadioRef = useRef<HTMLInputElement>(null);
+
+    // Focus the default (Upgrade) radio on open. Use a microtask so the
+    // ref is populated after the dialog mounts. Reset on close so a
+    // re-open is clean.
+    useEffect(() => {
+        if (open) {
+            setChoice('upgrade');
+            setError(null);
+            const id = window.setTimeout(() => {
+                upgradeRadioRef.current?.focus();
+            }, 0);
+            return () => window.clearTimeout(id);
+        }
+    }, [open]);
+
+    const handleConfirm = () => {
+        setError(null);
+        if (choice === 'empty') {
+            // No API call — just close. Parent handles navigation.
+            onClose(false);
+            return;
+        }
+        startTransition(() => {
+            void (async () => {
+                try {
+                    const res = await fetch(
+                        `/api/organizations/${encodeURIComponent(organization.id)}/upgrade-from-account`,
+                        {
+                            method: 'POST',
+                            credentials: 'include',
+                            cache: 'no-store',
+                            headers: { 'Content-Type': 'application/json' },
+                        },
+                    );
+                    if (!res.ok) {
+                        const body = await res.json().catch(() => ({}));
+                        const code = (body as { code?: string; message?: string }).code;
+                        if (
+                            res.status === 409 ||
+                            code === UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS
+                        ) {
+                            setError(t('errors.notAvailable'));
+                        } else {
+                            setError(
+                                (body as { message?: string; error?: string }).message ??
+                                    (body as { error?: string }).error ??
+                                    t('errors.generic'),
+                            );
+                        }
+                        return;
+                    }
+                    onClose(true);
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : t('errors.generic'));
+                }
+            })();
+        });
+    };
+
+    const handleCancel = () => {
+        if (pending) return;
+        onClose(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => !next && handleCancel()}>
+            <DialogContent className="max-w-md">
+                <DialogClose onClose={handleCancel} />
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                        {t('title')}
+                    </DialogTitle>
+                    <DialogDescription>{t('description')}</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-3">
+                    <ChoiceRow
+                        id="upgrade-or-create-upgrade"
+                        radioRef={upgradeRadioRef}
+                        checked={choice === 'upgrade'}
+                        onChange={() => setChoice('upgrade')}
+                        label={t('upgradeOption')}
+                        help={t('upgradeHelp')}
+                        disabled={pending}
+                    />
+                    <ChoiceRow
+                        id="upgrade-or-create-empty"
+                        checked={choice === 'empty'}
+                        onChange={() => setChoice('empty')}
+                        label={t('emptyOption')}
+                        help={t('emptyHelp')}
+                        disabled={pending}
+                    />
+                </div>
+
+                {error && (
+                    <p className="mt-3 text-sm text-danger" role="alert">
+                        {error}
+                    </p>
+                )}
+
+                <DialogFooter>
+                    <Button variant="ghost" onClick={handleCancel} disabled={pending}>
+                        {t('cancel')}
+                    </Button>
+                    <Button onClick={handleConfirm} loading={pending} disabled={pending}>
+                        {t('confirm')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function ChoiceRow({
+    id,
+    radioRef,
+    checked,
+    onChange,
+    label,
+    help,
+    disabled,
+}: {
+    id: string;
+    radioRef?: React.RefObject<HTMLInputElement | null>;
+    checked: boolean;
+    onChange: () => void;
+    label: string;
+    help: string;
+    disabled?: boolean;
+}) {
+    return (
+        <label
+            htmlFor={id}
+            className={`block rounded-lg border p-3 transition-colors cursor-pointer ${
+                checked
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border/60 dark:border-border-dark/60 hover:border-border dark:hover:border-border-dark'
+            } ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+        >
+            <div className="flex items-start gap-3">
+                <input
+                    ref={radioRef}
+                    id={id}
+                    type="radio"
+                    name="upgrade-or-create-choice"
+                    checked={checked}
+                    onChange={onChange}
+                    disabled={disabled}
+                    className="mt-0.5"
+                />
+                <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-text dark:text-text-dark">{label}</div>
+                    <div className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                        {help}
+                    </div>
+                </div>
+            </div>
+        </label>
+    );
+}

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string, args?: Record<string, string | number>) => {
+        const path = `${ns}.${key}`;
+        if (!args) return path;
+        const interp = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${path} ${interp}`;
+    },
+}));
+
+// Button (used in DialogFooter) imports `Link` from `@/i18n/navigation`.
+// Short-circuit the locale-aware navigation module so the test doesn't
+// pull in next-intl's createNavigation chain.
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+    useRouter: () => ({
+        push: vi.fn(),
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+    getPathname: ({ href }: { href: string }) => href,
+}));
+
+import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+
+const fakeOrg: OrganizationResponse = {
+    id: 'o-test-1',
+    tenantId: 't-1',
+    slug: 'acme',
+    legalName: null,
+    displayName: 'Acme Inc',
+    countryCode: null,
+    registrationProvider: null,
+    registrationStatus: null,
+    linkedWorkId: null,
+    createdAt: '2026-05-28T00:00:00.000Z',
+    updatedAt: '2026-05-28T00:00:00.000Z',
+};
+
+describe('UpgradeOrCreateDialog — EW-661 Phase 9', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Upgrade radio is the default selection and gets focus on open
+     * (spec §5.2 — "Default option: Upgrade current account").
+     */
+    it('defaults to the Upgrade radio and focuses it on open', async () => {
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={vi.fn()} />);
+
+        const upgradeRadio = screen.getByLabelText(/upgrade.upgradeOption/i, {
+            exact: false,
+        }) as HTMLInputElement;
+        expect(upgradeRadio.checked).toBe(true);
+
+        const emptyRadio = screen.getByLabelText(/upgrade.emptyOption/i, {
+            exact: false,
+        }) as HTMLInputElement;
+        expect(emptyRadio.checked).toBe(false);
+
+        // Focused element is the Upgrade radio (focus is scheduled with
+        // setTimeout(0), so wait for it).
+        await waitFor(() => {
+            expect(document.activeElement).toBe(upgradeRadio);
+        });
+    });
+
+    /**
+     * Picking "Empty" + confirm dispatches NO fetch and reports
+     * `didUpgrade=false` back to the parent.
+     */
+    it('empty branch: calls onClose(false) without firing the upgrade API', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        const onClose = vi.fn();
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        const emptyRadio = screen.getByLabelText(/upgrade.emptyOption/i, {
+            exact: false,
+        }) as HTMLInputElement;
+        fireEvent.click(emptyRadio);
+        expect(emptyRadio.checked).toBe(true);
+
+        const confirm = screen.getByText('organizations.upgrade.confirm');
+        fireEvent.click(confirm);
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalledWith(false);
+    });
+
+    /**
+     * Picking "Upgrade" + confirm POSTs to the upgrade-from-account
+     * endpoint and reports `didUpgrade=true` on success.
+     */
+    it('upgrade branch: POSTs to /upgrade-from-account and onClose(true) on success', async () => {
+        const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    organizationId: fakeOrg.id,
+                    tenantId: fakeOrg.tenantId,
+                    tierARowsUpdated: 0,
+                    tierBRowsUpdated: 0,
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } },
+            ),
+        );
+        const onClose = vi.fn();
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        const confirm = screen.getByText('organizations.upgrade.confirm');
+        fireEvent.click(confirm);
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                `/api/organizations/${fakeOrg.id}/upgrade-from-account`,
+                expect.objectContaining({ method: 'POST' }),
+            );
+            expect(onClose).toHaveBeenCalledWith(true);
+        });
+    });
+
+    /**
+     * 409 UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS — first-Org-only
+     * guard fired on the API side. The dialog surfaces a generic
+     * "not available" message and stays open.
+     */
+    it('handles 409 UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS gracefully', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    code: 'UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS',
+                    message: 'Already past the first-Org window',
+                }),
+                { status: 409, headers: { 'Content-Type': 'application/json' } },
+            ),
+        );
+        const onClose = vi.fn();
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        const confirm = screen.getByText('organizations.upgrade.confirm');
+        fireEvent.click(confirm);
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert').textContent).toContain(
+                'organizations.upgrade.errors.notAvailable',
+            );
+        });
+        // Did NOT close — user is still on the dialog so they can pick
+        // "Empty" or dismiss.
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -7,6 +7,7 @@ import { updateProfile, resendVerificationEmail } from '@/app/actions/settings';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import { Mail } from 'lucide-react';
+import { CreateFirstOrgBanner } from '@/components/organizations/CreateFirstOrgBanner';
 
 interface ProfileSettingsProps {
     user: {
@@ -77,6 +78,13 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
 
     return (
         <div className="space-y-6">
+            {/*
+             * EW-661 — surfaces a "Create your first Organization"
+             * banner. Auto-hides itself once `organizations.length > 0`,
+             * so this is a no-op for users who already have an Org.
+             */}
+            <CreateFirstOrgBanner />
+
             <div>
                 <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-4">
                     {t('title')}


### PR DESCRIPTION
## Summary

Phase 9 of the Tenants & Organizations rollout (EW-661). Ships the modal flow from [spec.md §5.2](docs/specs/features/tenants-and-organizations/spec.md#52-user-creates-their-first-organization):

- **`CreateOrganizationModal`** — single-name form with live slug preview + debounced availability hint (`GET /api/organizations/check-slug`). Submits `POST /api/organizations`; first Org hands off to the upgrade dialog, 2nd+ navigates straight to `/{slug}/dashboard`.
- **`UpgradeOrCreateDialog`** — first-Org-only radio choice. Upgrade is default + auto-focused on open. "Move existing items" calls `POST /api/organizations/:id/upgrade-from-account`; "Start empty" is local-only. Handles 409 `UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS` gracefully.
- **`CreateFirstOrgBanner`** — Settings → Account banner. Auto-hides once `organizations.length > 0`. Wired into `<ProfileSettings>` (`/settings`).
- Wires the modal into `<WorkspaceSwitcher>`'s `+ Create Organization` footer row (replacing Phase 8's stub).
- BFF proxies: `GET /api/organizations/check-slug`, `POST /api/organizations` (extends Phase 8's GET handler), and `POST /api/organizations/:id/upgrade-from-account`.
- i18n keys under `organizations.{create,upgrade,banner}` added to `en.json` and mirrored across all 20 other locales as English fallbacks (lockstep with Phase 8).

## Test plan

- [x] `pnpm -F ever-works-web build` — clean (`/api/organizations`, `/api/organizations/[id]/upgrade-from-account`, `/api/organizations/check-slug` show in the route list).
- [x] `pnpm format:check` — clean.
- [x] Full vitest suite — 586 / 586 pass (67 files).
- [x] New tests — 8 cover empty-submit error, valid submit → fetch + navigate, live slug preview normalization, first-Org hand-off, upgrade-radio default + focus, both upgrade choices dispatching correctly, 409 graceful handling.
- [x] `pnpm -F ever-works-web lint` — 110/13 errors/warnings, **identical to `develop` baseline** (no new violations introduced relative to existing tree; the `react-hooks/set-state-in-effect` hits in the new components match the existing pattern across `apps/web`).

## Notes

- No new dependencies.
- Empty-state `<WorkspaceSwitcher>` (no orgs, no chevron) is unchanged — `+ Create Organization` is only reachable from the popover (Phase 8) and now the settings banner.
- Lint baseline check: verified by `git stash` + `pnpm lint` round-trip — totals match before/after.
- Locale files: I initially attempted to rewrite all 20 via `JSON.parse` round-trip, which dedup'd duplicate keys present in the originals and produced massive diffs. Reverted those and instead applied a targeted regex append to `organizations.switcher`'s closing block, which leaves every unrelated key untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization creation modal, onboarding banner, and an upgrade/migration flow to move existing items into a new organization
  * Live slug preview and availability validation during creation

* **Localization**
  * Added/updated UI translations for organization flows across 21 locales (create, upgrade, banner)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->