### PR TITLE
fix(email,notify): scope outbound address + channel lookups to caller (Codex on #1085)

### DIFF
--- a/apps/api/src/email/email.service.spec.ts
+++ b/apps/api/src/email/email.service.spec.ts
@@ -1,0 +1,112 @@
+// Stub the agent subpaths so their transitive `@ever-works/agent/database` →
+// `database.config.ts` (api-only `@src/config`) is never pulled into this spec.
+jest.mock('@ever-works/agent/database', () => ({
+    TenantEmailAddressRepository: class TenantEmailAddressRepository {},
+    AgentEmailAssignmentRepository: class AgentEmailAssignmentRepository {},
+    EmailMessageRepository: class EmailMessageRepository {},
+}));
+jest.mock('@ever-works/agent/facades', () => ({
+    EmailFacadeService: class EmailFacadeService {},
+}));
+jest.mock('./templates/render', () => ({
+    renderTemplate: jest.fn(),
+    listTemplates: jest.fn(() => []),
+}));
+
+import { NotFoundException } from '@nestjs/common';
+import { EmailService } from './email.service';
+
+/**
+ * EmailService — security-scoped behaviour around `sendMessage`.
+ *
+ * Covers the Codex P1 finding on PR #1085: when `fromAddressId` is omitted,
+ * the resolved primary-outbound address MUST belong to the calling user.
+ * Otherwise an authenticated caller who knows another user's `agentId` could
+ * send mail from that user's outbound address.
+ */
+describe('EmailService.sendMessage authorization', () => {
+    let addresses: {
+        findByIdForUser: jest.Mock;
+        findById: jest.Mock;
+    };
+    let assignments: { findPrimaryOutboundForAgent: jest.Mock };
+    let messages: Record<string, jest.Mock>;
+    let emailFacade: { send: jest.Mock };
+    let service: EmailService;
+
+    beforeEach(() => {
+        addresses = {
+            findByIdForUser: jest.fn(),
+            findById: jest.fn(),
+        };
+        assignments = { findPrimaryOutboundForAgent: jest.fn() };
+        messages = {};
+        emailFacade = { send: jest.fn().mockResolvedValue({ providerMessageId: 'pm-1' }) };
+        service = new EmailService(
+            addresses as never,
+            assignments as never,
+            messages as never,
+            emailFacade as never,
+        );
+    });
+
+    it('default path: scopes the resolved address to the caller (findByIdForUser)', async () => {
+        assignments.findPrimaryOutboundForAgent.mockResolvedValue({
+            emailAddressId: 'addr-foreign',
+        });
+        addresses.findByIdForUser.mockResolvedValue({
+            id: 'addr-foreign',
+            address: 'me@x.com',
+            userId: 'user-1',
+        });
+
+        await service.sendMessage('user-1', {
+            agentId: 'agent-foreign',
+            to: ['to@x.com'],
+            subject: 's',
+            bodyText: 'b',
+        });
+
+        expect(addresses.findByIdForUser).toHaveBeenCalledWith('addr-foreign', 'user-1');
+        expect(addresses.findById).not.toHaveBeenCalled();
+    });
+
+    it('default path: throws NotFound when the resolved address belongs to a different user', async () => {
+        assignments.findPrimaryOutboundForAgent.mockResolvedValue({
+            emailAddressId: 'addr-foreign',
+        });
+        // findByIdForUser returns null when (id, userId) does not match — i.e. the
+        // address belongs to another user. We must not fall through to findById.
+        addresses.findByIdForUser.mockResolvedValue(null);
+
+        await expect(
+            service.sendMessage('user-1', {
+                agentId: 'agent-foreign',
+                to: ['to@x.com'],
+                subject: 's',
+                bodyText: 'b',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundException);
+
+        expect(emailFacade.send).not.toHaveBeenCalled();
+    });
+
+    it('explicit fromAddressId path remains user-scoped (no regression)', async () => {
+        addresses.findByIdForUser.mockResolvedValue({
+            id: 'addr-1',
+            address: 'me@x.com',
+            userId: 'user-1',
+        });
+
+        await service.sendMessage('user-1', {
+            agentId: 'agent-1',
+            to: ['to@x.com'],
+            subject: 's',
+            bodyText: 'b',
+            fromAddressId: 'addr-1',
+        });
+
+        expect(addresses.findByIdForUser).toHaveBeenCalledWith('addr-1', 'user-1');
+        expect(assignments.findPrimaryOutboundForAgent).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -148,7 +148,10 @@ export class EmailService {
         } else {
             const assignment = await this.assignments.findPrimaryOutboundForAgent(input.agentId);
             if (assignment) {
-                address = await this.addresses.findById(assignment.emailAddressId);
+                // Codex P1 (PR #1085): scope the resolved address to the caller. Otherwise
+                // an authenticated user who knows another user's agentId could send from
+                // that user's outbound address.
+                address = await this.addresses.findByIdForUser(assignment.emailAddressId, userId);
             }
         }
         if (!address) {

--- a/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../notification-channel.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { NotificationChannelRepository } from '../../database/repositories/notification-channel.repository';
 
 /**
  * EW-672 / T11 — NotificationChannelFacadeService construction + fan-out
@@ -74,5 +75,73 @@ describe('NotificationChannelFacadeService', () => {
                 { userId: 'user-1' },
             ),
         ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
+    });
+});
+
+/**
+ * Codex P2 (PR #1085) — scoping the channel lookup to the caller.
+ *
+ * Without this, an authenticated user could pass a leaked channel UUID owned
+ * by another user and have their text fan out to that user's webhook.
+ */
+describe('NotificationChannelFacadeService channel-ownership scoping', () => {
+    let registry: jest.Mocked<PluginRegistryService>;
+    let settings: jest.Mocked<PluginSettingsService>;
+    let channels: jest.Mocked<NotificationChannelRepository>;
+    let facade: NotificationChannelFacadeService;
+
+    beforeEach(async () => {
+        registry = {
+            getByCapability: jest.fn().mockReturnValue([]),
+        } as unknown as jest.Mocked<PluginRegistryService>;
+        settings = {
+            getResolvedSettings: jest.fn().mockResolvedValue({}),
+        } as unknown as jest.Mocked<PluginSettingsService>;
+        channels = {
+            findById: jest.fn(),
+            findByIdForUser: jest.fn(),
+        } as unknown as jest.Mocked<NotificationChannelRepository>;
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                NotificationChannelFacadeService,
+                { provide: PluginRegistryService, useValue: registry },
+                { provide: PluginSettingsService, useValue: settings },
+                { provide: NotificationChannelRepository, useValue: channels },
+            ],
+        }).compile();
+
+        facade = moduleRef.get(NotificationChannelFacadeService);
+    });
+
+    it('uses findByIdForUser when options.userId is set', async () => {
+        channels.findByIdForUser.mockResolvedValue(null);
+
+        const result = await facade.sendDirect(
+            'channel-foreign',
+            { text: 'pwned', messageRef: 'ref-1' },
+            { userId: 'user-1' },
+        );
+
+        expect(channels.findByIdForUser).toHaveBeenCalledWith('channel-foreign', 'user-1');
+        expect(channels.findById).not.toHaveBeenCalled();
+        // Foreign / missing channel is reported as failed without leaking which.
+        expect(result.status).toBe('failed');
+        expect(result.error).toContain('not found');
+    });
+
+    it('returns "not found" failure when the channel exists but belongs to another user', async () => {
+        // The user-scoped repo method returns null for "exists but foreign" — the
+        // facade must NOT fall back to an unscoped lookup in that case.
+        channels.findByIdForUser.mockResolvedValue(null);
+
+        const result = await facade.sendDirect(
+            'channel-foreign',
+            { text: 'pwned', messageRef: 'ref-1' },
+            { userId: 'user-1' },
+        );
+
+        expect(result.status).toBe('failed');
+        expect(channels.findById).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -157,7 +157,14 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
                 error: 'channels repository not injected',
             };
         }
-        const channel = await this.channels.findById(channelId);
+        // Codex P2 (PR #1085): scope channel lookup to the caller when a userId is
+        // available. Otherwise a caller could supply a leaked channel UUID owned by
+        // another user and have their text fan out to that user's webhook. We
+        // intentionally return the same "not found" shape for "doesn't exist" and
+        // "belongs to someone else" so we don't leak channel existence across users.
+        const channel = options.userId
+            ? await this.channels.findByIdForUser(channelId, options.userId)
+            : await this.channels.findById(channelId);
         if (!channel) {
             return {
                 channelId,


### PR DESCRIPTION
## Summary

Two authorization fixes raised by Codex on the **stage → main cascade PR #1085**. Both bugs let an authenticated user act on another user's resource if they could discover its UUID.

### P1 — `EmailService.sendMessage` default-from path
When the request omits `fromAddressId`, the service resolved the agent's primary-outbound assignment and then loaded the backing tenant address with **unscoped** `addresses.findById(...)`. An authenticated caller who knew another user's `agentId` could make `POST /api/email/messages` select that user's outbound address and send from it.

**Fix:** swap `findById` → `findByIdForUser(emailAddressId, userId)` so the resolved address must belong to the caller. The repo method already exists and is used by the explicit-`fromAddressId` branch right above.

### P2 — `NotificationChannelFacadeService.sendOne` channel lookup
The channel was loaded with unscoped `channels.findById(channelId)`. The fanout path, the per-channel "Test" button, and the agent `notifyChannel` adapter all accept caller-controlled channel ids. A user with a leaked channel UUID owned by someone else could have their text fanned out to that user's webhook.

**Fix:** prefer `channels.findByIdForUser(channelId, options.userId)` when `options.userId` is set, returning the same "not found" failure shape for "doesn't exist" and "belongs to someone else" so we don't leak channel existence across users. The unscoped fallback only fires for genuinely system-level callers (no `userId` on `FacadeOptions`), preserving today's internal callers.

## Test plan

- [x] New `apps/api/src/email/email.service.spec.ts` — default path uses `findByIdForUser`, throws `NotFoundException` on a foreign address, and the explicit-`fromAddressId` path is unchanged.
- [x] New cases in `packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts` — `sendDirect` routes through `findByIdForUser`, foreign channel is reported as failed without falling back to an unscoped lookup.
- [x] `pnpm --filter @ever-works/agent type-check` — green.
- [ ] CI `lint-and-test (22.x)` — must be green.
- [ ] CodeRabbit / Codex pass on the cascade up-stack.

## Notes for reviewers

- Targeting `develop` so this rides the normal release flow (`develop → stage → main`). The cascade PR #1085 will eat these fixes via its next develop→stage rebuild.
- `findByIdForUser` was already on both repos — no schema or signature changes.
- No new dependencies, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)