### PR TITLE
chore(release): cascade develop → stage (signup fix + locale E2E sweep + tenants 8/9)

### DIFF
--- a/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.spec.ts
@@ -404,7 +404,7 @@ describe('createAuthRuntimeInstance', () => {
             expect(additionalFields.committerEmail.type).toBe('string');
         });
 
-        it('declares exactly the seven documented additionalFields (regression guard)', () => {
+        it('declares exactly the eight documented additionalFields (regression guard)', () => {
             createAuthRuntimeInstance(makeDataSource('postgres', { master: {} }) as any);
 
             const keys = Object.keys(getCapturedOptions().user.additionalFields).sort();
@@ -417,6 +417,9 @@ describe('createAuthRuntimeInstance', () => {
                     'lastLoginIp',
                     'password',
                     'registrationProvider',
+                    // EW-652 Phase 0 — Better Auth must include the `slug`
+                    // column in its INSERT (NOT NULL DB constraint).
+                    'slug',
                 ].sort(),
             );
         });
@@ -524,6 +527,10 @@ describe('createAuthRuntimeInstance', () => {
                     password: 'hashed-uuid-fixture',
                     registrationProvider: RegistrationProvider.LOCAL,
                     isActive: true,
+                    // EW-652 Phase 0 — auto-derived from `username`. The
+                    // `users.slug` NOT NULL column would otherwise reject
+                    // the INSERT and surface as `FAILED_TO_CREATE_USER` 422.
+                    slug: 'someone',
                 },
             });
             // L-07: synthetic password is hashed at the configured cost (default 12).

--- a/apps/api/src/auth/providers/auth-runtime.instance.ts
+++ b/apps/api/src/auth/providers/auth-runtime.instance.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from 'better-auth';
 import type { BetterAuthOptions } from 'better-auth';
 import { bearer } from 'better-auth/plugins';
-import { randomUUID } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import { DataSource } from 'typeorm';
 import { AUTH_RUNTIME_BASE_PATH } from './auth-provider.constants';
 import { config, AuthProvider as RegistrationProvider } from '../../config/constants';
@@ -45,6 +45,36 @@ function getInitializedDatabaseClient(dataSource: DataSource): any {
     throw new Error(
         `Unable to resolve Better Auth database client from initialized TypeORM driver "${dataSource.options.type}".`,
     );
+}
+
+/**
+ * EW-652 Phase 0 — mirrors `UsernameAllocatorService.normalize()` in
+ * `apps/api/src/users/services/username-allocator.service.ts`, which is
+ * the slug shape the `/api/users/check-username` preflight reports as
+ * available. Keeping these in lockstep is load-bearing: a divergence
+ * lets the preflight return `available: true` for a normalized name
+ * whose actual Better Auth INSERT would then collide on the UNIQUE
+ * `users.slug` constraint.
+ *
+ * The User entity's `@BeforeInsert deriveSlugIfMissing()` hook falls
+ * back to the fixed string `u-anon`, but only one row in the entire
+ * table can have that slug (UNIQUE). Subsequent degenerate-username
+ * signups would collide there. Codex P2 on PR #1064: use a random
+ * suffix here so degenerate names like `!!!` or `---` each get a
+ * unique slug instead of all racing for the same `u-anon` row.
+ */
+function deriveSlugFromName(name: string | undefined | null): string {
+    const fallback = (): string => `u-${randomBytes(4).toString('hex')}`;
+
+    if (!name) {
+        return fallback();
+    }
+    const normalized = name
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    return normalized.length > 0 ? normalized : fallback();
 }
 
 function getTrustedOrigins() {
@@ -143,6 +173,23 @@ export function createAuthRuntimeInstance(dataSource: DataSource) {
                     input: false,
                     required: false,
                 },
+                // EW-652 (Tenants & Organizations Phase 0) — `users.slug` is
+                // a NOT NULL UNIQUE column added by
+                // `1779991001000-AddSlugToUsers.ts`. Better Auth writes through
+                // its own DB adapter (raw SQL via the Postgres pool extracted
+                // from TypeORM), which bypasses the User entity's
+                // `@BeforeInsert deriveSlugIfMissing()` hook — so without an
+                // explicit `slug` value the INSERT fails with
+                // `null value in column "slug" violates not-null constraint`
+                // and Better Auth wraps it as `FAILED_TO_CREATE_USER` (HTTP
+                // 422 "Failed to create user"). Declaring it here as an
+                // additional field with `input: false` lets the `before`
+                // hook below populate it before the INSERT runs.
+                slug: {
+                    type: 'string',
+                    input: false,
+                    required: false,
+                },
             },
         },
         account: {
@@ -198,6 +245,27 @@ export function createAuthRuntimeInstance(dataSource: DataSource) {
                                 password: await bcrypt.hash(randomUUID(), getBcryptCost()),
                                 registrationProvider: RegistrationProvider.LOCAL,
                                 isActive: true,
+                                // EW-652 Phase 0 — derive the URL-safe `slug`
+                                // from the username. Mirrors the User
+                                // entity's `@BeforeInsert deriveSlugIfMissing()`,
+                                // which is bypassed because Better Auth
+                                // INSERTs through its own DB adapter rather
+                                // than the TypeORM repository. The DB UNIQUE
+                                // constraint on `slug` is the final
+                                // authority — racing duplicates will surface
+                                // as 422 to the caller, same as a duplicate
+                                // username. Better Auth applies its
+                                // `user.fields.name → username` mapping
+                                // before invoking this hook, so the column
+                                // name is available either as `username`
+                                // (post-mapping) or as the original `name`
+                                // (depending on adapter internals); we read
+                                // both for robustness across Better Auth
+                                // versions.
+                                slug: deriveSlugFromName(
+                                    (user as { username?: string }).username ??
+                                        (user as { name?: string }).name,
+                                ),
                             },
                         };
                     },

--- a/apps/web/e2e/geo-redirect-respect-pref.spec.ts
+++ b/apps/web/e2e/geo-redirect-respect-pref.spec.ts
@@ -1,60 +1,89 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Geo-redirect respect preference — pass 20. When a user explicitly
- * picks `/es/` in the URL, an `Accept-Language: en-US` header sent
- * by the browser should NOT cause the server to redirect to `/en/`.
- * URL locale > Accept-Language hint.
+ * Locale preference — explicit URL beats Accept-Language. When a user
+ * explicitly picks `/es/login` in the URL, an `Accept-Language: en-US`
+ * header sent by the browser should NOT cause the server to flip them
+ * to English. URL-stated locale > Accept-Language hint.
+ *
+ * PR #1052 switched next-intl from `localePrefix: 'always'` to
+ * `'never'`, so `/<locale>/<path>` is now a legacy bookmark shape that
+ * 307-redirects to the unprefixed `/<path>` AND seeds the
+ * `NEXT_LOCALE` cookie with the explicit locale (only if the visitor
+ * doesn't already have a cookie preference). The "URL locale wins"
+ * contract survives the cutover via the cookie; the URL bar just no
+ * longer carries the locale segment.
  */
 
 test.describe('Locale preference — explicit URL beats Accept-Language', () => {
-    test('GET /es/login with Accept-Language: en-US returns Spanish-locale response', async ({
+    test('GET /es/login with Accept-Language: en-US lands on /login with NEXT_LOCALE=es', async ({
         page,
         baseURL,
+        context,
     }) => {
-        // Tell the browser context to send Accept-Language: en-US.
+        // Clean slate — no pre-existing locale preference cookie.
+        await context.clearCookies();
         await page.setExtraHTTPHeaders({ 'Accept-Language': 'en-US,en;q=0.9' });
+
         const res = await page.goto(`${baseURL || 'http://localhost:3000'}/es/login`, {
             waitUntil: 'domcontentloaded',
         });
-        // 200 — not 3xx redirect to /en/.
         expect(
             res?.status() ?? 0,
             `/es/login status: ${res?.status() ?? 'no-response'}`,
         ).toBeLessThan(500);
-        // After load, URL should still be /es/ (not redirected to
-        // /en/).
+
+        // URL bar drops the locale segment (PR #1052) — the explicit
+        // locale survives in the `NEXT_LOCALE` cookie set by the legacy
+        // redirect (proxy.ts).
         const finalUrl = page.url();
-        expect(finalUrl, `/es/login redirected to ${finalUrl} despite explicit URL locale`).toMatch(
-            /\/es\//,
-        );
-        // html lang should reflect Spanish.
+        expect(
+            finalUrl,
+            `/es/login should redirect to unprefixed /login (PR #1052) — got ${finalUrl}`,
+        ).toMatch(/\/login(\?|$|#)/);
+
+        const cookies = await context.cookies();
+        const nextLocale = cookies.find((c) => c.name === 'NEXT_LOCALE');
+        expect(
+            nextLocale?.value,
+            'NEXT_LOCALE cookie should be seeded with the explicit URL locale',
+        ).toBe('es');
+
+        // html lang should reflect Spanish — soft signal (server may
+        // default back to en for missing translations).
         const lang = await page.locator('html').getAttribute('lang');
-        if (lang) {
-            // Acceptable: lang starts with es. Some servers may default
-            // back to en for missing translations — that's a soft
-            // signal, not a hard fail.
-            if (!lang.toLowerCase().startsWith('es')) {
-                test.info().annotations.push({
-                    type: 'informational',
-                    description: `/es/login has lang="${lang}" — Spanish translations may be missing`,
-                });
-            }
+        if (lang && !lang.toLowerCase().startsWith('es')) {
+            test.info().annotations.push({
+                type: 'informational',
+                description: `/es/login has lang="${lang}" — Spanish translations may be missing`,
+            });
         }
     });
 
-    test('GET /en/login with Accept-Language: es-ES still loads English', async ({
+    test('GET /en/login with Accept-Language: es-ES lands on /login with NEXT_LOCALE=en', async ({
         page,
         baseURL,
+        context,
     }) => {
+        await context.clearCookies();
         await page.setExtraHTTPHeaders({ 'Accept-Language': 'es-ES,es;q=0.9' });
+
         const res = await page.goto(`${baseURL || 'http://localhost:3000'}/en/login`, {
             waitUntil: 'domcontentloaded',
         });
         expect(res?.status() ?? 0).toBeLessThan(500);
+
         const finalUrl = page.url();
-        expect(finalUrl, `/en/login redirected to ${finalUrl} despite explicit URL locale`).toMatch(
-            /\/en\//,
-        );
+        expect(
+            finalUrl,
+            `/en/login should redirect to unprefixed /login (PR #1052) — got ${finalUrl}`,
+        ).toMatch(/\/login(\?|$|#)/);
+
+        const cookies = await context.cookies();
+        const nextLocale = cookies.find((c) => c.name === 'NEXT_LOCALE');
+        expect(
+            nextLocale?.value,
+            'NEXT_LOCALE cookie should be seeded with the explicit URL locale',
+        ).toBe('en');
     });
 });

--- a/apps/web/e2e/i18n-fallback.spec.ts
+++ b/apps/web/e2e/i18n-fallback.spec.ts
@@ -17,15 +17,20 @@ test.describe('i18n — unknown locale falls back', () => {
         expect(res?.status() ?? 0).toBeLessThan(500);
     });
 
-    test('root path / redirects to default locale', async ({ page, baseURL }) => {
+    test('root path / stays unprefixed (PR #1052 `localePrefix: never`)', async ({
+        page,
+        baseURL,
+    }) => {
         const res = await page.goto(`${baseURL || 'http://localhost:3000'}/`, {
             waitUntil: 'domcontentloaded',
         });
         expect(res?.status() ?? 0).toBeLessThan(500);
-        // After the redirect, the URL should contain a locale prefix.
-        // Default is `en`, but some builds may detect from Accept-Language.
+        // PR #1052 dropped the URL-level locale prefix. `/` no longer
+        // redirects to `/en/` — it renders the canonical unprefixed
+        // home directly. Assert that the URL does NOT contain a
+        // `/<locale>/` segment.
         const url = page.url();
-        expect(url).toMatch(/\/(en|fr|es|de|it|pt|nl|ja|zh|ru|ar)(\/|$|\?)/);
+        expect(url).not.toMatch(/\/(en|fr|es|de|it|pt|nl|ja|zh|ru|ar)(\/|$|\?|#)/);
     });
 });
 

--- a/apps/web/e2e/magic-link-ui.spec.ts
+++ b/apps/web/e2e/magic-link-ui.spec.ts
@@ -142,9 +142,13 @@ test.describe('Magic-link login UI — EW-633', () => {
         await page.goto(pathAndQuery);
 
         // On success the redeem server action redirects to the
-        // dashboard. The dashboard route is the locale-prefixed root
-        // ("/" plus the locale prefix next-intl adds).
-        await page.waitForURL(/\/(en|fr|[a-z]{2})\/?$/, { timeout: 30_000 });
+        // dashboard. PR #1052 (`localePrefix: 'never'`) dropped the
+        // URL-level locale prefix — the dashboard route is now the
+        // unprefixed root `/`. Legacy `/en/` URLs still 307-redirect
+        // to `/`, so accept both shapes during the rollout.
+        await page.waitForURL(/^https?:\/\/[^/]+(?:\/(en|fr|[a-z]{2}))?\/?(\?|#|$)/, {
+            timeout: 30_000,
+        });
         expect(page.url()).not.toContain('/login');
     });
 

--- a/apps/web/e2e/works-public.spec.ts
+++ b/apps/web/e2e/works-public.spec.ts
@@ -36,13 +36,26 @@ test.describe('Works — public routes', () => {
         });
     }
 
-    const publicPages = ['/en/login', '/en/register', '/en/forgot-password'];
+    // Path pairs: [legacy /en/<path>, canonical /<path>]. PR #1052
+    // (`localePrefix: 'never'`) 307-redirects the legacy form to the
+    // canonical form. The final URL after navigation is the canonical
+    // shape — the test asserts the page loads AND that we ended up on
+    // the right page (login → /login, register → /register, etc.),
+    // regardless of which input form was used.
+    const publicPages: Array<{ entry: string; canonical: RegExp }> = [
+        { entry: '/en/login', canonical: /\/login(\?|#|$)/ },
+        { entry: '/en/register', canonical: /\/register(\?|#|$)/ },
+        { entry: '/en/forgot-password', canonical: /\/forgot-password(\?|#|$)/ },
+    ];
 
-    for (const path of publicPages) {
-        test(`public page ${path} loads (no redirect)`, async ({ page }) => {
-            const response = await page.goto(path, { waitUntil: 'networkidle' });
-            expect(response?.status(), `${path} should not 5xx`).toBeLessThan(500);
-            expect(page.url(), `${path} should not redirect away`).toContain(path);
+    for (const { entry, canonical } of publicPages) {
+        test(`public page ${entry} loads and lands on the canonical path`, async ({ page }) => {
+            const response = await page.goto(entry, { waitUntil: 'networkidle' });
+            expect(response?.status(), `${entry} should not 5xx`).toBeLessThan(500);
+            expect(
+                page.url(),
+                `${entry} should land on the canonical unprefixed path (PR #1052)`,
+            ).toMatch(canonical);
         });
     }
 

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4825,5 +4825,13 @@
             "private": "خاص",
             "public": "عام"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4825,5 +4825,13 @@
             "private": "Частен",
             "public": "Публичен"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4825,5 +4825,13 @@
             "private": "Privat",
             "public": "Öffentlich"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4644,5 +4644,13 @@
             "private": "Private",
             "public": "Public"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4651,6 +4651,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4825,5 +4825,13 @@
             "private": "Privado",
             "public": "Público"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4825,5 +4825,13 @@
             "private": "Privé",
             "public": "Public"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4832,6 +4832,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4825,5 +4825,13 @@
             "private": "פרטי",
             "public": "ציבורי"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4889,5 +4889,13 @@
             "private": "निजी",
             "public": "सार्वजनिक"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4889,5 +4889,13 @@
             "private": "Pribadi",
             "public": "Publik"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4889,5 +4889,13 @@
             "private": "Privato",
             "public": "Pubblico"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4889,5 +4889,13 @@
             "private": "非公開",
             "public": "公開"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4889,5 +4889,13 @@
             "private": "비공개",
             "public": "공개"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4889,5 +4889,13 @@
             "private": "Privé",
             "public": "Openbaar"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4889,5 +4889,13 @@
             "private": "Prywatny",
             "public": "Publiczny"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4889,5 +4889,13 @@
             "private": "Privado",
             "public": "Público"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4889,5 +4889,13 @@
             "private": "Приватный",
             "public": "Публичный"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4889,5 +4889,13 @@
             "private": "ส่วนตัว",
             "public": "สาธารณะ"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4889,5 +4889,13 @@
             "private": "Özel",
             "public": "Genel"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4889,5 +4889,13 @@
             "private": "Приватний",
             "public": "Публічний"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4889,5 +4889,13 @@
             "private": "Riêng tư",
             "public": "Công khai"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4896,6 +4896,44 @@
             "createNew": "+ Create Organization",
             "bareTenant": "My account",
             "loading": "Loading…"
+        },
+        "create": {
+            "title": "Create Organization",
+            "description": "Give your Organization a name. We'll allocate a unique slug for its URL.",
+            "nameLabel": "Name",
+            "namePlaceholder": "Acme Inc.",
+            "slugPreview": "Slug:",
+            "slugChecking": "Checking availability…",
+            "slugAvailable": "Available",
+            "slugTaken": "Taken, try: {suggestion}",
+            "slugTakenNoSuggestion": "That slug is taken",
+            "slugCheckError": "Couldn't check availability — you can still submit",
+            "submit": "Create",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Name is required",
+                "nameTooLong": "Name must be 200 characters or fewer",
+                "generic": "Failed to create Organization"
+            }
+        },
+        "upgrade": {
+            "title": "Move your existing items?",
+            "description": "You can pull your existing work into this Organization, or start it empty.",
+            "upgradeOption": "Move existing items",
+            "upgradeHelp": "Recommended. Your missions, ideas, and works move into this Organization.",
+            "emptyOption": "Start empty",
+            "emptyHelp": "Keep your existing items in your personal account. This Organization starts fresh.",
+            "confirm": "Continue",
+            "cancel": "Cancel",
+            "errors": {
+                "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
+                "generic": "Failed to move your existing items"
+            }
+        },
+        "banner": {
+            "title": "Create your first Organization",
+            "description": "Organize your work, share with teammates, and collaborate as a team.",
+            "cta": "Create Organization"
         }
     }
 }

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4889,5 +4889,13 @@
             "private": "私有",
             "public": "公开"
         }
+    },
+    "organizations": {
+        "switcher": {
+            "heading": "Organizations",
+            "createNew": "+ Create Organization",
+            "bareTenant": "My account",
+            "loading": "Loading…"
+        }
     }
 }

--- a/apps/web/src/app/api/organizations/[id]/upgrade-from-account/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/upgrade-from-account/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
+ * `POST /api/organizations/:id/upgrade-from-account`.
+ *
+ * Triggered from the `UpgradeOrCreateDialog` after the user creates
+ * their first Organization and picks "Move existing items". The upstream
+ * service enforces the first-Org guard (spec §5.2) and may return 409
+ * with `UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS` — we pass that body
+ * through verbatim so the dialog can surface the right copy.
+ */
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    if (!id) {
+        return NextResponse.json({ error: 'Missing organization id' }, { status: 400 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    try {
+        const upstream = await fetch(
+            `${API_URL}/organizations/${encodeURIComponent(id)}/upgrade-from-account`,
+            {
+                method: 'POST',
+                headers,
+                cache: 'no-store',
+            },
+        );
+        const text = await upstream.text();
+        const payload = text ? safeParse(text) : null;
+        if (!upstream.ok) {
+            return NextResponse.json(payload ?? { error: 'Failed to upgrade from account' }, {
+                status: upstream.status || 500,
+            });
+        }
+        return NextResponse.json(payload, { status: 200 });
+    } catch (error) {
+        console.error('Failed to proxy POST /api/organizations/:id/upgrade-from-account:', error);
+        return NextResponse.json({ error: 'Failed to upgrade from account' }, { status: 500 });
+    }
+}
+
+function safeParse(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/app/api/organizations/check-slug/route.ts
+++ b/apps/web/src/app/api/organizations/check-slug/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
+ * `GET /api/organizations/check-slug?value=<name>`.
+ *
+ * Mirrors the shape of `apps/web/src/app/api/organizations/route.ts` so
+ * the client-side CreateOrganizationModal can hit a same-origin URL. The
+ * upstream endpoint is `@Public()` + throttled, so this proxy does NOT
+ * attach the auth cookie — but we keep the proxy in place anyway for two
+ * reasons:
+ *
+ *  1. The browser never needs to know `API_URL` (kept server-side only).
+ *  2. Future hardening (e.g. CSRF, rate-limit by user) can land here
+ *     without touching the modal.
+ */
+export async function GET(request: NextRequest) {
+    const value = request.nextUrl.searchParams.get('value');
+    if (!value || value.length === 0) {
+        return NextResponse.json(
+            { error: 'Missing required `value` query parameter' },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const upstream = await fetch(
+            `${API_URL}/organizations/check-slug?value=${encodeURIComponent(value)}`,
+            {
+                method: 'GET',
+                cache: 'no-store',
+            },
+        );
+        if (!upstream.ok) {
+            return NextResponse.json(
+                { error: 'Failed to check slug availability' },
+                { status: upstream.status || 500 },
+            );
+        }
+        const body = await upstream.json();
+        return NextResponse.json(body, { status: 200 });
+    } catch (error) {
+        console.error('Failed to proxy /api/organizations/check-slug:', error);
+        return NextResponse.json({ error: 'Failed to check slug availability' }, { status: 500 });
+    }
+}

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — web BFF proxy for
+ * `GET /api/organizations`.
+ *
+ * Forwards to the NestJS API at `${API_URL}/organizations` with the
+ * user's auth token attached as a Bearer header (the encrypted
+ * `auth_token` cookie is decrypted here, NEVER shipped to the browser).
+ *
+ * Returns the upstream `OrganizationResponse[]` payload as-is. On 401
+ * or upstream error we fall through to `{ status }` so the client-side
+ * `useOrganizations()` hook can surface a sensible `error` value without
+ * mistaking the auth-failure for an empty-orgs list.
+ */
+export async function GET(_request: NextRequest) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+
+    try {
+        const upstream = await fetch(`${API_URL}/organizations`, {
+            method: 'GET',
+            headers,
+            cache: 'no-store',
+        });
+        if (!upstream.ok) {
+            return NextResponse.json(
+                { error: 'Failed to fetch organizations' },
+                { status: upstream.status || 500 },
+            );
+        }
+        const body = await upstream.json();
+        return NextResponse.json(body, { status: 200 });
+    } catch (error) {
+        console.error('Failed to proxy /api/organizations:', error);
+        return NextResponse.json({ error: 'Failed to fetch organizations' }, { status: 500 });
+    }
+}

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -43,3 +43,63 @@ export async function GET(_request: NextRequest) {
         return NextResponse.json({ error: 'Failed to fetch organizations' }, { status: 500 });
     }
 }
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — web BFF proxy for
+ * `POST /api/organizations`.
+ *
+ * Forwards the JSON body (`{ name, slug? }`) verbatim to the NestJS API
+ * with the user's bearer token attached. Returns the new
+ * `OrganizationResponse` payload as-is so the client-side
+ * `CreateOrganizationModal` can read `slug` to navigate, and `id` to
+ * call the follow-up `upgrade-from-account` endpoint.
+ *
+ * Error status codes from the upstream are passed through (e.g. 409
+ * slug-conflict, 400 validation failure) so the modal can render the
+ * right copy.
+ */
+export async function POST(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    try {
+        const upstream = await fetch(`${API_URL}/organizations`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            cache: 'no-store',
+        });
+        const text = await upstream.text();
+        const payload = text ? safeParse(text) : null;
+        if (!upstream.ok) {
+            return NextResponse.json(payload ?? { error: 'Failed to create organization' }, {
+                status: upstream.status || 500,
+            });
+        }
+        return NextResponse.json(payload, { status: 201 });
+    } catch (error) {
+        console.error('Failed to proxy POST /api/organizations:', error);
+        return NextResponse.json({ error: 'Failed to create organization' }, { status: 500 });
+    }
+}
+
+function safeParse(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -39,7 +39,8 @@ import {
     DropdownMenuSeparator,
     DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu';
-import { LogoEverWork, FaviconEverWork } from '../logos';
+import { FaviconEverWork } from '../logos';
+import { WorkspaceSwitcher } from '../layout/WorkspaceSwitcher';
 import { useWorkDetail } from '../works/detail/WorkDetailContext';
 import { ChatPanelExpandButton } from '@/components/ai/ChatPanel';
 import { SidebarActivityIndicator } from './SidebarActivityIndicator';
@@ -151,12 +152,24 @@ export function DashboardSidebar({
                     )}
                 >
                     <div className="w-full relative">
+                        {/*
+                            EW-660 (Tenants & Organizations Phase 8) —
+                            the expanded sidebar swaps `<LogoEverWork>`
+                            for `<WorkspaceSwitcher>`, which itself
+                            renders the unmodified logo when the user
+                            has zero Organizations (NN #20 — extension,
+                            not replacement). The collapsed sidebar
+                            keeps the bare favicon: there's no room for
+                            a chip+chevron at 16px column width, and
+                            users in that mode already expand the
+                            sidebar before reaching for the switcher.
+                        */}
                         <div className={cn('flex items-center -ml-2')}>
-                            <FaviconEverWork
-                                config={config}
-                                className={cn(isCollapsed ? 'w-11 ml-[5px]' : 'w-12')}
-                            />
-                            <LogoEverWork config={config} className={cn(isCollapsed && 'hidden')} />
+                            {isCollapsed ? (
+                                <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
+                            ) : (
+                                <WorkspaceSwitcher config={config} logoClassName="" />
+                            )}
                         </div>
                         <div
                             className={cn(

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Building2, Check, ChevronsUpDown, Plus } from 'lucide-react';
 import { useRouter } from '@/i18n/navigation';
@@ -15,6 +16,7 @@ import {
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { useActiveScope } from '@/lib/hooks/use-active-scope';
 import { LogoEverWork } from '../logos';
+import { CreateOrganizationModal } from '../organizations/CreateOrganizationModal';
 import type { WorkConfig } from '@/lib/api';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
@@ -82,6 +84,11 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
     const { activeOrganization } = useActiveScope();
+    // Phase 9 — EW-661 — lifts the create-Org modal state into the
+    // switcher. `+ Create Organization` opens it; on success the modal
+    // routes to `/{slug}/dashboard` and (if first Org) chains into the
+    // upgrade-or-empty dialog.
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
 
     // Empty state: no orgs yet → render the existing logo unmodified.
     // We intentionally treat `isLoading` as empty for the initial
@@ -121,75 +128,75 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
     };
 
     const handleCreateOrg = () => {
-        // Phase 9 — EW-661 lands the modal. For now we log so the
-        // wiring point is explicit and easy to grep for during the
-        // next PR.
-        console.log('TODO Phase 9: open CreateOrganizationModal');
+        setIsCreateOpen(true);
     };
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger
-                className={cn(
-                    'w-full rounded-md transition-colors cursor-pointer',
-                    'focus:outline-none focus-visible:outline-none',
-                    'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                    'px-2 py-1.5',
-                )}
-            >
-                <div className="flex items-center gap-2 w-full">
-                    <OrgAvatar org={triggerOrg} />
-                    <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                        {pickLabel(triggerOrg)}
-                    </span>
-                    <ChevronsUpDown
-                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                        strokeWidth={1.5}
-                        aria-hidden="true"
-                    />
-                </div>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="start" className="w-60">
-                <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
-                {organizations.map((org) => {
-                    const isActive = activeOrganization?.id === org.id;
-                    return (
-                        <DropdownMenuItem
-                            key={org.id}
-                            onClick={() => handleSelectOrg(org)}
-                            className="cursor-pointer"
-                        >
-                            <div className="flex items-center gap-2 w-full">
-                                <OrgAvatar org={org} size="xs" />
-                                <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
-                                    {pickLabel(org)}
-                                </span>
-                                {isActive && (
-                                    <Check
-                                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                                        strokeWidth={1.5}
-                                        aria-label="Active organization"
-                                    />
-                                )}
-                            </div>
-                        </DropdownMenuItem>
-                    );
-                })}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    className={cn(
+                        'w-full rounded-md transition-colors cursor-pointer',
+                        'focus:outline-none focus-visible:outline-none',
+                        'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
+                        'px-2 py-1.5',
+                    )}
+                >
                     <div className="flex items-center gap-2 w-full">
-                        <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">
-                            <Plus
-                                className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
-                                strokeWidth={1.5}
-                            />
+                        <OrgAvatar org={triggerOrg} />
+                        <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                            {pickLabel(triggerOrg)}
                         </span>
-                        <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
-                            {t('createNew')}
-                        </span>
+                        <ChevronsUpDown
+                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                            strokeWidth={1.5}
+                            aria-hidden="true"
+                        />
                     </div>
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="bottom" align="start" className="w-60">
+                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
+                    {organizations.map((org) => {
+                        const isActive = activeOrganization?.id === org.id;
+                        return (
+                            <DropdownMenuItem
+                                key={org.id}
+                                onClick={() => handleSelectOrg(org)}
+                                className="cursor-pointer"
+                            >
+                                <div className="flex items-center gap-2 w-full">
+                                    <OrgAvatar org={org} size="xs" />
+                                    <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                        {pickLabel(org)}
+                                    </span>
+                                    {isActive && (
+                                        <Check
+                                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                            strokeWidth={1.5}
+                                            aria-label="Active organization"
+                                        />
+                                    )}
+                                </div>
+                            </DropdownMenuItem>
+                        );
+                    })}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
+                        <div className="flex items-center gap-2 w-full">
+                            <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">
+                                <Plus
+                                    className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
+                                    strokeWidth={1.5}
+                                />
+                            </span>
+                            <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                {t('createNew')}
+                            </span>
+                        </div>
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+            <CreateOrganizationModal open={isCreateOpen} onOpenChange={setIsCreateOpen} />
+        </>
     );
 }

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Building2, Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { useRouter } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { useActiveScope } from '@/lib/hooks/use-active-scope';
+import { LogoEverWork } from '../logos';
+import type { WorkConfig } from '@/lib/api';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+interface WorkspaceSwitcherProps {
+    /** Site config passed through to the empty-state `<LogoEverWork>`. */
+    config?: WorkConfig | null;
+    /** Tailwind class for the empty-state logo. Lets the sidebar size it. */
+    logoClassName?: string;
+}
+
+function pickInitial(org: OrganizationResponse): string {
+    const source = org.displayName ?? org.slug ?? '';
+    return source.charAt(0).toUpperCase() || '?';
+}
+
+function pickLabel(org: OrganizationResponse): string {
+    return org.displayName ?? org.slug;
+}
+
+/**
+ * Avatar circle for an Organization. Mimics shadcn `sidebar-07`
+ * TeamSwitcher's visual: a colored square with the first initial.
+ * `Building2` is used as a fallback when the initial would be empty.
+ */
+function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' }) {
+    const initial = pickInitial(org);
+    return (
+        <div
+            className={cn(
+                'shrink-0 inline-flex items-center justify-center rounded-md',
+                'bg-surface-tertiary dark:bg-surface-tertiary-dark',
+                'text-text dark:text-text-dark',
+                'font-semibold',
+                size === 'sm' ? 'w-7 h-7 text-xs' : 'w-5 h-5 text-[10px]',
+            )}
+            aria-hidden="true"
+        >
+            {initial || <Building2 className="w-3.5 h-3.5" strokeWidth={1.5} />}
+        </div>
+    );
+}
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — top-of-sidebar component
+ * showing the active Organization (or the bare Ever Works logo when
+ * the user has zero Orgs) with a popover to switch between Orgs.
+ *
+ * Behavior matrix:
+ *
+ * | Org count | Trigger UI                       | Popover                   |
+ * |-----------|----------------------------------|---------------------------|
+ * | 0         | `<LogoEverWork />` unmodified    | none (no chevron)         |
+ * | 1+        | Chip: [avatar] [name] [chevron]  | List of orgs + create row |
+ *
+ * The empty-state branch renders `<LogoEverWork />` AS-IS so the
+ * sidebar visuals for the no-org majority of users stay pixel-identical
+ * (NN #20 — extension, not replacement).
+ *
+ * Clicking an Org row navigates to `/{org.slug}/dashboard`. Clicking
+ * "+ Create Organization" is a stub for Phase 9 — it `console.log`s
+ * and the modal lands in EW-661.
+ */
+export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
+    const t = useTranslations('organizations.switcher');
+    const router = useRouter();
+    const { organizations, isLoading } = useOrganizations();
+    const { activeOrganization } = useActiveScope();
+
+    // Empty state: no orgs yet → render the existing logo unmodified.
+    // We intentionally treat `isLoading` as empty for the initial
+    // render so we don't flash a "Loading…" chip in the most common
+    // case (zero orgs). Once the fetch resolves and orgs > 0, the
+    // chip appears.
+    if (!isLoading && organizations.length === 0) {
+        return <LogoEverWork config={config} className={logoClassName} />;
+    }
+
+    // Loading state, but only on the very first fetch when we don't
+    // yet know whether the user has orgs. Render a minimal skeleton
+    // (same width as the chip) so layout doesn't jump.
+    if (isLoading && organizations.length === 0) {
+        return (
+            <div
+                className={cn(
+                    'flex items-center gap-2 px-2 py-1.5 rounded-md',
+                    'text-text-muted dark:text-text-muted-dark',
+                    'text-sm',
+                )}
+                aria-busy="true"
+            >
+                <span className="w-7 h-7 rounded-md bg-surface-tertiary/60 dark:bg-surface-tertiary-dark/60 animate-pulse" />
+                <span className="truncate">{t('loading')}</span>
+            </div>
+        );
+    }
+
+    // Active state: 1+ orgs. Pick the trigger label — if we know the
+    // active Org from the URL slug, use it; otherwise fall back to the
+    // first org in the list so the chip never shows up empty.
+    const triggerOrg = activeOrganization ?? organizations[0];
+
+    const handleSelectOrg = (org: OrganizationResponse) => {
+        router.push(`/${org.slug}/dashboard`);
+    };
+
+    const handleCreateOrg = () => {
+        // Phase 9 — EW-661 lands the modal. For now we log so the
+        // wiring point is explicit and easy to grep for during the
+        // next PR.
+        console.log('TODO Phase 9: open CreateOrganizationModal');
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                className={cn(
+                    'w-full rounded-md transition-colors cursor-pointer',
+                    'focus:outline-none focus-visible:outline-none',
+                    'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
+                    'px-2 py-1.5',
+                )}
+            >
+                <div className="flex items-center gap-2 w-full">
+                    <OrgAvatar org={triggerOrg} />
+                    <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                        {pickLabel(triggerOrg)}
+                    </span>
+                    <ChevronsUpDown
+                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                        strokeWidth={1.5}
+                        aria-hidden="true"
+                    />
+                </div>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="start" className="w-60">
+                <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
+                {organizations.map((org) => {
+                    const isActive = activeOrganization?.id === org.id;
+                    return (
+                        <DropdownMenuItem
+                            key={org.id}
+                            onClick={() => handleSelectOrg(org)}
+                            className="cursor-pointer"
+                        >
+                            <div className="flex items-center gap-2 w-full">
+                                <OrgAvatar org={org} size="xs" />
+                                <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                    {pickLabel(org)}
+                                </span>
+                                {isActive && (
+                                    <Check
+                                        className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                        strokeWidth={1.5}
+                                        aria-label="Active organization"
+                                    />
+                                )}
+                            </div>
+                        </DropdownMenuItem>
+                    );
+                })}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
+                    <div className="flex items-center gap-2 w-full">
+                        <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">
+                            <Plus
+                                className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
+                                strokeWidth={1.5}
+                            />
+                        </span>
+                        <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                            {t('createNew')}
+                        </span>
+                    </div>
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+// next-intl — return the key path verbatim so assertions can match
+// against the namespaced keys (we don't care about translated copy
+// here, only structure).
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+// next/navigation — `useParams()` returns the URL slug. We mock it
+// per-test via `paramsMock`.
+const paramsMock = vi.fn<() => { slug?: string }>();
+paramsMock.mockReturnValue({});
+vi.mock('next/navigation', () => ({
+    useParams: () => paramsMock(),
+}));
+
+// i18n navigation — `useRouter().push()` for the switch-on-click flow.
+const routerPushMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href: string }) => (
+        <a {...rest}>{children}</a>
+    ),
+    useRouter: () => ({ push: routerPushMock }),
+}));
+
+// Mock the LogoEverWork to a simple sentinel — we don't want to render
+// the real Next.js Image (jsdom) and we want a stable test selector
+// for the empty-state assertion.
+vi.mock('../logos', () => ({
+    LogoEverWork: () => <div data-testid="logo-everwork">LogoEverWork</div>,
+}));
+
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+function makeOrg(overrides: Partial<OrganizationResponse> = {}): OrganizationResponse {
+    return {
+        id: `o-${Math.random().toString(36).slice(2, 8)}`,
+        tenantId: 't-1',
+        slug: 'acme',
+        legalName: null,
+        displayName: 'Acme Inc',
+        countryCode: null,
+        registrationProvider: null,
+        registrationStatus: null,
+        linkedWorkId: null,
+        createdAt: '2026-05-28T00:00:00.000Z',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        routerPushMock.mockReset();
+        paramsMock.mockReset().mockReturnValue({});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Empty state: `organizations.length === 0` → falls back to the
+     * unmodified `<LogoEverWork>` (NN #20 — extension, not replacement).
+     * No popover trigger should be present.
+     */
+    it('renders the LogoEverWork (no popover trigger) when the user has zero organizations', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        const { container } = render(<WorkspaceSwitcher />);
+
+        expect(screen.getByTestId('logo-everwork')).toBeInTheDocument();
+        // No popover-trigger button — the empty state is the bare logo.
+        expect(container.querySelector('[role="button"]')).toBeNull();
+        // And the chevron icon — used as the trigger affordance — is
+        // absent.
+        expect(container.querySelectorAll('svg').length).toBe(0);
+    });
+
+    /**
+     * Active state with 1 org: the chip renders with the org's display
+     * name AND a trigger affordance (chevron icon).
+     */
+    it('renders the chip with the org name and a popover trigger when the user has 1 organization', () => {
+        const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher />);
+
+        // Chip text shows the display name.
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
+        // The logo from the empty-state branch should NOT render.
+        expect(screen.queryByTestId('logo-everwork')).toBeNull();
+    });
+
+    /**
+     * 3 orgs — when the popover opens, all three list rows are
+     * present. We assert against the DOM (text content) rather than
+     * driving headlessui's actual open animation, since the items are
+     * rendered into the menu's items container regardless of open
+     * state at the JSX level.
+     */
+    it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
+        const orgs = [
+            makeOrg({ id: 'o-1', slug: 'acme', displayName: 'Acme Inc' }),
+            makeOrg({ id: 'o-2', slug: 'globex', displayName: 'Globex LLC' }),
+            makeOrg({ id: 'o-3', slug: 'initech', displayName: 'Initech' }),
+        ];
+        __seedOrganizationsStoreForTests({
+            data: orgs,
+            isLoading: false,
+            error: null,
+        });
+
+        // Force the popover to open by clicking the trigger. Headless UI's
+        // MenuButton handles the click; the items mount on open.
+        render(<WorkspaceSwitcher />);
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+
+        // All three display names appear in the rendered tree (some
+        // also in the trigger chip — assert >= 1 for each).
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Globex LLC').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Initech').length).toBeGreaterThanOrEqual(1);
+
+        // The "+ Create Organization" row uses the i18n key
+        // `organizations.switcher.createNew` (our mock returns the key
+        // verbatim).
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Falls back to the org's slug when `displayName` is null — slug is
+     * NOT NULL on the DB row, so this is the right fallback shape.
+     */
+    it('uses the org slug as the chip label when displayName is null', () => {
+        const org = makeOrg({ displayName: null, slug: 'fallback-org' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher />);
+
+        expect(screen.getAllByText('fallback-org').length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/apps/web/src/components/organizations/CreateFirstOrgBanner.tsx
+++ b/apps/web/src/components/organizations/CreateFirstOrgBanner.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Building2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { CreateOrganizationModal } from './CreateOrganizationModal';
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — Settings → Account banner
+ * surfacing the "Create your first Organization" CTA per spec §5.5
+ * (empty-state entry points list).
+ *
+ * Renders ONLY when `organizations.length === 0` (and we're not still
+ * doing the initial fetch). Once the user has at least one Org the
+ * banner quietly disappears.
+ *
+ * Drop this at the top of any settings/account-style page — currently
+ * wired into `<ProfileSettings>`.
+ */
+export function CreateFirstOrgBanner() {
+    const t = useTranslations('organizations.banner');
+    const { organizations, isLoading } = useOrganizations();
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    // Hide the banner UI while loading or once at least one Org
+    // exists, BUT keep the modal mounted unconditionally so the
+    // post-create upgrade dialog has a place to render. If the modal
+    // shared this guard, creating-the-first-Org would flip
+    // `organizations.length` to 1 and immediately unmount the modal
+    // before the UpgradeOrCreateDialog could appear. (Codex P1 on PR
+    // #1063.)
+    const shouldShowBanner = !isLoading && organizations.length === 0;
+
+    return (
+        <>
+            {shouldShowBanner && (
+                <div className="flex items-start gap-4 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                    <div className="shrink-0 w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                        <Building2 className="w-5 h-5 text-primary" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-text dark:text-text-dark">
+                            {t('title')}
+                        </p>
+                        <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+                            {t('description')}
+                        </p>
+                    </div>
+                    <Button size="sm" onClick={() => setIsModalOpen(true)}>
+                        {t('cta')}
+                    </Button>
+                </div>
+            )}
+            <CreateOrganizationModal open={isModalOpen} onOpenChange={setIsModalOpen} />
+        </>
+    );
+}

--- a/apps/web/src/components/organizations/CreateOrganizationModal.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import type {
+    CheckSlugAvailabilityResponse,
+    OrganizationResponse,
+} from '@ever-works/contracts/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { useRouter } from '@/i18n/navigation';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+
+/**
+ * Mirror of `User.deriveSlugIfMissing` (and the server-side
+ * `UsernameAllocatorService.normalize`) so the live preview matches
+ * what the server would allocate when the user submits. We deliberately
+ * do NOT call out to the API on every keystroke for normalization —
+ * only the availability check is debounced and remote.
+ */
+function normalizeSlugPreview(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+const DEBOUNCE_MS = 300;
+const MAX_NAME_LENGTH = 200;
+
+export interface CreateOrganizationModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+type SlugStatus =
+    | { kind: 'idle' }
+    | { kind: 'checking' }
+    | { kind: 'available'; normalized: string }
+    | { kind: 'taken'; normalized: string; suggestion?: string }
+    | { kind: 'error'; message: string };
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — first half of the
+ * create-Org flow from spec §5.2.
+ *
+ * Form contract:
+ *   - Single input `Name` (required, 1-200 chars).
+ *   - Live, debounced slug-availability check against
+ *     `GET /api/organizations/check-slug?value=<name>` shows
+ *     "Available" / "Taken (try: acme-2)" hints.
+ *   - Submit → `POST /api/organizations` with `{ name }`. The server
+ *     allocates the slug + creates the lazy Tenant.
+ *
+ * Post-submit branching:
+ *   - First Org (organizations.length === 0 before submit) → hands off
+ *     to `<UpgradeOrCreateDialog>` so the user can choose the upgrade
+ *     vs empty branch.
+ *   - 2nd+ Org → close modal and navigate to `/{slug}/dashboard`
+ *     directly. Subsequent Orgs skip the upgrade dialog entirely
+ *     (spec §5.3).
+ *
+ * Wires into `useOrganizations().mutate()` on success so the
+ * `<WorkspaceSwitcher>` populates without a full page reload.
+ */
+export function CreateOrganizationModal({ open, onOpenChange }: CreateOrganizationModalProps) {
+    const t = useTranslations('organizations.create');
+    const router = useRouter();
+    const { organizations, mutate } = useOrganizations();
+
+    const [name, setName] = useState('');
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const [slugStatus, setSlugStatus] = useState<SlugStatus>({ kind: 'idle' });
+    const [createdOrg, setCreatedOrg] = useState<OrganizationResponse | null>(null);
+    const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
+    /**
+     * Captures whether THIS submission is the user's first Org. Read
+     * once at submit-time so the post-mutate `organizations.length`
+     * can't flip the decision underneath us (post-mutate it's 1).
+     */
+    const wasFirstOrgRef = useRef(false);
+
+    const slugPreview = useMemo(() => normalizeSlugPreview(name.trim()), [name]);
+
+    // Reset state whenever the modal is closed so reopening starts fresh.
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setSubmitError(null);
+            setSlugStatus({ kind: 'idle' });
+            setCreatedOrg(null);
+            setShowUpgradeDialog(false);
+        }
+    }, [open]);
+
+    // Debounced slug-availability check. Each keystroke resets the
+    // 300ms timer; the request only fires once typing pauses.
+    useEffect(() => {
+        if (!open) return;
+        const trimmed = name.trim();
+        if (trimmed.length === 0) {
+            setSlugStatus({ kind: 'idle' });
+            return;
+        }
+        setSlugStatus({ kind: 'checking' });
+        const controller = new AbortController();
+        const timer = setTimeout(() => {
+            void (async () => {
+                try {
+                    const res = await fetch(
+                        `/api/organizations/check-slug?value=${encodeURIComponent(trimmed)}`,
+                        {
+                            method: 'GET',
+                            signal: controller.signal,
+                            cache: 'no-store',
+                        },
+                    );
+                    if (!res.ok) {
+                        setSlugStatus({ kind: 'error', message: `HTTP ${res.status}` });
+                        return;
+                    }
+                    const body = (await res.json()) as CheckSlugAvailabilityResponse;
+                    if (body.available) {
+                        setSlugStatus({ kind: 'available', normalized: body.normalized });
+                    } else {
+                        setSlugStatus({
+                            kind: 'taken',
+                            normalized: body.normalized,
+                            suggestion: body.suggestion,
+                        });
+                    }
+                } catch (err) {
+                    if ((err as { name?: string })?.name === 'AbortError') return;
+                    setSlugStatus({
+                        kind: 'error',
+                        message: err instanceof Error ? err.message : 'Network error',
+                    });
+                }
+            })();
+        }, DEBOUNCE_MS);
+        return () => {
+            controller.abort();
+            clearTimeout(timer);
+        };
+    }, [name, open]);
+
+    const handleSubmit = useCallback(() => {
+        const trimmed = name.trim();
+        if (trimmed.length === 0) {
+            setSubmitError(t('errors.nameRequired'));
+            return;
+        }
+        if (trimmed.length > MAX_NAME_LENGTH) {
+            setSubmitError(t('errors.nameTooLong'));
+            return;
+        }
+        setSubmitError(null);
+        wasFirstOrgRef.current = organizations.length === 0;
+        startTransition(() => {
+            void (async () => {
+                try {
+                    const res = await fetch('/api/organizations', {
+                        method: 'POST',
+                        credentials: 'include',
+                        cache: 'no-store',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ name: trimmed }),
+                    });
+                    if (!res.ok) {
+                        const body = await res
+                            .json()
+                            .catch(() => ({ error: 'Failed to create Organization' }));
+                        setSubmitError(
+                            (body as { message?: string; error?: string }).message ??
+                                (body as { error?: string }).error ??
+                                t('errors.generic'),
+                        );
+                        return;
+                    }
+                    const org = (await res.json()) as OrganizationResponse;
+                    // Refresh the org list so the switcher updates and
+                    // subsequent first-Org checks aren't fooled.
+                    //
+                    // **Best-effort**: the POST already succeeded; the Org
+                    // exists. A transient 500/401/network failure on the
+                    // follow-up GET /api/organizations must NOT surface as
+                    // a creation error — otherwise the user retries and
+                    // we end up with duplicate Orgs. (Codex P2 on PR
+                    // #1063.) The switcher will pick up the new Org on
+                    // its next natural refresh.
+                    try {
+                        await mutate();
+                    } catch {
+                        // Swallow — see comment above.
+                    }
+                    if (wasFirstOrgRef.current) {
+                        // Keep the parent modal mounted but hidden behind
+                        // the upgrade dialog so the user can't backtrack
+                        // into a half-finished form.
+                        setCreatedOrg(org);
+                        setShowUpgradeDialog(true);
+                    } else {
+                        onOpenChange(false);
+                        router.push(`/${org.slug}/dashboard`);
+                    }
+                } catch (err) {
+                    setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
+                }
+            })();
+        });
+    }, [name, organizations.length, mutate, onOpenChange, router, t]);
+
+    const handleUpgradeDialogClose = useCallback(
+        (didUpgrade: boolean) => {
+            setShowUpgradeDialog(false);
+            const target = createdOrg;
+            // Reset modal state then close the outer dialog. Navigation
+            // happens after close so a route change doesn't fight the
+            // transition.
+            setCreatedOrg(null);
+            onOpenChange(false);
+            if (target) {
+                router.push(`/${target.slug}/dashboard`);
+                // Pull the freshly-upgraded org list (tenantId is now set
+                // on the user, so subsequent fetches reflect that).
+                if (didUpgrade) void mutate();
+            }
+        },
+        [createdOrg, mutate, onOpenChange, router],
+    );
+
+    // Hide the modal panel while the upgrade dialog is visible so the
+    // user only sees one surface at a time. The Dialog `open` prop stays
+    // true so the create-modal state isn't reset mid-flow.
+    const showCreatePanel = !showUpgradeDialog;
+
+    return (
+        <>
+            <Dialog open={open} onOpenChange={onOpenChange}>
+                {showCreatePanel && (
+                    <DialogContent className="max-w-md">
+                        <DialogClose onClose={() => onOpenChange(false)} />
+                        <DialogHeader>
+                            <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                                {t('title')}
+                            </DialogTitle>
+                            <DialogDescription>{t('description')}</DialogDescription>
+                        </DialogHeader>
+
+                        <div className="space-y-4">
+                            <Input
+                                label={t('nameLabel')}
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                placeholder={t('namePlaceholder')}
+                                maxLength={MAX_NAME_LENGTH}
+                                autoFocus
+                                disabled={pending}
+                                error={submitError ?? undefined}
+                            />
+
+                            <SlugPreview
+                                preview={slugPreview}
+                                status={slugStatus}
+                                t={t}
+                                hasName={name.trim().length > 0}
+                            />
+                        </div>
+
+                        <DialogFooter>
+                            <Button
+                                variant="ghost"
+                                onClick={() => onOpenChange(false)}
+                                disabled={pending}
+                            >
+                                {t('cancel')}
+                            </Button>
+                            <Button
+                                onClick={handleSubmit}
+                                loading={pending}
+                                disabled={pending || name.trim().length === 0}
+                            >
+                                {t('submit')}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                )}
+            </Dialog>
+
+            {createdOrg && (
+                <UpgradeOrCreateDialog
+                    open={showUpgradeDialog}
+                    organization={createdOrg}
+                    onClose={handleUpgradeDialogClose}
+                />
+            )}
+        </>
+    );
+}
+
+function SlugPreview({
+    preview,
+    status,
+    t,
+    hasName,
+}: {
+    preview: string;
+    status: SlugStatus;
+    t: ReturnType<typeof useTranslations>;
+    hasName: boolean;
+}) {
+    if (!hasName) {
+        return null;
+    }
+    return (
+        <div className="text-xs text-text-muted dark:text-text-muted-dark">
+            <div>
+                <span className="font-medium text-text-secondary dark:text-text-secondary-dark">
+                    {t('slugPreview')}
+                </span>{' '}
+                <span
+                    className="font-mono text-text dark:text-text-dark"
+                    data-testid="slug-preview-value"
+                >
+                    {preview || '—'}
+                </span>
+            </div>
+            <div className="mt-1" data-testid="slug-status">
+                {status.kind === 'checking' && <span>{t('slugChecking')}</span>}
+                {status.kind === 'available' && (
+                    <span className="text-success">{t('slugAvailable')}</span>
+                )}
+                {status.kind === 'taken' && (
+                    <span className="text-warning">
+                        {status.suggestion
+                            ? t('slugTaken', { suggestion: status.suggestion })
+                            : t('slugTakenNoSuggestion')}
+                    </span>
+                )}
+                {status.kind === 'error' && (
+                    <span className="text-text-muted dark:text-text-muted-dark">
+                        {t('slugCheckError')}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
+++ b/apps/web/src/components/organizations/CreateOrganizationModal.unit.spec.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+// next-intl — return the key plus any `{var}` interpolations so the
+// assertions match against the namespaced keys without coupling to
+// translated copy.
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string, args?: Record<string, string | number>) => {
+        const path = `${ns}.${key}`;
+        if (!args) return path;
+        const interp = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${path} ${interp}`;
+    },
+}));
+
+const routerPushMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    // `Button` imports `Link` from this module; export a passthrough.
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+    useRouter: () => ({
+        push: routerPushMock,
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+    getPathname: ({ href }: { href: string }) => href,
+}));
+
+// next-intl `Dialog` uses Headless UI's Transition.show — render the
+// real dialog so we can drive the form. No additional mock needed.
+
+import { CreateOrganizationModal } from './CreateOrganizationModal';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+function org(overrides: Partial<OrganizationResponse> = {}): OrganizationResponse {
+    return {
+        id: 'o-new',
+        tenantId: 't-1',
+        slug: 'acme',
+        legalName: null,
+        displayName: 'Acme Inc',
+        countryCode: null,
+        registrationProvider: null,
+        registrationStatus: null,
+        linkedWorkId: null,
+        createdAt: '2026-05-28T00:00:00.000Z',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('CreateOrganizationModal — EW-661 Phase 9', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        routerPushMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Submitting with an empty name surfaces the inline validation error
+     * and does NOT fire the POST.
+     */
+    it('shows an inline error when submit is attempted with an empty name', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        const onOpenChange = vi.fn();
+        render(<CreateOrganizationModal open={true} onOpenChange={onOpenChange} />);
+
+        // The Create button is disabled while the name is empty — but
+        // we exercise the validation path by typing whitespace and
+        // submitting. (Whitespace-only is also invalid.)
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+        fireEvent.change(input, { target: { value: '   ' } });
+        const submit = screen.getByText('organizations.create.submit');
+        expect((submit as HTMLButtonElement).disabled).toBe(true);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Valid submission triggers `POST /api/organizations` with the
+     * trimmed name and (for non-first-Org) navigates to the new dashboard.
+     */
+    it('calls POST /api/organizations with the name and navigates after success (2nd Org skips upgrade dialog)', async () => {
+        __seedOrganizationsStoreForTests({
+            data: [org({ id: 'o-existing' })], // 1 existing = not first Org
+            isLoading: false,
+            error: null,
+        });
+        const newOrg = org({ id: 'o-new', slug: 'globex', displayName: 'Globex LLC' });
+        const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u.includes('/api/organizations/check-slug')) {
+                return new Response(JSON.stringify({ available: true, normalized: 'globex' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), {
+                    status: 201,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations') {
+                return new Response(JSON.stringify([newOrg]), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            throw new Error(`Unexpected fetch: ${u}`);
+        });
+
+        const onOpenChange = vi.fn();
+        render(<CreateOrganizationModal open={true} onOpenChange={onOpenChange} />);
+
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+        fireEvent.change(input, { target: { value: 'Globex LLC' } });
+
+        const submit = screen.getByText('organizations.create.submit');
+        fireEvent.click(submit);
+
+        await waitFor(() => {
+            // Modal closed.
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+            // Navigated to the new Org's dashboard.
+            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+        });
+
+        // POST request body carried the trimmed name.
+        const postCall = fetchMock.mock.calls.find(
+            ([url, init]) =>
+                String(url) === '/api/organizations' &&
+                (init as RequestInit | undefined)?.method === 'POST',
+        );
+        expect(postCall).toBeDefined();
+        const body = JSON.parse((postCall![1] as RequestInit).body as string);
+        expect(body).toEqual({ name: 'Globex LLC' });
+    });
+
+    /**
+     * As the user types, the slug preview updates live (no debounce —
+     * pure local string normalization). Mirror of the API normalizer.
+     */
+    it('renders a live slug preview that mirrors the server-side normalization', () => {
+        render(<CreateOrganizationModal open={true} onOpenChange={vi.fn()} />);
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+
+        // Pre-type: preview not shown yet.
+        expect(screen.queryByTestId('slug-preview-value')).toBeNull();
+
+        fireEvent.change(input, { target: { value: 'Acme Inc.' } });
+        expect(screen.getByTestId('slug-preview-value').textContent).toBe('acme-inc');
+
+        fireEvent.change(input, { target: { value: 'Globex Co/Ltd' } });
+        expect(screen.getByTestId('slug-preview-value').textContent).toBe('globex-co-ltd');
+    });
+
+    /**
+     * Submitting with zero existing Orgs → hands off to the upgrade
+     * dialog (rendered conditionally, so the create panel hides).
+     */
+    it('chains into the UpgradeOrCreateDialog when this is the user first Org', async () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        const newOrg = org({ id: 'o-first', slug: 'first-org', displayName: 'First Org' });
+        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u.includes('/api/organizations/check-slug')) {
+                return new Response(JSON.stringify({ available: true, normalized: 'first-org' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            return new Response(JSON.stringify([newOrg]), { status: 200 });
+        });
+
+        render(<CreateOrganizationModal open={true} onOpenChange={vi.fn()} />);
+
+        const input = screen.getByPlaceholderText('organizations.create.namePlaceholder');
+        fireEvent.change(input, { target: { value: 'First Org' } });
+
+        const submit = screen.getByText('organizations.create.submit');
+        fireEvent.click(submit);
+
+        await waitFor(() => {
+            // Upgrade dialog mounts.
+            expect(screen.getByText('organizations.upgrade.title')).toBeInTheDocument();
+            // Create panel hides (the Create submit button is no longer present).
+            expect(screen.queryByText('organizations.create.submit')).toBeNull();
+        });
+        // No navigation yet — that happens after upgrade choice.
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useRef, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS } from '@ever-works/contracts/api';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+
+type UpgradeChoice = 'upgrade' | 'empty';
+
+export interface UpgradeOrCreateDialogProps {
+    open: boolean;
+    organization: OrganizationResponse;
+    /**
+     * Fired when the dialog finishes (either branch completes, or the
+     * user cancels). `didUpgrade=true` means the upgrade API call ran
+     * and succeeded — the caller may want to refresh data tied to the
+     * promoted Tenant.
+     */
+    onClose: (didUpgrade: boolean) => void;
+}
+
+/**
+ * EW-661 (Tenants & Organizations Phase 9) — second half of the
+ * create-Org flow from spec §5.2 step 2. Only renders for the user's
+ * FIRST Organization.
+ *
+ * Two radio choices:
+ *
+ *  - **Upgrade** (default, focused) → calls
+ *    `POST /api/organizations/:id/upgrade-from-account`, which sets
+ *    `organizationId = newOrg.id` on the user's existing Tier A + Tier
+ *    C rows. After it resolves we navigate the parent (via `onClose`)
+ *    to the new Org's dashboard.
+ *  - **Empty** → no API call. The new Org is already empty; the user's
+ *    existing rows stay in the bare-Tenant scope. We just close + let
+ *    the parent navigate.
+ *
+ * Handles 409 `UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS` gracefully —
+ * shouldn't happen here (this is first-Org only) but if a race lets it
+ * through we surface a generic "not available" message rather than
+ * silently failing.
+ */
+export function UpgradeOrCreateDialog({ open, organization, onClose }: UpgradeOrCreateDialogProps) {
+    const t = useTranslations('organizations.upgrade');
+    const [choice, setChoice] = useState<UpgradeChoice>('upgrade');
+    const [error, setError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const upgradeRadioRef = useRef<HTMLInputElement>(null);
+
+    // Focus the default (Upgrade) radio on open. Use a microtask so the
+    // ref is populated after the dialog mounts. Reset on close so a
+    // re-open is clean.
+    useEffect(() => {
+        if (open) {
+            setChoice('upgrade');
+            setError(null);
+            const id = window.setTimeout(() => {
+                upgradeRadioRef.current?.focus();
+            }, 0);
+            return () => window.clearTimeout(id);
+        }
+    }, [open]);
+
+    const handleConfirm = () => {
+        setError(null);
+        if (choice === 'empty') {
+            // No API call — just close. Parent handles navigation.
+            onClose(false);
+            return;
+        }
+        startTransition(() => {
+            void (async () => {
+                try {
+                    const res = await fetch(
+                        `/api/organizations/${encodeURIComponent(organization.id)}/upgrade-from-account`,
+                        {
+                            method: 'POST',
+                            credentials: 'include',
+                            cache: 'no-store',
+                            headers: { 'Content-Type': 'application/json' },
+                        },
+                    );
+                    if (!res.ok) {
+                        const body = await res.json().catch(() => ({}));
+                        const code = (body as { code?: string; message?: string }).code;
+                        if (
+                            res.status === 409 ||
+                            code === UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS
+                        ) {
+                            setError(t('errors.notAvailable'));
+                        } else {
+                            setError(
+                                (body as { message?: string; error?: string }).message ??
+                                    (body as { error?: string }).error ??
+                                    t('errors.generic'),
+                            );
+                        }
+                        return;
+                    }
+                    onClose(true);
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : t('errors.generic'));
+                }
+            })();
+        });
+    };
+
+    const handleCancel = () => {
+        if (pending) return;
+        onClose(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => !next && handleCancel()}>
+            <DialogContent className="max-w-md">
+                <DialogClose onClose={handleCancel} />
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                        {t('title')}
+                    </DialogTitle>
+                    <DialogDescription>{t('description')}</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-3">
+                    <ChoiceRow
+                        id="upgrade-or-create-upgrade"
+                        radioRef={upgradeRadioRef}
+                        checked={choice === 'upgrade'}
+                        onChange={() => setChoice('upgrade')}
+                        label={t('upgradeOption')}
+                        help={t('upgradeHelp')}
+                        disabled={pending}
+                    />
+                    <ChoiceRow
+                        id="upgrade-or-create-empty"
+                        checked={choice === 'empty'}
+                        onChange={() => setChoice('empty')}
+                        label={t('emptyOption')}
+                        help={t('emptyHelp')}
+                        disabled={pending}
+                    />
+                </div>
+
+                {error && (
+                    <p className="mt-3 text-sm text-danger" role="alert">
+                        {error}
+                    </p>
+                )}
+
+                <DialogFooter>
+                    <Button variant="ghost" onClick={handleCancel} disabled={pending}>
+                        {t('cancel')}
+                    </Button>
+                    <Button onClick={handleConfirm} loading={pending} disabled={pending}>
+                        {t('confirm')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function ChoiceRow({
+    id,
+    radioRef,
+    checked,
+    onChange,
+    label,
+    help,
+    disabled,
+}: {
+    id: string;
+    radioRef?: React.RefObject<HTMLInputElement | null>;
+    checked: boolean;
+    onChange: () => void;
+    label: string;
+    help: string;
+    disabled?: boolean;
+}) {
+    return (
+        <label
+            htmlFor={id}
+            className={`block rounded-lg border p-3 transition-colors cursor-pointer ${
+                checked
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border/60 dark:border-border-dark/60 hover:border-border dark:hover:border-border-dark'
+            } ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+        >
+            <div className="flex items-start gap-3">
+                <input
+                    ref={radioRef}
+                    id={id}
+                    type="radio"
+                    name="upgrade-or-create-choice"
+                    checked={checked}
+                    onChange={onChange}
+                    disabled={disabled}
+                    className="mt-0.5"
+                />
+                <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-text dark:text-text-dark">{label}</div>
+                    <div className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                        {help}
+                    </div>
+                </div>
+            </div>
+        </label>
+    );
+}

--- a/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/UpgradeOrCreateDialog.unit.spec.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string, args?: Record<string, string | number>) => {
+        const path = `${ns}.${key}`;
+        if (!args) return path;
+        const interp = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${path} ${interp}`;
+    },
+}));
+
+// Button (used in DialogFooter) imports `Link` from `@/i18n/navigation`.
+// Short-circuit the locale-aware navigation module so the test doesn't
+// pull in next-intl's createNavigation chain.
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+    useRouter: () => ({
+        push: vi.fn(),
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+    getPathname: ({ href }: { href: string }) => href,
+}));
+
+import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+
+const fakeOrg: OrganizationResponse = {
+    id: 'o-test-1',
+    tenantId: 't-1',
+    slug: 'acme',
+    legalName: null,
+    displayName: 'Acme Inc',
+    countryCode: null,
+    registrationProvider: null,
+    registrationStatus: null,
+    linkedWorkId: null,
+    createdAt: '2026-05-28T00:00:00.000Z',
+    updatedAt: '2026-05-28T00:00:00.000Z',
+};
+
+describe('UpgradeOrCreateDialog — EW-661 Phase 9', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Upgrade radio is the default selection and gets focus on open
+     * (spec §5.2 — "Default option: Upgrade current account").
+     */
+    it('defaults to the Upgrade radio and focuses it on open', async () => {
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={vi.fn()} />);
+
+        const upgradeRadio = screen.getByLabelText(/upgrade.upgradeOption/i, {
+            exact: false,
+        }) as HTMLInputElement;
+        expect(upgradeRadio.checked).toBe(true);
+
+        const emptyRadio = screen.getByLabelText(/upgrade.emptyOption/i, {
+            exact: false,
+        }) as HTMLInputElement;
+        expect(emptyRadio.checked).toBe(false);
+
+        // Focused element is the Upgrade radio (focus is scheduled with
+        // setTimeout(0), so wait for it).
+        await waitFor(() => {
+            expect(document.activeElement).toBe(upgradeRadio);
+        });
+    });
+
+    /**
+     * Picking "Empty" + confirm dispatches NO fetch and reports
+     * `didUpgrade=false` back to the parent.
+     */
+    it('empty branch: calls onClose(false) without firing the upgrade API', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        const onClose = vi.fn();
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        const emptyRadio = screen.getByLabelText(/upgrade.emptyOption/i, {
+            exact: false,
+        }) as HTMLInputElement;
+        fireEvent.click(emptyRadio);
+        expect(emptyRadio.checked).toBe(true);
+
+        const confirm = screen.getByText('organizations.upgrade.confirm');
+        fireEvent.click(confirm);
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalledWith(false);
+    });
+
+    /**
+     * Picking "Upgrade" + confirm POSTs to the upgrade-from-account
+     * endpoint and reports `didUpgrade=true` on success.
+     */
+    it('upgrade branch: POSTs to /upgrade-from-account and onClose(true) on success', async () => {
+        const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    organizationId: fakeOrg.id,
+                    tenantId: fakeOrg.tenantId,
+                    tierARowsUpdated: 0,
+                    tierBRowsUpdated: 0,
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } },
+            ),
+        );
+        const onClose = vi.fn();
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        const confirm = screen.getByText('organizations.upgrade.confirm');
+        fireEvent.click(confirm);
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                `/api/organizations/${fakeOrg.id}/upgrade-from-account`,
+                expect.objectContaining({ method: 'POST' }),
+            );
+            expect(onClose).toHaveBeenCalledWith(true);
+        });
+    });
+
+    /**
+     * 409 UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS — first-Org-only
+     * guard fired on the API side. The dialog surfaces a generic
+     * "not available" message and stays open.
+     */
+    it('handles 409 UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS gracefully', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    code: 'UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS',
+                    message: 'Already past the first-Org window',
+                }),
+                { status: 409, headers: { 'Content-Type': 'application/json' } },
+            ),
+        );
+        const onClose = vi.fn();
+        render(<UpgradeOrCreateDialog open={true} organization={fakeOrg} onClose={onClose} />);
+
+        const confirm = screen.getByText('organizations.upgrade.confirm');
+        fireEvent.click(confirm);
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert').textContent).toContain(
+                'organizations.upgrade.errors.notAvailable',
+            );
+        });
+        // Did NOT close — user is still on the dialog so they can pick
+        // "Empty" or dismiss.
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/settings/ProfileSettings.tsx
+++ b/apps/web/src/components/settings/ProfileSettings.tsx
@@ -7,6 +7,7 @@ import { updateProfile, resendVerificationEmail } from '@/app/actions/settings';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import { Mail } from 'lucide-react';
+import { CreateFirstOrgBanner } from '@/components/organizations/CreateFirstOrgBanner';
 
 interface ProfileSettingsProps {
     user: {
@@ -77,6 +78,13 @@ export function ProfileSettings({ user }: ProfileSettingsProps) {
 
     return (
         <div className="space-y-6">
+            {/*
+             * EW-661 — surfaces a "Create your first Organization"
+             * banner. Auto-hides itself once `organizations.length > 0`,
+             * so this is a no-op for users who already have an Org.
+             */}
+            <CreateFirstOrgBanner />
+
             <div>
                 <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-4">
                     {t('title')}

--- a/apps/web/src/lib/hooks/use-active-scope.ts
+++ b/apps/web/src/lib/hooks/use-active-scope.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { useOrganizations } from './use-organizations';
+
+export interface UseActiveScopeResult {
+    /**
+     * The slug from the URL — `/[slug]/...`. Returns `null` when the
+     * route doesn't carry a slug (e.g. bare `/dashboard`,
+     * `/[userSlug]/dashboard` before Phase 7 web-side wiring lands, or
+     * when navigating outside the slug-prefixed routes entirely).
+     */
+    slug: string | null;
+    /**
+     * The Organization whose `slug` matches the URL slug. `null` when
+     * the user is in bare-Tenant scope, when the URL doesn't carry an
+     * org slug, or when the slug exists but isn't in the user's
+     * fetched org list (defensive fallback — shouldn't normally happen
+     * because the API only returns orgs the user can see).
+     */
+    activeOrganization: OrganizationResponse | null;
+}
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — derives the user's active
+ * Organization from the URL slug. Reads `useParams()` from the App
+ * Router (Phase 7's `[slug]` segment, when it lands web-side) and
+ * cross-references it against `useOrganizations()`.
+ *
+ * Today most users have zero organizations and bare-Tenant routes don't
+ * carry a slug, so this hook will return `{ slug: null,
+ * activeOrganization: null }` for them — the WorkspaceSwitcher uses
+ * that signal plus `organizations.length === 0` to render the
+ * empty-state logo.
+ */
+export function useActiveScope(): UseActiveScopeResult {
+    const params = useParams<{ slug?: string | string[] }>();
+    const { organizations } = useOrganizations();
+
+    const rawSlug = params?.slug;
+    const slug = Array.isArray(rawSlug) ? (rawSlug[0] ?? null) : (rawSlug ?? null);
+
+    const activeOrganization = slug
+        ? (organizations.find((org) => org.slug === slug) ?? null)
+        : null;
+
+    return { slug, activeOrganization };
+}

--- a/apps/web/src/lib/hooks/use-organizations.ts
+++ b/apps/web/src/lib/hooks/use-organizations.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+/**
+ * EW-660 (Tenants & Organizations Phase 8) — client-side hook fetching
+ * `GET /api/organizations` (proxied by `apps/web/src/app/api/organizations/route.ts`).
+ *
+ * The spec called for an SWR hook, but SWR is not a dependency of
+ * `apps/web` (verified against `package.json`) and Phase 8 explicitly
+ * forbids adding new deps. We implement the same surface — cache shared
+ * across components, `mutate()` to revalidate — with a module-level
+ * store + `useSyncExternalStore`, matching the pattern already used by
+ * `use-dashboard-current-work.tsx`.
+ *
+ * Surface:
+ *   - `organizations` — `OrganizationResponse[]` (defaults to `[]` until
+ *     the first successful fetch, NOT `undefined`, so the empty-state
+ *     check `organizations.length === 0` works on the very first render
+ *     without a flash of the active-state chip).
+ *   - `isLoading` — `true` until the first fetch resolves (success or
+ *     error).
+ *   - `error` — `Error | null`. `null` when the last fetch succeeded.
+ *   - `mutate()` — re-runs the fetch and updates all subscribers.
+ */
+
+type Listener = () => void;
+
+interface OrganizationsStore {
+    data: OrganizationResponse[];
+    isLoading: boolean;
+    error: Error | null;
+}
+
+let store: OrganizationsStore = {
+    data: [],
+    isLoading: true,
+    error: null,
+};
+// `let` rather than `const` because the underlying Set is mutated via
+// add/delete/clear throughout the module. Team convention (Greptile P2,
+// ref: ever-co/ever-gauzy#8961) prefers `let` for conceptually-mutable
+// container vars even when the binding itself isn't reassigned.
+let listeners = new Set<Listener>();
+let inFlight: Promise<void> | null = null;
+let hasFetchedAtLeastOnce = false;
+
+function emit() {
+    for (const listener of listeners) {
+        listener();
+    }
+}
+
+function setStore(next: Partial<OrganizationsStore>) {
+    store = { ...store, ...next };
+    emit();
+}
+
+function subscribe(listener: Listener) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+function getSnapshot() {
+    return store;
+}
+
+function getServerSnapshot() {
+    return store;
+}
+
+async function fetchOrganizations(): Promise<void> {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+        try {
+            const response = await fetch('/api/organizations', {
+                method: 'GET',
+                credentials: 'include',
+                cache: 'no-store',
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to fetch organizations (${response.status})`);
+            }
+            const body = (await response.json()) as OrganizationResponse[];
+            const data = Array.isArray(body) ? body : [];
+            setStore({ data, isLoading: false, error: null });
+        } catch (err) {
+            // Keep `data` so a transient failure doesn't blow away the
+            // user's current org list mid-session (extension, not
+            // replacement — NN #20).
+            setStore({
+                isLoading: false,
+                error: err instanceof Error ? err : new Error('Unknown error'),
+            });
+        } finally {
+            hasFetchedAtLeastOnce = true;
+            inFlight = null;
+        }
+    })();
+    return inFlight;
+}
+
+export interface UseOrganizationsResult {
+    organizations: OrganizationResponse[];
+    isLoading: boolean;
+    error: Error | null;
+    mutate: () => Promise<void>;
+}
+
+export function useOrganizations(): UseOrganizationsResult {
+    const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+    useEffect(() => {
+        if (!hasFetchedAtLeastOnce) {
+            void fetchOrganizations();
+        }
+    }, []);
+
+    const mutate = useCallback(() => fetchOrganizations(), []);
+
+    return {
+        organizations: snapshot.data,
+        isLoading: snapshot.isLoading,
+        error: snapshot.error,
+        mutate,
+    };
+}
+
+/**
+ * Test-only helper. Resets the module-level cache between unit tests so
+ * one test's fetched data doesn't bleed into the next. Not exported from
+ * any barrel — import the hook module directly.
+ */
+export function __resetOrganizationsStoreForTests() {
+    store = { data: [], isLoading: true, error: null };
+    inFlight = null;
+    hasFetchedAtLeastOnce = false;
+    listeners.clear();
+}
+
+/**
+ * Test-only helper. Lets a unit test pre-seed the store without going
+ * through a real fetch — useful when asserting purely visual states
+ * (empty / 1 org / 3 orgs).
+ */
+export function __seedOrganizationsStoreForTests(next: Partial<OrganizationsStore>) {
+    store = { ...store, ...next };
+    hasFetchedAtLeastOnce = true;
+    emit();
+}
+
+// Tiny stand-in to silence TS "unused" complaints from default state
+// shape exports; consumers that need a placeholder Loading view rely on
+// `isLoading`.
+export type { OrganizationsStore };


### PR DESCRIPTION
## Summary

Follow-up cascade after [ever-works#1061](https://github.com/ever-works/ever-works/pull/1061). 3 commits ahead of stage.

### What's in this cascade

- **[ever-works#1064](https://github.com/ever-works/ever-works/pull/1064)** — derives \`users.slug\` in the Better Auth create hook + finishes the locale-prefix E2E sweep. Unblocks user registration (the 422 \"Failed to create user\" regression) and the remaining 4 locale-prefix specs missed by [PR #1060](https://github.com/ever-works/ever-works/pull/1060). Should make PR #1057 (stage→main) finally green.
- **[ever-works#1063](https://github.com/ever-works/ever-works/pull/1063)** — Tenants/Orgs Phase 9: Create Organization modal + upgrade dialog (EW-661).
- **[ever-works#1062](https://github.com/ever-works/ever-works/pull/1062)** — Tenants/Orgs Phase 8: WorkspaceSwitcher UI (EW-660).

## Test plan

- [ ] CI green on stage after merge.
- [ ] Stage deploy succeeds.
- [ ] PR #1057 (stage→main) re-runs heavy CI: all 29 previously-failed E2E tests pass; signup flow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)