### PR TITLE
fix(web): harden register-company against org-list race + null body (PR #1071 P1s)

### DIFF
--- a/apps/web/src/app/api/organizations/register-company/route.ts
+++ b/apps/web/src/app/api/organizations/register-company/route.ts
@@ -44,6 +44,15 @@ export async function POST(request: NextRequest) {
                 status: upstream.status || 500,
             });
         }
+        if (payload === null) {
+            // The NestJS controller always serialises a full
+            // OrganizationResponse on success, so a 2xx with an empty /
+            // unparseable body is an upstream contract violation. Surface it
+            // as an error instead of forwarding a literal `null` the dialog
+            // would deref as `org.slug` and crash on. (Greptile P1, PR #1071.)
+            console.error('register-company: upstream returned a 2xx with no body');
+            return NextResponse.json({ error: 'Failed to register company' }, { status: 502 });
+        }
         return NextResponse.json(payload, { status: 201 });
     } catch (error) {
         console.error('Failed to proxy POST /api/organizations/register-company:', error);

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
@@ -35,7 +35,10 @@ export interface RegisterCompanyDialogProps {
  * `registrationProvider = 'manual'` + `registrationStatus =
  * 'registered'` for v1 — the Stripe Atlas integration is deferred.
  *
- * Post-submit behavior mirrors the Phase 9 CreateOrganizationModal:
+ * Post-submit behavior mirrors the Phase 9 CreateOrganizationModal
+ * (decided only once the org list has loaded — submit is gated on the
+ * hook's `isLoading` so a still-loading `[]` can't misclassify an
+ * existing-org user as first-org):
  *  - First Org (`organizations.length === 0` pre-submit) → hands off
  *    to `<UpgradeOrCreateDialog>` so the user can choose Upgrade vs
  *    Empty.
@@ -50,7 +53,7 @@ export interface RegisterCompanyDialogProps {
 export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDialogProps) {
     const t = useTranslations('organizations.registerCompany');
     const router = useRouter();
-    const { organizations, mutate } = useOrganizations();
+    const { organizations, isLoading, mutate } = useOrganizations();
 
     const [name, setName] = useState('');
     const [countryCode, setCountryCode] = useState('');
@@ -90,6 +93,16 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
         if (isSubmitting) {
             return;
         }
+        // The first-org branch below is decided from `organizations.length`,
+        // which is `[]` until the initial GET /api/organizations resolves.
+        // Block submit until that fetch settles (isLoading flips false on
+        // success OR error) so an existing-org user submitting during a slow
+        // first load isn't misclassified as first-org and sent down the
+        // upgrade-from-account path, which 409s for 2nd+ orgs. (Greptile +
+        // Codex P1 on PR #1071.)
+        if (isLoading) {
+            return;
+        }
         const trimmedName = name.trim();
         if (trimmedName.length === 0) {
             setSubmitError(t('errors.nameRequired'));
@@ -116,7 +129,9 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     name: trimmedName,
-                    ...(cc.length > 0 ? { countryCode: cc.toUpperCase() } : {}),
+                    // Server normalizes (`dto.countryCode?.toUpperCase()`) — keep
+                    // it the single source of truth, send the raw 2-letter input.
+                    ...(cc.length > 0 ? { countryCode: cc } : {}),
                 }),
             });
             if (!res.ok) {
@@ -152,7 +167,17 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
         } finally {
             setIsSubmitting(false);
         }
-    }, [isSubmitting, name, countryCode, organizations.length, mutate, onOpenChange, router, t]);
+    }, [
+        isSubmitting,
+        isLoading,
+        name,
+        countryCode,
+        organizations.length,
+        mutate,
+        onOpenChange,
+        router,
+        t,
+    ]);
 
     const handleUpgradeDialogClose = useCallback(
         (didUpgrade: boolean) => {
@@ -225,8 +250,8 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                             </Button>
                             <Button
                                 onClick={handleSubmit}
-                                loading={isSubmitting}
-                                disabled={isSubmitting || name.trim().length === 0}
+                                loading={isSubmitting || isLoading}
+                                disabled={isSubmitting || isLoading || name.trim().length === 0}
                                 data-testid="register-company-submit"
                             >
                                 {t('submit')}

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.tsx
@@ -53,7 +53,7 @@ export interface RegisterCompanyDialogProps {
 export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDialogProps) {
     const t = useTranslations('organizations.registerCompany');
     const router = useRouter();
-    const { organizations, isLoading, mutate } = useOrganizations();
+    const { organizations, isLoading, error: orgsError, mutate } = useOrganizations();
 
     const [name, setName] = useState('');
     const [countryCode, setCountryCode] = useState('');
@@ -118,7 +118,12 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
             return;
         }
         setSubmitError(null);
-        wasFirstOrgRef.current = organizations.length === 0;
+        // Only treat this as the user's first Org when we have a CONFIRMED
+        // empty list. If the org-list GET errored, `organizations` is still
+        // `[]` but unreliable — defaulting to not-first-org sends the user to
+        // the dashboard (recoverable) rather than into upgrade-from-account,
+        // which 409s for 2nd+ orgs. (Greptile P2 on PR #1077.)
+        wasFirstOrgRef.current = !orgsError && organizations.length === 0;
         setIsSubmitting(true);
 
         try {
@@ -170,6 +175,7 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
     }, [
         isSubmitting,
         isLoading,
+        orgsError,
         name,
         countryCode,
         organizations.length,
@@ -250,7 +256,7 @@ export function RegisterCompanyDialog({ open, onOpenChange }: RegisterCompanyDia
                             </Button>
                             <Button
                                 onClick={handleSubmit}
-                                loading={isSubmitting || isLoading}
+                                loading={isSubmitting}
                                 disabled={isSubmitting || isLoading || name.trim().length === 0}
                                 data-testid="register-company-submit"
                             >

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
@@ -201,4 +201,42 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
         // No direct router navigation yet — the upgrade dialog owns the next step.
         expect(routerPushMock).not.toHaveBeenCalled();
     });
+
+    /**
+     * Regression — when the org-list GET errored, `organizations` is `[]`
+     * but unreliable, so the user must NOT be treated as first-org (which
+     * would route into upgrade-from-account → 409 for 2nd+ orgs). A
+     * successful register navigates straight to the dashboard instead.
+     * (Greptile P2 on PR #1077.)
+     */
+    it('does not misclassify as first-org when the org-list fetch errored', async () => {
+        __seedOrganizationsStoreForTests({
+            data: [],
+            isLoading: false,
+            error: new Error('GET /api/organizations failed'),
+        });
+        const newOrg = org({ id: 'o-3', slug: 'initech', displayName: 'Initech' });
+        vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+            const u = String(url);
+            if (u === '/api/organizations/register-company' && init?.method === 'POST') {
+                return new Response(JSON.stringify(newOrg), { status: 201 });
+            }
+            return new Response(JSON.stringify([newOrg]), { status: 200 });
+        });
+
+        const onOpenChange = vi.fn();
+        render(<RegisterCompanyDialog open={true} onOpenChange={onOpenChange} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Initech' },
+        });
+        fireEvent.click(screen.getByTestId('register-company-submit'));
+
+        await waitFor(() => {
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+            expect(routerPushMock).toHaveBeenCalledWith(`/${newOrg.slug}/dashboard`);
+        });
+        // The upgrade dialog (first-org path) must NOT appear.
+        expect(screen.queryByText('organizations.upgrade.title')).toBeNull();
+    });
 });

--- a/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
+++ b/apps/web/src/components/organizations/RegisterCompanyDialog.unit.spec.tsx
@@ -145,8 +145,31 @@ describe('RegisterCompanyDialog — EW-662 Phase 10', () => {
         );
         expect(postCall).toBeDefined();
         const body = JSON.parse((postCall![1] as RequestInit).body as string);
-        // countryCode is auto-uppercased before submit.
-        expect(body).toEqual({ name: 'Globex LLC', countryCode: 'DE' });
+        // countryCode is sent raw; the server normalizes (single source of
+        // truth — Greptile P2 on PR #1071).
+        expect(body).toEqual({ name: 'Globex LLC', countryCode: 'de' });
+    });
+
+    /**
+     * Regression — first-org classification races the initial org-list
+     * fetch. While `isLoading` is true the store's `data` is still `[]`, so
+     * an existing-org user must NOT be able to submit (and be misclassified
+     * as first-org → routed into upgrade-from-account, which 409s for 2nd+
+     * orgs). Submit stays gated until the fetch settles. (Greptile + Codex
+     * P1 on PR #1071.)
+     */
+    it('gates submit while the org list is still loading', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: true, error: null });
+        const fetchMock = vi.spyOn(global, 'fetch');
+        render(<RegisterCompanyDialog open={true} onOpenChange={vi.fn()} />);
+
+        fireEvent.change(screen.getByTestId('register-company-name'), {
+            target: { value: 'Acme Inc.' },
+        });
+        const submit = screen.getByTestId('register-company-submit') as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+        fireEvent.click(submit);
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     /**


### PR DESCRIPTION
## Summary

Addresses the bot P1/P2 findings surfaced on the `stage → main` cascade ([#1071](https://github.com/ever-works/ever-works/pull/1071)) against the Phase 10 (EW-662) Register-Company flow. These ship to production via the overnight cascade, so they're fixed before promotion (per the "bot reviews clean before merge" gate).

- **P1 (Greptile + Codex) — first-org check races the org-list fetch.** While `useOrganizations()` is loading, `organizations` is `[]`, so an existing-org user submitting during a slow first load was misclassified as first-org → routed into `upgrade-from-account`, which 409s for 2nd+ orgs. Submit is now gated on the hook's `isLoading`, so the branch is decided only from a settled fetch.
- **P1 (Greptile) — BFF forwarded a null body as a 201.** An upstream 2xx with an empty body became `NextResponse.json(null, 201)`; the dialog then deref'd `org.slug` and crashed. A null payload on success is now treated as an upstream contract violation (502), so the dialog's error path handles it gracefully.
- **P2 (Greptile) — double-uppercased countryCode.** The client stopped pre-uppercasing; the NestJS controller normalizes it (single source of truth).

## Test plan
- [x] `RegisterCompanyDialog.unit.spec.tsx` — 5/5 pass locally (vitest), incl. a new test asserting submit stays gated while the org list loads; updated the countryCode assertion to expect the raw value.
- [x] ESLint clean on changed files.
- [ ] CI `lint-and-test` + build checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API now treats empty or unparseable upstream responses as errors and reports them instead of returning null payloads.
  * Registration form submission is blocked while the organizations list is loading to prevent premature submissions.
  * Country code input is sent as-entered (no automatic uppercasing) during company registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->