### PR TITLE
feat(web): make works-store flag-controlled, drop hardcoded SOON baseline

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -170,10 +170,14 @@ export default function NewWorkClient({
         return selected?.connectionInfo?.connected ?? false;
     }, [selectedProviderId, providers]);
 
-    // `store` + `company` are inert "Soon" chips (roadmap, not shipped).
-    // `comingSoon` is the union of that hardcoded baseline and any kind
-    // whose `works-<value>` PostHog flag resolved to an explicit `false`
-    // server-side. Missing/undefined flags stay enabled.
+    // `store` is now flag-controlled via `works-store` like every other
+    // kind (the flag currently resolves to `false`, so the chip still
+    // renders inert "Soon" today). `company` stays a hardcoded inert
+    // "Soon" baseline on this surface — the live company chip lives on
+    // `/new`, not `/works/new`.
+    // `comingSoon` per live kind is purely driven by whether its
+    // `works-<value>` PostHog flag resolved to `false` server-side.
+    // Missing/undefined flags stay enabled (fail-open).
     const disabledSet = useMemo(() => new Set(disabledKinds), [disabledKinds]);
 
     // Effective selection — derived during render so a flag-disabled kind
@@ -192,10 +196,12 @@ export default function NewWorkClient({
         [effectiveKind],
     );
 
-    // Full work-kind chip catalog. `store` + `company` are inert "Soon"
-    // chips (roadmap, not shipped) appended after the live kinds so they
-    // match the marketing site's chip catalog without breaking the
-    // existing /works/new kind picker behavior.
+    // Full work-kind chip catalog. `store` is now flag-controlled via
+    // `works-store` like every other kind; `company` stays a hardcoded
+    // inert "Soon" baseline here (the live Company chip lives on `/new`).
+    // Both are appended after the live kinds so they match the marketing
+    // site's chip catalog without breaking the existing /works/new kind
+    // picker behavior.
     const workKindChips = useMemo<ReadonlyArray<PromptChip<InitialWorkKind | 'store' | 'company'>>>(
         () => [
             ...WORK_KIND_ORDER.map((k) => ({
@@ -204,8 +210,18 @@ export default function NewWorkClient({
                 Icon: WORK_KIND_ICONS[k],
                 comingSoon: disabledSet.has(k),
             })),
-            // `store` + `company` are hardcoded coming-soon baseline.
-            { value: 'store' as const, label: 'Store', Icon: Store, comingSoon: true },
+            // store is flag-controlled via works-store like every other kind.
+            // The `works-store` PostHog flag exists as `active: false`, so
+            // the chip continues to render as the inert "Soon" baseline
+            // until the flag is flipped — no code change required to enable.
+            // `company` stays hardcoded coming-soon here (the live company
+            // chip lives on `/new`, not `/works/new`).
+            {
+                value: 'store' as const,
+                label: 'Store',
+                Icon: Store,
+                comingSoon: disabledSet.has('store'),
+            },
             { value: 'company' as const, label: 'Company', Icon: Building2, comingSoon: true },
         ],
         [t, disabledSet],

--- a/apps/web/src/components/new/NewPageClient.tsx
+++ b/apps/web/src/components/new/NewPageClient.tsx
@@ -46,8 +46,11 @@ import { RegisterCompanyDialog } from '@/components/organizations/RegisterCompan
  *
  * `store` is a catalog entry telegraphing roadmap scope (see Workspace
  * notes `2026-05-23-missions-ideas-works-spec.md` + AGENTS.md "stores
- * + companies are in-scope future use cases"). It renders as an inert
- * "Soon" chip, matching how the marketing site telegraphs it.
+ * + companies are in-scope future use cases"). It's flag-controlled via
+ * the `works-store` PostHog flag like every other kind; today the flag
+ * resolves to `false`, so the chip still renders as an inert "Soon"
+ * chip matching how the marketing site telegraphs it — but it can be
+ * flipped from PostHog without a code change.
  *
  * EW-662 (Phase 10) — `company` graduated from inert to live: picking
  * the Company chip opens the Register-Company dialog (spec §5.4), which
@@ -436,18 +439,21 @@ export function NewPageClient({
         [effectiveChip],
     );
 
-    // Full chip catalog. `store` stays as an inert "Soon" chip,
-    // appended after the live chips so it sits at the end of the
-    // horizontal scroll the way the marketing site does it.
+    // Full chip catalog. `store` is appended after the live `CHIP_ORDER`
+    // chips so it sits at the end of the horizontal scroll the way the
+    // marketing site does it. Its `comingSoon` is now driven by the
+    // `works-store` PostHog flag like every other kind (the flag currently
+    // resolves to `false`, so the chip still renders as inert "Soon" with
+    // no user-facing change — but it's now controllable from PostHog).
     //
     // EW-662 Phase 10 — `company` graduated from "Soon" to live; it
     // sits at the end of the live `CHIP_ORDER` list so we render it
     // automatically from the loop below. Picking it opens the
     // Register-Company dialog on submit (see `submit()` above).
     //
-    // `comingSoon` per live chip is the union of its hardcoded baseline
-    // and any chip whose `works-<value>` PostHog flag resolved to an
-    // explicit `false` server-side. Missing/undefined flags stay enabled.
+    // `comingSoon` per chip is `disabledSet.has(value)` — i.e. driven
+    // entirely by `works-<value>` PostHog flags resolved server-side.
+    // Missing/undefined flags stay enabled (fail-open).
     const allChips = useMemo<ReadonlyArray<PromptChip<ChipType | 'store'>>>(
         () => [
             ...CHIP_ORDER.map((c) => ({
@@ -456,10 +462,16 @@ export function NewPageClient({
                 Icon: CHIP_ICONS[c],
                 comingSoon: disabledSet.has(c),
             })),
-            // `store` is the only hardcoded coming-soon baseline now
-            // (`company` graduated to a live chip in EW-662 Phase 10).
-            // Its `comingSoon` is pinned `true` regardless of any flag.
-            { value: 'store' as const, label: 'Store', Icon: Store, comingSoon: true },
+            // store is flag-controlled via works-store like every other kind.
+            // The `works-store` PostHog flag exists as `active: false`, so
+            // the chip continues to render as the inert "Soon" baseline
+            // until the flag is flipped — no code change required to enable.
+            {
+                value: 'store' as const,
+                label: 'Store',
+                Icon: Store,
+                comingSoon: disabledSet.has('store'),
+            },
         ],
         [t, disabledSet],
     );

--- a/apps/web/src/components/new/NewPageClient.unit.spec.tsx
+++ b/apps/web/src/components/new/NewPageClient.unit.spec.tsx
@@ -55,15 +55,21 @@ function getSubmit(container: HTMLElement): HTMLButtonElement {
 }
 
 describe('NewPageClient (chat-open + canvas-route on submit)', () => {
-    it('renders all 10 chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo, Company', () => {
-        const { container } = render(<NewPageClient />);
+    it('renders all 10 live chips in the spec order: Mission, Idea, Agent, Task, Website, Landing Page, Blog, Directory, Awesome Repo, Company (with `works-store` disabled so the catalog matches its production state)', () => {
+        // `store` is now flag-controlled via `works-store` like every
+        // other kind. We pass `disabledKinds={['store']}` here to mirror
+        // its current PostHog state (`active: false`), which keeps `store`
+        // as the inert "Soon" span — i.e. the same 10 live chips this
+        // test has always asserted. With every other flag fail-open, the
+        // resulting button-option list is exactly the live chip order.
+        const { container } = render(<NewPageClient disabledKinds={['store']} />);
         const chipButtons = Array.from(
             container.querySelectorAll('button[role="option"][aria-selected]'),
         ) as HTMLButtonElement[];
         // EW-662 Phase 10 — `company` joined the live chip set so the
-        // total is now 10. `store` stays as an inert "Soon" chip
-        // (a `button[role="option"]` without `aria-selected` — filtered
-        // out by the selector above).
+        // total is now 10. `store` renders as an inert "Soon" chip
+        // (a `span[aria-disabled="true"]` — filtered out by the selector
+        // above).
         expect(chipButtons).toHaveLength(10);
         const labels = chipButtons.map((b) => b.textContent?.trim());
         expect(labels).toEqual([
@@ -114,6 +120,40 @@ describe('NewPageClient (chat-open + canvas-route on submit)', () => {
         // And it's NOT rendered as the inert coming-soon span.
         const blogSpan = container.querySelector('span[data-testid="new-chip-blog"]');
         expect(blogSpan).toBeNull();
+    });
+
+    describe('store chip is flag-controlled like every other kind', () => {
+        // store graduated from a hardcoded `comingSoon: true` baseline to
+        // being driven by the `works-store` PostHog flag like every other
+        // kind. With the flag resolving to `false` (its current PostHog
+        // state) it renders as the inert "Soon" span — same as before, so
+        // no user-facing change today. With the flag resolving to `true`
+        // (hypothetical — the flag does not currently activate it) it
+        // would render as a clickable button.
+        it('renders store as the inert "Soon" span when `works-store` is disabled (current PostHog state)', () => {
+            const { container } = render(<NewPageClient disabledKinds={['store']} />);
+            const storeSpan = container.querySelector('span[data-testid="new-chip-store"]');
+            expect(storeSpan).not.toBeNull();
+            expect(storeSpan?.getAttribute('aria-disabled')).toBe('true');
+            // And it's NOT a clickable button-option.
+            const storeButton = Array.from(
+                container.querySelectorAll('button[role="option"][aria-selected]'),
+            ).find((b) => b.textContent?.includes('Store'));
+            expect(storeButton).toBeUndefined();
+        });
+
+        it('renders store as a clickable button when `works-store` is enabled (flag flipped on)', () => {
+            // disabledKinds=[] mirrors every flag resolving to true (or
+            // missing — fail-open). For store specifically this means the
+            // hypothetical post-flip state where the flag is `active: true`.
+            const { container } = render(<NewPageClient disabledKinds={[]} />);
+            const storeSpan = container.querySelector('span[data-testid="new-chip-store"]');
+            expect(storeSpan).toBeNull();
+            const storeButton = Array.from(
+                container.querySelectorAll('button[role="option"][aria-selected]'),
+            ).find((b) => b.textContent?.includes('Store'));
+            expect(storeButton).toBeTruthy();
+        });
     });
 
     it('pre-selects the chip from initialType prop', () => {


### PR DESCRIPTION
## Summary

Replaces the hardcoded `comingSoon: true` baseline on the `store` chip with `disabledSet.has('store')` in both `/new` (`NewPageClient.tsx`) and `/works/new` (`new-work-client.tsx`). The chip's SOON state is now driven by the `works-store` PostHog flag like every other work kind.

The `works-store` flag exists in PostHog (project `144390`, id `693323`) with `active: false`, so the chip continues to render as the inert "Soon" baseline today — **no user-facing change**. The win is that the SOON state can now be flipped from PostHog without a code change, matching how every other kind already works.

Surrounding chip-comment blocks updated to reflect that `store` is no longer the lone hardcoded baseline. Nothing else is touched — selection guards, `ALL_*_CHIP_VALUES` (already include `'store'`), submit handlers, and the `'store' as const` literal all stay as they are. `company` stays a hardcoded baseline on `/works/new` (its live counterpart lives on `/new`).

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @ever-works/contracts build && pnpm --filter @ever-works/plugin build` (dist required by tsc)
- [x] `tsc --noEmit -p apps/web/tsconfig.json` — clean (no production-source errors)
- [x] `eslint` on the three changed files — clean
- [x] `vitest run apps/web/src/components/new/NewPageClient.unit.spec.tsx` — 19/19 pass, including:
  - existing "10 live chips in spec order" test, retargeted with `disabledKinds={['store']}` to mirror the current PostHog state
  - new `store chip is flag-controlled like every other kind` describe-block: store renders as the inert "Soon" span when `disabledKinds={['store']}` (flag off) and as a clickable button when `disabledKinds={[]}` (flag on)
- [ ] PostHog flag flip smoke (manual, post-merge): toggle `works-store` to `active: true` for a target user and confirm the chip becomes clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)