### PR TITLE
fix(web): chip row pans via transform — no native scrolling

### DIFF
--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -2,29 +2,29 @@
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { cn } from '@/lib/utils/cn';
 
 /**
- * Horizontally-scrollable chip row for the dashboard prompt surfaces
- * (`/new`, `/works/new`). Mirrors the marketing site's
- * `GenerationTypeChips` (see
- * `Ever Works/Code/website/packages/web/components/global/
- * GenerationTypeChips.tsx`) so the dashboard and landing pages share
- * the same chip behavior:
+ * Arrow-paged chip row for the dashboard prompt surfaces (`/new`,
+ * `/works/new`, `/works`).
  *
- *   - Chips overflow horizontally instead of wrapping to a second row.
- *   - Mouse-friendly ◀ / ▶ buttons appear when the row overflows; the
- *     buttons disable themselves at the start / end so they always
- *     reflect what's actually scrollable.
- *   - Edge gradient fades make the chips appear to slide under the
- *     buttons.
- *   - Trackpad + touch swipe still work — the scroll position drives
- *     the button enabled state through a `ResizeObserver` and a
- *     passive scroll listener.
+ * Behavior:
+ *   - Chips never wrap to a second row. When the row's natural width
+ *     exceeds the container, ◀ / ▶ buttons appear on the side that
+ *     has hidden chips; the buttons disable themselves at the start /
+ *     end so they always reflect what's actually pannable.
+ *   - Edge gradient fades make the hidden chips appear to slide under
+ *     the buttons.
+ *   - There is **no native scrolling** — the container uses
+ *     `overflow-hidden` and the inner track is panned via
+ *     `transform: translateX(...)` controlled by React state. Trackpad
+ *     swipes, touch gestures, and mousewheel cannot move the chips;
+ *     only the arrow buttons do. Keyboard arrow keys on a focused chip
+ *     fall back to the browser's default behavior.
  *   - `comingSoon` chips render as inert `<span>`s with a "SOON" badge
- *     (matching the marketing site) so the chip catalog can telegraph
- *     upcoming kinds without making them clickable.
+ *     so the catalog can telegraph upcoming kinds without making them
+ *     clickable.
  */
 export interface PromptChip<TValue extends string = string> {
     readonly value: TValue;
@@ -51,6 +51,9 @@ export interface PromptChipsRowProps<TValue extends string = string> {
     readonly className?: string;
 }
 
+/** How far one click of ◀ / ▶ pans the track, in CSS pixels. */
+const STEP = 220;
+
 export function PromptChipsRow<TValue extends string = string>({
     chips,
     value,
@@ -59,36 +62,55 @@ export function PromptChipsRow<TValue extends string = string>({
     testIdPrefix,
     className,
 }: PromptChipsRowProps<TValue>) {
-    const scrollerRef = useRef<HTMLDivElement | null>(null);
-    const [overflowing, setOverflowing] = useState(false);
-    const [atStart, setAtStart] = useState(true);
-    const [atEnd, setAtEnd] = useState(false);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const trackRef = useRef<HTMLDivElement | null>(null);
 
-    const measure = useCallback(() => {
-        const el = scrollerRef.current;
-        if (!el) return;
-        const overflows = el.scrollWidth > el.clientWidth + 1;
-        setOverflowing(overflows);
-        setAtStart(el.scrollLeft <= 1);
-        setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
-    }, []);
+    const [offset, setOffset] = useState(0);
+    const [containerWidth, setContainerWidth] = useState(0);
+    const [trackWidth, setTrackWidth] = useState(0);
 
+    // ResizeObserver on both the container (its width changes when the
+    // chat panel opens/closes) and the track (its width changes when
+    // the chips array changes language / coming-soon set). Either one
+    // changing means we need to re-clamp the offset.
     useEffect(() => {
-        const el = scrollerRef.current;
-        if (!el) return;
-        measure();
-        const ro = new ResizeObserver(measure);
-        ro.observe(el);
-        el.addEventListener('scroll', measure, { passive: true });
-        return () => {
-            ro.disconnect();
-            el.removeEventListener('scroll', measure);
-        };
-    }, [measure]);
+        const container = containerRef.current;
+        const track = trackRef.current;
+        if (!container || !track) return;
 
-    const scrollBy = (delta: number) => {
-        scrollerRef.current?.scrollBy({ left: delta, behavior: 'smooth' });
-    };
+        const measure = () => {
+            setContainerWidth(container.clientWidth);
+            setTrackWidth(track.scrollWidth);
+        };
+        measure();
+
+        const ro = new ResizeObserver(measure);
+        ro.observe(container);
+        ro.observe(track);
+        return () => ro.disconnect();
+    }, [chips]);
+
+    const maxOffset = Math.max(0, trackWidth - containerWidth);
+
+    // Clamp `offset` whenever the track or container resizes. Without
+    // this, shrinking the viewport when the row is already panned to
+    // the right leaves a visible empty gap on the right edge.
+    useEffect(() => {
+        setOffset((prev) => Math.min(prev, maxOffset));
+    }, [maxOffset]);
+
+    const overflowing = trackWidth > containerWidth + 1;
+    const atStart = offset <= 0;
+    const atEnd = offset >= maxOffset - 1;
+
+    const panBy = useCallback(
+        (delta: number) => {
+            setOffset((prev) => Math.max(0, Math.min(maxOffset, prev + delta)));
+        },
+        [maxOffset],
+    );
+
+    const trackStyle = useMemo(() => ({ transform: `translate3d(${-offset}px, 0, 0)` }), [offset]);
 
     return (
         <div className={cn('relative w-full', className)}>
@@ -100,8 +122,8 @@ export function PromptChipsRow<TValue extends string = string>({
                     />
                     <button
                         type="button"
-                        onClick={() => scrollBy(-220)}
-                        aria-label="Scroll chips left"
+                        onClick={() => panBy(-STEP)}
+                        aria-label="Show previous chips"
                         className="absolute left-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
                         data-testid={testIdPrefix ? `${testIdPrefix}-scroll-left` : undefined}
                     >
@@ -111,25 +133,11 @@ export function PromptChipsRow<TValue extends string = string>({
             ) : null}
 
             <div
-                ref={scrollerRef}
-                role="listbox"
-                aria-label={ariaLabel}
-                data-testid={testIdPrefix ? `${testIdPrefix}-chips` : undefined}
+                ref={containerRef}
                 className={cn(
-                    'flex gap-2 overflow-x-auto overscroll-x-contain scroll-smooth py-1',
-                    // Hide native scrollbar across browsers (Firefox uses
-                    // `scrollbar-width`, WebKit/Chromium uses the
-                    // `::-webkit-scrollbar` pseudo). Without both, some
-                    // users still see a horizontal scrollbar even though
-                    // the explicit ◀ / ▶ buttons are the intended
-                    // affordance.
-                    '[scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
+                    'overflow-hidden py-1',
                     // Asymmetric padding — only reserve room for an arrow
                     // button on the side that's currently showing one.
-                    // Without this, the first chip ("Mission") looked like
-                    // it had stray left padding when the row was scrolled
-                    // to the start: the left button was hidden but the
-                    // padding was still applied.
                     !overflowing && 'px-1',
                     overflowing && !atStart && 'pl-10',
                     overflowing && atStart && 'pl-1',
@@ -137,57 +145,67 @@ export function PromptChipsRow<TValue extends string = string>({
                     overflowing && atEnd && 'pr-1',
                 )}
             >
-                {chips.map((c) => {
-                    const { Icon } = c;
-                    if (c.comingSoon) {
+                <div
+                    ref={trackRef}
+                    role="listbox"
+                    aria-label={ariaLabel}
+                    data-testid={testIdPrefix ? `${testIdPrefix}-chips` : undefined}
+                    style={trackStyle}
+                    className="flex w-max gap-2 transition-transform duration-200 ease-out will-change-transform"
+                >
+                    {chips.map((c) => {
+                        const { Icon } = c;
+                        if (c.comingSoon) {
+                            return (
+                                <span
+                                    key={c.value}
+                                    role="option"
+                                    aria-disabled="true"
+                                    aria-selected="false"
+                                    title="Coming soon"
+                                    className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-sm border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
+                                    data-testid={
+                                        testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
+                                    }
+                                >
+                                    <Icon className="size-3.5 opacity-70" aria-hidden="true" />
+                                    <span className="whitespace-nowrap">{c.label}</span>
+                                    <span
+                                        aria-label="Coming soon"
+                                        className="ml-1 rounded-full bg-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted dark:bg-white/10 dark:text-text-muted-dark"
+                                    >
+                                        Soon
+                                    </span>
+                                </span>
+                            );
+                        }
+                        const selected = value === c.value;
                         return (
-                            <span
+                            <button
                                 key={c.value}
+                                type="button"
                                 role="option"
-                                aria-disabled="true"
-                                aria-selected="false"
-                                title="Coming soon"
-                                className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-sm border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
+                                aria-selected={selected}
+                                // role="option" doesn't support aria-pressed
+                                // (jsx-a11y/role-supports-aria-props). aria-selected
+                                // is the right toggle state inside a listbox.
+                                onClick={() => onChange(selected ? null : c.value)}
                                 data-testid={
                                     testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
                                 }
+                                className={cn(
+                                    'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                    selected
+                                        ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
+                                        : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
+                                )}
                             >
-                                <Icon className="size-3.5 opacity-70" aria-hidden="true" />
-                                <span className="whitespace-nowrap">{c.label}</span>
-                                <span
-                                    aria-label="Coming soon"
-                                    className="ml-1 rounded-full bg-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted dark:bg-white/10 dark:text-text-muted-dark"
-                                >
-                                    Soon
-                                </span>
-                            </span>
+                                <Icon className="size-3.5" aria-hidden="true" />
+                                {c.label}
+                            </button>
                         );
-                    }
-                    const selected = value === c.value;
-                    return (
-                        <button
-                            key={c.value}
-                            type="button"
-                            role="option"
-                            aria-selected={selected}
-                            // role="option" doesn't support aria-pressed
-                            // (jsx-a11y/role-supports-aria-props). aria-selected
-                            // is the right toggle state inside a listbox; tests
-                            // querying by `[aria-selected]` get the live chips.
-                            onClick={() => onChange(selected ? null : c.value)}
-                            data-testid={testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined}
-                            className={cn(
-                                'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
-                                selected
-                                    ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
-                                    : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
-                            )}
-                        >
-                            <Icon className="size-3.5" aria-hidden="true" />
-                            {c.label}
-                        </button>
-                    );
-                })}
+                    })}
+                </div>
             </div>
 
             {overflowing && !atEnd ? (
@@ -198,8 +216,8 @@ export function PromptChipsRow<TValue extends string = string>({
                     />
                     <button
                         type="button"
-                        onClick={() => scrollBy(220)}
-                        aria-label="Scroll chips right"
+                        onClick={() => panBy(STEP)}
+                        aria-label="Show next chips"
                         className="absolute right-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
                         data-testid={testIdPrefix ? `${testIdPrefix}-scroll-right` : undefined}
                     >

--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -54,6 +54,22 @@ export interface PromptChipsRowProps<TValue extends string = string> {
 /** How far one click of ◀ / ▶ pans the track, in CSS pixels. */
 const STEP = 220;
 
+/**
+ * Total horizontal padding in the container when the row is panned to
+ * either boundary (atStart: `pl-1 pr-10` = 4 + 40 = 44; atEnd:
+ * `pl-10 pr-1` = 40 + 4 = 44). Used to compute `maxOffset` so the
+ * last chip's right edge can fully reach the visible area when the
+ * user clicks ▶ all the way — without this, `maxOffset` underestimates
+ * by `PADDING_AT_BOUNDARY` and `atEnd` triggers ~40px early (Codex P2
+ * on PR #1069).
+ */
+const PADDING_AT_BOUNDARY = 44;
+
+/** Padding values that match the Tailwind classes below. Pixel-perfect
+ *  mirrors of `pl-1 = 4`, `pl-10 = 40`, etc. */
+const PADDING_LARGE = 40; // pl-10 / pr-10
+const PADDING_SMALL = 4; // pl-1 / pr-1
+
 export function PromptChipsRow<TValue extends string = string>({
     chips,
     value,
@@ -90,7 +106,16 @@ export function PromptChipsRow<TValue extends string = string>({
         return () => ro.disconnect();
     }, [chips]);
 
-    const maxOffset = Math.max(0, trackWidth - containerWidth);
+    // `clientWidth` includes the container's padding. When the user has
+    // panned away from the start, that padding is `pl-10 pr-10` (80px
+    // total); at the boundaries it's `pl-1 pr-10` or `pl-10 pr-1`
+    // (44px total). The chip area visible to the user is therefore
+    // `clientWidth - totalPadding`. The largest valid `offset` keeps
+    // the last chip's right edge aligned with the inner right padding
+    // when atEnd, which is `trackWidth - (containerWidth - 44)`.
+    // (Codex P2 on PR #1069 — the previous `trackWidth - containerWidth`
+    // formula clipped the last ~44px of chips before atEnd flipped.)
+    const maxOffset = Math.max(0, trackWidth - containerWidth + PADDING_AT_BOUNDARY);
 
     // Clamp `offset` whenever the track or container resizes. Without
     // this, shrinking the viewport when the row is already panned to
@@ -108,6 +133,45 @@ export function PromptChipsRow<TValue extends string = string>({
             setOffset((prev) => Math.max(0, Math.min(maxOffset, prev + delta)));
         },
         [maxOffset],
+    );
+
+    /**
+     * Keyboard accessibility — pan the track so a newly-focused chip is
+     * fully visible. With the transform-based pan replacing the native
+     * scroller (PR #1069), the browser no longer scrolls hidden chip
+     * buttons into view when Tab focus advances. Codex P2 on PR #1069:
+     * without this, a keyboard user can tab to off-screen options with
+     * no visible focus indicator.
+     *
+     * Uses `getBoundingClientRect` for absolute position comparison —
+     * dodges the question of which element is the focused chip's
+     * `offsetParent` (it depends on `position` on ancestors).
+     */
+    const ensureChipVisible = useCallback(
+        (buttonEl: HTMLElement) => {
+            const container = containerRef.current;
+            if (!container) return;
+
+            const containerRect = container.getBoundingClientRect();
+            const buttonRect = buttonEl.getBoundingClientRect();
+
+            // Visible chip window: container interior minus arrow
+            // gutters. The gutter is `PADDING_LARGE` on the side that
+            // has a button and `PADDING_SMALL` on the side that doesn't.
+            const leftGutter = atStart ? PADDING_SMALL : PADDING_LARGE;
+            const rightGutter = atEnd ? PADDING_SMALL : PADDING_LARGE;
+            const visibleStart = containerRect.left + leftGutter;
+            const visibleEnd = containerRect.right - rightGutter;
+
+            if (buttonRect.left < visibleStart) {
+                const delta = buttonRect.left - visibleStart; // negative
+                setOffset((prev) => Math.max(0, prev + delta));
+            } else if (buttonRect.right > visibleEnd) {
+                const delta = buttonRect.right - visibleEnd; // positive
+                setOffset((prev) => Math.min(maxOffset, prev + delta));
+            }
+        },
+        [atStart, atEnd, maxOffset],
     );
 
     const trackStyle = useMemo(() => ({ transform: `translate3d(${-offset}px, 0, 0)` }), [offset]);
@@ -190,6 +254,13 @@ export function PromptChipsRow<TValue extends string = string>({
                                 // (jsx-a11y/role-supports-aria-props). aria-selected
                                 // is the right toggle state inside a listbox.
                                 onClick={() => onChange(selected ? null : c.value)}
+                                // Keyboard accessibility: when Tab moves focus
+                                // to a chip that's currently panned off-screen,
+                                // pan the track so the focused chip is in
+                                // view. Native scrolling used to handle this
+                                // automatically; the transform-based pan does
+                                // not, so we wire it explicitly.
+                                onFocus={(e) => ensureChipVisible(e.currentTarget)}
                                 data-testid={
                                     testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
                                 }


### PR DESCRIPTION
## Summary

User feedback: \`/new\` chip row still allowed trackpad / touch / wheel scrolling even though [PR #1054](https://github.com/ever-works/ever-works/pull/1054) had hidden the scrollbar visually and added ◀ / ▶ arrow buttons. The intent was arrows-only; the implementation kept native scrolling silently enabled.

## What changed

\`apps/web/src/components/common/PromptChipsRow.tsx\` — switch from native scroll to a CSS-transform pan:

- Container is \`overflow-hidden\` (was \`overflow-x-auto\`) — there is no scrollable overflow, so trackpad / touch / wheel cannot move the chips.
- Inner track is a \`flex w-max\` row with \`transform: translate3d(-offset, 0, 0)\`.
- \`offset\` is React state, mutated only by the ◀ / ▶ click handlers (\`panBy(±220)\`), clamped to \`[0, trackWidth - containerWidth]\`.
- \`ResizeObserver\` watches both the container and the track so the row recalculates when the chat panel opens/closes or the chips list changes (i18n / coming-soon).
- \`transition-transform duration-200 ease-out\` preserves the smooth feel the old \`scroll-smooth\` had.

Same \`data-testid\` hooks kept (\`-scroll-left\`, \`-scroll-right\`, \`-chips\`) so existing tests + selectors keep working.

## Test plan

- [ ] NewPageClient unit tests pass (13/13 locally).
- [ ] \`/new\` chip row: no horizontal scroll on trackpad two-finger swipe, mouse-wheel, shift-wheel, or touch drag.
- [ ] Arrow buttons appear only on the side that has hidden chips; disabled at start / end.
- [ ] Clicking ▶ → ◀ toggles correctly without jumping.
- [ ] Resizing the viewport (or opening the chat panel) re-clamps the offset so no empty right-edge gap appears.
- [ ] \`/works/new\` and \`/works\` chip rows (same component) behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chips row navigation with arrow buttons for better accessibility and keyboard support.
  * Enhanced chip visibility when using keyboard navigation to ensure focused chips remain in view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->