### PR TITLE
feat(i18n): rename user-facing "Generator" to "Worker" in platform UI

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1554,7 +1554,7 @@
                 "overview": "نظرة عامة",
                 "activity": "النشاط",
                 "items": "العناصر",
-                "generator": "مولد",
+                "generator": "Worker",
                 "schedule": "جدولة",
                 "history": "سجل",
                 "comparisons": "مقارنات",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "لم يبدأ التوليد",
                     "description": "ابدأ في توليد العناصر لعملك لملئه بالمحتوى.",
-                    "action": "بدء التوليد"
+                    "action": "بدء الـWork"
                 },
                 "generating": {
                     "title": "التوليد قيد التقدم",
@@ -1769,12 +1769,12 @@
                     "title": "فشل التوليد",
                     "description": "حدث خطأ أثناء التوليد.",
                     "withWarnings": "فشل التوليد مع أخطاء:",
-                    "retry": "إعادة محاولة التوليد"
+                    "retry": "إعادة محاولة الـWork"
                 },
                 "cancelled": {
                     "title": "تم إلغاء التوليد",
                     "description": "تم إيقاف التوليد السابق قبل الاكتمال.",
-                    "restart": "إعادة تشغيل التوليد"
+                    "restart": "إعادة تشغيل الـWork"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "تفاصيل التهيئة",
-                "initialPrompt": "موجه التوليد الأولي",
+                "initialPrompt": "موجه الـWorker الأولي",
                 "companyDetails": "معلومات الشركة",
                 "companyName": "اسم الشركة",
                 "companyWebsite": "الموقع الإلكتروني",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "توليد",
+                    "generate": "Work",
                     "schedule": "جدولة",
                     "history": "التاريخ",
                     "comparisons": "المقارنات",
-                    "navigationLabel": "تبويبات المولد"
+                    "navigationLabel": "تبويبات Worker"
                 },
                 "regenerationWarning": "تحذير إعادة التوليد",
                 "regenerationWarningDescription": "تم توليد هذا المجلد بالفعل. بدء توليد جديد سيستبدل العناصر الموجودة.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "فشل في تحميل تكوين النموذج",
                 "selectOption": "اختر خيارًا",
                 "workName": "اسم المجلد",
-                "generationPrompt": "موجه التوليد",
+                "generationPrompt": "موجه الـWorker",
                 "modelOverride": "تجاوز نموذج الذكاء الاصطناعي",
                 "modelOverridePlaceholder": "مثل openai/gpt-4.1 أو openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "اختياري. يستخدم النموذج المستورد أو السابق افتراضيًا إلا إذا قمت بتجاوزه هنا.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "كن محددًا بشأن نوع المحتوى الذي تريد توليده",
                 "repositoryDescription": "وصف المستودع",
                 "repositoryPlaceholder": "وصف موجز للمستودع (اختياري)",
-                "startGeneration": "بدء التوليد",
+                "startGeneration": "بدء الـWork",
                 "regenerateItems": "إعادة توليد العناصر",
                 "updateItems": "تشغيل التوليد",
                 "recreateWork": "إعادة إنشاء المجلد",
@@ -4638,7 +4638,7 @@
             "work": "العمل",
             "overview": "نظرة عامة",
             "items": "العناصر",
-            "generator": "المولد",
+            "generator": "Worker",
             "settings": "الإعدادات",
             "deploy": "النشر",
             "members": "الأعضاء",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1554,7 +1554,7 @@
                 "overview": "Преглед",
                 "activity": "Активност",
                 "items": "Елементи",
-                "generator": "Генератор",
+                "generator": "Worker",
                 "schedule": "График",
                 "history": "История",
                 "comparisons": "Сравнения",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Генериране не е започнато",
                     "description": "Стартирай генериране на елементи за твоята работа, за да я запълниш със съдържание.",
-                    "action": "Стартирай генериране"
+                    "action": "Стартирай Work"
                 },
                 "generating": {
                     "title": "Генериране в ход",
@@ -1769,12 +1769,12 @@
                     "title": "Генерирането неуспешно",
                     "description": "Грешка по време на генериране.",
                     "withWarnings": "Генерирането завърши с грешки:",
-                    "retry": "Опитай отново генериране"
+                    "retry": "Опитай отново Work"
                 },
                 "cancelled": {
                     "title": "Генерирането отменено",
                     "description": "Предишното генериране беше спрено преди завършване.",
-                    "restart": "Рестартирай генериране"
+                    "restart": "Рестартирай Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Детайли на конфигурацията",
-                "initialPrompt": "Първоначална подсказка за генериране",
+                "initialPrompt": "Първоначална подсказка за Worker",
                 "companyDetails": "Информация за компанията",
                 "companyName": "Име на компанията",
                 "companyWebsite": "Уебсайт",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Генериране",
+                    "generate": "Work",
                     "schedule": "График",
                     "history": "История",
                     "comparisons": "Сравнения",
-                    "navigationLabel": "Разделители на генератора"
+                    "navigationLabel": "Раздели на Worker"
                 },
                 "regenerationWarning": "Предупреждение за регенериране",
                 "regenerationWarningDescription": "Тази работа вече е генерирана. Стартирането на нова генерация ще замени съществуващите елементи.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Неуспешно зареждане на конфигурацията на формата",
                 "selectOption": "Изберете опция",
                 "workName": "Име на работата",
-                "generationPrompt": "Подсказка за генериране",
+                "generationPrompt": "Подсказка за Worker",
                 "modelOverride": "Презаписване на AI модел",
                 "modelOverridePlaceholder": "нпр. openai/gpt-4.1 или openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Не задължително. По подразбиране използва импортирания или предишния модел, освен ако не го презапишете тук.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Бъдете конкретни относно типа съдържание, което искате да генерирате",
                 "repositoryDescription": "Описание на репозиторията",
                 "repositoryPlaceholder": "Кратко описание на репозиторията (по избор)",
-                "startGeneration": "Започни генериране",
+                "startGeneration": "Започни Work",
                 "regenerateItems": "Регенерирай елементи",
                 "updateItems": "Изпълни генериране",
                 "recreateWork": "Създай отново работата",
@@ -4638,7 +4638,7 @@
             "work": "Работа",
             "overview": "Преглед",
             "items": "Елементи",
-            "generator": "Генератор",
+            "generator": "Worker",
             "settings": "Настройки",
             "deploy": "Разположи",
             "members": "Членове",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1554,7 +1554,7 @@
                 "overview": "Übersicht",
                 "activity": "Aktivität",
                 "items": "Elemente",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Zeitplan",
                 "history": "Verlauf",
                 "comparisons": "Vergleiche",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generierung nicht gestartet",
                     "description": "Starten Sie die Generierung von Elementen für Ihr Werk, um es mit Inhalten zu füllen.",
-                    "action": "Generierung starten"
+                    "action": "Work starten"
                 },
                 "generating": {
                     "title": "Generierung läuft",
@@ -1769,12 +1769,12 @@
                     "title": "Generierung fehlgeschlagen",
                     "description": "Während der Generierung ist ein Fehler aufgetreten.",
                     "withWarnings": "Generierung mit Fehlern fehlgeschlagen:",
-                    "retry": "Generierung wiederholen"
+                    "retry": "Work wiederholen"
                 },
                 "cancelled": {
                     "title": "Generierung abgebrochen",
                     "description": "Die vorherige Generierung wurde vor Abschluss gestoppt.",
-                    "restart": "Generierung neu starten"
+                    "restart": "Work neu starten"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Konfigurationsdetails",
-                "initialPrompt": "Anfänglicher Generierungsprompt",
+                "initialPrompt": "Anfänglicher Worker-Prompt",
                 "companyDetails": "Firmeninformationen",
                 "companyName": "Firmenname",
                 "companyWebsite": "Website",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generieren",
+                    "generate": "Work",
                     "schedule": "Zeitplan",
                     "history": "Verlauf",
                     "comparisons": "Vergleiche",
-                    "navigationLabel": "Generator-Registerkarten"
+                    "navigationLabel": "Worker-Registerkarten"
                 },
                 "regenerationWarning": "Regenerierungswarnung",
                 "regenerationWarningDescription": "Dieses Werk wurde bereits generiert. Das Starten einer neuen Generierung ersetzt bestehende Elemente.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Fehler beim Laden der Formular-Konfiguration",
                 "selectOption": "Option auswählen",
                 "workName": "Ordnername",
-                "generationPrompt": "Generierungs-Prompt",
+                "generationPrompt": "Worker-Prompt",
                 "modelOverride": "KI-Modell überschreiben",
                 "modelOverridePlaceholder": "z. B. openai/gpt-4.1 oder openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optional. Verwendet standardmäßig das importierte oder vorherige Modell, es sei denn, Sie überschreiben es hier.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Seien Sie spezifisch bezüglich des Typs von Inhalt, den Sie generieren möchten",
                 "repositoryDescription": "Repository-Beschreibung",
                 "repositoryPlaceholder": "Kurze Beschreibung des Repositories (optional)",
-                "startGeneration": "Generierung starten",
+                "startGeneration": "Work starten",
                 "regenerateItems": "Elemente neu generieren",
                 "updateItems": "Generierung ausführen",
                 "recreateWork": "Ordner neu erstellen",
@@ -4638,7 +4638,7 @@
             "work": "Werk",
             "overview": "Übersicht",
             "items": "Einträge",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Einstellungen",
             "deploy": "Bereitstellen",
             "members": "Mitglieder",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1565,7 +1565,7 @@
                 "overview": "Overview",
                 "activity": "Activity",
                 "items": "Items",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Schedule",
                 "history": "History",
                 "comparisons": "Comparisons",
@@ -1758,7 +1758,7 @@
                 "notStarted": {
                     "title": "Generation Not Started",
                     "description": "Start generating items for your Work to populate it with content.",
-                    "action": "Start Generation"
+                    "action": "Start Work"
                 },
                 "generating": {
                     "title": "Generation in Progress",
@@ -1780,12 +1780,12 @@
                     "title": "Generation Failed",
                     "description": "An error occurred during generation.",
                     "withWarnings": "Generation failed with errors:",
-                    "retry": "Retry Generation"
+                    "retry": "Retry Work"
                 },
                 "cancelled": {
                     "title": "Generation Cancelled",
                     "description": "The previous generation was stopped before completion.",
-                    "restart": "Restart Generation"
+                    "restart": "Restart Work"
                 }
             },
             "stats": {
@@ -1984,7 +1984,7 @@
             },
             "config": {
                 "title": "Configuration Details",
-                "initialPrompt": "Initial Generation Prompt",
+                "initialPrompt": "Initial Worker Prompt",
                 "companyDetails": "Company Information",
                 "companyName": "Company Name",
                 "companyWebsite": "Website",
@@ -2354,11 +2354,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generate",
+                    "generate": "Work",
                     "schedule": "Schedule",
                     "history": "History",
                     "comparisons": "Comparisons",
-                    "navigationLabel": "Generator tabs"
+                    "navigationLabel": "Worker tabs"
                 },
                 "regenerationWarning": "Regeneration Warning",
                 "regenerationWarningDescription": "This Work has already been generated. Starting a new generation will replace existing items.",
@@ -2372,7 +2372,7 @@
                 "failedToLoadFormSchema": "Failed to load form configuration",
                 "selectOption": "Select an option",
                 "workName": "Work Name",
-                "generationPrompt": "Generation Prompt",
+                "generationPrompt": "Worker Prompt",
                 "modelOverride": "AI Model Override",
                 "modelOverridePlaceholder": "e.g. openai/gpt-4.1 or openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optional. Uses the imported or previous model by default unless you override it here.",
@@ -2384,7 +2384,7 @@
                 "promptHelperText": "Be specific about the type of content you want to generate",
                 "repositoryDescription": "Repository Description",
                 "repositoryPlaceholder": "Brief description of the repository (optional)",
-                "startGeneration": "Start Generation",
+                "startGeneration": "Start Work",
                 "regenerateItems": "Regenerate Items",
                 "updateItems": "Run Generation",
                 "recreateWork": "Recreate Work",
@@ -4457,7 +4457,7 @@
             "work": "Work",
             "overview": "Overview",
             "items": "Items",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Settings",
             "deploy": "Deploy",
             "members": "Members",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1554,7 +1554,7 @@
                 "overview": "Resumen",
                 "activity": "Actividad",
                 "items": "Elementos",
-                "generator": "Generador",
+                "generator": "Worker",
                 "schedule": "Programación",
                 "history": "Historial",
                 "comparisons": "Comparaciones",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generación no iniciada",
                     "description": "Inicia la generación de elementos para tu trabajo para poblarlo con contenido.",
-                    "action": "Iniciar generación"
+                    "action": "Iniciar Work"
                 },
                 "generating": {
                     "title": "Generación en progreso",
@@ -1769,12 +1769,12 @@
                     "title": "Generación fallida",
                     "description": "Ocurrió un error durante la generación.",
                     "withWarnings": "Generación fallida con errores:",
-                    "retry": "Reintentar generación"
+                    "retry": "Reintentar Work"
                 },
                 "cancelled": {
                     "title": "Generación cancelada",
                     "description": "La generación anterior se detuvo antes de completarse.",
-                    "restart": "Reiniciar generación"
+                    "restart": "Reiniciar Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Detalles de configuración",
-                "initialPrompt": "Prompt inicial de generación",
+                "initialPrompt": "Prompt inicial de Worker",
                 "companyDetails": "Información de la empresa",
                 "companyName": "Nombre de la empresa",
                 "companyWebsite": "Sitio web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generar",
+                    "generate": "Work",
                     "schedule": "Programar",
                     "history": "Historial",
                     "comparisons": "Comparaciones",
-                    "navigationLabel": "Pestañas del generador"
+                    "navigationLabel": "Pestañas de Worker"
                 },
                 "regenerationWarning": "Advertencia de regeneración",
                 "regenerationWarningDescription": "Este trabajo ya ha sido generado. Iniciar una nueva generación reemplazará los elementos existentes.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Error al cargar la configuración del formulario",
                 "selectOption": "Selecciona una opción",
                 "workName": "Nombre del trabajo",
-                "generationPrompt": "Prompt de generación",
+                "generationPrompt": "Prompt de Worker",
                 "modelOverride": "Anulación de modelo de IA",
                 "modelOverridePlaceholder": "p. ej. openai/gpt-4.1 o openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opcional. Utiliza el modelo importado o anterior por defecto a menos que lo sobrescribas aquí.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Sé específico sobre el tipo de contenido que deseas generar",
                 "repositoryDescription": "Descripción del repositorio",
                 "repositoryPlaceholder": "Breve descripción del repositorio (opcional)",
-                "startGeneration": "Iniciar generación",
+                "startGeneration": "Iniciar Work",
                 "regenerateItems": "Regenerar elementos",
                 "updateItems": "Ejecutar generación",
                 "recreateWork": "Recrear trabajo",
@@ -4638,7 +4638,7 @@
             "work": "Trabajo",
             "overview": "Resumen",
             "items": "Elementos",
-            "generator": "Generador",
+            "generator": "Worker",
             "settings": "Configuración",
             "deploy": "Implementar",
             "members": "Miembros",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1554,7 +1554,7 @@
                 "overview": "Aperçu",
                 "activity": "Activité",
                 "items": "Éléments",
-                "generator": "Générateur",
+                "generator": "Worker",
                 "schedule": "Programmation",
                 "history": "Historique",
                 "comparisons": "Comparaisons",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Génération non démarrée",
                     "description": "Commencez à générer des éléments pour votre travail afin de le peupler de contenu.",
-                    "action": "Démarrer la génération"
+                    "action": "Démarrer le Work"
                 },
                 "generating": {
                     "title": "Génération en cours",
@@ -1769,12 +1769,12 @@
                     "title": "Échec de la génération",
                     "description": "Une erreur s'est produite pendant la génération.",
                     "withWarnings": "Échec de la génération avec erreurs :",
-                    "retry": "Relancer la génération"
+                    "retry": "Relancer le Work"
                 },
                 "cancelled": {
                     "title": "Génération annulée",
                     "description": "La génération précédente a été arrêtée avant achèvement.",
-                    "restart": "Redémarrer la génération"
+                    "restart": "Redémarrer le Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Détails de configuration",
-                "initialPrompt": "Invite initiale de génération",
+                "initialPrompt": "Invite initiale du Worker",
                 "companyDetails": "Informations sur l'entreprise",
                 "companyName": "Nom de l'entreprise",
                 "companyWebsite": "Site web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Générer",
+                    "generate": "Work",
                     "schedule": "Planification",
                     "history": "Historique",
                     "comparisons": "Comparaisons",
-                    "navigationLabel": "Onglets du générateur"
+                    "navigationLabel": "Onglets Worker"
                 },
                 "regenerationWarning": "Avertissement de régénération",
                 "regenerationWarningDescription": "Ce travail a déjà été généré. Lancer une nouvelle génération remplacera les éléments existants.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Échec du chargement de la configuration du formulaire",
                 "selectOption": "Sélectionner une option",
                 "workName": "Nom du travail",
-                "generationPrompt": "Prompt de génération",
+                "generationPrompt": "Prompt du Worker",
                 "modelOverride": "Remplacement du modèle IA",
                 "modelOverridePlaceholder": "par ex. openai/gpt-4.1 ou openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optionnel. Utilise par défaut le modèle importé ou précédent, sauf si vous le remplacez ici.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Soyez précis sur le type de contenu que vous souhaitez générer",
                 "repositoryDescription": "Description du dépôt",
                 "repositoryPlaceholder": "Brève description du dépôt (optionnel)",
-                "startGeneration": "Démarrer la génération",
+                "startGeneration": "Démarrer le Work",
                 "regenerateItems": "Régénérer les éléments",
                 "updateItems": "Exécuter la génération",
                 "recreateWork": "Recréer le travail",
@@ -4638,7 +4638,7 @@
             "work": "Travail",
             "overview": "Aperçu",
             "items": "Éléments",
-            "generator": "Générateur",
+            "generator": "Worker",
             "settings": "Paramètres",
             "deploy": "Déployer",
             "members": "Membres",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1554,7 +1554,7 @@
                 "overview": "סקירה כללית",
                 "activity": "פעילות",
                 "items": "פריטים",
-                "generator": "מחולל",
+                "generator": "Worker",
                 "schedule": "לוח זמנים",
                 "history": "היסטוריה",
                 "comparisons": "השוואות",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "יצירה לא התחילה",
                     "description": "התחל לייצר פריטים לעבודה שלך כדי לאכלס אותה בתוכן.",
-                    "action": "התחל יצירה"
+                    "action": "התחל Work"
                 },
                 "generating": {
                     "title": "יצירה בתהליך",
@@ -1769,12 +1769,12 @@
                     "title": "יצירה נכשלה",
                     "description": "אירעה שגיאה במהלך היצירה.",
                     "withWarnings": "יצירה נכשלה עם שגיאות:",
-                    "retry": "נסה יצירה שוב"
+                    "retry": "נסה Work שוב"
                 },
                 "cancelled": {
                     "title": "יצירה בוטלה",
                     "description": "היצירה הקודמת הופסקה לפני השלמה.",
-                    "restart": "התחל יצירה מחדש"
+                    "restart": "התחל Work מחדש"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "פרטי הגדרה",
-                "initialPrompt": "טקסט פתיחה ליצירה",
+                "initialPrompt": "טקסט פתיחה ל-Worker",
                 "companyDetails": "מידע על החברה",
                 "companyName": "שם חברה",
                 "companyWebsite": "אתר",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "יצירה",
+                    "generate": "Work",
                     "schedule": "לוח זמנים",
                     "history": "היסטוריה",
                     "comparisons": "השוואות",
-                    "navigationLabel": "לשוניות יצירה"
+                    "navigationLabel": "לשוניות Worker"
                 },
                 "regenerationWarning": "אזהרת יצירה מחדש",
                 "regenerationWarningDescription": "תיקייה זו כבר נוצרה. התחלת יצירה חדשה תחליף את הפריטים הקיימים.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "נכשל בטעינת הגדרת הטופס",
                 "selectOption": "בחר אפשרות",
                 "workName": "שם תיקייה",
-                "generationPrompt": "הנחיית יצירה",
+                "generationPrompt": "הנחיית Worker",
                 "modelOverride": "עקיפת מודל AI",
                 "modelOverridePlaceholder": "לדוגמה openai/gpt-4.1 או openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "אופציונלי. משתמש במודל המיובא או הקודם כברירת מחדל אלא אם תעקוף אותו כאן.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "היה ספציפי לגבי סוג התוכן שברצונך לייצר",
                 "repositoryDescription": "תיאור מאגר",
                 "repositoryPlaceholder": "תיאור קצר של המאגר (אופציונלי)",
-                "startGeneration": "התחל יצירה",
+                "startGeneration": "התחל Work",
                 "regenerateItems": "צור מחדש פריטים",
                 "updateItems": "הרץ יצירה",
                 "recreateWork": "צור מחדש תיקייה",
@@ -4638,7 +4638,7 @@
             "work": "עבודה",
             "overview": "סקירה כללית",
             "items": "פריטים",
-            "generator": "מחולל",
+            "generator": "Worker",
             "settings": "הגדרות",
             "deploy": "פרס",
             "members": "חברים",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1554,7 +1554,7 @@
                 "overview": "अवलोकन",
                 "activity": "गतिविधि",
                 "items": "आइटम",
-                "generator": "जनरेटर",
+                "generator": "Worker",
                 "schedule": "अनुसूची",
                 "history": "इतिहास",
                 "comparisons": "तुलनाएँ",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "उत्पत्ति आरंभ नहीं हुई",
                     "description": "अपनी कार्य को सामग्री से भरने के लिए आइटम उत्पन्न करना आरंभ करें।",
-                    "action": "उत्पत्ति आरंभ करें"
+                    "action": "Work आरंभ करें"
                 },
                 "generating": {
                     "title": "उत्पत्ति प्रगति पर",
@@ -1769,12 +1769,12 @@
                     "title": "उत्पत्ति विफल",
                     "description": "उत्पत्ति के दौरान त्रुटि हुई।",
                     "withWarnings": "त्रुटियों के साथ उत्पत्ति विफल:",
-                    "retry": "उत्पत्ति पुनः प्रयास करें"
+                    "retry": "Work पुनः प्रयास करें"
                 },
                 "cancelled": {
                     "title": "उत्पत्ति रद्द",
                     "description": "पिछली उत्पत्ति पूर्ण होने से पहले रोक दी गई थी।",
-                    "restart": "उत्पत्ति पुनः आरंभ करें"
+                    "restart": "Work पुनः आरंभ करें"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "कॉन्फ़िगरेशन विवरण",
-                "initialPrompt": "आरंभिक उत्पत्ति प्रॉम्प्ट",
+                "initialPrompt": "आरंभिक Worker प्रॉम्प्ट",
                 "companyDetails": "कंपनी जानकारी",
                 "companyName": "कंपनी नाम",
                 "companyWebsite": "वेबसाइट",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "उत्पन्न करें",
+                    "generate": "Work",
                     "schedule": "शेड्यूल",
                     "history": "इतिहास",
                     "comparisons": "तुलनाएँ",
-                    "navigationLabel": "जनरेटर टैब"
+                    "navigationLabel": "Worker टैब"
                 },
                 "regenerationWarning": "पुनःउत्पादन चेतावनी",
                 "regenerationWarningDescription": "इस कार्य को पहले ही उत्पन्न किया जा चुका है। नया उत्पादन शुरू करने से मौजूदा आइटम प्रतिस्थापित हो जाएँगे।",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "फ़ॉर्म कॉन्फ़िगरेशन लोड करने में विफल",
                 "selectOption": "एक विकल्प चुनें",
                 "workName": "कार्य का नाम",
-                "generationPrompt": "उत्पादन प्रॉम्प्ट",
+                "generationPrompt": "Worker प्रॉम्प्ट",
                 "modelOverride": "एआई मॉडल ओवरराइड",
                 "modelOverridePlaceholder": "जैसे openai/gpt-4.1 या openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "वैकल्पिक। डिफ़ॉल्ट रूप से आयातित या पिछला मॉडल उपयोग किया जाता है जब तक कि आप इसे यहाँ ओवरराइड न करें।",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "उत्पन्न करने वाले कंटेंट के प्रकार के बारे में विशिष्ट रहें",
                 "repositoryDescription": "रीपॉजिटरी विवरण",
                 "repositoryPlaceholder": "रीपॉजिटरी का संक्षिप्त विवरण (वैकल्पिक)",
-                "startGeneration": "उत्पादन शुरू करें",
+                "startGeneration": "Work शुरू करें",
                 "regenerateItems": "आइटम पुनःउत्पन्न करें",
                 "updateItems": "उत्पादन चलाएँ",
                 "recreateWork": "कार्य पुनःबनाएँ",
@@ -4702,7 +4702,7 @@
             "work": "कार्य",
             "overview": "अवलोकन",
             "items": "आइटम्स",
-            "generator": "जनरेटर",
+            "generator": "Worker",
             "settings": "सेटिंग्स",
             "deploy": "डिप्लॉय करें",
             "members": "सदस्य",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1554,7 +1554,7 @@
                 "overview": "Ringkasan",
                 "activity": "Aktivitas",
                 "items": "Item",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Jadwal",
                 "history": "Riwayat",
                 "comparisons": "Perbandingan",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generasi Belum Dimulai",
                     "description": "Mulai menghasilkan item untuk karya Anda agar diisi dengan konten.",
-                    "action": "Mulai Generasi"
+                    "action": "Mulai Work"
                 },
                 "generating": {
                     "title": "Generasi Sedang Berlangsung",
@@ -1769,12 +1769,12 @@
                     "title": "Generasi Gagal",
                     "description": "Terjadi kesalahan selama generasi.",
                     "withWarnings": "Generasi gagal dengan kesalahan:",
-                    "retry": "Coba Generasi Lagi"
+                    "retry": "Coba Work Lagi"
                 },
                 "cancelled": {
                     "title": "Generasi Dibatalkan",
                     "description": "Generasi sebelumnya dihentikan sebelum selesai.",
-                    "restart": "Mulai Ulang Generasi"
+                    "restart": "Mulai Ulang Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Detail Konfigurasi",
-                "initialPrompt": "Prompt Generasi Awal",
+                "initialPrompt": "Prompt Worker Awal",
                 "companyDetails": "Informasi Perusahaan",
                 "companyName": "Nama Perusahaan",
                 "companyWebsite": "Situs Web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Hasilkan",
+                    "generate": "Work",
                     "schedule": "Jadwal",
                     "history": "Riwayat",
                     "comparisons": "Perbandingan",
-                    "navigationLabel": "Tab Generator"
+                    "navigationLabel": "Tab Worker"
                 },
                 "regenerationWarning": "Peringatan Regenerasi",
                 "regenerationWarningDescription": "Karya ini sudah dihasilkan. Memulai generasi baru akan mengganti item yang ada.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Gagal memuat konfigurasi formulir",
                 "selectOption": "Pilih opsi",
                 "workName": "Nama Karya",
-                "generationPrompt": "Prompt Generasi",
+                "generationPrompt": "Prompt Worker",
                 "modelOverride": "Penggantian Model AI",
                 "modelOverridePlaceholder": "misalnya openai/gpt-4.1 atau openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opsional. Secara default menggunakan model yang diimpor atau model sebelumnya kecuali Anda menimpa di sini.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Jadilah spesifik tentang jenis konten yang ingin Anda hasilkan",
                 "repositoryDescription": "Deskripsi Repositori",
                 "repositoryPlaceholder": "Deskripsi singkat repositori (opsional)",
-                "startGeneration": "Mulai Generasi",
+                "startGeneration": "Mulai Work",
                 "regenerateItems": "Regenerasi Item",
                 "updateItems": "Jalankan Generasi",
                 "recreateWork": "Buat Ulang Karya",
@@ -4702,7 +4702,7 @@
             "work": "Karya",
             "overview": "Ikhtisar",
             "items": "Item",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Pengaturan",
             "deploy": "Penerapan",
             "members": "Anggota",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1554,7 +1554,7 @@
                 "overview": "Panoramica",
                 "activity": "Attività",
                 "items": "Elementi",
-                "generator": "Generatore",
+                "generator": "Worker",
                 "schedule": "Programmazione",
                 "history": "Cronologia",
                 "comparisons": "Confronti",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generazione non avviata",
                     "description": "Avvia la generazione degli elementi per popolare la lavori con contenuti.",
-                    "action": "Avvia generazione"
+                    "action": "Avvia Work"
                 },
                 "generating": {
                     "title": "Generazione in corso",
@@ -1769,12 +1769,12 @@
                     "title": "Generazione fallita",
                     "description": "Si è verificato un errore durante la generazione.",
                     "withWarnings": "Generazione fallita con errori:",
-                    "retry": "Riprova generazione"
+                    "retry": "Riprova Work"
                 },
                 "cancelled": {
                     "title": "Generazione annullata",
                     "description": "La generazione precedente è stata fermata prima del completamento.",
-                    "restart": "Riavvia generazione"
+                    "restart": "Riavvia Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Dettagli configurazione",
-                "initialPrompt": "Prompt iniziale generazione",
+                "initialPrompt": "Prompt iniziale del Worker",
                 "companyDetails": "Informazioni azienda",
                 "companyName": "Nome azienda",
                 "companyWebsite": "Sito web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Genera",
+                    "generate": "Work",
                     "schedule": "Programma",
                     "history": "Cronologia",
                     "comparisons": "Confronti",
-                    "navigationLabel": "Schede Generatore"
+                    "navigationLabel": "Schede Worker"
                 },
                 "regenerationWarning": "Avviso di Rigenerazione",
                 "regenerationWarningDescription": "Questa lavori è già stata generata. Avviare una nuova generazione sostituirà gli elementi esistenti.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Impossibile caricare la configurazione del modulo",
                 "selectOption": "Seleziona un'opzione",
                 "workName": "Nome Lavori",
-                "generationPrompt": "Prompt di Generazione",
+                "generationPrompt": "Prompt del Worker",
                 "modelOverride": "Sovrascrittura modello AI",
                 "modelOverridePlaceholder": "es. openai/gpt-4.1 o openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opzionale. Usa il modello importato o precedente per impostazione predefinita a meno che non lo sovrascriva qui.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Sii specifico sul tipo di contenuto che vuoi generare",
                 "repositoryDescription": "Descrizione Repository",
                 "repositoryPlaceholder": "Breve descrizione del repository (opzionale)",
-                "startGeneration": "Avvia Generazione",
+                "startGeneration": "Avvia Work",
                 "regenerateItems": "Rigenera Elementi",
                 "updateItems": "Esegui Generazione",
                 "recreateWork": "Ricarica Lavori",
@@ -4702,7 +4702,7 @@
             "work": "Lavori",
             "overview": "Panoramica",
             "items": "Elementi",
-            "generator": "Generatore",
+            "generator": "Worker",
             "settings": "Impostazioni",
             "deploy": "Distribuisci",
             "members": "Membri",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1554,7 +1554,7 @@
                 "overview": "概要",
                 "activity": "アクティビティ",
                 "items": "アイテム",
-                "generator": "ジェネレーター",
+                "generator": "Worker",
                 "schedule": "スケジュール",
                 "history": "履歴",
                 "comparisons": "比較",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "生成未開始",
                     "description": "ワークにコンテンツを格納するためにアイテムの生成を開始してください。",
-                    "action": "生成を開始"
+                    "action": "Work を開始"
                 },
                 "generating": {
                     "title": "生成中",
@@ -1769,12 +1769,12 @@
                     "title": "生成エラー",
                     "description": "生成中にエラーが発生しました。",
                     "withWarnings": "エラーで生成に失敗:",
-                    "retry": "生成を再試行"
+                    "retry": "Work を再試行"
                 },
                 "cancelled": {
                     "title": "生成キャンセル",
                     "description": "前の生成が完了前に停止されました。",
-                    "restart": "生成を再開"
+                    "restart": "Work を再開"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "設定詳細",
-                "initialPrompt": "初期生成プロンプト",
+                "initialPrompt": "初期 Worker プロンプト",
                 "companyDetails": "会社情報",
                 "companyName": "会社名",
                 "companyWebsite": "ウェブサイト",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "生成",
+                    "generate": "Work",
                     "schedule": "スケジュール",
                     "history": "履歴",
                     "comparisons": "比較",
-                    "navigationLabel": "ジェネレーター タブ"
+                    "navigationLabel": "Worker タブ"
                 },
                 "regenerationWarning": "再生成の警告",
                 "regenerationWarningDescription": "このワークはすでに生成されています。新規生成を開始すると、既存のアイテムが置き換えられます。",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "フォーム構成の読み込みに失敗しました",
                 "selectOption": "オプションを選択",
                 "workName": "ワーク名",
-                "generationPrompt": "生成プロンプト",
+                "generationPrompt": "Worker プロンプト",
                 "modelOverride": "AI モデル上書き",
                 "modelOverridePlaceholder": "例: openai/gpt-4.1 または openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "オプションです。デフォルトではインポートされたモデルまたは以前のモデルを使用しますが、ここで上書きできます。",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "生成したいコンテンツの種類について具体的に記述してください",
                 "repositoryDescription": "リポジトリの説明",
                 "repositoryPlaceholder": "リポジトリの簡単な説明（オプション）",
-                "startGeneration": "生成を開始",
+                "startGeneration": "Work を開始",
                 "regenerateItems": "アイテムを再生成",
                 "updateItems": "生成を実行",
                 "recreateWork": "ワークを再作成",
@@ -4702,7 +4702,7 @@
             "work": "ワーク",
             "overview": "概要",
             "items": "アイテム",
-            "generator": "ジェネレーター",
+            "generator": "Worker",
             "settings": "設定",
             "deploy": "デプロイ",
             "members": "メンバー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1554,7 +1554,7 @@
                 "overview": "개요",
                 "activity": "활동",
                 "items": "항목",
-                "generator": "생성기",
+                "generator": "Worker",
                 "schedule": "스케줄",
                 "history": "기록",
                 "comparisons": "비교",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "생성 시작되지 않음",
                     "description": "워크를 콘텐츠로 채우려면 항목 생성을 시작하세요.",
-                    "action": "생성 시작"
+                    "action": "Work 시작"
                 },
                 "generating": {
                     "title": "생성 진행 중",
@@ -1769,12 +1769,12 @@
                     "title": "생성 실패",
                     "description": "생성 중 오류가 발생했습니다.",
                     "withWarnings": "오류와 함께 생성 실패:",
-                    "retry": "생성 재시도"
+                    "retry": "Work 재시도"
                 },
                 "cancelled": {
                     "title": "생성 취소됨",
                     "description": "이전 생성이 완료 전에 중지되었습니다.",
-                    "restart": "생성 재시작"
+                    "restart": "Work 재시작"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "구성 세부 정보",
-                "initialPrompt": "초기 생성 프롬프트",
+                "initialPrompt": "초기 Worker 프롬프트",
                 "companyDetails": "회사 정보",
                 "companyName": "회사 이름",
                 "companyWebsite": "웹사이트",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "생성",
+                    "generate": "Work",
                     "schedule": "스케줄",
                     "history": "기록",
                     "comparisons": "비교",
-                    "navigationLabel": "생성기 탭"
+                    "navigationLabel": "Worker 탭"
                 },
                 "regenerationWarning": "재생성 경고",
                 "regenerationWarningDescription": "이 워크는 이미 생성되었습니다. 새 생성을 시작하면 기존 항목이 대체됩니다.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "양식 구성 로딩에 실패했습니다",
                 "selectOption": "옵션 선택",
                 "workName": "워크 이름",
-                "generationPrompt": "생성 프롬프트",
+                "generationPrompt": "Worker 프롬프트",
                 "modelOverride": "AI 모델 재정의",
                 "modelOverridePlaceholder": "예: openai/gpt-4.1 또는 openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "선택 사항입니다. 여기에 재정의하지 않으면 기본적으로 가져온 모델 또는 이전 모델을 사용합니다.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "생성하려는 콘텐츠 유형에 대해 구체적으로 설명하세요",
                 "repositoryDescription": "리포지토리 설명",
                 "repositoryPlaceholder": "리포지토리의 간단한 설명 (선택)",
-                "startGeneration": "생성 시작",
+                "startGeneration": "Work 시작",
                 "regenerateItems": "항목 재생성",
                 "updateItems": "생성 실행",
                 "recreateWork": "워크 재생성",
@@ -4702,7 +4702,7 @@
             "work": "워크",
             "overview": "개요",
             "items": "항목",
-            "generator": "생성기",
+            "generator": "Worker",
             "settings": "설정",
             "deploy": "배포",
             "members": "멤버",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1554,7 +1554,7 @@
                 "overview": "Overzicht",
                 "activity": "Activiteit",
                 "items": "Items",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Planning",
                 "history": "Geschiedenis",
                 "comparisons": "Vergelijkingen",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generatie nog niet gestart",
                     "description": "Start met genereren van items voor uw map om deze met inhoud te vullen.",
-                    "action": "Generatie starten"
+                    "action": "Work starten"
                 },
                 "generating": {
                     "title": "Generatie bezig",
@@ -1769,12 +1769,12 @@
                     "title": "Generatie mislukt",
                     "description": "Er is een fout opgetreden tijdens de generatie.",
                     "withWarnings": "Generatie mislukt met fouten:",
-                    "retry": "Generatie opnieuw proberen"
+                    "retry": "Work opnieuw proberen"
                 },
                 "cancelled": {
                     "title": "Generatie geannuleerd",
                     "description": "De vorige generatie is gestopt voordat deze voltooid was.",
-                    "restart": "Generatie herstarten"
+                    "restart": "Work herstarten"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Configuratiedetails",
-                "initialPrompt": "Initiële generatieprompt",
+                "initialPrompt": "Initiële Worker-prompt",
                 "companyDetails": "Bedrijfsgegevens",
                 "companyName": "Bedrijfsnaam",
                 "companyWebsite": "Website",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Genereren",
+                    "generate": "Work",
                     "schedule": "Schema",
                     "history": "Geschiedenis",
                     "comparisons": "Vergelijkingen",
-                    "navigationLabel": "Generator-tabbladen"
+                    "navigationLabel": "Worker-tabbladen"
                 },
                 "regenerationWarning": "Waarschuwing hergeneratie",
                 "regenerationWarningDescription": "Deze map is al gegenereerd. Het starten van een nieuwe generatie zal bestaande items vervangen.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Kon formulierconfiguratie niet laden",
                 "selectOption": "Selecteer een optie",
                 "workName": "Mapnaam",
-                "generationPrompt": "Generatieprompt",
+                "generationPrompt": "Worker-prompt",
                 "modelOverride": "AI-model overschrijven",
                 "modelOverridePlaceholder": "bijv. openai/gpt-4.1 of openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optioneel. Gebruikt standaard het geïmporteerde of vorige model, tenzij je het hier overschrijft.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Wees specifiek over het type content dat je wilt genereren",
                 "repositoryDescription": "Repository-beschrijving",
                 "repositoryPlaceholder": "Korte beschrijving van de repository (optioneel)",
-                "startGeneration": "Generatie starten",
+                "startGeneration": "Work starten",
                 "regenerateItems": "Items opnieuw genereren",
                 "updateItems": "Generatie uitvoeren",
                 "recreateWork": "Map opnieuw aanmaken",
@@ -4702,7 +4702,7 @@
             "work": "Werk",
             "overview": "Overzicht",
             "items": "Items",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Instellingen",
             "deploy": "Deployen",
             "members": "Leden",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1554,7 +1554,7 @@
                 "overview": "Przegląd",
                 "activity": "Aktywność",
                 "items": "Elementy",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Harmonogram",
                 "history": "Historia",
                 "comparisons": "Porównania",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generowanie nie rozpoczęte",
                     "description": "Rozpocznij generowanie elementów dla pracy, aby wypełnić go zawartością.",
-                    "action": "Rozpocznij generowanie"
+                    "action": "Rozpocznij Work"
                 },
                 "generating": {
                     "title": "Generowanie w toku",
@@ -1769,12 +1769,12 @@
                     "title": "Generowanie nie powiodło się",
                     "description": "Wystąpił błąd podczas generowania.",
                     "withWarnings": "Generowanie nie powiodło się z błędami:",
-                    "retry": "Ponów generowanie"
+                    "retry": "Ponów Work"
                 },
                 "cancelled": {
                     "title": "Generowanie anulowane",
                     "description": "Poprzednie generowanie zostało zatrzymane przed ukończeniem.",
-                    "restart": "Uruchom ponownie generowanie"
+                    "restart": "Uruchom ponownie Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Szczegóły konfiguracji",
-                "initialPrompt": "Początkowy prompt generowania",
+                "initialPrompt": "Początkowy prompt Worker",
                 "companyDetails": "Informacje o firmie",
                 "companyName": "Nazwa firmy",
                 "companyWebsite": "Strona internetowa",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generuj",
+                    "generate": "Work",
                     "schedule": "Harmonogram",
                     "history": "Historia",
                     "comparisons": "Porównania",
-                    "navigationLabel": "Zakładki generatora"
+                    "navigationLabel": "Zakładki Worker"
                 },
                 "regenerationWarning": "Ostrzeżenie przed ponowną generacją",
                 "regenerationWarningDescription": "Ten praca został już wygenerowany. Rozpoczęcie nowej generacji zastąpi istniejące elementy.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Nie udało się załadować konfiguracji formularza",
                 "selectOption": "Wybierz opcję",
                 "workName": "Nazwa pracy",
-                "generationPrompt": "Prompt generacji",
+                "generationPrompt": "Prompt Worker",
                 "modelOverride": "Nadpisanie modelu AI",
                 "modelOverridePlaceholder": "np. openai/gpt-4.1 lub openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opcjonalne. Domyślnie używa importowanego lub poprzedniego modelu, chyba że nadpiszesz go tutaj.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Bądź precyzyjny co do typu treści, którą chcesz wygenerować",
                 "repositoryDescription": "Opis repozytorium",
                 "repositoryPlaceholder": "Krótki opis repozytorium (opcjonalnie)",
-                "startGeneration": "Rozpocznij generację",
+                "startGeneration": "Rozpocznij Work",
                 "regenerateItems": "Zregeneruj elementy",
                 "updateItems": "Uruchom generację",
                 "recreateWork": "Odtwórz praca",
@@ -4702,7 +4702,7 @@
             "work": "Praca",
             "overview": "Przegląd",
             "items": "Elementy",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Ustawienia",
             "deploy": "Wdróż",
             "members": "Członkowie",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1554,7 +1554,7 @@
                 "overview": "Visão Geral",
                 "activity": "Atividade",
                 "items": "Itens",
-                "generator": "Gerador",
+                "generator": "Worker",
                 "schedule": "Agendamento",
                 "history": "Histórico",
                 "comparisons": "Comparações",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Geração Não Iniciada",
                     "description": "Inicie a geração de itens para seu trabalho para preenchê-lo com conteúdo.",
-                    "action": "Iniciar Geração"
+                    "action": "Iniciar Work"
                 },
                 "generating": {
                     "title": "Geração em Andamento",
@@ -1769,12 +1769,12 @@
                     "title": "Geração Falhou",
                     "description": "Ocorreu um erro durante a geração.",
                     "withWarnings": "Geração falhou com erros:",
-                    "retry": "Tentar Geração Novamente"
+                    "retry": "Tentar Work Novamente"
                 },
                 "cancelled": {
                     "title": "Geração Cancelada",
                     "description": "A geração anterior foi interrompida antes da conclusão.",
-                    "restart": "Reiniciar Geração"
+                    "restart": "Reiniciar Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Detalhes de Configuração",
-                "initialPrompt": "Prompt Inicial de Geração",
+                "initialPrompt": "Prompt Inicial do Worker",
                 "companyDetails": "Informações da Empresa",
                 "companyName": "Nome da Empresa",
                 "companyWebsite": "Site",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Gerar",
+                    "generate": "Work",
                     "schedule": "Agendar",
                     "history": "Histórico",
                     "comparisons": "Comparações",
-                    "navigationLabel": "Abas do Gerador"
+                    "navigationLabel": "Abas do Worker"
                 },
                 "regenerationWarning": "Aviso de Regeneração",
                 "regenerationWarningDescription": "Este trabalho já foi gerado. Iniciar uma nova geração substituirá os itens existentes.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Falha ao carregar configuração do formulário",
                 "selectOption": "Selecione uma opção",
                 "workName": "Nome do Trabalho",
-                "generationPrompt": "Prompt de Geração",
+                "generationPrompt": "Prompt do Worker",
                 "modelOverride": "Substituição de Modelo de IA",
                 "modelOverridePlaceholder": "ex.: openai/gpt-4.1 ou openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opcional. Usa o modelo importado ou anterior por padrão, a menos que você o substitua aqui.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Seja específico sobre o tipo de conteúdo que deseja gerar",
                 "repositoryDescription": "Descrição do Repositório",
                 "repositoryPlaceholder": "Breve descrição do repositório (opcional)",
-                "startGeneration": "Iniciar Geração",
+                "startGeneration": "Iniciar Work",
                 "regenerateItems": "Regenerar Itens",
                 "updateItems": "Executar Geração",
                 "recreateWork": "Recriar Trabalho",
@@ -4702,7 +4702,7 @@
             "work": "Trabalho",
             "overview": "Visão Geral",
             "items": "Itens",
-            "generator": "Gerador",
+            "generator": "Worker",
             "settings": "Configurações",
             "deploy": "Implantar",
             "members": "Membros",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1554,7 +1554,7 @@
                 "overview": "Обзор",
                 "activity": "Активность",
                 "items": "Элементы",
-                "generator": "Генератор",
+                "generator": "Worker",
                 "schedule": "Расписание",
                 "history": "История",
                 "comparisons": "Сравнения",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Генерация не начата",
                     "description": "Начните генерацию элементов для заполнения работы содержимым.",
-                    "action": "Начать генерацию"
+                    "action": "Начать Work"
                 },
                 "generating": {
                     "title": "Генерация выполняется",
@@ -1769,12 +1769,12 @@
                     "title": "Генерация не удалась",
                     "description": "Во время генерации произошла ошибка.",
                     "withWarnings": "Генерация завершилась ошибками:",
-                    "retry": "Повторить генерацию"
+                    "retry": "Повторить Work"
                 },
                 "cancelled": {
                     "title": "Генерация отменена",
                     "description": "Предыдущая генерация была остановлена до завершения.",
-                    "restart": "Перезапустить генерацию"
+                    "restart": "Перезапустить Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Детали конфигурации",
-                "initialPrompt": "Начальный промпт генерации",
+                "initialPrompt": "Начальный промпт Worker",
                 "companyDetails": "Информация о компании",
                 "companyName": "Название компании",
                 "companyWebsite": "Сайт",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Генерировать",
+                    "generate": "Work",
                     "schedule": "Расписание",
                     "history": "История",
                     "comparisons": "Сравнения",
-                    "navigationLabel": "Вкладки генератора"
+                    "navigationLabel": "Вкладки Worker"
                 },
                 "regenerationWarning": "Предупреждение о регенерации",
                 "regenerationWarningDescription": "Эта работа уже сгенерирована. Запуск новой генерации заменит существующие элементы.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Не удалось загрузить конфигурацию формы",
                 "selectOption": "Выберите вариант",
                 "workName": "Имя работы",
-                "generationPrompt": "Промпт генерации",
+                "generationPrompt": "Промпт Worker",
                 "modelOverride": "Переопределение модели ИИ",
                 "modelOverridePlaceholder": "например, openai/gpt-4.1 или openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Необязательно. По умолчанию используется импортированная или предыдущая модель, если вы не переопределите её здесь.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Будьте конкретны относительно типа контента, который хотите сгенерировать",
                 "repositoryDescription": "Описание репозитория",
                 "repositoryPlaceholder": "Краткое описание репозитория (необязательно)",
-                "startGeneration": "Запустить генерацию",
+                "startGeneration": "Запустить Work",
                 "regenerateItems": "Регенерировать элементы",
                 "updateItems": "Запустить генерацию",
                 "recreateWork": "Пересоздать директорию",
@@ -4702,7 +4702,7 @@
             "work": "Работа",
             "overview": "Обзор",
             "items": "Элементы",
-            "generator": "Генератор",
+            "generator": "Worker",
             "settings": "Настройки",
             "deploy": "Развернуть",
             "members": "Участники",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1554,7 +1554,7 @@
                 "overview": "ภาพรวม",
                 "activity": "กิจกรรม",
                 "items": "รายการ",
-                "generator": "เครื่องสร้าง",
+                "generator": "Worker",
                 "schedule": "กำหนดการ",
                 "history": "ประวัติ",
                 "comparisons": "การเปรียบเทียบ",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "ยังไม่เริ่มการสร้าง",
                     "description": "เริ่มสร้างรายการสำหรับงานของคุณเพื่อเติมเนื้อหา",
-                    "action": "เริ่มการสร้าง"
+                    "action": "เริ่ม Work"
                 },
                 "generating": {
                     "title": "กำลังสร้าง",
@@ -1769,12 +1769,12 @@
                     "title": "การสร้างล้มเหลว",
                     "description": "เกิดข้อผิดพลาดระหว่างการสร้าง",
                     "withWarnings": "การสร้างล้มเหลวพร้อมข้อผิดพลาด:",
-                    "retry": "ลองสร้างใหม่"
+                    "retry": "ลอง Work ใหม่"
                 },
                 "cancelled": {
                     "title": "ยกเลิกการสร้าง",
                     "description": "การสร้างก่อนหน้าถูกหยุดก่อนเสร็จสิ้น",
-                    "restart": "เริ่มการสร้างใหม่"
+                    "restart": "เริ่ม Work ใหม่"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "รายละเอียดการตั้งค่า",
-                "initialPrompt": "พรอมต์การสร้างเริ่มต้น",
+                "initialPrompt": "พรอมต์ Worker เริ่มต้น",
                 "companyDetails": "ข้อมูลบริษัท",
                 "companyName": "ชื่อบริษัท",
                 "companyWebsite": "เว็บไซต์",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "สร้าง",
+                    "generate": "Work",
                     "schedule": "กำหนดการ",
                     "history": "ประวัติ",
                     "comparisons": "การเปรียบเทียบ",
-                    "navigationLabel": "แท็บเครื่องมือสร้าง"
+                    "navigationLabel": "แท็บ Worker"
                 },
                 "regenerationWarning": "คำเตือนการสร้างใหม่",
                 "regenerationWarningDescription": "งานนี้ถูกสร้างแล้ว การเริ่มสร้างใหม่จะแทนที่รายการที่มีอยู่",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "ไม่สามารถโหลดการตั้งค่าฟอร์มได้",
                 "selectOption": "เลือกตัวเลือก",
                 "workName": "ชื่องาน",
-                "generationPrompt": "พรอมต์การสร้าง",
+                "generationPrompt": "พรอมต์ Worker",
                 "modelOverride": "แทนที่โมเดล AI",
                 "modelOverridePlaceholder": "เช่น openai/gpt-4.1 หรือ openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "ไม่บังคับ ใช้โมเดลที่นำเข้าหรือโมเดลก่อนหน้าเป็นค่าเริ่มต้น เว้นแต่จะแทนที่ที่นี่",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "ระบุรายละเอียดเกี่ยวกับประเภทเนื้อหาที่ต้องการสร้าง",
                 "repositoryDescription": "คำอธิบายคลัง",
                 "repositoryPlaceholder": "คำอธิบายสั้น ๆ ของคลัง (ไม่บังคับ)",
-                "startGeneration": "เริ่มสร้าง",
+                "startGeneration": "เริ่ม Work",
                 "regenerateItems": "สร้างรายการใหม่",
                 "updateItems": "เรียกใช้การสร้าง",
                 "recreateWork": "สร้างงานใหม่",
@@ -4702,7 +4702,7 @@
             "work": "งาน",
             "overview": "ภาพรวม",
             "items": "รายการ",
-            "generator": "ตัวสร้าง",
+            "generator": "Worker",
             "settings": "การตั้งค่า",
             "deploy": "เผยแพร่",
             "members": "สมาชิก",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1554,7 +1554,7 @@
                 "overview": "Genel Bakış",
                 "activity": "Etkinlik",
                 "items": "Öğeler",
-                "generator": "Oluşturucu",
+                "generator": "Worker",
                 "schedule": "Program",
                 "history": "Geçmiş",
                 "comparisons": "Karşılaştırmalar",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Oluşturma Başlatılmadı",
                     "description": "İşizi içerikle doldurmak için öğe oluşturmaya başlayın.",
-                    "action": "Oluşturmayı Başlat"
+                    "action": "Work'i Başlat"
                 },
                 "generating": {
                     "title": "Oluşturma Devam Ediyor",
@@ -1769,12 +1769,12 @@
                     "title": "Oluşturma Başarısız",
                     "description": "Oluşturma sırasında bir hata oluştu.",
                     "withWarnings": "Hatalarla başarısız oldu:",
-                    "retry": "Oluşturmayı Tekrar Dene"
+                    "retry": "Work'i Tekrar Dene"
                 },
                 "cancelled": {
                     "title": "Oluşturma İptal Edildi",
                     "description": "Önceki oluşturma tamamlanmadan durduruldu.",
-                    "restart": "Oluşturmayı Yeniden Başlat"
+                    "restart": "Work'i Yeniden Başlat"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Yapılandırma Detayları",
-                "initialPrompt": "İlk Oluşturma İstem",
+                "initialPrompt": "İlk Worker İstemi",
                 "companyDetails": "Şirket Bilgileri",
                 "companyName": "Şirket Adı",
                 "companyWebsite": "Web Sitesi",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Oluştur",
+                    "generate": "Work",
                     "schedule": "Zamanlama",
                     "history": "Geçmiş",
                     "comparisons": "Karşılaştırmalar",
-                    "navigationLabel": "Oluşturucu sekmeleri"
+                    "navigationLabel": "Worker sekmeleri"
                 },
                 "regenerationWarning": "Yeniden Oluşturma Uyarısı",
                 "regenerationWarningDescription": "Bu iş zaten oluşturulmuş. Yeni bir oluşturma başlatmak mevcut öğeleri değiştirecektir.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Form yapılandırması yüklenemedi",
                 "selectOption": "Bir seçenek seçin",
                 "workName": "İş Adı",
-                "generationPrompt": "Oluşturma İstemı",
+                "generationPrompt": "Worker İstemi",
                 "modelOverride": "AI Modeli Geçersiz Kılma",
                 "modelOverridePlaceholder": "ör. openai/gpt-4.1 veya openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "İsteğe bağlı. Burada geçersiz kılmadığınız sürece varsayılan olarak içe aktarılan veya önceki modeli kullanır.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Oluşturmak istediğiniz içerik türünü detaylı belirtin",
                 "repositoryDescription": "Depo Tanımı",
                 "repositoryPlaceholder": "Deponun kısa tanımı (isteğe bağlı)",
-                "startGeneration": "Oluşturmayı Başlat",
+                "startGeneration": "Work'i Başlat",
                 "regenerateItems": "Öğeleri Yeniden Oluştur",
                 "updateItems": "Oluşturmayı Çalıştır",
                 "recreateWork": "İşi Yeniden Oluştur",
@@ -4702,7 +4702,7 @@
             "work": "İş",
             "overview": "Genel Bakış",
             "items": "Öğeler",
-            "generator": "Üretici",
+            "generator": "Worker",
             "settings": "Ayarlar",
             "deploy": "Dağıt",
             "members": "Üyeler",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1554,7 +1554,7 @@
                 "overview": "Огляд",
                 "activity": "Активність",
                 "items": "Елементи",
-                "generator": "Генератор",
+                "generator": "Worker",
                 "schedule": "Розклад",
                 "history": "Історія",
                 "comparisons": "Порівняння",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Генерацію не розпочато",
                     "description": "Розпочніть генерацію елементів для вашого роботау, щоб заповнити його вмістом.",
-                    "action": "Розпочати генерацію"
+                    "action": "Розпочати Work"
                 },
                 "generating": {
                     "title": "Генерація триває",
@@ -1769,12 +1769,12 @@
                     "title": "Генерацію не вдалося завершити",
                     "description": "Під час генерації сталася помилка.",
                     "withWarnings": "Генерацію не вдалося завершити з помилками:",
-                    "retry": "Повторити генерацію"
+                    "retry": "Повторити Work"
                 },
                 "cancelled": {
                     "title": "Генерацію скасовано",
                     "description": "Попередню генерацію зупинено перед завершенням.",
-                    "restart": "Перезапустити генерацію"
+                    "restart": "Перезапустити Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Деталі конфігурації",
-                "initialPrompt": "Початковий запит генерації",
+                "initialPrompt": "Початковий запит Worker",
                 "companyDetails": "Інформація про компанію",
                 "companyName": "Назва компанії",
                 "companyWebsite": "Вебсайт",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Генерувати",
+                    "generate": "Work",
                     "schedule": "Розклад",
                     "history": "Історія",
                     "comparisons": "Порівняння",
-                    "navigationLabel": "Вкладки генератора"
+                    "navigationLabel": "Вкладки Worker"
                 },
                 "regenerationWarning": "Попередження про регенерацію",
                 "regenerationWarningDescription": "Цей робота уже згенеровано. Запуск нової генерації замінить існуючі елементи.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Не вдалося завантажити конфігурацію форми",
                 "selectOption": "Виберіть опцію",
                 "workName": "Назва роботау",
-                "generationPrompt": "Запит генерації",
+                "generationPrompt": "Запит Worker",
                 "modelOverride": "Перевизначення моделі ШІ",
                 "modelOverridePlaceholder": "наприклад openai/gpt-4.1 або openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Необов’язково. За замовчуванням використовує імпортовану або попередню модель, доки ви не перевизначите її тут.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Будьте конкретними щодо типу контенту, який ви хочете згенерувати",
                 "repositoryDescription": "Опис репозиторію",
                 "repositoryPlaceholder": "Короткий опис репозиторію (необов'язково)",
-                "startGeneration": "Розпочати генерацію",
+                "startGeneration": "Розпочати Work",
                 "regenerateItems": "Регенерувати елементи",
                 "updateItems": "Запустити генерацію",
                 "recreateWork": "Перестворити робота",
@@ -4702,7 +4702,7 @@
             "work": "Робота",
             "overview": "Огляд",
             "items": "Елементи",
-            "generator": "Генератор",
+            "generator": "Worker",
             "settings": "Налаштування",
             "deploy": "Розгорнути",
             "members": "Учасники",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1554,7 +1554,7 @@
                 "overview": "Tổng quan",
                 "activity": "Hoạt động",
                 "items": "Mục",
-                "generator": "Trình tạo",
+                "generator": "Worker",
                 "schedule": "Lịch trình",
                 "history": "Lịch sử",
                 "comparisons": "So sánh",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Chưa bắt đầu tạo",
                     "description": "Bắt đầu tạo mục cho công việc của bạn để điền nội dung.",
-                    "action": "Bắt đầu tạo"
+                    "action": "Bắt đầu Work"
                 },
                 "generating": {
                     "title": "Đang tạo",
@@ -1769,12 +1769,12 @@
                     "title": "Tạo thất bại",
                     "description": "Có lỗi xảy ra trong quá trình tạo.",
                     "withWarnings": "Tạo thất bại kèm lỗi:",
-                    "retry": "Thử lại tạo"
+                    "retry": "Thử lại Work"
                 },
                 "cancelled": {
                     "title": "Tạo đã hủy",
                     "description": "Lần tạo trước đã bị dừng trước khi hoàn tất.",
-                    "restart": "Khởi động lại tạo"
+                    "restart": "Khởi động lại Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Chi tiết cấu hình",
-                "initialPrompt": "Lời nhắc tạo ban đầu",
+                "initialPrompt": "Lời nhắc Worker ban đầu",
                 "companyDetails": "Thông tin công ty",
                 "companyName": "Tên công ty",
                 "companyWebsite": "Trang web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Tạo",
+                    "generate": "Work",
                     "schedule": "Lập lịch",
                     "history": "Lịch sử",
                     "comparisons": "So sánh",
-                    "navigationLabel": "Tab Trình tạo"
+                    "navigationLabel": "Tab Worker"
                 },
                 "regenerationWarning": "Cảnh báo Tái tạo",
                 "regenerationWarningDescription": "Công việc này đã được tạo. Bắt đầu tạo mới sẽ thay thế các mục hiện có.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Không thể tải cấu hình biểu mẫu",
                 "selectOption": "Chọn một tùy chọn",
                 "workName": "Tên Công việc",
-                "generationPrompt": "Prompt Tạo",
+                "generationPrompt": "Prompt Worker",
                 "modelOverride": "Ghi đè mô hình AI",
                 "modelOverridePlaceholder": "ví dụ: openai/gpt-4.1 hoặc openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Tùy chọn. Mặc định sử dụng mô hình đã nhập hoặc mô hình trước đó trừ khi bạn ghi đè ở đây.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Hãy cụ thể về loại nội dung bạn muốn tạo",
                 "repositoryDescription": "Mô tả Kho",
                 "repositoryPlaceholder": "Mô tả ngắn gọn về kho (tùy chọn)",
-                "startGeneration": "Bắt đầu Tạo",
+                "startGeneration": "Bắt đầu Work",
                 "regenerateItems": "Tái tạo Mục",
                 "updateItems": "Chạy Tạo",
                 "recreateWork": "Tái tạo Công việc",
@@ -4702,7 +4702,7 @@
             "work": "Công việc",
             "overview": "Tổng quan",
             "items": "Mục",
-            "generator": "Trình tạo",
+            "generator": "Worker",
             "settings": "Cài đặt",
             "deploy": "Triển khai",
             "members": "Thành viên",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1554,7 +1554,7 @@
                 "overview": "概览",
                 "activity": "活动",
                 "items": "项目",
-                "generator": "生成器",
+                "generator": "Worker",
                 "schedule": "计划",
                 "history": "历史记录",
                 "comparisons": "比较",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "生成未开始",
                     "description": "启动生成项目以用内容填充您的作品。",
-                    "action": "开始生成"
+                    "action": "开始 Work"
                 },
                 "generating": {
                     "title": "生成中",
@@ -1769,12 +1769,12 @@
                     "title": "生成失败",
                     "description": "生成过程中发生错误。",
                     "withWarnings": "生成失败，错误如下：",
-                    "retry": "重试生成"
+                    "retry": "重试 Work"
                 },
                 "cancelled": {
                     "title": "生成已取消",
                     "description": "先前的生成在完成前被停止。",
-                    "restart": "重新启动生成"
+                    "restart": "重新启动 Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "配置详情",
-                "initialPrompt": "初始生成提示",
+                "initialPrompt": "初始 Worker 提示",
                 "companyDetails": "公司信息",
                 "companyName": "公司名称",
                 "companyWebsite": "网站",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "生成",
+                    "generate": "Work",
                     "schedule": "计划",
                     "history": "历史",
                     "comparisons": "比较",
-                    "navigationLabel": "生成器选项卡"
+                    "navigationLabel": "Worker 选项卡"
                 },
                 "regenerationWarning": "重新生成警告",
                 "regenerationWarningDescription": "此作品已生成。启动新生成将替换现有项目。",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "加载表单配置失败",
                 "selectOption": "选择选项",
                 "workName": "作品名称",
-                "generationPrompt": "生成提示",
+                "generationPrompt": "Worker 提示",
                 "modelOverride": "AI 模型覆盖",
                 "modelOverridePlaceholder": "例如 openai/gpt-4.1 或 openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "可选。默认使用导入或之前的模型，除非在此处覆盖。",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "具体说明您想要生成的内容类型",
                 "repositoryDescription": "仓库描述",
                 "repositoryPlaceholder": "仓库的简要描述（可选）",
-                "startGeneration": "开始生成",
+                "startGeneration": "开始 Work",
                 "regenerateItems": "重新生成项目",
                 "updateItems": "运行生成",
                 "recreateWork": "重新创建作品",
@@ -4702,7 +4702,7 @@
             "work": "作品",
             "overview": "概览",
             "items": "项目",
-            "generator": "生成器",
+            "generator": "Worker",
             "settings": "设置",
             "deploy": "部署",
             "members": "成员",

--- a/docs/web-dashboard/work-detail-components.md
+++ b/docs/web-dashboard/work-detail-components.md
@@ -144,7 +144,7 @@ Renders a horizontal tab navigation bar. Each tab is a link that navigates to a 
 | ------------- | ----------- | ------------------------------------- |
 | `overview`    | Overview    | Always                                |
 | `items`       | Items       | Always                                |
-| `generator`   | Generator   | Always                                |
+| `generator`   | Worker      | Always                                |
 | `schedule`    | Schedule    | Always                                |
 | `history`     | History     | Always                                |
 | `comparisons` | Comparisons | Always                                |

--- a/docs/web-dashboard/work-pages.md
+++ b/docs/web-dashboard/work-pages.md
@@ -98,7 +98,7 @@ The detail layout wraps all sub-pages with shared navigation:
 | ----------- | ------------------------- | ---------------------------- |
 | Overview    | `/works/[id]`             | Work stats and quick actions |
 | Items       | `/works/[id]/items`       | Manage work items            |
-| Generator   | `/works/[id]/generator`   | Run item generation          |
+| Worker      | `/works/[id]/generator`   | Run item generation          |
 | Comparisons | `/works/[id]/comparisons` | Item comparison pages        |
 | History     | `/works/[id]/history`     | Generation run history       |
 | Members     | `/works/[id]/members`     | Team access management       |


### PR DESCRIPTION
Renames the user-facing **Generator** concept to **Worker** across the platform UI. Scope: **UI strings (all 21 locales) + doc UI labels only** — backend/API symbols, routes (`/generator`), components (`GeneratorForm`), spec-feature names (`website-generator`, `data-generator`, …), and agent-pipeline component names keep "Generator" (out of scope).

## Locale changes (21 files, 10 keys each)
"Work" / "Worker" are kept as **English brand tokens** in every locale, matching the existing convention where `Work` is already left untranslated everywhere.

| Key | Before (en) | After (en) | Token |
| --- | --- | --- | --- |
| `dashboard.workDetail.tabs.generator` | Generator | **Worker** | feature name |
| `metadata.pages.generator` | Generator | **Worker** | feature name |
| `generator.tabs.navigationLabel` | Generator tabs | **Worker tabs** | feature name |
| `generator.generationPrompt` | Generation Prompt | **Worker Prompt** | feature config |
| `config.initialPrompt` | Initial Generation Prompt | **Initial Worker Prompt** | feature config |
| `generator.tabs.generate` | Generate | **Work** | action |
| `statusCard.notStarted.action` / `generator.startGeneration` | Start Generation | **Start Work** | action |
| `statusCard.error.retry` | Retry Generation | **Retry Work** | action |
| `statusCard.cancelled.restart` | Restart Generation | **Restart Work** | action |

Localized verbs/word order are preserved (e.g. de `Generierung starten` → `Work starten`; ru `Повторить генерацию` → `Повторить Work`; ar `بدء التوليد` → `بدء الـWork`).

## Docs (2 files)
Tab-label cells updated to match the UI (`Generator` → `Worker`) in `work-pages.md` and `work-detail-components.md`; route `/works/[id]/generator` and tab id `generator` retained.

## Deliberately NOT changed
- The literal verb "generate / generation" for the act of producing items (e.g. "Run item generation", "Target number of new items to generate").
- The comparisons "Generate" button (different feature).
- Any JSON keys, code symbols, routes, packages, or backend pipeline component names.

All 21 JSON files re-parsed and verified post-edit; per-locale formatting and line endings preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated UI terminology across all supported languages, replacing "Generator/Generation" with "Worker/Work" in tabs, action buttons (start, retry, restart), and prompt labels.

* **Documentation**
  * Updated component and navigation documentation to reflect the new "Worker" terminology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->