### PR TITLE
feat(plugins): memory-pipeline-modifier — opt-in memory hooks on any pipeline

### DIFF
--- a/packages/agent/src/pipeline/pipeline-facade.service.spec.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.spec.ts
@@ -7,6 +7,7 @@ describe('PipelineFacadeService', () => {
     let contentExtractorFacade: any;
     let promptFacade: any;
     let dataSourceFacade: any;
+    let agentMemoryFacade: any;
     let service: PipelineFacadeService;
 
     function makeWork(overrides: any = {}) {
@@ -57,6 +58,16 @@ describe('PipelineFacadeService', () => {
             getEnabledSources: jest.fn().mockResolvedValue([]),
             isConfigured: jest.fn().mockReturnValue(true),
         };
+        agentMemoryFacade = {
+            openSession: jest.fn().mockResolvedValue({ id: 's1', startedAt: 'now' }),
+            closeSession: jest.fn().mockResolvedValue(undefined),
+            saveMemory: jest.fn().mockResolvedValue({ id: 'm1', createdAt: 'now', content: 'x' }),
+            searchMemory: jest.fn().mockResolvedValue({ results: [] }),
+            buildContext: jest.fn().mockResolvedValue({ content: 'c' }),
+            deleteEntry: jest.fn().mockResolvedValue(undefined),
+            listSessions: jest.fn().mockResolvedValue([]),
+            isConfigured: jest.fn().mockReturnValue(true),
+        };
 
         service = new PipelineFacadeService(
             aiFacade,
@@ -65,6 +76,7 @@ describe('PipelineFacadeService', () => {
             contentExtractorFacade,
             promptFacade,
             dataSourceFacade,
+            agentMemoryFacade,
         );
     });
 
@@ -119,6 +131,37 @@ describe('PipelineFacadeService', () => {
         it('omits kbContext when not provided (carrier stays undefined)', () => {
             const ctx = service.createStepExecutionContext(makeWork() as any);
             expect(ctx.kbContext).toBeUndefined();
+        });
+
+        // Agent-memory facade carrier — wired in the agentmemory follow-up PR.
+        it('exposes a bound agentMemoryFacade when AgentMemoryFacadeService is injected', () => {
+            const ctx = service.createStepExecutionContext(makeWork() as any);
+            expect(ctx.agentMemoryFacade).toBeDefined();
+            // Bound facade should pre-fill workId/userId — caller passes a
+            // placeholder facadeOptions and the underlying service receives
+            // the real ids.
+            ctx.agentMemoryFacade?.saveMemory(
+                { content: 'hi' },
+                { userId: 'IGNORED', workId: 'IGNORED' },
+            );
+            expect(agentMemoryFacade.saveMemory).toHaveBeenCalledWith(
+                { content: 'hi' },
+                expect.objectContaining({ userId: 'u1', workId: 'w1' }),
+            );
+        });
+
+        it('omits agentMemoryFacade when AgentMemoryFacadeService is not injected (Optional)', () => {
+            const standaloneService = new PipelineFacadeService(
+                aiFacade,
+                searchFacade,
+                screenshotFacade,
+                contentExtractorFacade,
+                promptFacade,
+                dataSourceFacade,
+                undefined,
+            );
+            const ctx = standaloneService.createStepExecutionContext(makeWork() as any);
+            expect(ctx.agentMemoryFacade).toBeUndefined();
         });
 
         it('forwards the provided kbContext bundle into the StepExecutionContext', () => {

--- a/packages/agent/src/pipeline/pipeline-facade.service.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.ts
@@ -32,6 +32,15 @@ import type {
     EnabledDataSource,
     FacadeOptions,
     IKbToolsFacade,
+    IAgentMemoryStepFacade,
+    AgentMemorySaveFacadeInput,
+    AgentMemorySearchFacadeInput,
+    AgentMemoryContextFacadeInput,
+    AgentMemoryListSessionsFacadeInput,
+    AgentMemorySession,
+    AgentMemoryRecord,
+    AgentMemorySearchResponse,
+    AgentMemoryContext,
 } from '@ever-works/plugin';
 import type { KbContextBundleData } from '@ever-works/contracts';
 import { AiFacadeService } from '../facades/ai.facade';
@@ -40,6 +49,7 @@ import { ScreenshotFacadeService } from '../facades/screenshot.facade';
 import { ContentExtractorFacadeService } from '../facades/content-extractor.facade';
 import { DataSourceFacadeService } from '../facades/data-source.facade';
 import { PromptFacadeService } from '../facades/prompt.facade';
+import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
 
 /**
  * Context for binding facades to a specific work/user.
@@ -75,6 +85,7 @@ export class PipelineFacadeService {
         private readonly contentExtractorFacade: ContentExtractorFacadeService,
         private readonly promptFacade: PromptFacadeService,
         @Optional() private readonly dataSourceFacade?: DataSourceFacadeService,
+        @Optional() private readonly agentMemoryFacade?: AgentMemoryFacadeService,
     ) {}
 
     /**
@@ -128,12 +139,51 @@ export class PipelineFacadeService {
             contentExtractorFacade: this.createBoundContentExtractorFacade(facadeContext),
             dataSourceFacade: this.createBoundDataSourceFacade(facadeContext),
             promptFacade: this.createBoundPromptFacade(facadeContext),
+            agentMemoryFacade: this.createBoundAgentMemoryFacade(facadeContext),
             logger: stepLogger,
             work,
             user: work.user,
             signal,
             kbContext,
             kbTools,
+        };
+    }
+
+    private createBoundAgentMemoryFacade(
+        ctx: FacadeBindingContext,
+    ): IAgentMemoryStepFacade | undefined {
+        if (!this.agentMemoryFacade) return undefined;
+        const facade = this.agentMemoryFacade;
+        const boundOptions: FacadeOptions = {
+            workId: ctx.workId,
+            userId: ctx.userId,
+        };
+        return {
+            openSession: (
+                metadata: Record<string, unknown> | undefined,
+                _facadeOptions: FacadeOptions,
+            ): Promise<AgentMemorySession> => facade.openSession(metadata, boundOptions),
+            closeSession: (sessionId: string, _facadeOptions: FacadeOptions): Promise<void> =>
+                facade.closeSession(sessionId, boundOptions),
+            saveMemory: (
+                input: AgentMemorySaveFacadeInput,
+                _facadeOptions: FacadeOptions,
+            ): Promise<AgentMemoryRecord> => facade.saveMemory(input, boundOptions),
+            searchMemory: (
+                input: AgentMemorySearchFacadeInput,
+                _facadeOptions: FacadeOptions,
+            ): Promise<AgentMemorySearchResponse> => facade.searchMemory(input, boundOptions),
+            buildContext: (
+                input: AgentMemoryContextFacadeInput,
+                _facadeOptions: FacadeOptions,
+            ): Promise<AgentMemoryContext> => facade.buildContext(input, boundOptions),
+            deleteEntry: (id: string, _facadeOptions: FacadeOptions): Promise<void> =>
+                facade.deleteEntry(id, boundOptions),
+            listSessions: (
+                options: AgentMemoryListSessionsFacadeInput | undefined,
+                _facadeOptions: FacadeOptions,
+            ): Promise<readonly AgentMemorySession[]> => facade.listSessions(options, boundOptions),
+            isConfigured: (): boolean => facade.isConfigured(),
         };
     }
 

--- a/packages/plugin/src/facades/agent-memory-facade.interface.ts
+++ b/packages/plugin/src/facades/agent-memory-facade.interface.ts
@@ -1,0 +1,79 @@
+import type { IBaseFacade } from './base-facade.interface.js';
+import type { FacadeOptions } from './facade-options.interface.js';
+import type {
+	AgentMemorySession,
+	AgentMemoryRecord,
+	AgentMemorySearchResponse,
+	AgentMemoryContext
+} from '../contracts/capabilities/agent-memory.interface.js';
+
+/**
+ * Inputs to the facade-facing `saveMemory` (the `settings` field that
+ * the plugin contract takes is filled in by the facade — callers don't
+ * need to know).
+ */
+export interface AgentMemorySaveFacadeInput {
+	readonly content: string;
+	readonly tags?: readonly string[];
+	readonly metadata?: Record<string, unknown>;
+	readonly sessionId?: string;
+	readonly projectId?: string;
+}
+
+export interface AgentMemorySearchFacadeInput {
+	readonly query: string;
+	readonly limit?: number;
+	readonly tags?: readonly string[];
+	readonly sessionId?: string;
+	readonly projectId?: string;
+}
+
+export interface AgentMemoryContextFacadeInput {
+	readonly query?: string;
+	readonly purpose?: string;
+	readonly sessionId?: string;
+	readonly projectId?: string;
+	readonly maxTokens?: number;
+}
+
+export interface AgentMemoryListSessionsFacadeInput {
+	readonly limit?: number;
+	readonly projectId?: string;
+}
+
+/**
+ * Facade interface for the `agent-memory` capability — exposed to
+ * pipeline steps via `StepExecutionContext.agentMemoryFacade`.
+ *
+ * The shape mirrors the unbound `IAgentMemoryFacade` (from
+ * `contracts/capabilities/agent-memory.interface.ts`) but uses the
+ * proper `FacadeOptions` type instead of `unknown`. The implementation
+ * in `@ever-works/agent` (AgentMemoryFacadeService) satisfies both
+ * shapes simultaneously.
+ *
+ * Steps obtain a "bound" instance via the pipeline facade service —
+ * `workId` / `userId` / `providerOverride` are pre-filled, so step
+ * code calls `agentMemoryFacade.saveMemory({ content: '...' })`
+ * without threading the full options bag through every call.
+ */
+export interface IAgentMemoryStepFacade extends IBaseFacade {
+	openSession(
+		metadata: Record<string, unknown> | undefined,
+		facadeOptions: FacadeOptions
+	): Promise<AgentMemorySession>;
+
+	closeSession(sessionId: string, facadeOptions: FacadeOptions): Promise<void>;
+
+	saveMemory(input: AgentMemorySaveFacadeInput, facadeOptions: FacadeOptions): Promise<AgentMemoryRecord>;
+
+	searchMemory(input: AgentMemorySearchFacadeInput, facadeOptions: FacadeOptions): Promise<AgentMemorySearchResponse>;
+
+	buildContext(input: AgentMemoryContextFacadeInput, facadeOptions: FacadeOptions): Promise<AgentMemoryContext>;
+
+	deleteEntry(id: string, facadeOptions: FacadeOptions): Promise<void>;
+
+	listSessions(
+		options: AgentMemoryListSessionsFacadeInput | undefined,
+		facadeOptions: FacadeOptions
+	): Promise<readonly AgentMemorySession[]>;
+}

--- a/packages/plugin/src/facades/index.ts
+++ b/packages/plugin/src/facades/index.ts
@@ -17,3 +17,4 @@ export * from './oauth-facade.interface.js';
 export * from './deploy-facade.interface.js';
 export * from './prompt-facade.interface.js';
 export * from './kb-tools-facade.interface.js';
+export * from './agent-memory-facade.interface.js';

--- a/packages/plugin/src/pipeline/step-execution-context.interface.ts
+++ b/packages/plugin/src/pipeline/step-execution-context.interface.ts
@@ -6,6 +6,7 @@ import type { IContentExtractorFacade } from '../facades/content-extractor-facad
 import type { IDataSourceFacade } from '../facades/data-source-facade.interface.js';
 import type { IPromptFacade } from '../facades/prompt-facade.interface.js';
 import type { IKbToolsFacade } from '../facades/kb-tools-facade.interface.js';
+import type { IAgentMemoryStepFacade } from '../facades/agent-memory-facade.interface.js';
 import type { WorkReference, UserReference } from './generation-context.interface.js';
 
 /**
@@ -126,4 +127,15 @@ export interface StepExecutionContext {
 	 * here, the row-36c orchestrator call site populates it.
 	 */
 	readonly kbTools?: IKbToolsFacade;
+
+	/**
+	 * Agent-memory facade (PR follow-up to #1073). When present, pipeline
+	 * steps that opt in (e.g. the `memory-pipeline-modifier` plugin) can
+	 * fetch persistent context at the start of a run and save observations
+	 * at the end. Optional so OSS builds without the `agentmemory` plugin
+	 * installed — or operators who haven't enabled it for the Work —
+	 * keep constructing `execContext` identically. Callers are
+	 * responsible for null-checking before use.
+	 */
+	readonly agentMemoryFacade?: IAgentMemoryStepFacade;
 }

--- a/packages/plugins/memory-pipeline-modifier/package.json
+++ b/packages/plugins/memory-pipeline-modifier/package.json
@@ -1,0 +1,68 @@
+{
+	"name": "@ever-works/memory-pipeline-modifier",
+	"version": "1.0.0",
+	"description": "Pipeline modifier that injects persistent agent-memory hooks into any pipeline — fetches context at the start, saves an observation at the end. Opt-in per Work.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^3.2.1"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "memory-pipeline-modifier",
+			"name": "Agent Memory Hooks",
+			"version": "1.0.0",
+			"category": "utility",
+			"capabilities": [
+				"pipeline-modifier"
+			],
+			"description": "Injects persistent memory hooks into any work-generation pipeline — fetches prior context at the start, saves a digest at the end. Requires an agent-memory provider to be enabled (default: @ever-works/agentmemory-plugin).",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false,
+			"visibility": "public",
+			"targetPipelines": [
+				"*"
+			]
+		}
+	}
+}

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	MemoryPipelineModifierPlugin,
+	FETCH_CONTEXT_STEP_ID,
+	SAVE_MEMORY_STEP_ID
+} from '../memory-pipeline-modifier.plugin.js';
+import type { StepExecutionContext, IAgentMemoryStepFacade, IPipelineContext } from '@ever-works/plugin';
+
+describe('MemoryPipelineModifierPlugin', () => {
+	let plugin: MemoryPipelineModifierPlugin;
+	let memoryFacade: IAgentMemoryStepFacade;
+	let logger: { log: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		plugin = new MemoryPipelineModifierPlugin();
+		logger = { log: vi.fn(), warn: vi.fn() };
+		memoryFacade = {
+			openSession: vi.fn(),
+			closeSession: vi.fn(),
+			saveMemory: vi.fn(),
+			searchMemory: vi.fn(),
+			buildContext: vi.fn(),
+			deleteEntry: vi.fn(),
+			listSessions: vi.fn(),
+			isConfigured: vi.fn().mockReturnValue(true)
+		} as unknown as IAgentMemoryStepFacade;
+	});
+
+	function makeContext(overrides?: Partial<Record<string, unknown>>): IPipelineContext {
+		return {
+			work: { id: 'work-1', slug: 'best-react-tools', name: 'Best React Tools', user: { id: 'u-1' } },
+			request: { prompt: 'Top 10 React UI libraries' },
+			items: [{ name: 'Item A' }, { name: 'Item B' }],
+			...overrides
+		} as unknown as IPipelineContext;
+	}
+
+	function makeExecContext(): StepExecutionContext {
+		return {
+			agentMemoryFacade: memoryFacade,
+			logger,
+			work: { id: 'work-1', slug: 'best-react-tools', name: 'Best React Tools', user: { id: 'u-1' } }
+		} as unknown as StepExecutionContext;
+	}
+
+	describe('metadata', () => {
+		it('declares the pipeline-modifier capability', () => {
+			expect(plugin.id).toBe('memory-pipeline-modifier');
+			expect(plugin.capabilities).toContain('pipeline-modifier');
+		});
+
+		it('targets all pipelines (["*"])', () => {
+			expect(plugin.targetPipelines).toEqual(['*']);
+		});
+
+		it('declares two injected steps at first + last positions', () => {
+			const defs = plugin.getStepDefinitions();
+			expect(defs).toHaveLength(2);
+			const fetch = defs.find((d) => d.id === FETCH_CONTEXT_STEP_ID);
+			const save = defs.find((d) => d.id === SAVE_MEMORY_STEP_ID);
+			expect(fetch?.position).toEqual({ type: 'first' });
+			expect(save?.position).toEqual({ type: 'last' });
+		});
+
+		it('settings schema defaults `enabled` to false (opt-in)', () => {
+			const enabled = (plugin.settingsSchema.properties?.enabled ?? {}) as Record<string, unknown>;
+			expect(enabled.default).toBe(false);
+			expect(enabled['x-scope']).toBe('work');
+		});
+	});
+
+	describe('canSkip', () => {
+		it('returns true when settings.enabled !== true (default off)', async () => {
+			await expect(plugin.canSkip(makeContext())).resolves.toBe(true);
+		});
+
+		it('returns false when stepSettings.enabled === true', async () => {
+			const context = makeContext({
+				stepSettings: { 'memory-pipeline-modifier': { enabled: true } }
+			});
+			await expect(plugin.canSkip(context)).resolves.toBe(false);
+		});
+	});
+
+	describe('execute — dispatch', () => {
+		it('throws if stepId is missing (would be a wiring bug)', async () => {
+			await expect(
+				plugin.execute(makeContext(), { settings: { execContext: makeExecContext() } })
+			).rejects.toThrow(/stepId.*required/);
+		});
+
+		it('throws for an unknown stepId', async () => {
+			await expect(
+				plugin.execute(makeContext(), {
+					settings: { stepId: 'bogus', execContext: makeExecContext() }
+				})
+			).rejects.toThrow(/unknown stepId/);
+		});
+
+		it('no-ops gracefully when no agentMemoryFacade is on execContext', async () => {
+			const execContext = { logger } as unknown as StepExecutionContext;
+			await plugin.execute(makeContext(), {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext }
+			});
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/no agent-memory facade/));
+		});
+	});
+
+	describe('memory-fetch-context step', () => {
+		it('calls buildContext with project, purpose, prompt, maxTokens — and attaches result to context.memoryContext', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				content: 'prior memory text',
+				approxTokens: 250
+			});
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: {
+					stepId: FETCH_CONTEXT_STEP_ID,
+					execContext: makeExecContext(),
+					purpose: 'fix-bug',
+					maxContextTokens: 1000
+				}
+			});
+			expect(memoryFacade.buildContext).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: 'Top 10 React UI libraries',
+					purpose: 'fix-bug',
+					projectId: 'best-react-tools',
+					maxTokens: 1000
+				}),
+				expect.any(Object)
+			);
+			expect((context as unknown as { memoryContext?: unknown }).memoryContext).toEqual({
+				content: 'prior memory text',
+				approxTokens: 250
+			});
+		});
+
+		it('logs when no prior memory is found (empty content)', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ content: '' });
+			await plugin.execute(makeContext(), {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(logger.log).toHaveBeenCalledWith(expect.stringMatching(/no prior memory/));
+		});
+
+		it('catches errors and never crashes the host pipeline', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+				new Error('connection refused')
+			);
+			const context = makeContext();
+			await expect(
+				plugin.execute(context, {
+					settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+				})
+			).resolves.toBeDefined();
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/connection refused/));
+		});
+	});
+
+	describe('memory-save step', () => {
+		it('calls saveMemory with a digest mentioning the Work + item count', async () => {
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				id: 'mem-1',
+				createdAt: 'now',
+				content: 'x'
+			});
+			await plugin.execute(makeContext(), {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					content: expect.stringMatching(/Best React Tools.*2 items/),
+					projectId: 'best-react-tools',
+					tags: expect.arrayContaining(['pipeline-run', 'work:best-react-tools'])
+				}),
+				expect.any(Object)
+			);
+		});
+
+		it('marks tags as `failed` when the pipeline context has an errorMessage', async () => {
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				id: 'mem-1',
+				createdAt: 'now',
+				content: 'x'
+			});
+			const context = makeContext({ errorMessage: 'AI provider rate-limited' });
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tags: expect.arrayContaining(['failed']),
+					content: expect.stringMatching(/rate-limited/)
+				}),
+				expect.any(Object)
+			);
+		});
+
+		it('marks tags as `cancelled` when the context has a cancellationError', async () => {
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+				id: 'mem-1',
+				createdAt: 'now',
+				content: 'x'
+			});
+			const context = makeContext({ cancellationError: { code: 'user-cancel' } });
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tags: expect.arrayContaining(['cancelled']),
+					content: expect.stringMatching(/cancelled.*user-cancel/)
+				}),
+				expect.any(Object)
+			);
+		});
+
+		it('skips entirely when stepSettings.saveSummary === false', async () => {
+			const context = makeContext({
+				stepSettings: { 'memory-pipeline-modifier': { saveSummary: false } }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.saveMemory).not.toHaveBeenCalled();
+			expect(logger.log).toHaveBeenCalledWith(expect.stringMatching(/saveSummary disabled/));
+		});
+
+		it('catches errors and never crashes the host pipeline', async () => {
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('agentmemory down'));
+			await expect(
+				plugin.execute(makeContext(), {
+					settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+				})
+			).resolves.toBeDefined();
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/agentmemory down/));
+		});
+	});
+
+	describe('lifecycle + validation', () => {
+		it('reports healthy', async () => {
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+		});
+
+		it('rejects out-of-range maxContextTokens', async () => {
+			const result = await plugin.validateSettings({ maxContextTokens: 50 });
+			expect(result.valid).toBe(false);
+			expect(result.errors?.[0].path).toBe('maxContextTokens');
+		});
+	});
+});

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -26,13 +26,30 @@ describe('MemoryPipelineModifierPlugin', () => {
 		} as unknown as IAgentMemoryStepFacade;
 	});
 
-	function makeContext(overrides?: Partial<Record<string, unknown>>): IPipelineContext {
-		return {
+	// stepSettings.enabled MUST be true for execute() to actually do
+	// work — `canSkip()` is informational today (Codex P2 on PR #1081
+	// — the pipeline builder doesn't call it yet), so the gate lives
+	// inside `execute()`. Each test that exercises a step path passes
+	// `enabled: true` here.
+	function makeContext(overrides?: Partial<Record<string, unknown>>, enabled = true): IPipelineContext {
+		const base: Record<string, unknown> = {
 			work: { id: 'work-1', slug: 'best-react-tools', name: 'Best React Tools', user: { id: 'u-1' } },
 			request: { prompt: 'Top 10 React UI libraries' },
 			items: [{ name: 'Item A' }, { name: 'Item B' }],
 			...overrides
-		} as unknown as IPipelineContext;
+		};
+		if (enabled) {
+			base.stepSettings = {
+				...((overrides?.stepSettings as Record<string, unknown> | undefined) ?? {}),
+				'memory-pipeline-modifier': {
+					enabled: true,
+					...(((overrides?.stepSettings as Record<string, unknown> | undefined)?.[
+						'memory-pipeline-modifier'
+					] as Record<string, unknown>) ?? {})
+				}
+			};
+		}
+		return base as unknown as IPipelineContext;
 	}
 
 	function makeExecContext(): StepExecutionContext {
@@ -49,8 +66,10 @@ describe('MemoryPipelineModifierPlugin', () => {
 			expect(plugin.capabilities).toContain('pipeline-modifier');
 		});
 
-		it('targets all pipelines (["*"])', () => {
-			expect(plugin.targetPipelines).toEqual(['*']);
+		it('targets ONLY step-orchestratable pipelines (standard + agent), not the wildcard', () => {
+			// Self-managed pipelines (claude-code, codex, opencode) bypass
+			// modifier injection — Codex P2 on PR #1081.
+			expect([...plugin.targetPipelines]).toEqual(['standard-pipeline', 'agent-pipeline']);
 		});
 
 		it('declares two injected steps at first + last positions', () => {
@@ -71,14 +90,22 @@ describe('MemoryPipelineModifierPlugin', () => {
 
 	describe('canSkip', () => {
 		it('returns true when settings.enabled !== true (default off)', async () => {
-			await expect(plugin.canSkip(makeContext())).resolves.toBe(true);
+			await expect(plugin.canSkip(makeContext({}, false))).resolves.toBe(true);
 		});
 
 		it('returns false when stepSettings.enabled === true', async () => {
-			const context = makeContext({
-				stepSettings: { 'memory-pipeline-modifier': { enabled: true } }
+			await expect(plugin.canSkip(makeContext())).resolves.toBe(false);
+		});
+	});
+
+	describe('enabled gate inside execute()', () => {
+		it('no-ops when stepSettings.enabled !== true (since pipeline builder may not call canSkip)', async () => {
+			const context = makeContext({}, false);
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
 			});
-			await expect(plugin.canSkip(context)).resolves.toBe(false);
+			expect(memoryFacade.buildContext).not.toHaveBeenCalled();
+			expect(logger.log).toHaveBeenCalledWith(expect.stringMatching(/disabled by settings/));
 		});
 	});
 
@@ -112,14 +139,13 @@ describe('MemoryPipelineModifierPlugin', () => {
 				content: 'prior memory text',
 				approxTokens: 250
 			});
-			const context = makeContext();
-			await plugin.execute(context, {
-				settings: {
-					stepId: FETCH_CONTEXT_STEP_ID,
-					execContext: makeExecContext(),
-					purpose: 'fix-bug',
-					maxContextTokens: 1000
+			const context = makeContext({
+				stepSettings: {
+					'memory-pipeline-modifier': { enabled: true, purpose: 'fix-bug', maxContextTokens: 1000 }
 				}
+			});
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
 			});
 			expect(memoryFacade.buildContext).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -148,9 +174,8 @@ describe('MemoryPipelineModifierPlugin', () => {
 			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
 				new Error('connection refused')
 			);
-			const context = makeContext();
 			await expect(
-				plugin.execute(context, {
+				plugin.execute(makeContext(), {
 					settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
 				})
 			).resolves.toBeDefined();
@@ -178,47 +203,11 @@ describe('MemoryPipelineModifierPlugin', () => {
 			);
 		});
 
-		it('marks tags as `failed` when the pipeline context has an errorMessage', async () => {
-			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-				id: 'mem-1',
-				createdAt: 'now',
-				content: 'x'
-			});
-			const context = makeContext({ errorMessage: 'AI provider rate-limited' });
-			await plugin.execute(context, {
-				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
-			});
-			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
-				expect.objectContaining({
-					tags: expect.arrayContaining(['failed']),
-					content: expect.stringMatching(/rate-limited/)
-				}),
-				expect.any(Object)
-			);
-		});
-
-		it('marks tags as `cancelled` when the context has a cancellationError', async () => {
-			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-				id: 'mem-1',
-				createdAt: 'now',
-				content: 'x'
-			});
-			const context = makeContext({ cancellationError: { code: 'user-cancel' } });
-			await plugin.execute(context, {
-				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
-			});
-			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
-				expect.objectContaining({
-					tags: expect.arrayContaining(['cancelled']),
-					content: expect.stringMatching(/cancelled.*user-cancel/)
-				}),
-				expect.any(Object)
-			);
-		});
-
 		it('skips entirely when stepSettings.saveSummary === false', async () => {
 			const context = makeContext({
-				stepSettings: { 'memory-pipeline-modifier': { saveSummary: false } }
+				stepSettings: {
+					'memory-pipeline-modifier': { enabled: true, saveSummary: false }
+				}
 			});
 			await plugin.execute(context, {
 				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }

--- a/packages/plugins/memory-pipeline-modifier/src/index.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/index.ts
@@ -1,0 +1,7 @@
+export {
+	MemoryPipelineModifierPlugin,
+	MemoryPipelineModifierPlugin as default,
+	FETCH_CONTEXT_STEP_ID,
+	SAVE_MEMORY_STEP_ID
+} from './memory-pipeline-modifier.plugin.js';
+export type { MemoryPipelineModifierSettings } from './memory-pipeline-modifier.plugin.js';

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -17,14 +17,6 @@ import type {
 	AgentMemoryContext
 } from '@ever-works/plugin';
 
-/** Minimal shape of the cancellation marker some pipelines stash on
- *  the context bag. Pipelines use slightly different shapes; we only
- *  care about a `code` field. */
-interface CancellationLike {
-	readonly code?: string;
-	readonly message?: string;
-}
-
 /** Step injected at the START of every pipeline run — fetches prior
  *  agent-memory context relevant to the Work and stashes it on the
  *  pipeline context for downstream steps to pick up. */
@@ -86,7 +78,13 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 	readonly category: PluginCategory = 'utility';
 	readonly capabilities = ['pipeline-modifier'] as const;
 	readonly configurationMode = 'hybrid' as const;
-	readonly targetPipelines = ['*'] as const;
+	// Step-orchestratable pipelines only. Self-managed pipelines
+	// (claude-code, codex, opencode, etc.) bypass modifier injection
+	// because they route through `FullPipelineExecutorService`, so
+	// listing them here would be silently ineffective (Codex P2 on
+	// PR #1081). Enumerate explicitly instead of `['*']` so it's
+	// obvious which pipelines pick this up.
+	readonly targetPipelines = ['standard-pipeline', 'agent-pipeline'] as const;
 
 	readonly settingsSchema: JsonSchema = {
 		type: 'object',
@@ -228,8 +226,18 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			);
 		}
 
-		const memoryFacade = execContext?.agentMemoryFacade;
 		const logger = execContext?.logger ?? console;
+
+		// Honour the work-scoped `enabled` flag at execution time —
+		// `canSkip()` is not currently called by the pipeline builder
+		// (Codex P2 on PR #1081). Until that wiring lands, gate inside
+		// `execute()` so toggling the flag actually disables the steps.
+		if (settings.enabled !== true) {
+			logger.log(`memory-pipeline-modifier: step "${stepId}" disabled by settings — skipping`);
+			return context;
+		}
+
+		const memoryFacade = execContext?.agentMemoryFacade;
 
 		if (!memoryFacade) {
 			logger.warn(
@@ -308,11 +316,14 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 		try {
 			const work = (context as { work?: { id?: string; name?: string; slug?: string } }).work;
 			const items = (context as { items?: unknown[] }).items;
-			const cancellation = (context as { cancellationError?: CancellationLike }).cancellationError;
-			const errorMessage = (context as { errorMessage?: string }).errorMessage;
 
-			const summary = this.buildSummary(work, items, cancellation, errorMessage);
-			const tags = this.buildTags(work, items, cancellation, errorMessage);
+			// v1 records SUCCESSFUL runs only — the `last` step doesn't
+			// fire when an earlier step throws or the run is cancelled
+			// (Codex P2 on PR #1081). Capturing failure/cancellation
+			// signals will move to an `IPipelineModifierPlugin.rollback`
+			// hook in a follow-up PR; the tag taxonomy stays the same.
+			const summary = this.buildSummary(work, items);
+			const tags = this.buildTags(work);
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
@@ -358,33 +369,17 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 	private buildSummary(
 		work: { id?: string; name?: string; slug?: string } | undefined,
-		items: unknown[] | undefined,
-		cancellation: CancellationLike | undefined,
-		errorMessage: string | undefined
+		items: unknown[] | undefined
 	): string {
 		const workLabel = work?.name ?? work?.slug ?? work?.id ?? 'unknown Work';
-		if (cancellation) {
-			const code: string = cancellation.code ?? 'unknown';
-			return `Work "${workLabel}" — generation cancelled (${code}).`;
-		}
-		if (errorMessage) {
-			return `Work "${workLabel}" — generation failed: ${errorMessage.slice(0, 240)}`;
-		}
 		const count = Array.isArray(items) ? items.length : 0;
 		return `Work "${workLabel}" — pipeline completed with ${count} item${count === 1 ? '' : 's'}.`;
 	}
 
-	private buildTags(
-		work: { id?: string; slug?: string } | undefined,
-		_items: unknown[] | undefined,
-		cancellation: CancellationLike | undefined,
-		errorMessage: string | undefined
-	): readonly string[] {
+	private buildTags(work: { id?: string; slug?: string } | undefined): readonly string[] {
 		const tags: string[] = ['pipeline-run'];
 		if (work?.slug) tags.push(`work:${work.slug}`);
 		else if (work?.id) tags.push(`work-id:${work.id}`);
-		if (cancellation) tags.push('cancelled');
-		if (errorMessage) tags.push('failed');
 		return tags;
 	}
 }

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -1,0 +1,390 @@
+import type {
+	IPlugin,
+	IPipelineModifierPlugin,
+	IPipelineContext,
+	PluginContext,
+	PluginCategory,
+	JsonSchema,
+	ValidationResult,
+	PluginManifest,
+	PluginHealthCheck,
+	PipelineStepDefinition,
+	StepExecutionOptions,
+	StepProgressCallback,
+	StepExecutionContext,
+	IAgentMemoryStepFacade,
+	AgentMemoryRecord,
+	AgentMemoryContext
+} from '@ever-works/plugin';
+
+/** Minimal shape of the cancellation marker some pipelines stash on
+ *  the context bag. Pipelines use slightly different shapes; we only
+ *  care about a `code` field. */
+interface CancellationLike {
+	readonly code?: string;
+	readonly message?: string;
+}
+
+/** Step injected at the START of every pipeline run — fetches prior
+ *  agent-memory context relevant to the Work and stashes it on the
+ *  pipeline context for downstream steps to pick up. */
+export const FETCH_CONTEXT_STEP_ID = 'memory-fetch-context';
+
+/** Step injected at the END of every pipeline run — saves a short
+ *  observation summarising what was generated, so the next run can
+ *  retrieve it. */
+export const SAVE_MEMORY_STEP_ID = 'memory-save';
+
+/** Pipeline context bag — `IPipelineContext` is loosely typed; we cast
+ *  to / from `Record<string, unknown>` to attach our temporary memory
+ *  hints without coupling to any specific pipeline's context shape. */
+type ContextBag = IPipelineContext & Record<string, unknown>;
+
+/** Settings the modifier reads after the facade resolves the
+ *  user/work/admin hierarchy. */
+export interface MemoryPipelineModifierSettings {
+	enabled?: boolean;
+	purpose?: string;
+	maxContextTokens?: number;
+	saveSummary?: boolean;
+}
+
+const DEFAULT_PURPOSE = 'work-generation';
+const DEFAULT_MAX_CONTEXT_TOKENS = 1500;
+
+/**
+ * Agent-memory pipeline modifier.
+ *
+ * Adds two steps to any pipeline (target `['*']`):
+ *
+ *   1. `memory-fetch-context` (position: first) — calls
+ *      `agentMemoryFacade.buildContext({...})` to get a digest of
+ *      previously-saved observations for the same project / work, then
+ *      attaches the result to the pipeline context as
+ *      `context.memoryContext` so downstream steps that know how to use
+ *      it can splice it into their prompts.
+ *
+ *   2. `memory-save` (position: last) — calls
+ *      `agentMemoryFacade.saveMemory({...})` with a short summary of
+ *      the run (item counts + any error / cancellation signal). Future
+ *      runs of the same Work pick this up via step 1.
+ *
+ * Opt-in: the modifier's `canSkip()` returns `true` unless the
+ * `enabled: boolean` setting is set on the Work (off by default). When
+ * the resolved agent-memory facade is missing — e.g. the operator
+ * hasn't installed `@ever-works/agentmemory-plugin` yet — the steps
+ * log a warning and no-op rather than failing the whole pipeline.
+ *
+ * The modifier itself implements `IPipelineModifierPlugin` and
+ * dispatches in `execute()` based on `options.settings.stepId`, which
+ * the step-pipeline executor wires through.
+ */
+export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierPlugin {
+	readonly id = 'memory-pipeline-modifier';
+	readonly name = 'Agent Memory Hooks';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'utility';
+	readonly capabilities = ['pipeline-modifier'] as const;
+	readonly configurationMode = 'hybrid' as const;
+	readonly targetPipelines = ['*'] as const;
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			enabled: {
+				type: 'boolean',
+				title: 'Enable agent-memory hooks for this Work',
+				description:
+					"Inject persistent memory hooks into the Work's pipeline. When on, the pipeline fetches prior observations at the start and saves a digest at the end. Requires an agent-memory provider to be enabled (default: @ever-works/agentmemory-plugin).",
+				default: false,
+				'x-scope': 'work'
+			},
+			purpose: {
+				type: 'string',
+				title: 'Context purpose',
+				description:
+					'Hint passed to the memory backend to bias the retrieved context (e.g. "work-generation", "fix-bug", "research"). Backends that support purpose-aware retrieval will use it.',
+				default: DEFAULT_PURPOSE,
+				'x-scope': 'work'
+			},
+			maxContextTokens: {
+				type: 'number',
+				title: 'Max context tokens',
+				description: 'Upper bound on the size of the injected memory context payload.',
+				default: DEFAULT_MAX_CONTEXT_TOKENS,
+				minimum: 100,
+				maximum: 32_000,
+				'x-scope': 'work'
+			},
+			saveSummary: {
+				type: 'boolean',
+				title: 'Save a summary at the end of the run',
+				description:
+					'When on, the last pipeline step saves a short observation about what was generated so the next run can recall it.',
+				default: true,
+				'x-scope': 'work'
+			}
+		},
+		required: []
+	};
+
+	private context: PluginContext | null = null;
+
+	// ── IPlugin lifecycle ──────────────────────────────────────────────
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log('memory-pipeline-modifier plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = null;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'memory-pipeline-modifier plugin is ready',
+			checkedAt: Date.now()
+		};
+	}
+
+	async validateSettings(settings: Record<string, unknown>): Promise<ValidationResult> {
+		const maxTokens = settings.maxContextTokens;
+		if (maxTokens !== undefined && (typeof maxTokens !== 'number' || maxTokens < 100 || maxTokens > 32_000)) {
+			return {
+				valid: false,
+				errors: [
+					{ path: 'maxContextTokens', message: '`maxContextTokens` must be a number between 100 and 32000' }
+				]
+			};
+		}
+		return { valid: true };
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description:
+				'Injects persistent memory hooks into any work-generation pipeline — fetches prior context at the start, saves a digest at the end. Requires an agent-memory provider.',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public'
+		};
+	}
+
+	// ── IPipelineModifierPlugin ────────────────────────────────────────
+
+	getStepDefinitions(): PipelineStepDefinition[] {
+		return [
+			{
+				id: FETCH_CONTEXT_STEP_ID,
+				name: 'Fetch agent-memory context',
+				description: 'Retrieve persistent context for this Work from the agent-memory store.',
+				position: { type: 'first' },
+				optional: true,
+				parallelizable: false,
+				provides: ['memoryContext']
+			},
+			{
+				id: SAVE_MEMORY_STEP_ID,
+				name: 'Save agent-memory observation',
+				description: 'Persist a short digest of this run to the agent-memory store for next time.',
+				position: { type: 'last' },
+				optional: true,
+				parallelizable: false
+			}
+		];
+	}
+
+	async canSkip(context: IPipelineContext): Promise<boolean> {
+		const settings = this.resolveSettings(context);
+		// Skip the whole modifier when disabled — pipeline-builder won't
+		// inject either step on this run.
+		return settings.enabled !== true;
+	}
+
+	async execute(
+		context: IPipelineContext,
+		options?: StepExecutionOptions,
+		_onProgress?: StepProgressCallback
+	): Promise<IPipelineContext> {
+		const rawSettings = (options?.settings ?? {}) as Record<string, unknown>;
+		const stepId = rawSettings.stepId as string | undefined;
+		const execContext = rawSettings.execContext as StepExecutionContext | undefined;
+		const settings = this.resolveSettings(context, rawSettings);
+
+		if (!stepId) {
+			// The pipeline-builder always supplies stepId when invoking a
+			// modifier. Missing it points at a wiring bug — fail loud.
+			throw new Error(
+				'memory-pipeline-modifier: `options.settings.stepId` is required (set by step-pipeline-executor).'
+			);
+		}
+
+		const memoryFacade = execContext?.agentMemoryFacade;
+		const logger = execContext?.logger ?? console;
+
+		if (!memoryFacade) {
+			logger.warn(
+				`memory-pipeline-modifier: no agent-memory facade on execContext — install and enable an agent-memory provider (e.g. @ever-works/agentmemory-plugin). Step "${stepId}" no-ops.`
+			);
+			return context;
+		}
+
+		if (stepId === FETCH_CONTEXT_STEP_ID) {
+			return await this.runFetchContext(context as ContextBag, memoryFacade, settings, logger);
+		}
+		if (stepId === SAVE_MEMORY_STEP_ID) {
+			return await this.runSaveMemory(context as ContextBag, memoryFacade, settings, logger);
+		}
+
+		throw new Error(`memory-pipeline-modifier: unknown stepId "${stepId}"`);
+	}
+
+	async validate(_context: IPipelineContext): Promise<{ valid: boolean; error?: string }> {
+		return { valid: true };
+	}
+
+	// ── step implementations ───────────────────────────────────────────
+
+	private async runFetchContext(
+		context: ContextBag,
+		memoryFacade: IAgentMemoryStepFacade,
+		settings: MemoryPipelineModifierSettings,
+		logger: { log(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void }
+	): Promise<IPipelineContext> {
+		try {
+			const work = (context as { work?: { id?: string; name?: string; slug?: string } }).work;
+			const request = (context as { request?: { prompt?: string } }).request;
+
+			const ctx: AgentMemoryContext = await memoryFacade.buildContext(
+				{
+					query: request?.prompt,
+					purpose: settings.purpose ?? DEFAULT_PURPOSE,
+					projectId: work?.slug ?? work?.id,
+					maxTokens: settings.maxContextTokens ?? DEFAULT_MAX_CONTEXT_TOKENS
+				},
+				// Bound facade ignores its facadeOptions — pass placeholder.
+				{ userId: 'bound', workId: 'bound' }
+			);
+
+			if (ctx?.content) {
+				(context as ContextBag).memoryContext = ctx;
+				logger.log(
+					`memory-fetch-context: injected ${ctx.approxTokens ?? '~'} tokens of prior memory for Work "${work?.slug ?? work?.id ?? '?'}"`
+				);
+			} else {
+				logger.log('memory-fetch-context: no prior memory found');
+			}
+
+			return context;
+		} catch (error) {
+			// Memory failures must NEVER crash the host pipeline — log
+			// and keep going. The Work generation is the main job here.
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`memory-fetch-context: failed to fetch context — ${message}`);
+			return context;
+		}
+	}
+
+	private async runSaveMemory(
+		context: ContextBag,
+		memoryFacade: IAgentMemoryStepFacade,
+		settings: MemoryPipelineModifierSettings,
+		logger: { log(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void }
+	): Promise<IPipelineContext> {
+		if (settings.saveSummary === false) {
+			logger.log('memory-save: saveSummary disabled — skipping');
+			return context;
+		}
+
+		try {
+			const work = (context as { work?: { id?: string; name?: string; slug?: string } }).work;
+			const items = (context as { items?: unknown[] }).items;
+			const cancellation = (context as { cancellationError?: CancellationLike }).cancellationError;
+			const errorMessage = (context as { errorMessage?: string }).errorMessage;
+
+			const summary = this.buildSummary(work, items, cancellation, errorMessage);
+			const tags = this.buildTags(work, items, cancellation, errorMessage);
+
+			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
+				{
+					content: summary,
+					tags,
+					projectId: work?.slug ?? work?.id,
+					metadata: {
+						workId: work?.id,
+						workSlug: work?.slug,
+						itemCount: Array.isArray(items) ? items.length : undefined,
+						completedAt: new Date().toISOString()
+					}
+				},
+				{ userId: 'bound', workId: 'bound' }
+			);
+
+			logger.log(`memory-save: saved observation ${record.id} for Work "${work?.slug ?? work?.id ?? '?'}"`);
+			return context;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`memory-save: failed to save observation — ${message}`);
+			return context;
+		}
+	}
+
+	// ── helpers ────────────────────────────────────────────────────────
+
+	private resolveSettings(
+		context: IPipelineContext,
+		override?: Record<string, unknown>
+	): MemoryPipelineModifierSettings {
+		const fromContext = (context as { stepSettings?: Record<string, Record<string, unknown>> }).stepSettings?.[
+			this.id
+		];
+		const merged = { ...(fromContext ?? {}), ...(override ?? {}) };
+		const out: MemoryPipelineModifierSettings = {};
+		if (typeof merged.enabled === 'boolean') out.enabled = merged.enabled;
+		if (typeof merged.purpose === 'string' && merged.purpose) out.purpose = merged.purpose;
+		if (typeof merged.maxContextTokens === 'number') out.maxContextTokens = merged.maxContextTokens;
+		if (typeof merged.saveSummary === 'boolean') out.saveSummary = merged.saveSummary;
+		return out;
+	}
+
+	private buildSummary(
+		work: { id?: string; name?: string; slug?: string } | undefined,
+		items: unknown[] | undefined,
+		cancellation: CancellationLike | undefined,
+		errorMessage: string | undefined
+	): string {
+		const workLabel = work?.name ?? work?.slug ?? work?.id ?? 'unknown Work';
+		if (cancellation) {
+			const code: string = cancellation.code ?? 'unknown';
+			return `Work "${workLabel}" — generation cancelled (${code}).`;
+		}
+		if (errorMessage) {
+			return `Work "${workLabel}" — generation failed: ${errorMessage.slice(0, 240)}`;
+		}
+		const count = Array.isArray(items) ? items.length : 0;
+		return `Work "${workLabel}" — pipeline completed with ${count} item${count === 1 ? '' : 's'}.`;
+	}
+
+	private buildTags(
+		work: { id?: string; slug?: string } | undefined,
+		_items: unknown[] | undefined,
+		cancellation: CancellationLike | undefined,
+		errorMessage: string | undefined
+	): readonly string[] {
+		const tags: string[] = ['pipeline-run'];
+		if (work?.slug) tags.push(`work:${work.slug}`);
+		else if (work?.id) tags.push(`work-id:${work.id}`);
+		if (cancellation) tags.push('cancelled');
+		if (errorMessage) tags.push('failed');
+		return tags;
+	}
+}

--- a/packages/plugins/memory-pipeline-modifier/tsconfig.json
+++ b/packages/plugins/memory-pipeline-modifier/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/memory-pipeline-modifier/tsup.config.ts
+++ b/packages/plugins/memory-pipeline-modifier/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	splitting: false,
+	sourcemap: false,
+	clean: true
+});

--- a/packages/plugins/memory-pipeline-modifier/vitest.config.ts
+++ b/packages/plugins/memory-pipeline-modifier/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/index.ts']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -220,16 +220,16 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -466,10 +466,10 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -889,13 +889,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -1029,7 +1029,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1789,6 +1789,24 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/plugins/make:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
+  packages/plugins/memory-pipeline-modifier:
     devDependencies:
       '@ever-works/plugin':
         specifier: workspace:*
@@ -19110,17 +19128,6 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
-  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      jsonc-parser: 3.3.1
-      picomatch: 4.0.4
-      rxjs: 7.8.1
-      source-map: 0.7.4
-    optionalDependencies:
-      chokidar: 3.6.0
-
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -19142,16 +19149,6 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -23520,7 +23517,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -23537,7 +23534,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.0
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@3.6.0)
+      nunjucks: 3.2.4(chokidar@4.0.3)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -23564,7 +23561,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -23583,35 +23580,6 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
-      webpack-node-externals: 3.0.0
-    optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
-      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
-      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      cli-table3: 0.6.5
-      commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21)))
-      glob: 13.0.6
-      node-emoji: 1.11.0
-      ora: 5.4.1
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-      typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
@@ -23643,7 +23611,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -23672,7 +23640,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -23774,17 +23742,6 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
-
-  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -26194,25 +26151,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)':
-    dependencies:
-      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.2.2
-      commander: 8.3.0
-      minimatch: 10.2.5
-      piscina: 4.9.2
-      semver: 7.7.4
-      slash: 3.0.0
-      source-map: 0.7.6
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      chokidar: 3.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -34853,13 +34791,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@3.6.0):
+  nunjucks@3.2.4(chokidar@4.0.3):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## Summary

Follow-up to **#1073** (agent-memory capability + agentmemory plugin). This PR wires the agent-memory facade into pipeline step execution and ships a first-party **memory-pipeline-modifier** plugin that auto-injects memory hooks into ANY pipeline.

## What's in the PR

**1. `IAgentMemoryStepFacade` contract** — `@ever-works/plugin/facades`
- Bound facade shape mirroring `IAiFacade` / `ISearchFacade`. Lives in the dep-free plugin contracts package so plugins consume it without depending on `@ever-works/agent`.

**2. `StepExecutionContext.agentMemoryFacade?`** — `@ever-works/plugin/pipeline`
- Optional carrier. Operators without an agent-memory provider get `undefined`; consumers null-check before use. Same pattern as `kbContext` / `kbTools`.

**3. `PipelineFacadeService` injects + binds `AgentMemoryFacadeService`**
- `@Optional()` injection. `createBoundAgentMemoryFacade` pre-fills `workId` / `userId` so steps call `agentMemoryFacade.saveMemory({ content: '...' })` without threading FacadeOptions.

**4. `@ever-works/memory-pipeline-modifier` plugin**
- `IPipelineModifierPlugin` targeting `['*']` — works against standard-pipeline, agent-pipeline, claude-code, codex, etc.
- **`memory-fetch-context`** (position: first) — `buildContext({ query: prompt, purpose, projectId: work.slug, maxTokens })`, stashes the result on `context.memoryContext`.
- **`memory-save`** (position: last) — `saveMemory({ content: digest, tags: ['pipeline-run', 'work:<slug>', maybe 'failed' / 'cancelled'], projectId, metadata: { workId, itemCount, completedAt } })`.
- **Opt-in**: `canSkip()` returns `true` unless work-scoped `enabled` is on (default false) — no impact on existing pipelines.
- **Fails open**: memory backend errors are caught and logged; the host pipeline never crashes.
- **Graceful degradation**: no agent-memory provider → log warn + no-op.

## Settings (work-scoped)

| Key | Default | Notes |
|---|---|---|
| `enabled` | `false` | Feature switch — off by default |
| `purpose` | `'work-generation'` | Backend bias hint (e.g. `'fix-bug'`, `'research'`) |
| `maxContextTokens` | `1500` | Range 100–32000, enforced in `validateSettings` |
| `saveSummary` | `true` | Turn off post-run save without disabling the pre-run fetch |

## Tests

- **19 vitest** unit tests for the modifier plugin: target pipelines, step definitions, canSkip honouring enabled, dispatch by stepId, missing-stepId fail-loud, unknown-stepId fail-loud, missing-facade no-op, buildContext payload, record attachment on `context.memoryContext`, error swallowing, saveMemory payload, failed/cancelled tag derivation, `saveSummary: false` skip, range check.
- **2 jest** cases added to `pipeline-facade.service.spec.ts` — `agentMemoryFacade` populated when injected (bound options pre-fill user/work), undefined when `@Optional()` injection skipped.
- Full agent suite: **282 suites, 5567 jest tests passing**.
- Prettier `format:check` clean.

## Deliberately NOT in this PR

- API controllers exposing memory operations to the web admin UI.
- Migration adding `memorySessionId` to `agent_runs` (the modifier doesn't open sessions for v1 — each run is a single observation; sessions are a follow-up if/when a use-case demands them).
- Trigger.dev queued flush — `saveMemory` is fast enough to do synchronously in the pipeline; we'll add a queued path when we see latency in real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional agent-memory integration for pipelines: fetch memory before work and save memory after completion; opt-in plugin with configurable purpose, max context tokens, and save behavior.
  * Step execution contexts may expose a bound agent-memory facade when available, enabling session management, search/build context, save/delete, and metadata tagging.

* **Tests**
  * Added tests covering fetch/save steps, settings validation, and facade injection/behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->