### PR TITLE
[EW-665] feat: Phase 13 - Work.kind + Work.status + Company-Work → Org lifecycle

### DIFF
--- a/apps/api/src/migrations/1779991010000-AddWorkKindAndStatus.ts
+++ b/apps/api/src/migrations/1779991010000-AddWorkKindAndStatus.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — adds the Work-level
+ * `kind` + `status` lifecycle columns to the `works` table.
+ *
+ * See [spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)
+ * for the Work-of-type-Company → Organization flow these columns drive.
+ *
+ * **`kind`** — `varchar(32)`, default `'default'`, NOT NULL. Mirrors
+ * the `TemplateKind` convention (a TS string union backed by a plain
+ * varchar rather than a Postgres enum type, so new members never need a
+ * type-altering migration). Values today: `'default' | 'company'`. Every
+ * pre-Phase-13 row is a plain Work → backfilled to `'default'`.
+ *
+ * **`status`** — `varchar(32)`, default `'active'`, NOT NULL. The
+ * platform had NO Work-level lifecycle status before this phase
+ * (generation / deployment / schedule status columns are independent and
+ * don't represent the Work as a whole), so `'active'` is the
+ * behavior-preserving default: a Work that exists is "live". Values:
+ * `'draft' | 'active' | 'registered' | 'archived'`. The
+ * `draft → registered` transition on a `kind = 'company'` Work is what
+ * fires the `work.status.changed` event → `WorkRegisteredListener` →
+ * `OrganizationService.createOrganizationFromCompanyWork`.
+ *
+ * Both columns are added with a non-NULL DB default so Postgres
+ * backfills every existing row in the same `ALTER TABLE` — no separate
+ * `UPDATE` pass is needed. We make the columns nullable-false at the
+ * SQL level by relying on the default; `addColumn` with `default` set
+ * and `isNullable: false` is the same shape the column-add migrations on
+ * this table use elsewhere.
+ *
+ * Forward-only, additive, idempotent (gates on `hasColumn`). The
+ * `down()` drops both columns.
+ */
+export class AddWorkKindAndStatus1779991010000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasColumn('works', 'kind'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'kind',
+                    type: 'varchar',
+                    length: '32',
+                    isNullable: false,
+                    default: "'default'",
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasColumn('works', 'status'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'status',
+                    type: 'varchar',
+                    length: '32',
+                    isNullable: false,
+                    default: "'active'",
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasColumn('works', 'status')) {
+            await queryRunner.dropColumn('works', 'status');
+        }
+        if (await queryRunner.hasColumn('works', 'kind')) {
+            await queryRunner.dropColumn('works', 'kind');
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddWorkKindAndStatus.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddWorkKindAndStatus.spec.ts
@@ -1,0 +1,92 @@
+import { DataSource } from 'typeorm';
+import { AddWorkKindAndStatus1779991010000 } from '../1779991010000-AddWorkKindAndStatus';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — migration test for the
+ * `works.kind` + `works.status` columns.
+ *
+ * Runs the real migration's `up()` / `down()` against an in-memory
+ * better-sqlite3 DataSource (same harness the agent package's
+ * timestamp-column integration test uses). Asserts that:
+ *   - both columns exist after `up()`,
+ *   - a row inserted WITHOUT specifying them backfills to the column
+ *     defaults (`kind = 'default'`, `status = 'active'`),
+ *   - the migration is idempotent (running `up()` twice is a no-op), and
+ *   - `down()` drops both columns.
+ */
+describe('AddWorkKindAndStatus1779991010000 (EW-665 Phase 13)', () => {
+    let dataSource: DataSource;
+    const migration = new AddWorkKindAndStatus1779991010000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        // Minimal `works` table — just enough to add the columns onto. The
+        // migration only touches `kind` / `status`, so a couple of NOT NULL
+        // columns are enough to prove the defaults backfill an INSERT that
+        // omits them.
+        await dataSource.query(
+            `CREATE TABLE "works" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar NOT NULL)`,
+        );
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function columnNames(): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(`PRAGMA table_info("works")`);
+        return rows.map((r) => r.name);
+    }
+
+    it('adds kind + status columns with the documented defaults', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const cols = await columnNames();
+        expect(cols).toEqual(expect.arrayContaining(['kind', 'status']));
+
+        // Insert a row WITHOUT kind/status — the DB defaults must backfill.
+        await dataSource.query(`INSERT INTO "works" ("id", "name") VALUES ('w-1', 'Acme')`);
+        const [row] = await dataSource.query(
+            `SELECT "kind", "status" FROM "works" WHERE "id" = 'w-1'`,
+        );
+        expect(row.kind).toBe('default');
+        expect(row.status).toBe('active');
+    });
+
+    it('is idempotent — running up() twice does not throw or duplicate columns', async () => {
+        const r1 = dataSource.createQueryRunner();
+        await migration.up(r1);
+        await r1.release();
+
+        const r2 = dataSource.createQueryRunner();
+        await expect(migration.up(r2)).resolves.toBeUndefined();
+        await r2.release();
+
+        const cols = await columnNames();
+        expect(cols.filter((c) => c === 'kind')).toHaveLength(1);
+        expect(cols.filter((c) => c === 'status')).toHaveLength(1);
+    });
+
+    it('down() drops both columns', async () => {
+        const up = dataSource.createQueryRunner();
+        await migration.up(up);
+        await up.release();
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+
+        const cols = await columnNames();
+        expect(cols).not.toContain('kind');
+        expect(cols).not.toContain('status');
+    });
+});

--- a/apps/api/src/organizations/__tests__/organization.service.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization.service.spec.ts
@@ -25,6 +25,7 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
         organizationById?: Org | null;
         orgCountByTenant?: number;
         tenantId?: string;
+        existingLinkedOrg?: (Org & { linkedWorkId?: string | null }) | null;
     }) {
         const queryLog: QueryRecord[] = [];
 
@@ -47,6 +48,11 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
             findBySlug: jest.fn().mockResolvedValue(null),
             findByTenantId: jest.fn().mockResolvedValue([]),
             countByTenantId: jest.fn().mockResolvedValue(opts.orgCountByTenant ?? 0),
+            // EW-665 (Phase 13) — idempotency guard in
+            // createOrganizationFromCompanyWork looks up an existing Org by
+            // its backing Work id. Default to "none linked yet"; tests that
+            // exercise the re-fire path override this per-case.
+            findByLinkedWorkId: jest.fn().mockResolvedValue(opts.existingLinkedOrg ?? null),
             update: jest.fn().mockResolvedValue(undefined),
         };
 
@@ -747,6 +753,35 @@ describe('OrganizationService (EW-658 Phase 6)', () => {
             await expect(
                 service.createOrganizationFromCompanyWork('u-1', { id: 'w-x', name: '' }),
             ).rejects.toBeInstanceOf(ConflictException);
+        });
+
+        it('EW-665 Phase 13: is idempotent on linkedWorkId — returns the existing Org without creating a new one', async () => {
+            const existing = {
+                id: 'o-existing',
+                tenantId: 't-1',
+                slug: 'acme',
+                displayName: 'Acme Inc.',
+                linkedWorkId: 'w-42',
+            };
+            const { service, organizationRepository, tenantBootstrap } = makeService({
+                user: { id: 'u-1', tenantId: 't-1', lastScopeOrganizationId: 'o-existing' },
+                existingLinkedOrg: existing,
+            });
+
+            const org = (await service.createOrganizationFromCompanyWork('u-1', {
+                id: 'w-42',
+                name: 'acme-website',
+                companyName: 'Acme Inc.',
+            })) as unknown as { id: string; linkedWorkId: string | null };
+
+            // Returned the pre-existing Org, NOT a freshly-minted 'o-new'.
+            expect(org.id).toBe('o-existing');
+            expect(org.linkedWorkId).toBe('w-42');
+            expect(organizationRepository.findByLinkedWorkId).toHaveBeenCalledWith('w-42');
+            // Short-circuited before touching the create path — Tenant
+            // bootstrap (the first side-effect of createOrganization) is
+            // never reached.
+            expect(tenantBootstrap.ensureTenant).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/api/src/organizations/__tests__/organizations.controller.register-company.spec.ts
+++ b/apps/api/src/organizations/__tests__/organizations.controller.register-company.spec.ts
@@ -117,4 +117,28 @@ describe('OrganizationsController.registerCompany (EW-665 Phase 13)', () => {
 
         expect(order).toEqual(['createWork', 'registerCompany', 'transition']);
     });
+
+    it('rejects a whitespace-only name BEFORE creating any Work (Codex P2)', async () => {
+        const { controller, workLifecycle, organizationService } = makeController();
+
+        await expect(
+            controller.registerCompany({ user: { userId: 'u-1' } }, { name: '   ' } as never),
+        ).rejects.toThrow();
+
+        // No orphan Work / Org created for the invalid name.
+        expect(workLifecycle.createCompanyWork).not.toHaveBeenCalled();
+        expect(organizationService.registerCompany).not.toHaveBeenCalled();
+    });
+
+    it('rejects a name longer than 200 chars before creating any Work', async () => {
+        const { controller, workLifecycle } = makeController();
+
+        await expect(
+            controller.registerCompany({ user: { userId: 'u-1' } }, {
+                name: 'x'.repeat(201),
+            } as never),
+        ).rejects.toThrow();
+
+        expect(workLifecycle.createCompanyWork).not.toHaveBeenCalled();
+    });
 });

--- a/apps/api/src/organizations/__tests__/organizations.controller.register-company.spec.ts
+++ b/apps/api/src/organizations/__tests__/organizations.controller.register-company.spec.ts
@@ -1,0 +1,120 @@
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+jest.mock('@ever-works/agent/services', () => ({}));
+jest.mock('@ever-works/contracts/api', () => ({}));
+
+import { OrganizationsController } from '../organizations.controller';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — register-company wiring.
+ *
+ * Asserts the controller's Register-Company flow (approach "a"):
+ *   1. lands a backing Company Work (kind=company, status=draft),
+ *   2. creates the Org via the Phase 10 `registerCompany` path with
+ *      `linkedWorkId` pointing at that Work, then
+ *   3. transitions the Work to `registered` (firing the lifecycle event).
+ *
+ * The end state is an Organization linked to the Work.
+ */
+describe('OrganizationsController.registerCompany (EW-665 Phase 13)', () => {
+    function makeController() {
+        const createdWork = { id: 'w-100', name: 'Acme Inc.' };
+        const createdOrg = {
+            id: 'o-1',
+            tenantId: 't-1',
+            slug: 'acme-inc',
+            legalName: 'Acme, Inc.',
+            displayName: 'Acme Inc.',
+            countryCode: 'US',
+            registrationProvider: 'manual',
+            registrationStatus: 'registered',
+            linkedWorkId: 'w-100',
+            createdAt: new Date('2026-01-01'),
+            updatedAt: new Date('2026-01-01'),
+        };
+
+        const organizationService = {
+            registerCompany: jest.fn().mockResolvedValue(createdOrg),
+        };
+        const workLifecycle = {
+            createCompanyWork: jest.fn().mockResolvedValue(createdWork),
+            transitionStatus: jest.fn().mockResolvedValue({ ...createdWork, status: 'registered' }),
+        };
+        const usernameAllocator = {
+            normalize: jest.fn((s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-')),
+        };
+
+        const controller = new OrganizationsController(
+            organizationService as never,
+            workLifecycle as never,
+            usernameAllocator as never,
+        );
+
+        return { controller, organizationService, workLifecycle, usernameAllocator, createdOrg };
+    }
+
+    it('creates a Company Work, links it to the Org, and transitions it to registered', async () => {
+        const { controller, organizationService, workLifecycle, createdOrg } = makeController();
+
+        const res = await controller.registerCompany({ user: { userId: 'u-1' } }, {
+            name: 'Acme Inc.',
+            legalName: 'Acme, Inc.',
+            countryCode: 'us',
+        } as never);
+
+        // Step 1 — backing Company Work created.
+        expect(workLifecycle.createCompanyWork).toHaveBeenCalledTimes(1);
+        const [, workParams] = workLifecycle.createCompanyWork.mock.calls[0];
+        expect(workParams).toMatchObject({
+            name: 'Acme Inc.',
+            companyName: 'Acme, Inc.',
+            status: 'draft',
+        });
+
+        // Step 2 — Org created with linkedWorkId + uppercased countryCode.
+        expect(organizationService.registerCompany).toHaveBeenCalledWith(
+            'u-1',
+            expect.objectContaining({
+                name: 'Acme Inc.',
+                legalName: 'Acme, Inc.',
+                countryCode: 'US',
+                linkedWorkId: 'w-100',
+            }),
+        );
+
+        // Step 3 — Work driven through the registered transition.
+        expect(workLifecycle.transitionStatus).toHaveBeenCalledWith('w-100', 'registered');
+
+        // Response is the linked Org.
+        expect(res.id).toBe(createdOrg.id);
+        expect(res.linkedWorkId).toBe('w-100');
+    });
+
+    it('orders the steps: Work create → Org register → status transition', async () => {
+        const { controller, organizationService, workLifecycle } = makeController();
+        const order: string[] = [];
+        workLifecycle.createCompanyWork.mockImplementation(async () => {
+            order.push('createWork');
+            return { id: 'w-100', name: 'Acme Inc.' };
+        });
+        organizationService.registerCompany.mockImplementation(async () => {
+            order.push('registerCompany');
+            return {
+                id: 'o-1',
+                linkedWorkId: 'w-100',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            };
+        });
+        workLifecycle.transitionStatus.mockImplementation(async () => {
+            order.push('transition');
+            return { id: 'w-100', status: 'registered' };
+        });
+
+        await controller.registerCompany({ user: { userId: 'u-1' } }, {
+            name: 'Acme Inc.',
+        } as never);
+
+        expect(order).toEqual(['createWork', 'registerCompany', 'transition']);
+    });
+});

--- a/apps/api/src/organizations/__tests__/work-registered.listener.spec.ts
+++ b/apps/api/src/organizations/__tests__/work-registered.listener.spec.ts
@@ -1,0 +1,133 @@
+// Mock the agent barrels so importing the listener doesn't drag in the
+// full TypeORM DataSource graph. We only need `WorkStatusChangedEvent`
+// to construct test payloads. Same pattern as organization.service.spec.ts.
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/events', () => ({
+    WorkStatusChangedEvent: class WorkStatusChangedEvent {
+        static EVENT_NAME = 'work.status.changed';
+        constructor(
+            public readonly workId: string,
+            public readonly userId: string,
+            public readonly kind: string,
+            public readonly previousStatus: string,
+            public readonly newStatus: string,
+        ) {}
+    },
+}));
+
+import { WorkStatusChangedEvent } from '@ever-works/agent/events';
+import { WorkRegisteredListener } from '../work-registered.listener';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — unit tests for the
+ * `work.status.changed` → Organization listener.
+ */
+describe('WorkRegisteredListener (EW-665 Phase 13)', () => {
+    function makeListener(opts?: {
+        work?: { id: string; name: string; companyName?: string | null } | null;
+        createThrows?: boolean;
+    }) {
+        const work =
+            opts?.work === undefined
+                ? { id: 'w-1', name: 'Acme Work', companyName: 'Acme Inc.', companyWebsite: null }
+                : opts.work;
+
+        const workRepository = {
+            findById: jest.fn().mockResolvedValue(work),
+        };
+        const organizationService = {
+            createOrganizationFromCompanyWork: opts?.createThrows
+                ? jest.fn().mockRejectedValue(new Error('boom'))
+                : jest.fn().mockResolvedValue({ id: 'o-1', slug: 'acme' }),
+        };
+
+        const listener = new WorkRegisteredListener(
+            organizationService as never,
+            workRepository as never,
+        );
+
+        return { listener, workRepository, organizationService };
+    }
+
+    function evt(
+        overrides: Partial<{
+            workId: string;
+            userId: string;
+            kind: string;
+            previousStatus: string;
+            newStatus: string;
+        }> = {},
+    ) {
+        return new (WorkStatusChangedEvent as never as new (
+            workId: string,
+            userId: string,
+            kind: string,
+            previousStatus: string,
+            newStatus: string,
+        ) => WorkStatusChangedEvent)(
+            overrides.workId ?? 'w-1',
+            overrides.userId ?? 'u-1',
+            overrides.kind ?? 'company',
+            overrides.previousStatus ?? 'draft',
+            overrides.newStatus ?? 'registered',
+        );
+    }
+
+    it('creates an Organization for a company Work transitioning → registered', async () => {
+        const { listener, organizationService, workRepository } = makeListener();
+
+        await listener.onWorkStatusChanged(evt());
+
+        expect(workRepository.findById).toHaveBeenCalledWith('w-1');
+        expect(organizationService.createOrganizationFromCompanyWork).toHaveBeenCalledWith('u-1', {
+            id: 'w-1',
+            name: 'Acme Work',
+            companyName: 'Acme Inc.',
+            companyWebsite: null,
+        });
+    });
+
+    it('skips non-company Works', async () => {
+        const { listener, organizationService, workRepository } = makeListener();
+
+        await listener.onWorkStatusChanged(evt({ kind: 'default' }));
+
+        expect(workRepository.findById).not.toHaveBeenCalled();
+        expect(organizationService.createOrganizationFromCompanyWork).not.toHaveBeenCalled();
+    });
+
+    it('skips transitions that are not → registered', async () => {
+        const { listener, organizationService } = makeListener();
+
+        await listener.onWorkStatusChanged(evt({ newStatus: 'active' }));
+        await listener.onWorkStatusChanged(evt({ newStatus: 'archived' }));
+
+        expect(organizationService.createOrganizationFromCompanyWork).not.toHaveBeenCalled();
+    });
+
+    it('skips re-fires where the Work was already registered (previousStatus === registered)', async () => {
+        const { listener, organizationService } = makeListener();
+
+        await listener.onWorkStatusChanged(
+            evt({ previousStatus: 'registered', newStatus: 'registered' }),
+        );
+
+        expect(organizationService.createOrganizationFromCompanyWork).not.toHaveBeenCalled();
+    });
+
+    it('skips (without throwing) when the Work no longer exists', async () => {
+        const { listener, organizationService } = makeListener({ work: null });
+
+        await expect(listener.onWorkStatusChanged(evt())).resolves.toBeUndefined();
+        expect(organizationService.createOrganizationFromCompanyWork).not.toHaveBeenCalled();
+    });
+
+    it('swallows + logs errors from Org creation (never rethrows — detached handler)', async () => {
+        const { listener, organizationService } = makeListener({ createThrows: true });
+
+        // Must resolve, not reject — a throw here would surface as an
+        // unhandled rejection in the originating request.
+        await expect(listener.onWorkStatusChanged(evt())).resolves.toBeUndefined();
+        expect(organizationService.createOrganizationFromCompanyWork).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/api/src/organizations/organization.service.ts
+++ b/apps/api/src/organizations/organization.service.ts
@@ -601,6 +601,13 @@ export class OrganizationService {
      * Use this whenever a caller has a real `Work` row to link.
      * Otherwise prefer `registerCompany` which is the chip-driven
      * manual-completion path.
+     *
+     * **Idempotent on `linkedWorkId` (EW-665 Phase 13):** if an
+     * Organization already points at this Work (e.g. the
+     * `work.status.changed` listener re-fired, or the Register-Company
+     * controller already linked the Work), the existing Org is returned
+     * unchanged rather than creating a duplicate. This keeps the
+     * event-driven listener safe to invoke more than once.
      */
     async createOrganizationFromCompanyWork(
         userId: string,
@@ -616,6 +623,18 @@ export class OrganizationService {
         if (!displayName) {
             throw new ConflictException('Work has no usable name for Organization creation');
         }
+
+        // Idempotency guard: never spawn a second Org for the same backing
+        // Work. The listener can fire more than once (detached handlers,
+        // retries, double-transition) so this is the safe re-entry point.
+        const existing = await this.organizationRepository.findByLinkedWorkId(work.id);
+        if (existing) {
+            this.logger.log(
+                `Organization ${existing.id} already linked to Work ${work.id}; skipping duplicate create`,
+            );
+            return existing;
+        }
+
         return this.registerCompany(userId, {
             name: displayName,
             countryCode: params?.countryCode ?? null,

--- a/apps/api/src/organizations/organizations.controller.ts
+++ b/apps/api/src/organizations/organizations.controller.ts
@@ -17,7 +17,9 @@ import type {
     OrganizationResponse,
     UpgradeFromAccountResponse,
 } from '@ever-works/contracts/api';
-import type { Organization } from '@ever-works/agent/entities';
+import type { Organization, User } from '@ever-works/agent/entities';
+import { WorkLifecycleService } from '@ever-works/agent/services';
+import { UsernameAllocatorService } from '../users/services/username-allocator.service';
 import { Public } from '../auth/decorators/public.decorator';
 import { OrganizationService } from './organization.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
@@ -47,7 +49,15 @@ import { RegisterCompanyDto } from './dto/register-company.dto';
 @ApiBearerAuth('JWT-auth')
 @Controller('api/organizations')
 export class OrganizationsController {
-    constructor(private readonly organizationService: OrganizationService) {}
+    constructor(
+        private readonly organizationService: OrganizationService,
+        // EW-665 (Phase 13) — the Register-Company flow now lands a backing
+        // Company `Work` and drives it through the `→ registered` lifecycle
+        // transition, so the data model is consistent with §5.4 (one Work
+        // of type Company backs each registered Org).
+        private readonly workLifecycle: WorkLifecycleService,
+        private readonly usernameAllocator: UsernameAllocatorService,
+    ) {}
 
     @Post()
     @ApiOperation({
@@ -70,21 +80,52 @@ export class OrganizationsController {
 
     @Post('register-company')
     @ApiOperation({
-        summary: 'Register a Company (Phase 10 — Company chip)',
+        summary: 'Register a Company (Phase 10 chip → Phase 13 Work lifecycle)',
         description:
-            "EW-662: Registers a Company via the manual-completion path ([spec.md §5.4](../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)). Creates an Organization with `registrationProvider = 'manual'` and `registrationStatus = 'registered'` directly — the Stripe Atlas SDK integration is deferred. Lazy-creates the Tenant + backfills `tenantId` the same way `POST /api/organizations` does.",
+            "EW-662 / EW-665: Registers a Company via the manual-completion path ([spec.md §5.4](../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)). Phase 13 lands a backing Work of `kind = 'company'`, links it to the Organization, then transitions the Work to `status = 'registered'` (firing the `work.status.changed` lifecycle event). The Organization is created with `registrationProvider = 'manual'` and `registrationStatus = 'registered'` — the Stripe Atlas SDK integration is deferred. Lazy-creates the Tenant + backfills `tenantId` the same way `POST /api/organizations` does.",
     })
     @ApiResponse({ status: 201, description: 'Company registered + Organization created' })
     async registerCompany(
         @Req() req: { user: { userId: string } },
         @Body() dto: RegisterCompanyDto,
     ): Promise<OrganizationResponse> {
-        const org = await this.organizationService.registerCompany(req.user.userId, {
+        const userId = req.user.userId;
+        const countryCode = dto.countryCode?.toUpperCase() ?? null;
+
+        // EW-665 (Phase 13) step 1 — land a backing Company Work in DRAFT.
+        // This is a lightweight registration record (no data/website repo
+        // provisioning), so it goes through `createCompanyWork` rather than
+        // the heavy `createWork` path. A short random suffix keeps the
+        // per-user Work slug unique without a lookup loop.
+        const workSlug = `${this.usernameAllocator.normalize(dto.name)}-${Date.now().toString(36)}`;
+        const work = await this.workLifecycle.createCompanyWork({ id: userId } as User, {
+            name: dto.name,
+            slug: workSlug,
+            companyName: dto.legalName ?? dto.name,
+            status: 'draft',
+        });
+
+        // Step 2 — create the Organization linked to the backing Work. This
+        // is the working Phase 10 `registerCompany` path, now threading
+        // `linkedWorkId` so `organizations.linkedWorkId` points at the Work
+        // (spec §5.4 step 4). Keeping this direct create is the lower-risk
+        // half of "approach (a)" — the Org is created here deterministically.
+        const org = await this.organizationService.registerCompany(userId, {
             name: dto.name,
             legalName: dto.legalName,
-            countryCode: dto.countryCode?.toUpperCase() ?? null,
+            countryCode,
             slugOverride: dto.slug,
+            linkedWorkId: work.id,
         });
+
+        // Step 3 — drive the Work through the lifecycle transition that
+        // fires `work.status.changed`. `WorkRegisteredListener` reacts, but
+        // its `createOrganizationFromCompanyWork` is idempotent on
+        // `linkedWorkId` so it finds the Org created in step 2 and no-ops —
+        // no duplicate Org. The transition is still the canonical hook the
+        // future Stripe-Atlas / manual-completion paths will reuse.
+        await this.workLifecycle.transitionStatus(work.id, 'registered');
+
         return this.toResponse(org);
     }
 

--- a/apps/api/src/organizations/organizations.controller.ts
+++ b/apps/api/src/organizations/organizations.controller.ts
@@ -1,4 +1,5 @@
 import {
+    BadRequestException,
     Body,
     Controller,
     Get,
@@ -91,6 +92,20 @@ export class OrganizationsController {
     ): Promise<OrganizationResponse> {
         const userId = req.user.userId;
         const countryCode = dto.countryCode?.toUpperCase() ?? null;
+
+        // Prevalidate the name BEFORE creating the backing Work. The DTO's
+        // @Length(1, 200) counts whitespace, so a whitespace-only name
+        // passes validation but then `OrganizationService.registerCompany`
+        // rejects the trimmed-empty name in step 2 — leaving an orphan
+        // draft Work behind. Trim-check here so an invalid name fails
+        // before any row is created. (Codex P2 on PR #1075.)
+        const trimmedName = dto.name?.trim();
+        if (!trimmedName) {
+            throw new BadRequestException('Company name is required');
+        }
+        if (trimmedName.length > 200) {
+            throw new BadRequestException('Company name exceeds 200 characters');
+        }
 
         // EW-665 (Phase 13) step 1 — land a backing Company Work in DRAFT.
         // This is a lightweight registration record (no data/website repo

--- a/apps/api/src/organizations/organizations.module.ts
+++ b/apps/api/src/organizations/organizations.module.ts
@@ -4,11 +4,14 @@ import {
     OrganizationRepository,
     TenantRepository,
     UserRepository,
+    WorkRepository,
 } from '@ever-works/agent/database';
+import { WorkModule } from '@ever-works/agent/services';
 import { TenantBootstrapService } from '../scope/tenant-bootstrap.service';
 import { UsersModule } from '../users/users.module';
 import { OrganizationService } from './organization.service';
 import { OrganizationsController } from './organizations.controller';
+import { WorkRegisteredListener } from './work-registered.listener';
 
 /**
  * EW-658 (Tenants & Organizations Phase 6) — Organizations module.
@@ -27,13 +30,22 @@ import { OrganizationsController } from './organizations.controller';
  * and `OrganizationService` consume it for slug allocation.
  */
 @Module({
-    imports: [DatabaseModule, UsersModule],
+    // EW-665 (Phase 13) — `WorkModule` provides `WorkLifecycleService`, used
+    // by the Register-Company controller to land + transition the backing
+    // Company Work. `WorkModule` doesn't import Organizations, so no cycle.
+    imports: [DatabaseModule, UsersModule, WorkModule],
     providers: [
         UserRepository,
         TenantRepository,
         OrganizationRepository,
+        // EW-665 (Phase 13) — `WorkRegisteredListener` loads the full
+        // Company Work to read its name/website before spawning the Org.
+        WorkRepository,
         TenantBootstrapService,
         OrganizationService,
+        // EW-665 (Phase 13) — turns a Company Work's `→ registered`
+        // transition (the `work.status.changed` event) into an Org.
+        WorkRegisteredListener,
     ],
     controllers: [OrganizationsController],
     exports: [OrganizationService, TenantBootstrapService],

--- a/apps/api/src/organizations/work-registered.listener.ts
+++ b/apps/api/src/organizations/work-registered.listener.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WorkStatusChangedEvent } from '@ever-works/agent/events';
+import { WorkRepository } from '@ever-works/agent/database';
+import { OrganizationService } from './organization.service';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — turns a Company Work's
+ * `→ registered` lifecycle transition into a backing `Organization`
+ * ([spec.md §5.4](../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+ *
+ * Listens for `work.status.changed` (emitted by
+ * `WorkLifecycleService.transitionStatus`). Acts ONLY when:
+ *   - `kind === 'company'` — plain Works never spawn an Org; AND
+ *   - `newStatus === 'registered'` — the inflection point; AND
+ *   - `previousStatus !== 'registered'` — guards against a double-fire
+ *     re-entering on an already-registered Work.
+ *
+ * On a match it re-loads the full Work (the event payload is lean and
+ * doesn't carry the company name/website) and calls
+ * `OrganizationService.createOrganizationFromCompanyWork`, which is
+ * itself idempotent on `linkedWorkId` — so even if this listener fires
+ * twice, at most one Org is created per Work.
+ *
+ * **Errors are swallowed + logged, never rethrown.** Event handlers run
+ * detached from the request that triggered the transition; a throw here
+ * would surface as an unhandled rejection (and on `emitAsync` could fail
+ * the caller). The status transition itself already succeeded and is the
+ * source of truth — Org creation is a best-effort downstream effect that
+ * a retry / manual re-transition can recover.
+ */
+@Injectable()
+export class WorkRegisteredListener {
+    private readonly logger = new Logger(WorkRegisteredListener.name);
+
+    constructor(
+        private readonly organizationService: OrganizationService,
+        private readonly workRepository: WorkRepository,
+    ) {}
+
+    @OnEvent(WorkStatusChangedEvent.EVENT_NAME)
+    async onWorkStatusChanged(event: WorkStatusChangedEvent): Promise<void> {
+        // Cheap synchronous gate before any DB work.
+        if (
+            event.kind !== 'company' ||
+            event.newStatus !== 'registered' ||
+            event.previousStatus === 'registered'
+        ) {
+            return;
+        }
+
+        try {
+            const work = await this.workRepository.findById(event.workId);
+            if (!work) {
+                this.logger.warn(
+                    `work.status.changed for ${event.workId} → registered but Work no longer exists; skipping Org create`,
+                );
+                return;
+            }
+
+            const org = await this.organizationService.createOrganizationFromCompanyWork(
+                event.userId,
+                {
+                    id: work.id,
+                    name: work.name,
+                    companyName: work.companyName ?? null,
+                    companyWebsite: work.companyWebsite ?? null,
+                },
+            );
+
+            this.logger.log(
+                `Company Work ${work.id} registered → Organization ${org.id} (slug=${org.slug})`,
+            );
+        } catch (error) {
+            // Detached handler — must not crash the originating request /
+            // bubble as an unhandled rejection. Log + move on.
+            this.logger.error(
+                `Failed to create Organization from registered Company Work ${event.workId}: ${
+                    (error as Error)?.message ?? error
+                }`,
+                (error as Error)?.stack,
+            );
+        }
+    }
+}

--- a/packages/agent/src/entities/__tests__/work.entity.kind-status.spec.ts
+++ b/packages/agent/src/entities/__tests__/work.entity.kind-status.spec.ts
@@ -1,0 +1,33 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Work } from '../work.entity';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — shape tests for the new
+ * `Work.kind` + `Work.status` lifecycle columns. The DB-level defaults +
+ * backfill are covered by the migration test in apps/api; this asserts
+ * the entity metadata matches the migration (varchar(32), NOT NULL,
+ * defaults `'default'` / `'active'`).
+ */
+describe('Work entity — kind + status (EW-665 Phase 13)', () => {
+    const storage = getMetadataArgsStorage();
+    const columns = storage.columns.filter((c) => c.target === Work);
+
+    it('declares the `kind` column: varchar(32), default "default"', () => {
+        const kind = columns.find((c) => c.propertyName === 'kind');
+        expect(kind).toBeDefined();
+        expect(kind?.options.type).toBe('varchar');
+        expect(kind?.options.length).toBe(32);
+        expect(kind?.options.default).toBe('default');
+        // NOT NULL — never explicitly marked nullable.
+        expect(kind?.options.nullable).not.toBe(true);
+    });
+
+    it('declares the `status` column: varchar(32), default "active"', () => {
+        const status = columns.find((c) => c.propertyName === 'status');
+        expect(status).toBeDefined();
+        expect(status?.options.type).toBe('varchar');
+        expect(status?.options.length).toBe(32);
+        expect(status?.options.default).toBe('active');
+        expect(status?.options.nullable).not.toBe(true);
+    });
+});

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -103,11 +103,14 @@ export class Work {
     @Column({ default: 'user-github' })
     storageProvider: string; // 'ever-works-git' | 'user-github' | 'user-gitlab' | 'user-git'
 
-    @Column({ default: 'ever-works', nullable: true })
-    // `| null` (the column is already `nullable: true`): Company Works
-    // (EW-665) explicitly set this to null so they're excluded from the
-    // Ever Works Deploy quota counter. Widening the TS type to match the
-    // DB nullability — no schema change.
+    // Explicit `type: 'varchar'` is REQUIRED now that the TS type is a
+    // `string | null` union: without it TypeORM's reflect-metadata
+    // infers the column type as `Object`, which better-sqlite3 (the
+    // test/CLI adapter) rejects with DataTypeNotSupportedError. The
+    // `| null` itself exists because Company Works (EW-665) set this to
+    // null to stay out of the Ever Works Deploy quota counter. Still no
+    // schema change — the column was already `nullable: true` varchar.
+    @Column({ type: 'varchar', default: 'ever-works', nullable: true })
     deployProvider?: string | null; // 'ever-works' | 'vercel' | 'k8s' | null (company) | ...
 
     @Column({ nullable: true })

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -104,7 +104,11 @@ export class Work {
     storageProvider: string; // 'ever-works-git' | 'user-github' | 'user-gitlab' | 'user-git'
 
     @Column({ default: 'ever-works', nullable: true })
-    deployProvider?: string; // 'ever-works' | 'vercel' | 'k8s' | 'netlify' | ...
+    // `| null` (the column is already `nullable: true`): Company Works
+    // (EW-665) explicitly set this to null so they're excluded from the
+    // Ever Works Deploy quota counter. Widening the TS type to match the
+    // DB nullability — no schema change.
+    deployProvider?: string | null; // 'ever-works' | 'vercel' | 'k8s' | null (company) | ...
 
     @Column({ nullable: true })
     website: string;

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -35,6 +35,43 @@ import { WorkDeployment } from './work-deployment.entity';
 import { WorkMember } from './work-member.entity';
 import type { WorkKbConfig } from './kb-types';
 
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — Work "kind" discriminator.
+ *
+ *   - `'default'` — every Work that exists today (directories, websites,
+ *     landing pages, etc.). The column default, so every pre-Phase-13
+ *     row backfills to it.
+ *   - `'company'` — a Work registered through the Company chip /
+ *     Register-Company flow ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+ *     When such a Work transitions to `status = 'registered'`, a
+ *     `work.status.changed` event fires and the
+ *     `WorkRegisteredListener` (API layer) spawns the backing
+ *     `Organization` via `OrganizationService.createOrganizationFromCompanyWork`.
+ *
+ * String union + `varchar(32)` mirrors the `TemplateKind` convention on
+ * `template.entity.ts` — keeps the value space open without churning a
+ * Postgres enum type on every new member.
+ */
+export type WorkKind = 'default' | 'company';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — Work lifecycle status.
+ *
+ * The platform had no Work-level lifecycle status before this phase
+ * (generation / deployment / schedule each have their own independent
+ * status columns — `generateStatus`, `deploymentState`,
+ * `scheduledStatus` — none of which represent the Work as a whole).
+ *
+ *   - `'active'` — the column default. Every existing row backfills to
+ *     it so behavior is unchanged (a Work that exists is "live").
+ *   - `'draft'` — created-but-not-yet-finalized (e.g. a Company Work
+ *     before its registration completes).
+ *   - `'registered'` — the inflection point for Company Works: the
+ *     transition into this state is what fires the Org-create lifecycle.
+ *   - `'archived'` — soft-retired; reserved for a future archive flow.
+ */
+export type WorkStatus = 'draft' | 'active' | 'registered' | 'archived';
+
 @Entity({ name: 'works' })
 export class Work {
     @PrimaryGeneratedColumn('uuid')
@@ -91,6 +128,25 @@ export class Work {
 
     @Column({ default: false })
     organization: boolean;
+
+    /**
+     * EW-665 (Tenants & Organizations Phase 13) — Work "kind"
+     * discriminator. `'default'` for every Work that exists today;
+     * `'company'` for Works created via the Register-Company flow. See
+     * the `WorkKind` type above. `varchar(32)` mirrors `TemplateKind`.
+     */
+    @Column({ type: 'varchar', length: 32, default: 'default' })
+    kind: WorkKind;
+
+    /**
+     * EW-665 (Tenants & Organizations Phase 13) — Work lifecycle status.
+     * Defaults to `'active'` so every existing row is treated as live
+     * (no behavior change). The `'draft' → 'registered'` transition on a
+     * `kind = 'company'` Work is what fires the `work.status.changed`
+     * event that spawns the backing Organization. See `WorkStatus` above.
+     */
+    @Column({ type: 'varchar', length: 32, default: 'active' })
+    status: WorkStatus;
 
     // EW-655 (Tenants & Organizations Phase 3) — Tier A tenant scope.
     // organizationId already exists from earlier work (below); tenantId

--- a/packages/agent/src/events/events.spec.ts
+++ b/packages/agent/src/events/events.spec.ts
@@ -7,6 +7,7 @@ import {
     type DeploymentEventPayload,
 } from './deployment.events';
 import { WorkCreatedEvent } from './work-created.event';
+import { WorkStatusChangedEvent } from './work-status-changed.event';
 import { WorkGenerationCompletedEvent } from './work-generation-completed.event';
 import {
     WorksConfigSyncRequestedEvent,
@@ -111,6 +112,22 @@ describe('agent/events submodule', () => {
         it('captures work as a readonly positional arg', () => {
             const evt = new WorkCreatedEvent(fakeWork);
             expect(evt.work).toBe(fakeWork);
+        });
+    });
+
+    describe('WorkStatusChangedEvent (EW-665 Phase 13)', () => {
+        it('has the documented EVENT_NAME', () => {
+            expect(WorkStatusChangedEvent.EVENT_NAME).toBe('work.status.changed');
+        });
+
+        it('captures workId / userId / kind / previousStatus / newStatus positionally', () => {
+            const evt = new WorkStatusChangedEvent('w1', 'u1', 'company', 'draft', 'registered');
+            expect(evt.workId).toBe('w1');
+            expect(evt.userId).toBe('u1');
+            expect(evt.kind).toBe('company');
+            expect(evt.previousStatus).toBe('draft');
+            expect(evt.newStatus).toBe('registered');
+            expect(evt).toBeInstanceOf(BaseEvent);
         });
     });
 
@@ -259,6 +276,7 @@ describe('agent/events submodule', () => {
 
         it('re-exports every published event class', () => {
             expect(eventsBarrel.WorkCreatedEvent).toBe(WorkCreatedEvent);
+            expect(eventsBarrel.WorkStatusChangedEvent).toBe(WorkStatusChangedEvent);
             expect(eventsBarrel.WorkGenerationCompletedEvent).toBe(WorkGenerationCompletedEvent);
             expect(eventsBarrel.WorksConfigSyncRequestedEvent).toBe(WorksConfigSyncRequestedEvent);
             expect(eventsBarrel.WorksConfigSyncFailedEvent).toBe(WorksConfigSyncFailedEvent);
@@ -278,6 +296,7 @@ describe('agent/events submodule', () => {
                     'DeploymentDispatchedEvent',
                     'DeploymentFailedEvent',
                     'WorkCreatedEvent',
+                    'WorkStatusChangedEvent',
                     'WorkGenerationCompletedEvent',
                     'WorksConfigSyncFailedEvent',
                     'WorksConfigSyncRequestedEvent',

--- a/packages/agent/src/events/index.ts
+++ b/packages/agent/src/events/index.ts
@@ -1,4 +1,5 @@
 export * from './work-created.event';
+export * from './work-status-changed.event';
 export * from './work-generation-completed.event';
 export * from './works-config-sync-failed.event';
 export * from './works-config-sync-requested.event';

--- a/packages/agent/src/events/work-status-changed.event.ts
+++ b/packages/agent/src/events/work-status-changed.event.ts
@@ -1,0 +1,33 @@
+import { BaseEvent } from './base';
+import type { WorkKind, WorkStatus } from '@src/entities/work.entity';
+
+/**
+ * EW-665 (Tenants & Organizations Phase 13) — emitted by
+ * `WorkLifecycleService.transitionStatus` whenever a Work's lifecycle
+ * `status` actually changes (a no-op transition to the same status does
+ * NOT emit).
+ *
+ * The primary consumer is the API-layer `WorkRegisteredListener`, which
+ * spawns a backing `Organization` when a `kind === 'company'` Work
+ * transitions into `'registered'` (see
+ * [spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
+ *
+ * The payload carries enough to make the listener's decision WITHOUT a
+ * DB read (`kind`, `previousStatus`, `newStatus`) but the listener still
+ * re-loads the full Work by `workId` when it needs the company
+ * name/website for Org creation — the event is intentionally lean so it
+ * stays cheap to emit and serialise.
+ */
+export class WorkStatusChangedEvent extends BaseEvent {
+    static EVENT_NAME = 'work.status.changed';
+
+    constructor(
+        public readonly workId: string,
+        public readonly userId: string,
+        public readonly kind: WorkKind,
+        public readonly previousStatus: WorkStatus,
+        public readonly newStatus: WorkStatus,
+    ) {
+        super();
+    }
+}

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -52,6 +52,7 @@ describe('WorkLifecycleService', () => {
             create: jest.fn(),
             update: jest.fn().mockResolvedValue(undefined),
             updateGenerateStatus: jest.fn(),
+            findById: jest.fn(),
         };
         dataGenerator = {
             getItems: jest.fn(),
@@ -400,5 +401,101 @@ describe('WorkLifecycleService', () => {
         expect(work.websiteTemplateId).toBe('classic');
         expect(work.websiteTemplateLastCommit).toBe('abc123');
         expect(work.websiteTemplateLastError).toBe('old error');
+    });
+
+    describe('transitionStatus (EW-665 Phase 13)', () => {
+        it('updates status, saves, and emits work.status.changed with the right payload', async () => {
+            const work = { id: 'w-1', userId: 'u1', kind: 'company', status: 'draft' } as any;
+            workRepository.findById.mockResolvedValue(work);
+            workRepository.update.mockResolvedValue({ ...work, status: 'registered' });
+
+            const result = await service.transitionStatus('w-1', 'registered');
+
+            expect(workRepository.update).toHaveBeenCalledWith('w-1', { status: 'registered' });
+            expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+            const [eventName, payload] = eventEmitter.emit.mock.calls[0];
+            expect(eventName).toBe('work.status.changed');
+            expect(payload).toMatchObject({
+                workId: 'w-1',
+                userId: 'u1',
+                kind: 'company',
+                previousStatus: 'draft',
+                newStatus: 'registered',
+            });
+            expect(result.status).toBe('registered');
+        });
+
+        it('is a no-op (no update, no emit) when the status is unchanged', async () => {
+            const work = { id: 'w-1', userId: 'u1', kind: 'company', status: 'registered' } as any;
+            workRepository.findById.mockResolvedValue(work);
+
+            const result = await service.transitionStatus('w-1', 'registered');
+
+            expect(workRepository.update).not.toHaveBeenCalled();
+            expect(eventEmitter.emit).not.toHaveBeenCalled();
+            expect(result).toBe(work);
+        });
+
+        it('defaults kind to "default" in the payload when the Work has none', async () => {
+            const work = { id: 'w-2', userId: 'u1', status: 'active' } as any;
+            workRepository.findById.mockResolvedValue(work);
+            workRepository.update.mockResolvedValue({ ...work, status: 'archived' });
+
+            await service.transitionStatus('w-2', 'archived');
+
+            const [, payload] = eventEmitter.emit.mock.calls[0];
+            expect(payload).toMatchObject({ kind: 'default', newStatus: 'archived' });
+        });
+
+        it('throws NotFoundException when the Work does not exist', async () => {
+            workRepository.findById.mockResolvedValue(null);
+            await expect(service.transitionStatus('missing', 'registered')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(eventEmitter.emit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('createCompanyWork (EW-665 Phase 13)', () => {
+        it('persists a kind=company Work with the chosen status, no repo side-effects', async () => {
+            const persisted = {
+                id: 'w-9',
+                kind: 'company',
+                status: 'draft',
+                name: 'Acme',
+            } as any;
+            workRepository.create.mockResolvedValue(persisted);
+
+            const result = await service.createCompanyWork(user, {
+                name: 'Acme',
+                slug: 'acme-abc',
+                companyName: 'Acme Inc.',
+                status: 'draft',
+            });
+
+            expect(workRepository.create).toHaveBeenCalledTimes(1);
+            const [dto] = workRepository.create.mock.calls[0];
+            expect(dto).toMatchObject({
+                kind: 'company',
+                status: 'draft',
+                slug: 'acme-abc',
+                name: 'Acme',
+                companyName: 'Acme Inc.',
+                userId: user.id,
+            });
+            // No generator/git side-effects for a registration record.
+            expect(dataGenerator.getItems).not.toHaveBeenCalled();
+            expect(result).toBe(persisted);
+        });
+
+        it('defaults status to draft when omitted', async () => {
+            workRepository.create.mockResolvedValue({ id: 'w-10' } as any);
+
+            await service.createCompanyWork(user, { name: 'Globex', slug: 'globex-1' });
+
+            const [dto] = workRepository.create.mock.calls[0];
+            expect(dto.status).toBe('draft');
+            expect(dto.kind).toBe('company');
+        });
     });
 });

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -483,6 +483,10 @@ describe('WorkLifecycleService', () => {
                 companyName: 'Acme Inc.',
                 userId: user.id,
             });
+            // EW-665: deployProvider must be null so the Ever Works
+            // Deploy quota counter (WHERE deployProvider = 'ever-works')
+            // never counts a registration-only Company Work. (Codex P2.)
+            expect(dto.deployProvider).toBeNull();
             // No generator/git side-effects for a registration record.
             expect(dataGenerator.getItems).not.toHaveBeenCalled();
             expect(result).toBe(persisted);

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -414,6 +414,16 @@ export class WorkLifecycleService {
             status: params.status ?? 'draft',
             companyName: params.companyName ?? params.name,
             companyWebsite: params.companyWebsite ?? null,
+            // A Company Work is a registration record, NOT a deployable
+            // website. `deployProvider` defaults to 'ever-works', and
+            // `WorkRepository.countActiveByDeployProvider(userId,
+            // 'ever-works')` counts every non-archived/deleted row with
+            // that provider against the user's Ever Works Deploy quota.
+            // Leaving the default would let registered companies eat the
+            // deploy cap and block real website creation. Set it to null
+            // so the `WHERE deployProvider = 'ever-works'` quota query
+            // never matches these rows. (Codex P2 on PR #1075.)
+            deployProvider: null,
         };
 
         try {

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -12,6 +12,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
 import {
     WorkCreatedEvent,
+    WorkStatusChangedEvent,
     WorksConfigSyncRequestedEvent,
     type WorkCreatedPlatformActor,
 } from '@src/events';
@@ -22,7 +23,7 @@ import { WebsiteUpdateService } from '@src/generators/website-generator/website-
 import { CreateWorkDto } from '@src/dto/create-work.dto';
 import { UpdateWorkDto } from '@src/dto';
 import { DeleteWorkDto, DeleteWorkResponseDto } from '@src/items-generator/dto';
-import { Work } from '@src/entities/work.entity';
+import { Work, type WorkKind, type WorkStatus } from '@src/entities/work.entity';
 import { User } from '@src/entities/user.entity';
 import { WorkOwnershipService } from './work-ownership.service';
 import { rethrowAsNormalized } from './utils/error.utils';
@@ -370,6 +371,102 @@ export class WorkLifecycleService {
         } catch (error) {
             rethrowAsNormalized(error, this.logger, 'creating work');
         }
+    }
+
+    /**
+     * EW-665 (Tenants & Organizations Phase 13) — create a lightweight
+     * "Company" Work row WITHOUT the heavy repo/git side-effects that
+     * `createWork` triggers.
+     *
+     * A Company Work is a registration record, not a directory/website,
+     * so it has no data repo to provision. We persist a minimal row
+     * (`kind = 'company'`, the caller-chosen initial `status`) directly
+     * via the repository, bypassing the data/markdown/website generators.
+     *
+     * Returns the persisted Work. The caller is expected to follow up
+     * with `transitionStatus(work.id, 'registered')` once registration
+     * completes (or pass `status: 'registered'` directly when the
+     * registration is already done, e.g. the manual-completion path).
+     *
+     * Emitting the `work.status.changed` event is deliberately NOT done
+     * here — `createWork`-style "created" emission is a separate concern,
+     * and the Org-spawning listener keys off the status TRANSITION, not
+     * the create. Callers drive the transition explicitly so the flow
+     * stays observable + testable.
+     */
+    async createCompanyWork(
+        user: User,
+        params: {
+            name: string;
+            slug: string;
+            description?: string;
+            companyName?: string | null;
+            companyWebsite?: string | null;
+            status?: WorkStatus;
+        },
+    ): Promise<Work> {
+        const workData: Partial<Work> = {
+            slug: params.slug,
+            name: params.name,
+            description: params.description ?? params.name,
+            userId: user.id,
+            kind: 'company',
+            status: params.status ?? 'draft',
+            companyName: params.companyName ?? params.name,
+            companyWebsite: params.companyWebsite ?? null,
+        };
+
+        try {
+            return await this.workRepository.create(workData, user);
+        } catch (error) {
+            rethrowAsNormalized(error, this.logger, 'creating company work');
+        }
+    }
+
+    /**
+     * EW-665 (Tenants & Organizations Phase 13) — transition a Work's
+     * lifecycle `status` and emit `work.status.changed` when (and only
+     * when) the status actually changes.
+     *
+     * This is the single choke-point for Work-status mutations introduced
+     * by Phase 13 — `status` is a brand-new column, so there was no
+     * pre-existing update path to fold into. The Register-Company flow
+     * drives a Company Work into `'registered'` through here, which fires
+     * the event that the API-layer `WorkRegisteredListener` turns into an
+     * `Organization`.
+     *
+     * No-op (no save, no emit) when the Work is already at `newStatus`,
+     * so re-running a transition is idempotent and never double-fires the
+     * downstream listener.
+     */
+    async transitionStatus(workId: string, newStatus: WorkStatus): Promise<Work> {
+        const work = await this.workRepository.findById(workId);
+        if (!work) {
+            throw new NotFoundException({ status: 'error', message: 'Work not found' });
+        }
+
+        const previousStatus: WorkStatus = work.status;
+        if (previousStatus === newStatus) {
+            // Idempotent no-op: same status in → same status out, no event.
+            return work;
+        }
+
+        const updated = await this.workRepository.update(workId, { status: newStatus });
+        if (!updated) {
+            throw new NotFoundException({ status: 'error', message: 'Work not found' });
+        }
+
+        // Fire-and-forget the status-change notification. The Org-spawning
+        // listener catches its own errors (detached handler — see
+        // `WorkRegisteredListener`), so a failure there cannot turn this
+        // transition into a request failure.
+        const kind: WorkKind = updated.kind ?? 'default';
+        this.eventEmitter.emit(
+            WorkStatusChangedEvent.EVENT_NAME,
+            new WorkStatusChangedEvent(workId, updated.userId, kind, previousStatus, newStatus),
+        );
+
+        return updated;
     }
 
     /**


### PR DESCRIPTION
## Summary

Final feature phase of the Tenants & Organizations rollout (EW-651). Adds the Work-level `kind` + `status` lifecycle columns, an event that fires on the status transition, and a listener that spawns an `Organization` when a Company Work is registered. **NOT Stripe Atlas** — the `registered` transition is driven by the existing register-company flow / manual completion.

## Investigation findings

- **`Work` has no `kind` / `status` column today.** The entity has several independent status-ish columns (`generateStatus`, `deploymentState`, `scheduledStatus`, `activitySyncMode`) but none represent the Work's overall lifecycle. The Phase 10 agent's note in `OrganizationService` ("Today the platform's `Work` entity has neither a `kind` column nor a `status` column") is still accurate. No duplicate to adapt — both columns are new.
- **`WorkLifecycleService` lives in `@ever-works/agent` and already injects `EventEmitter2`.** It emits `WorkCreatedEvent` via `emitAsync` and `WorksConfigSyncRequestedEvent` via `emit`. There was **no status-transition path** (status didn't exist), so I added `transitionStatus` as the single choke-point. Mirrored the existing `@OnEvent` listener pattern from `apps/api/src/work-proposals/work-created.listener.ts`.
- **`createOrganizationFromCompanyWork(userId, work, params?)` (Phase 10) already exists** and delegates to `registerCompany`. It expects `{ id, name, companyName?, companyWebsite? }`. It was **not** idempotent on `linkedWorkId` — now it is (`OrganizationRepository.findByLinkedWorkId` already existed).
- **The Phase 10 register-company flow created an Org directly, no Work.** Web dialog → BFF route → `POST /api/organizations/register-company` → `OrganizationService.registerCompany` (provider `manual`, status `registered`). No backing Work row was created.
- **Latest migration timestamp was `1779991009000`** → new migration is `1779991010000` (sorts last).

## What changed

### Columns + migration (same PR — NN #16)
- `packages/agent/src/entities/work.entity.ts`: `kind: WorkKind` (`'default' | 'company'`, `varchar(32)`, default `'default'`, NOT NULL) and `status: WorkStatus` (`'draft' | 'active' | 'registered' | 'archived'`, `varchar(32)`, default `'active'`, NOT NULL). Inline TS unions + `varchar(32)` matching the `TemplateKind` convention.
- `apps/api/src/migrations/1779991010000-AddWorkKindAndStatus.ts`: idempotent (`hasColumn` guards), forward-only, both columns added with DB defaults so existing rows backfill in the `ALTER TABLE` (no separate `UPDATE`). `down()` drops both. `'active'` is the behavior-preserving default — a Work that exists is "live".

### Event + listener
- `packages/agent/src/events/work-status-changed.event.ts`: `WorkStatusChangedEvent` (`work.status.changed`) carrying `{ workId, userId, kind, previousStatus, newStatus }`.
- `WorkLifecycleService.transitionStatus(workId, newStatus)`: loads → updates → emits. **No-op + no emit when status is unchanged** (idempotent, never double-fires). Also added `createCompanyWork` to land a lightweight Company Work without the heavy repo/git side-effects of `createWork`.
- `apps/api/src/organizations/work-registered.listener.ts`: `@OnEvent('work.status.changed')`. Acts only when `kind === 'company' && newStatus === 'registered' && previousStatus !== 'registered'`. Re-loads the full Work, calls `createOrganizationFromCompanyWork`. **Errors are swallowed + logged, never rethrown** (detached handler).

### Idempotency guard
- `createOrganizationFromCompanyWork` now checks `findByLinkedWorkId(work.id)` first and returns the existing Org if found — so a re-fire / double-transition never creates a duplicate Org.

### Register-flow wiring — **approach (a)** (chosen, lower-risk)
The controller's `registerCompany`: (1) lands a backing Company Work (`kind='company'`, `status='draft'`), (2) creates the Org via the **unchanged Phase 10 `registerCompany`** path with `linkedWorkId` set, (3) transitions the Work to `registered`. The listener fires on step 3 but idempotently no-ops because the Org already exists. **Why (a):** keeps the working Phase 10 direct path intact (NN #15 — no deletes), just adds the Work row + linkage so the data model matches spec §5.4 (one Company Work backs each Org). The event→listener path is still fully built + unit-tested as the canonical hook the future Stripe-Atlas / manual-completion transition will reuse.

## Test plan

- [x] Migration test (`AddWorkKindAndStatus.spec.ts`): runs `up()`/`down()` on in-memory sqlite — asserts both columns exist, a bare INSERT backfills to `'default'`/`'active'`, idempotent on double-`up()`, `down()` drops both.
- [x] Entity shape test (`work.entity.kind-status.spec.ts`): varchar(32), NOT NULL, correct defaults.
- [x] `transitionStatus` emits `work.status.changed` with the right payload; no emit when status unchanged; defaults `kind` to `'default'`; throws `NotFoundException` for a missing Work. `createCompanyWork` persists `kind='company'` with no generator side-effects.
- [x] Listener: fires only for `kind=company && →registered`; skips other kinds/statuses; skips re-fire (`previousStatus===registered`); skips missing Work; swallows + logs Org-create errors.
- [x] Idempotency: `createOrganizationFromCompanyWork` returns the existing Org (and skips Tenant bootstrap) when one is already linked.
- [x] Register flow (controller spec): create Work → register Org with `linkedWorkId` → transition to `registered`, in that order; response is the linked Org.
- [x] `pnpm build` (60/60 turbo tasks) clean; `pnpm format:check` clean; agent `npx jest` (281 suites / 5555 tests) + api `npx jest` (153 suites / 2468 tests) green; `type-check` clean. Web untouched (existing route works as-is).

## Constraints honored

- NOT Stripe Atlas — no payment SDK, no new deps.
- Entity change + migration in the same PR (NN #16).
- No deletes of existing behavior (NN #15) — Phase 10 `registerCompany` direct path preserved.
- Did not touch `apps/api/src/scope/*` or the `api.module.ts` guard-registration block (Phase 12 owns those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add work lifecycle fields: kind (default/company) and status (draft/active/registered/archived) with defaults.
  * New APIs: create company work and transition work status; emits work.status.changed event.
  * Company-registration flow: improved endpoint validation, slug generation, and automatic organization creation when a company work becomes registered.

* **Tests**
  * Added comprehensive tests for migration, entity metadata, lifecycle transitions, events, listeners, and organization registration/idempotency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->