### PR TITLE
chore(release): cascade develop → stage (chip row no-scroll + tenants 10 + Worker rename)

### DIFF
--- a/apps/api/src/organizations/__tests__/organization.service.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization.service.spec.ts
@@ -318,4 +318,139 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
             expect(usernameAllocator.suggest).toHaveBeenCalledWith('alice');
         });
     });
+
+    /**
+     * EW-662 (Phase 10) — Register-Company sub-flow tests.
+     *
+     * Both `registerCompany` and `createOrganizationFromCompanyWork` end
+     * up calling `createOrganization` with a populated `extra` field;
+     * we assert the resulting Org row carries the right registration
+     * metadata (provider, status, legalName, countryCode, linkedWorkId).
+     */
+    describe('registerCompany (EW-662 Phase 10)', () => {
+        it('rejects empty name with ConflictException', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+            await expect(service.registerCompany('u-1', { name: '' })).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            await expect(service.registerCompany('u-1', { name: '   ' })).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('creates Org with manual provider + registered status + supplied metadata', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.registerCompany('u-1', {
+                name: 'Acme Inc.',
+                countryCode: 'US',
+                legalName: 'Acme, Inc.',
+            })) as unknown as {
+                id: string;
+                slug: string;
+                legalName: string;
+                countryCode: string;
+                registrationProvider: string;
+                registrationStatus: string;
+                linkedWorkId: string | null;
+            };
+
+            expect(org.id).toBe('o-new');
+            expect(org.legalName).toBe('Acme, Inc.');
+            expect(org.countryCode).toBe('US');
+            expect(org.registrationProvider).toBe('manual');
+            expect(org.registrationStatus).toBe('registered');
+            // No backing Work in the manual-completion path — linkedWorkId stays null.
+            expect(org.linkedWorkId).toBeNull();
+        });
+
+        it('defaults legalName to the trimmed name when caller omits it', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.registerCompany('u-1', {
+                name: '  Globex Holdings  ',
+            })) as unknown as { legalName: string };
+
+            expect(org.legalName).toBe('Globex Holdings');
+        });
+
+        it('passes a slugOverride straight through to the allocator', async () => {
+            const { service, usernameAllocator } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            await service.registerCompany('u-1', {
+                name: 'Acme Inc.',
+                slugOverride: 'acme-corp',
+            });
+
+            expect(usernameAllocator.allocateUsername).toHaveBeenCalledWith('acme-corp');
+        });
+    });
+
+    describe('createOrganizationFromCompanyWork (EW-662 Phase 10)', () => {
+        it('sets linkedWorkId + uses Work.companyName when present', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.createOrganizationFromCompanyWork(
+                'u-1',
+                {
+                    id: 'w-42',
+                    name: 'acme-website',
+                    companyName: 'Acme Inc.',
+                    companyWebsite: 'https://acme.example',
+                },
+                { countryCode: 'DE' },
+            )) as unknown as {
+                id: string;
+                linkedWorkId: string | null;
+                legalName: string;
+                countryCode: string;
+                registrationProvider: string;
+                registrationStatus: string;
+            };
+
+            expect(org.linkedWorkId).toBe('w-42');
+            expect(org.legalName).toBe('Acme Inc.');
+            expect(org.countryCode).toBe('DE');
+            expect(org.registrationProvider).toBe('manual');
+            expect(org.registrationStatus).toBe('registered');
+        });
+
+        it('falls back to Work.name when companyName is missing', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            const org = (await service.createOrganizationFromCompanyWork('u-1', {
+                id: 'w-7',
+                name: 'Initech',
+            })) as unknown as { linkedWorkId: string; legalName: string };
+
+            expect(org.linkedWorkId).toBe('w-7');
+            // No companyName + no override → legalName defaults to the
+            // (trimmed) display name. This matches `registerCompany`'s
+            // own fallback so the v1 manual-completion path always ends
+            // up with a non-null legalName.
+            expect(org.legalName).toBe('Initech');
+        });
+
+        it('throws ConflictException when the Work has no usable name', async () => {
+            const { service } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: null },
+            });
+
+            await expect(
+                service.createOrganizationFromCompanyWork('u-1', { id: 'w-x', name: '' }),
+            ).rejects.toBeInstanceOf(ConflictException);
+        });
+    });
 });

--- a/apps/api/src/organizations/dto/register-company.dto.ts
+++ b/apps/api/src/organizations/dto/register-company.dto.ts
@@ -1,0 +1,62 @@
+import { IsOptional, IsString, Length, Matches } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — body for
+ * `POST /api/organizations/register-company`.
+ *
+ * Mirrors the chip-driven Register-Company form on `+ New` (the
+ * "Company" chip). All fields except `name` are optional; the
+ * Stripe-Atlas integration is deferred to a later phase, so v1
+ * lands the Org with `registrationProvider = 'manual'` and
+ * `registrationStatus = 'registered'` regardless of what the
+ * client passes (the service hard-codes those, this DTO only
+ * captures the user-supplied bits).
+ */
+export class RegisterCompanyDto {
+    @ApiProperty({
+        description: 'Display name for the Company. 1-200 chars.',
+        example: 'Acme Inc.',
+        minLength: 1,
+        maxLength: 200,
+    })
+    @IsString()
+    @Length(1, 200)
+    name!: string;
+
+    @ApiPropertyOptional({
+        description: 'Registered legal name (defaults to `name` if omitted).',
+        example: 'Acme, Inc.',
+        maxLength: 200,
+    })
+    @IsOptional()
+    @IsString()
+    @Length(1, 200)
+    legalName?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'ISO 3166-1 alpha-2 country code (e.g. "US", "DE"). Used by the registration provider to pick the right entity-formation pipeline.',
+        example: 'US',
+        minLength: 2,
+        maxLength: 2,
+    })
+    @IsOptional()
+    @IsString()
+    @Matches(/^[A-Za-z]{2}$/, {
+        message: 'countryCode must be a 2-letter ISO 3166-1 alpha-2 code',
+    })
+    countryCode?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Optional slug override. If omitted, allocated from `name` via UsernameAllocatorService.',
+        example: 'acme',
+        minLength: 1,
+        maxLength: 64,
+    })
+    @IsOptional()
+    @IsString()
+    @Length(1, 64)
+    slug?: string;
+}

--- a/apps/api/src/organizations/organization.service.ts
+++ b/apps/api/src/organizations/organization.service.ts
@@ -8,7 +8,11 @@ import {
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { OrganizationRepository, UserRepository } from '@ever-works/agent/database';
-import type { Organization } from '@ever-works/agent/entities';
+import type {
+    Organization,
+    OrganizationRegistrationProvider,
+    OrganizationRegistrationStatus,
+} from '@ever-works/agent/entities';
 import { UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS } from '@ever-works/contracts/api';
 import { UsernameAllocatorService } from '../users/services/username-allocator.service';
 import { TenantBootstrapService } from '../scope/tenant-bootstrap.service';
@@ -131,11 +135,26 @@ export class OrganizationService {
      * outside the txn because it's idempotent (the
      * `tenants.ownerUserId UNIQUE` constraint catches racers), but
      * the rest must be atomic.
+     *
+     * EW-662 (Phase 10) added the optional `extra` parameter so the
+     * Register-Company path ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company))
+     * can persist `legalName`, `countryCode`, `registrationProvider`,
+     * `registrationStatus`, and `linkedWorkId` in the same atomic
+     * insert. All `extra` fields default to NULL / `'draft'` if
+     * omitted, so the existing Phase 6/9 Settings + Switcher callers
+     * keep behaving exactly as before.
      */
     async createOrganization(
         userId: string,
         name: string,
         slugOverride?: string,
+        extra?: {
+            legalName?: string | null;
+            countryCode?: string | null;
+            registrationProvider?: OrganizationRegistrationProvider | null;
+            registrationStatus?: OrganizationRegistrationStatus | null;
+            linkedWorkId?: string | null;
+        },
     ): Promise<Organization> {
         const trimmedName = name?.trim();
         if (!trimmedName) {
@@ -153,10 +172,21 @@ export class OrganizationService {
         return this.dataSource.transaction(async (manager) => {
             // Use the manager's repository so the INSERT lands in the
             // same transaction as the backfill UPDATEs below.
+            //
+            // `extra` fields are layered on top of the base shape so
+            // Phase 6 callers (which pass nothing) keep producing
+            // `{ tenantId, slug, displayName }` exactly as before. The
+            // entity's column defaults handle the unspecified columns
+            // (registrationStatus defaults to `'draft'`).
             const org = manager.getRepository<Organization>('organizations').create({
                 tenantId: tenant.id,
                 slug,
                 displayName: trimmedName,
+                legalName: extra?.legalName ?? null,
+                countryCode: extra?.countryCode ?? null,
+                registrationProvider: extra?.registrationProvider ?? null,
+                registrationStatus: extra?.registrationStatus ?? 'draft',
+                linkedWorkId: extra?.linkedWorkId ?? null,
             });
             const saved = await manager.getRepository<Organization>('organizations').save(org);
 
@@ -191,6 +221,87 @@ export class OrganizationService {
             );
 
             return saved;
+        });
+    }
+
+    /**
+     * EW-662 (Tenants & Organizations Phase 10) — Register-Company
+     * sub-flow entry point ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+     *
+     * Creates an Organization directly from the chip-driven form on the
+     * `+ New` page (Company chip → Register-Company modal). For v1 the
+     * Stripe-Atlas integration is deferred; we land the Org with
+     * `registrationProvider = 'manual'` and `registrationStatus =
+     * 'registered'` so it behaves like any other Org from the moment
+     * the form submits.
+     *
+     * This is essentially `createOrganization` with the registration
+     * metadata pre-populated and the slug allocated from the legal
+     * name (so e.g. "Acme, Inc." becomes `acme-inc`). When a Phase 11+
+     * SDK integration creates a backing Work first, the same shape
+     * works — pass `linkedWorkId` to point at the Work.
+     */
+    async registerCompany(
+        userId: string,
+        params: {
+            name: string;
+            countryCode?: string | null;
+            legalName?: string | null;
+            linkedWorkId?: string | null;
+            slugOverride?: string;
+        },
+    ): Promise<Organization> {
+        const trimmed = params.name?.trim();
+        if (!trimmed) {
+            throw new ConflictException('Company name is required');
+        }
+        const trimmedLegal = params.legalName?.trim() || trimmed;
+
+        return this.createOrganization(userId, trimmed, params.slugOverride, {
+            legalName: trimmedLegal,
+            countryCode: params.countryCode?.trim() || null,
+            registrationProvider: 'manual',
+            registrationStatus: 'registered',
+            linkedWorkId: params.linkedWorkId ?? null,
+        });
+    }
+
+    /**
+     * EW-662 (Tenants & Organizations Phase 10) — wire-up entry point
+     * for a future Work-of-type-Company `registered` status transition
+     * (plan.md Phase 10 step 3).
+     *
+     * Today the platform's `Work` entity has neither a `kind` column
+     * nor a `status` column, so the actual status-transition hook
+     * doesn't fire yet. This method exists so the moment those columns
+     * land (Phase 11+ when the Stripe Atlas SDK ships), the calling
+     * code is a one-liner — the entity-to-Org plumbing is already in
+     * place + unit-tested here.
+     *
+     * Use this whenever a caller has a real `Work` row to link.
+     * Otherwise prefer `registerCompany` which is the chip-driven
+     * manual-completion path.
+     */
+    async createOrganizationFromCompanyWork(
+        userId: string,
+        work: {
+            id: string;
+            name: string;
+            companyName?: string | null;
+            companyWebsite?: string | null;
+        },
+        params?: { countryCode?: string | null; legalName?: string | null; slugOverride?: string },
+    ): Promise<Organization> {
+        const displayName = (work.companyName?.trim() || work.name)?.trim();
+        if (!displayName) {
+            throw new ConflictException('Work has no usable name for Organization creation');
+        }
+        return this.registerCompany(userId, {
+            name: displayName,
+            countryCode: params?.countryCode ?? null,
+            legalName: params?.legalName ?? work.companyName ?? null,
+            linkedWorkId: work.id,
+            slugOverride: params?.slugOverride,
         });
     }
 

--- a/apps/api/src/organizations/organizations.controller.ts
+++ b/apps/api/src/organizations/organizations.controller.ts
@@ -23,6 +23,7 @@ import { OrganizationService } from './organization.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { CheckSlugQueryDto } from './dto/check-slug.dto';
+import { RegisterCompanyDto } from './dto/register-company.dto';
 
 /**
  * EW-658 (Tenants & Organizations Phase 6) — Organization CRUD +
@@ -64,6 +65,26 @@ export class OrganizationsController {
             dto.name,
             dto.slug,
         );
+        return this.toResponse(org);
+    }
+
+    @Post('register-company')
+    @ApiOperation({
+        summary: 'Register a Company (Phase 10 — Company chip)',
+        description:
+            "EW-662: Registers a Company via the manual-completion path ([spec.md §5.4](../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)). Creates an Organization with `registrationProvider = 'manual'` and `registrationStatus = 'registered'` directly — the Stripe Atlas SDK integration is deferred. Lazy-creates the Tenant + backfills `tenantId` the same way `POST /api/organizations` does.",
+    })
+    @ApiResponse({ status: 201, description: 'Company registered + Organization created' })
+    async registerCompany(
+        @Req() req: { user: { userId: string } },
+        @Body() dto: RegisterCompanyDto,
+    ): Promise<OrganizationResponse> {
+        const org = await this.organizationService.registerCompany(req.user.userId, {
+            name: dto.name,
+            legalName: dto.legalName,
+            countryCode: dto.countryCode?.toUpperCase() ?? null,
+            slugOverride: dto.slug,
+        });
         return this.toResponse(org);
     }
 

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1554,7 +1554,7 @@
                 "overview": "نظرة عامة",
                 "activity": "النشاط",
                 "items": "العناصر",
-                "generator": "مولد",
+                "generator": "Worker",
                 "schedule": "جدولة",
                 "history": "سجل",
                 "comparisons": "مقارنات",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "لم يبدأ التوليد",
                     "description": "ابدأ في توليد العناصر لعملك لملئه بالمحتوى.",
-                    "action": "بدء التوليد"
+                    "action": "بدء الـWork"
                 },
                 "generating": {
                     "title": "التوليد قيد التقدم",
@@ -1769,12 +1769,12 @@
                     "title": "فشل التوليد",
                     "description": "حدث خطأ أثناء التوليد.",
                     "withWarnings": "فشل التوليد مع أخطاء:",
-                    "retry": "إعادة محاولة التوليد"
+                    "retry": "إعادة محاولة الـWork"
                 },
                 "cancelled": {
                     "title": "تم إلغاء التوليد",
                     "description": "تم إيقاف التوليد السابق قبل الاكتمال.",
-                    "restart": "إعادة تشغيل التوليد"
+                    "restart": "إعادة تشغيل الـWork"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "تفاصيل التهيئة",
-                "initialPrompt": "موجه التوليد الأولي",
+                "initialPrompt": "موجه الـWorker الأولي",
                 "companyDetails": "معلومات الشركة",
                 "companyName": "اسم الشركة",
                 "companyWebsite": "الموقع الإلكتروني",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "توليد",
+                    "generate": "Work",
                     "schedule": "جدولة",
                     "history": "التاريخ",
                     "comparisons": "المقارنات",
-                    "navigationLabel": "تبويبات المولد"
+                    "navigationLabel": "تبويبات Worker"
                 },
                 "regenerationWarning": "تحذير إعادة التوليد",
                 "regenerationWarningDescription": "تم توليد هذا المجلد بالفعل. بدء توليد جديد سيستبدل العناصر الموجودة.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "فشل في تحميل تكوين النموذج",
                 "selectOption": "اختر خيارًا",
                 "workName": "اسم المجلد",
-                "generationPrompt": "موجه التوليد",
+                "generationPrompt": "موجه الـWorker",
                 "modelOverride": "تجاوز نموذج الذكاء الاصطناعي",
                 "modelOverridePlaceholder": "مثل openai/gpt-4.1 أو openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "اختياري. يستخدم النموذج المستورد أو السابق افتراضيًا إلا إذا قمت بتجاوزه هنا.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "كن محددًا بشأن نوع المحتوى الذي تريد توليده",
                 "repositoryDescription": "وصف المستودع",
                 "repositoryPlaceholder": "وصف موجز للمستودع (اختياري)",
-                "startGeneration": "بدء التوليد",
+                "startGeneration": "بدء الـWork",
                 "regenerateItems": "إعادة توليد العناصر",
                 "updateItems": "تشغيل التوليد",
                 "recreateWork": "إعادة إنشاء المجلد",
@@ -4638,7 +4638,7 @@
             "work": "العمل",
             "overview": "نظرة عامة",
             "items": "العناصر",
-            "generator": "المولد",
+            "generator": "Worker",
             "settings": "الإعدادات",
             "deploy": "النشر",
             "members": "الأعضاء",

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "هدف مستمر يعمل عليه الوكلاء باستمرار — ينتج أفكرة وفق جدولة أو لمرة واحدة.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "صفحة مركزة واحدة — قوائم الانتظار، إطلاق المنتجات، تسجيلات الندوات، التقاط العملاء.",
                 "blog": "مدونة مع فئات، RSS، تمييز الكود، ومحتوى جاهز لتحسين محركات البحث.",
                 "directory": "موقع دليل مختار مع بحث، عوامل تصفية، وبيانات منظمة للعناصر.",
-                "awesome-repo": "مستودع قائمة رائعة — فهرس markdown، روابط مصنفة، وبيانات قابلة للتحديث."
+                "awesome-repo": "مستودع قائمة رائعة — فهرس markdown، روابط مصنفة، وبيانات قابلة للتحديث.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "إنشاء",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Текуща Цел, с която Агентът продължава да работи — генерира Идеи по график или еднократно.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Фокусирана едностранична страница — списъци с чакащи, пускане на продукти, записване за уебинар, улавяне на лидове.",
                 "blog": "Блог с категории, RSS, подсветка на код и SEO-готово съдържание.",
                 "directory": "Куриран сайт с директория, с търсене, филтри и структурирани данни за елементи.",
-                "awesome-repo": "Awesome-list репозитори — markdown индекс, категоризирани линкове и освежаеми метаданни."
+                "awesome-repo": "Awesome-list репозитори — markdown индекс, категоризирани линкове и освежаеми метаданни.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Създай",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1554,7 +1554,7 @@
                 "overview": "Преглед",
                 "activity": "Активност",
                 "items": "Елементи",
-                "generator": "Генератор",
+                "generator": "Worker",
                 "schedule": "График",
                 "history": "История",
                 "comparisons": "Сравнения",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Генериране не е започнато",
                     "description": "Стартирай генериране на елементи за твоята работа, за да я запълниш със съдържание.",
-                    "action": "Стартирай генериране"
+                    "action": "Стартирай Work"
                 },
                 "generating": {
                     "title": "Генериране в ход",
@@ -1769,12 +1769,12 @@
                     "title": "Генерирането неуспешно",
                     "description": "Грешка по време на генериране.",
                     "withWarnings": "Генерирането завърши с грешки:",
-                    "retry": "Опитай отново генериране"
+                    "retry": "Опитай отново Work"
                 },
                 "cancelled": {
                     "title": "Генерирането отменено",
                     "description": "Предишното генериране беше спрено преди завършване.",
-                    "restart": "Рестартирай генериране"
+                    "restart": "Рестартирай Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Детайли на конфигурацията",
-                "initialPrompt": "Първоначална подсказка за генериране",
+                "initialPrompt": "Първоначална подсказка за Worker",
                 "companyDetails": "Информация за компанията",
                 "companyName": "Име на компанията",
                 "companyWebsite": "Уебсайт",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Генериране",
+                    "generate": "Work",
                     "schedule": "График",
                     "history": "История",
                     "comparisons": "Сравнения",
-                    "navigationLabel": "Разделители на генератора"
+                    "navigationLabel": "Раздели на Worker"
                 },
                 "regenerationWarning": "Предупреждение за регенериране",
                 "regenerationWarningDescription": "Тази работа вече е генерирана. Стартирането на нова генерация ще замени съществуващите елементи.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Неуспешно зареждане на конфигурацията на формата",
                 "selectOption": "Изберете опция",
                 "workName": "Име на работата",
-                "generationPrompt": "Подсказка за генериране",
+                "generationPrompt": "Подсказка за Worker",
                 "modelOverride": "Презаписване на AI модел",
                 "modelOverridePlaceholder": "нпр. openai/gpt-4.1 или openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Не задължително. По подразбиране използва импортирания или предишния модел, освен ако не го презапишете тук.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Бъдете конкретни относно типа съдържание, което искате да генерирате",
                 "repositoryDescription": "Описание на репозиторията",
                 "repositoryPlaceholder": "Кратко описание на репозиторията (по избор)",
-                "startGeneration": "Започни генериране",
+                "startGeneration": "Започни Work",
                 "regenerateItems": "Регенерирай елементи",
                 "updateItems": "Изпълни генериране",
                 "recreateWork": "Създай отново работата",
@@ -4638,7 +4638,7 @@
             "work": "Работа",
             "overview": "Преглед",
             "items": "Елементи",
-            "generator": "Генератор",
+            "generator": "Worker",
             "settings": "Настройки",
             "deploy": "Разположи",
             "members": "Членове",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Ein fortlaufendes Ziel, an dem der Agent weiterarbeitet - generiert Ideen nach einem Zeitplan oder einmalig.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Eine fokussierte Ein-Seiten-Website - Wartelisten, Produktstarts, Webinare-Anmeldungen, Lead-Erfassung.",
                 "blog": "Ein Blog mit Kategorien, RSS, Code-Hervorhebung und SEO-gerechtem Inhalt.",
                 "directory": "Eine kuratierte Verzeichniswebsite mit Suchfunktion, Filtern und strukturierten Artikeldaten.",
-                "awesome-repo": "Ein Awesome-List-Repository - Markdown-Index, kategorisierte Links und aktualisierbare Metadaten."
+                "awesome-repo": "Ein Awesome-List-Repository - Markdown-Index, kategorisierte Links und aktualisierbare Metadaten.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Erstellen",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1554,7 +1554,7 @@
                 "overview": "Übersicht",
                 "activity": "Aktivität",
                 "items": "Elemente",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Zeitplan",
                 "history": "Verlauf",
                 "comparisons": "Vergleiche",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generierung nicht gestartet",
                     "description": "Starten Sie die Generierung von Elementen für Ihr Werk, um es mit Inhalten zu füllen.",
-                    "action": "Generierung starten"
+                    "action": "Work starten"
                 },
                 "generating": {
                     "title": "Generierung läuft",
@@ -1769,12 +1769,12 @@
                     "title": "Generierung fehlgeschlagen",
                     "description": "Während der Generierung ist ein Fehler aufgetreten.",
                     "withWarnings": "Generierung mit Fehlern fehlgeschlagen:",
-                    "retry": "Generierung wiederholen"
+                    "retry": "Work wiederholen"
                 },
                 "cancelled": {
                     "title": "Generierung abgebrochen",
                     "description": "Die vorherige Generierung wurde vor Abschluss gestoppt.",
-                    "restart": "Generierung neu starten"
+                    "restart": "Work neu starten"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Konfigurationsdetails",
-                "initialPrompt": "Anfänglicher Generierungsprompt",
+                "initialPrompt": "Anfänglicher Worker-Prompt",
                 "companyDetails": "Firmeninformationen",
                 "companyName": "Firmenname",
                 "companyWebsite": "Website",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generieren",
+                    "generate": "Work",
                     "schedule": "Zeitplan",
                     "history": "Verlauf",
                     "comparisons": "Vergleiche",
-                    "navigationLabel": "Generator-Registerkarten"
+                    "navigationLabel": "Worker-Registerkarten"
                 },
                 "regenerationWarning": "Regenerierungswarnung",
                 "regenerationWarningDescription": "Dieses Werk wurde bereits generiert. Das Starten einer neuen Generierung ersetzt bestehende Elemente.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Fehler beim Laden der Formular-Konfiguration",
                 "selectOption": "Option auswählen",
                 "workName": "Ordnername",
-                "generationPrompt": "Generierungs-Prompt",
+                "generationPrompt": "Worker-Prompt",
                 "modelOverride": "KI-Modell überschreiben",
                 "modelOverridePlaceholder": "z. B. openai/gpt-4.1 oder openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optional. Verwendet standardmäßig das importierte oder vorherige Modell, es sei denn, Sie überschreiben es hier.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Seien Sie spezifisch bezüglich des Typs von Inhalt, den Sie generieren möchten",
                 "repositoryDescription": "Repository-Beschreibung",
                 "repositoryPlaceholder": "Kurze Beschreibung des Repositories (optional)",
-                "startGeneration": "Generierung starten",
+                "startGeneration": "Work starten",
                 "regenerateItems": "Elemente neu generieren",
                 "updateItems": "Generierung ausführen",
                 "recreateWork": "Ordner neu erstellen",
@@ -4638,7 +4638,7 @@
             "work": "Werk",
             "overview": "Übersicht",
             "items": "Einträge",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Einstellungen",
             "deploy": "Bereitstellen",
             "members": "Mitglieder",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1565,7 +1565,7 @@
                 "overview": "Overview",
                 "activity": "Activity",
                 "items": "Items",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Schedule",
                 "history": "History",
                 "comparisons": "Comparisons",
@@ -1758,7 +1758,7 @@
                 "notStarted": {
                     "title": "Generation Not Started",
                     "description": "Start generating items for your Work to populate it with content.",
-                    "action": "Start Generation"
+                    "action": "Start Work"
                 },
                 "generating": {
                     "title": "Generation in Progress",
@@ -1780,12 +1780,12 @@
                     "title": "Generation Failed",
                     "description": "An error occurred during generation.",
                     "withWarnings": "Generation failed with errors:",
-                    "retry": "Retry Generation"
+                    "retry": "Retry Work"
                 },
                 "cancelled": {
                     "title": "Generation Cancelled",
                     "description": "The previous generation was stopped before completion.",
-                    "restart": "Restart Generation"
+                    "restart": "Restart Work"
                 }
             },
             "stats": {
@@ -1984,7 +1984,7 @@
             },
             "config": {
                 "title": "Configuration Details",
-                "initialPrompt": "Initial Generation Prompt",
+                "initialPrompt": "Initial Worker Prompt",
                 "companyDetails": "Company Information",
                 "companyName": "Company Name",
                 "companyWebsite": "Website",
@@ -2354,11 +2354,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generate",
+                    "generate": "Work",
                     "schedule": "Schedule",
                     "history": "History",
                     "comparisons": "Comparisons",
-                    "navigationLabel": "Generator tabs"
+                    "navigationLabel": "Worker tabs"
                 },
                 "regenerationWarning": "Regeneration Warning",
                 "regenerationWarningDescription": "This Work has already been generated. Starting a new generation will replace existing items.",
@@ -2372,7 +2372,7 @@
                 "failedToLoadFormSchema": "Failed to load form configuration",
                 "selectOption": "Select an option",
                 "workName": "Work Name",
-                "generationPrompt": "Generation Prompt",
+                "generationPrompt": "Worker Prompt",
                 "modelOverride": "AI Model Override",
                 "modelOverridePlaceholder": "e.g. openai/gpt-4.1 or openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optional. Uses the imported or previous model by default unless you override it here.",
@@ -2384,7 +2384,7 @@
                 "promptHelperText": "Be specific about the type of content you want to generate",
                 "repositoryDescription": "Repository Description",
                 "repositoryPlaceholder": "Brief description of the repository (optional)",
-                "startGeneration": "Start Generation",
+                "startGeneration": "Start Work",
                 "regenerateItems": "Regenerate Items",
                 "updateItems": "Run Generation",
                 "recreateWork": "Recreate Work",
@@ -4457,7 +4457,7 @@
             "work": "Work",
             "overview": "Overview",
             "items": "Items",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Settings",
             "deploy": "Deploy",
             "members": "Members",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3296,7 +3296,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
@@ -3307,7 +3308,8 @@
                 "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
                 "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
                 "directory": "A curated directory site with search, filters, and structured item data.",
-                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata."
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Create",
@@ -4683,6 +4685,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Un objetivo continuo en el que el agente sigue trabajando — genera Ideas de forma programada o puntuales.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Una página de aterrizaje enfocada — listas de espera, lanzamientos de productos, inscripciones a webinars, captación de leads.",
                 "blog": "Un blog con categorías, RSS, resaltado de código y contenido optimizado para SEO.",
                 "directory": "Un sitio de directorio curado con búsqueda, filtros y datos estructurados de elementos.",
-                "awesome-repo": "Un repositorio de tipo awesome-list — índice markdown, enlaces categorizados y metadatos actualizables."
+                "awesome-repo": "Un repositorio de tipo awesome-list — índice markdown, enlaces categorizados y metadatos actualizables.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Crear",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1554,7 +1554,7 @@
                 "overview": "Resumen",
                 "activity": "Actividad",
                 "items": "Elementos",
-                "generator": "Generador",
+                "generator": "Worker",
                 "schedule": "Programación",
                 "history": "Historial",
                 "comparisons": "Comparaciones",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generación no iniciada",
                     "description": "Inicia la generación de elementos para tu trabajo para poblarlo con contenido.",
-                    "action": "Iniciar generación"
+                    "action": "Iniciar Work"
                 },
                 "generating": {
                     "title": "Generación en progreso",
@@ -1769,12 +1769,12 @@
                     "title": "Generación fallida",
                     "description": "Ocurrió un error durante la generación.",
                     "withWarnings": "Generación fallida con errores:",
-                    "retry": "Reintentar generación"
+                    "retry": "Reintentar Work"
                 },
                 "cancelled": {
                     "title": "Generación cancelada",
                     "description": "La generación anterior se detuvo antes de completarse.",
-                    "restart": "Reiniciar generación"
+                    "restart": "Reiniciar Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Detalles de configuración",
-                "initialPrompt": "Prompt inicial de generación",
+                "initialPrompt": "Prompt inicial de Worker",
                 "companyDetails": "Información de la empresa",
                 "companyName": "Nombre de la empresa",
                 "companyWebsite": "Sitio web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generar",
+                    "generate": "Work",
                     "schedule": "Programar",
                     "history": "Historial",
                     "comparisons": "Comparaciones",
-                    "navigationLabel": "Pestañas del generador"
+                    "navigationLabel": "Pestañas de Worker"
                 },
                 "regenerationWarning": "Advertencia de regeneración",
                 "regenerationWarningDescription": "Este trabajo ya ha sido generado. Iniciar una nueva generación reemplazará los elementos existentes.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Error al cargar la configuración del formulario",
                 "selectOption": "Selecciona una opción",
                 "workName": "Nombre del trabajo",
-                "generationPrompt": "Prompt de generación",
+                "generationPrompt": "Prompt de Worker",
                 "modelOverride": "Anulación de modelo de IA",
                 "modelOverridePlaceholder": "p. ej. openai/gpt-4.1 o openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opcional. Utiliza el modelo importado o anterior por defecto a menos que lo sobrescribas aquí.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Sé específico sobre el tipo de contenido que deseas generar",
                 "repositoryDescription": "Descripción del repositorio",
                 "repositoryPlaceholder": "Breve descripción del repositorio (opcional)",
-                "startGeneration": "Iniciar generación",
+                "startGeneration": "Iniciar Work",
                 "regenerateItems": "Regenerar elementos",
                 "updateItems": "Ejecutar generación",
                 "recreateWork": "Recrear trabajo",
@@ -4638,7 +4638,7 @@
             "work": "Trabajo",
             "overview": "Resumen",
             "items": "Elementos",
-            "generator": "Generador",
+            "generator": "Worker",
             "settings": "Configuración",
             "deploy": "Implementar",
             "members": "Miembros",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1554,7 +1554,7 @@
                 "overview": "Aperçu",
                 "activity": "Activité",
                 "items": "Éléments",
-                "generator": "Générateur",
+                "generator": "Worker",
                 "schedule": "Programmation",
                 "history": "Historique",
                 "comparisons": "Comparaisons",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Génération non démarrée",
                     "description": "Commencez à générer des éléments pour votre travail afin de le peupler de contenu.",
-                    "action": "Démarrer la génération"
+                    "action": "Démarrer le Work"
                 },
                 "generating": {
                     "title": "Génération en cours",
@@ -1769,12 +1769,12 @@
                     "title": "Échec de la génération",
                     "description": "Une erreur s'est produite pendant la génération.",
                     "withWarnings": "Échec de la génération avec erreurs :",
-                    "retry": "Relancer la génération"
+                    "retry": "Relancer le Work"
                 },
                 "cancelled": {
                     "title": "Génération annulée",
                     "description": "La génération précédente a été arrêtée avant achèvement.",
-                    "restart": "Redémarrer la génération"
+                    "restart": "Redémarrer le Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Détails de configuration",
-                "initialPrompt": "Invite initiale de génération",
+                "initialPrompt": "Invite initiale du Worker",
                 "companyDetails": "Informations sur l'entreprise",
                 "companyName": "Nom de l'entreprise",
                 "companyWebsite": "Site web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Générer",
+                    "generate": "Work",
                     "schedule": "Planification",
                     "history": "Historique",
                     "comparisons": "Comparaisons",
-                    "navigationLabel": "Onglets du générateur"
+                    "navigationLabel": "Onglets Worker"
                 },
                 "regenerationWarning": "Avertissement de régénération",
                 "regenerationWarningDescription": "Ce travail a déjà été généré. Lancer une nouvelle génération remplacera les éléments existants.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Échec du chargement de la configuration du formulaire",
                 "selectOption": "Sélectionner une option",
                 "workName": "Nom du travail",
-                "generationPrompt": "Prompt de génération",
+                "generationPrompt": "Prompt du Worker",
                 "modelOverride": "Remplacement du modèle IA",
                 "modelOverridePlaceholder": "par ex. openai/gpt-4.1 ou openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optionnel. Utilise par défaut le modèle importé ou précédent, sauf si vous le remplacez ici.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Soyez précis sur le type de contenu que vous souhaitez générer",
                 "repositoryDescription": "Description du dépôt",
                 "repositoryPlaceholder": "Brève description du dépôt (optionnel)",
-                "startGeneration": "Démarrer la génération",
+                "startGeneration": "Démarrer le Work",
                 "regenerateItems": "Régénérer les éléments",
                 "updateItems": "Exécuter la génération",
                 "recreateWork": "Recréer le travail",
@@ -4638,7 +4638,7 @@
             "work": "Travail",
             "overview": "Aperçu",
             "items": "Éléments",
-            "generator": "Générateur",
+            "generator": "Worker",
             "settings": "Paramètres",
             "deploy": "Déployer",
             "members": "Membres",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Un objectif continu que l'agent continue de traiter — génère des Idées de manière planifiée ou ponctuelle.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Une page d'atterrissage concentrée — listes d'attente, lancements de produits, inscriptions à des webinaires, capture de prospects.",
                 "blog": "Un blog avec catégories, RSS, coloration syntaxique et contenu prêt pour le SEO.",
                 "directory": "Un site de répertoire curaté avec recherche, filtres et données d'articles structurées.",
-                "awesome-repo": "Un dépôt de type awesome-list — index markdown, liens catégorisés et métadonnées actualisables."
+                "awesome-repo": "Un dépôt de type awesome-list — index markdown, liens catégorisés et métadonnées actualisables.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Créer",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1554,7 +1554,7 @@
                 "overview": "סקירה כללית",
                 "activity": "פעילות",
                 "items": "פריטים",
-                "generator": "מחולל",
+                "generator": "Worker",
                 "schedule": "לוח זמנים",
                 "history": "היסטוריה",
                 "comparisons": "השוואות",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "יצירה לא התחילה",
                     "description": "התחל לייצר פריטים לעבודה שלך כדי לאכלס אותה בתוכן.",
-                    "action": "התחל יצירה"
+                    "action": "התחל Work"
                 },
                 "generating": {
                     "title": "יצירה בתהליך",
@@ -1769,12 +1769,12 @@
                     "title": "יצירה נכשלה",
                     "description": "אירעה שגיאה במהלך היצירה.",
                     "withWarnings": "יצירה נכשלה עם שגיאות:",
-                    "retry": "נסה יצירה שוב"
+                    "retry": "נסה Work שוב"
                 },
                 "cancelled": {
                     "title": "יצירה בוטלה",
                     "description": "היצירה הקודמת הופסקה לפני השלמה.",
-                    "restart": "התחל יצירה מחדש"
+                    "restart": "התחל Work מחדש"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "פרטי הגדרה",
-                "initialPrompt": "טקסט פתיחה ליצירה",
+                "initialPrompt": "טקסט פתיחה ל-Worker",
                 "companyDetails": "מידע על החברה",
                 "companyName": "שם חברה",
                 "companyWebsite": "אתר",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "יצירה",
+                    "generate": "Work",
                     "schedule": "לוח זמנים",
                     "history": "היסטוריה",
                     "comparisons": "השוואות",
-                    "navigationLabel": "לשוניות יצירה"
+                    "navigationLabel": "לשוניות Worker"
                 },
                 "regenerationWarning": "אזהרת יצירה מחדש",
                 "regenerationWarningDescription": "תיקייה זו כבר נוצרה. התחלת יצירה חדשה תחליף את הפריטים הקיימים.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "נכשל בטעינת הגדרת הטופס",
                 "selectOption": "בחר אפשרות",
                 "workName": "שם תיקייה",
-                "generationPrompt": "הנחיית יצירה",
+                "generationPrompt": "הנחיית Worker",
                 "modelOverride": "עקיפת מודל AI",
                 "modelOverridePlaceholder": "לדוגמה openai/gpt-4.1 או openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "אופציונלי. משתמש במודל המיובא או הקודם כברירת מחדל אלא אם תעקוף אותו כאן.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "היה ספציפי לגבי סוג התוכן שברצונך לייצר",
                 "repositoryDescription": "תיאור מאגר",
                 "repositoryPlaceholder": "תיאור קצר של המאגר (אופציונלי)",
-                "startGeneration": "התחל יצירה",
+                "startGeneration": "התחל Work",
                 "regenerateItems": "צור מחדש פריטים",
                 "updateItems": "הרץ יצירה",
                 "recreateWork": "צור מחדש תיקייה",
@@ -4638,7 +4638,7 @@
             "work": "עבודה",
             "overview": "סקירה כללית",
             "items": "פריטים",
-            "generator": "מחולל",
+            "generator": "Worker",
             "settings": "הגדרות",
             "deploy": "פרס",
             "members": "חברים",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "מטרה רציפה שהסוכן ממשיך לעבוד עליה - מייצר רעיונות על פי לוח זמנים או פעם אחת.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "דף אחד ממוקד - רשימות המתנה, השקות מוצרים, הרשמות להרצאות, לכידת לידים.",
                 "blog": "בלוג עם קטגוריות, RSS, הדגשת קוד, ותוכן מוכן ל-SEO.",
                 "directory": "אתר קטלוג מסונן עם חיפוש, מסננים ונתונים מובנים של פריטים.",
-                "awesome-repo": "מאגר awesome-list - אינדקס markdown, קישורים מסוננים, ומטא-נתונים רעננים."
+                "awesome-repo": "מאגר awesome-list - אינדקס markdown, קישורים מסוננים, ומטא-נתונים רעננים.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "צור",
@@ -4533,7 +4535,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4864,6 +4879,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "एक निरंतर लक्ष्य जिस पर एजेंट लगातार काम करता है — अनुसूची या एक बार पर विचार उत्पन्न करता है।",
@@ -3292,7 +3293,8 @@
                 "landing-page": "एक केंद्रित एक-पृष्ठ — इंतजार सूचियां, उत्पाद लॉन्च, वेबिनार साइनअप, लीड कैप्चर।",
                 "blog": "श्रेणियों, RSS, कोड हाइलाइटिंग, और SEO-तैयार सामग्री के साथ एक ब्लॉग।",
                 "directory": "खोज, फ़िल्टर, और संरचित आइटम डेटा के साथ एक क्यूरेटेड निर्देशित साइट।",
-                "awesome-repo": "एक अवसर-सूची रेपो — मार्कडाउन इंडेक्स, श्रेणीबद्ध लिंक, और ताज़ा होने योग्य मेटाडेटा।"
+                "awesome-repo": "एक अवसर-सूची रेपो — मार्कडाउन इंडेक्स, श्रेणीबद्ध लिंक, और ताज़ा होने योग्य मेटाडेटा।",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "बनाएं",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1554,7 +1554,7 @@
                 "overview": "अवलोकन",
                 "activity": "गतिविधि",
                 "items": "आइटम",
-                "generator": "जनरेटर",
+                "generator": "Worker",
                 "schedule": "अनुसूची",
                 "history": "इतिहास",
                 "comparisons": "तुलनाएँ",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "उत्पत्ति आरंभ नहीं हुई",
                     "description": "अपनी कार्य को सामग्री से भरने के लिए आइटम उत्पन्न करना आरंभ करें।",
-                    "action": "उत्पत्ति आरंभ करें"
+                    "action": "Work आरंभ करें"
                 },
                 "generating": {
                     "title": "उत्पत्ति प्रगति पर",
@@ -1769,12 +1769,12 @@
                     "title": "उत्पत्ति विफल",
                     "description": "उत्पत्ति के दौरान त्रुटि हुई।",
                     "withWarnings": "त्रुटियों के साथ उत्पत्ति विफल:",
-                    "retry": "उत्पत्ति पुनः प्रयास करें"
+                    "retry": "Work पुनः प्रयास करें"
                 },
                 "cancelled": {
                     "title": "उत्पत्ति रद्द",
                     "description": "पिछली उत्पत्ति पूर्ण होने से पहले रोक दी गई थी।",
-                    "restart": "उत्पत्ति पुनः आरंभ करें"
+                    "restart": "Work पुनः आरंभ करें"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "कॉन्फ़िगरेशन विवरण",
-                "initialPrompt": "आरंभिक उत्पत्ति प्रॉम्प्ट",
+                "initialPrompt": "आरंभिक Worker प्रॉम्प्ट",
                 "companyDetails": "कंपनी जानकारी",
                 "companyName": "कंपनी नाम",
                 "companyWebsite": "वेबसाइट",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "उत्पन्न करें",
+                    "generate": "Work",
                     "schedule": "शेड्यूल",
                     "history": "इतिहास",
                     "comparisons": "तुलनाएँ",
-                    "navigationLabel": "जनरेटर टैब"
+                    "navigationLabel": "Worker टैब"
                 },
                 "regenerationWarning": "पुनःउत्पादन चेतावनी",
                 "regenerationWarningDescription": "इस कार्य को पहले ही उत्पन्न किया जा चुका है। नया उत्पादन शुरू करने से मौजूदा आइटम प्रतिस्थापित हो जाएँगे।",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "फ़ॉर्म कॉन्फ़िगरेशन लोड करने में विफल",
                 "selectOption": "एक विकल्प चुनें",
                 "workName": "कार्य का नाम",
-                "generationPrompt": "उत्पादन प्रॉम्प्ट",
+                "generationPrompt": "Worker प्रॉम्प्ट",
                 "modelOverride": "एआई मॉडल ओवरराइड",
                 "modelOverridePlaceholder": "जैसे openai/gpt-4.1 या openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "वैकल्पिक। डिफ़ॉल्ट रूप से आयातित या पिछला मॉडल उपयोग किया जाता है जब तक कि आप इसे यहाँ ओवरराइड न करें।",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "उत्पन्न करने वाले कंटेंट के प्रकार के बारे में विशिष्ट रहें",
                 "repositoryDescription": "रीपॉजिटरी विवरण",
                 "repositoryPlaceholder": "रीपॉजिटरी का संक्षिप्त विवरण (वैकल्पिक)",
-                "startGeneration": "उत्पादन शुरू करें",
+                "startGeneration": "Work शुरू करें",
                 "regenerateItems": "आइटम पुनःउत्पन्न करें",
                 "updateItems": "उत्पादन चलाएँ",
                 "recreateWork": "कार्य पुनःबनाएँ",
@@ -4702,7 +4702,7 @@
             "work": "कार्य",
             "overview": "अवलोकन",
             "items": "आइटम्स",
-            "generator": "जनरेटर",
+            "generator": "Worker",
             "settings": "सेटिंग्स",
             "deploy": "डिप्लॉय करें",
             "members": "सदस्य",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1554,7 +1554,7 @@
                 "overview": "Ringkasan",
                 "activity": "Aktivitas",
                 "items": "Item",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Jadwal",
                 "history": "Riwayat",
                 "comparisons": "Perbandingan",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generasi Belum Dimulai",
                     "description": "Mulai menghasilkan item untuk karya Anda agar diisi dengan konten.",
-                    "action": "Mulai Generasi"
+                    "action": "Mulai Work"
                 },
                 "generating": {
                     "title": "Generasi Sedang Berlangsung",
@@ -1769,12 +1769,12 @@
                     "title": "Generasi Gagal",
                     "description": "Terjadi kesalahan selama generasi.",
                     "withWarnings": "Generasi gagal dengan kesalahan:",
-                    "retry": "Coba Generasi Lagi"
+                    "retry": "Coba Work Lagi"
                 },
                 "cancelled": {
                     "title": "Generasi Dibatalkan",
                     "description": "Generasi sebelumnya dihentikan sebelum selesai.",
-                    "restart": "Mulai Ulang Generasi"
+                    "restart": "Mulai Ulang Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Detail Konfigurasi",
-                "initialPrompt": "Prompt Generasi Awal",
+                "initialPrompt": "Prompt Worker Awal",
                 "companyDetails": "Informasi Perusahaan",
                 "companyName": "Nama Perusahaan",
                 "companyWebsite": "Situs Web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Hasilkan",
+                    "generate": "Work",
                     "schedule": "Jadwal",
                     "history": "Riwayat",
                     "comparisons": "Perbandingan",
-                    "navigationLabel": "Tab Generator"
+                    "navigationLabel": "Tab Worker"
                 },
                 "regenerationWarning": "Peringatan Regenerasi",
                 "regenerationWarningDescription": "Karya ini sudah dihasilkan. Memulai generasi baru akan mengganti item yang ada.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Gagal memuat konfigurasi formulir",
                 "selectOption": "Pilih opsi",
                 "workName": "Nama Karya",
-                "generationPrompt": "Prompt Generasi",
+                "generationPrompt": "Prompt Worker",
                 "modelOverride": "Penggantian Model AI",
                 "modelOverridePlaceholder": "misalnya openai/gpt-4.1 atau openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opsional. Secara default menggunakan model yang diimpor atau model sebelumnya kecuali Anda menimpa di sini.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Jadilah spesifik tentang jenis konten yang ingin Anda hasilkan",
                 "repositoryDescription": "Deskripsi Repositori",
                 "repositoryPlaceholder": "Deskripsi singkat repositori (opsional)",
-                "startGeneration": "Mulai Generasi",
+                "startGeneration": "Mulai Work",
                 "regenerateItems": "Regenerasi Item",
                 "updateItems": "Jalankan Generasi",
                 "recreateWork": "Buat Ulang Karya",
@@ -4702,7 +4702,7 @@
             "work": "Karya",
             "overview": "Ikhtisar",
             "items": "Item",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Pengaturan",
             "deploy": "Penerapan",
             "members": "Anggota",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Tujuan berkelanjutan yang agen terus kerjakan — menghasilkan Ide secara berkala atau sekali saja.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Satu halaman yang fokus — daftar tunggu, peluncuran produk, pendaftaran webinar, penangkap leads.",
                 "blog": "Blog dengan kategori, RSS, sorotan kode, dan konten yang siap SEO.",
                 "directory": "Situs direktori yang dikurasi dengan pencarian, filter, dan data item terstruktur.",
-                "awesome-repo": "Repo daftar awesome — indeks markdown, tautan yang dikategorikan, dan metadata yang dapat diperbarui."
+                "awesome-repo": "Repo daftar awesome — indeks markdown, tautan yang dikategorikan, dan metadata yang dapat diperbarui.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Buat",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1554,7 +1554,7 @@
                 "overview": "Panoramica",
                 "activity": "Attività",
                 "items": "Elementi",
-                "generator": "Generatore",
+                "generator": "Worker",
                 "schedule": "Programmazione",
                 "history": "Cronologia",
                 "comparisons": "Confronti",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generazione non avviata",
                     "description": "Avvia la generazione degli elementi per popolare la lavori con contenuti.",
-                    "action": "Avvia generazione"
+                    "action": "Avvia Work"
                 },
                 "generating": {
                     "title": "Generazione in corso",
@@ -1769,12 +1769,12 @@
                     "title": "Generazione fallita",
                     "description": "Si è verificato un errore durante la generazione.",
                     "withWarnings": "Generazione fallita con errori:",
-                    "retry": "Riprova generazione"
+                    "retry": "Riprova Work"
                 },
                 "cancelled": {
                     "title": "Generazione annullata",
                     "description": "La generazione precedente è stata fermata prima del completamento.",
-                    "restart": "Riavvia generazione"
+                    "restart": "Riavvia Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Dettagli configurazione",
-                "initialPrompt": "Prompt iniziale generazione",
+                "initialPrompt": "Prompt iniziale del Worker",
                 "companyDetails": "Informazioni azienda",
                 "companyName": "Nome azienda",
                 "companyWebsite": "Sito web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Genera",
+                    "generate": "Work",
                     "schedule": "Programma",
                     "history": "Cronologia",
                     "comparisons": "Confronti",
-                    "navigationLabel": "Schede Generatore"
+                    "navigationLabel": "Schede Worker"
                 },
                 "regenerationWarning": "Avviso di Rigenerazione",
                 "regenerationWarningDescription": "Questa lavori è già stata generata. Avviare una nuova generazione sostituirà gli elementi esistenti.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Impossibile caricare la configurazione del modulo",
                 "selectOption": "Seleziona un'opzione",
                 "workName": "Nome Lavori",
-                "generationPrompt": "Prompt di Generazione",
+                "generationPrompt": "Prompt del Worker",
                 "modelOverride": "Sovrascrittura modello AI",
                 "modelOverridePlaceholder": "es. openai/gpt-4.1 o openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opzionale. Usa il modello importato o precedente per impostazione predefinita a meno che non lo sovrascriva qui.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Sii specifico sul tipo di contenuto che vuoi generare",
                 "repositoryDescription": "Descrizione Repository",
                 "repositoryPlaceholder": "Breve descrizione del repository (opzionale)",
-                "startGeneration": "Avvia Generazione",
+                "startGeneration": "Avvia Work",
                 "regenerateItems": "Rigenera Elementi",
                 "updateItems": "Esegui Generazione",
                 "recreateWork": "Ricarica Lavori",
@@ -4702,7 +4702,7 @@
             "work": "Lavori",
             "overview": "Panoramica",
             "items": "Elementi",
-            "generator": "Generatore",
+            "generator": "Worker",
             "settings": "Impostazioni",
             "deploy": "Distribuisci",
             "members": "Membri",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Un Obiettivo continuo su cui l'agente continua a lavorare — genera Idee secondo una pianificazione o in una singola esecuzione.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Una pagina singola e focalizzata — liste d'attesa, lanci di prodotti, iscrizioni a webinar, acquisizione contatti.",
                 "blog": "Un blog con categorie, RSS, evidenziazione di codice e contenuti ottimizzati per SEO.",
                 "directory": "Un sito di directory curato con ricerca, filtri e dati strutturati per gli elementi.",
-                "awesome-repo": "Un repository awesome-list — indice markdown, link categorizzati e metadati aggiornabili."
+                "awesome-repo": "Un repository awesome-list — indice markdown, link categorizzati e metadati aggiornabili.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Crea",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "エージェントが継続的に取り組む継続的な目標 — スケジュールまたはワンショットでアイデアを生成します。",
@@ -3292,7 +3293,8 @@
                 "landing-page": "焦点の当てられたワンページ — 等待リスト、製品ローンチ、ウェビナー登録、リード取得。",
                 "blog": "カテゴリ、RSS、コードハイライト、SEO対応コンテンツ付きブログ。",
                 "directory": "検索、フィルター、構造化された項目データ付きのキュレートされたディレクトリサイト。",
-                "awesome-repo": "すごいリストリポジトリ — マークダウンインデックス、カテゴリ分けされたリンク、更新可能なメタデータ。"
+                "awesome-repo": "すごいリストリポジトリ — マークダウンインデックス、カテゴリ分けされたリンク、更新可能なメタデータ。",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "作成",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1554,7 +1554,7 @@
                 "overview": "概要",
                 "activity": "アクティビティ",
                 "items": "アイテム",
-                "generator": "ジェネレーター",
+                "generator": "Worker",
                 "schedule": "スケジュール",
                 "history": "履歴",
                 "comparisons": "比較",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "生成未開始",
                     "description": "ワークにコンテンツを格納するためにアイテムの生成を開始してください。",
-                    "action": "生成を開始"
+                    "action": "Work を開始"
                 },
                 "generating": {
                     "title": "生成中",
@@ -1769,12 +1769,12 @@
                     "title": "生成エラー",
                     "description": "生成中にエラーが発生しました。",
                     "withWarnings": "エラーで生成に失敗:",
-                    "retry": "生成を再試行"
+                    "retry": "Work を再試行"
                 },
                 "cancelled": {
                     "title": "生成キャンセル",
                     "description": "前の生成が完了前に停止されました。",
-                    "restart": "生成を再開"
+                    "restart": "Work を再開"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "設定詳細",
-                "initialPrompt": "初期生成プロンプト",
+                "initialPrompt": "初期 Worker プロンプト",
                 "companyDetails": "会社情報",
                 "companyName": "会社名",
                 "companyWebsite": "ウェブサイト",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "生成",
+                    "generate": "Work",
                     "schedule": "スケジュール",
                     "history": "履歴",
                     "comparisons": "比較",
-                    "navigationLabel": "ジェネレーター タブ"
+                    "navigationLabel": "Worker タブ"
                 },
                 "regenerationWarning": "再生成の警告",
                 "regenerationWarningDescription": "このワークはすでに生成されています。新規生成を開始すると、既存のアイテムが置き換えられます。",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "フォーム構成の読み込みに失敗しました",
                 "selectOption": "オプションを選択",
                 "workName": "ワーク名",
-                "generationPrompt": "生成プロンプト",
+                "generationPrompt": "Worker プロンプト",
                 "modelOverride": "AI モデル上書き",
                 "modelOverridePlaceholder": "例: openai/gpt-4.1 または openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "オプションです。デフォルトではインポートされたモデルまたは以前のモデルを使用しますが、ここで上書きできます。",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "生成したいコンテンツの種類について具体的に記述してください",
                 "repositoryDescription": "リポジトリの説明",
                 "repositoryPlaceholder": "リポジトリの簡単な説明（オプション）",
-                "startGeneration": "生成を開始",
+                "startGeneration": "Work を開始",
                 "regenerateItems": "アイテムを再生成",
                 "updateItems": "生成を実行",
                 "recreateWork": "ワークを再作成",
@@ -4702,7 +4702,7 @@
             "work": "ワーク",
             "overview": "概要",
             "items": "アイテム",
-            "generator": "ジェネレーター",
+            "generator": "Worker",
             "settings": "設定",
             "deploy": "デプロイ",
             "members": "メンバー",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "에이전트가 계속 작업하는 지속적인 목표입니다 - 일정 또는 일회성으로 아이디어를 생성합니다.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "집중된 일페이지 - 대기자 명단, 제품 출시, 웨비나 신청, 리드 확보.",
                 "blog": "카테고리, RSS, 코드 하이라이트 및 SEO 준비된 콘텐츠를 갖춘 블로그.",
                 "directory": "검색, 필터 및 구조화된 항목 데이터를 갖춘 선별된 디렉토리 사이트.",
-                "awesome-repo": "멋진 목록 저장소 - 마크다운 인덱스, 분류된 링크 및 새로 고칠 수 있는 메타데이터."
+                "awesome-repo": "멋진 목록 저장소 - 마크다운 인덱스, 분류된 링크 및 새로 고칠 수 있는 메타데이터.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "생성",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1554,7 +1554,7 @@
                 "overview": "개요",
                 "activity": "활동",
                 "items": "항목",
-                "generator": "생성기",
+                "generator": "Worker",
                 "schedule": "스케줄",
                 "history": "기록",
                 "comparisons": "비교",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "생성 시작되지 않음",
                     "description": "워크를 콘텐츠로 채우려면 항목 생성을 시작하세요.",
-                    "action": "생성 시작"
+                    "action": "Work 시작"
                 },
                 "generating": {
                     "title": "생성 진행 중",
@@ -1769,12 +1769,12 @@
                     "title": "생성 실패",
                     "description": "생성 중 오류가 발생했습니다.",
                     "withWarnings": "오류와 함께 생성 실패:",
-                    "retry": "생성 재시도"
+                    "retry": "Work 재시도"
                 },
                 "cancelled": {
                     "title": "생성 취소됨",
                     "description": "이전 생성이 완료 전에 중지되었습니다.",
-                    "restart": "생성 재시작"
+                    "restart": "Work 재시작"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "구성 세부 정보",
-                "initialPrompt": "초기 생성 프롬프트",
+                "initialPrompt": "초기 Worker 프롬프트",
                 "companyDetails": "회사 정보",
                 "companyName": "회사 이름",
                 "companyWebsite": "웹사이트",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "생성",
+                    "generate": "Work",
                     "schedule": "스케줄",
                     "history": "기록",
                     "comparisons": "비교",
-                    "navigationLabel": "생성기 탭"
+                    "navigationLabel": "Worker 탭"
                 },
                 "regenerationWarning": "재생성 경고",
                 "regenerationWarningDescription": "이 워크는 이미 생성되었습니다. 새 생성을 시작하면 기존 항목이 대체됩니다.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "양식 구성 로딩에 실패했습니다",
                 "selectOption": "옵션 선택",
                 "workName": "워크 이름",
-                "generationPrompt": "생성 프롬프트",
+                "generationPrompt": "Worker 프롬프트",
                 "modelOverride": "AI 모델 재정의",
                 "modelOverridePlaceholder": "예: openai/gpt-4.1 또는 openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "선택 사항입니다. 여기에 재정의하지 않으면 기본적으로 가져온 모델 또는 이전 모델을 사용합니다.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "생성하려는 콘텐츠 유형에 대해 구체적으로 설명하세요",
                 "repositoryDescription": "리포지토리 설명",
                 "repositoryPlaceholder": "리포지토리의 간단한 설명 (선택)",
-                "startGeneration": "생성 시작",
+                "startGeneration": "Work 시작",
                 "regenerateItems": "항목 재생성",
                 "updateItems": "생성 실행",
                 "recreateWork": "워크 재생성",
@@ -4702,7 +4702,7 @@
             "work": "워크",
             "overview": "개요",
             "items": "항목",
-            "generator": "생성기",
+            "generator": "Worker",
             "settings": "설정",
             "deploy": "배포",
             "members": "멤버",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Een doorlopend Doel waar de agent aan blijft werken — genereert Idees op een schema of in één keer.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Een gerichte één-pagina — wachtlijsten, productlanceringen, webinar aanmeldingen, lead capture.",
                 "blog": "Een blog met categorieën, RSS, code highlighting, en SEO-ready content.",
                 "directory": "Een geselecteerde directory site met zoekfunctie, filters, en gestructureerde item data.",
-                "awesome-repo": "Een awesome-list repo — markdown index, gecategoriseerde links, en verversbare metadata."
+                "awesome-repo": "Een awesome-list repo — markdown index, gecategoriseerde links, en verversbare metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Maken",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1554,7 +1554,7 @@
                 "overview": "Overzicht",
                 "activity": "Activiteit",
                 "items": "Items",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Planning",
                 "history": "Geschiedenis",
                 "comparisons": "Vergelijkingen",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generatie nog niet gestart",
                     "description": "Start met genereren van items voor uw map om deze met inhoud te vullen.",
-                    "action": "Generatie starten"
+                    "action": "Work starten"
                 },
                 "generating": {
                     "title": "Generatie bezig",
@@ -1769,12 +1769,12 @@
                     "title": "Generatie mislukt",
                     "description": "Er is een fout opgetreden tijdens de generatie.",
                     "withWarnings": "Generatie mislukt met fouten:",
-                    "retry": "Generatie opnieuw proberen"
+                    "retry": "Work opnieuw proberen"
                 },
                 "cancelled": {
                     "title": "Generatie geannuleerd",
                     "description": "De vorige generatie is gestopt voordat deze voltooid was.",
-                    "restart": "Generatie herstarten"
+                    "restart": "Work herstarten"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Configuratiedetails",
-                "initialPrompt": "Initiële generatieprompt",
+                "initialPrompt": "Initiële Worker-prompt",
                 "companyDetails": "Bedrijfsgegevens",
                 "companyName": "Bedrijfsnaam",
                 "companyWebsite": "Website",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Genereren",
+                    "generate": "Work",
                     "schedule": "Schema",
                     "history": "Geschiedenis",
                     "comparisons": "Vergelijkingen",
-                    "navigationLabel": "Generator-tabbladen"
+                    "navigationLabel": "Worker-tabbladen"
                 },
                 "regenerationWarning": "Waarschuwing hergeneratie",
                 "regenerationWarningDescription": "Deze map is al gegenereerd. Het starten van een nieuwe generatie zal bestaande items vervangen.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Kon formulierconfiguratie niet laden",
                 "selectOption": "Selecteer een optie",
                 "workName": "Mapnaam",
-                "generationPrompt": "Generatieprompt",
+                "generationPrompt": "Worker-prompt",
                 "modelOverride": "AI-model overschrijven",
                 "modelOverridePlaceholder": "bijv. openai/gpt-4.1 of openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Optioneel. Gebruikt standaard het geïmporteerde of vorige model, tenzij je het hier overschrijft.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Wees specifiek over het type content dat je wilt genereren",
                 "repositoryDescription": "Repository-beschrijving",
                 "repositoryPlaceholder": "Korte beschrijving van de repository (optioneel)",
-                "startGeneration": "Generatie starten",
+                "startGeneration": "Work starten",
                 "regenerateItems": "Items opnieuw genereren",
                 "updateItems": "Generatie uitvoeren",
                 "recreateWork": "Map opnieuw aanmaken",
@@ -4702,7 +4702,7 @@
             "work": "Werk",
             "overview": "Overzicht",
             "items": "Items",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Instellingen",
             "deploy": "Deployen",
             "members": "Leden",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Trwający Cel, nad którym Agent stale pracuje — generuje Pomysły według harmonogramu lub jednorazowo.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Skoncentrowana strona jednopodstronowa — listy oczekujących, uruchomienia produktów, zapisy na webinary, przechwytywanie leadów.",
                 "blog": "Blog z kategoriami, RSS, podświetlaniem kodu i treścią gotową do SEO.",
                 "directory": "Kuratorska strona katalogowa z wyszukiwarką, filtrami i strukturyzowanymi danymi.",
-                "awesome-repo": "Repozytorium awesome-list — indeks markdown, kategoryzowane linki i odświeżalne metadane."
+                "awesome-repo": "Repozytorium awesome-list — indeks markdown, kategoryzowane linki i odświeżalne metadane.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Utwórz",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1554,7 +1554,7 @@
                 "overview": "Przegląd",
                 "activity": "Aktywność",
                 "items": "Elementy",
-                "generator": "Generator",
+                "generator": "Worker",
                 "schedule": "Harmonogram",
                 "history": "Historia",
                 "comparisons": "Porównania",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Generowanie nie rozpoczęte",
                     "description": "Rozpocznij generowanie elementów dla pracy, aby wypełnić go zawartością.",
-                    "action": "Rozpocznij generowanie"
+                    "action": "Rozpocznij Work"
                 },
                 "generating": {
                     "title": "Generowanie w toku",
@@ -1769,12 +1769,12 @@
                     "title": "Generowanie nie powiodło się",
                     "description": "Wystąpił błąd podczas generowania.",
                     "withWarnings": "Generowanie nie powiodło się z błędami:",
-                    "retry": "Ponów generowanie"
+                    "retry": "Ponów Work"
                 },
                 "cancelled": {
                     "title": "Generowanie anulowane",
                     "description": "Poprzednie generowanie zostało zatrzymane przed ukończeniem.",
-                    "restart": "Uruchom ponownie generowanie"
+                    "restart": "Uruchom ponownie Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Szczegóły konfiguracji",
-                "initialPrompt": "Początkowy prompt generowania",
+                "initialPrompt": "Początkowy prompt Worker",
                 "companyDetails": "Informacje o firmie",
                 "companyName": "Nazwa firmy",
                 "companyWebsite": "Strona internetowa",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Generuj",
+                    "generate": "Work",
                     "schedule": "Harmonogram",
                     "history": "Historia",
                     "comparisons": "Porównania",
-                    "navigationLabel": "Zakładki generatora"
+                    "navigationLabel": "Zakładki Worker"
                 },
                 "regenerationWarning": "Ostrzeżenie przed ponowną generacją",
                 "regenerationWarningDescription": "Ten praca został już wygenerowany. Rozpoczęcie nowej generacji zastąpi istniejące elementy.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Nie udało się załadować konfiguracji formularza",
                 "selectOption": "Wybierz opcję",
                 "workName": "Nazwa pracy",
-                "generationPrompt": "Prompt generacji",
+                "generationPrompt": "Prompt Worker",
                 "modelOverride": "Nadpisanie modelu AI",
                 "modelOverridePlaceholder": "np. openai/gpt-4.1 lub openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opcjonalne. Domyślnie używa importowanego lub poprzedniego modelu, chyba że nadpiszesz go tutaj.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Bądź precyzyjny co do typu treści, którą chcesz wygenerować",
                 "repositoryDescription": "Opis repozytorium",
                 "repositoryPlaceholder": "Krótki opis repozytorium (opcjonalnie)",
-                "startGeneration": "Rozpocznij generację",
+                "startGeneration": "Rozpocznij Work",
                 "regenerateItems": "Zregeneruj elementy",
                 "updateItems": "Uruchom generację",
                 "recreateWork": "Odtwórz praca",
@@ -4702,7 +4702,7 @@
             "work": "Praca",
             "overview": "Przegląd",
             "items": "Elementy",
-            "generator": "Generator",
+            "generator": "Worker",
             "settings": "Ustawienia",
             "deploy": "Wdróż",
             "members": "Członkowie",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Um Objetivo contínuo que o agente continua trabalhando — gera Ideias em um agendamento ou único.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Um único focado de página — listas de espera, lançamentos de produtos, inscrições de webinário, captação de leads.",
                 "blog": "Um blog com categorias, RSS, destaque de código e conteúdo pronto para SEO.",
                 "directory": "Um site de diretório curado com busca, filtros e dados estruturados de itens.",
-                "awesome-repo": "Um repo de lista-awesome — índice markdown, links categorizados e metadados atualizáveis."
+                "awesome-repo": "Um repo de lista-awesome — índice markdown, links categorizados e metadados atualizáveis.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Criar",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1554,7 +1554,7 @@
                 "overview": "Visão Geral",
                 "activity": "Atividade",
                 "items": "Itens",
-                "generator": "Gerador",
+                "generator": "Worker",
                 "schedule": "Agendamento",
                 "history": "Histórico",
                 "comparisons": "Comparações",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Geração Não Iniciada",
                     "description": "Inicie a geração de itens para seu trabalho para preenchê-lo com conteúdo.",
-                    "action": "Iniciar Geração"
+                    "action": "Iniciar Work"
                 },
                 "generating": {
                     "title": "Geração em Andamento",
@@ -1769,12 +1769,12 @@
                     "title": "Geração Falhou",
                     "description": "Ocorreu um erro durante a geração.",
                     "withWarnings": "Geração falhou com erros:",
-                    "retry": "Tentar Geração Novamente"
+                    "retry": "Tentar Work Novamente"
                 },
                 "cancelled": {
                     "title": "Geração Cancelada",
                     "description": "A geração anterior foi interrompida antes da conclusão.",
-                    "restart": "Reiniciar Geração"
+                    "restart": "Reiniciar Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Detalhes de Configuração",
-                "initialPrompt": "Prompt Inicial de Geração",
+                "initialPrompt": "Prompt Inicial do Worker",
                 "companyDetails": "Informações da Empresa",
                 "companyName": "Nome da Empresa",
                 "companyWebsite": "Site",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Gerar",
+                    "generate": "Work",
                     "schedule": "Agendar",
                     "history": "Histórico",
                     "comparisons": "Comparações",
-                    "navigationLabel": "Abas do Gerador"
+                    "navigationLabel": "Abas do Worker"
                 },
                 "regenerationWarning": "Aviso de Regeneração",
                 "regenerationWarningDescription": "Este trabalho já foi gerado. Iniciar uma nova geração substituirá os itens existentes.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Falha ao carregar configuração do formulário",
                 "selectOption": "Selecione uma opção",
                 "workName": "Nome do Trabalho",
-                "generationPrompt": "Prompt de Geração",
+                "generationPrompt": "Prompt do Worker",
                 "modelOverride": "Substituição de Modelo de IA",
                 "modelOverridePlaceholder": "ex.: openai/gpt-4.1 ou openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Opcional. Usa o modelo importado ou anterior por padrão, a menos que você o substitua aqui.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Seja específico sobre o tipo de conteúdo que deseja gerar",
                 "repositoryDescription": "Descrição do Repositório",
                 "repositoryPlaceholder": "Breve descrição do repositório (opcional)",
-                "startGeneration": "Iniciar Geração",
+                "startGeneration": "Iniciar Work",
                 "regenerateItems": "Regenerar Itens",
                 "updateItems": "Executar Geração",
                 "recreateWork": "Recriar Trabalho",
@@ -4702,7 +4702,7 @@
             "work": "Trabalho",
             "overview": "Visão Geral",
             "items": "Itens",
-            "generator": "Gerador",
+            "generator": "Worker",
             "settings": "Configurações",
             "deploy": "Implantar",
             "members": "Membros",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1554,7 +1554,7 @@
                 "overview": "Обзор",
                 "activity": "Активность",
                 "items": "Элементы",
-                "generator": "Генератор",
+                "generator": "Worker",
                 "schedule": "Расписание",
                 "history": "История",
                 "comparisons": "Сравнения",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Генерация не начата",
                     "description": "Начните генерацию элементов для заполнения работы содержимым.",
-                    "action": "Начать генерацию"
+                    "action": "Начать Work"
                 },
                 "generating": {
                     "title": "Генерация выполняется",
@@ -1769,12 +1769,12 @@
                     "title": "Генерация не удалась",
                     "description": "Во время генерации произошла ошибка.",
                     "withWarnings": "Генерация завершилась ошибками:",
-                    "retry": "Повторить генерацию"
+                    "retry": "Повторить Work"
                 },
                 "cancelled": {
                     "title": "Генерация отменена",
                     "description": "Предыдущая генерация была остановлена до завершения.",
-                    "restart": "Перезапустить генерацию"
+                    "restart": "Перезапустить Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Детали конфигурации",
-                "initialPrompt": "Начальный промпт генерации",
+                "initialPrompt": "Начальный промпт Worker",
                 "companyDetails": "Информация о компании",
                 "companyName": "Название компании",
                 "companyWebsite": "Сайт",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Генерировать",
+                    "generate": "Work",
                     "schedule": "Расписание",
                     "history": "История",
                     "comparisons": "Сравнения",
-                    "navigationLabel": "Вкладки генератора"
+                    "navigationLabel": "Вкладки Worker"
                 },
                 "regenerationWarning": "Предупреждение о регенерации",
                 "regenerationWarningDescription": "Эта работа уже сгенерирована. Запуск новой генерации заменит существующие элементы.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Не удалось загрузить конфигурацию формы",
                 "selectOption": "Выберите вариант",
                 "workName": "Имя работы",
-                "generationPrompt": "Промпт генерации",
+                "generationPrompt": "Промпт Worker",
                 "modelOverride": "Переопределение модели ИИ",
                 "modelOverridePlaceholder": "например, openai/gpt-4.1 или openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Необязательно. По умолчанию используется импортированная или предыдущая модель, если вы не переопределите её здесь.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Будьте конкретны относительно типа контента, который хотите сгенерировать",
                 "repositoryDescription": "Описание репозитория",
                 "repositoryPlaceholder": "Краткое описание репозитория (необязательно)",
-                "startGeneration": "Запустить генерацию",
+                "startGeneration": "Запустить Work",
                 "regenerateItems": "Регенерировать элементы",
                 "updateItems": "Запустить генерацию",
                 "recreateWork": "Пересоздать директорию",
@@ -4702,7 +4702,7 @@
             "work": "Работа",
             "overview": "Обзор",
             "items": "Элементы",
-            "generator": "Генератор",
+            "generator": "Worker",
             "settings": "Настройки",
             "deploy": "Развернуть",
             "members": "Участники",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Непрерывная цель, над которой агент постоянно работает — генерирует идеи по расписанию или однократно.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Фокусированная одностраничная страница — листы ожидания, запуски продуктов, регистрация на вебинары, сбор лидов.",
                 "blog": "Блог с категориями, RSS, подсветкой кода и контентом, готовым для SEO.",
                 "directory": "Сайт-каталог с поиском, фильтрами и структурированными данными элементов.",
-                "awesome-repo": "Хранилище awesome-list — индекс markdown, категоризированные ссылки и обновляемые метаданные."
+                "awesome-repo": "Хранилище awesome-list — индекс markdown, категоризированные ссылки и обновляемые метаданные.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Создать",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1554,7 +1554,7 @@
                 "overview": "ภาพรวม",
                 "activity": "กิจกรรม",
                 "items": "รายการ",
-                "generator": "เครื่องสร้าง",
+                "generator": "Worker",
                 "schedule": "กำหนดการ",
                 "history": "ประวัติ",
                 "comparisons": "การเปรียบเทียบ",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "ยังไม่เริ่มการสร้าง",
                     "description": "เริ่มสร้างรายการสำหรับงานของคุณเพื่อเติมเนื้อหา",
-                    "action": "เริ่มการสร้าง"
+                    "action": "เริ่ม Work"
                 },
                 "generating": {
                     "title": "กำลังสร้าง",
@@ -1769,12 +1769,12 @@
                     "title": "การสร้างล้มเหลว",
                     "description": "เกิดข้อผิดพลาดระหว่างการสร้าง",
                     "withWarnings": "การสร้างล้มเหลวพร้อมข้อผิดพลาด:",
-                    "retry": "ลองสร้างใหม่"
+                    "retry": "ลอง Work ใหม่"
                 },
                 "cancelled": {
                     "title": "ยกเลิกการสร้าง",
                     "description": "การสร้างก่อนหน้าถูกหยุดก่อนเสร็จสิ้น",
-                    "restart": "เริ่มการสร้างใหม่"
+                    "restart": "เริ่ม Work ใหม่"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "รายละเอียดการตั้งค่า",
-                "initialPrompt": "พรอมต์การสร้างเริ่มต้น",
+                "initialPrompt": "พรอมต์ Worker เริ่มต้น",
                 "companyDetails": "ข้อมูลบริษัท",
                 "companyName": "ชื่อบริษัท",
                 "companyWebsite": "เว็บไซต์",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "สร้าง",
+                    "generate": "Work",
                     "schedule": "กำหนดการ",
                     "history": "ประวัติ",
                     "comparisons": "การเปรียบเทียบ",
-                    "navigationLabel": "แท็บเครื่องมือสร้าง"
+                    "navigationLabel": "แท็บ Worker"
                 },
                 "regenerationWarning": "คำเตือนการสร้างใหม่",
                 "regenerationWarningDescription": "งานนี้ถูกสร้างแล้ว การเริ่มสร้างใหม่จะแทนที่รายการที่มีอยู่",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "ไม่สามารถโหลดการตั้งค่าฟอร์มได้",
                 "selectOption": "เลือกตัวเลือก",
                 "workName": "ชื่องาน",
-                "generationPrompt": "พรอมต์การสร้าง",
+                "generationPrompt": "พรอมต์ Worker",
                 "modelOverride": "แทนที่โมเดล AI",
                 "modelOverridePlaceholder": "เช่น openai/gpt-4.1 หรือ openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "ไม่บังคับ ใช้โมเดลที่นำเข้าหรือโมเดลก่อนหน้าเป็นค่าเริ่มต้น เว้นแต่จะแทนที่ที่นี่",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "ระบุรายละเอียดเกี่ยวกับประเภทเนื้อหาที่ต้องการสร้าง",
                 "repositoryDescription": "คำอธิบายคลัง",
                 "repositoryPlaceholder": "คำอธิบายสั้น ๆ ของคลัง (ไม่บังคับ)",
-                "startGeneration": "เริ่มสร้าง",
+                "startGeneration": "เริ่ม Work",
                 "regenerateItems": "สร้างรายการใหม่",
                 "updateItems": "เรียกใช้การสร้าง",
                 "recreateWork": "สร้างงานใหม่",
@@ -4702,7 +4702,7 @@
             "work": "งาน",
             "overview": "ภาพรวม",
             "items": "รายการ",
-            "generator": "ตัวสร้าง",
+            "generator": "Worker",
             "settings": "การตั้งค่า",
             "deploy": "เผยแพร่",
             "members": "สมาชิก",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "เป้าหมายที่ดำเนินต่อไป — สร้างความคิดตามกำหนดการหรือครั้งเดียว",
@@ -3292,7 +3293,8 @@
                 "landing-page": "หน้าเดียวที่มุ่งเน้น — รายชื่อรอ การเปิดตัวผลิตภัณฑ์ การลงทะเบียนเวบินาร์ การดึงลูกค้า",
                 "blog": "บล็อกที่มีหมวดหมู่ RSS การเน้นโค้ด และเนื้อหาที่พร้อมใช้กับ SEO",
                 "directory": "เว็บไดเรกทอรี่ที่คัดสรรมาแล้ว พร้อมค้นหา ตัวกรอง และข้อมูลรายการที่มโนรม",
-                "awesome-repo": "เรโพซิทอรี่อะไรก็ได้ที่น่าทึ่ง — ดัชนี markdown ลิงก์ที่จัดหมวดหมู่ และเมตาดาทาที่รีเฟรชได้"
+                "awesome-repo": "เรโพซิทอรี่อะไรก็ได้ที่น่าทึ่ง — ดัชนี markdown ลิงก์ที่จัดหมวดหมู่ และเมตาดาทาที่รีเฟรชได้",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "สร้าง",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Ajnın üzerinde sürekli çalıştığı devam eden bir Hedef — zamanlamaya göre veya tek seferlik Fikirler oluşturur.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Odaklanmış tek sayfalık bir sayfa — bekleme listeleri, ürün lansmanları, webinar kayıtları, potansiyel müşteri yakalama.",
                 "blog": "Kategoriler, RSS, kod vurgulama ve SEO hazır içeriği olan bir blog.",
                 "directory": "Arama, filtreler ve yapılandırılmış öğe verileriyle düzenlenmiş bir dizin sitesi.",
-                "awesome-repo": "Awesome-list deposu — markdown indeksi, kategorilere ayrılmış bağlantılar ve yenilenebilir metadata."
+                "awesome-repo": "Awesome-list deposu — markdown indeksi, kategorilere ayrılmış bağlantılar ve yenilenebilir metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Oluştur",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1554,7 +1554,7 @@
                 "overview": "Genel Bakış",
                 "activity": "Etkinlik",
                 "items": "Öğeler",
-                "generator": "Oluşturucu",
+                "generator": "Worker",
                 "schedule": "Program",
                 "history": "Geçmiş",
                 "comparisons": "Karşılaştırmalar",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Oluşturma Başlatılmadı",
                     "description": "İşizi içerikle doldurmak için öğe oluşturmaya başlayın.",
-                    "action": "Oluşturmayı Başlat"
+                    "action": "Work'i Başlat"
                 },
                 "generating": {
                     "title": "Oluşturma Devam Ediyor",
@@ -1769,12 +1769,12 @@
                     "title": "Oluşturma Başarısız",
                     "description": "Oluşturma sırasında bir hata oluştu.",
                     "withWarnings": "Hatalarla başarısız oldu:",
-                    "retry": "Oluşturmayı Tekrar Dene"
+                    "retry": "Work'i Tekrar Dene"
                 },
                 "cancelled": {
                     "title": "Oluşturma İptal Edildi",
                     "description": "Önceki oluşturma tamamlanmadan durduruldu.",
-                    "restart": "Oluşturmayı Yeniden Başlat"
+                    "restart": "Work'i Yeniden Başlat"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Yapılandırma Detayları",
-                "initialPrompt": "İlk Oluşturma İstem",
+                "initialPrompt": "İlk Worker İstemi",
                 "companyDetails": "Şirket Bilgileri",
                 "companyName": "Şirket Adı",
                 "companyWebsite": "Web Sitesi",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Oluştur",
+                    "generate": "Work",
                     "schedule": "Zamanlama",
                     "history": "Geçmiş",
                     "comparisons": "Karşılaştırmalar",
-                    "navigationLabel": "Oluşturucu sekmeleri"
+                    "navigationLabel": "Worker sekmeleri"
                 },
                 "regenerationWarning": "Yeniden Oluşturma Uyarısı",
                 "regenerationWarningDescription": "Bu iş zaten oluşturulmuş. Yeni bir oluşturma başlatmak mevcut öğeleri değiştirecektir.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Form yapılandırması yüklenemedi",
                 "selectOption": "Bir seçenek seçin",
                 "workName": "İş Adı",
-                "generationPrompt": "Oluşturma İstemı",
+                "generationPrompt": "Worker İstemi",
                 "modelOverride": "AI Modeli Geçersiz Kılma",
                 "modelOverridePlaceholder": "ör. openai/gpt-4.1 veya openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "İsteğe bağlı. Burada geçersiz kılmadığınız sürece varsayılan olarak içe aktarılan veya önceki modeli kullanır.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Oluşturmak istediğiniz içerik türünü detaylı belirtin",
                 "repositoryDescription": "Depo Tanımı",
                 "repositoryPlaceholder": "Deponun kısa tanımı (isteğe bağlı)",
-                "startGeneration": "Oluşturmayı Başlat",
+                "startGeneration": "Work'i Başlat",
                 "regenerateItems": "Öğeleri Yeniden Oluştur",
                 "updateItems": "Oluşturmayı Çalıştır",
                 "recreateWork": "İşi Yeniden Oluştur",
@@ -4702,7 +4702,7 @@
             "work": "İş",
             "overview": "Genel Bakış",
             "items": "Öğeler",
-            "generator": "Üretici",
+            "generator": "Worker",
             "settings": "Ayarlar",
             "deploy": "Dağıt",
             "members": "Üyeler",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Тривала Мета, над якою агент постійно працює — створює Ідеї за розкладом або одноразово.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Фокусна одна сторінка — списки очікування, запуски продуктів, реєстрація на вебінари, захоплення лідів.",
                 "blog": "Блог з категоріями, RSS, підсвічуванням коду та контентом, готовим до SEO.",
                 "directory": "Кураторський сайт-каталог з пошуком, фільтрами та структурованими даними елементів.",
-                "awesome-repo": "Репозиторій з класними списками — індекс markdown, категоризовані посилання та оновлювані метадані."
+                "awesome-repo": "Репозиторій з класними списками — індекс markdown, категоризовані посилання та оновлювані метадані.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Створити",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1554,7 +1554,7 @@
                 "overview": "Огляд",
                 "activity": "Активність",
                 "items": "Елементи",
-                "generator": "Генератор",
+                "generator": "Worker",
                 "schedule": "Розклад",
                 "history": "Історія",
                 "comparisons": "Порівняння",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Генерацію не розпочато",
                     "description": "Розпочніть генерацію елементів для вашого роботау, щоб заповнити його вмістом.",
-                    "action": "Розпочати генерацію"
+                    "action": "Розпочати Work"
                 },
                 "generating": {
                     "title": "Генерація триває",
@@ -1769,12 +1769,12 @@
                     "title": "Генерацію не вдалося завершити",
                     "description": "Під час генерації сталася помилка.",
                     "withWarnings": "Генерацію не вдалося завершити з помилками:",
-                    "retry": "Повторити генерацію"
+                    "retry": "Повторити Work"
                 },
                 "cancelled": {
                     "title": "Генерацію скасовано",
                     "description": "Попередню генерацію зупинено перед завершенням.",
-                    "restart": "Перезапустити генерацію"
+                    "restart": "Перезапустити Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Деталі конфігурації",
-                "initialPrompt": "Початковий запит генерації",
+                "initialPrompt": "Початковий запит Worker",
                 "companyDetails": "Інформація про компанію",
                 "companyName": "Назва компанії",
                 "companyWebsite": "Вебсайт",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Генерувати",
+                    "generate": "Work",
                     "schedule": "Розклад",
                     "history": "Історія",
                     "comparisons": "Порівняння",
-                    "navigationLabel": "Вкладки генератора"
+                    "navigationLabel": "Вкладки Worker"
                 },
                 "regenerationWarning": "Попередження про регенерацію",
                 "regenerationWarningDescription": "Цей робота уже згенеровано. Запуск нової генерації замінить існуючі елементи.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Не вдалося завантажити конфігурацію форми",
                 "selectOption": "Виберіть опцію",
                 "workName": "Назва роботау",
-                "generationPrompt": "Запит генерації",
+                "generationPrompt": "Запит Worker",
                 "modelOverride": "Перевизначення моделі ШІ",
                 "modelOverridePlaceholder": "наприклад openai/gpt-4.1 або openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Необов’язково. За замовчуванням використовує імпортовану або попередню модель, доки ви не перевизначите її тут.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Будьте конкретними щодо типу контенту, який ви хочете згенерувати",
                 "repositoryDescription": "Опис репозиторію",
                 "repositoryPlaceholder": "Короткий опис репозиторію (необов'язково)",
-                "startGeneration": "Розпочати генерацію",
+                "startGeneration": "Розпочати Work",
                 "regenerateItems": "Регенерувати елементи",
                 "updateItems": "Запустити генерацію",
                 "recreateWork": "Перестворити робота",
@@ -4702,7 +4702,7 @@
             "work": "Робота",
             "overview": "Огляд",
             "items": "Елементи",
-            "generator": "Генератор",
+            "generator": "Worker",
             "settings": "Налаштування",
             "deploy": "Розгорнути",
             "members": "Учасники",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1554,7 +1554,7 @@
                 "overview": "Tổng quan",
                 "activity": "Hoạt động",
                 "items": "Mục",
-                "generator": "Trình tạo",
+                "generator": "Worker",
                 "schedule": "Lịch trình",
                 "history": "Lịch sử",
                 "comparisons": "So sánh",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "Chưa bắt đầu tạo",
                     "description": "Bắt đầu tạo mục cho công việc của bạn để điền nội dung.",
-                    "action": "Bắt đầu tạo"
+                    "action": "Bắt đầu Work"
                 },
                 "generating": {
                     "title": "Đang tạo",
@@ -1769,12 +1769,12 @@
                     "title": "Tạo thất bại",
                     "description": "Có lỗi xảy ra trong quá trình tạo.",
                     "withWarnings": "Tạo thất bại kèm lỗi:",
-                    "retry": "Thử lại tạo"
+                    "retry": "Thử lại Work"
                 },
                 "cancelled": {
                     "title": "Tạo đã hủy",
                     "description": "Lần tạo trước đã bị dừng trước khi hoàn tất.",
-                    "restart": "Khởi động lại tạo"
+                    "restart": "Khởi động lại Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "Chi tiết cấu hình",
-                "initialPrompt": "Lời nhắc tạo ban đầu",
+                "initialPrompt": "Lời nhắc Worker ban đầu",
                 "companyDetails": "Thông tin công ty",
                 "companyName": "Tên công ty",
                 "companyWebsite": "Trang web",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "Tạo",
+                    "generate": "Work",
                     "schedule": "Lập lịch",
                     "history": "Lịch sử",
                     "comparisons": "So sánh",
-                    "navigationLabel": "Tab Trình tạo"
+                    "navigationLabel": "Tab Worker"
                 },
                 "regenerationWarning": "Cảnh báo Tái tạo",
                 "regenerationWarningDescription": "Công việc này đã được tạo. Bắt đầu tạo mới sẽ thay thế các mục hiện có.",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "Không thể tải cấu hình biểu mẫu",
                 "selectOption": "Chọn một tùy chọn",
                 "workName": "Tên Công việc",
-                "generationPrompt": "Prompt Tạo",
+                "generationPrompt": "Prompt Worker",
                 "modelOverride": "Ghi đè mô hình AI",
                 "modelOverridePlaceholder": "ví dụ: openai/gpt-4.1 hoặc openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "Tùy chọn. Mặc định sử dụng mô hình đã nhập hoặc mô hình trước đó trừ khi bạn ghi đè ở đây.",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "Hãy cụ thể về loại nội dung bạn muốn tạo",
                 "repositoryDescription": "Mô tả Kho",
                 "repositoryPlaceholder": "Mô tả ngắn gọn về kho (tùy chọn)",
-                "startGeneration": "Bắt đầu Tạo",
+                "startGeneration": "Bắt đầu Work",
                 "regenerateItems": "Tái tạo Mục",
                 "updateItems": "Chạy Tạo",
                 "recreateWork": "Tái tạo Công việc",
@@ -4702,7 +4702,7 @@
             "work": "Công việc",
             "overview": "Tổng quan",
             "items": "Mục",
-            "generator": "Trình tạo",
+            "generator": "Worker",
             "settings": "Cài đặt",
             "deploy": "Triển khai",
             "members": "Thành viên",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "Một Mục tiêu liên tục mà Agent tiếp tục làm việc - tạo ra các Ý tưởng theo lịch trình hoặc một lần.",
@@ -3292,7 +3293,8 @@
                 "landing-page": "Một trang một trang tập trung - danh sách chờ, ra mắt sản phẩm, đăng ký webinar, thu thập khách hàng tiềm năng.",
                 "blog": "Một blog với danh mục, RSS, làm nổi bật mã và nội dung sẵn sàng SEO.",
                 "directory": "Một trang web thư mục được biên tập với tìm kiếm, bộ lọc và dữ liệu cấu trúc hóa mục.",
-                "awesome-repo": "Kho awesome-list - chỉ mục markdown, liên kết được phân loại và metadata có thể làm mới."
+                "awesome-repo": "Kho awesome-list - chỉ mục markdown, liên kết được phân loại và metadata có thể làm mới.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "Tạo",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -3283,7 +3283,8 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
             },
             "chipDescriptions": {
                 "mission": "代理持续关注的目标——按计划或一次性生成想法。",
@@ -3292,7 +3293,8 @@
                 "landing-page": "专注的单页网站——等待列表、产品发布、网络研讨会注册、潜在客户获取。",
                 "blog": "带有分类、RSS、代码高亮和SEO就绪内容的博客。",
                 "directory": "带有搜索、筛选和结构化项目数据的精选目录网站。",
-                "awesome-repo": "awesome-list仓库——markdown索引、分类链接和可刷新的元数据。"
+                "awesome-repo": "awesome-list仓库——markdown索引、分类链接和可刷新的元数据。",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "submitTitle": "创建",
@@ -4597,7 +4599,20 @@
                 "landing-page": "Landing Page",
                 "blog": "Blog",
                 "directory": "Directory",
-                "awesome-repo": "Awesome Repo"
+                "awesome-repo": "Awesome Repo",
+                "company": "Company"
+            },
+            "chipDescriptions": {
+                "mission": "An ongoing Goal the agent keeps working on — generates Ideas on a schedule or one-shot.",
+                "idea": "A one-shot brief the agent turns into a Work plan you can build.",
+                "agent": "An AI teammate that acts across Missions, Works, or your whole Workspace.",
+                "task": "A trackable item assigned to a person or an Agent.",
+                "website": "A multi-page site for a business, service, or brand — generated content + code.",
+                "landing-page": "A focused one-pager — waitlists, product launches, webinar signups, lead capture.",
+                "blog": "A blog with categories, RSS, code highlighting, and SEO-ready content.",
+                "directory": "A curated directory site with search, filters, and structured item data.",
+                "awesome-repo": "An awesome-list repo — markdown index, categorized links, and refreshable metadata.",
+                "company": "Register a new entity. Becomes an Organization in your account."
             },
             "submit": "Create",
             "or": "or",
@@ -4928,6 +4943,23 @@
             "errors": {
                 "notAvailable": "Move isn't available for this Organization — your existing items will stay in your personal account.",
                 "generic": "Failed to move your existing items"
+            }
+        },
+        "registerCompany": {
+            "title": "Register Company",
+            "description": "Register a new legal entity. We'll create an Organization in your account so you can run Missions, Ideas, and Works under it.",
+            "nameLabel": "Company name",
+            "namePlaceholder": "Acme Inc.",
+            "countryCodeLabel": "Country (ISO 3166-1)",
+            "countryCodePlaceholder": "US",
+            "helpProviderManual": "Manual registration for v1. Stripe Atlas integration is coming — your Organization will be linked automatically once it ships.",
+            "submit": "Register",
+            "cancel": "Cancel",
+            "errors": {
+                "nameRequired": "Company name is required",
+                "nameTooLong": "Company name must be 200 characters or fewer",
+                "countryCodeInvalid": "Country code must be a 2-letter ISO 3166-1 code (e.g. US, DE)",
+                "generic": "Failed to register company"
             }
         },
         "banner": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1554,7 +1554,7 @@
                 "overview": "概览",
                 "activity": "活动",
                 "items": "项目",
-                "generator": "生成器",
+                "generator": "Worker",
                 "schedule": "计划",
                 "history": "历史记录",
                 "comparisons": "比较",
@@ -1747,7 +1747,7 @@
                 "notStarted": {
                     "title": "生成未开始",
                     "description": "启动生成项目以用内容填充您的作品。",
-                    "action": "开始生成"
+                    "action": "开始 Work"
                 },
                 "generating": {
                     "title": "生成中",
@@ -1769,12 +1769,12 @@
                     "title": "生成失败",
                     "description": "生成过程中发生错误。",
                     "withWarnings": "生成失败，错误如下：",
-                    "retry": "重试生成"
+                    "retry": "重试 Work"
                 },
                 "cancelled": {
                     "title": "生成已取消",
                     "description": "先前的生成在完成前被停止。",
-                    "restart": "重新启动生成"
+                    "restart": "重新启动 Work"
                 }
             },
             "stats": {
@@ -1973,7 +1973,7 @@
             },
             "config": {
                 "title": "配置详情",
-                "initialPrompt": "初始生成提示",
+                "initialPrompt": "初始 Worker 提示",
                 "companyDetails": "公司信息",
                 "companyName": "公司名称",
                 "companyWebsite": "网站",
@@ -2343,11 +2343,11 @@
             },
             "generator": {
                 "tabs": {
-                    "generate": "生成",
+                    "generate": "Work",
                     "schedule": "计划",
                     "history": "历史",
                     "comparisons": "比较",
-                    "navigationLabel": "生成器选项卡"
+                    "navigationLabel": "Worker 选项卡"
                 },
                 "regenerationWarning": "重新生成警告",
                 "regenerationWarningDescription": "此作品已生成。启动新生成将替换现有项目。",
@@ -2361,7 +2361,7 @@
                 "failedToLoadFormSchema": "加载表单配置失败",
                 "selectOption": "选择选项",
                 "workName": "作品名称",
-                "generationPrompt": "生成提示",
+                "generationPrompt": "Worker 提示",
                 "modelOverride": "AI 模型覆盖",
                 "modelOverridePlaceholder": "例如 openai/gpt-4.1 或 openrouter/openai/gpt-4.1",
                 "modelOverrideHelperText": "可选。默认使用导入或之前的模型，除非在此处覆盖。",
@@ -2373,7 +2373,7 @@
                 "promptHelperText": "具体说明您想要生成的内容类型",
                 "repositoryDescription": "仓库描述",
                 "repositoryPlaceholder": "仓库的简要描述（可选）",
-                "startGeneration": "开始生成",
+                "startGeneration": "开始 Work",
                 "regenerateItems": "重新生成项目",
                 "updateItems": "运行生成",
                 "recreateWork": "重新创建作品",
@@ -4702,7 +4702,7 @@
             "work": "作品",
             "overview": "概览",
             "items": "项目",
-            "generator": "生成器",
+            "generator": "Worker",
             "settings": "设置",
             "deploy": "部署",
             "members": "成员",

--- a/apps/web/src/app/[locale]/(dashboard)/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/new/page.tsx
@@ -19,6 +19,9 @@ const VALID_CHIP_TYPES: ChipType[] = [
     'blog',
     'directory',
     'awesome-repo',
+    // EW-662 (Phase 10) — Company joins the live chip set so
+    // `/new?type=company` lands directly on the Register-Company flow.
+    'company',
 ];
 
 /**

--- a/apps/web/src/app/api/organizations/register-company/route.ts
+++ b/apps/web/src/app/api/organizations/register-company/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — web BFF proxy for
+ * `POST /api/organizations/register-company`.
+ *
+ * Triggered by the Register-Company dialog (Company chip → form
+ * submit). Forwards the JSON body verbatim to the NestJS API with the
+ * user's bearer token attached. On success returns the new
+ * `OrganizationResponse` so the dialog can hand off to the
+ * `<UpgradeOrCreateDialog>` (for first-Org users) or navigate to
+ * `/${org.slug}/dashboard`.
+ */
+export async function POST(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Content-Type', 'application/json');
+
+    try {
+        const upstream = await fetch(`${API_URL}/organizations/register-company`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            cache: 'no-store',
+        });
+        const text = await upstream.text();
+        const payload = text ? safeParse(text) : null;
+        if (!upstream.ok) {
+            return NextResponse.json(payload ?? { error: 'Failed to register company' }, {
+                status: upstream.status || 500,
+            });
+        }
+        return NextResponse.json(payload, { status: 201 });
+    } catch (error) {
+        console.error('Failed to proxy POST /api/organizations/register-company:', error);
+        return NextResponse.json({ error: 'Failed to register company' }, { status: 500 });
+    }
+}
+
+function safeParse(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/components/common/PromptChipsRow.tsx
+++ b/apps/web/src/components/common/PromptChipsRow.tsx
@@ -2,29 +2,29 @@
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { cn } from '@/lib/utils/cn';
 
 /**
- * Horizontally-scrollable chip row for the dashboard prompt surfaces
- * (`/new`, `/works/new`). Mirrors the marketing site's
- * `GenerationTypeChips` (see
- * `Ever Works/Code/website/packages/web/components/global/
- * GenerationTypeChips.tsx`) so the dashboard and landing pages share
- * the same chip behavior:
+ * Arrow-paged chip row for the dashboard prompt surfaces (`/new`,
+ * `/works/new`, `/works`).
  *
- *   - Chips overflow horizontally instead of wrapping to a second row.
- *   - Mouse-friendly ◀ / ▶ buttons appear when the row overflows; the
- *     buttons disable themselves at the start / end so they always
- *     reflect what's actually scrollable.
- *   - Edge gradient fades make the chips appear to slide under the
- *     buttons.
- *   - Trackpad + touch swipe still work — the scroll position drives
- *     the button enabled state through a `ResizeObserver` and a
- *     passive scroll listener.
+ * Behavior:
+ *   - Chips never wrap to a second row. When the row's natural width
+ *     exceeds the container, ◀ / ▶ buttons appear on the side that
+ *     has hidden chips; the buttons disable themselves at the start /
+ *     end so they always reflect what's actually pannable.
+ *   - Edge gradient fades make the hidden chips appear to slide under
+ *     the buttons.
+ *   - There is **no native scrolling** — the container uses
+ *     `overflow-hidden` and the inner track is panned via
+ *     `transform: translateX(...)` controlled by React state. Trackpad
+ *     swipes, touch gestures, and mousewheel cannot move the chips;
+ *     only the arrow buttons do. Keyboard arrow keys on a focused chip
+ *     fall back to the browser's default behavior.
  *   - `comingSoon` chips render as inert `<span>`s with a "SOON" badge
- *     (matching the marketing site) so the chip catalog can telegraph
- *     upcoming kinds without making them clickable.
+ *     so the catalog can telegraph upcoming kinds without making them
+ *     clickable.
  */
 export interface PromptChip<TValue extends string = string> {
     readonly value: TValue;
@@ -51,6 +51,25 @@ export interface PromptChipsRowProps<TValue extends string = string> {
     readonly className?: string;
 }
 
+/** How far one click of ◀ / ▶ pans the track, in CSS pixels. */
+const STEP = 220;
+
+/**
+ * Total horizontal padding in the container when the row is panned to
+ * either boundary (atStart: `pl-1 pr-10` = 4 + 40 = 44; atEnd:
+ * `pl-10 pr-1` = 40 + 4 = 44). Used to compute `maxOffset` so the
+ * last chip's right edge can fully reach the visible area when the
+ * user clicks ▶ all the way — without this, `maxOffset` underestimates
+ * by `PADDING_AT_BOUNDARY` and `atEnd` triggers ~40px early (Codex P2
+ * on PR #1069).
+ */
+const PADDING_AT_BOUNDARY = 44;
+
+/** Padding values that match the Tailwind classes below. Pixel-perfect
+ *  mirrors of `pl-1 = 4`, `pl-10 = 40`, etc. */
+const PADDING_LARGE = 40; // pl-10 / pr-10
+const PADDING_SMALL = 4; // pl-1 / pr-1
+
 export function PromptChipsRow<TValue extends string = string>({
     chips,
     value,
@@ -59,36 +78,103 @@ export function PromptChipsRow<TValue extends string = string>({
     testIdPrefix,
     className,
 }: PromptChipsRowProps<TValue>) {
-    const scrollerRef = useRef<HTMLDivElement | null>(null);
-    const [overflowing, setOverflowing] = useState(false);
-    const [atStart, setAtStart] = useState(true);
-    const [atEnd, setAtEnd] = useState(false);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const trackRef = useRef<HTMLDivElement | null>(null);
 
-    const measure = useCallback(() => {
-        const el = scrollerRef.current;
-        if (!el) return;
-        const overflows = el.scrollWidth > el.clientWidth + 1;
-        setOverflowing(overflows);
-        setAtStart(el.scrollLeft <= 1);
-        setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
-    }, []);
+    const [offset, setOffset] = useState(0);
+    const [containerWidth, setContainerWidth] = useState(0);
+    const [trackWidth, setTrackWidth] = useState(0);
 
+    // ResizeObserver on both the container (its width changes when the
+    // chat panel opens/closes) and the track (its width changes when
+    // the chips array changes language / coming-soon set). Either one
+    // changing means we need to re-clamp the offset.
     useEffect(() => {
-        const el = scrollerRef.current;
-        if (!el) return;
-        measure();
-        const ro = new ResizeObserver(measure);
-        ro.observe(el);
-        el.addEventListener('scroll', measure, { passive: true });
-        return () => {
-            ro.disconnect();
-            el.removeEventListener('scroll', measure);
-        };
-    }, [measure]);
+        const container = containerRef.current;
+        const track = trackRef.current;
+        if (!container || !track) return;
 
-    const scrollBy = (delta: number) => {
-        scrollerRef.current?.scrollBy({ left: delta, behavior: 'smooth' });
-    };
+        const measure = () => {
+            setContainerWidth(container.clientWidth);
+            setTrackWidth(track.scrollWidth);
+        };
+        measure();
+
+        const ro = new ResizeObserver(measure);
+        ro.observe(container);
+        ro.observe(track);
+        return () => ro.disconnect();
+    }, [chips]);
+
+    // `clientWidth` includes the container's padding. When the user has
+    // panned away from the start, that padding is `pl-10 pr-10` (80px
+    // total); at the boundaries it's `pl-1 pr-10` or `pl-10 pr-1`
+    // (44px total). The chip area visible to the user is therefore
+    // `clientWidth - totalPadding`. The largest valid `offset` keeps
+    // the last chip's right edge aligned with the inner right padding
+    // when atEnd, which is `trackWidth - (containerWidth - 44)`.
+    // (Codex P2 on PR #1069 — the previous `trackWidth - containerWidth`
+    // formula clipped the last ~44px of chips before atEnd flipped.)
+    const maxOffset = Math.max(0, trackWidth - containerWidth + PADDING_AT_BOUNDARY);
+
+    // Clamp `offset` whenever the track or container resizes. Without
+    // this, shrinking the viewport when the row is already panned to
+    // the right leaves a visible empty gap on the right edge.
+    useEffect(() => {
+        setOffset((prev) => Math.min(prev, maxOffset));
+    }, [maxOffset]);
+
+    const overflowing = trackWidth > containerWidth + 1;
+    const atStart = offset <= 0;
+    const atEnd = offset >= maxOffset - 1;
+
+    const panBy = useCallback(
+        (delta: number) => {
+            setOffset((prev) => Math.max(0, Math.min(maxOffset, prev + delta)));
+        },
+        [maxOffset],
+    );
+
+    /**
+     * Keyboard accessibility — pan the track so a newly-focused chip is
+     * fully visible. With the transform-based pan replacing the native
+     * scroller (PR #1069), the browser no longer scrolls hidden chip
+     * buttons into view when Tab focus advances. Codex P2 on PR #1069:
+     * without this, a keyboard user can tab to off-screen options with
+     * no visible focus indicator.
+     *
+     * Uses `getBoundingClientRect` for absolute position comparison —
+     * dodges the question of which element is the focused chip's
+     * `offsetParent` (it depends on `position` on ancestors).
+     */
+    const ensureChipVisible = useCallback(
+        (buttonEl: HTMLElement) => {
+            const container = containerRef.current;
+            if (!container) return;
+
+            const containerRect = container.getBoundingClientRect();
+            const buttonRect = buttonEl.getBoundingClientRect();
+
+            // Visible chip window: container interior minus arrow
+            // gutters. The gutter is `PADDING_LARGE` on the side that
+            // has a button and `PADDING_SMALL` on the side that doesn't.
+            const leftGutter = atStart ? PADDING_SMALL : PADDING_LARGE;
+            const rightGutter = atEnd ? PADDING_SMALL : PADDING_LARGE;
+            const visibleStart = containerRect.left + leftGutter;
+            const visibleEnd = containerRect.right - rightGutter;
+
+            if (buttonRect.left < visibleStart) {
+                const delta = buttonRect.left - visibleStart; // negative
+                setOffset((prev) => Math.max(0, prev + delta));
+            } else if (buttonRect.right > visibleEnd) {
+                const delta = buttonRect.right - visibleEnd; // positive
+                setOffset((prev) => Math.min(maxOffset, prev + delta));
+            }
+        },
+        [atStart, atEnd, maxOffset],
+    );
+
+    const trackStyle = useMemo(() => ({ transform: `translate3d(${-offset}px, 0, 0)` }), [offset]);
 
     return (
         <div className={cn('relative w-full', className)}>
@@ -100,8 +186,8 @@ export function PromptChipsRow<TValue extends string = string>({
                     />
                     <button
                         type="button"
-                        onClick={() => scrollBy(-220)}
-                        aria-label="Scroll chips left"
+                        onClick={() => panBy(-STEP)}
+                        aria-label="Show previous chips"
                         className="absolute left-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
                         data-testid={testIdPrefix ? `${testIdPrefix}-scroll-left` : undefined}
                     >
@@ -111,25 +197,11 @@ export function PromptChipsRow<TValue extends string = string>({
             ) : null}
 
             <div
-                ref={scrollerRef}
-                role="listbox"
-                aria-label={ariaLabel}
-                data-testid={testIdPrefix ? `${testIdPrefix}-chips` : undefined}
+                ref={containerRef}
                 className={cn(
-                    'flex gap-2 overflow-x-auto overscroll-x-contain scroll-smooth py-1',
-                    // Hide native scrollbar across browsers (Firefox uses
-                    // `scrollbar-width`, WebKit/Chromium uses the
-                    // `::-webkit-scrollbar` pseudo). Without both, some
-                    // users still see a horizontal scrollbar even though
-                    // the explicit ◀ / ▶ buttons are the intended
-                    // affordance.
-                    '[scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
+                    'overflow-hidden py-1',
                     // Asymmetric padding — only reserve room for an arrow
                     // button on the side that's currently showing one.
-                    // Without this, the first chip ("Mission") looked like
-                    // it had stray left padding when the row was scrolled
-                    // to the start: the left button was hidden but the
-                    // padding was still applied.
                     !overflowing && 'px-1',
                     overflowing && !atStart && 'pl-10',
                     overflowing && atStart && 'pl-1',
@@ -137,57 +209,74 @@ export function PromptChipsRow<TValue extends string = string>({
                     overflowing && atEnd && 'pr-1',
                 )}
             >
-                {chips.map((c) => {
-                    const { Icon } = c;
-                    if (c.comingSoon) {
+                <div
+                    ref={trackRef}
+                    role="listbox"
+                    aria-label={ariaLabel}
+                    data-testid={testIdPrefix ? `${testIdPrefix}-chips` : undefined}
+                    style={trackStyle}
+                    className="flex w-max gap-2 transition-transform duration-200 ease-out will-change-transform"
+                >
+                    {chips.map((c) => {
+                        const { Icon } = c;
+                        if (c.comingSoon) {
+                            return (
+                                <span
+                                    key={c.value}
+                                    role="option"
+                                    aria-disabled="true"
+                                    aria-selected="false"
+                                    title="Coming soon"
+                                    className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-sm border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
+                                    data-testid={
+                                        testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
+                                    }
+                                >
+                                    <Icon className="size-3.5 opacity-70" aria-hidden="true" />
+                                    <span className="whitespace-nowrap">{c.label}</span>
+                                    <span
+                                        aria-label="Coming soon"
+                                        className="ml-1 rounded-full bg-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted dark:bg-white/10 dark:text-text-muted-dark"
+                                    >
+                                        Soon
+                                    </span>
+                                </span>
+                            );
+                        }
+                        const selected = value === c.value;
                         return (
-                            <span
+                            <button
                                 key={c.value}
+                                type="button"
                                 role="option"
-                                aria-disabled="true"
-                                aria-selected="false"
-                                title="Coming soon"
-                                className="inline-flex shrink-0 cursor-not-allowed select-none items-center gap-2 rounded-full border px-3 py-1.5 text-sm border-border/40 dark:border-white/5 bg-foreground/[0.03] text-text-muted dark:text-text-muted-dark"
+                                aria-selected={selected}
+                                // role="option" doesn't support aria-pressed
+                                // (jsx-a11y/role-supports-aria-props). aria-selected
+                                // is the right toggle state inside a listbox.
+                                onClick={() => onChange(selected ? null : c.value)}
+                                // Keyboard accessibility: when Tab moves focus
+                                // to a chip that's currently panned off-screen,
+                                // pan the track so the focused chip is in
+                                // view. Native scrolling used to handle this
+                                // automatically; the transform-based pan does
+                                // not, so we wire it explicitly.
+                                onFocus={(e) => ensureChipVisible(e.currentTarget)}
                                 data-testid={
                                     testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined
                                 }
+                                className={cn(
+                                    'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
+                                    selected
+                                        ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
+                                        : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
+                                )}
                             >
-                                <Icon className="size-3.5 opacity-70" aria-hidden="true" />
-                                <span className="whitespace-nowrap">{c.label}</span>
-                                <span
-                                    aria-label="Coming soon"
-                                    className="ml-1 rounded-full bg-foreground/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted dark:bg-white/10 dark:text-text-muted-dark"
-                                >
-                                    Soon
-                                </span>
-                            </span>
+                                <Icon className="size-3.5" aria-hidden="true" />
+                                {c.label}
+                            </button>
                         );
-                    }
-                    const selected = value === c.value;
-                    return (
-                        <button
-                            key={c.value}
-                            type="button"
-                            role="option"
-                            aria-selected={selected}
-                            // role="option" doesn't support aria-pressed
-                            // (jsx-a11y/role-supports-aria-props). aria-selected
-                            // is the right toggle state inside a listbox; tests
-                            // querying by `[aria-selected]` get the live chips.
-                            onClick={() => onChange(selected ? null : c.value)}
-                            data-testid={testIdPrefix ? `${testIdPrefix}-${c.value}` : undefined}
-                            className={cn(
-                                'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors',
-                                selected
-                                    ? 'border-primary/60 bg-primary/10 text-primary shadow-sm'
-                                    : 'border-border/60 dark:border-white/10 bg-transparent text-text-secondary dark:text-text-secondary-dark hover:border-primary/40',
-                            )}
-                        >
-                            <Icon className="size-3.5" aria-hidden="true" />
-                            {c.label}
-                        </button>
-                    );
-                })}
+                    })}
+                </div>
             </div>
 
             {overflowing && !atEnd ? (
@@ -198,8 +287,8 @@ export function PromptChipsRow<TValue extends string = string>({
                     />
                     <button
                         type="button"
-                        onClick={() => scrollBy(220)}
-                        aria-label="Scroll chips right"
+                        onClick={() => panBy(STEP)}
+                        aria-label="Show next chips"
                         className="absolute right-0 top-1/2 z-20 grid -translate-y-1/2 place-items-center rounded-full border border-border/60 dark:border-white/10 bg-background/90 dark:bg-black/80 size-8 shadow-md hover:bg-foreground/5"
                         data-testid={testIdPrefix ? `${testIdPrefix}-scroll-right` : undefined}
                     >

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -28,6 +28,7 @@ import { ROUTES } from '@/lib/constants';
 import { useChatPanel } from '@/lib/hooks/use-chat-panel';
 import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import { attachUploadToMissionAction, createMissionAction } from '@/app/actions/dashboard/missions';
+import { RegisterCompanyDialog } from '@/components/organizations/RegisterCompanyDialog';
 
 /**
  * Unified `/new` page — single prompt input + chips for every
@@ -43,11 +44,17 @@ import { attachUploadToMissionAction, createMissionAction } from '@/app/actions/
  *   - website + 4 work kinds — forwarded to `/works/new` with the
  *                       prompt and the selected kind preserved.
  *
- * `store` and `company` are catalog entries telegraphing roadmap
- * scope (see Workspace notes `2026-05-23-missions-ideas-works-spec.md`
- * + AGENTS.md "stores + companies are in-scope future use cases"). They
- * render as inert "Soon" chips and aren't selectable yet, matching how
- * the marketing site already telegraphs them.
+ * `store` is a catalog entry telegraphing roadmap scope (see Workspace
+ * notes `2026-05-23-missions-ideas-works-spec.md` + AGENTS.md "stores
+ * + companies are in-scope future use cases"). It renders as an inert
+ * "Soon" chip, matching how the marketing site telegraphs it.
+ *
+ * EW-662 (Phase 10) — `company` graduated from inert to live: picking
+ * the Company chip opens the Register-Company dialog (spec §5.4), which
+ * creates an Organization with `registrationProvider = 'manual'` and
+ * `registrationStatus = 'registered'`. The full Stripe Atlas SDK
+ * integration is deferred to a later phase; for v1 the manual-completion
+ * path is the only way Company Works produce Orgs.
  *
  * The chat panel is auto-collapsed on mount so the prompt + chips
  * get the full main column on first land. Users can reopen it from
@@ -62,8 +69,17 @@ export type ChipType =
     | 'landing-page'
     | 'blog'
     | 'directory'
-    | 'awesome-repo';
+    | 'awesome-repo'
+    | 'company';
 
+// Spec §6.3 order:
+// `Mission · Idea · Website · Landing Page · Store · Blog · Directory
+//  · Awesome Repo · Knowledge Base · Company`.
+//
+// Live chips below stay in their current order (mission first, ideas
+// second, then content chips). `Company` joins at the end of the live
+// chip list per the spec, sitting next to the inert `store` chip which
+// is appended afterwards.
 const CHIP_ORDER: ChipType[] = [
     'mission',
     'idea',
@@ -74,6 +90,7 @@ const CHIP_ORDER: ChipType[] = [
     'blog',
     'directory',
     'awesome-repo',
+    'company',
 ];
 
 const CHIP_ICONS: Record<ChipType, LucideIcon> = {
@@ -88,6 +105,9 @@ const CHIP_ICONS: Record<ChipType, LucideIcon> = {
     // makes the two chips visually indistinguishable in the chip row.
     directory: FolderOpen,
     'awesome-repo': Star,
+    // EW-662 Phase 10 — same `Building2` icon the WorkspaceSwitcher
+    // empty state uses for consistency.
+    company: Building2,
 };
 
 const PLACEHOLDERS_BY_CHIP: Record<ChipType, ReadonlyArray<string>> = {
@@ -152,6 +172,17 @@ const PLACEHOLDERS_BY_CHIP: Record<ChipType, ReadonlyArray<string>> = {
         'e.g. "Awesome list of agent frameworks (LangChain, AutoGen, CrewAI…) with pros/cons"',
         'e.g. "Awesome list of free design resources for indie founders — icons, illustrations, fonts"',
     ],
+    // EW-662 Phase 10 — Company placeholders telegraph that this chip
+    // ends in a registered Organization (manual-completion path for v1).
+    // The prompt input is ignored on submit — the chip opens the
+    // Register-Company dialog directly — but the placeholder still
+    // sets context if the user lands on `?type=company` first.
+    company: [
+        'e.g. "Acme Inc. — an Org for our consultancy"',
+        'e.g. "Globex Holdings — the umbrella entity for our product lines"',
+        'e.g. "Soylent Labs — research entity for AI experimentation"',
+        'e.g. "Initech LLC — billing entity for our SaaS clients"',
+    ],
 };
 
 export interface NewPageClientProps {
@@ -170,6 +201,7 @@ const CHIP_INTENT_LABEL: Record<ChipType, string> = {
     blog: 'blog',
     directory: 'directory',
     'awesome-repo': 'awesome list repo',
+    company: 'Company',
 };
 
 const CHIP_TO_CANVAS_ROUTE: Partial<Record<ChipType, string>> = {
@@ -202,6 +234,24 @@ export function NewPageClient({
     const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [submitting, startSubmit] = useTransition();
     const startFromPrompt = useStartFromPrompt();
+    // EW-662 Phase 10 — Company chip is a special chip whose submit
+    // opens the Register-Company dialog instead of going through the
+    // chat-AI / canvas pipeline. We hold the dialog open-state here so
+    // it survives chip switches.
+    const [companyDialogOpen, setCompanyDialogOpen] = useState(false);
+
+    // Auto-open the dialog when the user lands on `/new?type=company`
+    // (e.g. from the Settings → Account banner). The chip is selected
+    // by the page's initialType param; we mirror that into the dialog
+    // open state once on mount.
+    useEffect(() => {
+        if (initialType === 'company') {
+            setCompanyDialogOpen(true);
+        }
+        // Only run on mount — chip switches are handled by the click
+        // handler in PromptChipsRow below.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // `buildAttachmentRefs` imported from PromptComposer — turns the
     // composer's full attachment list into chat-ready refs (filtering
@@ -223,6 +273,17 @@ export function NewPageClient({
     }, [setChatOpen]);
 
     const submit = () => {
+        // EW-662 Phase 10 — Company chip short-circuits the chat-AI
+        // path. There's no prompt-to-mission/work pipeline here: the
+        // user is going to register an Organization-backed Company,
+        // and that flow is owned by `<RegisterCompanyDialog>` (which
+        // collects the name + countryCode form). Open it and bail out
+        // of the rest of the submit logic — no min-length check,
+        // because the prompt input is incidental for this chip.
+        if (selectedChip === 'company') {
+            setCompanyDialogOpen(true);
+            return;
+        }
         const description = prompt.trim();
         if (description.length < 10) {
             toast.error(t('hints.minLength'));
@@ -340,10 +401,15 @@ export function NewPageClient({
         [selectedChip],
     );
 
-    // Full chip catalog. `store` + `company` are inert "Soon" chips,
-    // appended after the live chips so they sit at the end of the
+    // Full chip catalog. `store` stays as an inert "Soon" chip,
+    // appended after the live chips so it sits at the end of the
     // horizontal scroll the way the marketing site does it.
-    const allChips = useMemo<ReadonlyArray<PromptChip<ChipType | 'store' | 'company'>>>(
+    //
+    // EW-662 Phase 10 — `company` graduated from "Soon" to live; it
+    // sits at the end of the live `CHIP_ORDER` list so we render it
+    // automatically from the loop below. Picking it opens the
+    // Register-Company dialog on submit (see `submit()` above).
+    const allChips = useMemo<ReadonlyArray<PromptChip<ChipType | 'store'>>>(
         () => [
             ...CHIP_ORDER.map((c) => ({
                 value: c,
@@ -351,7 +417,6 @@ export function NewPageClient({
                 Icon: CHIP_ICONS[c],
             })),
             { value: 'store' as const, label: 'Store', Icon: Store, comingSoon: true },
-            { value: 'company' as const, label: 'Company', Icon: Building2, comingSoon: true },
         ],
         [t],
     );
@@ -386,10 +451,13 @@ export function NewPageClient({
                             chips={allChips}
                             value={selectedChip}
                             onChange={(next) => {
-                                // `store` and `company` are inert, so the
-                                // chips row never emits them — narrow back
-                                // to ChipType before persisting.
-                                if (next === null || next === 'store' || next === 'company') {
+                                // `store` is the last remaining inert "Soon"
+                                // chip — the chips row never emits it.
+                                // Narrow back to ChipType before persisting.
+                                // (`company` graduated to live in EW-662
+                                // Phase 10 and is handled like any other
+                                // ChipType.)
+                                if (next === null || next === 'store') {
                                     return;
                                 }
                                 setSelectedChip(next);
@@ -403,6 +471,11 @@ export function NewPageClient({
                     </div>
                 }
             />
+
+            {/* EW-662 Phase 10 — Register-Company dialog. Opens when the
+                user submits the Company chip or lands on
+                `/new?type=company`. */}
+            <RegisterCompanyDialog open={companyDialogOpen} onOpenChange={setCompanyDialogOpen} />
         </div>
     );
 }

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -55,12 +55,16 @@ function getSubmit(container: HTMLElement): HTMLButtonElement {
 }
 
 describe('NewPageClient (chat-open + canvas-route on submit)', () => {
-    it('renders all 9 chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo', () => {
+    it('renders all 10 chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo, Company', () => {
         const { container } = render(<NewPageClient />);
         const chipButtons = Array.from(
             container.querySelectorAll('button[role="option"][aria-selected]'),
         ) as HTMLButtonElement[];
-        expect(chipButtons).toHaveLength(9);
+        // EW-662 Phase 10 — `company` joined the live chip set so the
+        // total is now 10. `store` stays as an inert "Soon" chip
+        // (a `button[role="option"]` without `aria-selected` — filtered
+        // out by the selector above).
+        expect(chipButtons).toHaveLength(10);
         const labels = chipButtons.map((b) => b.textContent?.trim());
         expect(labels).toEqual([
             'dashboard.newPage.chips.mission',
@@ -72,6 +76,7 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
             'dashboard.newPage.chips.blog',
             'dashboard.newPage.chips.directory',
             'dashboard.newPage.chips.awesome-repo',
+            'dashboard.newPage.chips.company',
         ]);
     });
 

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { useRouter } from '@/i18n/navigation';
+import { useOrganizations } from '@/lib/hooks/use-organizations';
+import { UpgradeOrCreateDialog } from './UpgradeOrCreateDialog';
+
+const MAX_NAME_LENGTH = 200;
+
+export interface RegisterCompanyDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — Register-Company flow
+ * ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+ *
+ * Opened from the Company chip on `+ New`. Captures the user-visible
+ * Company fields (name + optional countryCode) and submits to
+ * `POST /api/organizations/register-company`. The server hard-codes
+ * `registrationProvider = 'manual'` + `registrationStatus =
+ * 'registered'` for v1 — the Stripe Atlas integration is deferred.
+ *
+ * Post-submit behavior mirrors the Phase 9 CreateOrganizationModal:
+ *  - First Org (`organizations.length === 0` pre-submit) → hands off
+ *    to `<UpgradeOrCreateDialog>` so the user can choose Upgrade vs
+ *    Empty.
+ *  - 2nd+ Org → close + navigate to `/${org.slug}/dashboard`.
+ *
+ * The full Stripe Atlas form (paperwork inputs, jurisdiction picker,
+ * etc.) is intentionally out of scope here — the chip's value in v1
+ * is that it gets the user to a registered Org in one form, with the
+ * registration metadata preserved so we can re-key into a real
+ * provider in a future phase without schema churn.
+ */
+export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDialogProps) {
+    const t = useTranslations('organizations.registerCompany');
+    const router = useRouter();
+    const { organizations, mutate } = useOrganizations();
+
+    const [name, setName] = useState('');
+    const [countryCode, setCountryCode] = useState('');
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    // Explicit submitting flag rather than `useTransition`'s `pending`:
+    // `useTransition`'s pending state only stays true synchronously inside
+    // its callback, and our submit kicks off a detached async IIFE, so
+    // `pending` flipped back to false immediately and the disabled button
+    // wasn't actually preventing double-submit. (Codex P2 on PR #1067.)
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [createdOrg, setCreatedOrg] = useState<OrganizationResponse | null>(null);
+    const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
+    /**
+     * Captures whether THIS submission is the user's first Org. Read
+     * once at submit-time so post-mutate `organizations.length` (=1
+     * after a successful create) can't flip the branch decision
+     * mid-flight.
+     */
+    const wasFirstOrgRef = useRef(false);
+
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setCountryCode('');
+            setSubmitError(null);
+            setCreatedOrg(null);
+            setShowUpgradeDialog(false);
+            setIsSubmitting(false);
+        }
+    }, [open]);
+
+    const handleSubmit = useCallback(async () => {
+        // Guard against double-submit while the previous request is
+        // still in flight. The `disabled={isSubmitting}` on the button
+        // covers click-through-keyboard / Enter; this guard covers any
+        // direct programmatic call.
+        if (isSubmitting) {
+            return;
+        }
+        const trimmedName = name.trim();
+        if (trimmedName.length === 0) {
+            setSubmitError(t('errors.nameRequired'));
+            return;
+        }
+        if (trimmedName.length > MAX_NAME_LENGTH) {
+            setSubmitError(t('errors.nameTooLong'));
+            return;
+        }
+        const cc = countryCode.trim();
+        if (cc.length > 0 && !/^[A-Za-z]{2}$/.test(cc)) {
+            setSubmitError(t('errors.countryCodeInvalid'));
+            return;
+        }
+        setSubmitError(null);
+        wasFirstOrgRef.current = organizations.length === 0;
+        setIsSubmitting(true);
+
+        try {
+            const res = await fetch('/api/organizations/register-company', {
+                method: 'POST',
+                credentials: 'include',
+                cache: 'no-store',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: trimmedName,
+                    ...(cc.length > 0 ? { countryCode: cc.toUpperCase() } : {}),
+                }),
+            });
+            if (!res.ok) {
+                const body = await res
+                    .json()
+                    .catch(() => ({ error: 'Failed to register company' }));
+                setSubmitError(
+                    (body as { message?: string; error?: string }).message ??
+                        (body as { error?: string }).error ??
+                        t('errors.generic'),
+                );
+                return;
+            }
+            const org = (await res.json()) as OrganizationResponse;
+            // Refresh the org list (best-effort — the POST already
+            // succeeded; a transient GET failure must not surface as
+            // a register error, otherwise the user retries + we end
+            // up with duplicate Orgs).
+            try {
+                await mutate();
+            } catch {
+                // Swallow.
+            }
+            if (wasFirstOrgRef.current) {
+                setCreatedOrg(org);
+                setShowUpgradeDialog(true);
+            } else {
+                onOpenChange(false);
+                router.push(`/${org.slug}/dashboard`);
+            }
+        } catch (err) {
+            setSubmitError(err instanceof Error ? err.message : t('errors.generic'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [isSubmitting, name, countryCode, organizations.length, mutate, onOpenChange, router, t]);
+
+    const handleUpgradeDialogClose = useCallback(
+        (didUpgrade: boolean) => {
+            setShowUpgradeDialog(false);
+            const target = createdOrg;
+            setCreatedOrg(null);
+            onOpenChange(false);
+            if (target) {
+                router.push(`/${target.slug}/dashboard`);
+                if (didUpgrade) void mutate();
+            }
+        },
+        [createdOrg, mutate, onOpenChange, router],
+    );
+
+    const showCreatePanel = !showUpgradeDialog;
+
+    return (
+        <>
+            <Dialog open={open} onOpenChange={onOpenChange}>
+                {showCreatePanel && (
+                    <DialogContent className="max-w-md">
+                        <DialogClose onClose={() => onOpenChange(false)} />
+                        <DialogHeader>
+                            <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                                {t('title')}
+                            </DialogTitle>
+                            <DialogDescription>{t('description')}</DialogDescription>
+                        </DialogHeader>
+
+                        <div className="space-y-4">
+                            <Input
+                                label={t('nameLabel')}
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                placeholder={t('namePlaceholder')}
+                                maxLength={MAX_NAME_LENGTH}
+                                autoFocus
+                                disabled={isSubmitting}
+                                data-testid="register-company-name"
+                            />
+                            <Input
+                                label={t('countryCodeLabel')}
+                                type="text"
+                                value={countryCode}
+                                onChange={(e) => setCountryCode(e.target.value)}
+                                placeholder={t('countryCodePlaceholder')}
+                                maxLength={2}
+                                disabled={isSubmitting}
+                                data-testid="register-company-country"
+                            />
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('helpProviderManual')}
+                            </p>
+                            {submitError && (
+                                <p className="text-sm text-danger" role="alert">
+                                    {submitError}
+                                </p>
+                            )}
+                        </div>
+
+                        <DialogFooter>
+                            <Button
+                                variant="ghost"
+                                onClick={() => onOpenChange(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t('cancel')}
+                            </Button>
+                            <Button
+                                onClick={handleSubmit}
+                                loading={isSubmitting}
+                                disabled={isSubmitting || name.trim().length === 0}
+                                data-testid="register-company-submit"
+                            >
+                                {t('submit')}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                )}
+            </Dialog>
+
+            {createdOrg && (
+                <UpgradeOrCreateDialog
+                    open={showUpgradeDialog}
+                    organization={createdOrg}
+                    onClose={handleUpgradeDialogClose}
+                />
+            )}
+        </>
+    );
+}

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OrganizationResponse } from '@ever-works/contracts/api';
+
+// next-intl — return the key plus any `{var}` interpolations so the
+// assertions match against the namespaced keys without coupling to
+// translated copy. Same pattern as the Phase 9 modal tests.
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string, args?: Record<string, string | number>) => {
+        const path = `${ns}.${key}`;
+        if (!args) return path;
+        const interp = Object.entries(args)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ');
+        return `${path} ${interp}`;
+    },
+}));
+
+const routerPushMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, ...rest }: { children: React.ReactNode; href?: string }) =>
+        React.createElement('a', rest as Record<string, unknown>, children),
+    useRouter: () => ({
+        push: routerPushMock,
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+    getPathname: ({ href }: { href: string }) => href,
+}));
+
+import { RegisterCompanyDialog } from './RegisterCompanyDialog';
+import {
+    __resetOrganizationsStoreForTests,
+    __seedOrganizationsStoreForTests,
+} from '@/lib/hooks/use-organizations';
+
+function org(overrides: Partial<OrganizationResponse> = {}): OrganizationResponse {
+    return {
+        id: 'o-new',
+        tenantId: 't-1',
+        slug: 'acme',
+        legalName: 'Acme Inc.',
+        displayName: 'Acme Inc.',
+        countryCode: 'US',
+        registrationProvider: 'manual',
+        registrationStatus: 'registered',
+        linkedWorkId: null,
+        createdAt: '2026-05-28T00:00:00.000Z',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
+    beforeEach(() => {
+        __resetOrganizationsStoreForTests();
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        routerPushMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('disables submit when name is empty and never fires the POST', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        const submit = screen.getByTestId('register-company-submit') as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        fireEvent.click(submit);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid country code inline (no POST fired)', () => {
+        const fetchMock = vi.spyOn(global, 'fetch');
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Acme Inc.' },
+        });
+        fireEvent.change(screen.getByTestId('register-company-country'), {
+            target: { value: 'USA' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(
+            screen.getByText('organizations.registerCompany.errors.countryCodeInvalid'),
+        ).toBeTruthy();
+    });
+
+    /**
+     * Happy path — 2nd Org (skips the upgrade dialog). Submits to the
+     * register-company endpoint, navigates to the new Org's dashboard,
+     * and closes the modal.
+     */
+    it('calls POST /api/organizations/register-company and navigates after success (2nd Org)', async () => {
+        __seedOrganizationsStoreForTests({
+            data: [org({ id: 'o-existing', slug: 'existing' })],
+            isLoading: false,
+            error: null,
+        });
+        const newOrg = org({ id: 'o-2', slug: 'globex', displayName: 'Globex LLC' });
+        const fetchMock = vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), {
+                    status: 201,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (u === '/api/organizations') {
+                // best-effort `mutate()` after success.
+                return new Response(JSON.stringify([newOrg]), { status: 200 });
+            }
+            throw new Error(`Unexpected fetch: ${u}`);
+        });
+
+        const onOpenChange = vi.fn();
+        render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Globex LLC' },
+        });
+        fireEvent.change(screen.getByTestId('register-company-country'), {
+            target: { value: 'de' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+
+        await waitFor(() => {
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+        });
+
+        const postCall = fetchMock.mock.calls.find(
+            ([u, init]) =>
+                String(u) === '/api/organizations/register-company' &&
+                (init as RequestInit | undefined)?.method === 'POST',
+        );
+        expect(postCall).toBeDefined();
+        const body = JSON.parse((postCall![1] as RequestInit).body as string);
+        // countryCode is auto-uppercased before submit.
+        expect(body).toEqual({ name: 'Globex LLC', countryCode: 'DE' });
+    });
+
+    /**
+     * First-Org path — after a successful POST, hand off to the
+     * UpgradeOrCreateDialog so the user can pick Upgrade vs Empty.
+     */
+    it('chains into the UpgradeOrCreateDialog when this is the user first Org', async () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+        const newOrg = org({ id: 'o-first', slug: 'first-co', displayName: 'First Company' });
+        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            return new Response(JSON.stringify([newOrg]), { status: 200 });
+        });
+
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'First Company' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+
+        // The UpgradeOrCreateDialog renders the `organizations.upgrade.title` key.
+        await waitFor(() => {
+            expect(screen.queryByText('organizations.upgrade.title')).toBeTruthy();
+        });
+        // No direct router navigation yet — the upgrade dialog owns the next step.
+        expect(routerPushMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -7,7 +7,13 @@ import { APIResponse } from './types';
 // in sync to avoid a runtime dep on the agent package from
 // apps/web). PR X seeds Mission Template repos; PR Y wires the
 // "Use this Template" button to pre-fill /new?type=mission.
-export type TemplateKind = 'website' | 'work' | 'mission';
+//
+// EW-662 (Tenants & Organizations Phase 10) — `'company'` joins the
+// union so the Company WorkType has a place in the catalog. No seed
+// templates ship in v1; the chip on `+ New` routes directly into
+// the Register-Company form which calls the OrganizationService
+// manual-completion path.
+export type TemplateKind = 'website' | 'work' | 'mission' | 'company';
 export type TemplateSourceType = 'built_in' | 'custom';
 export type TemplateOriginType = 'standard' | 'forked' | 'custom_url';
 

--- a/docs/web-dashboard/work-detail-components.md
+++ b/docs/web-dashboard/work-detail-components.md
@@ -144,7 +144,7 @@ Renders a horizontal tab navigation bar. Each tab is a link that navigates to a 
 | ------------- | ----------- | ------------------------------------- |
 | `overview`    | Overview    | Always                                |
 | `items`       | Items       | Always                                |
-| `generator`   | Generator   | Always                                |
+| `generator`   | Worker      | Always                                |
 | `schedule`    | Schedule    | Always                                |
 | `history`     | History     | Always                                |
 | `comparisons` | Comparisons | Always                                |

--- a/docs/web-dashboard/work-pages.md
+++ b/docs/web-dashboard/work-pages.md
@@ -98,7 +98,7 @@ The detail layout wraps all sub-pages with shared navigation:
 | ----------- | ------------------------- | ---------------------------- |
 | Overview    | `/works/[id]`             | Work stats and quick actions |
 | Items       | `/works/[id]/items`       | Manage work items            |
-| Generator   | `/works/[id]/generator`   | Run item generation          |
+| Worker      | `/works/[id]/generator`   | Run item generation          |
 | Comparisons | `/works/[id]/comparisons` | Item comparison pages        |
 | History     | `/works/[id]/history`     | Generation run history       |
 | Members     | `/works/[id]/members`     | Team access management       |

--- a/packages/agent/src/entities/template.entity.ts
+++ b/packages/agent/src/entities/template.entity.ts
@@ -5,7 +5,16 @@ import { Column, CreateDateColumn, Entity, Index, PrimaryColumn, UpdateDateColum
 // templates in the catalog. The DB column is `varchar(32)` so
 // the new value fits without a migration; PR X seeds the
 // Mission Template repos.
-export type TemplateKind = 'website' | 'work' | 'mission';
+//
+// EW-662 (Tenants & Organizations Phase 10) — `'company'` joins the
+// union for the Company WorkType. Companies are a special template
+// kind that, when their backing Work transitions to `registered`,
+// spawn an `Organization` row (see `OrganizationService.createOrganizationFromCompanyWork`).
+// Same `varchar(32)` column — no migration needed for the new value.
+// No seed templates ship in v1 (Stripe Atlas integration is deferred);
+// the chip on `+ New` routes directly into the Register-Company
+// form which calls the `OrganizationService` manual-completion path.
+export type TemplateKind = 'website' | 'work' | 'mission' | 'company';
 export type TemplateSourceType = 'built_in' | 'custom';
 
 @Entity({ name: 'templates' })

--- a/packages/contracts/src/api/organization/index.ts
+++ b/packages/contracts/src/api/organization/index.ts
@@ -15,6 +15,26 @@ export interface CreateOrganizationRequest {
 	slug?: string;
 }
 
+/**
+ * EW-662 (Tenants & Organizations Phase 10) — body for
+ * `POST /api/organizations/register-company`.
+ *
+ * Driven by the Company chip on `+ New`. The service hard-codes
+ * `registrationProvider = 'manual'` and `registrationStatus =
+ * 'registered'` for v1 (Stripe Atlas integration is deferred); the
+ * client only supplies the user-visible fields.
+ */
+export interface RegisterCompanyRequest {
+	/** Display name. 1-200 chars. */
+	name: string;
+	/** Registered legal name. Defaults to `name` when omitted. */
+	legalName?: string;
+	/** ISO 3166-1 alpha-2 country code (e.g. `'US'`). */
+	countryCode?: string;
+	/** Optional slug override. If omitted, allocated from `name`. */
+	slug?: string;
+}
+
 export interface UpdateOrganizationRequest {
 	displayName?: string;
 	legalName?: string;


### PR DESCRIPTION
## Summary

Routine cascade. 3 commits ahead of stage.

### What's in this cascade

- **[ever-works#1069](https://github.com/ever-works/ever-works/pull/1069)** — chip row pans via CSS transform (`translateX`); no trackpad / touch / wheel scrolling, arrows only. Also fixes the maxOffset gutter math (last chips were being clipped on the right) and wires \`onFocus\` so Tab into a hidden chip pans the track to bring it into view.
- **[ever-works#1068](https://github.com/ever-works/ever-works/pull/1068)** — rename user-facing \"Generator\" → \"Worker\" in platform UI (i18n).
- **[ever-works#1067](https://github.com/ever-works/ever-works/pull/1067)** — Tenants/Orgs Phase 10: Company chip + Work→Org wire-up (EW-662).

## Test plan

- [ ] CI green on stage.
- [ ] Stage deploy succeeds.
- [ ] /new chip row: trackpad swipe + mouse wheel + touch drag cannot move the chips. Only the ◀ / ▶ buttons do.
- [ ] Tab through chips: a hidden chip pans into view when focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)