### PR TITLE
fix(auth): derive users.slug in Better Auth hook + finish locale-prefix E2E sweep

### DIFF
--- a/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
@@ -404,7 +404,7 @@ describe('createAuthRuntimeInstance', () => {
             expect(additionalFields.committerEmail.type).toBe('string');
         });
 
-        it('declares exactly the seven documented additionalFields (regression guard)', () => {
+        it('declares exactly the eight documented additionalFields (regression guard)', () => {
             createAuthRuntimeInstance(makeDataSource('postgres', { master: {} }) as any);
 
             const keys = Object.keys(getCapturedOptions().user.additionalFields).sort();
@@ -417,6 +417,9 @@ describe('createAuthRuntimeInstance', () => {
                     'lastLoginIp',
                     'password',
                     'registrationProvider',
+                    // EW-652 Phase 0 — Better Auth must include the `slug`
+                    // column in its INSERT (NOT NULL DB constraint).
+                    'slug',
                 ].sort(),
             );
         });
@@ -524,6 +527,10 @@ describe('createAuthRuntimeInstance', () => {
                     password: 'hashed-uuid-fixture',
                     registrationProvider: RegistrationProvider.LOCAL,
                     isActive: true,
+                    // EW-652 Phase 0 — auto-derived from `username`. The
+                    // `users.slug` NOT NULL column would otherwise reject
+                    // the INSERT and surface as `FAILED_TO_CREATE_USER` 422.
+                    slug: 'someone',
                 },
             });
             // L-07: synthetic password is hashed at the configured cost (default 12).

--- a/apps/api/src/auth/providers/auth-runtime.instance.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from 'better-auth';
 import type { BetterAuthOptions } from 'better-auth';
 import { bearer } from 'better-auth/plugins';
-import { randomUUID } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import { DataSource } from 'typeorm';
 import { AUTH_RUNTIME_BASE_PATH } from './auth-provider.constants';
 import { config, AuthProvider as RegistrationProvider } from '../../config/constants';
@@ -48,23 +48,33 @@ function getInitializedDatabaseClient(dataSource: DataSource): any {
 }
 
 /**
- * EW-652 Phase 0 — keep this in lockstep with `User.deriveSlugIfMissing()`
- * in `packages/agent/src/entities/user.entity.ts` and with
- * `UsernameAllocatorService.normalize()` in
- * `apps/api/src/users/services/username-allocator.service.ts`. All three
- * sites must produce the same slug shape for a given input or the
- * cross-table uniqueness contract breaks.
+ * EW-652 Phase 0 — mirrors `UsernameAllocatorService.normalize()` in
+ * `apps/api/src/users/services/username-allocator.service.ts`, which is
+ * the slug shape the `/api/users/check-username` preflight reports as
+ * available. Keeping these in lockstep is load-bearing: a divergence
+ * lets the preflight return `available: true` for a normalized name
+ * whose actual Better Auth INSERT would then collide on the UNIQUE
+ * `users.slug` constraint.
+ *
+ * The User entity's `@BeforeInsert deriveSlugIfMissing()` hook falls
+ * back to the fixed string `u-anon`, but only one row in the entire
+ * table can have that slug (UNIQUE). Subsequent degenerate-username
+ * signups would collide there. Codex P2 on PR #1064: use a random
+ * suffix here so degenerate names like `!!!` or `---` each get a
+ * unique slug instead of all racing for the same `u-anon` row.
  */
 function deriveSlugFromName(name: string | undefined | null): string {
+    const fallback = (): string => `u-${randomBytes(4).toString('hex')}`;
+
     if (!name) {
-        return 'u-anon';
+        return fallback();
     }
     const normalized = name
         .toLowerCase()
         .replace(/[^a-z0-9-]+/g, '-')
         .replace(/-+/g, '-')
         .replace(/^-+|-+$/g, '');
-    return normalized.length > 0 ? normalized : 'u-anon';
+    return normalized.length > 0 ? normalized : fallback();
 }
 
 function getTrustedOrigins() {

--- a/apps/api/src/auth/providers/auth-runtime.instance.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.ts
@@ -47,6 +47,26 @@ function getInitializedDatabaseClient(dataSource: DataSource): any {
     );
 }
 
+/**
+ * EW-652 Phase 0 — keep this in lockstep with `User.deriveSlugIfMissing()`
+ * in `packages/agent/src/entities/user.entity.ts` and with
+ * `UsernameAllocatorService.normalize()` in
+ * `apps/api/src/users/services/username-allocator.service.ts`. All three
+ * sites must produce the same slug shape for a given input or the
+ * cross-table uniqueness contract breaks.
+ */
+function deriveSlugFromName(name: string | undefined | null): string {
+    if (!name) {
+        return 'u-anon';
+    }
+    const normalized = name
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    return normalized.length > 0 ? normalized : 'u-anon';
+}
+
 function getTrustedOrigins() {
     const origins = new Set<string>();
     const configuredOrigins = process.env.ALLOWED_ORIGINS?.split(',') || [];
@@ -143,6 +163,23 @@ export function createAuthRuntimeInstance(dataSource: DataSource) {
                     input: false,
                     required: false,
                 },
+                // EW-652 (Tenants & Organizations Phase 0) — `users.slug` is
+                // a NOT NULL UNIQUE column added by
+                // `1779991001000-AddSlugToUsers.ts`. Better Auth writes through
+                // its own DB adapter (raw SQL via the Postgres pool extracted
+                // from TypeORM), which bypasses the User entity's
+                // `@BeforeInsert deriveSlugIfMissing()` hook — so without an
+                // explicit `slug` value the INSERT fails with
+                // `null value in column "slug" violates not-null constraint`
+                // and Better Auth wraps it as `FAILED_TO_CREATE_USER` (HTTP
+                // 422 "Failed to create user"). Declaring it here as an
+                // additional field with `input: false` lets the `before`
+                // hook below populate it before the INSERT runs.
+                slug: {
+                    type: 'string',
+                    input: false,
+                    required: false,
+                },
             },
         },
         account: {
@@ -198,6 +235,27 @@ export function createAuthRuntimeInstance(dataSource: DataSource) {
                                 password: await bcrypt.hash(randomUUID(), getBcryptCost()),
                                 registrationProvider: RegistrationProvider.LOCAL,
                                 isActive: true,
+                                // EW-652 Phase 0 — derive the URL-safe `slug`
+                                // from the username. Mirrors the User
+                                // entity's `@BeforeInsert deriveSlugIfMissing()`,
+                                // which is bypassed because Better Auth
+                                // INSERTs through its own DB adapter rather
+                                // than the TypeORM repository. The DB UNIQUE
+                                // constraint on `slug` is the final
+                                // authority — racing duplicates will surface
+                                // as 422 to the caller, same as a duplicate
+                                // username. Better Auth applies its
+                                // `user.fields.name → username` mapping
+                                // before invoking this hook, so the column
+                                // name is available either as `username`
+                                // (post-mapping) or as the original `name`
+                                // (depending on adapter internals); we read
+                                // both for robustness across Better Auth
+                                // versions.
+                                slug: deriveSlugFromName(
+                                    (user as { username?: string }).username ??
+                                        (user as { name?: string }).name,
+                                ),
                             },
                         };
                     },

--- a/apps/web/e2e/geo-redirect-respect-pref.spec.ts
+++ b/apps/web/e2e/geo-redirect-respect-pref.spec.ts
@@ -1,60 +1,89 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Geo-redirect respect preference — pass 20. When a user explicitly
- * picks `/es/` in the URL, an `Accept-Language: en-US` header sent
- * by the browser should NOT cause the server to redirect to `/en/`.
- * URL locale > Accept-Language hint.
+ * Locale preference — explicit URL beats Accept-Language. When a user
+ * explicitly picks `/es/login` in the URL, an `Accept-Language: en-US`
+ * header sent by the browser should NOT cause the server to flip them
+ * to English. URL-stated locale > Accept-Language hint.
+ *
+ * PR #1052 switched next-intl from `localePrefix: 'always'` to
+ * `'never'`, so `/<locale>/<path>` is now a legacy bookmark shape that
+ * 307-redirects to the unprefixed `/<path>` AND seeds the
+ * `NEXT_LOCALE` cookie with the explicit locale (only if the visitor
+ * doesn't already have a cookie preference). The "URL locale wins"
+ * contract survives the cutover via the cookie; the URL bar just no
+ * longer carries the locale segment.
  */
 
 test.describe('Locale preference — explicit URL beats Accept-Language', () => {
-    test('GET /es/login with Accept-Language: en-US returns Spanish-locale response', async ({
+    test('GET /es/login with Accept-Language: en-US lands on /login with NEXT_LOCALE=es', async ({
         page,
         baseURL,
+        context,
     }) => {
-        // Tell the browser context to send Accept-Language: en-US.
+        // Clean slate — no pre-existing locale preference cookie.
+        await context.clearCookies();
         await page.setExtraHTTPHeaders({ 'Accept-Language': 'en-US,en;q=0.9' });
+
         const res = await page.goto(`${baseURL || 'http://localhost:3000'}/es/login`, {
             waitUntil: 'domcontentloaded',
         });
-        // 200 — not 3xx redirect to /en/.
         expect(
             res?.status() ?? 0,
             `/es/login status: ${res?.status() ?? 'no-response'}`,
         ).toBeLessThan(500);
-        // After load, URL should still be /es/ (not redirected to
-        // /en/).
+
+        // URL bar drops the locale segment (PR #1052) — the explicit
+        // locale survives in the `NEXT_LOCALE` cookie set by the legacy
+        // redirect (proxy.ts).
         const finalUrl = page.url();
-        expect(finalUrl, `/es/login redirected to ${finalUrl} despite explicit URL locale`).toMatch(
-            /\/es\//,
-        );
-        // html lang should reflect Spanish.
+        expect(
+            finalUrl,
+            `/es/login should redirect to unprefixed /login (PR #1052) — got ${finalUrl}`,
+        ).toMatch(/\/login(\?|$|#)/);
+
+        const cookies = await context.cookies();
+        const nextLocale = cookies.find((c) => c.name === 'NEXT_LOCALE');
+        expect(
+            nextLocale?.value,
+            'NEXT_LOCALE cookie should be seeded with the explicit URL locale',
+        ).toBe('es');
+
+        // html lang should reflect Spanish — soft signal (server may
+        // default back to en for missing translations).
         const lang = await page.locator('html').getAttribute('lang');
-        if (lang) {
-            // Acceptable: lang starts with es. Some servers may default
-            // back to en for missing translations — that's a soft
-            // signal, not a hard fail.
-            if (!lang.toLowerCase().startsWith('es')) {
-                test.info().annotations.push({
-                    type: 'informational',
-                    description: `/es/login has lang="${lang}" — Spanish translations may be missing`,
-                });
-            }
+        if (lang && !lang.toLowerCase().startsWith('es')) {
+            test.info().annotations.push({
+                type: 'informational',
+                description: `/es/login has lang="${lang}" — Spanish translations may be missing`,
+            });
         }
     });
 
-    test('GET /en/login with Accept-Language: es-ES still loads English', async ({
+    test('GET /en/login with Accept-Language: es-ES lands on /login with NEXT_LOCALE=en', async ({
         page,
         baseURL,
+        context,
     }) => {
+        await context.clearCookies();
         await page.setExtraHTTPHeaders({ 'Accept-Language': 'es-ES,es;q=0.9' });
+
         const res = await page.goto(`${baseURL || 'http://localhost:3000'}/en/login`, {
             waitUntil: 'domcontentloaded',
         });
         expect(res?.status() ?? 0).toBeLessThan(500);
+
         const finalUrl = page.url();
-        expect(finalUrl, `/en/login redirected to ${finalUrl} despite explicit URL locale`).toMatch(
-            /\/en\//,
-        );
+        expect(
+            finalUrl,
+            `/en/login should redirect to unprefixed /login (PR #1052) — got ${finalUrl}`,
+        ).toMatch(/\/login(\?|$|#)/);
+
+        const cookies = await context.cookies();
+        const nextLocale = cookies.find((c) => c.name === 'NEXT_LOCALE');
+        expect(
+            nextLocale?.value,
+            'NEXT_LOCALE cookie should be seeded with the explicit URL locale',
+        ).toBe('en');
     });
 });

--- a/apps/web/e2e/i18n-fallback.spec.ts
+++ b/apps/web/e2e/i18n-fallback.spec.ts
@@ -17,15 +17,20 @@ test.describe('i18n — unknown locale falls back', () => {
         expect(res?.status() ?? 0).toBeLessThan(500);
     });
 
-    test('root path / redirects to default locale', async ({ page, baseURL }) => {
+    test('root path / stays unprefixed (PR #1052 `localePrefix: never`)', async ({
+        page,
+        baseURL,
+    }) => {
         const res = await page.goto(`${baseURL || 'http://localhost:3000'}/`, {
             waitUntil: 'domcontentloaded',
         });
         expect(res?.status() ?? 0).toBeLessThan(500);
-        // After the redirect, the URL should contain a locale prefix.
-        // Default is `en`, but some builds may detect from Accept-Language.
+        // PR #1052 dropped the URL-level locale prefix. `/` no longer
+        // redirects to `/en/` — it renders the canonical unprefixed
+        // home directly. Assert that the URL does NOT contain a
+        // `/<locale>/` segment.
         const url = page.url();
-        expect(url).toMatch(/\/(en|fr|es|de|it|pt|nl|ja|zh|ru|ar)(\/|$|\?)/);
+        expect(url).not.toMatch(/\/(en|fr|es|de|it|pt|nl|ja|zh|ru|ar)(\/|$|\?|#)/);
     });
 });
 

--- a/apps/web/e2e/magic-link-ui.spec.ts
+++ b/apps/web/e2e/magic-link-ui.spec.ts
@@ -142,9 +142,13 @@ test.describe('Magic-link login UI — EW-633', () => {
         await page.goto(pathAndQuery);
 
         // On success the redeem server action redirects to the
-        // dashboard. The dashboard route is the locale-prefixed root
-        // ("/" plus the locale prefix next-intl adds).
-        await page.waitForURL(/\/(en|fr|[a-z]{2})\/?$/, { timeout: 30_000 });
+        // dashboard. PR #1052 (`localePrefix: 'never'`) dropped the
+        // URL-level locale prefix — the dashboard route is now the
+        // unprefixed root `/`. Legacy `/en/` URLs still 307-redirect
+        // to `/`, so accept both shapes during the rollout.
+        await page.waitForURL(/^https?:\/\/[^/]+(?:\/(en|fr|[a-z]{2}))?\/?(\?|#|$)/, {
+            timeout: 30_000,
+        });
         expect(page.url()).not.toContain('/login');
     });
 

--- a/apps/web/e2e/works-public.spec.ts
+++ b/apps/web/e2e/works-public.spec.ts
@@ -36,13 +36,26 @@ test.describe('Works — public routes', () => {
         });
     }
 
-    const publicPages = ['/en/login', '/en/register', '/en/forgot-password'];
+    // Path pairs: [legacy /en/<path>, canonical /<path>]. PR #1052
+    // (`localePrefix: 'never'`) 307-redirects the legacy form to the
+    // canonical form. The final URL after navigation is the canonical
+    // shape — the test asserts the page loads AND that we ended up on
+    // the right page (login → /login, register → /register, etc.),
+    // regardless of which input form was used.
+    const publicPages: Array<{ entry: string; canonical: RegExp }> = [
+        { entry: '/en/login', canonical: /\/login(\?|#|$)/ },
+        { entry: '/en/register', canonical: /\/register(\?|#|$)/ },
+        { entry: '/en/forgot-password', canonical: /\/forgot-password(\?|#|$)/ },
+    ];
 
-    for (const path of publicPages) {
-        test(`public page ${path} loads (no redirect)`, async ({ page }) => {
-            const response = await page.goto(path, { waitUntil: 'networkidle' });
-            expect(response?.status(), `${path} should not 5xx`).toBeLessThan(500);
-            expect(page.url(), `${path} should not redirect away`).toContain(path);
+    for (const { entry, canonical } of publicPages) {
+        test(`public page ${entry} loads and lands on the canonical path`, async ({ page }) => {
+            const response = await page.goto(entry, { waitUntil: 'networkidle' });
+            expect(response?.status(), `${entry} should not 5xx`).toBeLessThan(500);
+            expect(
+                page.url(),
+                `${entry} should land on the canonical unprefixed path (PR #1052)`,
+            ).toMatch(canonical);
         });
     }
 


### PR DESCRIPTION
## Summary

Two unrelated regressions blocking the open stage→main cascade ([PR #1057](https://github.com/ever-works/ever-works/pull/1057)). Bundled here because both have to land before E2E goes green; splitting them would force another empty cascade.

### A. \`POST /api/auth/register\` returned **HTTP 422 \"Failed to create user\"**

Phase 0 migration [\`1779991001000-AddSlugToUsers.ts\`](https://github.com/ever-works/ever-works/blob/develop/apps/api/src/migrations/1779991001000-AddSlugToUsers.ts) added a **NOT NULL UNIQUE** \`slug\` column to \`users\`. The User entity has a TypeORM \`@BeforeInsert deriveSlugIfMissing()\` hook to populate it from \`username\`, but Better Auth writes through its own DB adapter (raw SQL via the Postgres pool extracted from TypeORM in \`auth-runtime.instance.ts:getInitializedDatabaseClient\`), **bypassing the TypeORM repository entirely**. Result: every signup hit \`null value in column \"slug\" violates not-null constraint\`, which Better Auth wraps as \`FAILED_TO_CREATE_USER\` → 422.

**Fix:**

- Declare \`slug\` as an \`additionalField\` (\`input: false\`) on Better Auth's \`user\` model so it's part of the INSERT payload.
- Set it in the existing \`databaseHooks.user.create.before\` hook, mirroring the entity's BeforeInsert logic. Reads \`user.username ?? user.name\` so it survives whichever name Better Auth's adapter hands us (the \`user.fields.name → username\` mapping is applied around the hook).
- Updated the auth-runtime unit spec — both the \`before\`-hook payload test and the \"additionalFields regression guard\". **141/141** tests pass on \`apps/api/src/auth/providers/\`.

### B. Remaining locale-prefix E2E assertions left from PR #1052

[PR #1060](https://github.com/ever-works/ever-works/pull/1060) (this branch's predecessor) caught the obvious \`waitForURL\` + sidebar locator cases. The second stage→main run surfaced four more specs still testing the pre-PR-#1052 \`localePrefix: 'always'\` behavior:

- **\`geo-redirect-respect-pref.spec.ts\`** — rewrote both tests around the new contract: URL strips to \`/login\`, locale survives via the \`NEXT_LOCALE\` cookie that \`proxy.ts\` seeds from the legacy redirect.
- **\`i18n-fallback.spec.ts\`** — \`root path /\` no longer redirects to \`/en/\`; assertion flipped to \"URL does NOT contain a \`/<locale>/\` segment\".
- **\`magic-link-ui.spec.ts\`** — the post-redeem dashboard URL is now \`/\` (unprefixed); \`waitForURL\` regex anchored at the protocol+host boundary and treats \`/en/\` as optional.
- **\`works-public.spec.ts\`** — public pages \`/en/login\`, \`/en/register\`, \`/en/forgot-password\` 307 to the unprefixed canonical path; test now asserts we land on the canonical, not that the entry URL survived.

## Why bundled

A and B are independent root causes, but both fail in the SAME stage→main run. The stage→main CI gate runs full E2E, so we can't tell A is fixed unless B is also fixed (and vice versa). Two separate PRs would each cascade through develop→stage and re-run heavy CI twice — bundling here saves ~30 minutes of CI wall-clock + reviewer mental switching.

## Test plan

- [ ] Lightweight CI green on this PR.
- [ ] After merge + cascade to stage, full E2E green: all 4 categories (\`global-setup\` + signup-dependent specs, geo-redirect, i18n-fallback, magic-link, works-public) pass.
- [ ] \`POST /api/auth/register\` returns 201 with a valid \`slug\` populated. Manual smoke on stage after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User accounts now include a unique slug identifier.

* **Bug Fixes**
  * Updated redirect behavior for locale-prefixed authentication pages—now uses unprefixed URLs.
  * Improved locale preference handling during authentication redirects.
  * Fixed locale detection on root path to prevent unnecessary URL prefixing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->