### PR TITLE
[EW-662] Phase 10 - Company chip + Work→Org wire-up

### DIFF
--- a/apps/api/src/organizations/__tests__/organization.service.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization.service.spec.ts
@@ -318,4 +318,139 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
             expect(usernameAllocator.suggest).toHaveBeenCalledWith('alice');
         });
     });
+
+    /**
+     * EW-662 (Phase 10) — Register-Company sub-flow tests.
+     *
+     * Both `registerCompany` and `createOrganizationFromCompanyWork` end
+     * up calling `createOrganization` with a populated `extra` field;
+     * we assert the resulting Org row carries the right registration
+     * metadata (provider, status, legalName, countryCode, linkedWorkId).
+     */
+    describe('registerCompany (EW-662 Phase 10)', () => {
+        it('rejects empty name with ConflictException', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+            await expect(service.registerCompany('u-1', { name: '' })).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            await expect(service.registerCompany('u-1', { name: '   ' })).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('creates Org with manual provider + registered status + supplied metadata', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.registerCompany('u-1', {
+                name: 'Acme Inc.',
+                countryCode: 'US',
+                legalName: 'Acme, Inc.',
+            })) as unknown as {
+                id: string;
+                slug: string;
+                legalName: string;
+                countryCode: string;
+                registrationProvider: string;
+                registrationStatus: string;
+                linkedWorkId: string | null;
+            };
+
+            expect(org.id).toBe('o-new');
+            expect(org.legalName).toBe('Acme, Inc.');
+            expect(org.countryCode).toBe('US');
+            expect(org.registrationProvider).toBe('manual');
+            expect(org.registrationStatus).toBe('registered');
+            // No backing Work in the manual-completion path — linkedWorkId stays null.
+            expect(org.linkedWorkId).toBeNull();
+        });
+
+        it('defaults legalName to the trimmed name when caller omits it', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.registerCompany('u-1', {
+                name: '  Globex Holdings  ',
+            })) as unknown as { legalName: string };
+
+            expect(org.legalName).toBe('Globex Holdings');
+        });
+
+        it('passes a slugOverride straight through to the allocator', async () => {
+            const { service, usernameAllocator } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            await service.registerCompany('u-1', {
+                name: 'Acme Inc.',
+                slugOverride: 'acme-corp',
+            });
+
+            expect(usernameAllocator.allocateUsername).toHaveBeenCalledWith('acme-corp');
+        });
+    });
+
+    describe('createOrganizationFromCompanyWork (EW-662 Phase 10)', () => {
+        it('sets linkedWorkId + uses Work.companyName when present', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.createOrganizationFromCompanyWork(
+                'u-1',
+                {
+                    id: 'w-42',
+                    name: 'acme-website',
+                    companyName: 'Acme Inc.',
+                    companyWebsite: 'https://acme.example',
+                },
+                { countryCode: 'DE' },
+            )) as unknown as {
+                id: string;
+                linkedWorkId: string | null;
+                legalName: string;
+                countryCode: string;
+                registrationProvider: string;
+                registrationStatus: string;
+            };
+
+            expect(org.linkedWorkId).toBe('w-42');
+            expect(org.legalName).toBe('Acme Inc.');
+            expect(org.countryCode).toBe('DE');
+            expect(org.registrationProvider).toBe('manual');
+            expect(org.registrationStatus).toBe('registered');
+        });
+
+        it('falls back to Work.name when companyName is missing', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.createOrganizationFromCompanyWork('u-1', {
+                id: 'w-7',
+                name: 'Initech',
+            })) as unknown as { linkedWorkId: string; legalName: string };
+
+            expect(org.linkedWorkId).toBe('w-7');
+            // No companyName + no override → legalName defaults to the
+            // (trimmed) display name. This matches `registerCompany`'s
+            // own fallback so the v1 manual-completion path always ends
+            // up with a non-null legalName.
+            expect(org.legalName).toBe('Initech');
+        });
+
+        it('throws ConflictException when the Work has no usable name', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            await expect(
+                service.createOrganizationFromCompanyWork('u-1', { id: 'w-x', name: '' }),
+            ).rejects.toBeInstanceOf(ConflictException);
+        });
+    });
 });

--- a/apps/api/src/organizations/dto/register-company.dto.ts
+++ b/apps/api/src/organizations/dto/register-company.dto.ts
@@ -1,0 +1,62 @@
+import { IsOptional, IsString, Length, Matches } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — body for
+ * `POST /api/organizations/register-company`.
+ *
+ * Mirrors the chip-driven Register-Company form on `+ New` (the
+ * "Company" chip). All fields except `name` are optional; the
+ * Stripe-Atlas integration is deferred to a later phase, so v1
+ * lands the Org with `registrationProvider = 'manual'` and
+ * `registrationStatus = 'registered'` regardless of what the
+ * client passes (the service hard-codes those, this DTO only
+ * captures the user-supplied bits).
+ */
+export class RegisterCompanyDto {
+    @ApiProperty({
+        description: 'Display name for the Company. 1-200 chars.',
+        example: 'Acme Inc.',
+        minLength: 1,
+        maxLength: 200,
+    })
+    @IsString()
+    @Length(1, 200)
+    name!: string;
+
+    @ApiPropertyOptional({
+        description: 'Registered legal name (defaults to `name` if omitted).',
+        example: 'Acme, Inc.',
+        maxLength: 200,
+    })
+    @IsOptional()
+    @IsString()
+    @Length(1, 200)
+    legalName?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'ISO 3166-1 alpha-2 country code (e.g. "US", "DE"). Used by the registration provider to pick the right entity-formation pipeline.',
+        example: 'US',
+        minLength: 2,
+        maxLength: 2,
+    })
+    @IsOptional()
+    @IsString()
+    @Matches(/^[A-Za-z]{2}$/, {
+        message: 'countryCode must be a 2-letter ISO 3166-1 alpha-2 code',
+    })
+    countryCode?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Optional slug override. If omitted, allocated from `name` via UsernameAllocatorService.',
+        example: 'acme',
+        minLength: 1,
+        maxLength: 64,
+    })
+    @IsOptional()
+    @IsString()
+    @Length(1, 64)
+    slug?: string;
+}

--- a/apps/api/src/organizations/organization.service.ts
+++ b/apps/api/src/organizations/organization.service.ts
@@ -8,7 +8,11 @@ import {
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
-import type { Organization } from '@ever-works/agent/entities';
+import type {
+    Organization,
+    OrganizationRegistrationProvider,
+    OrganizationRegistrationStatus,
+} from '@ever-works/agent/entities';
 import { UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS } from '@ever-works/contracts/api';
 import { UsernameAllocatorService } from '../users/services/username-allocator.service';
 import { TenantBootstrapService } from '../scope/tenant-bootstrap.service';
@@ -131,11 +135,26 @@ export class OrganizationService {
      * outside the txn because it's idempotent (the
      * `tenants.ownerUserId UNIQUE` constraint catches racers), but
      * the rest must be atomic.
+     *
+     * EW-662 (Phase 10) added the optional `extra` parameter so the
+     * Register-Company path ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company))
+     * can persist `legalName`, `countryCode`, `registrationProvider`,
+     * `registrationStatus`, and `linkedWorkId` in the same atomic
+     * insert. All `extra` fields default to NULL / `'draft'` if
+     * omitted, so the existing Phase 6/9 Settings + Switcher callers
+     * keep behaving exactly as before.
      */
     async createOrganization(
         userId: string,
         name: string,
         slugOverride?: string,
+        extra?: {
+            legalName?: string | null;
+            countryCode?: string | null;
+            registrationProvider?: OrganizationRegistrationProvider | null;
+            registrationStatus?: OrganizationRegistrationStatus | null;
+            linkedWorkId?: string | null;
+        },
     ): Promise<Organization> {
         const trimmedName = name?.trim();
         if (!trimmedName) {
@@ -153,10 +172,21 @@ export class OrganizationService {
         return this.dataSource.transaction(async (manager) => {
             // Use the manager's repository so the INSERT lands in the
             // same transaction as the backfill UPDATEs below.
+            //
+            // `extra` fields are layered on top of the base shape so
+            // Phase 6 callers (which pass nothing) keep producing
+            // `{ tenantId, slug, displayName }` exactly as before. The
+            // entity's column defaults handle the unspecified columns
+            // (registrationStatus defaults to `'draft'`).
             const org = manager.getRepository<Organization>('organizations').create({
                 tenantId: tenant.id,
                 slug,
                 displayName: trimmedName,
+                legalName: extra?.legalName ?? null,
+                countryCode: extra?.countryCode ?? null,
+                registrationProvider: extra?.registrationProvider ?? null,
+                registrationStatus: extra?.registrationStatus ?? 'draft',
+                linkedWorkId: extra?.linkedWorkId ?? null,
             });
             const saved = await manager.getRepository<Organization>('organizations').save(org);
 
@@ -191,6 +221,87 @@ export class OrganizationService {
             );
 
             return saved;
+        });
+    }
+
+    /**
+     * EW-662 (Tenants & Organizations Phase 10) — Register-Company
+     * sub-flow entry point ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+     *
+     * Creates an Organization directly from the chip-driven form on the
+     * `+ New` page (Company chip → Register-Company modal). For v1 the
+     * Stripe-Atlas integration is deferred; we land the Org with
+     * `registrationProvider = 'manual'` and `registrationStatus =
+     * 'registered'` so it behaves like any other Org from the moment
+     * the form submits.
+     *
+     * This is essentially `createOrganization` with the registration
+     * metadata pre-populated and the slug allocated from the legal
+     * name (so e.g. "Acme, Inc." becomes `acme-inc`). When a Phase 11+
+     * SDK integration creates a backing Work first, the same shape
+     * works — pass `linkedWorkId` to point at the Work.
+     */
+    async registerCompany(
+        userId: string,
+        params: {
+            name: string;
+            countryCode?: string | null;
+            legalName?: string | null;
+            linkedWorkId?: string | null;
+            slugOverride?: string;
+        },
+    ): Promise<Organization> {
+        const trimmed = params.name?.trim();
+        if (!trimmed) {
+            throw new ConflictException('Company name is required');
+        }
+        const trimmedLegal = params.legalName?.trim() || trimmed;
+
+        return this.createOrganization(userId, trimmed, params.slugOverride, {
+            legalName: trimmedLegal,
+            countryCode: params.countryCode?.trim() || null,
+            registrationProvider: 'manual',
+            registrationStatus: 'registered',
+            linkedWorkId: params.linkedWorkId ?? null,
+        });
+    }
+
+    /**
+     * EW-662 (Tenants & Organizations Phase 10) — wire-up entry point
+     * for a future Work-of-type-Company `registered` status transition
+     * (plan.md Phase 10 step 3).
+     *
+     * Today the platform's `Work` entity has neither a `kind` column
+     * nor a `status` column, so the actual status-transition hook
+     * doesn't fire yet. This method exists so the moment those columns
+     * land (Phase 11+ when the Stripe Atlas SDK ships), the calling
+     * code is a one-liner — the entity-to-Org plumbing is already in
+     * place + unit-tested here.
+     *
+     * Use this whenever a caller has a real `Work` row to link.
+     * Otherwise prefer `registerCompany` which is the chip-driven
+     * manual-completion path.
+     */
+    async createOrganizationFromCompanyWork(
+        userId: string,
+        work: {
+            id: string;
+            name: string;
+            companyName?: string | null;
+            companyWebsite?: string | null;
+        },
+        params?: { countryCode?: string | null; legalName?: string | null; slugOverride?: string },
+    ): Promise<Organization> {
+        const displayName = (work.companyName?.trim() || work.name)?.trim();
+        if (!displayName) {
+            throw new ConflictException('Work has no usable name for Organization creation');
+        }
+        return this.registerCompany(userId, {
+            name: displayName,
+            countryCode: params?.countryCode ?? null,
+            legalName: params?.legalName ?? work.companyName ?? null,
+            linkedWorkId: work.id,
+            slugOverride: params?.slugOverride,
         });
     }
 

--- a/apps/api/src/organizations/organizations.controller.ts
+++ b/apps/api/src/organizations/organizations.controller.ts
@@ -23,6 +23,7 @@ import { OrganizationService } from './organization.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { CheckSlugQueryDto } from './dto/check-slug.dto';
+import { RegisterCompanyDto } from './dto/register-company.dto';
 
 /**
  * EW-658 (Tenants & Organizations Phase 6) — Organization CRUD +
@@ -64,6 +65,26 @@ export class OrganizationsController {
             dto.name,
             dto.slug,
         );
+        return this.toResponse(org);
+    }
+
+    @Post('register-company')
+    @ApiOperation({
+        summary: 'Register a Company (Phase 10 — Company chip)',
+        description:
+            "EW-662: Registers a Company via the manual-completion path ([spec.md §5.4](../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)). Creates an Organization with `registrationProvider = 'manual'` and `registrationStatus = 'registered'` directly — the Stripe Atlas SDK integration is deferred. Lazy-creates the Tenant + backfills `tenantId` the same way `POST /api/organizations` does.",
+    })
+    @ApiResponse({ status: 201, description: 'Company registered + Organization created' })
+    async registerCompany(
+        @Req() req: { user: { userId: string } },
+        @Body() dto: RegisterCompanyDto,
+    ): Promise<OrganizationResponse> {
+        const org = await this.organizationService.registerCompany(req.user.userId, {
+            name: dto.name,
+            legalName: dto.legalName,
+            countryCode: dto.countryCode?.toUpperCase() ?? null,
+            slugOverride: dto.slug,
+        });
         return this.toResponse(org);
     }
 

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "هدف مستمر يعمل عليه الوكلاء باستمرار — ينتج أفكرة وفق جدولة أو لمرة واحدة.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "صفحة مركزة واحدة — قوائم الانتظار، إطلاق المنتجات، تسجيلات الندوات، التقاط العملاء.",
                 "blog": "مدونة مع فئات، RSS، تمييز الكود، ومحتوى جاهز لتحسين محركات البحث.",
                 "directory": "موقع دليل مختار مع بحث، عوامل تصفية، وبيانات منظمة للعناصر.",
-                "awesome-repo": "مستودع قائمة رائعة — فهرس markdown، روابط مصنفة، وبيانات قابلة للتحديث."
+                "awesome-repo": "مستودع قائمة رائعة — فهرس markdown، روابط مصنفة، وبيانات قابلة للتحديث.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "إنشاء",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Текуща Цел, с която Агентът продължава да работи — генерира Идеи по график или еднократно.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Фокусирана едностранична страница — списъци с чакащи, пускане на продукти, записване за уебинар, улавяне на лидове.",
                 "blog": "Блог с категории, RSS, подсветка на код и SEO-готово съдържание.",
                 "directory": "Куриран сайт с директория, с търсене, филтри и структурирани данни за елементи.",
-                "awesome-repo": "Awesome-list репозитори — markdown индекс, категоризирани линкове и освежаеми метаданни."
+                "awesome-repo": "Awesome-list репозитори — markdown индекс, категоризирани линкове и освежаеми метаданни.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Създай",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Ein fortlaufendes Ziel, an dem der Agent weiterarbeitet - generiert Ideen nach einem Zeitplan oder einmalig.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Eine fokussierte Ein-Seiten-Website - Wartelisten, Produktstarts, Webinare-Anmeldungen, Lead-Erfassung.",
                 "blog": "Ein Blog mit Kategorien, RSS, Code-Hervorhebung und SEO-gerechtem Inhalt.",
                 "directory": "Eine kuratierte Verzeichniswebsite mit Suchfunktion, Filtern und strukturierten Artikeldaten.",
-                "awesome-repo": "Ein Awesome-List-Repository - Markdown-Index, kategorisierte Links und aktualisierbare Metadaten."
+                "awesome-repo": "Ein Awesome-List-Repository - Markdown-Index, kategorisierte Links und aktualisierbare Metadaten.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Erstellen",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3296,7 +3296,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3307,7 +3308,8 @@
                 "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
                 "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
                 "directory": "A curated directory site with search, filters, and structured item data.",
-                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Create",
@@ -4683,6 +4685,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Un objetivo continuo en el que el agente sigue trabajando — genera Ideas de forma programada o puntuales.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Una página de aterrizaje enfocada — listas de espera, lanzamientos de productos, inscripciones a webinars, captación de leads.",
                 "blog": "Un blog con categorías, RSS, resaltado de código y contenido optimizado para SEO.",
                 "directory": "Un sitio de directorio curado con búsqueda, filtros y datos estructurados de elementos.",
-                "awesome-repo": "Un repositorio de tipo awesome-list — índice markdown, enlaces categorizados y metadatos actualizables."
+                "awesome-repo": "Un repositorio de tipo awesome-list — índice markdown, enlaces categorizados y metadatos actualizables.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Crear",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Un objectif continu que l'agent continue de traiter — génère des Idées de manière planifiée ou ponctuelle.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Une page d'atterrissage concentrée — listes d'attente, lancements de produits, inscriptions à des webinaires, capture de prospects.",
                 "blog": "Un blog avec catégories, RSS, coloration syntaxique et contenu prêt pour le SEO.",
                 "directory": "Un site de répertoire curaté avec recherche, filtres et données d'articles structurées.",
-                "awesome-repo": "Un dépôt de type awesome-list — index markdown, liens catégorisés et métadonnées actualisables."
+                "awesome-repo": "Un dépôt de type awesome-list — index markdown, liens catégorisés et métadonnées actualisables.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Créer",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "מטרה רציפה שהסוכן ממשיך לעבוד עליה - מייצר רעיונות על פי לוח זמנים או פעם אחת.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "דף אחד ממוקד - רשימות המתנה, השקות מוצרים, הרשמות להרצאות, לכידת לידים.",
                 "blog": "בלוג עם קטגוריות, RSS, הדגשת קוד, ותוכן מוכן ל-SEO.",
                 "directory": "אתר קטלוג מסונן עם חיפוש, מסננים ונתונים מובנים של פריטים.",
-                "awesome-repo": "מאגר awesome-list - אינדקס markdown, קישורים מסוננים, ומטא-נתונים רעננים."
+                "awesome-repo": "מאגר awesome-list - אינדקס markdown, קישורים מסוננים, ומטא-נתונים רעננים.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "צור",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "एक निरंतर लक्ष्य जिस पर एजेंट लगातार काम करता है — अनुसूची या एक बार पर विचार उत्पन्न करता है।",
@@ -3292,7 +3293,8 @@
                 "landing-page": "एक केंद्रित एक-पृष्ठ — इंतजार सूचियां, उत्पाद लॉन्च, वेबिनार साइनअप, लीड कैप्चर।",
                 "blog": "श्रेणियों, RSS, कोड हाइलाइटिंग, और SEO-तैयार सामग्री के साथ एक ब्लॉग।",
                 "directory": "खोज, फ़िल्टर, और संरचित आइटम डेटा के साथ एक क्यूरेटेड निर्देशित साइट।",
-                "awesome-repo": "एक अवसर-सूची रेपो — मार्कडाउन इंडेक्स, श्रेणीबद्ध लिंक, और ताज़ा होने योग्य मेटाडेटा।"
+                "awesome-repo": "एक अवसर-सूची रेपो — मार्कडाउन इंडेक्स, श्रेणीबद्ध लिंक, और ताज़ा होने योग्य मेटाडेटा।",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "बनाएं",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Tujuan berkelanjutan yang agen terus kerjakan — menghasilkan Ide secara berkala atau sekali saja.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Satu halaman yang fokus — daftar tunggu, peluncuran produk, pendaftaran webinar, penangkap leads.",
                 "blog": "Blog dengan kategori, RSS, sorotan kode, dan konten yang siap SEO.",
                 "directory": "Situs direktori yang dikurasi dengan pencarian, filter, dan data item terstruktur.",
-                "awesome-repo": "Repo daftar awesome — indeks markdown, tautan yang dikategorikan, dan metadata yang dapat diperbarui."
+                "awesome-repo": "Repo daftar awesome — indeks markdown, tautan yang dikategorikan, dan metadata yang dapat diperbarui.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Buat",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Un Obiettivo continuo su cui l'agente continua a lavorare — genera Idee secondo una pianificazione o in una singola esecuzione.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Una pagina singola e focalizzata — liste d'attesa, lanci di prodotti, iscrizioni a webinar, acquisizione contatti.",
                 "blog": "Un blog con categorie, RSS, evidenziazione di codice e contenuti ottimizzati per SEO.",
                 "directory": "Un sito di directory curato con ricerca, filtri e dati strutturati per gli elementi.",
-                "awesome-repo": "Un repository awesome-list — indice markdown, link categorizzati e metadati aggiornabili."
+                "awesome-repo": "Un repository awesome-list — indice markdown, link categorizzati e metadati aggiornabili.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Crea",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "エージェントが継続的に取り組む継続的な目標 — スケジュールまたはワンショットでアイデアを生成します。",
@@ -3292,7 +3293,8 @@
                 "landing-page": "焦点の当てられたワンページ — 等待リスト、製品ローンチ、ウェビナー登録、リード取得。",
                 "blog": "カテゴリ、RSS、コードハイライト、SEO対応コンテンツ付きブログ。",
                 "directory": "検索、フィルター、構造化された項目データ付きのキュレートされたディレクトリサイト。",
-                "awesome-repo": "すごいリストリポジトリ — マークダウンインデックス、カテゴリ分けされたリンク、更新可能なメタデータ。"
+                "awesome-repo": "すごいリストリポジトリ — マークダウンインデックス、カテゴリ分けされたリンク、更新可能なメタデータ。",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "作成",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "에이전트가 계속 작업하는 지속적인 목표입니다 - 일정 또는 일회성으로 아이디어를 생성합니다.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "집중된 일페이지 - 대기자 명단, 제품 출시, 웨비나 신청, 리드 확보.",
                 "blog": "카테고리, RSS, 코드 하이라이트 및 SEO 준비된 콘텐츠를 갖춘 블로그.",
                 "directory": "검색, 필터 및 구조화된 항목 데이터를 갖춘 선별된 디렉토리 사이트.",
-                "awesome-repo": "멋진 목록 저장소 - 마크다운 인덱스, 분류된 링크 및 새로 고칠 수 있는 메타데이터."
+                "awesome-repo": "멋진 목록 저장소 - 마크다운 인덱스, 분류된 링크 및 새로 고칠 수 있는 메타데이터.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "생성",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Een doorlopend Doel waar de agent aan blijft werken — genereert Idees op een schema of in één keer.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Een gerichte één-pagina — wachtlijsten, productlanceringen, webinar aanmeldingen, lead capture.",
                 "blog": "Een blog met categorieën, RSS, code highlighting, en SEO-ready content.",
                 "directory": "Een geselecteerde directory site met zoekfunctie, filters, en gestructureerde item data.",
-                "awesome-repo": "Een awesome-list repo — markdown index, gecategoriseerde links, en verversbare metadata."
+                "awesome-repo": "Een awesome-list repo — markdown index, gecategoriseerde links, en verversbare metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Maken",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Trwający Cel, nad którym Agent stale pracuje — generuje Pomysły według harmonogramu lub jednorazowo.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Skoncentrowana strona jednopodstronowa — listy oczekujących, uruchomienia produktów, zapisy na webinary, przechwytywanie leadów.",
                 "blog": "Blog z kategoriami, RSS, podświetlaniem kodu i treścią gotową do SEO.",
                 "directory": "Kuratorska strona katalogowa z wyszukiwarką, filtrami i strukturyzowanymi danymi.",
-                "awesome-repo": "Repozytorium awesome-list — indeks markdown, kategoryzowane linki i odświeżalne metadane."
+                "awesome-repo": "Repozytorium awesome-list — indeks markdown, kategoryzowane linki i odświeżalne metadane.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Utwórz",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Um Objetivo contínuo que o agente continua trabalhando — gera Ideias em um agendamento ou único.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Um único focado de página — listas de espera, lançamentos de produtos, inscrições de webinário, captação de leads.",
                 "blog": "Um blog com categorias, RSS, destaque de código e conteúdo pronto para SEO.",
                 "directory": "Um site de diretório curado com busca, filtros e dados estruturados de itens.",
-                "awesome-repo": "Um repo de lista-awesome — índice markdown, links categorizados e metadados atualizáveis."
+                "awesome-repo": "Um repo de lista-awesome — índice markdown, links categorizados e metadados atualizáveis.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Criar",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Непрерывная цель, над которой агент постоянно работает — генерирует идеи по расписанию или однократно.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Фокусированная одностраничная страница — листы ожидания, запуски продуктов, регистрация на вебинары, сбор лидов.",
                 "blog": "Блог с категориями, RSS, подсветкой кода и контентом, готовым для SEO.",
                 "directory": "Сайт-каталог с поиском, фильтрами и структурированными данными элементов.",
-                "awesome-repo": "Хранилище awesome-list — индекс markdown, категоризированные ссылки и обновляемые метаданные."
+                "awesome-repo": "Хранилище awesome-list — индекс markdown, категоризированные ссылки и обновляемые метаданные.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Создать",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "เป้าหมายที่ดำเนินต่อไป — สร้างความคิดตามกำหนดการหรือครั้งเดียว",
@@ -3292,7 +3293,8 @@
                 "landing-page": "หน้าเดียวที่มุ่งเน้น — รายชื่อรอ การเปิดตัวผลิตภัณฑ์ การลงทะเบียนเวบินาร์ การดึงลูกค้า",
                 "blog": "บล็อกที่มีหมวดหมู่ RSS การเน้นโค้ด และเนื้อหาที่พร้อมใช้กับ SEO",
                 "directory": "เว็บไดเรกทอรี่ที่คัดสรรมาแล้ว พร้อมค้นหา ตัวกรอง และข้อมูลรายการที่มโนรม",
-                "awesome-repo": "เรโพซิทอรี่อะไรก็ได้ที่น่าทึ่ง — ดัชนี markdown ลิงก์ที่จัดหมวดหมู่ และเมตาดาทาที่รีเฟรชได้"
+                "awesome-repo": "เรโพซิทอรี่อะไรก็ได้ที่น่าทึ่ง — ดัชนี markdown ลิงก์ที่จัดหมวดหมู่ และเมตาดาทาที่รีเฟรชได้",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "สร้าง",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Ajnın üzerinde sürekli çalıştığı devam eden bir Hedef — zamanlamaya göre veya tek seferlik Fikirler oluşturur.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Odaklanmış tek sayfalık bir sayfa — bekleme listeleri, ürün lansmanları, webinar kayıtları, potansiyel müşteri yakalama.",
                 "blog": "Kategoriler, RSS, kod vurgulama ve SEO hazır içeriği olan bir blog.",
                 "directory": "Arama, filtreler ve yapılandırılmış öğe verileriyle düzenlenmiş bir dizin sitesi.",
-                "awesome-repo": "Awesome-list deposu — markdown indeksi, kategorilere ayrılmış bağlantılar ve yenilenebilir metadata."
+                "awesome-repo": "Awesome-list deposu — markdown indeksi, kategorilere ayrılmış bağlantılar ve yenilenebilir metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Oluştur",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Тривала Мета, над якою агент постійно працює — створює Ідеї за розкладом або одноразово.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Фокусна одна сторінка — списки очікування, запуски продуктів, реєстрація на вебінари, захоплення лідів.",
                 "blog": "Блог з категоріями, RSS, підсвічуванням коду та контентом, готовим до SEO.",
                 "directory": "Кураторський сайт-каталог з пошуком, фільтрами та структурованими даними елементів.",
-                "awesome-repo": "Репозиторій з класними списками — індекс markdown, категоризовані посилання та оновлювані метадані."
+                "awesome-repo": "Репозиторій з класними списками — індекс markdown, категоризовані посилання та оновлювані метадані.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Створити",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Một Mục tiêu liên tục mà Agent tiếp tục làm việc - tạo ra các Ý tưởng theo lịch trình hoặc một lần.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Một trang một trang tập trung - danh sách chờ, ra mắt sản phẩm, đăng ký webinar, thu thập khách hàng tiềm năng.",
                 "blog": "Một blog với danh mục, RSS, làm nổi bật mã và nội dung sẵn sàng SEO.",
                 "directory": "Một trang web thư mục được biên tập với tìm kiếm, bộ lọc và dữ liệu cấu trúc hóa mục.",
-                "awesome-repo": "Kho awesome-list - chỉ mục markdown, liên kết được phân loại và metadata có thể làm mới."
+                "awesome-repo": "Kho awesome-list - chỉ mục markdown, liên kết được phân loại và metadata có thể làm mới.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Tạo",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "代理持续关注的目标——按计划或一次性生成想法。",
@@ -3292,7 +3293,8 @@
                 "landing-page": "专注的单页网站——等待列表、产品发布、网络研讨会注册、潜在客户获取。",
                 "blog": "带有分类、RSS、代码高亮和SEO就绪内容的博客。",
                 "directory": "带有搜索、筛选和结构化项目数据的精选目录网站。",
-                "awesome-repo": "awesome-list仓库——markdown索引、分类链接和可刷新的元数据。"
+                "awesome-repo": "awesome-list仓库——markdown索引、分类链接和可刷新的元数据。",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "创建",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/src/app/[locale]/(dashboard)/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/new/page.tsx
@@ -19,6 +19,9 @@ const VALID_CHIP_TYPES: ChipType[] = [
     'blog',
     'directory',
     'awesome-repo',
+    // EW-662 (Phase 10) — Company joins the live chip set so
+    // `/new?type=company` lands directly on the Register-Company flow.
+    'company',
 ];
 
 /**

--- a/apps/web/src/app/api/organizations/register-company/route.ts
+++ b/apps/web/src/app/api/organizations/register-company/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — web BFF proxy for
+ * `POST /api/organizations/register-company`.
+ *
+ * Triggered by the Register-Company dialog (Company chip → form
+ * submit). Forwards the JSON body verbatim to the NestJS API with the
+ * user's bearer token attached. On success returns the new
+ * `OrganizationResponse` so the dialog can hand off to the
+ * `<UpgradeOrCreateDialog>` (for first-Org users) or navigate to
+ * `/${org.slug}/dashboard`.
+ */
+export async function POST(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    try {
+        const upstream = await fetch(`${API_URL}/organizations/register-company`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            cache: 'no-store',
+        });
+        const text = await upstream.text();
+        const payload = text ? safeParse(text) : null;
+        if (!upstream.ok) {
+            return NextResponse.json(payload ?? { error: 'Failed to register company' }, {
+                status: upstream.status || 500,
+            });
+        }
+        return NextResponse.json(payload, { status: 201 });
+    } catch (error) {
+        console.error('Failed to proxy POST /api/organizations/register-company:', error);
+        return NextResponse.json({ error: 'Failed to register company' }, { status: 500 });
+    }
+}
+
+function safeParse(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -28,6 +28,7 @@ import { ROUTES } from '@/lib/constants';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import { attachUploadToMissionAction, createMissionAction } from '@/app/actions/dashboard/missions';
+import { RegisterCompanyDialog } from '@/components/organizations/RegisterCompanyDialog';
 
 /**
  * Unified `/new` page — single prompt input + chips for every
@@ -43,11 +44,17 @@ import { attachUploadToMissionAction, createMissionAction } from '@/app/actions/
  *   - website + 4 work kinds — forwarded to `/works/new` with the
  *                       prompt and the selected kind preserved.
  *
- * `store` and `company` are catalog entries telegraphing roadmap
- * scope (see Workspace notes `2026-05-23-missions-ideas-works-spec.md`
- * + AGENTS.md "stores + companies are in-scope future use cases"). They
- * render as inert "Soon" chips and aren't selectable yet, matching how
- * the marketing site already telegraphs them.
+ * `store` is a catalog entry telegraphing roadmap scope (see Workspace
+ * notes `2026-05-23-missions-ideas-works-spec.md` + AGENTS.md "stores
+ * + companies are in-scope future use cases"). It renders as an inert
+ * "Soon" chip, matching how the marketing site telegraphs it.
+ *
+ * EW-662 (Phase 10) — `company` graduated from inert to live: picking
+ * the Company chip opens the Register-Company dialog (spec §5.4), which
+ * creates an Organization with `registrationProvider = 'manual'` and
+ * `registrationStatus = 'registered'`. The full Stripe Atlas SDK
+ * integration is deferred to a later phase; for v1 the manual-completion
+ * path is the only way Company Works produce Orgs.
  *
  * The chat panel is auto-collapsed on mount so the prompt + chips
  * get the full main column on first land. Users can reopen it from
@@ -62,8 +69,17 @@ export type ChipType =
     | 'landing-page'
     | 'blog'
     | 'directory'
-    | 'awesome-repo';
+    | 'awesome-repo'
+    | 'company';
 
+// Spec §6.3 order:
+// `Mission · Idea · Website · Landing Page · Store · Blog · Directory
+//  · Awesome Repo · Knowledge Base · Company`.
+//
+// Live chips below stay in their current order (mission first, ideas
+// second, then content chips). `Company` joins at the end of the live
+// chip list per the spec, sitting next to the inert `store` chip which
+// is appended afterwards.
 const CHIP_ORDER: ChipType[] = [
     'mission',
     'idea',
@@ -74,6 +90,7 @@ const CHIP_ORDER: ChipType[] = [
     'blog',
     'directory',
     'awesome-repo',
+    'company',
 ];
 
 const CHIP_ICONS: Record<ChipType, LucideIcon> = {
@@ -88,6 +105,9 @@ const CHIP_ICONS: Record<ChipType, LucideIcon> = {
     // makes the two chips visually indistinguishable in the chip row.
     directory: FolderOpen,
     'awesome-repo': Star,
+    // EW-662 Phase 10 — same `Building2` icon the WorkspaceSwitcher
+    // empty state uses for consistency.
+    company: Building2,
 };
 
 const PLACEHOLDERS_BY_CHIP: Record<ChipType, ReadonlyArray<string>> = {
@@ -152,6 +172,17 @@ const PLACEHOLDERS_BY_CHIP: Record<ChipType, ReadonlyArray<string>> = {
         'e.g. "Awesome list of agent frameworks (LangChain, AutoGen, CrewAI…) with pros/cons"',
         'e.g. "Awesome list of free design resources for indie founders — icons, illustrations, fonts"',
     ],
+    // EW-662 Phase 10 — Company placeholders telegraph that this chip
+    // ends in a registered Organization (manual-completion path for v1).
+    // The prompt input is ignored on submit — the chip opens the
+    // Register-Company dialog directly — but the placeholder still
+    // sets context if the user lands on `?type=company` first.
+    company: [
+        'e.g. "Acme Inc. — an Org for our consultancy"',
+        'e.g. "Globex Holdings — the umbrella entity for our product lines"',
+        'e.g. "Soylent Labs — research entity for AI experimentation"',
+        'e.g. "Initech LLC — billing entity for our SaaS clients"',
+    ],
 };
 
 export interface NewPageClientProps {
@@ -170,6 +201,7 @@ const CHIP_INTENT_LABEL: Record<ChipType, string> = {
     blog: 'blog',
     directory: 'directory',
     'awesome-repo': 'awesome list repo',
+    company: 'Company',
 };
 
 const CHIP_TO_CANVAS_ROUTE: Partial<Record<ChipType, string>> = {
@@ -202,6 +234,24 @@ export function NewPageClient({
     const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [submitting, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
+    // EW-662 Phase 10 — Company chip is a special chip whose submit
+    // opens the Register-Company dialog instead of going through the
+    // chat-AI / canvas pipeline. We hold the dialog open-state here so
+    // it survives chip switches.
+    const [companyDialogOpen, setCompanyDialogOpen] = useState(false);
+
+    // Auto-open the dialog when the user lands on `/new?type=company`
+    // (e.g. from the Settings → Account banner). The chip is selected
+    // by the page's initialType param; we mirror that into the dialog
+    // open state once on mount.
+    useEffect(() => {
+        if (initialType === 'company') {
+            setCompanyDialogOpen(true);
+        }
+        // Only run on mount — chip switches are handled by the click
+        // handler in PromptChipsRow below.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // `buildAttachmentRefs` imported from PromptComposer — turns the
     // composer's full attachment list into chat-ready refs (filtering
@@ -223,6 +273,17 @@ export function NewPageClient({
     }, [setChatOpen]);
 
     const submit = () => {
+        // EW-662 Phase 10 — Company chip short-circuits the chat-AI
+        // path. There's no prompt-to-mission/work pipeline here: the
+        // user is going to register an Organization-backed Company,
+        // and that flow is owned by `<RegisterCompanyDialog>` (which
+        // collects the name + countryCode form). Open it and bail out
+        // of the rest of the submit logic — no min-length check,
+        // because the prompt input is incidental for this chip.
+        if (selectedChip === 'company') {
+            setCompanyDialogOpen(true);
+            return;
+        }
         const description = prompt.trim();
         if (description.length < 10) {
             toast.error(t('hints.minLength'));
@@ -340,10 +401,15 @@ export function NewPageClient({
         [selectedChip],
     );
 
-    // Full chip catalog. `store` + `company` are inert "Soon" chips,
-    // appended after the live chips so they sit at the end of the
+    // Full chip catalog. `store` stays as an inert "Soon" chip,
+    // appended after the live chips so it sits at the end of the
     // horizontal scroll the way the marketing site does it.
-    const allChips = useMemo<ReadonlyArray<PromptChip<ChipType | 'store' | 'company'>>>(
+    //
+    // EW-662 Phase 10 — `company` graduated from "Soon" to live; it
+    // sits at the end of the live `CHIP_ORDER` list so we render it
+    // automatically from the loop below. Picking it opens the
+    // Register-Company dialog on submit (see `submit()` above).
+    const allChips = useMemo<ReadonlyArray<PromptChip<ChipType | 'store'>>>(
         () => [
             ...CHIP_ORDER.map((c) => ({
                 value: c,
@@ -351,7 +417,6 @@ export function NewPageClient({
                 Icon: CHIP_ICONS[c],
             })),
             { value: 'store' as const, label: 'Store', Icon: Store, comingSoon: true },
-            { value: 'company' as const, label: 'Company', Icon: Building2, comingSoon: true },
         ],
         [t],
     );
@@ -386,10 +451,13 @@ export function NewPageClient({
                             chips={allChips}
                             value={selectedChip}
                             onChange={(next) => {
-                                // `store` and `company` are inert, so the
-                                // chips row never emits them — narrow back
-                                // to ChipType before persisting.
-                                if (next === null || next === 'store' || next === 'company') {
+                                // `store` is the last remaining inert "Soon"
+                                // chip — the chips row never emits it.
+                                // Narrow back to ChipType before persisting.
+                                // (`company` graduated to live in EW-662
+                                // Phase 10 and is handled like any other
+                                // ChipType.)
+                                if (next === null || next === 'store') {
                                     return;
                                 }
                                 setSelectedChip(next);
@@ -403,6 +471,11 @@ export function NewPageClient({
                     </div>
                 }
             />
+
+            {/* EW-662 Phase 10 — Register-Company dialog. Opens when the
+                user submits the Company chip or lands on
+                `/new?type=company`. */}
+            <RegisterCompanyDialog open={companyDialogOpen} onOpenChange={setCompanyDialogOpen} />
         </div>
     );
 }

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -55,12 +55,16 @@ function getSubmit(container: HTMLElement): HTMLButtonElement {
 }
 
 describe('NewPageClient (chat-open + canvas-route on submit)', () => {
-    it('renders all 9 chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo', () => {
+    it('renders all 10 chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo, Company', () => {
         const { container } = render(<NewPageClient />);
         const chipButtons = Array.from(
             container.querySelectorAll('button[role="option"][aria-selected]'),
         ) as HTMLButtonElement[];
-        expect(chipButtons).toHaveLength(9);
+        // EW-662 Phase 10 — `company` joined the live chip set so the
+        // total is now 10. `store` stays as an inert "Soon" chip
+        // (a `button[role="option"]` without `aria-selected` — filtered
+        // out by the selector above).
+        expect(chipButtons).toHaveLength(10);
         const labels = chipButtons.map((b) => b.textContent?.trim());
         expect(labels).toEqual([
             'dashboard.newPage.chips.mission',
@@ -72,6 +76,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             'dashboard.newPage.chips.blog',
             'dashboard.newPage.chips.directory',
             'dashboard.newPage.chips.awesome-repo',
+            'dashboard.newPage.chips.company',
         ]);
     });
 

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 import { Button } from '@/components/ui/button';
@@ -55,7 +55,12 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
     const [name, setName] = useState('');
     const [countryCode, setCountryCode] = useState('');
     const [submitError, setSubmitError] = useState<string | null>(null);
-    const [pending, startTransition] = useTransition();
+    // Explicit submitting flag rather than `useTransition`'s `pending`:
+    // `useTransition`'s pending state only stays true synchronously inside
+    // its callback, and our submit kicks off a detached async IIFE, so
+    // `pending` flipped back to false immediately and the disabled button
+    // wasn't actually preventing double-submit. (Codex P2 on PR #1067.)
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const [createdOrg, setCreatedOrg] = useState<OrganizationResponse | null>(null);
     const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
     /**
@@ -73,10 +78,18 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
             setSubmitError(null);
             setCreatedOrg(null);
             setShowUpgradeDialog(false);
+            setIsSubmitting(false);
         }
     }, [open]);
 
-    const handleSubmit = useCallback(() => {
+    const handleSubmit = useCallback(async () => {
+        // Guard against double-submit while the previous request is
+        // still in flight. The `disabled={isSubmitting}` on the button
+        // covers click-through-keyboard / Enter; this guard covers any
+        // direct programmatic call.
+        if (isSubmitting) {
+            return;
+        }
         const trimmedName = name.trim();
         if (trimmedName.length === 0) {
             setSubmitError(t('errors.nameRequired'));
@@ -93,54 +106,53 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
         }
         setSubmitError(null);
         wasFirstOrgRef.current = organizations.length === 0;
+        setIsSubmitting(true);
 
-        startTransition(() => {
-            void (async () => {
-                try {
-                    const res = await fetch('/api/organizations/register-company', {
-                        method: 'POST',
-                        credentials: 'include',
-                        cache: 'no-store',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            name: trimmedName,
-                            ...(cc.length > 0 ? { countryCode: cc.toUpperCase() } : {}),
-                        }),
-                    });
-                    if (!res.ok) {
-                        const body = await res
-                            .json()
-                            .catch(() => ({ error: 'Failed to register company' }));
-                        setSubmitError(
-                            (body as { message?: string; error?: string }).message ??
-                                (body as { error?: string }).error ??
-                                t('errors.generic'),
-                        );
-                        return;
-                    }
-                    const org = (await res.json()) as OrganizationResponse;
-                    // Refresh the org list (best-effort — the POST already
-                    // succeeded; a transient GET failure must not surface
-                    // as a register error, otherwise the user retries +
-                    // we end up with duplicate Orgs).
-                    try {
-                        await mutate();
-                    } catch {
-                        // Swallow.
-                    }
-                    if (wasFirstOrgRef.current) {
-                        setCreatedOrg(org);
-                        setShowUpgradeDialog(true);
-                    } else {
-                        onOpenChange(false);
-                        router.push(`/${org.slug}/dashboard`);
-                    }
-                } catch (err) {
-                    setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
-                }
-            })();
-        });
-    }, [name, countryCode, organizations.length, mutate, onOpenChange, router, t]);
+        try {
+            const res = await fetch('/api/organizations/register-company', {
+                method: 'POST',
+                credentials: 'include',
+                cache: 'no-store',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: trimmedName,
+                    ...(cc.length > 0 ? { countryCode: cc.toUpperCase() } : {}),
+                }),
+            });
+            if (!res.ok) {
+                const body = await res
+                    .json()
+                    .catch(() => ({ error: 'Failed to register company' }));
+                setSubmitError(
+                    (body as { message?: string; error?: string }).message ??
+                        (body as { error?: string }).error ??
+                        t('errors.generic'),
+                );
+                return;
+            }
+            const org = (await res.json()) as OrganizationResponse;
+            // Refresh the org list (best-effort — the POST already
+            // succeeded; a transient GET failure must not surface as
+            // a register error, otherwise the user retries + we end
+            // up with duplicate Orgs).
+            try {
+                await mutate();
+            } catch {
+                // Swallow.
+            }
+            if (wasFirstOrgRef.current) {
+                setCreatedOrg(org);
+                setShowUpgradeDialog(true);
+            } else {
+                onOpenChange(false);
+                router.push(`/${org.slug}/dashboard`);
+            }
+        } catch (err) {
+            setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [isSubmitting, name, countryCode, organizations.length, mutate, onOpenChange, router, t]);
 
     const handleUpgradeDialogClose = useCallback(
         (didUpgrade: boolean) => {
@@ -180,7 +192,7 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                                 placeholder={t('namePlaceholder')}
                                 maxLength={MAX_NAME_LENGTH}
                                 autoFocus
-                                disabled={pending}
+                                disabled={isSubmitting}
                                 data-testid="register-company-name"
                             />
                             <Input
@@ -190,7 +202,7 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                                 onChange={(e) => setCountryCode(e.target.value)}
                                 placeholder={t('countryCodePlaceholder')}
                                 maxLength={2}
-                                disabled={pending}
+                                disabled={isSubmitting}
                                 data-testid="register-company-country"
                             />
                             <p className="text-xs text-text-muted dark:text-text-muted-dark">
@@ -207,14 +219,14 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                             <Button
                                 variant="ghost"
                                 onClick={() => onOpenChange(false)}
-                                disabled={pending}
+                                disabled={isSubmitting}
                             >
                                 {t('cancel')}
                             </Button>
                             <Button
                                 onClick={handleSubmit}
-                                loading={pending}
-                                disabled={pending || name.trim().length === 0}
+                                loading={isSubmitting}
+                                disabled={isSubmitting || name.trim().length === 0}
                                 data-testid="register-company-submit"
                             >
                                 {t('submit')}

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { useRouter } from '@/i18n/navigation';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+
+const MAX_NAME_LENGTH = 200;
+
+export interface RegisterCompanyDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — Register-Company flow
+ * ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+ *
+ * Opened from the Company chip on `+ New`. Captures the user-visible
+ * Company fields (name + optional countryCode) and submits to
+ * `POST /api/organizations/register-company`. The server hard-codes
+ * `registrationProvider = 'manual'` + `registrationStatus =
+ * 'registered'` for v1 — the Stripe Atlas integration is deferred.
+ *
+ * Post-submit behavior mirrors the Phase 9 CreateOrganizationModal:
+ *  - First Org (`organizations.length === 0` pre-submit) → hands off
+ *    to `<UpgradeOrCreateDialog>` so the user can choose Upgrade vs
+ *    Empty.
+ *  - 2nd+ Org → close + navigate to `/${org.slug}/dashboard`.
+ *
+ * The full Stripe Atlas form (paperwork inputs, jurisdiction picker,
+ * etc.) is intentionally out of scope here — the chip's value in v1
+ * is that it gets the user to a registered Org in one form, with the
+ * registration metadata preserved so we can re-key into a real
+ * provider in a future phase without schema churn.
+ */
+export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDialogProps) {
+    const t = useTranslations('organizations.registerCompany');
+    const router = useRouter();
+    const { organizations, mutate } = useOrganizations();
+
+    const [name, setName] = useState('');
+    const [countryCode, setCountryCode] = useState('');
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const [createdOrg, setCreatedOrg] = useState<OrganizationResponse | null>(null);
+    const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
+    /**
+     * Captures whether THIS submission is the user's first Org. Read
+     * once at submit-time so post-mutate `organizations.length` (=1
+     * after a successful create) can't flip the branch decision
+     * mid-flight.
+     */
+    const wasFirstOrgRef = useRef(false);
+
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setCountryCode('');
+            setSubmitError(null);
+            setCreatedOrg(null);
+            setShowUpgradeDialog(false);
+        }
+    }, [open]);
+
+    const handleSubmit = useCallback(() => {
+        const trimmedName = name.trim();
+        if (trimmedName.length === 0) {
+            setSubmitError(t('errors.nameRequired'));
+            return;
+        }
+        if (trimmedName.length > MAX_NAME_LENGTH) {
+            setSubmitError(t('errors.nameTooLong'));
+            return;
+        }
+        const cc = countryCode.trim();
+        if (cc.length > 0 && !/^[A-Za-z]{2}$/.test(cc)) {
+            setSubmitError(t('errors.countryCodeInvalid'));
+            return;
+        }
+        setSubmitError(null);
+        wasFirstOrgRef.current = organizations.length === 0;
+
+        startTransition(() => {
+            void (async () => {
+                try {
+                    const res = await fetch('/api/organizations/register-company', {
+                        method: 'POST',
+                        credentials: 'include',
+                        cache: 'no-store',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            name: trimmedName,
+                            ...(cc.length > 0 ? { countryCode: cc.toUpperCase() } : {}),
+                        }),
+                    });
+                    if (!res.ok) {
+                        const body = await res
+                            .json()
+                            .catch(() => ({ error: 'Failed to register company' }));
+                        setSubmitError(
+                            (body as { message?: string; error?: string }).message ??
+                                (body as { error?: string }).error ??
+                                t('errors.generic'),
+                        );
+                        return;
+                    }
+                    const org = (await res.json()) as OrganizationResponse;
+                    // Refresh the org list (best-effort — the POST already
+                    // succeeded; a transient GET failure must not surface
+                    // as a register error, otherwise the user retries +
+                    // we end up with duplicate Orgs).
+                    try {
+                        await mutate();
+                    } catch {
+                        // Swallow.
+                    }
+                    if (wasFirstOrgRef.current) {
+                        setCreatedOrg(org);
+                        setShowUpgradeDialog(true);
+                    } else {
+                        onOpenChange(false);
+                        router.push(`/${org.slug}/dashboard`);
+                    }
+                } catch (err) {
+                    setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
+                }
+            })();
+        });
+    }, [name, countryCode, organizations.length, mutate, onOpenChange, router, t]);
+
+    const handleUpgradeDialogClose = useCallback(
+        (didUpgrade: boolean) => {
+            setShowUpgradeDialog(false);
+            const target = createdOrg;
+            setCreatedOrg(null);
+            onOpenChange(false);
+            if (target) {
+                router.push(`/${target.slug}/dashboard`);
+                if (didUpgrade) void mutate();
+            }
+        },
+        [createdOrg, mutate, onOpenChange, router],
+    );
+
+    const showCreatePanel = !showUpgradeDialog;
+
+    return (
+        <>
+            <Dialog open={open} onOpenChange={onOpenChange}>
+                {showCreatePanel && (
+                    <DialogContent className="max-w-md">
+                        <DialogClose onClose={() => onOpenChange(false)} />
+                        <DialogHeader>
+                            <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                                {t('title')}
+                            </DialogTitle>
+                            <DialogDescription>{t('description')}</DialogDescription>
+                        </DialogHeader>
+
+                        <div className="space-y-4">
+                            <Input
+                                label={t('nameLabel')}
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                placeholder={t('namePlaceholder')}
+                                maxLength={MAX_NAME_LENGTH}
+                                autoFocus
+                                disabled={pending}
+                                data-testid="register-company-name"
+                            />
+                            <Input
+                                label={t('countryCodeLabel')}
+                                type="text"
+                                value={countryCode}
+                                onChange={(e) => setCountryCode(e.target.value)}
+                                placeholder={t('countryCodePlaceholder')}
+                                maxLength={2}
+                                disabled={pending}
+                                data-testid="register-company-country"
+                            />
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('helpProviderManual')}
+                            </p>
+                            {submitError && (
+                                <p className="text-sm text-danger" role="alert">
+                                    {submitError}
+                                </p>
+                            )}
+                        </div>
+
+                        <DialogFooter>
+                            <Button
+                                variant="ghost"
+                                onClick={() => onOpenChange(false)}
+                                disabled={pending}
+                            >
+                                {t('cancel')}
+                            </Button>
+                            <Button
+                                onClick={handleSubmit}
+                                loading={pending}
+                                disabled={pending || name.trim().length === 0}
+                                data-testid="register-company-submit"
+                            >
+                                {t('submit')}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                )}
+            </Dialog>
+
+            {createdOrg && (
+                <UpgradeOrCreateDialog
+                    open={showUpgradeDialog}
+                    organization={createdOrg}
+                    onClose={handleUpgradeDialogClose}
+                />
+            )}
+        </>
+    );
+}

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+// next-intl — return the key plus any `{var}` interpolations so the
+// assertions match against the namespaced keys without coupling to
+// translated copy. Same pattern as the Phase 9 modal tests.
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string, args?: Record<string, string | number>) => {
+        const path = `${ns}.${key}`;
+        if (!args) return path;
+        const interp = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${path} ${interp}`;
+    },
+}));
+
+const routerPushMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+    useRouter: () => ({
+        push: routerPushMock,
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+    getPathname: ({ href }: { href: string }) => href,
+}));
+
+import { RegisterCompanyDialog } from './RegisterCompanyDialog';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+function org(overrides: Partial<OrganizationResponse> = {}): OrganizationResponse {
+    return {
+        id: 'o-new',
+        tenantId: 't-1',
+        slug: 'acme',
+        legalName: 'Acme Inc.',
+        displayName: 'Acme Inc.',
+        countryCode: 'US',
+        registrationProvider: 'manual',
+        registrationStatus: 'registered',
+        linkedWorkId: null,
+        createdAt: '2026-05-28T00:00:00.000Z',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        routerPushMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('disables submit when name is empty and never fires the POST', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        const submit = screen.getByTestId('register-company-submit') as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        fireEvent.click(submit);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid country code inline (no POST fired)', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Acme Inc.' },
+        });
+        fireEvent.change(screen.getByTestId('register-company-country'), {
+            target: { value: 'USA' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(
+            screen.getByText('organizations.registerCompany.errors.countryCodeInvalid'),
+        ).toBeTruthy();
+    });
+
+    /**
+     * Happy path — 2nd Org (skips the upgrade dialog). Submits to the
+     * register-company endpoint, navigates to the new Org's dashboard,
+     * and closes the modal.
+     */
+    it('calls POST /api/organizations/register-company and navigates after success (2nd Org)', async () => {
+        __seedOrganizationsStoreForTests({
+            data: [org({ id: 'o-existing', slug: 'existing' })],
+            isLoading: false,
+            error: null,
+        });
+        const newOrg = org({ id: 'o-2', slug: 'globex', displayName: 'Globex LLC' });
+        const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), {
+                    status: 201,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations') {
+                // best-effort `mutate()` after success.
+                return new Response(JSON.stringify([newOrg]), { status: 200 });
+            }
+            throw new Error(`Unexpected fetch: ${u}`);
+        });
+
+        const onOpenChange = vi.fn();
+        render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Globex LLC' },
+        });
+        fireEvent.change(screen.getByTestId('register-company-country'), {
+            target: { value: 'de' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+
+        await waitFor(() => {
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+        });
+
+        const postCall = fetchMock.mock.calls.find(
+            ([u, init]) =>
+                String(u) === '/api/organizations/register-company' &&
+                (init as RequestInit | undefined)?.method === 'POST',
+        );
+        expect(postCall).toBeDefined();
+        const body = JSON.parse((postCall![1] as RequestInit).body as string);
+        // countryCode is auto-uppercased before submit.
+        expect(body).toEqual({ name: 'Globex LLC', countryCode: 'DE' });
+    });
+
+    /**
+     * First-Org path — after a successful POST, hand off to the
+     * UpgradeOrCreateDialog so the user can pick Upgrade vs Empty.
+     */
+    it('chains into the UpgradeOrCreateDialog when this is the user first Org', async () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        const newOrg = org({ id: 'o-first', slug: 'first-co', displayName: 'First Company' });
+        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            return new Response(JSON.stringify([newOrg]), { status: 200 });
+        });
+
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'First Company' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+
+        // The UpgradeOrCreateDialog renders the `organizations.upgrade.title` key.
+        await waitFor(() => {
+            expect(screen.queryByText('organizations.upgrade.title')).toBeTruthy();
+        });
+        // No direct router navigation yet — the upgrade dialog owns the next step.
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -7,7 +7,13 @@ import { APIResponse } from './types';
 // in sync to avoid a runtime dep on the agent package from
 // apps/web). PR X seeds Mission Template repos; PR Y wires the
 // "Use this Template" button to pre-fill /new?type=mission.
-export type TemplateKind = 'website' | 'work' | 'mission';
+//
+// EW-662 (Tenants & Organizations Phase 10) — `'company'` joins the
+// union so the Company WorkType has a place in the catalog. No seed
+// templates ship in v1; the chip on `+ New` routes directly into
+// the Register-Company form which calls the OrganizationService
+// manual-completion path.
+export type TemplateKind = 'website' | 'work' | 'mission' | 'company';
 export type TemplateSourceType = 'built_in' | 'custom';
 export type TemplateOriginType = 'standard' | 'forked' | 'custom_url';
 

--- a/packages/agent/src/entities/template.entity.ts
+++ b/packages/agent/src/entities/template.entity.ts
@@ -5,7 +5,16 @@ import { Column, CreateDateColumn, Entity, Index, PrimaryColumn, UpdateDateColum
 // templates in the catalog. The DB column is `varchar(32)` so
 // the new value fits without a migration; PR X seeds the
 // Mission Template repos.
-export type TemplateKind = 'website' | 'work' | 'mission';
+//
+// EW-662 (Tenants & Organizations Phase 10) — `'company'` joins the
+// union for the Company WorkType. Companies are a special template
+// kind that, when their backing Work transitions to `registered`,
+// spawn an `Organization` row (see `OrganizationService.createOrganizationFromCompanyWork`).
+// Same `varchar(32)` column — no migration needed for the new value.
+// No seed templates ship in v1 (Stripe Atlas integration is deferred);
+// the chip on `+ New` routes directly into the Register-Company
+// form which calls the `OrganizationService` manual-completion path.
+export type TemplateKind = 'website' | 'work' | 'mission' | 'company';
 export type TemplateSourceType = 'built_in' | 'custom';
 
 @Entity({ name: 'templates' })

--- a/packages/contracts/src/api/organization/index.ts
+++ b/packages/contracts/src/api/organization/index.ts
@@ -15,6 +15,26 @@ export interface CreateOrganizationRequest {
 	slug?: string;
 }
 
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — body for
+ * `POST /api/organizations/register-company`.
+ *
+ * Driven by the Company chip on `+ New`. The service hard-codes
+ * `registrationProvider = 'manual'` and `registrationStatus =
+ * 'registered'` for v1 (Stripe Atlas integration is deferred); the
+ * client only supplies the user-visible fields.
+ */
+export interface RegisterCompanyRequest {
+	/** Display name. 1-200 chars. */
+	name: string;
+	/** Registered legal name. Defaults to `name` when omitted. */
+	legalName?: string;
+	/** ISO 3166-1 alpha-2 country code (e.g. `'US'`). */
+	countryCode?: string;
+	/** Optional slug override. If omitted, allocated from `name`. */
+	slug?: string;
+}
+
 export interface UpdateOrganizationRequest {
 	displayName?: string;
 	legalName?: string;


### PR DESCRIPTION
## Summary

Phase 10 of the Tenants & Organizations rollout (EW-662) — **the final phase**. Adds the `Company` chip on the unified `+ New` page and the service-layer plumbing that produces an `Organization` row out of the chip's submit. Designed so the future Stripe-Atlas / Work-of-type-Company `registered` transition can land as a one-line caller into the same service entry point.

- **Company chip is live**: graduates from inert "Soon" to selectable. Picking it opens a new `RegisterCompanyDialog` (minimal name + countryCode form). Routes to the existing `<UpgradeOrCreateDialog>` for first-Org users, otherwise navigates to `/${org.slug}/dashboard`.
- **`POST /api/organizations/register-company`**: new endpoint that hard-codes `registrationProvider = 'manual'` + `registrationStatus = 'registered'` for v1. Stripe Atlas integration is explicitly out of scope per plan.md. Lazy-creates the Tenant + backfills `tenantId` exactly the same way the Phase 6 `POST /api/organizations` does.
- **`OrganizationService.createOrganization` extended** with an optional `extra` parameter carrying `legalName`, `countryCode`, `registrationProvider`, `registrationStatus`, `linkedWorkId`. Fully backwards compatible — existing Phase 6/9 callers omit `extra` and behave identically.
- **`OrganizationService.createOrganizationFromCompanyWork(userId, work)`**: future-Phase entry point that wraps `registerCompany` + sets `linkedWorkId` from the Work id. Unit-tested today so the moment Phase 11+ adds `Work.kind` / `Work.status` columns, calling this from a lifecycle hook is a one-liner.
- **`TemplateKind` union grows `'company'`** (additive; `varchar(32)` fits the new value with no migration). Mirrored in `apps/web` so the catalog stays in sync.
- **i18n**: new `dashboard.newPage.chips.company`, `dashboard.newPage.chipDescriptions.company`, and `organizations.registerCompany.*` keys; mirrored as English fallbacks across all 20 non-English locales.

## Investigation findings

- **Chip plumbing** lives in `apps/web/src/components/new/NewPageClient.tsx`. It's a `ChipType` union driving `CHIP_ORDER`, `CHIP_ICONS`, `PLACEHOLDERS_BY_CHIP`, `CHIP_INTENT_LABEL`, `CHIP_TO_CANVAS_ROUTE`, `CHIP_TO_WORK_KIND`. Pre-Phase-10, `'company'` was an inert "Soon" entry appended after `CHIP_ORDER`. Phase 10 promotes it into `CHIP_ORDER` itself.
- **`+ New` page**: `apps/web/src/app/[locale]/(dashboard)/new/page.tsx`. Pre-resolves `?type=` against `VALID_CHIP_TYPES`. `'company'` joined that allow-list.
- **WorkType / WorkKind enum**: there is **none on the `Work` entity** today. No `kind` column, no `status` column. The closest neighbor is `TemplateKind = 'website' | 'work' | 'mission'` in `packages/agent/src/entities/template.entity.ts`. Phase 10 adds `'company'` there (additive, no migration).
- **Status-transition hook**: I looked at `WorkLifecycleService` (`packages/agent/src/services/work-lifecycle.service.ts`) — it emits `WorkCreatedEvent` via `@nestjs/event-emitter` but there's no `'work.status.changed'` listener pattern today, because there's no status column. So the prompt's "When a Company Work transitions to `status = 'registered'`" path **doesn't have a hook point to attach to in v1**.
- **Decision (deviation from prompt)**: rather than invent a `Work.status` column + lifecycle event in this phase (out of scope per plan.md, and would force a schema migration), Phase 10 ships:
  1. The chip + form (manual-completion path — the form's submit *is* the "registered" transition for v1).
  2. `createOrganizationFromCompanyWork(userId, work)` as a unit-tested entry point so when Phase 11+ adds `Work.kind` / `Work.status`, the calling code is a one-liner.
  This matches plan.md's "the WorkType + manual-completion path is enough for v1" language.

## Test results

- **Agent**: 280 suites, 5545/5545 pass (+2 skipped). No regressions from the `TemplateKind` union extension.
- **API**: 148/150 suites pass (+1 skipped), 2425/2425 tests pass (+9 skipped). 2 pre-existing failures in `plugins-capabilities/git-provider/*.spec.ts` (TypeScript error in `git-provider.service.ts:38` — `id` not on `GitProviderConnectionInfo`). Unrelated to Phase 10; the file last touched by PR #414 in 2026.
- **Web**: 68/68 suites pass, 590/590 tests pass. Includes 5 new tests in `OrganizationService` spec and 4 new tests in `RegisterCompanyDialog` spec.

## Build / format / lint

- `pnpm build` — 60/60 turbo tasks pass. The new BFF route shows up in the Next.js build manifest (`/api/organizations/register-company`).
- `pnpm format:check` — clean.
- `pnpm lint` — clean for new files. The cascading-renders rule warns on `setName('')` inside the `open` reset `useEffect`, but that's the same warning Phase 9's `CreateOrganizationModal` already carries — kept consistent with the existing pattern. (37 pre-existing files have unrelated lint errors on develop.)

## Test plan

- [ ] Open `/new`, confirm Company chip renders last in the live chip list with `Building2` icon
- [ ] Click Company chip → submit → RegisterCompanyDialog opens
- [ ] Submit form with name only → for a first-Org user, UpgradeOrCreateDialog opens
- [ ] Submit form with name + `de` → BFF posts `{ name, countryCode: "DE" }` (auto-uppercase)
- [ ] For a 2nd+ Org user → navigates to `/${slug}/dashboard` and skips upgrade dialog
- [ ] Land on `/new?type=company` → chip pre-selected and dialog auto-opens
- [ ] Check `Organization` row carries `registrationProvider='manual'`, `registrationStatus='registered'`, populated `legalName`/`countryCode`
- [ ] Confirm existing chips (Mission, Idea, Website, Agent, Task, Landing Page, Blog, Directory, Awesome Repo) still route to their pre-Phase-10 destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added company registration functionality, allowing users to register a legal company entity with optional country code and legal name fields
  * Added "Company" as a new chip type in the creation flow, enabling direct access to company registration from the new work page

* **Internationalization**
  * Extended language support across all locales with new company registration form labels, placeholders, and validation messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->