### PR TITLE
feat(pipeline): canSkipAtBuildTime hook + drop in-execute gate on memory modifier

### DIFF
--- a/packages/agent/src/pipeline/__tests__/pipeline-builder.service.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/pipeline-builder.service.spec.ts
@@ -6,6 +6,7 @@ import {
     MissingDependencyError,
 } from '../pipeline-builder.service';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
 import { MockPipelinePlugin } from './mock-pipeline-plugin';
 import type {
     IPlugin,
@@ -123,7 +124,10 @@ describe('PipelineBuilderService', () => {
         autoEnable: true,
     });
 
+    let settingsService: { getSettings: jest.Mock };
+
     beforeEach(async () => {
+        settingsService = { getSettings: jest.fn().mockResolvedValue({}) };
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 PipelineBuilderService,
@@ -136,6 +140,13 @@ describe('PipelineBuilderService', () => {
                         on: jest.fn(),
                         off: jest.fn(),
                     },
+                },
+                {
+                    // PR #1087 — builder now calls
+                    // `PluginSettingsService.getSettings` to resolve
+                    // settings for `canSkipAtBuildTime`.
+                    provide: PluginSettingsService,
+                    useValue: settingsService,
                 },
             ],
         }).compile();
@@ -577,6 +588,107 @@ describe('PipelineBuilderService', () => {
 
             expect(pipeline.steps.some((s) => s.id === 'enabled-step')).toBe(true);
             expect(pipeline.steps.some((s) => s.id === 'disabled-step')).toBe(false);
+        });
+    });
+
+    describe('canSkipAtBuildTime wiring (PR #1087 — KB option B)', () => {
+        function makeModifierWithBuildTimeSkip(
+            id: string,
+            stepId: string,
+            canSkipAtBuildTime: jest.Mock,
+        ) {
+            const stepDef: PipelineStepDefinition = {
+                id: stepId,
+                name: 'Injected step',
+                position: { type: 'last' },
+            };
+            const modifier: any = {
+                id,
+                name: `Plugin ${id}`,
+                version: '1.0.0',
+                category: 'utility',
+                capabilities: ['pipeline-modifier'],
+                targetPipelines: ['standard-pipeline'],
+                settingsSchema: { type: 'object', properties: {} },
+                configurationMode: 'hybrid',
+                onLoad: jest.fn(),
+                onUnload: jest.fn(),
+                getStepDefinition: () => stepDef,
+                execute: jest.fn().mockImplementation((ctx: any) => Promise.resolve(ctx)),
+                canSkipAtBuildTime,
+            };
+            return { modifier, stepId };
+        }
+
+        it('omits the modifier and its injected step when canSkipAtBuildTime returns true', async () => {
+            const canSkip = jest.fn().mockResolvedValue(true);
+            const { modifier, stepId } = makeModifierWithBuildTimeSkip(
+                'mod-opt-out',
+                'opt-out-step',
+                canSkip,
+            );
+            settingsService.getSettings.mockResolvedValueOnce({ enabled: false });
+            registry.register(modifier, createMockManifest('mod-opt-out'), { state: 'loaded' });
+
+            const pipeline = await service.build(standardPlugin, 'work-1', 'user-1');
+
+            expect(canSkip).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    settings: { enabled: false },
+                    workId: 'work-1',
+                    userId: 'user-1',
+                    pipelineId: 'standard-pipeline',
+                }),
+            );
+            expect(pipeline.steps.some((s) => s.id === stepId)).toBe(false);
+        });
+
+        it('includes the modifier when canSkipAtBuildTime returns false', async () => {
+            const canSkip = jest.fn().mockResolvedValue(false);
+            const { modifier, stepId } = makeModifierWithBuildTimeSkip(
+                'mod-opt-in',
+                'opt-in-step',
+                canSkip,
+            );
+            settingsService.getSettings.mockResolvedValueOnce({ enabled: true });
+            registry.register(modifier, createMockManifest('mod-opt-in'), { state: 'loaded' });
+
+            const pipeline = await service.build(standardPlugin, 'work-1', 'user-1');
+
+            expect(canSkip).toHaveBeenCalledTimes(1);
+            expect(pipeline.steps.some((s) => s.id === stepId)).toBe(true);
+        });
+
+        it('treats a throwing canSkipAtBuildTime as "do not skip" (fail-open)', async () => {
+            const canSkip = jest.fn().mockRejectedValueOnce(new Error('settings DB down'));
+            const { modifier, stepId } = makeModifierWithBuildTimeSkip(
+                'mod-broken',
+                'broken-modifier-step',
+                canSkip,
+            );
+            registry.register(modifier, createMockManifest('mod-broken'), { state: 'loaded' });
+
+            const pipeline = await service.build(standardPlugin, 'work-1', 'user-1');
+
+            expect(pipeline.steps.some((s) => s.id === stepId)).toBe(true);
+        });
+
+        it('still injects when canSkipAtBuildTime is undefined (backwards compatible)', async () => {
+            const stepDef: PipelineStepDefinition = {
+                id: 'legacy-modifier-step',
+                name: 'Legacy injected step',
+                position: { type: 'last' },
+            };
+            const legacy = createMockPipelinePlugin('legacy-mod', stepDef);
+            // canSkipAtBuildTime is intentionally absent on the legacy
+            // mock — the builder must not require it.
+            registry.register(legacy as unknown as IPlugin, createMockManifest('legacy-mod'), {
+                state: 'loaded',
+            });
+
+            const pipeline = await service.build(standardPlugin, 'work-1', 'user-1');
+
+            expect(pipeline.steps.some((s) => s.id === stepDef.id)).toBe(true);
         });
     });
 });

--- a/packages/agent/src/pipeline/pipeline-builder.service.ts
+++ b/packages/agent/src/pipeline/pipeline-builder.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import type {
     PipelineStepDefinition,
     StepPosition,
@@ -13,6 +13,7 @@ import {
     PluginRegistryService,
     RegisteredPlugin,
 } from '../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 
 /**
  * Create an empty executable pipeline
@@ -89,7 +90,14 @@ export class MissingDependencyError extends Error {
 export class PipelineBuilderService {
     private readonly logger = new Logger(PipelineBuilderService.name);
 
-    constructor(private readonly registry: PluginRegistryService) {}
+    constructor(
+        private readonly registry: PluginRegistryService,
+        // @Optional() because some unit tests construct this service
+        // directly without a settings service. PR #1087 — KB option B
+        // (canSkipAtBuildTime) needs settings resolution to call the
+        // hook with the resolved per-Work hierarchy.
+        @Optional() private readonly settingsService?: PluginSettingsService,
+    ) {}
 
     /**
      * Build an executable pipeline for a work.
@@ -235,6 +243,42 @@ export class PipelineBuilderService {
             const targets =
                 registered.plugin.targetPipelines ?? registered.manifest.targetPipelines;
             if (!targets?.includes(pipelineId) && !targets?.includes('*')) continue;
+
+            // PR #1087 — KB option B. If the modifier implements
+            // `canSkipAtBuildTime`, resolve its settings and let it
+            // decide whether to participate in this run. This replaces
+            // the previous pattern where modifiers had to gate inside
+            // `execute()` after their steps were already injected.
+            // Fail-open: a thrown error is treated as "don't skip" so
+            // a buggy modifier doesn't silently disappear.
+            if (typeof registered.plugin.canSkipAtBuildTime === 'function') {
+                let skip = false;
+                try {
+                    const settings = this.settingsService
+                        ? await this.settingsService.getSettings(registered.plugin.id, {
+                              userId,
+                              workId,
+                              includeSecrets: true,
+                          })
+                        : {};
+                    skip = await registered.plugin.canSkipAtBuildTime({
+                        settings,
+                        ...(workId ? { workId } : {}),
+                        ...(userId ? { userId } : {}),
+                        pipelineId,
+                    });
+                } catch (err) {
+                    this.logger.warn(
+                        `Modifier "${registered.plugin.id}".canSkipAtBuildTime threw — treating as don't-skip: ${(err as Error).message}`,
+                    );
+                }
+                if (skip) {
+                    this.logger.debug(
+                        `Modifier "${registered.plugin.id}" requested skip for pipeline=${pipelineId} work=${workId ?? '-'} user=${userId ?? '-'}`,
+                    );
+                    continue;
+                }
+            }
 
             result.push({
                 registered,

--- a/packages/plugin/src/contracts/capabilities/pipeline-modifier.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/pipeline-modifier.interface.ts
@@ -4,6 +4,27 @@ import type { PipelineStepDefinition } from '../../pipeline/step-definition.type
 import type { StepExecutionOptions, StepProgressCallback } from './pipeline-plugin.interface.js';
 
 /**
+ * Build-time check input passed to `IPipelineModifierPlugin.canSkipAtBuildTime`.
+ *
+ * The narrow shape — settings + scope keys + pipeline id — is everything
+ * a sensible build-time decision needs. We deliberately do NOT pass an
+ * `IPipelineContext` here because the host pipeline hasn't constructed
+ * its context yet at build time, and a "partial context" contract would
+ * be a footgun (each modifier would have to defensively `?.` every field
+ * it might want to read).
+ */
+export interface ModifierBuildTimeCheck {
+	/** Resolved plugin settings (4-level hierarchy, secrets included). */
+	readonly settings: Record<string, unknown>;
+	/** The Work the pipeline is being built for, when one exists. */
+	readonly workId?: string;
+	/** The user the pipeline is being built for, when one exists. */
+	readonly userId?: string;
+	/** Id of the host pipeline (e.g. `'standard-pipeline'`). */
+	readonly pipelineId: string;
+}
+
+/**
  * Pipeline modifier plugin interface.
  * Capability: 'pipeline-modifier'
  *
@@ -23,6 +44,24 @@ export interface IPipelineModifierPlugin extends IPlugin {
 		options?: StepExecutionOptions,
 		onProgress?: StepProgressCallback
 	): Promise<IPipelineContext>;
+
+	/**
+	 * Called by `PipelineBuilderService` before this modifier's steps
+	 * are injected into the host pipeline. Return `true` to skip the
+	 * modifier entirely for the given run — neither its injected steps
+	 * nor its `execute()` will fire.
+	 *
+	 * Distinct from `canSkip(context)` (kept for backwards compatibility
+	 * / runtime-decided skips): the build-time hook has a narrow,
+	 * settings-focused signature that's resolvable BEFORE the host
+	 * pipeline has constructed its context. Use this for the common
+	 * "skip when an opt-in flag is off" case; use `canSkip(context)`
+	 * for runtime decisions that need pipeline state.
+	 *
+	 * Added in PR #1087 — Workspace KB
+	 * `2026-05-28-pipeline-builder-canskip-proposal.md` option B.
+	 */
+	canSkipAtBuildTime?(input: ModifierBuildTimeCheck): Promise<boolean>;
 
 	canSkip?(context: IPipelineContext): Promise<boolean>;
 	validate?(context: IPipelineContext): Promise<{ valid: boolean; error?: string }>;

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -98,14 +98,44 @@ describe('MemoryPipelineModifierPlugin', () => {
 		});
 	});
 
-	describe('enabled gate inside execute()', () => {
-		it('no-ops when stepSettings.enabled !== true (since pipeline builder may not call canSkip)', async () => {
+	describe("defensive enabled guard inside execute() (host doesn't honour canSkipAtBuildTime)", () => {
+		it('silently no-ops when stepSettings.enabled !== true', async () => {
+			// PR #1087 makes canSkipAtBuildTime the canonical gate, but
+			// we keep this guard for older agent builds / third-party
+			// orchestrators that don't call it.
 			const context = makeContext({}, false);
 			await plugin.execute(context, {
 				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
 			});
 			expect(memoryFacade.buildContext).not.toHaveBeenCalled();
-			expect(logger.log).toHaveBeenCalledWith(expect.stringMatching(/disabled by settings/));
+		});
+	});
+
+	describe('canSkipAtBuildTime (KB option B, PR #1087)', () => {
+		it('returns true when settings.enabled is missing (default off)', async () => {
+			await expect(plugin.canSkipAtBuildTime({ settings: {}, pipelineId: 'standard-pipeline' })).resolves.toBe(
+				true
+			);
+		});
+
+		it('returns true when settings.enabled === false', async () => {
+			await expect(
+				plugin.canSkipAtBuildTime({
+					settings: { enabled: false },
+					pipelineId: 'standard-pipeline'
+				})
+			).resolves.toBe(true);
+		});
+
+		it('returns false when settings.enabled === true (work opts in)', async () => {
+			await expect(
+				plugin.canSkipAtBuildTime({
+					settings: { enabled: true },
+					pipelineId: 'standard-pipeline',
+					workId: 'work-1',
+					userId: 'u-1'
+				})
+			).resolves.toBe(false);
 		});
 	});
 

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -2,6 +2,7 @@ import type {
 	IPlugin,
 	IPipelineModifierPlugin,
 	IPipelineContext,
+	ModifierBuildTimeCheck,
 	PluginContext,
 	PluginCategory,
 	JsonSchema,
@@ -208,6 +209,17 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 		return settings.enabled !== true;
 	}
 
+	/**
+	 * KB option B (PR #1087). The pipeline-builder calls this BEFORE
+	 * injecting our steps, so disabling the modifier here means zero
+	 * overhead on the host pipeline — no STEP_STARTED events, no step
+	 * metrics, no executor branching. Decision is purely settings-based,
+	 * matching the existing `canSkip(context)` semantics.
+	 */
+	async canSkipAtBuildTime(input: ModifierBuildTimeCheck): Promise<boolean> {
+		return input.settings.enabled !== true;
+	}
+
 	async execute(
 		context: IPipelineContext,
 		options?: StepExecutionOptions,
@@ -228,12 +240,13 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 		const logger = execContext?.logger ?? console;
 
-		// Honour the work-scoped `enabled` flag at execution time —
-		// `canSkip()` is not currently called by the pipeline builder
-		// (Codex P2 on PR #1081). Until that wiring lands, gate inside
-		// `execute()` so toggling the flag actually disables the steps.
+		// As of PR #1087, `canSkipAtBuildTime` gates this modifier
+		// before its steps are injected, so reaching `execute()` already
+		// implies `settings.enabled === true`. We keep a defensive
+		// check here as a safety net in case the host doesn't honour
+		// canSkipAtBuildTime (older agent build, third-party orchestrator):
+		// silently no-op without warning.
 		if (settings.enabled !== true) {
-			logger.log(`memory-pipeline-modifier: step "${stepId}" disabled by settings — skipping`);
 			return context;
 		}
 


### PR DESCRIPTION
## Summary

Implements **option B** from the [KB article \`2026-05-28-pipeline-builder-canskip-proposal.md\`](https://github.com/ever-works/workspace/blob/develop/knowledge/notes/2026-05-28-pipeline-builder-canskip-proposal.md). Adds a new build-time skip hook to the modifier interface and wires it into the pipeline builder; removes the in-execute gate that \`memory-pipeline-modifier\` carried as a workaround.

## What's in the PR

**1. \`IPipelineModifierPlugin\` contract** — \`@ever-works/plugin\`
- New \`ModifierBuildTimeCheck\` interface: \`{ settings, workId?, userId?, pipelineId }\`.
- New optional \`canSkipAtBuildTime?(input): Promise<boolean>\` on \`IPipelineModifierPlugin\`. JSDoc clearly distinguishes it from the existing \`canSkip(context)\` — the new hook is for settings-driven decisions resolved BEFORE the host pipeline has constructed its context.

**2. \`PipelineBuilderService\`** — \`@ever-works/agent\`
- Injects \`PluginSettingsService\` with \`@Optional()\` so direct-construction unit tests keep working.
- In \`getEnabledModifierPlugins\`, when a modifier implements \`canSkipAtBuildTime\`, resolves its settings via the existing 4-level hierarchy and calls the hook with the resolved scope keys + pipeline id. \`true\` skips the modifier entirely — no steps get injected.
- Fail-open on a throwing modifier: warn-log + treat as \"don't skip\" so a buggy modifier doesn't silently disappear.

**3. \`memory-pipeline-modifier\`**
- Implements \`canSkipAtBuildTime\` returning \`settings.enabled !== true\`.
- The in-execute gate is downgraded to a silent defensive guard (no log spam) so older agent builds or third-party orchestrators that don't honour the new hook still no-op cleanly.

## Tests

- **4 new jest** cases in \`pipeline-builder.service.spec.ts\`: skipped on \`true\`, included on \`false\`, throwing-hook fail-open, backwards-compat (modifier without the method still injected).
- **3 new vitest** cases on memory-pipeline-modifier covering all three return-value branches.
- Old \"no-ops when enabled !== true (since pipeline builder may not call canSkip)\" test reframed as the silent defensive guard.
- Full agent suite: **287 suites, 5625 tests passing** (was 5571 → +54 new in this PR + the three PRs landing alongside).
- Prettier \`format:check\` clean.

## Related

Builds directly on PRs **#1073**, **#1081**, **#1082**, **#1084**, **#1086** (all merged earlier this session) and closes the loop the KB article opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)