### PR TITLE
feat(api): REST surface for the agent-memory capability

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -26,6 +26,7 @@ import { GitProviderModule } from './plugins-capabilities/git-provider/git-provi
 import { OAuthModule } from './plugins-capabilities/oauth/oauth.module';
 import { DeviceAuthModule } from './plugins-capabilities/device-auth/device-auth.module';
 import { DeployModule } from './plugins-capabilities/deploy/deploy.module';
+import { AgentMemoryApiModule } from './plugins-capabilities/agent-memory/agent-memory.module';
 import { AiConversationModule } from './ai-conversation/ai-conversation.module';
 import { AccountModule } from './account/account.module';
 import { ActivityLogModule } from './activity-log/activity-log.module';
@@ -107,6 +108,7 @@ import { DatabaseModule } from '@ever-works/agent/database';
         OAuthModule,
         DeviceAuthModule,
         DeployModule,
+        AgentMemoryApiModule,
         AiConversationModule,
         AccountModule,
         ActivityLogModule,

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
@@ -1,0 +1,227 @@
+jest.mock('@ever-works/agent/facades', () => ({
+    AgentMemoryFacadeService: class {},
+    NoProviderError: class NoProviderError extends Error {
+        constructor(capability?: string) {
+            super(`No provider for ${capability ?? 'unknown'}`);
+            this.name = 'NoProviderError';
+        }
+    },
+}));
+jest.mock('@ever-works/agent/services', () => ({
+    WorkOwnershipService: class {},
+}));
+jest.mock('../../auth', () => ({
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AgentMemoryController } from './agent-memory.controller';
+import { NoProviderError } from '@ever-works/agent/facades';
+import type { AgentMemoryFacadeService } from '@ever-works/agent/facades';
+import type { WorkOwnershipService } from '@ever-works/agent/services';
+import type { AuthenticatedUser } from '../../auth/types/auth.types';
+
+describe('AgentMemoryController', () => {
+    let agentMemory: {
+        isConfigured: jest.Mock;
+        getDefaultProvider: jest.Mock;
+        openSession: jest.Mock;
+        closeSession: jest.Mock;
+        listSessions: jest.Mock;
+        saveMemory: jest.Mock;
+        searchMemory: jest.Mock;
+        buildContext: jest.Mock;
+        deleteEntry: jest.Mock;
+    };
+    let ownership: { ensureCanView: jest.Mock };
+    let controller: AgentMemoryController;
+    const auth: AuthenticatedUser = { userId: 'user-1' } as any;
+
+    beforeEach(() => {
+        agentMemory = {
+            isConfigured: jest.fn().mockReturnValue(true),
+            getDefaultProvider: jest
+                .fn()
+                .mockResolvedValue({ id: 'agentmemory', name: 'Agent Memory' }),
+            openSession: jest.fn().mockResolvedValue({ id: 's1', startedAt: 'now' }),
+            closeSession: jest.fn().mockResolvedValue(undefined),
+            listSessions: jest.fn().mockResolvedValue([]),
+            saveMemory: jest.fn().mockResolvedValue({ id: 'm1', content: 'x', createdAt: 'now' }),
+            searchMemory: jest.fn().mockResolvedValue({ results: [] }),
+            buildContext: jest.fn().mockResolvedValue({ content: 'ctx' }),
+            deleteEntry: jest.fn().mockResolvedValue(undefined),
+        };
+        ownership = { ensureCanView: jest.fn().mockResolvedValue(undefined) };
+        controller = new AgentMemoryController(
+            agentMemory as unknown as AgentMemoryFacadeService,
+            ownership as unknown as WorkOwnershipService,
+        );
+    });
+
+    describe('check-availability', () => {
+        it('returns available=false with a hint when no provider is loaded', async () => {
+            agentMemory.isConfigured.mockReturnValueOnce(false);
+            const result = await controller.checkAvailability(auth);
+            expect(result.available).toBe(false);
+            expect(result.message).toMatch(/Install \+ enable an agent-memory plugin/);
+        });
+
+        it('returns available=true + the active provider when configured', async () => {
+            const result = await controller.checkAvailability(auth);
+            expect(result.available).toBe(true);
+            expect(result.activeProvider).toEqual({ id: 'agentmemory', name: 'Agent Memory' });
+        });
+    });
+
+    describe('ownership enforcement', () => {
+        it('calls WorkOwnershipService.ensureCanView when a workId is supplied on save', async () => {
+            await controller.save(auth, {
+                content: 'x',
+                workId: 'work-1' as any,
+            });
+            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+        });
+
+        it('skips ownership when workId is not supplied (platform-wide reads)', async () => {
+            await controller.save(auth, { content: 'x' });
+            expect(ownership.ensureCanView).not.toHaveBeenCalled();
+        });
+
+        it('lets ownership errors bubble (e.g. 403 from the underlying guard)', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            await expect(
+                controller.save(auth, { content: 'x', workId: 'work-1' as any }),
+            ).rejects.toThrow('not your work');
+        });
+    });
+
+    describe('save', () => {
+        it('forwards content + tags + metadata + sessionId + projectId to the facade', async () => {
+            await controller.save(auth, {
+                content: 'remember this',
+                tags: ['bug'],
+                metadata: { file: 'a.ts' },
+                sessionId: 'sess-9',
+                projectId: 'proj-A',
+            });
+            expect(agentMemory.saveMemory).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: 'remember this',
+                    tags: ['bug'],
+                    metadata: { file: 'a.ts' },
+                    sessionId: 'sess-9',
+                    projectId: 'proj-A',
+                }),
+                expect.objectContaining({ userId: 'user-1' }),
+            );
+        });
+    });
+
+    describe('search', () => {
+        it('returns the facade response unchanged + status:success', async () => {
+            agentMemory.searchMemory.mockResolvedValueOnce({
+                results: [{ id: '1', content: 'a', createdAt: 'now' }],
+                summary: 's',
+            });
+            const result = await controller.search(auth, { query: 'q' });
+            expect(result.status).toBe('success');
+            expect(result.results).toHaveLength(1);
+            expect(result.summary).toBe('s');
+        });
+    });
+
+    describe('context', () => {
+        it('maps maxTokens to the facade buildContext call', async () => {
+            await controller.context(auth, { query: 'q', maxTokens: 1500 });
+            expect(agentMemory.buildContext).toHaveBeenCalledWith(
+                expect.objectContaining({ maxTokens: 1500 }),
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('sessions', () => {
+        it('openSession returns the facade session payload', async () => {
+            const result = await controller.openSession(auth, { metadata: { from: 'web' } });
+            expect(result.session).toEqual({ id: 's1', startedAt: 'now' });
+            expect(agentMemory.openSession).toHaveBeenCalledWith(
+                { from: 'web' },
+                expect.objectContaining({ userId: 'user-1' }),
+            );
+        });
+
+        it('closeSession rejects an empty sessionId', async () => {
+            await expect(controller.closeSession(auth, '')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('listSessions forwards limit + projectId', async () => {
+            await controller.listSessions(auth, { limit: 5, projectId: 'p' });
+            expect(agentMemory.listSessions).toHaveBeenCalledWith(
+                expect.objectContaining({ limit: 5, projectId: 'p' }),
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('deleteEntry', () => {
+        it('rejects an empty entryId', async () => {
+            await expect(controller.deleteEntry(auth, '')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('passes the id to the facade', async () => {
+            await controller.deleteEntry(auth, 'mem-42');
+            expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
+                'mem-42',
+                expect.objectContaining({ userId: 'user-1' }),
+            );
+        });
+    });
+
+    describe('error mapping', () => {
+        it('translates NoProviderError to 400 with a remediation hint', async () => {
+            agentMemory.saveMemory.mockRejectedValueOnce(new NoProviderError('agent-memory'));
+            try {
+                await controller.save(auth, { content: 'x' });
+                fail('expected throw');
+            } catch (err) {
+                expect(err).toBeInstanceOf(BadRequestException);
+                const response = (err as BadRequestException).getResponse() as Record<
+                    string,
+                    unknown
+                >;
+                expect(response.message).toMatch(/Install \+ enable an agent-memory plugin/);
+                expect(response.operation).toBe('saveMemory');
+            }
+        });
+
+        it('translates "does not support" errors to 404 (optional method missing)', async () => {
+            agentMemory.deleteEntry.mockRejectedValueOnce(
+                new Error('Agent-memory provider "x" does not support deleteEntry'),
+            );
+            await expect(controller.deleteEntry(auth, 'mem-1')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('translates anything else to 400 with the original message + operation tag', async () => {
+            agentMemory.searchMemory.mockRejectedValueOnce(new Error('agentmemory unreachable'));
+            try {
+                await controller.search(auth, { query: 'q' });
+                fail('expected throw');
+            } catch (err) {
+                expect(err).toBeInstanceOf(BadRequestException);
+                const response = (err as BadRequestException).getResponse() as Record<
+                    string,
+                    unknown
+                >;
+                expect(response.message).toBe('agentmemory unreachable');
+                expect(response.operation).toBe('searchMemory');
+            }
+        });
+    });
+});

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
@@ -81,9 +81,15 @@ export class AgentMemoryController {
     @ApiResponse({ status: 201, description: 'Opened session' })
     async openSession(@CurrentUser() auth: AuthenticatedUser, @Body() dto: OpenSessionDto) {
         await this.assertWorkAccess(auth, dto.workId);
+        // Codex P2 on PR #1086 — the facade's openSession takes
+        // `metadata` but the plugin reads `projectId` separately. Fold
+        // a caller-supplied projectId into metadata so the session
+        // actually scopes to the requested namespace.
+        const metadata: Record<string, unknown> = { ...(dto.metadata ?? {}) };
+        if (dto.projectId) metadata.projectId = dto.projectId;
         try {
             const session = await this.agentMemory.openSession(
-                dto.metadata,
+                metadata,
                 this.facadeOptions(auth, dto.workId),
             );
             return { status: 'success', session };

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
@@ -1,0 +1,256 @@
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    NotFoundException,
+    Param,
+    Post,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { AgentMemoryFacadeService, NoProviderError } from '@ever-works/agent/facades';
+import { WorkOwnershipService } from '@ever-works/agent/services';
+import type { FacadeOptions } from '@ever-works/plugin';
+import { CurrentUser, AuthSessionGuard } from '../../auth';
+import { AuthenticatedUser } from '../../auth/types/auth.types';
+import {
+    BuildContextDto,
+    ListSessionsQueryDto,
+    OpenSessionDto,
+    SaveMemoryDto,
+    SearchMemoryDto,
+} from './dto/agent-memory.dto';
+
+/**
+ * REST surface for the `agent-memory` capability (follow-up to PR #1073
+ * + #1081 + #1084). Lets the web admin UI list, search, save, and
+ * forget memory observations / sessions for the signed-in user.
+ *
+ * All endpoints are JWT-protected; mutating ones additionally enforce
+ * `WorkOwnershipService.ensureCanView` when a `workId` is supplied so
+ * users can't read another user's Work memory.
+ *
+ * Routing is mounted under `/api/agent-memory` to match the sibling
+ * capability controllers (`/api/search`, `/api/agent/memory` was
+ * considered but kept the flat `/api/agent-memory` form for
+ * consistency with the rest of `plugins-capabilities/`).
+ */
+@ApiTags('Agent Memory')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/agent-memory')
+@UseGuards(AuthSessionGuard)
+export class AgentMemoryController {
+    constructor(
+        private readonly agentMemory: AgentMemoryFacadeService,
+        private readonly ownership: WorkOwnershipService,
+    ) {}
+
+    @Get('/check-availability')
+    @ApiOperation({
+        summary: 'Check agent-memory availability',
+        description:
+            'Returns whether an agent-memory provider is currently registered + loaded. The provider may still be unconfigured per-user (e.g. no API key), which would surface as a 4xx on the actual call.',
+    })
+    @ApiResponse({ status: 200, description: 'Availability status' })
+    async checkAvailability(@CurrentUser() auth: AuthenticatedUser) {
+        const configured = this.agentMemory.isConfigured();
+        if (!configured) {
+            return {
+                status: 'success',
+                available: false,
+                activeProvider: null,
+                message:
+                    'No agent-memory provider is enabled. Install + enable an agent-memory plugin (e.g. `@ever-works/agentmemory-plugin`) in settings.',
+            };
+        }
+        const provider = await this.agentMemory
+            .getDefaultProvider(undefined, auth.userId)
+            .catch(() => null);
+        return {
+            status: 'success',
+            available: true,
+            activeProvider: provider,
+        };
+    }
+
+    @Post('/sessions')
+    @ApiOperation({ summary: 'Open a memory session' })
+    @ApiResponse({ status: 201, description: 'Opened session' })
+    async openSession(@CurrentUser() auth: AuthenticatedUser, @Body() dto: OpenSessionDto) {
+        await this.assertWorkAccess(auth, dto.workId);
+        try {
+            const session = await this.agentMemory.openSession(
+                dto.metadata,
+                this.facadeOptions(auth, dto.workId),
+            );
+            return { status: 'success', session };
+        } catch (error) {
+            throw this.toHttpError(error, 'openSession');
+        }
+    }
+
+    @Post('/sessions/:sessionId/close')
+    @ApiOperation({ summary: 'Close an open memory session' })
+    @ApiResponse({ status: 200, description: 'Closed' })
+    async closeSession(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('sessionId') sessionId: string,
+    ) {
+        if (!sessionId) throw new BadRequestException('sessionId is required');
+        try {
+            await this.agentMemory.closeSession(sessionId, this.facadeOptions(auth));
+            return { status: 'success' };
+        } catch (error) {
+            throw this.toHttpError(error, 'closeSession');
+        }
+    }
+
+    @Get('/sessions')
+    @ApiOperation({ summary: 'List recent memory sessions' })
+    @ApiResponse({ status: 200, description: 'Session list' })
+    async listSessions(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: ListSessionsQueryDto,
+    ) {
+        await this.assertWorkAccess(auth, query.workId);
+        try {
+            const sessions = await this.agentMemory.listSessions(
+                { limit: query.limit, projectId: query.projectId },
+                this.facadeOptions(auth, query.workId),
+            );
+            return { status: 'success', sessions };
+        } catch (error) {
+            throw this.toHttpError(error, 'listSessions');
+        }
+    }
+
+    @Post('/save')
+    @ApiOperation({ summary: 'Persist a memory observation' })
+    @ApiResponse({ status: 201, description: 'Saved record' })
+    async save(@CurrentUser() auth: AuthenticatedUser, @Body() dto: SaveMemoryDto) {
+        await this.assertWorkAccess(auth, dto.workId);
+        try {
+            const record = await this.agentMemory.saveMemory(
+                {
+                    content: dto.content,
+                    tags: dto.tags,
+                    metadata: dto.metadata,
+                    sessionId: dto.sessionId,
+                    projectId: dto.projectId,
+                },
+                this.facadeOptions(auth, dto.workId),
+            );
+            return { status: 'success', record };
+        } catch (error) {
+            throw this.toHttpError(error, 'saveMemory');
+        }
+    }
+
+    @Post('/search')
+    @ApiOperation({ summary: 'Search persisted memories' })
+    @ApiResponse({ status: 200, description: 'Search response' })
+    async search(@CurrentUser() auth: AuthenticatedUser, @Body() dto: SearchMemoryDto) {
+        await this.assertWorkAccess(auth, dto.workId);
+        try {
+            const response = await this.agentMemory.searchMemory(
+                {
+                    query: dto.query,
+                    limit: dto.limit,
+                    tags: dto.tags,
+                    sessionId: dto.sessionId,
+                    projectId: dto.projectId,
+                },
+                this.facadeOptions(auth, dto.workId),
+            );
+            return { status: 'success', ...response };
+        } catch (error) {
+            throw this.toHttpError(error, 'searchMemory');
+        }
+    }
+
+    @Post('/context')
+    @ApiOperation({ summary: 'Build a context payload for a prompt' })
+    @ApiResponse({ status: 200, description: 'Context payload' })
+    async context(@CurrentUser() auth: AuthenticatedUser, @Body() dto: BuildContextDto) {
+        await this.assertWorkAccess(auth, dto.workId);
+        try {
+            const context = await this.agentMemory.buildContext(
+                {
+                    query: dto.query,
+                    purpose: dto.purpose,
+                    sessionId: dto.sessionId,
+                    projectId: dto.projectId,
+                    maxTokens: dto.maxTokens,
+                },
+                this.facadeOptions(auth, dto.workId),
+            );
+            return { status: 'success', context };
+        } catch (error) {
+            throw this.toHttpError(error, 'buildContext');
+        }
+    }
+
+    @Delete('/entries/:entryId')
+    @ApiOperation({ summary: 'Forget a single memory record' })
+    @ApiResponse({ status: 200, description: 'Deleted' })
+    async deleteEntry(@CurrentUser() auth: AuthenticatedUser, @Param('entryId') entryId: string) {
+        if (!entryId) throw new BadRequestException('entryId is required');
+        try {
+            await this.agentMemory.deleteEntry(entryId, this.facadeOptions(auth));
+            return { status: 'success' };
+        } catch (error) {
+            throw this.toHttpError(error, 'deleteEntry');
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    /**
+     * Enforce ownership when the caller scopes the request to a Work.
+     * Anonymous-Work memory and platform-wide reads stay open per the
+     * existing search/screenshot/etc. capability convention.
+     */
+    private async assertWorkAccess(
+        auth: AuthenticatedUser,
+        workId: string | undefined,
+    ): Promise<void> {
+        if (!workId) return;
+        await this.ownership.ensureCanView(workId, auth.userId);
+    }
+
+    private facadeOptions(auth: AuthenticatedUser, workId?: string): FacadeOptions {
+        return {
+            userId: auth.userId,
+            ...(workId && { workId }),
+        };
+    }
+
+    /**
+     * Translate facade-layer errors into HTTP exceptions the client can
+     * act on. Notably:
+     *
+     *   - `NoProviderError` → 400 with a hint to enable a provider.
+     *   - "does not support …" errors thrown by the facade when the
+     *     resolved plugin omits an optional method → 404 (the operation
+     *     isn't available against this backend).
+     *   - Everything else → 400 with the original message.
+     */
+    private toHttpError(error: unknown, operation: string): Error {
+        if (error instanceof NoProviderError) {
+            return new BadRequestException({
+                status: 'error',
+                message:
+                    'No agent-memory provider is enabled. Install + enable an agent-memory plugin (e.g. `@ever-works/agentmemory-plugin`).',
+                operation,
+            });
+        }
+        const message = error instanceof Error ? error.message : 'Agent-memory operation failed';
+        if (message.includes('does not support')) {
+            return new NotFoundException({ status: 'error', message, operation });
+        }
+        return new BadRequestException({ status: 'error', message, operation });
+    }
+}

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.module.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { FacadesModule } from '@ever-works/agent/facades';
+import { AuthModule } from '../../auth/auth.module';
+import { WorkModule } from '@ever-works/agent/services';
+import { AgentMemoryController } from './agent-memory.controller';
+
+/**
+ * REST surface for the `agent-memory` capability. Mounted from
+ * `api.module.ts` alongside the other plugins-capabilities modules.
+ */
+@Module({
+    imports: [FacadesModule, AuthModule, WorkModule],
+    controllers: [AgentMemoryController],
+})
+export class AgentMemoryApiModule {}

--- a/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
@@ -1,0 +1,150 @@
+import {
+    IsString,
+    IsOptional,
+    IsNumber,
+    IsArray,
+    IsUUID,
+    IsObject,
+    Min,
+    Max,
+    MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Shared optional fields that show up on most agent-memory calls:
+ *
+ *   - `workId` — pre-fills the facade resolution context so per-Work
+ *     providers / settings are picked up; also drives the
+ *     `WorkOwnershipService.ensureCanView` access check so users can't
+ *     read another user's Work memory.
+ *   - `projectId` — namespace inside the memory backend. When omitted,
+ *     the plugin falls back to the `projectId` setting / env var /
+ *     hard-coded `ever-works` default.
+ */
+class WorkScopedDto {
+    @ApiPropertyOptional({
+        description: 'Work id to scope provider resolution + ownership check against.',
+        example: 'a0499a65-9b8c-4bf7-857e-895f52da30b3',
+    })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiPropertyOptional({
+        description: 'Memory backend project namespace (overrides plugin setting).',
+        example: 'best-react-tools',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    projectId?: string;
+}
+
+export class SaveMemoryDto extends WorkScopedDto {
+    @ApiProperty({
+        description: 'The observation text to persist.',
+        example: 'Fixed the broken auth migration by adding NOT NULL constraint backfill.',
+    })
+    @IsString()
+    @MaxLength(64_000)
+    content: string;
+
+    @ApiPropertyOptional({
+        description: 'Tags applied to the memory record for filtering.',
+        example: ['bug-fix', 'auth'],
+    })
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    tags?: string[];
+
+    @ApiPropertyOptional({
+        description: 'Arbitrary structured metadata stored alongside the record.',
+    })
+    @IsOptional()
+    @IsObject()
+    metadata?: Record<string, unknown>;
+
+    @ApiPropertyOptional({
+        description: 'When supplied, link the observation to a memory session.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    sessionId?: string;
+}
+
+export class SearchMemoryDto extends WorkScopedDto {
+    @ApiProperty({ description: 'Free-form search query.', example: 'auth migration fixes' })
+    @IsString()
+    @MaxLength(2_000)
+    query: string;
+
+    @ApiPropertyOptional({ description: 'Max results to return.', minimum: 1, maximum: 100 })
+    @IsOptional()
+    @IsNumber()
+    @Min(1)
+    @Max(100)
+    limit?: number;
+
+    @ApiPropertyOptional({ description: 'Tag filter — only records carrying any of these tags.' })
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    tags?: string[];
+
+    @ApiPropertyOptional({ description: 'Restrict search to this session.' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    sessionId?: string;
+}
+
+export class BuildContextDto extends WorkScopedDto {
+    @ApiPropertyOptional({ description: 'Optional retrieval query.' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(2_000)
+    query?: string;
+
+    @ApiPropertyOptional({
+        description: 'Hint that backends use to bias retrieval.',
+        example: 'fix-bug',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(64)
+    purpose?: string;
+
+    @ApiPropertyOptional({ description: 'Restrict context to this session.' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    sessionId?: string;
+
+    @ApiPropertyOptional({ description: 'Approximate token budget for the returned context.' })
+    @IsOptional()
+    @IsNumber()
+    @Min(100)
+    @Max(64_000)
+    maxTokens?: number;
+}
+
+export class OpenSessionDto extends WorkScopedDto {
+    @ApiPropertyOptional({
+        description: 'Seed metadata persisted on the session row.',
+    })
+    @IsOptional()
+    @IsObject()
+    metadata?: Record<string, unknown>;
+}
+
+export class ListSessionsQueryDto extends WorkScopedDto {
+    @ApiPropertyOptional({ description: 'Max sessions to return.', minimum: 1, maximum: 100 })
+    @IsOptional()
+    @IsNumber()
+    @Min(1)
+    @Max(100)
+    limit?: number;
+}

--- a/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
@@ -9,6 +9,7 @@ import {
     Max,
     MaxLength,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
@@ -56,7 +57,11 @@ export class SaveMemoryDto extends WorkScopedDto {
     })
     @IsOptional()
     @IsArray()
+    // Per-element MaxLength cap so a caller can't smuggle a multi-MB
+    // string into a single tag (greptile P2 on PR #1086). The array
+    // length cap is implicit at the storage layer.
     @IsString({ each: true })
+    @MaxLength(128, { each: true })
     tags?: string[];
 
     @ApiPropertyOptional({
@@ -92,6 +97,7 @@ export class SearchMemoryDto extends WorkScopedDto {
     @IsOptional()
     @IsArray()
     @IsString({ each: true })
+    @MaxLength(128, { each: true })
     tags?: string[];
 
     @ApiPropertyOptional({ description: 'Restrict search to this session.' })
@@ -143,6 +149,11 @@ export class OpenSessionDto extends WorkScopedDto {
 export class ListSessionsQueryDto extends WorkScopedDto {
     @ApiPropertyOptional({ description: 'Max sessions to return.', minimum: 1, maximum: 100 })
     @IsOptional()
+    // Query params arrive as strings — the global ValidationPipe in
+    // apps/api/src/main.ts uses `transform: true` without implicit
+    // conversion, so without `@Type(() => Number)` the @IsNumber()
+    // check fails for `?limit=5` (Codex + greptile P1 on PR #1086).
+    @Type(() => Number)
     @IsNumber()
     @Min(1)
     @Max(100)


### PR DESCRIPTION
## Summary

Item **#1** from the post-#1081 follow-up menu — expose the agent-memory facade through the API so the web admin can list sessions, save + search observations, and forget records.

## New module

\`apps/api/src/plugins-capabilities/agent-memory/\` — mounted from \`api.module.ts\` next to \`SearchModule\` / \`DeployModule\`. Follows the existing plugins-capabilities convention down to the folder layout, controller-spec mock shape, and Swagger \`@ApiTags\`.

## Endpoints (all JWT-protected via \`AuthSessionGuard\`)

| Method | Path | Purpose |
|---|---|---|
| GET | \`/api/agent-memory/check-availability\` | Provider + readiness probe for the UI |
| POST | \`/api/agent-memory/sessions\` | Open a session |
| POST | \`/api/agent-memory/sessions/:id/close\` | Close a session |
| GET | \`/api/agent-memory/sessions\` | List sessions |
| POST | \`/api/agent-memory/save\` | Persist an observation |
| POST | \`/api/agent-memory/search\` | Search persisted memory |
| POST | \`/api/agent-memory/context\` | Build a context payload for a prompt |
| DELETE | \`/api/agent-memory/entries/:entryId\` | Forget a single record |

## DTOs

\`WorkScopedDto\` (private base) carries the \`workId\` + \`projectId\` optional fields every other DTO inherits. Backed by class-validator: \`@IsUUID()\` on \`workId\`, \`@MaxLength\` caps on all strings, 1..100 result limits, 100..64000 token budget. Swagger annotations on every field.

## Ownership

When the request supplies \`workId\`, the controller invokes \`WorkOwnershipService.ensureCanView(workId, userId)\` before touching the facade — matches the SearchController pattern and keeps cross-user reads off the floor. Anonymous / platform-wide reads (no workId) stay open; the facade still resolves to the caller's userId.

## Error translation

- \`NoProviderError\` → 400 with a clear remediation hint.
- Errors whose message includes \`\"does not support\"\` → 404 (the facade throws this when the resolved plugin omits an optional method like \`listSessions\` / \`deleteEntry\`).
- Anything else → 400 with the original message + \`operation\` tag.

## Tests

- **14 jest** cases in \`agent-memory.controller.spec.ts\`: check-availability (configured + unconfigured), ownership enforcement (with/without workId, error bubbling), save / search / context / open-session / list-sessions / delete-entry happy paths, empty sessionId / entryId rejection, error mapping (NoProviderError, \"does not support\", generic).
- Full apps/api suite: **158 of 159 suites passing** (1 pre-existing skip), 2527 tests passing. No regressions.
- Prettier \`format:check\` clean.
- \`apps/api type-check\` clean.

## Related

- Builds on **#1073** (capability + facade), **#1081** (pipeline modifier), and the sibling **#1084** (sessions + \`AgentRun.memorySessionId\`).
- With this PR landed, a web admin page can call \`/api/agent-memory/sessions\` + \`/api/agent-memory/search\` to surface what an agent run remembered + forget on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agent Memory API endpoints for managing memory sessions, persisting observations, and retrieving memory context
  * Endpoints now support opening/closing memory sessions, saving and searching memory entries, and building contextual prompts
  * Implemented ownership and authorization controls for memory data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->