### PR TITLE
feat(deploy): add ever-works provider alias and k8s workflow support

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -209,6 +209,25 @@ describe('DeployController', () => {
             });
         });
 
+        it('treats ever-works as available when the k8s plugin is loaded', async () => {
+            deployFacade.getAvailableProviders.mockReturnValue([
+                { id: 'k8s', name: 'Kubernetes', enabled: true },
+            ]);
+            deployFacade.isProviderConfigured.mockResolvedValue(true);
+
+            const result = await controller.isProviderConfigured(auth, 'ever-works');
+
+            expect(deployFacade.isProviderConfigured).toHaveBeenCalledWith(
+                'ever-works',
+                'caller-1',
+            );
+            expect(result).toMatchObject({
+                configured: true,
+                available: true,
+                enabled: true,
+            });
+        });
+
         it('returns configured:false with the not-configured-message when enabled but unconfigured', async () => {
             deployFacade.getAvailableProviders.mockReturnValue([
                 { id: 'vercel', name: 'Vercel', enabled: true },

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -27,6 +27,15 @@ import { DeployWorkDto, RollbackDto } from './dto/deploy.dto';
 import { BatchDeployDto, BatchDeployResponseDto } from './dto/batch-deploy.dto';
 import { AddDomainDto } from './dto/domain.dto';
 
+const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
+const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
+
+function resolveDeployProviderId(providerId: string): string {
+    return providerId === EVER_WORKS_DEPLOY_PROVIDER_ID
+        ? KUBERNETES_DEPLOY_PROVIDER_ID
+        : providerId;
+}
+
 @ApiTags('Deploy')
 @ApiBearerAuth('JWT-auth')
 @Controller('api/deploy')
@@ -43,8 +52,9 @@ export class DeployController {
 
     private getProviderName(deployProvider: string | undefined): string {
         if (!deployProvider) return 'Deployment';
+        const resolvedProviderId = resolveDeployProviderId(deployProvider);
         const providers = this.deployFacade.getAvailableProviders();
-        const provider = providers.find((p) => p.id === deployProvider);
+        const provider = providers.find((p) => p.id === resolvedProviderId);
         return provider?.name || deployProvider;
     }
 
@@ -80,7 +90,8 @@ export class DeployController {
         @Param('providerId') providerId: string,
     ) {
         const providers = this.deployFacade.getAvailableProviders();
-        const provider = providers.find((p) => p.id === providerId);
+        const resolvedProviderId = resolveDeployProviderId(providerId);
+        const provider = providers.find((p) => p.id === resolvedProviderId);
 
         if (!provider) {
             return {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -62,6 +62,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         /** EW-120 dual-mode Activity Feed sync. Defaults to `push` to keep
          *  pre-dual-mode tests behaving as before. */
         activitySyncMode?: 'pull' | 'push' | 'disabled';
+        githubPluginOverrides?: Record<string, unknown>;
     }) => {
         const websiteOwner = overrides.websiteOwner ?? 'acme';
         const work = {
@@ -112,6 +113,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             dispatchWorkflow: jest.fn().mockResolvedValue(undefined),
             getRepositoryPublicKey: jest.fn().mockResolvedValue({ key_id: 'k', key: 'pubkey' }),
             enableDeploymentWorkflows: jest.fn().mockResolvedValue(undefined),
+            ...(overrides.githubPluginOverrides ?? {}),
         };
 
         const pluginRegistry = {
@@ -222,6 +224,36 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         const { dispatches } = captureCalls(githubPlugin);
         const workflows = dispatches.map((d: any) => d.workflow);
         expect(workflows).toEqual(['deploy_k8s.yaml']);
+    });
+
+    it('syncs the website template before dispatch when the required workflow is missing', async () => {
+        const notFound = Object.assign(new Error('Not found'), { status: 404 });
+        const getFileContent = jest
+            .fn()
+            .mockRejectedValueOnce(notFound)
+            .mockResolvedValueOnce('name: Kubernetes deploy');
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+            },
+            githubPluginOverrides: { getFileContent },
+        });
+        jest.spyOn(service as any, 'delay').mockResolvedValue(undefined);
+
+        const result = await service.deploy('work-1', 'user-1', {});
+
+        expect(result.dispatched).toBe(true);
+        expect(getFileContent).toHaveBeenNthCalledWith(
+            1,
+            'acme',
+            'acme-site',
+            '.github/workflows/deploy_k8s.yaml',
+            'gh-token',
+            'main',
+        );
+        expect(githubPlugin.dispatchWorkflow).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to deploy_prod.yaml for plugins without getWorkflowFilenames', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -870,6 +870,87 @@ export class DeployService {
         return randomBytes(this.CRON_SECRET_LENGTH).toString('hex');
     }
 
+    private async findMissingWorkflowFiles(
+        owner: string,
+        repo: string,
+        token: string,
+        branch: string,
+        workflowFiles: readonly string[],
+    ): Promise<string[] | null> {
+        const plugin = this.getGitHubPlugin();
+        if (typeof plugin.getFileContent !== 'function') {
+            return null;
+        }
+
+        const missing: string[] = [];
+        for (const workflowFile of workflowFiles) {
+            const workflowPath = `.github/workflows/${workflowFile}`;
+            try {
+                await plugin.getFileContent(owner, repo, workflowPath, token, branch);
+            } catch (error: any) {
+                if (this.isRepositoryFileNotFound(error)) {
+                    missing.push(workflowFile);
+                    continue;
+                }
+
+                this.logger.warn(
+                    `Could not preflight workflow file "${workflowPath}" in ${owner}/${repo}@${branch}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                return null;
+            }
+        }
+
+        return missing;
+    }
+
+    private isRepositoryFileNotFound(error: unknown): boolean {
+        const maybeError = error as {
+            status?: number;
+            response?: { status?: number };
+            message?: string;
+        };
+        const status = maybeError?.status ?? maybeError?.response?.status;
+        if (status === 404) return true;
+
+        return typeof maybeError?.message === 'string' && /not found/i.test(maybeError.message);
+    }
+
+    private async areAllWorkflowFilesMissing(params: {
+        owner: string;
+        repo: string;
+        token: string;
+        branch: string;
+        workflowFiles: readonly string[];
+        phase: 'initial' | 'post-update';
+    }): Promise<boolean> {
+        const missing = await this.findMissingWorkflowFiles(
+            params.owner,
+            params.repo,
+            params.token,
+            params.branch,
+            params.workflowFiles,
+        );
+
+        if (!missing || missing.length === 0) {
+            return false;
+        }
+
+        const missingList = missing.join(', ');
+        if (missing.length === params.workflowFiles.length) {
+            this.logger.warn(
+                `Deployment workflow preflight (${params.phase}) found no configured workflow files in ${params.owner}/${params.repo}@${params.branch}: ${missingList}`,
+            );
+            return true;
+        }
+
+        this.logger.warn(
+            `Deployment workflow preflight (${params.phase}) found missing optional workflow file(s) in ${params.owner}/${params.repo}@${params.branch}: ${missingList}`,
+        );
+        return false;
+    }
+
     private async dispatchWithRetry(
         work: Work,
         user: User,
@@ -927,8 +1008,17 @@ export class DeployService {
             return false;
         };
 
-        // First attempt
-        const firstAttemptSuccess = await tryDispatch();
+        // First attempt. If the repo is missing every expected workflow,
+        // skip the doomed dispatch and sync from the selected template first.
+        const skipFirstAttempt = await this.areAllWorkflowFilesMissing({
+            owner,
+            repo,
+            token: gitToken,
+            branch: dispatchBranch,
+            workflowFiles: workflowFilesToTry,
+            phase: 'initial',
+        });
+        const firstAttemptSuccess = skipFirstAttempt ? false : await tryDispatch();
         if (firstAttemptSuccess) {
             return true;
         }
@@ -939,6 +1029,21 @@ export class DeployService {
             await this.websiteUpdateService.updateRepository(work, user);
             await this.createTriggerCommit(work, user);
             await this.delay(3000);
+
+            const stillMissingAllWorkflows = await this.areAllWorkflowFilesMissing({
+                owner,
+                repo,
+                token: gitToken,
+                branch: dispatchBranch,
+                workflowFiles: workflowFilesToTry,
+                phase: 'post-update',
+            });
+            if (stillMissingAllWorkflows) {
+                this.logger.error(
+                    `Deployment cannot continue because ${owner}/${repo}@${dispatchBranch} does not contain any expected deployment workflow: ${workflowFilesToTry.join(', ')}`,
+                );
+                return false;
+            }
 
             const retrySuccess = await tryDispatch();
             if (retrySuccess) {

--- a/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.spec.ts
@@ -419,6 +419,29 @@ describe('DeploymentVerifierService', () => {
             expect((completedEvent as any).payload.providerName).toBe('Vercel');
         });
 
+        it('resolves ever-works through the k8s plugin for terminal event metadata', async () => {
+            deployFacade.lookupExistingDeployment.mockResolvedValueOnce({
+                found: true,
+                deploymentState: 'READY',
+            });
+            pluginRegistry.get.mockReturnValueOnce({
+                plugin: { providerName: 'Kubernetes', name: 'Kubernetes' },
+            } as any);
+
+            await service.startVerification(
+                buildWork({ deployProvider: 'ever-works' }) as any,
+                'user-1',
+            );
+            await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(pluginRegistry.get).toHaveBeenCalledWith('k8s');
+            const completedEvent = eventEmitter.emit.mock.calls.find(
+                (c) => c[0] === DeploymentCompletedEvent.EVENT_NAME,
+            )![1];
+            expect((completedEvent as any).payload.providerId).toBe('ever-works');
+            expect((completedEvent as any).payload.providerName).toBe('Kubernetes');
+        });
+
         it('falls back to plugin.name when providerName is missing', async () => {
             deployFacade.lookupExistingDeployment.mockResolvedValueOnce({
                 found: true,

--- a/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.ts
@@ -22,6 +22,15 @@ type DeploymentTerminalState = 'READY' | 'ERROR' | 'CANCELED' | 'TIMEOUT';
 const isTerminalState = (state: DeploymentReadyState): state is DeploymentTerminalState =>
     state === 'READY' || state === 'ERROR' || state === 'CANCELED' || state === 'TIMEOUT';
 
+const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
+const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
+
+function resolveDeployProviderId(providerId: string): string {
+    return providerId === EVER_WORKS_DEPLOY_PROVIDER_ID
+        ? KUBERNETES_DEPLOY_PROVIDER_ID
+        : providerId;
+}
+
 /**
  * DeploymentVerifierService monitors deployment progress and updates work status.
  *
@@ -224,7 +233,7 @@ export class DeploymentVerifierService {
         const providerId = work.deployProvider;
         if (!providerId) return;
 
-        const registered = this.pluginRegistry.get(providerId);
+        const registered = this.pluginRegistry.get(resolveDeployProviderId(providerId));
         const plugin = registered?.plugin as IDeploymentPlugin | undefined;
         const providerName = plugin?.providerName ?? plugin?.name ?? providerId;
 

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -88,6 +88,32 @@ describe('DeployFacadeService', () => {
         ]);
     });
 
+    it('checks configured state for the ever-works alias against k8s settings', async () => {
+        const { service, registry, settingsService } = createService({
+            deployProvider: 'ever-works',
+            pluginId: 'k8s',
+            settings: { clusterSource: { value: 'k8s-works' } },
+        });
+
+        await expect(service.isProviderConfigured('ever-works', 'user-1', 'work-1')).resolves.toBe(
+            true,
+        );
+
+        expect(registry.get).toHaveBeenCalledWith('k8s');
+        expect(settingsService.getResolvedSettings).toHaveBeenCalledWith('k8s', {
+            userId: 'user-1',
+            workId: 'work-1',
+            includeSecrets: true,
+        });
+    });
+
+    it('uses the resolved plugin display name for the ever-works alias', () => {
+        const { service } = createService({ deployProvider: 'ever-works', pluginId: 'k8s' });
+
+        expect(service.resolveProviderId('ever-works')).toBe('k8s');
+        expect(service.getProviderName('ever-works')).toBe('Kubernetes');
+    });
+
     it('does not report an unconfigured loaded provider as configured', async () => {
         const { service } = createService({
             deployProvider: 'k8s',
@@ -100,6 +126,34 @@ describe('DeployFacadeService', () => {
             id: 'k8s',
             enabled: true,
             configured: false,
+        });
+    });
+
+    describe('auto-assigned deployment domains', () => {
+        const originalDomain = process.env.EVER_WORKS_DOMAIN;
+
+        afterEach(() => {
+            if (originalDomain === undefined) {
+                delete process.env.EVER_WORKS_DOMAIN;
+            } else {
+                process.env.EVER_WORKS_DOMAIN = originalDomain;
+            }
+        });
+
+        it('treats Ever Works subdomains as auto-assigned', () => {
+            const { service } = createService({ deployProvider: 'k8s' });
+
+            expect((service as any).isAutoAssignedDomain('my-site.ever.works')).toBe(true);
+            expect((service as any).isAutoAssignedDomain('my-site.vercel.app')).toBe(true);
+            expect((service as any).isAutoAssignedDomain('www.customer.com')).toBe(false);
+        });
+
+        it('respects EVER_WORKS_DOMAIN overrides for auto-assigned domains', () => {
+            process.env.EVER_WORKS_DOMAIN = 'preview.ever.works';
+            const { service } = createService({ deployProvider: 'k8s' });
+
+            expect((service as any).isAutoAssignedDomain('my-site.preview.ever.works')).toBe(true);
+            expect((service as any).isAutoAssignedDomain('my-site.ever.works')).toBe(false);
         });
     });
 

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -94,6 +94,20 @@ export class DeployFacadeService implements IDeployFacade {
         private readonly workPluginRepository?: WorkPluginRepository,
     ) {}
 
+    resolveProviderId(providerId: string): string {
+        return resolvePluginProviderId(providerId);
+    }
+
+    getProviderName(providerId: string | undefined): string {
+        if (!providerId) return 'Deployment';
+
+        const resolvedProviderId = resolvePluginProviderId(providerId);
+        const registered = this.registry.get(resolvedProviderId);
+        const plugin = registered?.plugin as IDeploymentPlugin | undefined;
+
+        return plugin?.name || plugin?.providerName || providerId;
+    }
+
     /**
      * Check if deployment is configured for a work
      */
@@ -132,14 +146,15 @@ export class DeployFacadeService implements IDeployFacade {
         userId: string,
         workId?: string,
     ): Promise<boolean> {
-        const registered = this.registry.get(providerId);
+        const resolvedProviderId = resolvePluginProviderId(providerId);
+        const registered = this.registry.get(resolvedProviderId);
         if (!registered || registered.state !== 'loaded') {
             return false;
         }
         if (!registered.manifest.capabilities.includes(this.CAPABILITY)) {
             return false;
         }
-        return !!(await this.getTokenFromSettings(providerId, userId, workId));
+        return !!(await this.getTokenFromSettings(resolvedProviderId, userId, workId));
     }
 
     /**
@@ -574,7 +589,8 @@ export class DeployFacadeService implements IDeployFacade {
         if (!domain.verified) return;
 
         // Only promote to primary URL if current website is auto-assigned or unset
-        const isAutoAssigned = !work.website || work.website.endsWith('.vercel.app');
+        const currentHost = this.extractHostname(work.website);
+        const isAutoAssigned = !currentHost || this.isAutoAssignedDomain(currentHost);
         if (!isAutoAssigned) return;
 
         await this.workRepository.update(work.id, {
@@ -582,8 +598,34 @@ export class DeployFacadeService implements IDeployFacade {
         });
     }
 
+    private extractHostname(value?: string | null): string | undefined {
+        if (!value) return undefined;
+        try {
+            return new URL(value).hostname.toLowerCase();
+        } catch {
+            return (
+                value
+                    .replace(/^https?:\/\//, '')
+                    .split('/')[0]
+                    ?.toLowerCase() || undefined
+            );
+        }
+    }
+
     private isAutoAssignedDomain(domain: string): boolean {
-        return domain.endsWith('.vercel.app');
+        const host = this.extractHostname(domain);
+        if (!host) return false;
+
+        const everWorksDomain = (process.env.EVER_WORKS_DOMAIN || 'ever.works')
+            .trim()
+            .replace(/^\.+|\.+$/g, '')
+            .toLowerCase();
+
+        return (
+            host.endsWith('.vercel.app') ||
+            (Boolean(everWorksDomain) &&
+                (host === everWorksDomain || host.endsWith(`.${everWorksDomain}`)))
+        );
     }
 
     private sortDomainsForDisplay(domains: DeploymentDomain[]): DeploymentDomain[] {

--- a/packages/plugins/github/src/types.ts
+++ b/packages/plugins/github/src/types.ts
@@ -46,5 +46,6 @@ export interface GitHubActionSecret {
 export const ACTIVE_WORKFLOW_NAMES = ['Vercel Deployment', 'Production deployment'] as const;
 export const ACTIVE_WORKFLOW_FILES = [
 	'.github/workflows/deploy_vercel.yaml',
-	'.github/workflows/deploy_prod.yaml'
+	'.github/workflows/deploy_prod.yaml',
+	'.github/workflows/deploy_k8s.yaml'
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved deployment workflow detection with preflight checks; the system now verifies workflow files exist before dispatching to prevent failed deployments.
  * Fixed provider ID normalization for the "ever-works" deployment provider to ensure consistent configuration checks.
  * Enhanced domain auto-assignment detection to recognize Ever Works domains alongside Vercel domains.

* **New Features**
  * Added support for the `deploy_k8s.yaml` workflow file in deployment pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->