### PR TITLE
feat(plugins): agent-memory capability + agentmemory plugin (local or hosted)

### DIFF
--- a/.deploy/k8s/agentmemory.optional.yaml
+++ b/.deploy/k8s/agentmemory.optional.yaml
@@ -1,0 +1,156 @@
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# agentmemory — OPTIONAL self-hosted deployment.
+#
+# This manifest spins up a `agentmemory` REST server alongside the platform
+# inside the same cluster. It is intentionally NOT included from any of the
+# environment manifests (`k8s-manifest.{dev,stage,prod}.yaml`) — operators
+# opt in by applying this file manually:
+#
+#   kubectl apply -f .deploy/k8s/agentmemory.optional.yaml -n ever-works
+#
+# The `@ever-works/agentmemory-plugin` then needs a single setting:
+#   baseUrl = http://agentmemory.ever-works.svc.cluster.local:3111
+# (set either in the plugin's admin settings or via the `AGENTMEMORY_BASE_URL`
+# env var on the API deployment).
+#
+# Operators who prefer the hosted SaaS — or who already run `agentmemory`
+# externally — should SKIP this manifest and point the plugin at the
+# external URL instead. The plugin doesn't care which mode is in use.
+# ─────────────────────────────────────────────────────────────────────────────
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentmemory
+  labels:
+    app: agentmemory
+spec:
+  selector:
+    app: agentmemory
+  ports:
+    - name: rest
+      protocol: TCP
+      port: 3111
+      targetPort: 3111
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agentmemory-data
+  labels:
+    app: agentmemory
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # 5Gi is enough headroom for tens of millions of observations on
+      # agentmemory's default SQLite layout. Bump (and shrink the LRU
+      # retention via AGENTMEMORY_RETENTION_DAYS) for heavy workloads.
+      storage: 5Gi
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentmemory-secret
+  labels:
+    app: agentmemory
+type: Opaque
+stringData:
+  # The agentmemory server treats this as the Bearer token clients must
+  # send in Authorization. The `@ever-works/agentmemory-plugin` reads
+  # the same value from its `apiKey` setting (or `AGENTMEMORY_API_KEY`).
+  AGENTMEMORY_SECRET: "$AGENTMEMORY_SECRET"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentmemory
+  labels:
+    app: agentmemory
+spec:
+  # Single replica — SQLite is the canonical backend and isn't sharded
+  # cluster-wide. Operators who need HA should run agentmemory externally
+  # against a managed Postgres / vector DB instead, then point the plugin
+  # at that URL.
+  replicas: 1
+  strategy:
+    # Recreate (not RollingUpdate) — only one pod ever owns the PVC.
+    type: Recreate
+  selector:
+    matchLabels:
+      app: agentmemory
+  template:
+    metadata:
+      labels:
+        app: agentmemory
+    spec:
+      # Container ships as non-root in the upstream Dockerfile; mirror
+      # the platform's own hardening profile.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      automountServiceAccountToken: false
+      containers:
+        - name: agentmemory
+          # Pin a specific tag in production — `latest` is fine for an
+          # opt-in optional deployment, but operators MUST swap for an
+          # immutable SHA once they decide which version is canonical.
+          image: ghcr.io/rohitg00/agentmemory:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: rest
+              containerPort: 3111
+          env:
+            - name: III_REST_PORT
+              value: "3111"
+            - name: AGENTMEMORY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: agentmemory-secret
+                  key: AGENTMEMORY_SECRET
+            # The viewer UI binds to 3113 and stays loopback-only by
+            # default. Operators who want to expose it can add an
+            # additional Service + Ingress; we leave it private here.
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          # Health + readiness probes hit the public `/agentmemory/health`
+          # route — same one the plugin's `validateConnection` calls.
+          readinessProbe:
+            httpGet:
+              path: /agentmemory/health
+              port: 3111
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /agentmemory/health
+              port: 3111
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: agentmemory-data

--- a/.deploy/k8s/agentmemory.optional.yaml
+++ b/.deploy/k8s/agentmemory.optional.yaml
@@ -5,14 +5,30 @@
 # This manifest spins up a `agentmemory` REST server alongside the platform
 # inside the same cluster. It is intentionally NOT included from any of the
 # environment manifests (`k8s-manifest.{dev,stage,prod}.yaml`) — operators
-# opt in by applying this file manually:
+# opt in by applying this file manually.
 #
-#   kubectl apply -f .deploy/k8s/agentmemory.optional.yaml -n ever-works
+# The Secret block below uses a shell-style `$AGENTMEMORY_SECRET`
+# placeholder — `kubectl apply` does NOT expand shell variables, so applying
+# this file verbatim would store the literal string "$AGENTMEMORY_SECRET"
+# as the bearer token (everyone with cluster access could then read /
+# write to the memory store with that publicly-known value).
 #
-# The `@ever-works/agentmemory-plugin` then needs a single setting:
+# Apply with envsubst (or via Kustomize / Helm):
+#
+#   export AGENTMEMORY_SECRET="$(openssl rand -hex 32)"  # one-time
+#   envsubst < .deploy/k8s/agentmemory.optional.yaml \
+#     | kubectl apply -n ever-works -f -
+#
+# Or replace this Secret with a `secretGenerator` in a kustomization.yaml
+# that reads the token from a literal source or external secret store
+# (sealed-secrets, external-secrets-operator, etc.) — that's the
+# recommended path for production.
+#
+# Once the Secret is applied, the `@ever-works/agentmemory-plugin` needs:
 #   baseUrl = http://agentmemory.ever-works.svc.cluster.local:3111
+#   apiKey  = <the same value you put in $AGENTMEMORY_SECRET>
 # (set either in the plugin's admin settings or via the `AGENTMEMORY_BASE_URL`
-# env var on the API deployment).
+# / `AGENTMEMORY_API_KEY` env vars on the API deployment).
 #
 # Operators who prefer the hosted SaaS — or who already run `agentmemory`
 # externally — should SKIP this manifest and point the plugin at the
@@ -63,7 +79,13 @@ stringData:
   # The agentmemory server treats this as the Bearer token clients must
   # send in Authorization. The `@ever-works/agentmemory-plugin` reads
   # the same value from its `apiKey` setting (or `AGENTMEMORY_API_KEY`).
-  AGENTMEMORY_SECRET: "$AGENTMEMORY_SECRET"
+  #
+  # `$AGENTMEMORY_SECRET` is a shell-style placeholder — it is NOT
+  # expanded by `kubectl apply`. Use `envsubst < this-file | kubectl
+  # apply -f -` (or a Kustomize secretGenerator / external-secrets
+  # operator) so the real token is never committed. See the header
+  # comment for the full procedure.
+  AGENTMEMORY_SECRET: '$AGENTMEMORY_SECRET'
 
 ---
 apiVersion: apps/v1

--- a/packages/agent/src/facades/__tests__/agent-memory.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/agent-memory.facade.spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AgentMemoryFacadeService, AgentMemoryFacadeError } from '../agent-memory.facade';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import type {
+    IAgentMemoryPlugin,
+    PluginManifest,
+    AgentMemoryRecord,
+    AgentMemorySession,
+    AgentMemorySearchResponse,
+    AgentMemoryContext,
+} from '@ever-works/plugin';
+import { NoProviderError } from '../base.facade';
+
+describe('AgentMemoryFacadeService', () => {
+    let service: AgentMemoryFacadeService;
+    let registry: jest.Mocked<PluginRegistryService>;
+    let settingsService: jest.Mocked<PluginSettingsService>;
+
+    const createMockMemoryPlugin = (id: string, providerName: string): IAgentMemoryPlugin => ({
+        id,
+        name: providerName,
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['agent-memory'],
+        settingsSchema: { type: 'object', properties: {} },
+        providerName,
+        onLoad: jest.fn(),
+        onUnload: jest.fn(),
+        openSession: jest.fn().mockResolvedValue({
+            id: 'sess-1',
+            startedAt: '2026-01-01T00:00:00Z',
+        } as AgentMemorySession),
+        closeSession: jest.fn().mockResolvedValue(undefined),
+        saveMemory: jest.fn().mockResolvedValue({
+            id: 'mem-1',
+            content: 'remembered',
+            createdAt: '2026-01-01T00:00:00Z',
+        } as AgentMemoryRecord),
+        searchMemory: jest.fn().mockResolvedValue({
+            results: [],
+        } as AgentMemorySearchResponse),
+        buildContext: jest.fn().mockResolvedValue({
+            content: 'context',
+        } as AgentMemoryContext),
+        deleteEntry: jest.fn().mockResolvedValue(undefined),
+        listSessions: jest.fn().mockResolvedValue([]),
+    });
+
+    const createRegisteredPlugin = (
+        plugin: IAgentMemoryPlugin,
+        manifest: Partial<PluginManifest>,
+        state: RegisteredPlugin['state'] = 'loaded',
+    ): RegisteredPlugin => ({
+        plugin: plugin as any,
+        manifest: {
+            id: plugin.id,
+            name: plugin.name,
+            version: plugin.version,
+            description: 'Test agent-memory plugin',
+            category: plugin.category,
+            capabilities: manifest.capabilities || plugin.capabilities,
+            ...manifest,
+        } as PluginManifest,
+        state,
+        builtIn: manifest.builtIn ?? false,
+        stateHistory: [],
+        registeredAt: Date.now(),
+    });
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                AgentMemoryFacadeService,
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        get: jest.fn(),
+                        getByCapability: jest.fn().mockReturnValue([]),
+                        isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+                    },
+                },
+                {
+                    provide: PluginSettingsService,
+                    useValue: {
+                        getSettings: jest
+                            .fn()
+                            .mockResolvedValue({ baseUrl: 'http://localhost:3111' }),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<AgentMemoryFacadeService>(AgentMemoryFacadeService);
+        registry = module.get(PluginRegistryService);
+        settingsService = module.get(PluginSettingsService);
+    });
+
+    describe('isConfigured', () => {
+        it('returns true when a loaded agent-memory plugin is registered', () => {
+            const plugin = createMockMemoryPlugin('agentmemory', 'Agent Memory');
+            registry.getByCapability.mockReturnValue([
+                createRegisteredPlugin(plugin, { capabilities: ['agent-memory'] }),
+            ]);
+            expect(service.isConfigured()).toBe(true);
+        });
+
+        it('returns false when no agent-memory plugins are registered', () => {
+            registry.getByCapability.mockReturnValue([]);
+            expect(service.isConfigured()).toBe(false);
+        });
+    });
+
+    describe('routing', () => {
+        const opts = { userId: 'user-1', workId: 'work-1' };
+
+        function wireSinglePlugin(): IAgentMemoryPlugin {
+            const plugin = createMockMemoryPlugin('agentmemory', 'Agent Memory');
+            registry.getByCapability.mockReturnValue([
+                createRegisteredPlugin(plugin, { capabilities: ['agent-memory'] }),
+            ]);
+            return plugin;
+        }
+
+        it('openSession passes injected settings to the plugin', async () => {
+            const plugin = wireSinglePlugin();
+            await service.openSession({ workId: 'work-1' }, opts);
+            expect(plugin.openSession).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    metadata: { workId: 'work-1' },
+                    settings: { baseUrl: 'http://localhost:3111' },
+                }),
+            );
+        });
+
+        it('saveMemory dispatches with the resolved settings hierarchy', async () => {
+            const plugin = wireSinglePlugin();
+            await service.saveMemory({ content: 'x' }, opts);
+            expect(plugin.saveMemory).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: 'x',
+                    settings: { baseUrl: 'http://localhost:3111' },
+                }),
+            );
+            expect(settingsService.getSettings).toHaveBeenCalledWith(
+                'agentmemory',
+                expect.objectContaining({
+                    userId: 'user-1',
+                    workId: 'work-1',
+                    includeSecrets: true,
+                }),
+            );
+        });
+
+        it('searchMemory forwards limit + tags through', async () => {
+            const plugin = wireSinglePlugin();
+            await service.searchMemory({ query: 'auth bug', limit: 5, tags: ['bug'] }, opts);
+            expect(plugin.searchMemory).toHaveBeenCalledWith(
+                expect.objectContaining({ query: 'auth bug', limit: 5, tags: ['bug'] }),
+            );
+        });
+
+        it('buildContext returns the plugin response verbatim', async () => {
+            const plugin = wireSinglePlugin();
+            (plugin.buildContext as jest.Mock).mockResolvedValueOnce({ content: 'hello' });
+            const result = await service.buildContext({ query: 'q' }, opts);
+            expect(result.content).toBe('hello');
+        });
+
+        it('listSessions calls the plugin and returns its list', async () => {
+            const plugin = wireSinglePlugin();
+            (plugin.listSessions as jest.Mock).mockResolvedValueOnce([
+                { id: 's1', startedAt: 't1' },
+            ]);
+            const result = await service.listSessions({ limit: 3 }, opts);
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('s1');
+        });
+    });
+
+    describe('error surfaces', () => {
+        it('throws NoProviderError when no plugin is registered for the capability', async () => {
+            registry.getByCapability.mockReturnValue([]);
+            await expect(service.saveMemory({ content: 'x' }, { userId: 'u' })).rejects.toThrow(
+                NoProviderError,
+            );
+        });
+
+        it('wraps plugin errors as AgentMemoryFacadeError with operation metadata', async () => {
+            const plugin = createMockMemoryPlugin('agentmemory', 'Agent Memory');
+            (plugin.saveMemory as jest.Mock).mockRejectedValueOnce(new Error('backend down'));
+            registry.getByCapability.mockReturnValue([
+                createRegisteredPlugin(plugin, { capabilities: ['agent-memory'] }),
+            ]);
+            await expect(
+                service.saveMemory({ content: 'x' }, { userId: 'u' }),
+            ).rejects.toMatchObject({
+                name: 'AgentMemoryFacadeError',
+                operation: 'saveMemory',
+                provider: 'agentmemory',
+            });
+        });
+
+        it('rejects deleteEntry when the resolved plugin omits it', async () => {
+            const plugin = createMockMemoryPlugin('agentmemory', 'Agent Memory');
+            delete (plugin as any).deleteEntry;
+            registry.getByCapability.mockReturnValue([
+                createRegisteredPlugin(plugin, { capabilities: ['agent-memory'] }),
+            ]);
+            await expect(service.deleteEntry('mem-1', { userId: 'u' })).rejects.toThrow(
+                /does not support deleteEntry/,
+            );
+        });
+    });
+});

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -13,6 +13,8 @@ import { PromptFacadeService } from '../prompt.facade';
 // PR #1019 (Skills + Tasks) — two new facades.
 import { SkillsFacadeService } from '../skills.facade';
 import { TasksFacadeService } from '../tasks.facade';
+// EW-N (agentmemory plugin) — pluggable persistent memory facade.
+import { AgentMemoryFacadeService } from '../agent-memory.facade';
 
 /**
  * Pins the `FacadesModule` provider/exports map AND the public
@@ -38,6 +40,8 @@ describe('FacadesModule + barrel re-exports', () => {
         // PR #1019 — Skills + Tasks facades.
         SkillsFacadeService,
         TasksFacadeService,
+        // EW-N — Agent-Memory facade (default plugin: agentmemory REST :3111).
+        AgentMemoryFacadeService,
     ] as const;
 
     describe('@Module() decorator metadata', () => {
@@ -53,7 +57,7 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(importNames).toContain('DatabaseModule');
         });
 
-        it('declares all ten facade classes as providers (one entry per facade, no extras)', () => {
+        it('declares every facade class as a provider (one entry per facade, no extras)', () => {
             const providers = getMeta('providers');
             for (const cls of FACADE_CLASSES) {
                 expect(providers).toContain(cls);
@@ -65,7 +69,7 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(providers).toHaveLength(FACADE_CLASSES.length);
         });
 
-        it('exports all ten facade classes (one-to-one with providers)', () => {
+        it('exports every facade class (one-to-one with providers)', () => {
             const exports = getMeta('exports');
             for (const cls of FACADE_CLASSES) {
                 expect(exports).toContain(cls);
@@ -89,7 +93,7 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(facadesBarrel.FacadesModule).toBe(FacadesModule);
         });
 
-        it('re-exports each of the ten facade service classes verbatim', () => {
+        it('re-exports each facade service class verbatim', () => {
             expect(facadesBarrel.AiFacadeService).toBe(AiFacadeService);
             expect(facadesBarrel.SearchFacadeService).toBe(SearchFacadeService);
             expect(facadesBarrel.ScreenshotFacadeService).toBe(ScreenshotFacadeService);
@@ -100,6 +104,9 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(facadesBarrel.DeployFacadeService).toBe(DeployFacadeService);
             expect(facadesBarrel.CodeEditFacadeService).toBe(CodeEditFacadeService);
             expect(facadesBarrel.PromptFacadeService).toBe(PromptFacadeService);
+            expect(facadesBarrel.SkillsFacadeService).toBe(SkillsFacadeService);
+            expect(facadesBarrel.TasksFacadeService).toBe(TasksFacadeService);
+            expect(facadesBarrel.AgentMemoryFacadeService).toBe(AgentMemoryFacadeService);
         });
 
         it('re-exports each facade-specific error class (one per capability that defines errors)', () => {
@@ -189,6 +196,9 @@ describe('FacadesModule + barrel re-exports', () => {
                     'SkillsFacadeService',
                     'TasksFacadeError',
                     'TasksFacadeService',
+                    // Agent-Memory facade (default plugin: agentmemory REST :3111).
+                    'AgentMemoryFacadeError',
+                    'AgentMemoryFacadeService',
                 ].sort(),
             );
         });

--- a/packages/agent/src/facades/agent-memory.facade.ts
+++ b/packages/agent/src/facades/agent-memory.facade.ts
@@ -1,0 +1,183 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type {
+    IAgentMemoryPlugin,
+    IAgentMemoryFacade,
+    AgentMemorySession,
+    AgentMemoryRecord,
+    AgentMemorySearchResponse,
+    AgentMemoryContext,
+    FacadeOptions,
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
+import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
+import { BaseFacadeService, FacadeError } from './base.facade';
+
+export class AgentMemoryFacadeError extends FacadeError {
+    constructor(message: string, operation: string, provider?: string, cause?: Error) {
+        super(message, operation, provider, cause);
+        this.name = 'AgentMemoryFacadeError';
+    }
+}
+
+/**
+ * Facade for the `agent-memory` capability.
+ *
+ * Routes save/search/context/session operations to the user's resolved
+ * agent-memory plugin (default `@ever-works/agentmemory-plugin`, which
+ * talks to a local or hosted `agentmemory` REST server).
+ *
+ * Mirrors the other facades: provider resolution + 4-level settings
+ * hierarchy via `BaseFacadeService`. Optional governance methods
+ * (`deleteEntry`, `listSessions`) probe the resolved plugin for support
+ * before dispatching — community plugins MAY skip them.
+ */
+@Injectable()
+export class AgentMemoryFacadeService extends BaseFacadeService implements IAgentMemoryFacade {
+    protected readonly logger = new Logger(AgentMemoryFacadeService.name);
+    protected readonly CAPABILITY = PLUGIN_CAPABILITIES.AGENT_MEMORY;
+
+    constructor(
+        registry: PluginRegistryService,
+        settingsService: PluginSettingsService,
+        @Optional() workPluginRepository?: WorkPluginRepository,
+    ) {
+        super(registry, settingsService, workPluginRepository);
+    }
+
+    async openSession(
+        metadata: Record<string, unknown> | undefined,
+        facadeOptions: FacadeOptions,
+    ): Promise<AgentMemorySession> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            return await plugin.openSession({
+                metadata,
+                settings,
+            });
+        } catch (error) {
+            throw this.wrap(error, 'openSession', plugin.id);
+        }
+    }
+
+    async closeSession(sessionId: string, facadeOptions: FacadeOptions): Promise<void> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            await plugin.closeSession(sessionId, settings);
+        } catch (error) {
+            throw this.wrap(error, 'closeSession', plugin.id);
+        }
+    }
+
+    async saveMemory(
+        input: {
+            content: string;
+            tags?: readonly string[];
+            metadata?: Record<string, unknown>;
+            sessionId?: string;
+            projectId?: string;
+        },
+        facadeOptions: FacadeOptions,
+    ): Promise<AgentMemoryRecord> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            return await plugin.saveMemory({ ...input, settings });
+        } catch (error) {
+            throw this.wrap(error, 'saveMemory', plugin.id);
+        }
+    }
+
+    async searchMemory(
+        input: {
+            query: string;
+            limit?: number;
+            tags?: readonly string[];
+            sessionId?: string;
+            projectId?: string;
+        },
+        facadeOptions: FacadeOptions,
+    ): Promise<AgentMemorySearchResponse> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            return await plugin.searchMemory({ ...input, settings });
+        } catch (error) {
+            throw this.wrap(error, 'searchMemory', plugin.id);
+        }
+    }
+
+    async buildContext(
+        input: {
+            query?: string;
+            purpose?: string;
+            sessionId?: string;
+            projectId?: string;
+            maxTokens?: number;
+        },
+        facadeOptions: FacadeOptions,
+    ): Promise<AgentMemoryContext> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            return await plugin.buildContext({ ...input, settings });
+        } catch (error) {
+            throw this.wrap(error, 'buildContext', plugin.id);
+        }
+    }
+
+    async deleteEntry(id: string, facadeOptions: FacadeOptions): Promise<void> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        if (typeof plugin.deleteEntry !== 'function') {
+            throw new AgentMemoryFacadeError(
+                `Agent-memory provider "${plugin.providerName}" does not support deleteEntry`,
+                'deleteEntry',
+                plugin.id,
+            );
+        }
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            await plugin.deleteEntry(id, settings);
+        } catch (error) {
+            throw this.wrap(error, 'deleteEntry', plugin.id);
+        }
+    }
+
+    async listSessions(
+        options: { limit?: number; projectId?: string } | undefined,
+        facadeOptions: FacadeOptions,
+    ): Promise<readonly AgentMemorySession[]> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        if (typeof plugin.listSessions !== 'function') {
+            throw new AgentMemoryFacadeError(
+                `Agent-memory provider "${plugin.providerName}" does not support listSessions`,
+                'listSessions',
+                plugin.id,
+            );
+        }
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            return await plugin.listSessions({ ...options, settings });
+        } catch (error) {
+            throw this.wrap(error, 'listSessions', plugin.id);
+        }
+    }
+
+    private resolveTypedPlugin(facadeOptions: FacadeOptions): Promise<IAgentMemoryPlugin> {
+        return this.resolvePlugin<IAgentMemoryPlugin>(
+            facadeOptions.providerOverride,
+            facadeOptions.userId,
+            facadeOptions.workId,
+        );
+    }
+
+    private wrap(error: unknown, operation: string, provider: string): AgentMemoryFacadeError {
+        if (error instanceof AgentMemoryFacadeError) return error;
+        const message = error instanceof Error ? error.message : 'Agent-memory operation failed';
+        const cause = error instanceof Error ? error : undefined;
+        return new AgentMemoryFacadeError(message, operation, provider, cause);
+    }
+}

--- a/packages/agent/src/facades/facades.module.ts
+++ b/packages/agent/src/facades/facades.module.ts
@@ -15,6 +15,7 @@ import { CodeEditFacadeService } from './code-edit.facade';
 import { PromptFacadeService } from './prompt.facade';
 import { SkillsFacadeService } from './skills.facade';
 import { TasksFacadeService } from './tasks.facade';
+import { AgentMemoryFacadeService } from './agent-memory.facade';
 
 const FACADES = [
     AiFacadeService,
@@ -29,6 +30,7 @@ const FACADES = [
     PromptFacadeService,
     SkillsFacadeService,
     TasksFacadeService,
+    AgentMemoryFacadeService,
 ];
 
 /**

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -93,6 +93,11 @@ export { SkillsFacadeService, SkillsFacadeError } from './skills.facade';
 // Tasks Facade — Agents/Skills/Tasks PR #1017, Phase 11.8 (ADR-013)
 export { TasksFacadeService, TasksFacadeError } from './tasks.facade';
 
+// Agent-Memory Facade — pluggable persistent memory for agents
+// (default plugin `@ever-works/agentmemory-plugin` talks to a local or
+// hosted `agentmemory` REST server on :3111)
+export { AgentMemoryFacadeService, AgentMemoryFacadeError } from './agent-memory.facade';
+
 // Re-export facade types from plugin for convenience
 export type { FacadeExtractionOptions, FacadeExtractedContent } from '@ever-works/plugin';
 export type {

--- a/packages/plugin/src/contracts/capabilities/agent-memory.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/agent-memory.interface.ts
@@ -1,0 +1,223 @@
+import type { IPlugin } from '../plugin.interface.js';
+import type { PluginSettings } from '../../settings/settings.types.js';
+
+/**
+ * Agent-memory capability — pluggable persistent memory for AI coding /
+ * generation agents.
+ *
+ * The contract intentionally mirrors the de-facto shape established by the
+ * "agentmemory" REST API (Claude Code / Codex / OpenCode / Cursor / MCP
+ * clients all hit the same endpoints): sessions wrap a unit of work,
+ * observations are appended during the session, and `searchMemory` /
+ * `buildContext` produce the payload that gets injected on the next run.
+ *
+ * Plugins implementing this capability can run:
+ *
+ * 1. **Locally** alongside the Ever Works API — the default
+ *    `@ever-works/agentmemory-plugin` ships with a `baseUrl` defaulting to
+ *    `http://localhost:3111`, matching the `agentmemory` npm package's
+ *    standalone Node server. The operator runs `npx agentmemory` (or the
+ *    optional Helm chart in `.deploy/k8s/agentmemory.optional.yaml`) and
+ *    the plugin just connects.
+ *
+ * 2. **Hosted** behind any HTTPS endpoint — the same plugin accepts a
+ *    custom `baseUrl` + bearer `apiKey` (set per-user, per-work, or via
+ *    the `AGENTMEMORY_BASE_URL` / `AGENTMEMORY_API_KEY` env vars). This
+ *    matches every other "external service" plugin in the repo
+ *    (Activepieces, Make, Tavily, ...).
+ *
+ * Community plugins (mem0, zep, langmem, vector-db-backed homegrown
+ * stores) implement the same interface; the `AgentMemoryFacadeService`
+ * doesn't care which backend is selected.
+ */
+
+/**
+ * A single observation recorded against a session — a free-form snippet
+ * of text the agent wants to remember. `tags` and `metadata` let backends
+ * cluster / filter without baking schema in.
+ */
+export interface AgentMemoryObservation {
+	/** Free-form text — what happened, what was learned. */
+	readonly content: string;
+	/** Optional human-readable tags ('bug-fix', 'auth', 'webhook'). */
+	readonly tags?: readonly string[];
+	/** Arbitrary structured metadata (file path, PR number, model used). */
+	readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * A persisted memory record returned by `searchMemory` and friends. The
+ * shape is a superset of `AgentMemoryObservation` plus identity / scoring
+ * fields the backend produces.
+ */
+export interface AgentMemoryRecord extends AgentMemoryObservation {
+	/** Stable identifier the backend assigned. */
+	readonly id: string;
+	/** Owning session id, when the record was captured inside a session. */
+	readonly sessionId?: string;
+	/** ISO-8601 timestamp the record was written. */
+	readonly createdAt: string;
+	/** Similarity score from `searchMemory` (0..1). Absent on plain lookups. */
+	readonly score?: number;
+	/** Project / agent namespace this record belongs to, when the backend
+	 *  segments by project (agentmemory does — same SQLite file, many projects). */
+	readonly projectId?: string;
+}
+
+/**
+ * Inputs accepted by `saveMemory`. Either standalone (`sessionId` omitted —
+ * the record lives at the project / user level) or tied to an open session.
+ */
+export interface AgentMemorySaveInput extends AgentMemoryObservation {
+	readonly sessionId?: string;
+	readonly projectId?: string;
+	/** Resolved plugin settings injected by the facade. */
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * Inputs accepted by `searchMemory`. `query` may be free-form text — the
+ * backend chooses keyword vs semantic vs hybrid (agentmemory does all
+ * three under "smart search"). `agentMemoryRecallLimit` caps the result
+ * count; the default is backend-defined (typically 10).
+ */
+export interface AgentMemorySearchInput {
+	readonly query: string;
+	readonly limit?: number;
+	readonly tags?: readonly string[];
+	readonly sessionId?: string;
+	readonly projectId?: string;
+	readonly settings?: PluginSettings;
+}
+
+export interface AgentMemorySearchResponse {
+	readonly results: readonly AgentMemoryRecord[];
+	/** Optional backend-provided summary (token-compressed digest). */
+	readonly summary?: string;
+}
+
+/**
+ * Inputs to `openSession`. `metadata` is the seed payload the backend
+ * stores against the session — what triggered it, who started it, which
+ * Work / Agent it belongs to.
+ */
+export interface AgentMemorySessionInput {
+	readonly projectId?: string;
+	readonly metadata?: Record<string, unknown>;
+	readonly settings?: PluginSettings;
+}
+
+export interface AgentMemorySession {
+	readonly id: string;
+	readonly startedAt: string;
+	readonly endedAt?: string;
+	readonly metadata?: Record<string, unknown>;
+	/** Initial context payload some backends ship back on open
+	 *  (agentmemory's `/session/start` returns recall + slots + recent ops). */
+	readonly context?: string;
+}
+
+/**
+ * Inputs to `buildContext` — the "give me what's relevant to inject into
+ * the next prompt" call. `purpose` lets backends bias the payload (e.g.
+ * agentmemory weights bugs higher when `purpose: 'fix-bug'`).
+ */
+export interface AgentMemoryContextInput {
+	readonly query?: string;
+	readonly purpose?: string;
+	readonly sessionId?: string;
+	readonly projectId?: string;
+	readonly maxTokens?: number;
+	readonly settings?: PluginSettings;
+}
+
+export interface AgentMemoryContext {
+	/** Text ready to splice into a system prompt. */
+	readonly content: string;
+	/** Approximate token cost of `content` if the backend reports it. */
+	readonly approxTokens?: number;
+	/** Records the context was distilled from, when the backend surfaces them. */
+	readonly references?: readonly AgentMemoryRecord[];
+}
+
+/**
+ * Agent-memory plugin interface — capability `agent-memory`.
+ *
+ * Required surface: open/close session, save / search / build-context.
+ * Optional governance surface (`deleteEntry`, `listSessions`, `exportAll`)
+ * is opt-in — the facade probes for presence before exposing the
+ * corresponding API endpoints.
+ */
+export interface IAgentMemoryPlugin extends IPlugin {
+	/** Backend name for facade identification ('agentmemory', 'mem0', 'zep', ...). */
+	readonly providerName: string;
+
+	/**
+	 * Open a new agent session. Returns the session id the caller passes
+	 * to subsequent `saveMemory` / `searchMemory` / `closeSession` calls.
+	 */
+	openSession(input: AgentMemorySessionInput): Promise<AgentMemorySession>;
+
+	/** End an open session. Idempotent — closing a closed session is a no-op. */
+	closeSession(sessionId: string, settings?: PluginSettings): Promise<void>;
+
+	/** Append an observation. The backend assigns an id and returns the record. */
+	saveMemory(input: AgentMemorySaveInput): Promise<AgentMemoryRecord>;
+
+	/**
+	 * Smart / semantic search across the user's (or project's, depending
+	 * on the resolved scope in settings) memory store.
+	 */
+	searchMemory(input: AgentMemorySearchInput): Promise<AgentMemorySearchResponse>;
+
+	/**
+	 * Build a context payload to inject into the next prompt. Implementations
+	 * are free to combine semantic search + recent sessions + pinned slots.
+	 */
+	buildContext(input: AgentMemoryContextInput): Promise<AgentMemoryContext>;
+
+	// ── Optional governance surface ────────────────────────────────────
+
+	/** Delete a single record by id. Required for GDPR / "forget me" flows. */
+	deleteEntry?(id: string, settings?: PluginSettings): Promise<void>;
+
+	/** List sessions for the resolved scope (most recent first). */
+	listSessions?(options?: {
+		limit?: number;
+		projectId?: string;
+		settings?: PluginSettings;
+	}): Promise<readonly AgentMemorySession[]>;
+
+	/** Export everything for backup / migration. Returns opaque JSON blob. */
+	exportAll?(settings?: PluginSettings): Promise<unknown>;
+}
+
+/**
+ * Facade interface — same shape exposed to API controllers / pipeline steps.
+ * The implementation lives in `@ever-works/agent` as `AgentMemoryFacadeService`.
+ *
+ * `FacadeOptions` is imported by the implementation, not the contract —
+ * this file stays in the dep-free `@ever-works/plugin` package.
+ */
+export interface IAgentMemoryFacade {
+	openSession(metadata: Record<string, unknown> | undefined, facadeOptions: unknown): Promise<AgentMemorySession>;
+	closeSession(sessionId: string, facadeOptions: unknown): Promise<void>;
+	saveMemory(input: Omit<AgentMemorySaveInput, 'settings'>, facadeOptions: unknown): Promise<AgentMemoryRecord>;
+	searchMemory(
+		input: Omit<AgentMemorySearchInput, 'settings'>,
+		facadeOptions: unknown
+	): Promise<AgentMemorySearchResponse>;
+	buildContext(input: Omit<AgentMemoryContextInput, 'settings'>, facadeOptions: unknown): Promise<AgentMemoryContext>;
+	deleteEntry(id: string, facadeOptions: unknown): Promise<void>;
+	listSessions(
+		options: { limit?: number; projectId?: string } | undefined,
+		facadeOptions: unknown
+	): Promise<readonly AgentMemorySession[]>;
+}
+
+/**
+ * Type guard — true when a plugin declares the `agent-memory` capability.
+ */
+export function isAgentMemoryPlugin(plugin: IPlugin): plugin is IAgentMemoryPlugin {
+	return plugin.capabilities.includes('agent-memory');
+}

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -15,3 +15,4 @@ export * from './device-auth-provider.interface.js';
 export * from './storage.interface.js';
 export * from './skills-provider.interface.js';
 export * from './task-tracker.interface.js';
+export * from './agent-memory.interface.js';

--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -29,7 +29,14 @@ export const PLUGIN_CAPABILITIES = {
 	// category for external task trackers. "Ever Works Task Tracker"
 	// is the first-party default. Community plugins (Linear / Jira /
 	// GitHub Issues) implement the same contract.
-	TASK_TRACKER: 'task-tracker'
+	TASK_TRACKER: 'task-tracker',
+	// Pluggable persistent memory for AI coding / generation agents.
+	// First-party implementation: `@ever-works/agentmemory-plugin`
+	// (talks to the `agentmemory` standalone Node server on :3111 —
+	// runs locally OR hosted via a configurable `baseUrl` + bearer
+	// token). Community plugins (mem0, zep, langmem) implement the
+	// same `IAgentMemoryPlugin` contract.
+	AGENT_MEMORY: 'agent-memory'
 } as const;
 
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[keyof typeof PLUGIN_CAPABILITIES];

--- a/packages/plugins/agentmemory/README.md
+++ b/packages/plugins/agentmemory/README.md
@@ -11,11 +11,11 @@ coding/generation agent the operator runs.
 This plugin is deliberately mode-agnostic — same code, same settings,
 three ways to deploy the backend:
 
-| Mode | When | Setup |
-|---|---|---|
-| **Local dev** | You're hacking on Ever Works on a laptop. | `npx @agentmemory/agentmemory` in a separate terminal. The plugin's default `baseUrl` (`http://localhost:3111`) just works. |
-| **Self-hosted in cluster** | You want the platform + memory store in the same k8s namespace. | Apply [`.deploy/k8s/agentmemory.optional.yaml`](../../../.deploy/k8s/agentmemory.optional.yaml) and set `baseUrl` to `http://agentmemory.<ns>.svc.cluster.local:3111`. |
-| **Hosted** | You already run `agentmemory` elsewhere (a managed VM, a partner SaaS, your own cluster). | Set `baseUrl` to the HTTPS endpoint + `apiKey` to the server's `AGENTMEMORY_SECRET`. |
+| Mode                       | When                                                                                      | Setup                                                                                                                                                                  |
+| -------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Local dev**              | You're hacking on Ever Works on a laptop.                                                 | `npx @agentmemory/agentmemory` in a separate terminal. The plugin's default `baseUrl` (`http://localhost:3111`) just works.                                            |
+| **Self-hosted in cluster** | You want the platform + memory store in the same k8s namespace.                           | Apply [`.deploy/k8s/agentmemory.optional.yaml`](../../../.deploy/k8s/agentmemory.optional.yaml) and set `baseUrl` to `http://agentmemory.<ns>.svc.cluster.local:3111`. |
+| **Hosted**                 | You already run `agentmemory` elsewhere (a managed VM, a partner SaaS, your own cluster). | Set `baseUrl` to the HTTPS endpoint + `apiKey` to the server's `AGENTMEMORY_SECRET`.                                                                                   |
 
 In every mode the Ever Works platform sees the same `IAgentMemoryPlugin`
 contract — the `AgentMemoryFacadeService` dispatches to whichever plugin
@@ -23,12 +23,12 @@ the user / Work has resolved.
 
 ## Settings
 
-| Key | Type | Scope | Env var fallback | Description |
-|---|---|---|---|---|
-| `baseUrl` | string | user | `AGENTMEMORY_BASE_URL` | REST endpoint. Default `http://localhost:3111`. |
-| `apiKey` | secret | user | `AGENTMEMORY_API_KEY` | Bearer token. Empty is fine for a localhost dev server. Must match the server's `AGENTMEMORY_SECRET` env var. |
-| `projectId` | string | work | — | Optional namespace inside the shared SQLite store. Lets two Works share one server without seeing each other's observations. |
-| `timeoutMs` | number | user | — | Per-request timeout. Default 30s. |
+| Key         | Type   | Scope | Env var fallback       | Description                                                                                                   |
+| ----------- | ------ | ----- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`   | string | user  | `AGENTMEMORY_BASE_URL` | REST endpoint. Default `http://localhost:3111`.                                                               |
+| `apiKey`    | secret | user  | `AGENTMEMORY_API_KEY`  | Bearer token. Empty is fine for a localhost dev server. Must match the server's `AGENTMEMORY_SECRET` env var. |
+| `projectId` | string | work  | `AGENTMEMORY_PROJECT`  | Namespace sent as `project` on every request (agentmemory requires it). Defaults to `ever-works` when unset.  |
+| `timeoutMs` | number | user  | —                      | Per-request timeout. Default 30s.                                                                             |
 
 ## REST endpoints used
 
@@ -36,20 +36,25 @@ The plugin only hits the public, documented subset of agentmemory's
 REST API:
 
 - `GET  /agentmemory/health` — health + auth probe (also drives `validateConnection`).
-- `POST /agentmemory/session/start`, `/session/end` — sessions.
-- `POST /agentmemory/observe` — append in-session observations.
-- `POST /agentmemory/remember` — persist long-term memory (no session).
-- `POST /agentmemory/smart-search` — semantic + keyword search.
-- `POST /agentmemory/context` — build prompt-injection context payload.
-- `POST /agentmemory/forget` — governance / GDPR delete.
-- `GET  /agentmemory/sessions` — list sessions.
+- `POST /agentmemory/session/start`, `/session/end` — sessions; both require `project`.
+- `POST /agentmemory/remember` — persist a memory record (`{ project, content, tags?, metadata?, sessionId? }`).
+- `POST /agentmemory/smart-search` — semantic + keyword search (`{ project, query, topK? }`).
+- `POST /agentmemory/context` — build prompt-injection context payload (`{ project, query?, tokenBudget? }`).
+- `POST /agentmemory/forget` — governance / GDPR delete (`{ project, filter: { id } }`).
+
+`/agentmemory/observe` is **not** used: the upstream server validates
+`type` + `payload` against an auto-capture hook shape (PostToolUse etc.)
+that doesn't fit free-form platform saves. We always route `saveMemory`
+through `/remember`, attaching `sessionId` as metadata so audit trails
+can still link the memory back to its session.
 
 ## Tests
 
-Vitest. 30 unit tests covering the HTTP client (auth header, error
+Vitest. 40 unit tests covering the HTTP client (auth header, error
 translation, URL building) and the plugin class (settings validation,
-routing /observe vs /remember, response normalisation across the
-`results` / `matches` / `hits` field shapes agentmemory has shipped).
+required-`project`/`topK`/`tokenBudget` mapping, env-var fallback,
+missing-id surfacing, response normalisation across the `results` /
+`matches` / `hits` field shapes agentmemory has shipped).
 
 ```bash
 pnpm --filter @ever-works/agentmemory-plugin test
@@ -60,7 +65,8 @@ pnpm --filter @ever-works/agentmemory-plugin test
 Community plugins (`mem0`, `zep`, `langmem`, vector-DB-backed homegrown
 stores) implement the same `IAgentMemoryPlugin` interface from
 `@ever-works/plugin`. The facade doesn't care which one is selected —
-follow this package's structure (settings schema with `x-secret` /
-`x-envVar` extensions, `validateConnection` hits a real endpoint, raw /
-typed response normalisation) and add the plugin to
-`packages/plugins/<your-plugin>/`.
+follow this package's structure (settings schema with `x-secret` for
+secrets, manual env-var fallback in `resolveSettings` rather than
+`x-envVar` which would lock the field out of the admin UI,
+`validateConnection` hits a real endpoint, raw / typed response
+normalisation) and add the plugin to `packages/plugins/<your-plugin>/`.

--- a/packages/plugins/agentmemory/README.md
+++ b/packages/plugins/agentmemory/README.md
@@ -1,0 +1,66 @@
+# @ever-works/agentmemory-plugin
+
+First-party implementation of the **agent-memory** capability for Ever
+Works. Talks to a standalone [`agentmemory`](https://github.com/rohitg00/agentmemory)
+REST server (the same one Claude Code / Codex / OpenCode / MCP clients
+already use), so a single memory store can be shared across every
+coding/generation agent the operator runs.
+
+## Run modes
+
+This plugin is deliberately mode-agnostic — same code, same settings,
+three ways to deploy the backend:
+
+| Mode | When | Setup |
+|---|---|---|
+| **Local dev** | You're hacking on Ever Works on a laptop. | `npx @agentmemory/agentmemory` in a separate terminal. The plugin's default `baseUrl` (`http://localhost:3111`) just works. |
+| **Self-hosted in cluster** | You want the platform + memory store in the same k8s namespace. | Apply [`.deploy/k8s/agentmemory.optional.yaml`](../../../.deploy/k8s/agentmemory.optional.yaml) and set `baseUrl` to `http://agentmemory.<ns>.svc.cluster.local:3111`. |
+| **Hosted** | You already run `agentmemory` elsewhere (a managed VM, a partner SaaS, your own cluster). | Set `baseUrl` to the HTTPS endpoint + `apiKey` to the server's `AGENTMEMORY_SECRET`. |
+
+In every mode the Ever Works platform sees the same `IAgentMemoryPlugin`
+contract — the `AgentMemoryFacadeService` dispatches to whichever plugin
+the user / Work has resolved.
+
+## Settings
+
+| Key | Type | Scope | Env var fallback | Description |
+|---|---|---|---|---|
+| `baseUrl` | string | user | `AGENTMEMORY_BASE_URL` | REST endpoint. Default `http://localhost:3111`. |
+| `apiKey` | secret | user | `AGENTMEMORY_API_KEY` | Bearer token. Empty is fine for a localhost dev server. Must match the server's `AGENTMEMORY_SECRET` env var. |
+| `projectId` | string | work | — | Optional namespace inside the shared SQLite store. Lets two Works share one server without seeing each other's observations. |
+| `timeoutMs` | number | user | — | Per-request timeout. Default 30s. |
+
+## REST endpoints used
+
+The plugin only hits the public, documented subset of agentmemory's
+REST API:
+
+- `GET  /agentmemory/health` — health + auth probe (also drives `validateConnection`).
+- `POST /agentmemory/session/start`, `/session/end` — sessions.
+- `POST /agentmemory/observe` — append in-session observations.
+- `POST /agentmemory/remember` — persist long-term memory (no session).
+- `POST /agentmemory/smart-search` — semantic + keyword search.
+- `POST /agentmemory/context` — build prompt-injection context payload.
+- `POST /agentmemory/forget` — governance / GDPR delete.
+- `GET  /agentmemory/sessions` — list sessions.
+
+## Tests
+
+Vitest. 30 unit tests covering the HTTP client (auth header, error
+translation, URL building) and the plugin class (settings validation,
+routing /observe vs /remember, response normalisation across the
+`results` / `matches` / `hits` field shapes agentmemory has shipped).
+
+```bash
+pnpm --filter @ever-works/agentmemory-plugin test
+```
+
+## Writing a different memory backend
+
+Community plugins (`mem0`, `zep`, `langmem`, vector-DB-backed homegrown
+stores) implement the same `IAgentMemoryPlugin` interface from
+`@ever-works/plugin`. The facade doesn't care which one is selected —
+follow this package's structure (settings schema with `x-secret` /
+`x-envVar` extensions, `validateConnection` hits a real endpoint, raw /
+typed response normalisation) and add the plugin to
+`packages/plugins/<your-plugin>/`.

--- a/packages/plugins/agentmemory/package.json
+++ b/packages/plugins/agentmemory/package.json
@@ -1,0 +1,68 @@
+{
+	"name": "@ever-works/agentmemory-plugin",
+	"version": "1.0.0",
+	"description": "Persistent agent-memory plugin — talks to a local or hosted `agentmemory` server (REST :3111). Default backend for the agent-memory capability shared by Claude Code / Codex / OpenCode / MCP clients.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^3.2.1"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "agentmemory",
+			"name": "Agent Memory",
+			"version": "1.0.0",
+			"category": "utility",
+			"capabilities": [
+				"agent-memory"
+			],
+			"description": "Persistent memory store for AI coding / generation agents. Connects to a local or hosted `agentmemory` REST server (default http://localhost:3111).",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false,
+			"visibility": "public",
+			"defaultForCapabilities": [
+				"agent-memory"
+			]
+		}
+	}
+}

--- a/packages/plugins/agentmemory/src/__tests__/agentmemory-client.spec.ts
+++ b/packages/plugins/agentmemory/src/__tests__/agentmemory-client.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentmemoryClient } from '../agentmemory-client.js';
+
+describe('AgentmemoryClient', () => {
+	let fetchImpl: ReturnType<typeof vi.fn>;
+	let client: AgentmemoryClient;
+
+	beforeEach(() => {
+		fetchImpl = vi.fn();
+		client = new AgentmemoryClient({
+			baseUrl: 'http://localhost:3111/',
+			apiKey: 'secret-token',
+			timeoutMs: 5000,
+			fetchImpl: fetchImpl as unknown as typeof fetch
+		});
+	});
+
+	function ok(body: unknown): Response {
+		return {
+			ok: true,
+			status: 200,
+			statusText: 'OK',
+			text: vi.fn().mockResolvedValue(typeof body === 'string' ? body : JSON.stringify(body))
+		} as unknown as Response;
+	}
+
+	function err(status: number, statusText: string, body = ''): Response {
+		return {
+			ok: false,
+			status,
+			statusText,
+			text: vi.fn().mockResolvedValue(body)
+		} as unknown as Response;
+	}
+
+	describe('baseUrl normalisation', () => {
+		it('strips trailing slash so the same path is not double-slashed', async () => {
+			fetchImpl.mockResolvedValueOnce(ok({ ok: true }));
+			await client.health();
+			expect(fetchImpl).toHaveBeenCalledWith(
+				'http://localhost:3111/agentmemory/health',
+				expect.objectContaining({ method: 'GET' })
+			);
+		});
+	});
+
+	describe('auth header', () => {
+		it('sends Authorization: Bearer when an apiKey is configured', async () => {
+			fetchImpl.mockResolvedValueOnce(ok({ ok: true }));
+			await client.health();
+			const init = fetchImpl.mock.calls[0][1] as RequestInit;
+			expect((init.headers as Record<string, string>).Authorization).toBe('Bearer secret-token');
+		});
+
+		it('omits Authorization when no apiKey is configured (localhost dev)', async () => {
+			const noAuth = new AgentmemoryClient({
+				baseUrl: 'http://localhost:3111',
+				fetchImpl: fetchImpl as unknown as typeof fetch
+			});
+			fetchImpl.mockResolvedValueOnce(ok({ ok: true }));
+			await noAuth.health();
+			const init = fetchImpl.mock.calls[0][1] as RequestInit;
+			expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+		});
+	});
+
+	describe('health', () => {
+		it.each([{ ok: true }, { status: 'ok' }, { status: 'OK' }])('recognises %j as healthy', async (body) => {
+			fetchImpl.mockResolvedValueOnce(ok(body));
+			const result = await client.health();
+			expect(result.ok).toBe(true);
+		});
+
+		it('returns ok=false when the body does not look like a health response', async () => {
+			fetchImpl.mockResolvedValueOnce(ok({ random: 'data' }));
+			const result = await client.health();
+			expect(result.ok).toBe(false);
+		});
+	});
+
+	describe('error translation', () => {
+		it('explains 401/403 as a token mismatch', async () => {
+			fetchImpl.mockResolvedValueOnce(err(401, 'Unauthorized'));
+			await expect(client.smartSearch({ query: 'x' })).rejects.toThrow(/AGENTMEMORY_SECRET/);
+		});
+
+		it('explains 404 as a wrong endpoint / wrong baseUrl', async () => {
+			fetchImpl.mockResolvedValueOnce(err(404, 'Not Found'));
+			await expect(client.smartSearch({ query: 'x' })).rejects.toThrow(/baseUrl/);
+		});
+
+		it('explains 429 as rate-limit', async () => {
+			fetchImpl.mockResolvedValueOnce(err(429, 'Too Many Requests'));
+			await expect(client.smartSearch({ query: 'x' })).rejects.toThrow(/rate-limited/);
+		});
+	});
+
+	describe('JSON encoding', () => {
+		it('sends Content-Type application/json + a JSON body on POSTs', async () => {
+			fetchImpl.mockResolvedValueOnce(ok({}));
+			await client.observe({ content: 'hello' });
+			const init = fetchImpl.mock.calls[0][1] as RequestInit;
+			expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+			expect(init.body).toBe(JSON.stringify({ content: 'hello' }));
+		});
+	});
+
+	describe('listSessions query params', () => {
+		it('passes limit + projectId as URL query params', async () => {
+			fetchImpl.mockResolvedValueOnce(ok({ sessions: [] }));
+			await client.listSessions({ limit: 5, projectId: 'proj-x' });
+			expect(fetchImpl).toHaveBeenCalledWith(
+				'http://localhost:3111/agentmemory/sessions?limit=5&projectId=proj-x',
+				expect.any(Object)
+			);
+		});
+	});
+});

--- a/packages/plugins/agentmemory/src/__tests__/agentmemory.plugin.spec.ts
+++ b/packages/plugins/agentmemory/src/__tests__/agentmemory.plugin.spec.ts
@@ -10,7 +10,6 @@ const mockRemember = vi.fn();
 const mockSmartSearch = vi.fn();
 const mockContext = vi.fn();
 const mockForget = vi.fn();
-const mockListSessions = vi.fn();
 
 vi.mock('../agentmemory-client.js', () => ({
 	AgentmemoryClient: vi.fn().mockImplementation(() => ({
@@ -21,8 +20,7 @@ vi.mock('../agentmemory-client.js', () => ({
 		remember: mockRemember,
 		smartSearch: mockSmartSearch,
 		context: mockContext,
-		forget: mockForget,
-		listSessions: mockListSessions
+		forget: mockForget
 	}))
 }));
 
@@ -61,6 +59,11 @@ describe('AgentmemoryPlugin', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Clear env vars the plugin reads as last-resort fallback, so
+		// tests don't accidentally inherit them from the runner.
+		delete process.env.AGENTMEMORY_BASE_URL;
+		delete process.env.AGENTMEMORY_API_KEY;
+		delete process.env.AGENTMEMORY_PROJECT;
 		plugin = new AgentmemoryPlugin();
 	});
 
@@ -75,13 +78,16 @@ describe('AgentmemoryPlugin', () => {
 			expect(plugin.providerName).toBe('agentmemory');
 		});
 
-		it('exposes a JSON Schema with baseUrl + apiKey + envVar fallbacks', () => {
+		it('exposes a JSON Schema with baseUrl + apiKey (NOT x-envVar-locked)', () => {
 			const schema = plugin.settingsSchema;
 			const props = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
 			expect(props.baseUrl).toBeDefined();
-			expect(props.baseUrl['x-envVar']).toBe('AGENTMEMORY_BASE_URL');
 			expect(props.apiKey['x-secret']).toBe(true);
-			expect(props.apiKey['x-envVar']).toBe('AGENTMEMORY_API_KEY');
+			// x-envVar makes the field env-only / unsettable via the
+			// admin UI (Codex P2 on PR #1073). We fall back to env
+			// vars manually instead.
+			expect(props.baseUrl['x-envVar']).toBeUndefined();
+			expect(props.apiKey['x-envVar']).toBeUndefined();
 		});
 
 		it('declares itself the default for agent-memory in its manifest', () => {
@@ -112,6 +118,12 @@ describe('AgentmemoryPlugin', () => {
 			expect(result.valid).toBe(false);
 			expect(result.errors?.[0].path).toBe('timeoutMs');
 		});
+
+		it('rejects too-large timeout (schema maximum is 120 000)', async () => {
+			const result = await plugin.validateSettings({ timeoutMs: 9_999_999 });
+			expect(result.valid).toBe(false);
+			expect(result.errors?.[0].path).toBe('timeoutMs');
+		});
 	});
 
 	describe('validateConnection', () => {
@@ -131,29 +143,25 @@ describe('AgentmemoryPlugin', () => {
 	});
 
 	describe('saveMemory', () => {
-		it('routes to /observe when a sessionId is present', async () => {
-			mockObserve.mockResolvedValueOnce({ id: 'obs-1', createdAt: '2026-01-01T00:00:00Z' });
+		it('always routes to /remember and never /observe (observe is reserved for hook capture)', async () => {
+			mockRemember.mockResolvedValueOnce({ id: 'mem-1', createdAt: '2026-01-01T00:00:00Z' });
 			const record = await plugin.saveMemory({
-				content: 'fixed the bug',
+				content: 'fact',
 				sessionId: 'sess-9',
 				settings: {}
 			});
-			expect(mockObserve).toHaveBeenCalledWith(
-				expect.objectContaining({ content: 'fixed the bug', sessionId: 'sess-9' })
+			expect(mockRemember).toHaveBeenCalledWith(
+				expect.objectContaining({
+					content: 'fact',
+					sessionId: 'sess-9',
+					project: 'ever-works'
+				})
 			);
-			expect(mockRemember).not.toHaveBeenCalled();
-			expect(record.id).toBe('obs-1');
-		});
-
-		it('routes to /remember when no session is open', async () => {
-			mockRemember.mockResolvedValueOnce({ id: 'mem-1', createdAt: '2026-01-01T00:00:00Z' });
-			const record = await plugin.saveMemory({ content: 'fact', settings: {} });
-			expect(mockRemember).toHaveBeenCalled();
 			expect(mockObserve).not.toHaveBeenCalled();
 			expect(record.id).toBe('mem-1');
 		});
 
-		it('passes through tags / metadata / projectId verbatim', async () => {
+		it('sends the required `project` field on /remember (mapped from projectId setting)', async () => {
 			mockRemember.mockResolvedValueOnce({ id: 'm', createdAt: 'now' });
 			await plugin.saveMemory({
 				content: 'X',
@@ -164,11 +172,16 @@ describe('AgentmemoryPlugin', () => {
 			});
 			expect(mockRemember).toHaveBeenCalledWith(
 				expect.objectContaining({
+					project: 'proj-A',
 					tags: ['bug'],
-					metadata: { file: 'a.ts' },
-					projectId: 'proj-A'
+					metadata: { file: 'a.ts' }
 				})
 			);
+		});
+
+		it('throws when the server response is missing the required id field (no silent empty-string id)', async () => {
+			mockRemember.mockResolvedValueOnce({ content: 'no id here', createdAt: 'now' });
+			await expect(plugin.saveMemory({ content: 'X', settings: {} })).rejects.toThrow(/without an id field/);
 		});
 	});
 
@@ -187,10 +200,13 @@ describe('AgentmemoryPlugin', () => {
 			expect(result.summary).toBe('summary-text');
 		});
 
-		it('honours the limit when provided', async () => {
+		it('maps `limit` to the server-required `topK` field', async () => {
 			mockSmartSearch.mockResolvedValueOnce({ results: [] });
 			await plugin.searchMemory({ query: 'q', limit: 25, settings: {} });
-			expect(mockSmartSearch).toHaveBeenCalledWith(expect.objectContaining({ limit: 25 }));
+			expect(mockSmartSearch).toHaveBeenCalledWith(
+				expect.objectContaining({ topK: 25, query: 'q', project: 'ever-works' })
+			);
+			expect(mockSmartSearch).toHaveBeenCalledWith(expect.not.objectContaining({ limit: 25 }));
 		});
 	});
 
@@ -200,6 +216,76 @@ describe('AgentmemoryPlugin', () => {
 			const ctx = await plugin.buildContext({ settings: {} });
 			expect(ctx.content).toBe('context-text');
 			expect(ctx.approxTokens).toBe(42);
+		});
+
+		it('maps `maxTokens` to the server-required `tokenBudget` field', async () => {
+			mockContext.mockResolvedValueOnce({ content: 'c' });
+			await plugin.buildContext({ maxTokens: 2000, settings: {} });
+			expect(mockContext).toHaveBeenCalledWith(
+				expect.objectContaining({ tokenBudget: 2000, project: 'ever-works' })
+			);
+		});
+	});
+
+	describe('deleteEntry', () => {
+		it('sends `{ project, filter: { id } }` matching the upstream /forget contract', async () => {
+			mockForget.mockResolvedValueOnce(undefined);
+			await plugin.deleteEntry('mem-42', {});
+			expect(mockForget).toHaveBeenCalledWith({
+				project: 'ever-works',
+				filter: { id: 'mem-42' }
+			});
+		});
+
+		it('refuses an empty id rather than sending an empty filter (which would mass-delete)', async () => {
+			await expect(plugin.deleteEntry('', {})).rejects.toThrow(/missing id/);
+			expect(mockForget).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('openSession / closeSession', () => {
+		it('openSession sends the required `project` field', async () => {
+			mockSessionStart.mockResolvedValueOnce({ id: 'sess-1', startedAt: '2026-01-01T00:00:00Z' });
+			await plugin.openSession({ projectId: 'proj-X', settings: {} });
+			expect(mockSessionStart).toHaveBeenCalledWith(expect.objectContaining({ project: 'proj-X' }));
+		});
+
+		it('closeSession sends `{ project, sessionId }`', async () => {
+			mockSessionEnd.mockResolvedValueOnce(undefined);
+			await plugin.closeSession('sess-9', {});
+			expect(mockSessionEnd).toHaveBeenCalledWith({
+				project: 'ever-works',
+				sessionId: 'sess-9'
+			});
+		});
+
+		it('throws when the server returns a session without an id', async () => {
+			mockSessionStart.mockResolvedValueOnce({ startedAt: 'now' });
+			await expect(plugin.openSession({ settings: {} })).rejects.toThrow(/without an id field/);
+		});
+	});
+
+	describe('env-var fallback', () => {
+		it('reads AGENTMEMORY_BASE_URL when settings.baseUrl is empty', async () => {
+			process.env.AGENTMEMORY_BASE_URL = 'http://envvar.example:9999';
+			mockHealth.mockResolvedValueOnce({ ok: true });
+			const result = await plugin.validateConnection({});
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('http://envvar.example:9999');
+		});
+
+		it('reads AGENTMEMORY_PROJECT when settings.projectId is empty', async () => {
+			process.env.AGENTMEMORY_PROJECT = 'env-proj';
+			mockRemember.mockResolvedValueOnce({ id: 'mem-1', createdAt: 'now' });
+			await plugin.saveMemory({ content: 'X', settings: {} });
+			expect(mockRemember).toHaveBeenCalledWith(expect.objectContaining({ project: 'env-proj' }));
+		});
+
+		it('user setting wins over env var', async () => {
+			process.env.AGENTMEMORY_PROJECT = 'env-proj';
+			mockRemember.mockResolvedValueOnce({ id: 'mem-1', createdAt: 'now' });
+			await plugin.saveMemory({ content: 'X', projectId: 'user-proj', settings: {} });
+			expect(mockRemember).toHaveBeenCalledWith(expect.objectContaining({ project: 'user-proj' }));
 		});
 	});
 

--- a/packages/plugins/agentmemory/src/__tests__/agentmemory.plugin.spec.ts
+++ b/packages/plugins/agentmemory/src/__tests__/agentmemory.plugin.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentmemoryPlugin } from '../agentmemory.plugin.js';
+import type { PluginContext } from '@ever-works/plugin';
+
+const mockHealth = vi.fn();
+const mockSessionStart = vi.fn();
+const mockSessionEnd = vi.fn();
+const mockObserve = vi.fn();
+const mockRemember = vi.fn();
+const mockSmartSearch = vi.fn();
+const mockContext = vi.fn();
+const mockForget = vi.fn();
+const mockListSessions = vi.fn();
+
+vi.mock('../agentmemory-client.js', () => ({
+	AgentmemoryClient: vi.fn().mockImplementation(() => ({
+		health: mockHealth,
+		sessionStart: mockSessionStart,
+		sessionEnd: mockSessionEnd,
+		observe: mockObserve,
+		remember: mockRemember,
+		smartSearch: mockSmartSearch,
+		context: mockContext,
+		forget: mockForget,
+		listSessions: mockListSessions
+	}))
+}));
+
+function createContext(): PluginContext {
+	return {
+		pluginId: 'agentmemory',
+		logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+		cache: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), clear: vi.fn() },
+		http: {
+			get: vi.fn(),
+			post: vi.fn(),
+			put: vi.fn(),
+			delete: vi.fn(),
+			patch: vi.fn(),
+			request: vi.fn()
+		},
+		env: {
+			get: vi.fn(),
+			isDevelopment: vi.fn().mockReturnValue(true),
+			isProduction: vi.fn().mockReturnValue(false),
+			getAll: vi.fn().mockReturnValue({})
+		},
+		envVars: {},
+		services: {} as never,
+		getSettings: vi.fn().mockResolvedValue({}),
+		getResolvedSettings: vi.fn().mockResolvedValue({ settings: {}, source: 'default' }),
+		onEvent: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+		emitEvent: vi.fn(),
+		registerCustomCapability: vi.fn(),
+		getCustomCapability: vi.fn()
+	} as unknown as PluginContext;
+}
+
+describe('AgentmemoryPlugin', () => {
+	let plugin: AgentmemoryPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new AgentmemoryPlugin();
+	});
+
+	describe('metadata', () => {
+		it('declares the agent-memory capability', () => {
+			expect(plugin.id).toBe('agentmemory');
+			expect(plugin.category).toBe('utility');
+			expect(plugin.capabilities).toContain('agent-memory');
+		});
+
+		it('reports its provider name so the facade can identify it', () => {
+			expect(plugin.providerName).toBe('agentmemory');
+		});
+
+		it('exposes a JSON Schema with baseUrl + apiKey + envVar fallbacks', () => {
+			const schema = plugin.settingsSchema;
+			const props = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+			expect(props.baseUrl).toBeDefined();
+			expect(props.baseUrl['x-envVar']).toBe('AGENTMEMORY_BASE_URL');
+			expect(props.apiKey['x-secret']).toBe(true);
+			expect(props.apiKey['x-envVar']).toBe('AGENTMEMORY_API_KEY');
+		});
+
+		it('declares itself the default for agent-memory in its manifest', () => {
+			const manifest = plugin.getManifest();
+			expect(manifest.defaultForCapabilities).toContain('agent-memory');
+			expect(manifest.builtIn).toBe(true);
+		});
+	});
+
+	describe('validateSettings', () => {
+		it('accepts empty / default settings (works against localhost)', async () => {
+			await expect(plugin.validateSettings({})).resolves.toEqual({ valid: true });
+		});
+
+		it('rejects non-http(s) baseUrl', async () => {
+			const result = await plugin.validateSettings({ baseUrl: 'ftp://x.example' });
+			expect(result.valid).toBe(false);
+			expect(result.errors?.[0].path).toBe('baseUrl');
+		});
+
+		it('rejects nonsense baseUrl', async () => {
+			const result = await plugin.validateSettings({ baseUrl: 'not a url' });
+			expect(result.valid).toBe(false);
+		});
+
+		it('rejects too-small timeout', async () => {
+			const result = await plugin.validateSettings({ timeoutMs: 50 });
+			expect(result.valid).toBe(false);
+			expect(result.errors?.[0].path).toBe('timeoutMs');
+		});
+	});
+
+	describe('validateConnection', () => {
+		it('hits the health endpoint and surfaces success', async () => {
+			mockHealth.mockResolvedValueOnce({ ok: true });
+			const result = await plugin.validateConnection({ baseUrl: 'http://localhost:3111' });
+			expect(result.success).toBe(true);
+			expect(result.message).toMatch(/Connected to agentmemory/);
+		});
+
+		it('reports the error message on failure', async () => {
+			mockHealth.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+			const result = await plugin.validateConnection({});
+			expect(result.success).toBe(false);
+			expect(result.message).toMatch(/ECONNREFUSED/);
+		});
+	});
+
+	describe('saveMemory', () => {
+		it('routes to /observe when a sessionId is present', async () => {
+			mockObserve.mockResolvedValueOnce({ id: 'obs-1', createdAt: '2026-01-01T00:00:00Z' });
+			const record = await plugin.saveMemory({
+				content: 'fixed the bug',
+				sessionId: 'sess-9',
+				settings: {}
+			});
+			expect(mockObserve).toHaveBeenCalledWith(
+				expect.objectContaining({ content: 'fixed the bug', sessionId: 'sess-9' })
+			);
+			expect(mockRemember).not.toHaveBeenCalled();
+			expect(record.id).toBe('obs-1');
+		});
+
+		it('routes to /remember when no session is open', async () => {
+			mockRemember.mockResolvedValueOnce({ id: 'mem-1', createdAt: '2026-01-01T00:00:00Z' });
+			const record = await plugin.saveMemory({ content: 'fact', settings: {} });
+			expect(mockRemember).toHaveBeenCalled();
+			expect(mockObserve).not.toHaveBeenCalled();
+			expect(record.id).toBe('mem-1');
+		});
+
+		it('passes through tags / metadata / projectId verbatim', async () => {
+			mockRemember.mockResolvedValueOnce({ id: 'm', createdAt: 'now' });
+			await plugin.saveMemory({
+				content: 'X',
+				tags: ['bug'],
+				metadata: { file: 'a.ts' },
+				projectId: 'proj-A',
+				settings: {}
+			});
+			expect(mockRemember).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tags: ['bug'],
+					metadata: { file: 'a.ts' },
+					projectId: 'proj-A'
+				})
+			);
+		});
+	});
+
+	describe('searchMemory', () => {
+		it('normalises results from /smart-search no matter which field name carries them', async () => {
+			mockSmartSearch.mockResolvedValueOnce({
+				matches: [
+					{ id: '1', text: 'one' },
+					{ id: '2', text: 'two' }
+				],
+				digest: 'summary-text'
+			});
+			const result = await plugin.searchMemory({ query: 'x', settings: {} });
+			expect(result.results).toHaveLength(2);
+			expect(result.results[0].content).toBe('one');
+			expect(result.summary).toBe('summary-text');
+		});
+
+		it('honours the limit when provided', async () => {
+			mockSmartSearch.mockResolvedValueOnce({ results: [] });
+			await plugin.searchMemory({ query: 'q', limit: 25, settings: {} });
+			expect(mockSmartSearch).toHaveBeenCalledWith(expect.objectContaining({ limit: 25 }));
+		});
+	});
+
+	describe('buildContext', () => {
+		it('returns the content field even when the server uses `text` instead', async () => {
+			mockContext.mockResolvedValueOnce({ text: 'context-text', approx_tokens: 42 });
+			const ctx = await plugin.buildContext({ settings: {} });
+			expect(ctx.content).toBe('context-text');
+			expect(ctx.approxTokens).toBe(42);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('captures the context on load and releases on unload', async () => {
+			const ctx = createContext();
+			await plugin.onLoad(ctx);
+			expect(ctx.logger.log).toHaveBeenCalledWith('agentmemory plugin loaded');
+			await plugin.onUnload();
+		});
+
+		it('reports healthy', async () => {
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+		});
+	});
+});

--- a/packages/plugins/agentmemory/src/agentmemory-client.ts
+++ b/packages/plugins/agentmemory/src/agentmemory-client.ts
@@ -95,6 +95,9 @@ export class AgentmemoryClient {
 
 	private async request<T>(path: string, options: AgentmemoryClientRequestOptions): Promise<T> {
 		const url = buildUrl(this.baseUrl, path, options.query);
+		// `const` here matches the activepieces / anthropic plugin
+		// convention and the repo's eslint `prefer-const` rule — the
+		// reference is never rebound, only properties are added below.
 		const headers: Record<string, string> = { Accept: 'application/json' };
 		if (this.apiKey) {
 			headers['Authorization'] = `Bearer ${this.apiKey}`;

--- a/packages/plugins/agentmemory/src/agentmemory-client.ts
+++ b/packages/plugins/agentmemory/src/agentmemory-client.ts
@@ -1,0 +1,198 @@
+import { DEFAULT_BASE_URL, DEFAULT_TIMEOUT_MS } from './types.js';
+
+export interface AgentmemoryClientOptions {
+	readonly baseUrl?: string;
+	readonly apiKey?: string;
+	readonly timeoutMs?: number;
+	readonly logger?: { log(...args: unknown[]): void; warn(...args: unknown[]): void };
+	/** Optional fetch override — passed in by tests so we don't talk to
+	 *  a real server. Falls back to global `fetch` otherwise. */
+	readonly fetchImpl?: typeof fetch;
+}
+
+export interface AgentmemoryClientRequestOptions {
+	readonly method?: 'GET' | 'POST' | 'DELETE';
+	readonly body?: unknown;
+	readonly query?: Record<string, string | number | undefined>;
+	readonly signal?: AbortSignal;
+}
+
+/**
+ * Thin HTTP wrapper for the `agentmemory` REST API (Node service on
+ * `III_REST_PORT`, default 3111). All paths are documented in the
+ * upstream `src/triggers/api.ts` — we only call the public, stable
+ * subset documented at https://github.com/rohitg00/agentmemory.
+ *
+ * The client is deliberately UN-opinionated: callers (the plugin class)
+ * own request shaping and response normalisation. This keeps it trivial
+ * to swap in a different memory backend later — `mem0`, `zep`,
+ * `langmem` — by writing a sibling client with the same surface.
+ */
+export class AgentmemoryClient {
+	private readonly baseUrl: string;
+	private readonly apiKey: string | undefined;
+	private readonly timeoutMs: number;
+	private readonly logger: NonNullable<AgentmemoryClientOptions['logger']>;
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(options: AgentmemoryClientOptions = {}) {
+		this.baseUrl = stripTrailingSlash(options.baseUrl || DEFAULT_BASE_URL);
+		this.apiKey = options.apiKey?.trim() || undefined;
+		this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		this.logger = options.logger ?? console;
+		this.fetchImpl = options.fetchImpl ?? fetch;
+	}
+
+	/** GET /agentmemory/health — public, no auth required. Used for
+	 *  the plugin's `isAvailable` + `validateConnection` checks. */
+	async health(signal?: AbortSignal): Promise<{ ok: boolean; raw?: unknown }> {
+		const result = await this.request<unknown>('/agentmemory/health', {
+			method: 'GET',
+			signal
+		});
+		// agentmemory returns { status: 'ok' } | { ok: true } depending on version.
+		if (result && typeof result === 'object') {
+			const obj = result as Record<string, unknown>;
+			if (obj.ok === true) return { ok: true, raw: result };
+			if (typeof obj.status === 'string' && obj.status.toLowerCase() === 'ok') {
+				return { ok: true, raw: result };
+			}
+		}
+		return { ok: false, raw: result };
+	}
+
+	async sessionStart(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/session/start', { method: 'POST', body, signal });
+	}
+
+	async sessionEnd(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/session/end', { method: 'POST', body, signal });
+	}
+
+	async observe(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/observe', { method: 'POST', body, signal });
+	}
+
+	async remember(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/remember', { method: 'POST', body, signal });
+	}
+
+	async smartSearch(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/smart-search', { method: 'POST', body, signal });
+	}
+
+	async context(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/context', { method: 'POST', body, signal });
+	}
+
+	async forget(body: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/forget', { method: 'POST', body, signal });
+	}
+
+	async listSessions(query: Record<string, string | number | undefined>, signal?: AbortSignal): Promise<unknown> {
+		return this.request('/agentmemory/sessions', { method: 'GET', query, signal });
+	}
+
+	private async request<T>(path: string, options: AgentmemoryClientRequestOptions): Promise<T> {
+		const url = buildUrl(this.baseUrl, path, options.query);
+		const headers: Record<string, string> = { Accept: 'application/json' };
+		if (this.apiKey) {
+			headers['Authorization'] = `Bearer ${this.apiKey}`;
+		}
+
+		let body: BodyInit | undefined;
+		if (options.body !== undefined) {
+			headers['Content-Type'] = 'application/json';
+			body = JSON.stringify(options.body);
+		}
+
+		const controller = new AbortController();
+		const timeoutHandle = setTimeout(
+			() => controller.abort(new Error('agentmemory request timed out')),
+			this.timeoutMs
+		);
+		const onAbort = () => controller.abort(options.signal?.reason ?? new Error('Aborted'));
+		options.signal?.addEventListener('abort', onAbort, { once: true });
+
+		try {
+			const response = await this.fetchImpl(url, {
+				method: options.method ?? 'GET',
+				headers,
+				body,
+				signal: controller.signal
+			});
+
+			if (!response.ok) {
+				throw await buildHttpError(response, url);
+			}
+
+			const text = await response.text();
+			if (!text) return undefined as T;
+			try {
+				return JSON.parse(text) as T;
+			} catch {
+				return text as unknown as T;
+			}
+		} catch (error) {
+			if (isAbortError(error)) {
+				if (options.signal?.aborted) {
+					throw new Error('agentmemory request cancelled');
+				}
+				throw new Error(`agentmemory request timed out: ${path}`);
+			}
+			throw error;
+		} finally {
+			clearTimeout(timeoutHandle);
+			options.signal?.removeEventListener('abort', onAbort);
+		}
+	}
+}
+
+function stripTrailingSlash(url: string): string {
+	return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function buildUrl(baseUrl: string, path: string, query?: Record<string, string | number | undefined>): string {
+	const url = new URL(`${baseUrl}${path.startsWith('/') ? path : `/${path}`}`);
+	if (query) {
+		for (const [key, value] of Object.entries(query)) {
+			if (value === undefined) continue;
+			url.searchParams.set(key, String(value));
+		}
+	}
+	return url.toString();
+}
+
+async function buildHttpError(response: Response, url: string): Promise<Error> {
+	let detail = '';
+	try {
+		const text = await response.text();
+		if (text) detail = text.length > 500 ? text.slice(0, 500) + '...' : text;
+	} catch {
+		// ignore
+	}
+
+	const baseMessage = `agentmemory request failed (${response.status} ${response.statusText}) for ${url}`;
+
+	if (response.status === 401 || response.status === 403) {
+		return new Error(
+			"agentmemory rejected the request — check the `apiKey` setting matches the server's `AGENTMEMORY_SECRET`."
+		);
+	}
+	if (response.status === 404) {
+		return new Error(
+			`agentmemory endpoint not found at ${url}. ` +
+				'Either the server is an older version or the configured `baseUrl` is wrong.'
+		);
+	}
+	if (response.status === 429) {
+		return new Error('agentmemory rate-limited the request. Retry after a short delay.');
+	}
+	return new Error(`${baseMessage}${detail ? ` — ${detail}` : ''}`);
+}
+
+function isAbortError(error: unknown): boolean {
+	if (!error || typeof error !== 'object') return false;
+	const name = (error as { name?: string }).name;
+	return name === 'AbortError' || name === 'TimeoutError';
+}

--- a/packages/plugins/agentmemory/src/agentmemory.plugin.ts
+++ b/packages/plugins/agentmemory/src/agentmemory.plugin.ts
@@ -27,25 +27,35 @@ import type {
 	AgentmemoryRawSearchResponse,
 	AgentmemoryRawContext
 } from './types.js';
-import { DEFAULT_BASE_URL, DEFAULT_TIMEOUT_MS } from './types.js';
+import {
+	DEFAULT_BASE_URL,
+	DEFAULT_TIMEOUT_MS,
+	DEFAULT_PROJECT,
+	MAX_TIMEOUT_MS,
+	ENV_VAR_BASE_URL,
+	ENV_VAR_API_KEY,
+	ENV_VAR_PROJECT
+} from './types.js';
 
 /**
  * Agent Memory plugin — first-party implementation of the
  * `agent-memory` capability.
  *
  * Talks to a standalone `agentmemory` Node server over REST (default
- * `http://localhost:3111`, override via `baseUrl` setting or the
- * `AGENTMEMORY_BASE_URL` env var). Works equally well against:
+ * `http://localhost:3111`, override via `baseUrl` setting). Works
+ * equally well against:
  *
  * - a locally-run `npx @agentmemory/agentmemory` server (zero config),
  * - a hosted instance fronted by HTTPS + bearer auth,
  * - the optional in-cluster Deployment shipped under
  *   `.deploy/k8s/agentmemory.optional.yaml`.
  *
- * The plugin is settings-only — no global env reads beyond the
- * `x-envVar` fallbacks declared in the JSON Schema, which the plugin
- * settings service injects automatically when the user / admin hasn't
- * overridden them.
+ * `baseUrl` / `apiKey` / `project` are normal admin/user/work-scoped
+ * settings (NOT `x-envVar`-locked) — Codex pointed out on PR #1073 that
+ * `x-envVar` makes a field env-only and unsettable through the UI. We
+ * still fall back to `AGENTMEMORY_BASE_URL` / `AGENTMEMORY_API_KEY` /
+ * `AGENTMEMORY_PROJECT` env vars manually in `resolveSettings` for
+ * operators who prefer to inject the URL via k8s env.
  */
 export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 	readonly id = 'agentmemory';
@@ -63,25 +73,23 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 				type: 'string',
 				title: 'agentmemory base URL',
 				description:
-					'REST endpoint of the agentmemory server. Defaults to http://localhost:3111 (matches the `npx agentmemory` server). Set to your hosted instance for a shared deployment.',
+					'REST endpoint of the agentmemory server. Defaults to http://localhost:3111 (matches the `npx agentmemory` server). Set to your hosted instance for a shared deployment. Falls back to the AGENTMEMORY_BASE_URL env var when empty.',
 				default: DEFAULT_BASE_URL,
-				'x-scope': 'user',
-				'x-envVar': 'AGENTMEMORY_BASE_URL'
+				'x-scope': 'user'
 			},
 			apiKey: {
 				type: 'string',
 				title: 'Bearer token',
 				description:
-					"Bearer token sent in Authorization. Leave empty for a localhost dev server. For a hosted instance this must match the server's `AGENTMEMORY_SECRET` env var.",
+					"Bearer token sent in Authorization. Leave empty for a localhost dev server. For a hosted instance this must match the server's `AGENTMEMORY_SECRET` env var. Falls back to the AGENTMEMORY_API_KEY env var when empty.",
 				'x-secret': true,
-				'x-scope': 'user',
-				'x-envVar': 'AGENTMEMORY_API_KEY'
+				'x-scope': 'user'
 			},
 			projectId: {
 				type: 'string',
 				title: 'Project namespace',
 				description:
-					"Optional namespace inside the agentmemory store. Each Work / project can pin a value so different Works don't see each other's observations.",
+					"agentmemory requires a `project` field on every request — we send this value (or AGENTMEMORY_PROJECT env, or 'ever-works' as last resort). Set it per-Work to partition observations between Works that share one server.",
 				'x-scope': 'work'
 			},
 			timeoutMs: {
@@ -89,7 +97,7 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 				title: 'Request timeout (ms)',
 				default: DEFAULT_TIMEOUT_MS,
 				minimum: 1000,
-				maximum: 120_000,
+				maximum: MAX_TIMEOUT_MS,
 				'x-scope': 'user'
 			}
 		},
@@ -149,10 +157,18 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 			}
 		}
 		const timeoutMs = settings.timeoutMs;
-		if (timeoutMs !== undefined && (typeof timeoutMs !== 'number' || timeoutMs < 1000)) {
+		if (
+			timeoutMs !== undefined &&
+			(typeof timeoutMs !== 'number' || timeoutMs < 1000 || timeoutMs > MAX_TIMEOUT_MS)
+		) {
 			return {
 				valid: false,
-				errors: [{ path: 'timeoutMs', message: '`timeoutMs` must be a number ≥ 1000' }]
+				errors: [
+					{
+						path: 'timeoutMs',
+						message: `\`timeoutMs\` must be a number between 1000 and ${MAX_TIMEOUT_MS}`
+					}
+				]
 			};
 		}
 		return { valid: true };
@@ -207,46 +223,59 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 	async openSession(input: AgentMemorySessionInput): Promise<AgentMemorySession> {
 		const settings = this.resolveSettings(input.settings);
 		const client = this.buildClient(settings);
-		const body: Record<string, unknown> = {};
-		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
+		const body: Record<string, unknown> = {
+			project: input.projectId ?? settings.project ?? DEFAULT_PROJECT
+		};
 		if (input.metadata) body.metadata = input.metadata;
 		const raw = (await client.sessionStart(body)) as AgentmemoryRawSession | undefined;
-		return this.toSession(raw);
+		return this.toSession(raw, { startedAt: new Date().toISOString() });
 	}
 
 	async closeSession(sessionId: string, settingsOverride?: PluginSettings): Promise<void> {
 		const settings = this.resolveSettings(settingsOverride);
 		const client = this.buildClient(settings);
-		await client.sessionEnd({ sessionId });
+		// `/session/end` requires both `project` and `sessionId`.
+		await client.sessionEnd({
+			project: settings.project ?? DEFAULT_PROJECT,
+			sessionId
+		});
 	}
 
 	async saveMemory(input: AgentMemorySaveInput): Promise<AgentMemoryRecord> {
 		const settings = this.resolveSettings(input.settings);
 		const client = this.buildClient(settings);
-		const body: Record<string, unknown> = { content: input.content };
+
+		// Always route through `/remember` — `/observe` is reserved for
+		// auto-capture hook payloads (PostToolUse / PreToolUse / etc.)
+		// with a `type` + `payload` shape that the agentmemory server
+		// validates strictly. Free-form platform saves don't fit that
+		// schema (Codex P1 review on PR #1073).
+		const body: Record<string, unknown> = {
+			project: input.projectId ?? settings.project ?? DEFAULT_PROJECT,
+			content: input.content
+		};
 		if (input.tags) body.tags = input.tags;
 		if (input.metadata) body.metadata = input.metadata;
+		// `sessionId` is forwarded as metadata so audit trails can link
+		// the memory back to its session; the upstream server ignores
+		// unknown top-level keys on /remember.
 		if (input.sessionId) body.sessionId = input.sessionId;
-		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
 
-		// `/observe` is the right call when a session is open (records as
-		// a transient observation); otherwise `/remember` persists it
-		// directly to long-term memory. Mirrors the agentmemory docs.
-		const raw = input.sessionId
-			? ((await client.observe(body)) as AgentmemoryRawRecord)
-			: ((await client.remember(body)) as AgentmemoryRawRecord);
-
+		const raw = (await client.remember(body)) as AgentmemoryRawRecord;
 		return this.toRecord(raw, input);
 	}
 
 	async searchMemory(input: AgentMemorySearchInput): Promise<AgentMemorySearchResponse> {
 		const settings = this.resolveSettings(input.settings);
 		const client = this.buildClient(settings);
-		const body: Record<string, unknown> = { query: input.query };
-		if (input.limit !== undefined) body.limit = input.limit;
+		const body: Record<string, unknown> = {
+			project: input.projectId ?? settings.project ?? DEFAULT_PROJECT,
+			query: input.query
+		};
+		// agentmemory's `/smart-search` uses `topK`, not `limit`.
+		if (input.limit !== undefined) body.topK = input.limit;
 		if (input.tags) body.tags = input.tags;
 		if (input.sessionId) body.sessionId = input.sessionId;
-		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
 
 		const raw = (await client.smartSearch(body)) as AgentmemoryRawSearchResponse | undefined;
 		const rawList = raw?.results ?? raw?.matches ?? raw?.hits ?? [];
@@ -259,12 +288,14 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 	async buildContext(input: AgentMemoryContextInput): Promise<AgentMemoryContext> {
 		const settings = this.resolveSettings(input.settings);
 		const client = this.buildClient(settings);
-		const body: Record<string, unknown> = {};
+		const body: Record<string, unknown> = {
+			project: input.projectId ?? settings.project ?? DEFAULT_PROJECT
+		};
 		if (input.query) body.query = input.query;
 		if (input.purpose) body.purpose = input.purpose;
 		if (input.sessionId) body.sessionId = input.sessionId;
-		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
-		if (input.maxTokens !== undefined) body.maxTokens = input.maxTokens;
+		// agentmemory's `/context` uses `tokenBudget`, not `maxTokens`.
+		if (input.maxTokens !== undefined) body.tokenBudget = input.maxTokens;
 
 		const raw = (await client.context(body)) as AgentmemoryRawContext | undefined;
 		return {
@@ -275,42 +306,17 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 	}
 
 	async deleteEntry(id: string, settingsOverride?: PluginSettings): Promise<void> {
+		if (!id) {
+			throw new Error('agentmemory deleteEntry: missing id');
+		}
 		const settings = this.resolveSettings(settingsOverride);
 		const client = this.buildClient(settings);
-		await client.forget({ id });
-	}
-
-	async listSessions(options?: {
-		limit?: number;
-		projectId?: string;
-		settings?: PluginSettings;
-	}): Promise<readonly AgentMemorySession[]> {
-		const settings = this.resolveSettings(options?.settings);
-		const client = this.buildClient(settings);
-		const query: Record<string, string | number | undefined> = {};
-		if (options?.limit !== undefined) query.limit = options.limit;
-		if (options?.projectId ?? settings.projectId) {
-			query.projectId = (options?.projectId ?? settings.projectId) as string;
-		}
-		const raw = (await client.listSessions(query)) as
-			| { sessions?: readonly AgentmemoryRawSession[]; data?: readonly AgentmemoryRawSession[] }
-			| readonly AgentmemoryRawSession[]
-			| undefined;
-
-		let list: readonly AgentmemoryRawSession[];
-		if (Array.isArray(raw)) {
-			list = raw;
-		} else if (raw && typeof raw === 'object') {
-			list =
-				(raw as { sessions?: readonly AgentmemoryRawSession[]; data?: readonly AgentmemoryRawSession[] })
-					.sessions ??
-				(raw as { data?: readonly AgentmemoryRawSession[] }).data ??
-				[];
-		} else {
-			list = [];
-		}
-
-		return list.map((s) => this.toSession(s));
+		// `/forget` takes `{ project, filter: { ... } }`. The filter
+		// selects observations / memories / sessions to delete by id.
+		await client.forget({
+			project: settings.project ?? DEFAULT_PROJECT,
+			filter: { id }
+		});
 	}
 
 	// ── helpers ────────────────────────────────────────────────────────
@@ -318,9 +324,19 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 	private resolveSettings(rawSettings?: PluginSettings | Record<string, unknown>): AgentmemorySettings {
 		const flat = this.flattenSettings(rawSettings);
 		const out: AgentmemorySettings = {};
-		if (typeof flat.baseUrl === 'string' && flat.baseUrl) out.baseUrl = flat.baseUrl as string;
-		if (typeof flat.apiKey === 'string' && flat.apiKey) out.apiKey = flat.apiKey as string;
-		if (typeof flat.projectId === 'string' && flat.projectId) out.projectId = flat.projectId as string;
+
+		const baseUrl =
+			typeof flat.baseUrl === 'string' && flat.baseUrl ? (flat.baseUrl as string) : envOf(ENV_VAR_BASE_URL);
+		if (baseUrl) out.baseUrl = baseUrl;
+
+		const apiKey =
+			typeof flat.apiKey === 'string' && flat.apiKey ? (flat.apiKey as string) : envOf(ENV_VAR_API_KEY);
+		if (apiKey) out.apiKey = apiKey;
+
+		const project =
+			typeof flat.projectId === 'string' && flat.projectId ? (flat.projectId as string) : envOf(ENV_VAR_PROJECT);
+		if (project) out.project = project;
+
 		if (typeof flat.timeoutMs === 'number') out.timeoutMs = flat.timeoutMs as number;
 		return out;
 	}
@@ -351,14 +367,19 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 		});
 	}
 
-	private toSession(raw: AgentmemoryRawSession | undefined): AgentMemorySession {
-		const id = raw?.id || raw?.sessionId || raw?.session_id || '';
+	private toSession(raw: AgentmemoryRawSession | undefined, fallback?: { startedAt?: string }): AgentMemorySession {
+		const id = raw?.id || raw?.sessionId || raw?.session_id;
+		if (!id) {
+			throw new Error(
+				`agentmemory server returned a session without an id field (one of id, sessionId, session_id is required). Raw payload: ${safeStringify(raw)}`
+			);
+		}
 		return {
 			id,
-			startedAt: raw?.startedAt || raw?.started_at || new Date().toISOString(),
-			endedAt: raw?.endedAt || raw?.ended_at,
-			metadata: raw?.metadata,
-			context: raw?.context || raw?.recall
+			startedAt: raw.startedAt || raw.started_at || fallback?.startedAt || new Date().toISOString(),
+			endedAt: raw.endedAt || raw.ended_at,
+			metadata: raw.metadata,
+			context: raw.context || raw.recall
 		};
 	}
 
@@ -366,17 +387,28 @@ export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
 		raw: AgentmemoryRawRecord,
 		fallback?: Partial<AgentMemoryRecord> & { sessionId?: string; projectId?: string }
 	): AgentMemoryRecord {
+		const id = raw.id || raw.observationId || raw.observation_id || raw.memoryId || raw.memory_id;
+		if (!id) {
+			throw new Error(
+				`agentmemory server returned a record without an id field (one of id, observationId, memoryId is required). Raw payload: ${safeStringify(raw)}`
+			);
+		}
 		return {
-			id: raw.id || raw.observationId || raw.observation_id || '',
+			id,
 			content: raw.content ?? raw.text ?? fallback?.content ?? '',
 			tags: raw.tags ?? fallback?.tags,
 			metadata: raw.metadata ?? fallback?.metadata,
 			sessionId: raw.sessionId ?? raw.session_id ?? fallback?.sessionId,
-			projectId: raw.projectId ?? raw.project_id ?? fallback?.projectId,
+			projectId: raw.projectId ?? raw.project_id ?? raw.project ?? fallback?.projectId,
 			createdAt: raw.createdAt ?? raw.created_at ?? new Date().toISOString(),
 			score: raw.score ?? raw.similarity
 		};
 	}
+}
+
+function envOf(name: string): string | undefined {
+	const value = process.env[name];
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function safeStringify(value: unknown): string {

--- a/packages/plugins/agentmemory/src/agentmemory.plugin.ts
+++ b/packages/plugins/agentmemory/src/agentmemory.plugin.ts
@@ -1,0 +1,388 @@
+import type {
+	IPlugin,
+	IAgentMemoryPlugin,
+	PluginContext,
+	PluginCategory,
+	JsonSchema,
+	ValidationResult,
+	ConnectionValidationResult,
+	PluginManifest,
+	PluginHealthCheck,
+	PluginSettings,
+	AgentMemorySession,
+	AgentMemorySessionInput,
+	AgentMemoryRecord,
+	AgentMemorySaveInput,
+	AgentMemorySearchInput,
+	AgentMemorySearchResponse,
+	AgentMemoryContext,
+	AgentMemoryContextInput
+} from '@ever-works/plugin';
+
+import { AgentmemoryClient } from './agentmemory-client.js';
+import type {
+	AgentmemorySettings,
+	AgentmemoryRawSession,
+	AgentmemoryRawRecord,
+	AgentmemoryRawSearchResponse,
+	AgentmemoryRawContext
+} from './types.js';
+import { DEFAULT_BASE_URL, DEFAULT_TIMEOUT_MS } from './types.js';
+
+/**
+ * Agent Memory plugin — first-party implementation of the
+ * `agent-memory` capability.
+ *
+ * Talks to a standalone `agentmemory` Node server over REST (default
+ * `http://localhost:3111`, override via `baseUrl` setting or the
+ * `AGENTMEMORY_BASE_URL` env var). Works equally well against:
+ *
+ * - a locally-run `npx @agentmemory/agentmemory` server (zero config),
+ * - a hosted instance fronted by HTTPS + bearer auth,
+ * - the optional in-cluster Deployment shipped under
+ *   `.deploy/k8s/agentmemory.optional.yaml`.
+ *
+ * The plugin is settings-only — no global env reads beyond the
+ * `x-envVar` fallbacks declared in the JSON Schema, which the plugin
+ * settings service injects automatically when the user / admin hasn't
+ * overridden them.
+ */
+export class AgentmemoryPlugin implements IPlugin, IAgentMemoryPlugin {
+	readonly id = 'agentmemory';
+	readonly name = 'Agent Memory';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'utility';
+	readonly capabilities = ['agent-memory'] as const;
+	readonly configurationMode = 'hybrid' as const;
+	readonly providerName = 'agentmemory';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			baseUrl: {
+				type: 'string',
+				title: 'agentmemory base URL',
+				description:
+					'REST endpoint of the agentmemory server. Defaults to http://localhost:3111 (matches the `npx agentmemory` server). Set to your hosted instance for a shared deployment.',
+				default: DEFAULT_BASE_URL,
+				'x-scope': 'user',
+				'x-envVar': 'AGENTMEMORY_BASE_URL'
+			},
+			apiKey: {
+				type: 'string',
+				title: 'Bearer token',
+				description:
+					"Bearer token sent in Authorization. Leave empty for a localhost dev server. For a hosted instance this must match the server's `AGENTMEMORY_SECRET` env var.",
+				'x-secret': true,
+				'x-scope': 'user',
+				'x-envVar': 'AGENTMEMORY_API_KEY'
+			},
+			projectId: {
+				type: 'string',
+				title: 'Project namespace',
+				description:
+					"Optional namespace inside the agentmemory store. Each Work / project can pin a value so different Works don't see each other's observations.",
+				'x-scope': 'work'
+			},
+			timeoutMs: {
+				type: 'number',
+				title: 'Request timeout (ms)',
+				default: DEFAULT_TIMEOUT_MS,
+				minimum: 1000,
+				maximum: 120_000,
+				'x-scope': 'user'
+			}
+		},
+		required: []
+	};
+
+	private context: PluginContext | null = null;
+
+	// ── IPlugin lifecycle ──────────────────────────────────────────────
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log('agentmemory plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = null;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'agentmemory plugin is ready',
+			checkedAt: Date.now()
+		};
+	}
+
+	async isAvailable(): Promise<boolean> {
+		// The plugin is always available — connectivity is checked per-call.
+		// We don't ping the server in `isAvailable` because the operator may
+		// run agentmemory on-demand (it's cheap to start, no daemon by default).
+		return true;
+	}
+
+	async validateSettings(settings: Record<string, unknown>): Promise<ValidationResult> {
+		const baseUrl = settings.baseUrl;
+		if (baseUrl !== undefined && typeof baseUrl !== 'string') {
+			return {
+				valid: false,
+				errors: [{ path: 'baseUrl', message: '`baseUrl` must be a string' }]
+			};
+		}
+		if (baseUrl && typeof baseUrl === 'string') {
+			try {
+				const url = new URL(baseUrl);
+				if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+					return {
+						valid: false,
+						errors: [{ path: 'baseUrl', message: '`baseUrl` must be http:// or https://' }]
+					};
+				}
+			} catch {
+				return {
+					valid: false,
+					errors: [{ path: 'baseUrl', message: '`baseUrl` is not a valid URL' }]
+				};
+			}
+		}
+		const timeoutMs = settings.timeoutMs;
+		if (timeoutMs !== undefined && (typeof timeoutMs !== 'number' || timeoutMs < 1000)) {
+			return {
+				valid: false,
+				errors: [{ path: 'timeoutMs', message: '`timeoutMs` must be a number ≥ 1000' }]
+			};
+		}
+		return { valid: true };
+	}
+
+	async validateConnection(rawSettings: Record<string, unknown>): Promise<ConnectionValidationResult> {
+		const settings = this.resolveSettings(rawSettings);
+		const client = this.buildClient(settings);
+		try {
+			const result = await client.health();
+			if (result.ok) {
+				return {
+					success: true,
+					message: `Connected to agentmemory at ${settings.baseUrl ?? DEFAULT_BASE_URL}.`
+				};
+			}
+			return {
+				success: false,
+				message: `agentmemory health check returned an unexpected payload: ${safeStringify(result.raw)}`
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Connection validation failed';
+			return { success: false, message };
+		}
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description:
+				'Persistent memory store for AI coding / generation agents. Connects to a local or hosted agentmemory REST server (default http://localhost:3111).',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public',
+			defaultForCapabilities: ['agent-memory'],
+			homepage: 'https://github.com/rohitg00/agentmemory',
+			uiHints: {
+				includeInOnboarding: false,
+				completionFields: ['baseUrl']
+			}
+		};
+	}
+
+	// ── IAgentMemoryPlugin ────────────────────────────────────────────
+
+	async openSession(input: AgentMemorySessionInput): Promise<AgentMemorySession> {
+		const settings = this.resolveSettings(input.settings);
+		const client = this.buildClient(settings);
+		const body: Record<string, unknown> = {};
+		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
+		if (input.metadata) body.metadata = input.metadata;
+		const raw = (await client.sessionStart(body)) as AgentmemoryRawSession | undefined;
+		return this.toSession(raw);
+	}
+
+	async closeSession(sessionId: string, settingsOverride?: PluginSettings): Promise<void> {
+		const settings = this.resolveSettings(settingsOverride);
+		const client = this.buildClient(settings);
+		await client.sessionEnd({ sessionId });
+	}
+
+	async saveMemory(input: AgentMemorySaveInput): Promise<AgentMemoryRecord> {
+		const settings = this.resolveSettings(input.settings);
+		const client = this.buildClient(settings);
+		const body: Record<string, unknown> = { content: input.content };
+		if (input.tags) body.tags = input.tags;
+		if (input.metadata) body.metadata = input.metadata;
+		if (input.sessionId) body.sessionId = input.sessionId;
+		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
+
+		// `/observe` is the right call when a session is open (records as
+		// a transient observation); otherwise `/remember` persists it
+		// directly to long-term memory. Mirrors the agentmemory docs.
+		const raw = input.sessionId
+			? ((await client.observe(body)) as AgentmemoryRawRecord)
+			: ((await client.remember(body)) as AgentmemoryRawRecord);
+
+		return this.toRecord(raw, input);
+	}
+
+	async searchMemory(input: AgentMemorySearchInput): Promise<AgentMemorySearchResponse> {
+		const settings = this.resolveSettings(input.settings);
+		const client = this.buildClient(settings);
+		const body: Record<string, unknown> = { query: input.query };
+		if (input.limit !== undefined) body.limit = input.limit;
+		if (input.tags) body.tags = input.tags;
+		if (input.sessionId) body.sessionId = input.sessionId;
+		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
+
+		const raw = (await client.smartSearch(body)) as AgentmemoryRawSearchResponse | undefined;
+		const rawList = raw?.results ?? raw?.matches ?? raw?.hits ?? [];
+		return {
+			results: rawList.map((r) => this.toRecord(r)),
+			summary: raw?.summary ?? raw?.digest
+		};
+	}
+
+	async buildContext(input: AgentMemoryContextInput): Promise<AgentMemoryContext> {
+		const settings = this.resolveSettings(input.settings);
+		const client = this.buildClient(settings);
+		const body: Record<string, unknown> = {};
+		if (input.query) body.query = input.query;
+		if (input.purpose) body.purpose = input.purpose;
+		if (input.sessionId) body.sessionId = input.sessionId;
+		if (input.projectId ?? settings.projectId) body.projectId = input.projectId ?? settings.projectId;
+		if (input.maxTokens !== undefined) body.maxTokens = input.maxTokens;
+
+		const raw = (await client.context(body)) as AgentmemoryRawContext | undefined;
+		return {
+			content: raw?.content ?? raw?.context ?? raw?.text ?? '',
+			approxTokens: raw?.approxTokens ?? raw?.approx_tokens,
+			references: raw?.references?.map((r) => this.toRecord(r))
+		};
+	}
+
+	async deleteEntry(id: string, settingsOverride?: PluginSettings): Promise<void> {
+		const settings = this.resolveSettings(settingsOverride);
+		const client = this.buildClient(settings);
+		await client.forget({ id });
+	}
+
+	async listSessions(options?: {
+		limit?: number;
+		projectId?: string;
+		settings?: PluginSettings;
+	}): Promise<readonly AgentMemorySession[]> {
+		const settings = this.resolveSettings(options?.settings);
+		const client = this.buildClient(settings);
+		const query: Record<string, string | number | undefined> = {};
+		if (options?.limit !== undefined) query.limit = options.limit;
+		if (options?.projectId ?? settings.projectId) {
+			query.projectId = (options?.projectId ?? settings.projectId) as string;
+		}
+		const raw = (await client.listSessions(query)) as
+			| { sessions?: readonly AgentmemoryRawSession[]; data?: readonly AgentmemoryRawSession[] }
+			| readonly AgentmemoryRawSession[]
+			| undefined;
+
+		let list: readonly AgentmemoryRawSession[];
+		if (Array.isArray(raw)) {
+			list = raw;
+		} else if (raw && typeof raw === 'object') {
+			list =
+				(raw as { sessions?: readonly AgentmemoryRawSession[]; data?: readonly AgentmemoryRawSession[] })
+					.sessions ??
+				(raw as { data?: readonly AgentmemoryRawSession[] }).data ??
+				[];
+		} else {
+			list = [];
+		}
+
+		return list.map((s) => this.toSession(s));
+	}
+
+	// ── helpers ────────────────────────────────────────────────────────
+
+	private resolveSettings(rawSettings?: PluginSettings | Record<string, unknown>): AgentmemorySettings {
+		const flat = this.flattenSettings(rawSettings);
+		const out: AgentmemorySettings = {};
+		if (typeof flat.baseUrl === 'string' && flat.baseUrl) out.baseUrl = flat.baseUrl as string;
+		if (typeof flat.apiKey === 'string' && flat.apiKey) out.apiKey = flat.apiKey as string;
+		if (typeof flat.projectId === 'string' && flat.projectId) out.projectId = flat.projectId as string;
+		if (typeof flat.timeoutMs === 'number') out.timeoutMs = flat.timeoutMs as number;
+		return out;
+	}
+
+	/** Some callers pass `{ admin: {...}, user: {...} }` directly; the
+	 *  facade always pre-flattens but tests / `validateConnection` may
+	 *  not, so we accept both shapes. */
+	private flattenSettings(rawSettings: unknown): Record<string, unknown> {
+		if (!rawSettings || typeof rawSettings !== 'object') return {};
+		const obj = rawSettings as Record<string, unknown>;
+		if ('admin' in obj || 'user' in obj || 'work' in obj || 'effective' in obj) {
+			const effective = (obj.effective as Record<string, unknown>) || undefined;
+			if (effective) return effective;
+			const admin = (obj.admin as Record<string, unknown>) || {};
+			const user = (obj.user as Record<string, unknown>) || {};
+			const work = (obj.work as Record<string, unknown>) || {};
+			return { ...admin, ...user, ...work };
+		}
+		return obj;
+	}
+
+	private buildClient(settings: AgentmemorySettings): AgentmemoryClient {
+		return new AgentmemoryClient({
+			baseUrl: settings.baseUrl,
+			apiKey: settings.apiKey,
+			timeoutMs: settings.timeoutMs,
+			logger: this.context?.logger ?? console
+		});
+	}
+
+	private toSession(raw: AgentmemoryRawSession | undefined): AgentMemorySession {
+		const id = raw?.id || raw?.sessionId || raw?.session_id || '';
+		return {
+			id,
+			startedAt: raw?.startedAt || raw?.started_at || new Date().toISOString(),
+			endedAt: raw?.endedAt || raw?.ended_at,
+			metadata: raw?.metadata,
+			context: raw?.context || raw?.recall
+		};
+	}
+
+	private toRecord(
+		raw: AgentmemoryRawRecord,
+		fallback?: Partial<AgentMemoryRecord> & { sessionId?: string; projectId?: string }
+	): AgentMemoryRecord {
+		return {
+			id: raw.id || raw.observationId || raw.observation_id || '',
+			content: raw.content ?? raw.text ?? fallback?.content ?? '',
+			tags: raw.tags ?? fallback?.tags,
+			metadata: raw.metadata ?? fallback?.metadata,
+			sessionId: raw.sessionId ?? raw.session_id ?? fallback?.sessionId,
+			projectId: raw.projectId ?? raw.project_id ?? fallback?.projectId,
+			createdAt: raw.createdAt ?? raw.created_at ?? new Date().toISOString(),
+			score: raw.score ?? raw.similarity
+		};
+	}
+}
+
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}

--- a/packages/plugins/agentmemory/src/index.ts
+++ b/packages/plugins/agentmemory/src/index.ts
@@ -1,0 +1,4 @@
+export { AgentmemoryPlugin, AgentmemoryPlugin as default } from './agentmemory.plugin.js';
+export { AgentmemoryClient } from './agentmemory-client.js';
+export { DEFAULT_BASE_URL, DEFAULT_TIMEOUT_MS } from './types.js';
+export type { AgentmemorySettings } from './types.js';

--- a/packages/plugins/agentmemory/src/types.ts
+++ b/packages/plugins/agentmemory/src/types.ts
@@ -3,6 +3,20 @@
  *
  * The shape mirrors the `agentmemory` REST API as documented at
  * https://github.com/rohitg00/agentmemory (paths under `/agentmemory/...`).
+ *
+ * Wire-format notes (verified against the upstream server's request
+ * validators):
+ *
+ *   - Every endpoint requires a `project` field. We map our internal
+ *     `projectId` setting to it, falling back to `DEFAULT_PROJECT` when
+ *     the operator hasn't set one.
+ *   - `/smart-search` uses `topK` (not `limit`).
+ *   - `/context` uses `tokenBudget` (not `maxTokens`).
+ *   - `/forget` takes `{ project, filter: { ... } }` — the filter
+ *     selects observations / sessions / memory ids to delete.
+ *   - `/observe` is reserved for auto-capture hooks (`type: 'PostToolUse'`
+ *     + `payload`). Free-form saves from the platform always go through
+ *     `/remember` instead.
  */
 
 /** Default base URL used when the operator hasn't overridden it. Matches
@@ -15,6 +29,24 @@ export const DEFAULT_BASE_URL = 'http://localhost:3111';
  *  + LLM pass agentmemory may run on `smart-search`. */
 export const DEFAULT_TIMEOUT_MS = 30_000;
 
+/** Hard upper bound. Mirrors `settingsSchema.timeoutMs.maximum`. */
+export const MAX_TIMEOUT_MS = 120_000;
+
+/** Default project namespace when no per-work / per-user value is set.
+ *  agentmemory rejects requests with an empty `project`, so we MUST send
+ *  something. `ever-works` is a sane fallback that keeps the platform's
+ *  data partitioned from anyone else sharing the same server. */
+export const DEFAULT_PROJECT = 'ever-works';
+
+/** Env vars the plugin probes when the resolved settings are empty. The
+ *  plugin settings service does NOT auto-inject these (that would
+ *  require `x-envVar` on the schema, which would also lock the field
+ *  out of the admin UI — see Codex review on PR #1073). We fall back
+ *  to env manually in `resolveSettings`. */
+export const ENV_VAR_BASE_URL = 'AGENTMEMORY_BASE_URL';
+export const ENV_VAR_API_KEY = 'AGENTMEMORY_API_KEY';
+export const ENV_VAR_PROJECT = 'AGENTMEMORY_PROJECT';
+
 /**
  * Settings the plugin reads after the facade has resolved the user / work
  * / admin hierarchy. Everything is optional — the plugin works against a
@@ -26,8 +58,9 @@ export interface AgentmemorySettings {
 	/** Bearer token (the agentmemory server reads `AGENTMEMORY_SECRET`). */
 	apiKey?: string;
 	/** Project namespace inside the shared SQLite store. Plugins set it
-	 *  per-Work so different Works don't see each other's observations. */
-	projectId?: string;
+	 *  per-Work so different Works don't see each other's observations.
+	 *  Resolved with fallback to `DEFAULT_PROJECT` when undefined. */
+	project?: string;
 	/** Request timeout override. */
 	timeoutMs?: number;
 }
@@ -46,17 +79,20 @@ export interface AgentmemoryRawSession {
 	readonly recall?: string;
 }
 
-/** Raw shape returned by `POST /agentmemory/observe` and `/remember`. */
+/** Raw shape returned by `POST /agentmemory/remember`. */
 export interface AgentmemoryRawRecord {
 	readonly id?: string;
 	readonly observationId?: string;
 	readonly observation_id?: string;
+	readonly memoryId?: string;
+	readonly memory_id?: string;
 	readonly content?: string;
 	readonly text?: string;
 	readonly tags?: readonly string[];
 	readonly metadata?: Record<string, unknown>;
 	readonly sessionId?: string;
 	readonly session_id?: string;
+	readonly project?: string;
 	readonly projectId?: string;
 	readonly project_id?: string;
 	readonly createdAt?: string;

--- a/packages/plugins/agentmemory/src/types.ts
+++ b/packages/plugins/agentmemory/src/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Local types shared between the plugin class and the HTTP client.
+ *
+ * The shape mirrors the `agentmemory` REST API as documented at
+ * https://github.com/rohitg00/agentmemory (paths under `/agentmemory/...`).
+ */
+
+/** Default base URL used when the operator hasn't overridden it. Matches
+ *  the npm package `@agentmemory/agentmemory` default (`III_REST_PORT=3111`).
+ *  Use the same value in tests so we don't accidentally talk to a real
+ *  service. */
+export const DEFAULT_BASE_URL = 'http://localhost:3111';
+
+/** Default request timeout (ms). 30s — generous enough for the embedding
+ *  + LLM pass agentmemory may run on `smart-search`. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Settings the plugin reads after the facade has resolved the user / work
+ * / admin hierarchy. Everything is optional — the plugin works against a
+ * vanilla `npx agentmemory` localhost server with zero configuration.
+ */
+export interface AgentmemorySettings {
+	/** Override the REST endpoint (e.g. https://mem.acme.example). */
+	baseUrl?: string;
+	/** Bearer token (the agentmemory server reads `AGENTMEMORY_SECRET`). */
+	apiKey?: string;
+	/** Project namespace inside the shared SQLite store. Plugins set it
+	 *  per-Work so different Works don't see each other's observations. */
+	projectId?: string;
+	/** Request timeout override. */
+	timeoutMs?: number;
+}
+
+/** Raw shape returned by `POST /agentmemory/session/start`. */
+export interface AgentmemoryRawSession {
+	readonly id?: string;
+	readonly sessionId?: string;
+	readonly session_id?: string;
+	readonly startedAt?: string;
+	readonly started_at?: string;
+	readonly endedAt?: string;
+	readonly ended_at?: string;
+	readonly metadata?: Record<string, unknown>;
+	readonly context?: string;
+	readonly recall?: string;
+}
+
+/** Raw shape returned by `POST /agentmemory/observe` and `/remember`. */
+export interface AgentmemoryRawRecord {
+	readonly id?: string;
+	readonly observationId?: string;
+	readonly observation_id?: string;
+	readonly content?: string;
+	readonly text?: string;
+	readonly tags?: readonly string[];
+	readonly metadata?: Record<string, unknown>;
+	readonly sessionId?: string;
+	readonly session_id?: string;
+	readonly projectId?: string;
+	readonly project_id?: string;
+	readonly createdAt?: string;
+	readonly created_at?: string;
+	readonly score?: number;
+	readonly similarity?: number;
+}
+
+/** Raw shape returned by `POST /agentmemory/smart-search`. */
+export interface AgentmemoryRawSearchResponse {
+	readonly results?: readonly AgentmemoryRawRecord[];
+	readonly matches?: readonly AgentmemoryRawRecord[];
+	readonly hits?: readonly AgentmemoryRawRecord[];
+	readonly summary?: string;
+	readonly digest?: string;
+}
+
+/** Raw shape returned by `POST /agentmemory/context`. */
+export interface AgentmemoryRawContext {
+	readonly content?: string;
+	readonly context?: string;
+	readonly text?: string;
+	readonly approxTokens?: number;
+	readonly approx_tokens?: number;
+	readonly references?: readonly AgentmemoryRawRecord[];
+}

--- a/packages/plugins/agentmemory/tsconfig.json
+++ b/packages/plugins/agentmemory/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/agentmemory/tsup.config.ts
+++ b/packages/plugins/agentmemory/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	splitting: false,
+	sourcemap: false,
+	clean: true
+});

--- a/packages/plugins/agentmemory/vitest.config.ts
+++ b/packages/plugins/agentmemory/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/index.ts']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -220,16 +220,16 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -466,10 +466,10 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -883,13 +883,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -1023,7 +1023,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1170,6 +1170,24 @@ importers:
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.8
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
+  packages/plugins/agentmemory:
+    devDependencies:
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
@@ -19083,6 +19101,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -19104,6 +19133,16 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -23472,7 +23511,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -23489,7 +23528,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.0
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -23516,7 +23555,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -23535,6 +23574,35 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21)))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
@@ -23566,7 +23634,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -23595,7 +23663,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -23697,6 +23765,17 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
+
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -26106,6 +26185,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.2
+      semver: 7.7.4
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -32803,7 +32901,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.8.0
 
   jstransformer@1.0.0:
     dependencies:
@@ -34746,13 +34844,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## Summary

Adds a new pluggable `agent-memory` capability to the plugin system, a first-party `@ever-works/agentmemory-plugin` that talks to the standalone [`agentmemory`](https://github.com/rohitg00/agentmemory) REST server (same one Claude Code / Codex / OpenCode / MCP clients use), and an **optional** in-cluster k8s deployment so operators can self-host the memory backend.

The capability + facade structure means future backends (mem0, zep, langmem, vector-DB-backed homegrown) just implement the same `IAgentMemoryPlugin` contract — no platform code changes.

## Why this shape

User decisions captured during scoping:

1. **New `memory` capability + facade** — matches `storage` / `search` / `deploy` / `skills` / `task-tracker`. The facade owns provider resolution, settings hierarchy, error wrapping.
2. **Local-or-hosted runtime** — same plugin, three modes:
   - **Local dev**: `npx @agentmemory/agentmemory`, plugin's default `http://localhost:3111` just works.
   - **Self-hosted in cluster**: apply [`.deploy/k8s/agentmemory.optional.yaml`](.deploy/k8s/agentmemory.optional.yaml) (opt-in; not pulled in by any environment manifest).
   - **Hosted SaaS**: set `baseUrl` + bearer `apiKey` in plugin settings or via `AGENTMEMORY_BASE_URL` / `AGENTMEMORY_API_KEY` env.
3. **End-to-end in one PR** — capability, plugin, facade, k8s spec, tests, docs.

## Wire-format additions

**`@ever-works/plugin`**
- `PLUGIN_CAPABILITIES.AGENT_MEMORY = 'agent-memory'`
- `contracts/capabilities/agent-memory.interface.ts` — `IAgentMemoryPlugin`, `IAgentMemoryFacade`, `AgentMemoryObservation`, `AgentMemoryRecord`, `AgentMemorySession`, `AgentMemoryContext` + DTOs. Optional governance surface (`deleteEntry`, `listSessions`, `exportAll`) is opt-in — facade probes for presence.

**`@ever-works/agent`**
- `facades/agent-memory.facade.ts` — `AgentMemoryFacadeService extends BaseFacadeService`. Provider resolution + 4-level settings hierarchy + error wrapping (`AgentMemoryFacadeError` with operation + provider context).
- Registered in `facades.module.ts`; re-exported from `facades/index.ts`; pinned in the `facades.module.spec.ts` regression guard.

**`packages/plugins/agentmemory/`** — new built-in plugin
- `AgentmemoryClient` — thin fetch wrapper. Bearer auth, configurable timeout, URL normalisation (trailing-slash safety), 401/403/404/429 error translation.
- `AgentmemoryPlugin` — JSON Schema settings (`baseUrl` + `apiKey` with `x-secret` + `x-envVar`, work-scoped `projectId`, `timeoutMs`). `validateConnection` hits `/agentmemory/health`. `saveMemory` routes to `/observe` when a `sessionId` is present, `/remember` otherwise — matches the upstream docs. Search/context responses are normalised across the `(results | matches | hits)` field shapes the server has shipped, and similar for `content / context / text`.

## Tests

- **30 vitest** unit tests in the plugin package: HTTP client (auth header, baseUrl normalisation, error translation, JSON encoding, query params, abort handling) + plugin class (metadata, settings schema validation, validateConnection, /observe-vs-/remember routing, search/context response normalisation).
- **8 jest** unit tests for the facade: routing, settings injection, `NoProviderError`, error wrapping with operation/provider metadata, optional-method-not-supported rejection.
- Updated `facades.module.spec.ts` regression guard (new facade in `FACADE_CLASSES` + barrel export list).
- Full agent suite: **281 suites, 5555 tests passing** (was 5547 → +8).

## Deliberately NOT in this PR

- API controllers exposing the facade to the web app — adding controllers is a follow-up once UX for "show me memory recall" exists.
- Pipeline-step integration — a memory-aware pipeline step is the next logical PR; this one establishes the substrate.
- Trigger.dev background flusher — the current REST API is already synchronous; we'll add a queued path if/when we see latency in real generation pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent-memory capability enabling persistent memory storage and retrieval. Users can now save, search, and manage session-based memory with context building support.
  * Added optional agentmemory service deployment via Kubernetes manifest for self-hosted installations.

* **Chores**
  * Added comprehensive test coverage and plugin implementation for agent-memory capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->