### PR TITLE
feat(composio): migrate to @composio/core SDK (EW-684 PR-A)

### DIFF
--- a/packages/plugins/composio/README.md
+++ b/packages/plugins/composio/README.md
@@ -18,7 +18,7 @@ Composio Integrations Pipeline Plugin - Executes Composio tools across 500+ thir
 
 This plugin lets Ever Works call any of [Composio](https://composio.dev)'s 500+ third-party integrations (Gmail, Slack, GitHub, Notion, Linear, Salesforce, HubSpot, Stripe, Shopify, Airtable, …) during work generation. Composio brokers OAuth on your behalf — each user connects an app once through Composio's hosted flow, and the platform reuses that connection to execute tools.
 
-Instead of writing a per-app connector for every service your users want to integrate, you ship one plugin (this one) and your users get the entire Composio catalog. The plugin invokes tools via the Composio v3 REST API (`POST /api/v3/tools/execute/{tool_slug}`) and returns the result as pipeline outputs in one of three shapes: structured `{ items: [...] }`, native records with a field mapping, or side-effect only (fire-and-forget).
+Instead of writing a per-app connector for every service your users want to integrate, you ship one plugin (this one) and your users get the entire Composio catalog. The plugin invokes tools through the official [`@composio/core`](https://www.npmjs.com/package/@composio/core) SDK (per Workspace AGENTS.md NN #22 — always use the official vendor SDK) and returns the result as pipeline outputs in one of three shapes: structured `{ items: [...] }`, native records with a field mapping, or side-effect only (fire-and-forget).
 
 ## Why use it?
 
@@ -30,11 +30,11 @@ Instead of writing a per-app connector for every service your users want to inte
 
 ## How it works in Ever Works
 
-When this plugin is selected as the active pipeline, the platform calls the Composio v3 REST API. The 6 sequential steps:
+When this plugin is selected as the active pipeline, the platform drives a `Composio` client from `@composio/core` through 6 sequential steps:
 
-1. **Validate Composio Connection** — verifies the API key is accepted and the user has an ACTIVE connected account for the requested toolkit.
+1. **Validate Composio Connection** — `composio.toolkits.get(...)` confirms the API key is accepted, then `composio.connectedAccounts.list({ userIds, toolkitSlugs })` confirms the user has an ACTIVE connected account for the requested toolkit.
 2. **Prepare Tool Payload** — builds the `arguments` object with work metadata, an optional existing-items summary, an optional GitHub data repository, and any user-supplied tool params.
-3. **Execute Composio Tool** — `POST /tools/execute/{tool_slug}` with `{ user_id, arguments }`.
+3. **Execute Composio Tool** — `composio.tools.execute(toolSlug, { userId, arguments })`. The SDK unwraps the v3 response envelope (`{ successful, data, error, log_id }`) for us.
 4. **Collect & Validate Results** — parses the response, projects records onto work items if needed, deduplicates against existing items.
 5. **Capture Screenshots** (optional) — uses the configured screenshot plugin to fetch images for items without them.
 6. **Cleanup** — releases resources.
@@ -50,7 +50,7 @@ The plugin treats the **tool slug** as the unique identifier of an action (`GMAI
 
 ## Settings
 
-- `apiKey` (**secret**, required) — Composio API key, sent as `x-api-key` on every Composio v3 call.
+- `apiKey` (**secret**, required) — Composio API key, passed to the `@composio/core` SDK at construction time.
 - `baseUrl` — Override the Composio API base URL (leave empty for the default `https://backend.composio.dev/api/v3`).
 - `defaultUserId` — Composio `user_id` to run tools against. Defaults to your Ever Works user id.
 - `defaultToolkit` — Default toolkit slug (e.g. `GMAIL`).

--- a/packages/plugins/composio/package.json
+++ b/packages/plugins/composio/package.json
@@ -32,7 +32,9 @@
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"@composio/core": "^0.10.0"
+	},
 	"peerDependencies": {
 		"@ever-works/plugin": "workspace:*"
 	},

--- a/packages/plugins/composio/src/__tests__/composio-client.spec.ts
+++ b/packages/plugins/composio/src/__tests__/composio-client.spec.ts
@@ -1,29 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ComposioClient } from '../utils/composio-client.js';
+import { ComposioClient, type ComposioSdkLike } from '../utils/composio-client.js';
 import type { ComposioToolRef } from '../types.js';
 
-function jsonResponse(body: unknown, init?: ResponseInit): Response {
-	return new Response(JSON.stringify(body), {
-		status: 200,
-		headers: { 'content-type': 'application/json' },
-		...init
-	});
+/**
+ * Builds a minimal `ComposioSdkLike` stub that satisfies the SDK contract
+ * the plugin uses. Tests then `vi.mocked(stub.tools.execute).mockResolvedValue(...)`.
+ */
+function buildSdkStub(): ComposioSdkLike {
+	return {
+		toolkits: {
+			get: vi.fn()
+		},
+		connectedAccounts: {
+			list: vi.fn()
+		},
+		tools: {
+			execute: vi.fn()
+		}
+	} as unknown as ComposioSdkLike;
 }
 
-function errorResponse(status: number, body: string | object = ''): Response {
-	const text = typeof body === 'string' ? body : JSON.stringify(body);
-	return new Response(text, {
-		status,
-		headers: { 'content-type': typeof body === 'string' ? 'text/plain' : 'application/json' }
-	});
-}
-
-function createClient(fetchImpl: typeof fetch): ComposioClient {
+function createClient(sdk: ComposioSdkLike): ComposioClient {
 	return new ComposioClient({
 		apiKey: 'test-key',
 		baseUrl: 'https://composio.test/api/v3',
 		logger: { log: vi.fn(), warn: vi.fn() },
-		fetchImpl
+		sdkOverride: sdk
 	});
 }
 
@@ -36,7 +38,14 @@ function createRef(overrides: Partial<ComposioToolRef> = {}): ComposioToolRef {
 	};
 }
 
-describe('ComposioClient', () => {
+/** Builds a vendor-shaped error with a numeric `status` field, mirroring how the SDK surfaces HTTP errors. */
+function sdkError(status: number, message: string): Error {
+	const err = new Error(message);
+	(err as { status?: number }).status = status;
+	return err;
+}
+
+describe('ComposioClient (SDK-backed)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -52,223 +61,211 @@ describe('ComposioClient', () => {
 			).toThrow(/API key is required/i);
 		});
 
-		it('strips trailing slashes from the base URL', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [] }));
-			const client = new ComposioClient({
-				apiKey: 'k',
-				baseUrl: 'https://composio.test/api/v3///',
-				logger: { log: vi.fn(), warn: vi.fn() },
-				fetchImpl
-			});
-			await client.listToolkits();
-			const url = (fetchImpl.mock.calls[0][0] as string).split('?')[0];
-			expect(url).toBe('https://composio.test/api/v3/toolkits');
+		it('accepts an sdkOverride to bypass real SDK construction in tests', () => {
+			const sdk = buildSdkStub();
+			expect(() => createClient(sdk)).not.toThrow();
 		});
 	});
 
 	describe('listToolkits', () => {
-		it('sends GET with x-api-key and accept headers', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [{ slug: 'GMAIL', name: 'Gmail' }] }));
-			const client = createClient(fetchImpl);
+		it('calls sdk.toolkits.get with the requested limit', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockResolvedValue({
+				items: [{ slug: 'GMAIL', name: 'Gmail' }]
+			});
 
-			const result = await client.listToolkits(50);
+			const result = await createClient(sdk).listToolkits(50);
 
 			expect(result).toEqual([{ slug: 'GMAIL', name: 'Gmail' }]);
-			const [url, init] = fetchImpl.mock.calls[0];
-			expect((url as string).startsWith('https://composio.test/api/v3/toolkits')).toBe(true);
-			expect(url as string).toContain('limit=50');
-			const headers = new Headers((init as RequestInit).headers);
-			expect(headers.get('x-api-key')).toBe('test-key');
-			expect(headers.get('accept')).toBe('application/json');
+			expect(sdk.toolkits.get).toHaveBeenCalledWith({ limit: 50 });
 		});
 
 		it('clamps the limit into [1, 200]', async () => {
-			// Response bodies are single-use streams — make a fresh one per call.
-			const fetchImpl = vi.fn().mockImplementation(async () => jsonResponse({ items: [] }));
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockResolvedValue({ items: [] });
+			const client = createClient(sdk);
 
 			await client.listToolkits(99999);
-			expect(fetchImpl.mock.calls[0][0] as string).toContain('limit=200');
+			expect(sdk.toolkits.get).toHaveBeenLastCalledWith({ limit: 200 });
 
 			await client.listToolkits(0);
-			expect(fetchImpl.mock.calls[1][0] as string).toContain('limit=1');
+			expect(sdk.toolkits.get).toHaveBeenLastCalledWith({ limit: 1 });
 		});
 
-		it('extracts the array under .items', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [{ slug: 'A' }, { slug: 'B' }] }));
-			const client = createClient(fetchImpl);
-			expect(await client.listToolkits()).toHaveLength(2);
+		it('returns [] when the SDK response has no items', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockResolvedValue({ items: [] });
+
+			expect(await createClient(sdk).listToolkits()).toEqual([]);
 		});
 
-		it('falls back to .data envelope', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [{ slug: 'A' }] }));
-			const client = createClient(fetchImpl);
-			expect(await client.listToolkits()).toHaveLength(1);
-		});
+		it('translates 401 into an actionable API-key error', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(sdkError(401, 'unauthorized'));
 
-		it('returns [] for an unrecognized envelope', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ foo: 'bar' }));
-			const client = createClient(fetchImpl);
-			expect(await client.listToolkits()).toEqual([]);
-		});
-
-		it('translates 401 into an actionable error', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(401, 'bad key'));
-			const client = createClient(fetchImpl);
-
-			await expect(client.listToolkits()).rejects.toThrow(/rejected the API key.*HTTP 401/i);
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/rejected the API key.*HTTP 401/i);
 		});
 
 		it('translates 429 into a rate-limit error', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(429));
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(sdkError(429, 'throttled'));
 
-			await expect(client.listToolkits()).rejects.toThrow(/rate limit/i);
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/rate limit/i);
 		});
 
-		it('translates 5xx into a Composio status error', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(503, 'maintenance'));
-			const client = createClient(fetchImpl);
+		it('translates 5xx into a Composio-status error', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(sdkError(503, 'maintenance'));
 
-			await expect(client.listToolkits()).rejects.toThrow(/HTTP 503/);
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/HTTP 503/);
+		});
+
+		it('preserves the original message for non-HTTP errors', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(new Error('network down'));
+
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/network down/);
 		});
 	});
 
 	describe('listConnectedAccounts', () => {
-		it('sends user_ids and toolkit_slugs (uppercased)', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [] }));
-			const client = createClient(fetchImpl);
+		it('sends userIds and toolkitSlugs as arrays (toolkit uppercased)', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({ items: [] });
 
-			await client.listConnectedAccounts('user-123', 'gmail');
+			await createClient(sdk).listConnectedAccounts('user-123', 'gmail');
 
-			const url = fetchImpl.mock.calls[0][0] as string;
-			expect(url).toContain('user_ids=user-123');
-			expect(url).toContain('toolkit_slugs=GMAIL');
+			expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({
+				userIds: ['user-123'],
+				toolkitSlugs: ['GMAIL']
+			});
 		});
 
-		it('omits toolkit_slugs when toolkit is undefined', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [] }));
-			const client = createClient(fetchImpl);
+		it('omits toolkitSlugs when toolkit is undefined', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({ items: [] });
 
-			await client.listConnectedAccounts('user-123');
+			await createClient(sdk).listConnectedAccounts('user-123');
 
-			const url = fetchImpl.mock.calls[0][0] as string;
-			expect(url).not.toContain('toolkit_slugs=');
+			expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({ userIds: ['user-123'] });
+		});
+
+		it('translates a 401 from the SDK with the friendly API-key message', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockRejectedValue(sdkError(401, 'unauthorized'));
+
+			await expect(createClient(sdk).listConnectedAccounts('user-123')).rejects.toThrow(/rejected the API key/i);
 		});
 	});
 
 	describe('validateConnection', () => {
 		it('succeeds when an ACTIVE account exists', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(
-				jsonResponse({
-					items: [
-						{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } },
-						{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }
-					]
-				})
-			);
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({
+				items: [
+					{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } },
+					{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }
+				]
+			});
 
-			const account = await client.validateConnection(createRef());
+			const account = await createClient(sdk).validateConnection(createRef());
 			expect(account.id).toBe('ca_2');
 		});
 
 		it('normalizes status to upper-case before matching', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(
-					jsonResponse({ items: [{ id: 'ca_x', status: 'active', toolkit: { slug: 'GMAIL' } }] })
-				);
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({
+				items: [{ id: 'ca_x', status: 'active', toolkit: { slug: 'GMAIL' } }]
+			});
 
-			const account = await client.validateConnection(createRef());
+			const account = await createClient(sdk).validateConnection(createRef());
 			expect(account.id).toBe('ca_x');
 		});
 
 		it('throws a friendly error when no ACTIVE account exists', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(
-					jsonResponse({ items: [{ id: 'ca_1', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }] })
-				);
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({
+				items: [{ id: 'ca_1', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }]
+			});
 
-			await expect(client.validateConnection(createRef())).rejects.toThrow(
+			await expect(createClient(sdk).validateConnection(createRef())).rejects.toThrow(
 				/No active Composio connected account/i
 			);
 		});
 	});
 
 	describe('executeTool', () => {
-		it('POSTs to /tools/execute/{slug} with { user_id, arguments }', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(jsonResponse({ successful: true, data: { items: [{ name: 'A' }] } }));
-			const client = createClient(fetchImpl);
+		it('calls sdk.tools.execute with the slug, userId, and arguments', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockResolvedValue({
+				successful: true,
+				data: { items: [{ name: 'A' }] }
+			});
 
-			const result = await client.executeTool(createRef(), { to: 'a@b.c', subject: 'hi' });
+			const result = await createClient(sdk).executeTool(createRef(), { to: 'a@b.c', subject: 'hi' });
 
 			expect((result.data as { items: unknown[] }).items).toHaveLength(1);
 			expect(result.composioDuration).toBeGreaterThanOrEqual(0);
-
-			const [url, init] = fetchImpl.mock.calls[0];
-			expect(url).toBe('https://composio.test/api/v3/tools/execute/GMAIL_SEND_EMAIL');
-			expect((init as RequestInit).method).toBe('POST');
-			const body = JSON.parse((init as { body: string }).body);
-			expect(body.user_id).toBe('user-123');
-			expect(body.arguments).toEqual({ to: 'a@b.c', subject: 'hi' });
+			expect(sdk.tools.execute).toHaveBeenCalledWith('GMAIL_SEND_EMAIL', {
+				userId: 'user-123',
+				arguments: { to: 'a@b.c', subject: 'hi' }
+			});
 		});
 
-		it('URL-encodes the tool slug', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ successful: true, data: {} }));
-			const client = createClient(fetchImpl);
+		it('throws when the SDK envelope reports successful=false', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockResolvedValue({
+				successful: false,
+				error: 'gmail quota exceeded',
+				logId: 'log_42'
+			});
 
-			await client.executeTool(createRef({ toolSlug: 'TOOL/WITH SPACE' }), {});
-
-			const url = fetchImpl.mock.calls[0][0] as string;
-			expect(url).toBe('https://composio.test/api/v3/tools/execute/TOOL%2FWITH%20SPACE');
-		});
-
-		it('converts timeoutMs to seconds in the request body', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ successful: true, data: {} }));
-			const client = createClient(fetchImpl);
-
-			await client.executeTool(createRef(), {}, { timeoutMs: 90_000 });
-
-			const body = JSON.parse((fetchImpl.mock.calls[0][1] as { body: string }).body);
-			expect(body.timeout).toBe(90);
-		});
-
-		it('throws when successful=false even on HTTP 200', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(
-					jsonResponse({ successful: false, error: 'gmail quota exceeded', log_id: 'log_42' })
-				);
-			const client = createClient(fetchImpl);
-
-			await expect(client.executeTool(createRef(), {})).rejects.toThrow(/gmail quota exceeded.*log_42/i);
+			await expect(createClient(sdk).executeTool(createRef(), {})).rejects.toThrow(
+				/gmail quota exceeded.*log_42/i
+			);
 		});
 
 		it('rejects pre-aborted signals before issuing a request', async () => {
-			const fetchImpl = vi.fn();
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
 			const controller = new AbortController();
 			controller.abort();
 
-			await expect(client.executeTool(createRef(), {}, { signal: controller.signal })).rejects.toThrow(
+			await expect(createClient(sdk).executeTool(createRef(), {}, { signal: controller.signal })).rejects.toThrow(
 				/cancelled/i
 			);
-			expect(fetchImpl).not.toHaveBeenCalled();
+			expect(sdk.tools.execute).not.toHaveBeenCalled();
 		});
 
-		it('translates 404 into a tool-or-account-not-found message', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(404, 'not found'));
-			const client = createClient(fetchImpl);
+		it('rejects when the signal aborts after the SDK call starts but before it resolves', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockImplementation(
+				() =>
+					new Promise(() => {
+						/* never resolves */
+					})
+			);
+			const controller = new AbortController();
 
-			await expect(client.executeTool(createRef(), {})).rejects.toThrow(
+			const promise = createClient(sdk).executeTool(createRef(), {}, { signal: controller.signal });
+			controller.abort();
+
+			await expect(promise).rejects.toThrow(/cancelled/i);
+		});
+
+		it('translates SDK 404 into a tool-or-account-not-found message', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockRejectedValue(sdkError(404, 'not found'));
+
+			await expect(createClient(sdk).executeTool(createRef(), {})).rejects.toThrow(
 				/404.*tool slug or toolkit does not exist/i
 			);
+		});
+
+		it('translates SDK 401 with the friendly API-key message', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockRejectedValue(sdkError(401, 'unauthorized'));
+
+			await expect(createClient(sdk).executeTool(createRef(), {})).rejects.toThrow(/rejected the API key/i);
 		});
 	});
 });

--- a/packages/plugins/composio/src/__tests__/composio.spec.ts
+++ b/packages/plugins/composio/src/__tests__/composio.spec.ts
@@ -1,24 +1,29 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ComposioPlugin } from '../composio.plugin.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { WorkReference, GenerationRequest, ExistingItems, PluginContext } from '@ever-works/plugin';
 
-type ResponseFactory = () => Response;
+/**
+ * Hoisted SDK mocks. Each is a freshly-created `vi.fn()` that the tests
+ * configure via `mockResolvedValueOnce` / `mockRejectedValueOnce`. The mock
+ * constructor returns an object that exposes these exact spies as
+ * `toolkits.get`, `connectedAccounts.list`, `tools.execute` — matching the
+ * `ComposioSdkLike` shape consumed by `ComposioClient`.
+ */
+const { mockToolkitsGet, mockConnectedAccountsList, mockToolsExecute } = vi.hoisted(() => ({
+	mockToolkitsGet: vi.fn(),
+	mockConnectedAccountsList: vi.fn(),
+	mockToolsExecute: vi.fn()
+}));
 
-function jsonResponse(body: unknown, status = 200): ResponseFactory {
-	return () =>
-		new Response(JSON.stringify(body), {
-			status,
-			headers: { 'content-type': 'application/json' }
-		});
-}
+vi.mock('@composio/core', () => ({
+	Composio: vi.fn().mockImplementation(() => ({
+		toolkits: { get: mockToolkitsGet },
+		connectedAccounts: { list: mockConnectedAccountsList },
+		tools: { execute: mockToolsExecute }
+	}))
+}));
 
-function rawResponse(text: string, status = 200): ResponseFactory {
-	return () =>
-		new Response(text, {
-			status,
-			headers: { 'content-type': 'text/plain' }
-		});
-}
+// Import after vi.mock so the plugin's ComposioClient picks up the mocked SDK.
+const { ComposioPlugin } = await import('../composio.plugin.js');
 
 function createMockContext(settingsOverride?: Record<string, unknown>): PluginContext {
 	const settings = settingsOverride ?? { apiKey: 'test-key' };
@@ -99,39 +104,28 @@ function errorMessage(error: Error | string | undefined): string {
 	return typeof error === 'string' ? error : error.message;
 }
 
-/**
- * Stubs the global fetch with sequential response factories. Each factory
- * is invoked per call so a fresh `Response` (with an unread body stream) is
- * returned — module-scoped `Response` instances would otherwise throw
- * `Body is unusable` on the second test that touches them.
- */
-function stubFetchSequence(factories: ResponseFactory[]): ReturnType<typeof vi.fn> {
-	const spy = vi.fn();
-	for (const factory of factories) {
-		spy.mockImplementationOnce(async () => factory());
-	}
-	// Any further calls return an empty success envelope so tests don't hang.
-	spy.mockImplementation(async () => jsonResponse({ items: [] })());
-	(globalThis as { fetch: typeof fetch }).fetch = spy as unknown as typeof fetch;
-	return spy;
+const ACTIVE_GMAIL_ACCOUNTS = {
+	items: [{ id: 'ca_active', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }]
+};
+
+/** Helper: stage the SDK with an active connection + a successful tool response. */
+function stageHappyPath(toolData: unknown): void {
+	mockConnectedAccountsList.mockResolvedValueOnce(ACTIVE_GMAIL_ACCOUNTS);
+	mockToolsExecute.mockResolvedValueOnce({ successful: true, data: toolData });
 }
 
-const ACTIVE_GMAIL_ACCOUNT: ResponseFactory = jsonResponse({
-	items: [{ id: 'ca_active', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }]
-});
+function sdkError(status: number, message: string): Error {
+	const err = new Error(message);
+	(err as { status?: number }).status = status;
+	return err;
+}
 
 describe('ComposioPlugin', () => {
-	let plugin: ComposioPlugin;
-	let originalFetch: typeof fetch;
+	let plugin: InstanceType<typeof ComposioPlugin>;
 
 	beforeEach(() => {
 		plugin = new ComposioPlugin();
-		originalFetch = globalThis.fetch;
 		vi.clearAllMocks();
-	});
-
-	afterEach(() => {
-		(globalThis as { fetch: typeof fetch }).fetch = originalFetch;
 	});
 
 	describe('metadata', () => {
@@ -161,7 +155,6 @@ describe('ComposioPlugin', () => {
 
 		it('does not put tool selection in plugin settings (per-run config only)', () => {
 			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
-			// We DO have defaults, but per-tool fields live in the generator form
 			expect(props.toolkit).toBeUndefined();
 			expect(props.tool_slug).toBeUndefined();
 		});
@@ -297,13 +290,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('executes a structured-shape tool and returns items', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({
-					successful: true,
-					data: { items: [{ name: 'A', url: 'https://a' }, { name: 'B' }] }
-				})
-			]);
+			stageHappyPath({ items: [{ name: 'A', url: 'https://a' }, { name: 'B' }] });
 
 			const result = await plugin.execute(createWork(), createRequest(), createExisting());
 
@@ -312,29 +299,24 @@ describe('ComposioPlugin', () => {
 			expect(result.stepsCompleted).toBeGreaterThan(0);
 		});
 
-		it('calls /tools/execute/{slug} with the resolved user_id and arguments', async () => {
-			const spy = stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: true, data: { items: [{ name: 'X' }] } })
-			]);
+		it('calls sdk.tools.execute with the resolved userId and arguments', async () => {
+			stageHappyPath({ items: [{ name: 'X' }] });
 
 			await plugin.execute(createWork(), createRequest(), createExisting());
 
-			const execCall = spy.mock.calls.find(
-				([url]) => typeof url === 'string' && url.includes('/tools/execute/')
-			)!;
-			expect(execCall).toBeDefined();
-			expect(execCall[0]).toContain('/tools/execute/GMAIL_LIST_MESSAGES');
-			const body = JSON.parse((execCall[1] as { body: string }).body);
-			expect(body.user_id).toBe('user-456'); // defaults to ever works user id
-			expect(body.arguments.metadata.workSlug).toBe('test-work');
+			expect(mockToolsExecute).toHaveBeenCalledWith(
+				'GMAIL_LIST_MESSAGES',
+				expect.objectContaining({
+					userId: 'user-456', // defaults to ever works user id
+					arguments: expect.objectContaining({
+						metadata: expect.objectContaining({ workSlug: 'test-work' })
+					})
+				})
+			);
 		});
 
 		it('honors composio_user_id override', async () => {
-			const spy = stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: true, data: { items: [{ name: 'X' }] } })
-			]);
+			stageHappyPath({ items: [{ name: 'X' }] });
 
 			await plugin.execute(
 				createWork(),
@@ -348,15 +330,14 @@ describe('ComposioPlugin', () => {
 				createExisting()
 			);
 
-			const execCall = spy.mock.calls.find(
-				([url]) => typeof url === 'string' && url.includes('/tools/execute/')
-			)!;
-			const body = JSON.parse((execCall[1] as { body: string }).body);
-			expect(body.user_id).toBe('alice@example.com');
+			expect(mockToolsExecute).toHaveBeenCalledWith(
+				'GMAIL_LIST_MESSAGES',
+				expect.objectContaining({ userId: 'alice@example.com' })
+			);
 		});
 
 		it('completes successfully for a side-effect tool with no items', async () => {
-			stubFetchSequence([ACTIVE_GMAIL_ACCOUNT, jsonResponse({ successful: true, data: { ok: true } })]);
+			stageHappyPath({ ok: true });
 
 			const result = await plugin.execute(
 				createWork(),
@@ -376,13 +357,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('deduplicates items against existing names', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({
-					successful: true,
-					data: { items: [{ name: 'Alice' }, { name: 'Bob' }] }
-				})
-			]);
+			stageHappyPath({ items: [{ name: 'Alice' }, { name: 'Bob' }] });
 
 			const result = await plugin.execute(
 				createWork(),
@@ -395,9 +370,9 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('returns failure when no ACTIVE connected account exists', async () => {
-			stubFetchSequence([
-				jsonResponse({ items: [{ id: 'ca_x', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }] })
-			]);
+			mockConnectedAccountsList.mockResolvedValueOnce({
+				items: [{ id: 'ca_x', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }]
+			});
 
 			const result = await plugin.execute(createWork(), createRequest(), createExisting());
 			expect(result.success).toBe(false);
@@ -416,10 +391,8 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('surfaces Composio successful=false envelope as an error', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: false, error: 'gmail quota exceeded' })
-			]);
+			mockConnectedAccountsList.mockResolvedValueOnce(ACTIVE_GMAIL_ACCOUNTS);
+			mockToolsExecute.mockResolvedValueOnce({ successful: false, error: 'gmail quota exceeded' });
 
 			const result = await plugin.execute(createWork(), createRequest(), createExisting());
 			expect(result.success).toBe(false);
@@ -427,15 +400,9 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('executes a native-shape tool with field mapping', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({
-					successful: true,
-					data: [
-						{ subject: 'Alice', link: 'https://alice', labels: ['important'] },
-						{ subject: 'Bob', link: 'https://bob' }
-					]
-				})
+			stageHappyPath([
+				{ subject: 'Alice', link: 'https://alice', labels: ['important'] },
+				{ subject: 'Bob', link: 'https://bob' }
 			]);
 
 			const result = await plugin.execute(
@@ -460,10 +427,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('exposes pipeline state after execution', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: true, data: { items: [{ name: 'A' }] } })
-			]);
+			stageHappyPath({ items: [{ name: 'A' }] });
 
 			await plugin.execute(createWork(), createRequest(), createExisting());
 			const state = plugin.getState();
@@ -484,7 +448,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('succeeds when API key is accepted (no default toolkit set)', async () => {
-			stubFetchSequence([jsonResponse({ items: [{ slug: 'GMAIL', name: 'Gmail' }] })]);
+			mockToolkitsGet.mockResolvedValueOnce({ items: [{ slug: 'GMAIL', name: 'Gmail' }] });
 
 			const result = await plugin.validateConnection({ apiKey: 'test-key' });
 			expect(result.success).toBe(true);
@@ -492,10 +456,8 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('reports ACTIVE account for the default toolkit + user', async () => {
-			stubFetchSequence([
-				jsonResponse({ items: [{ slug: 'GMAIL' }] }),
-				jsonResponse({ items: [{ id: 'ca_a', status: 'ACTIVE' }] })
-			]);
+			mockToolkitsGet.mockResolvedValueOnce({ items: [{ slug: 'GMAIL' }] });
+			mockConnectedAccountsList.mockResolvedValueOnce({ items: [{ id: 'ca_a', status: 'ACTIVE' }] });
 
 			const result = await plugin.validateConnection({
 				apiKey: 'test-key',
@@ -508,7 +470,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('flattens wrapped settings values', async () => {
-			stubFetchSequence([jsonResponse({ items: [] })]);
+			mockToolkitsGet.mockResolvedValueOnce({ items: [] });
 
 			const result = await plugin.validateConnection({
 				apiKey: { value: 'wrapped-key' }
@@ -518,7 +480,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('reports underlying error when toolkit listing fails', async () => {
-			stubFetchSequence([rawResponse('forbidden', 403)]);
+			mockToolkitsGet.mockRejectedValueOnce(sdkError(403, 'forbidden'));
 
 			const result = await plugin.validateConnection({ apiKey: 'test-key' });
 			expect(result.success).toBe(false);

--- a/packages/plugins/composio/src/composio.plugin.ts
+++ b/packages/plugins/composio/src/composio.plugin.ts
@@ -378,10 +378,13 @@ export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 				`Starting tool "${toolRef.toolSlug}" for user "${toolRef.userId}"...`
 			);
 
+			// Timeout enforcement happens at the pipeline level via the `setTimeout`
+			// above that fires `abortController.abort()` — the SDK doesn't accept
+			// a timeout parameter, so we only forward the signal here.
 			const execResult: ComposioExecutionResult = await client.executeTool(
 				toolRef,
 				payload as unknown as Record<string, unknown>,
-				{ signal, timeoutMs: composioSettings.timeoutMs }
+				{ signal }
 			);
 
 			reportProgress(onProgress, 2, 70, 'Execute Composio Tool', 'Tool completed.');

--- a/packages/plugins/composio/src/utils/composio-client.ts
+++ b/packages/plugins/composio/src/utils/composio-client.ts
@@ -1,10 +1,12 @@
+import { Composio } from '@composio/core';
 import type { ComposioToolRef, ComposioConnectedAccount, ComposioToolkitEntry } from '../types.js';
 
 export interface ComposioExecutionResult {
 	/**
-	 * Raw data returned by the Composio tool. Composio v3 wraps every
-	 * response in `{ successful, data, error }`; we surface `data` here
-	 * and translate `successful=false` into a thrown error in {@link ComposioClient.executeTool}.
+	 * Raw data returned by the Composio tool. The official `@composio/core`
+	 * SDK already unwraps the v3 response envelope (`{ successful, data, error,
+	 * log_id }`) — successful executions resolve to the tool's `data` payload,
+	 * failures throw. We surface that `data` here verbatim.
 	 */
 	data: unknown;
 	composioDuration: number;
@@ -14,8 +16,13 @@ interface ComposioClientOptions {
 	apiKey: string;
 	baseUrl?: string;
 	logger: { log(...args: unknown[]): void; warn(...args: unknown[]): void };
-	/** Test seam — injected by unit tests. Defaults to global `fetch`. */
-	fetchImpl?: typeof fetch;
+	/**
+	 * Test seam — pass a stub `Composio`-shaped object to bypass SDK
+	 * construction. Unit tests inject their mocked SDK here instead of
+	 * `vi.mock`-ing the whole `@composio/core` module, which would also
+	 * trip the version-validation modifier the SDK installs at import time.
+	 */
+	sdkOverride?: ComposioSdkLike;
 }
 
 interface ExecuteToolOptions {
@@ -24,45 +31,79 @@ interface ExecuteToolOptions {
 }
 
 /**
- * Subset of the v3 envelope returned by `POST /tools/execute/{slug}`.
- *
- * Composio always wraps tool responses; even successful calls flag failures
- * via `successful: false` rather than HTTP status codes, so the client must
- * inspect the envelope, not just `response.ok`.
+ * Subset of the official `@composio/core` SDK surface we actually use.
+ * Pinned here so a stray major-version bump doesn't silently re-route us
+ * onto methods we haven't audited. Keep this in sync with the SDK reference
+ * at https://docs.composio.dev/sdk-reference/type-script/core-classes/composio.
  */
-interface ComposioExecuteEnvelope {
-	successful?: boolean;
-	data?: unknown;
-	error?: string;
-	log_id?: string;
+export interface ComposioSdkLike {
+	toolkits: {
+		get(query?: { limit?: number }): Promise<{ items: ComposioToolkitEntry[] }>;
+	};
+	connectedAccounts: {
+		list(query?: {
+			userIds?: string[];
+			toolkitSlugs?: string[];
+			limit?: number;
+		}): Promise<{ items: ComposioConnectedAccount[] }>;
+	};
+	tools: {
+		execute(
+			slug: string,
+			body: { userId: string; arguments?: Record<string, unknown> }
+		): Promise<{ successful?: boolean; data?: unknown; error?: string; logId?: string }>;
+	};
 }
 
 /**
- * Thin wrapper around the Composio v3 REST API.
+ * Thin wrapper around the official `@composio/core` SDK.
  *
- * Avoids the @composio/core SDK to keep dependency footprint small (matches
- * the activepieces / make pattern). Adds abort-signal support and translates
- * Composio's wrapped error envelope into Error instances.
+ * Per Workspace AGENTS.md NN #22 ("Always use the official SDK for
+ * third-party APIs — never hand-roll a REST client"), this replaces the
+ * v1 handwritten REST client that shipped in PR #1079. The SDK gets
+ * pagination, retries, response-envelope unwrapping, query-param list
+ * serialization (e.g. `user_ids` as repeated params), version validation,
+ * and breaking-change handling right — all of which we'd otherwise own.
+ *
+ * What's preserved from v1:
+ *  - The public surface (`validateConnection`, `listToolkits`,
+ *    `listConnectedAccounts`, `executeTool`) so `composio.plugin.ts`
+ *    doesn't change.
+ *  - Abort-signal support layered on top of the SDK via `Promise.race`.
+ *    Note: the SDK call itself can't be cancelled mid-flight; what we
+ *    cancel is our *await* on it. The HTTP request may still complete on
+ *    the wire — that's fine for the plugin's pipeline-timeout use case.
+ *  - Friendly error messages around 401/403, missing connections, etc.
  */
 export class ComposioClient {
-	private readonly apiKey: string;
-	private readonly baseUrl: string;
+	private readonly sdk: ComposioSdkLike;
 	private readonly logger: ComposioClientOptions['logger'];
-	private readonly fetchImpl: typeof fetch;
 
 	constructor(options: ComposioClientOptions) {
 		if (!options.apiKey || options.apiKey.trim() === '') {
 			throw new Error('Composio API key is required.');
 		}
-		this.apiKey = options.apiKey.trim();
-		this.baseUrl = (options.baseUrl ?? 'https://backend.composio.dev/api/v3').replace(/\/+$/, '');
 		this.logger = options.logger;
-		this.fetchImpl = options.fetchImpl ?? fetch;
+		this.sdk = options.sdkOverride ?? this.buildSdk(options.apiKey.trim(), options.baseUrl);
+	}
+
+	private buildSdk(apiKey: string, baseUrl: string | undefined): ComposioSdkLike {
+		const sdkConfig: { apiKey: string; baseURL?: string } = { apiKey };
+		if (baseUrl) {
+			// Composio's SDK config uses `baseURL` (capital L) — the underlying
+			// `@composio/client` follows axios-style naming. Strip trailing
+			// slashes so concatenation in the SDK works the same regardless
+			// of how the user typed it in settings.
+			sdkConfig.baseURL = baseUrl.replace(/\/+$/, '');
+		}
+		// The SDK constructor returns a richer instance than ComposioSdkLike
+		// declares; the structural cast pins us to the subset we actually use.
+		return new Composio(sdkConfig) as unknown as ComposioSdkLike;
 	}
 
 	/**
 	 * Validates that:
-	 *  1. The API key is accepted (200 from `/toolkits`).
+	 *  1. The API key is accepted (the SDK throws on 401/403).
 	 *  2. The toolkit exists.
 	 *  3. The user has at least one ACTIVE connected account for the toolkit.
 	 *
@@ -82,11 +123,12 @@ export class ComposioClient {
 
 	/** Lists toolkits the API key has access to. Used by `isAvailable` and the settings UI. */
 	async listToolkits(limit = 50): Promise<ComposioToolkitEntry[]> {
-		const url = new URL(`${this.baseUrl}/toolkits`);
-		url.searchParams.set('limit', String(Math.max(1, Math.min(limit, 200))));
-		const response = await this.request(url.toString(), { method: 'GET' });
-		const body = (await response.json()) as unknown;
-		return extractList<ComposioToolkitEntry>(body);
+		try {
+			const response = await this.sdk.toolkits.get({ limit: Math.max(1, Math.min(limit, 200)) });
+			return response.items ?? [];
+		} catch (error) {
+			throw this.wrapError(error, 'list toolkits');
+		}
 	}
 
 	/**
@@ -95,26 +137,26 @@ export class ComposioClient {
 	 * if the user has not connected any account yet.
 	 */
 	async listConnectedAccounts(userId: string, toolkit?: string): Promise<ComposioConnectedAccount[]> {
-		const url = new URL(`${this.baseUrl}/connected_accounts`);
-		// Composio v3 connected_accounts filters are list parameters — encode them
-		// as repeated query params (`?user_ids=a&user_ids=b`) which is the format
-		// the Composio Python SDK serializes. `.set()` would replace prior values
-		// AND, on Composio side, can be interpreted as a single value rather than
-		// a one-element list, which has been seen to filter strictly differently.
-		url.searchParams.append('user_ids', userId);
-		if (toolkit) url.searchParams.append('toolkit_slugs', toolkit.toUpperCase());
-		const response = await this.request(url.toString(), { method: 'GET' });
-		const body = (await response.json()) as unknown;
-		return extractList<ComposioConnectedAccount>(body);
+		try {
+			const query: { userIds: string[]; toolkitSlugs?: string[] } = { userIds: [userId] };
+			if (toolkit) query.toolkitSlugs = [toolkit.toUpperCase()];
+			const response = await this.sdk.connectedAccounts.list(query);
+			return response.items ?? [];
+		} catch (error) {
+			throw this.wrapError(error, 'list connected accounts');
+		}
 	}
 
 	/**
-	 * Executes a tool against the resolved user. Composio v3's response
-	 * envelope is always `{ successful, data, error, log_id }` — we extract
-	 * `data` on success and throw on failure with the upstream error text.
+	 * Executes a tool against the resolved user. The SDK unwraps the v3
+	 * envelope (`{ successful, data, error }`) — on success we return its
+	 * `data`; on failure (`successful === false`) we throw with the upstream
+	 * error text including the log id when present.
 	 *
-	 * Races against the abort signal so cancellation during long-running
-	 * tools still resolves cleanly.
+	 * Cancellation: the SDK does not accept an AbortSignal, so we race our
+	 * await against the signal. When the signal fires, this method rejects
+	 * with "Pipeline execution was cancelled"; the SDK's HTTP request may
+	 * still complete on the wire but its result is discarded.
 	 */
 	async executeTool(
 		ref: ComposioToolRef,
@@ -127,27 +169,21 @@ export class ComposioClient {
 		const startTime = Date.now();
 		this.logger.log(`Running Composio tool "${ref.toolSlug}" for user "${ref.userId}"`);
 
-		const url = `${this.baseUrl}/tools/execute/${encodeURIComponent(ref.toolSlug)}`;
-		const body: Record<string, unknown> = {
-			user_id: ref.userId,
-			arguments: args
-		};
-		if (options?.timeoutMs) body.timeout = Math.ceil(options.timeoutMs / 1000);
+		const execPromise = this.sdk.tools
+			.execute(ref.toolSlug, {
+				userId: ref.userId,
+				arguments: args
+			})
+			.catch((error: unknown) => {
+				throw this.wrapError(error, `execute tool ${ref.toolSlug}`);
+			});
 
-		const runPromise = this.request(url, {
-			method: 'POST',
-			headers: { 'content-type': 'application/json' },
-			body: JSON.stringify(body),
-			signal
-		});
-
-		const response = await runPromise;
-		const envelope = (await response.json()) as ComposioExecuteEnvelope;
+		const envelope = signal ? await raceWithAbort(execPromise, signal) : await execPromise;
 
 		if (envelope.successful === false) {
 			throw new Error(
 				`Composio tool "${ref.toolSlug}" execution failed: ${envelope.error ?? 'unknown error'}` +
-					(envelope.log_id ? ` (log_id=${envelope.log_id})` : '')
+					(envelope.logId ? ` (log_id=${envelope.logId})` : '')
 			);
 		}
 
@@ -157,99 +193,71 @@ export class ComposioClient {
 		};
 	}
 
-	private async request(url: string, init: RequestInit & { signal?: AbortSignal }): Promise<Response> {
-		const headers = new Headers(init.headers);
-		headers.set('x-api-key', this.apiKey);
-		headers.set('accept', 'application/json');
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, { ...init, headers });
-		} catch (error) {
-			if (init.signal?.aborted) throw new Error('Pipeline execution was cancelled');
-			throw this.wrapNetworkError(error, url);
-		}
-
-		if (!response.ok) {
-			throw await this.wrapHttpError(response, url);
-		}
-		return response;
-	}
-
-	private wrapNetworkError(error: unknown, url: string): Error {
+	private wrapError(error: unknown, context: string): Error {
 		if (error instanceof Error) {
-			return new Error(`Composio request to ${redactUrl(url)} failed: ${error.message}`);
-		}
-		return new Error(`Composio request to ${redactUrl(url)} failed: ${String(error)}`);
-	}
+			const message = error.message || String(error);
+			const status = readNumberProp(error, 'status') ?? readNumberProp(error, 'statusCode');
 
-	private async wrapHttpError(response: Response, url: string): Promise<Error> {
-		let body = '';
-		try {
-			body = await response.text();
-		} catch {
-			// ignore — best-effort read
+			if (status === 401 || status === 403) {
+				return new Error(
+					`Composio rejected the API key (HTTP ${status}) during ${context}. Verify COMPOSIO_API_KEY in plugin settings.`
+				);
+			}
+			if (status === 404) {
+				return new Error(
+					`Composio returned 404 during ${context}. Likely causes: the tool slug or toolkit does not exist, ` +
+						`or the user has no connected account.`
+				);
+			}
+			if (status === 408 || status === 504) {
+				return new Error(`Composio request timed out during ${context} (HTTP ${status}).`);
+			}
+			if (status === 429) {
+				return new Error('Composio rate limit exceeded (HTTP 429). Wait and retry.');
+			}
+			if (status !== undefined && status >= 500) {
+				return new Error(
+					`Composio is returning HTTP ${status} during ${context}. Check https://status.composio.dev. ` +
+						`(${message})`
+				);
+			}
+			// SDK error subclass we don't have a custom-rewording rule for — keep the original message.
+			return new Error(`Composio error during ${context}: ${message}`);
 		}
-		const preview = body.length > 500 ? `${body.slice(0, 500)}…` : body;
-		const redacted = redactUrl(url);
-
-		if (response.status === 401 || response.status === 403) {
-			return new Error(
-				`Composio rejected the API key (HTTP ${response.status}) when calling ${redacted}. ` +
-					`Verify COMPOSIO_API_KEY in plugin settings.${preview ? ` Response: ${preview}` : ''}`
-			);
-		}
-		if (response.status === 404) {
-			return new Error(
-				`Composio returned 404 for ${redacted}. ` +
-					`Likely causes: the tool slug or toolkit does not exist, or the user has no connected account.` +
-					(preview ? ` Response: ${preview}` : '')
-			);
-		}
-		if (response.status === 408 || response.status === 504) {
-			return new Error(`Composio request to ${redacted} timed out (HTTP ${response.status}).`);
-		}
-		if (response.status === 429) {
-			return new Error('Composio rate limit exceeded (HTTP 429). Wait and retry.');
-		}
-		if (response.status >= 500) {
-			return new Error(
-				`Composio is returning HTTP ${response.status} for ${redacted}. ` +
-					`Check https://status.composio.dev.${preview ? ` Response: ${preview}` : ''}`
-			);
-		}
-		return new Error(
-			`Composio request to ${redacted} failed: HTTP ${response.status}${preview ? ` — ${preview}` : ''}`
-		);
+		return new Error(`Unexpected error during ${context}: ${String(error)}`);
 	}
 }
 
-/**
- * Composio v3 list endpoints wrap results in `{ items: [...] }`. Older
- * preview endpoints sometimes returned `{ data: [...] }` or a bare array,
- * so handle all three.
- */
-function extractList<T>(body: unknown): T[] {
-	if (Array.isArray(body)) return body as T[];
-	if (body && typeof body === 'object') {
-		const record = body as Record<string, unknown>;
-		for (const key of ['items', 'data', 'results', 'records']) {
-			const value = record[key];
-			if (Array.isArray(value)) return value as T[];
-		}
-	}
-	return [];
-}
-
-function normalizeStatus(status: string): string {
+function normalizeStatus(status: string | undefined): string {
 	return (status || '').trim().toUpperCase();
 }
 
+function readNumberProp(target: object, prop: string): number | undefined {
+	const value = (target as Record<string, unknown>)[prop];
+	return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
 /**
- * Strips query strings from a URL before logging — Composio never embeds
- * secrets in query strings today, but `user_id` is PII so we redact it.
+ * Races a promise against an `AbortSignal`. When the signal fires we reject
+ * with the cancellation marker; when the promise settles first we forward
+ * its outcome and unhook the abort listener so we don't leak references.
  */
-function redactUrl(url: string): string {
-	const idx = url.indexOf('?');
-	return idx === -1 ? url : url.slice(0, idx);
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = (): void => {
+			signal.removeEventListener('abort', onAbort);
+			reject(new Error('Pipeline execution was cancelled'));
+		};
+		signal.addEventListener('abort', onAbort, { once: true });
+		promise.then(
+			(value) => {
+				signal.removeEventListener('abort', onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener('abort', onAbort);
+				reject(error as Error);
+			}
+		);
+	});
 }

--- a/packages/plugins/composio/src/utils/composio-client.ts
+++ b/packages/plugins/composio/src/utils/composio-client.ts
@@ -27,7 +27,6 @@ interface ComposioClientOptions {
 
 interface ExecuteToolOptions {
 	signal?: AbortSignal;
-	timeoutMs?: number;
 }
 
 /**
@@ -51,7 +50,20 @@ export interface ComposioSdkLike {
 		execute(
 			slug: string,
 			body: { userId: string; arguments?: Record<string, unknown> }
-		): Promise<{ successful?: boolean; data?: unknown; error?: string; logId?: string }>;
+		): Promise<{
+			successful?: boolean;
+			data?: unknown;
+			error?: string;
+			/**
+			 * The SDK transforms the v3 wire response from snake_case to camelCase
+			 * before resolving the promise — `log_id` → `logId`. Verified against
+			 * `@composio/core@0.10.0` (`dist/index.mjs`: `logId: response.log_id`).
+			 * We also tolerate `log_id` on the envelope as a defensive fallback
+			 * in case a future SDK version skips the transform.
+			 */
+			logId?: string;
+			log_id?: string;
+		}>;
 	};
 }
 
@@ -181,9 +193,13 @@ export class ComposioClient {
 		const envelope = signal ? await raceWithAbort(execPromise, signal) : await execPromise;
 
 		if (envelope.successful === false) {
+			// `logId` is the SDK-camelCased form; fall back to raw `log_id` in case
+			// a future SDK version stops transforming. Operators rely on this id
+			// to look up the upstream-app failure in the Composio dashboard.
+			const logId = envelope.logId ?? envelope.log_id;
 			throw new Error(
 				`Composio tool "${ref.toolSlug}" execution failed: ${envelope.error ?? 'unknown error'}` +
-					(envelope.logId ? ` (log_id=${envelope.logId})` : '')
+					(logId ? ` (log_id=${logId})` : '')
 			);
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -223,16 +223,16 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -469,10 +469,10 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -771,7 +771,7 @@ importers:
         version: link:../plugin
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
@@ -895,13 +895,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -1066,7 +1066,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1133,10 +1133,10 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -1187,7 +1187,7 @@ importers:
         version: 2.0.41(zod@3.25.76)
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       ai:
         specifier: ^6.0.154
         version: 6.0.154(zod@3.25.76)
@@ -1254,10 +1254,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1445,6 +1445,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/plugins/composio:
+    dependencies:
+      '@composio/core':
+        specifier: ^0.10.0
+        version: 0.10.0(ws@8.19.0)(zod@4.4.3)
     devDependencies:
       '@ever-works/plugin':
         specifier: workspace:*
@@ -1638,10 +1642,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1663,10 +1667,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1688,10 +1692,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1980,10 +1984,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2049,10 +2053,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2074,10 +2078,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2124,10 +2128,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2362,7 +2366,7 @@ importers:
     dependencies:
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       stopword:
         specifier: ^3.1.5
         version: 3.1.5
@@ -2503,10 +2507,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -3796,6 +3800,19 @@ packages:
   '@commitlint/types@19.8.1':
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
+
+  '@composio/client@0.1.0-alpha.72':
+    resolution: {integrity: sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ==}
+
+  '@composio/core@0.10.0':
+    resolution: {integrity: sha512-dG2BKF4NRiE8HHDzWLLgjMMo3FU4NJ6SxR961EpdLWWEKhkl+yP/mZlIN7p/4WnCR/fuDBKH1Qh+7kBdcHmEHA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  '@composio/json-schema-to-zod@0.1.20':
+    resolution: {integrity: sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q==}
+    peerDependencies:
+      zod: '>=3.25.76 <5'
 
   '@corvu/utils@0.4.2':
     resolution: {integrity: sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==}
@@ -15639,6 +15656,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.39.0:
+    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -16980,6 +17009,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pusher-js@8.5.0:
+    resolution: {integrity: sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -18571,6 +18603,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -19758,6 +19793,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -19779,6 +19825,16 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -21162,6 +21218,26 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
+
+  '@composio/client@0.1.0-alpha.72': {}
+
+  '@composio/core@0.10.0(ws@8.19.0)(zod@4.4.3)':
+    dependencies:
+      '@composio/client': 0.1.0-alpha.72
+      '@composio/json-schema-to-zod': 0.1.20(zod@4.4.3)
+      '@types/json-schema': 7.0.15
+      chalk: 4.1.2
+      openai: 6.39.0(ws@8.19.0)(zod@4.4.3)
+      pusher-js: 8.5.0
+      semver: 7.8.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+    transitivePeerDependencies:
+      - ws
+
+  '@composio/json-schema-to-zod@0.1.20(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@corvu/utils@0.4.2(solid-js@1.9.13)':
     dependencies:
@@ -23754,14 +23830,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -23775,18 +23851,48 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
       openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
+      js-tiktoken: 1.0.21
+      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
 
   '@langfuse/client@4.6.1(@opentelemetry/api@1.9.0)':
@@ -24213,7 +24319,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -24230,7 +24336,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.0
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -24257,7 +24363,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -24276,6 +24382,35 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21)))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
@@ -24307,7 +24442,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24336,7 +24471,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24438,6 +24573,17 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
+
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -27079,6 +27225,25 @@ snapshots:
       - supports-color
       - typescript
 
+  '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.2
+      semver: 7.7.4
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
   '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
@@ -28289,7 +28454,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.53.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -32123,7 +32288,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.0
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
@@ -32140,7 +32305,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.0
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
@@ -32157,7 +32322,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.0
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
@@ -33893,13 +34058,22 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
+  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      openai: 6.39.0(ws@8.19.0)(zod@3.25.76)
+      ws: 8.19.0
+
+  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      openai: 6.39.0(ws@8.19.0)(zod@4.4.3)
       ws: 8.19.0
 
   language-subtag-registry@0.3.23: {}
@@ -35745,13 +35919,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:
@@ -35904,6 +36078,17 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 3.25.76
+
+  openai@6.39.0(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
+    optional: true
+
+  openai@6.39.0(ws@8.19.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.4.3
 
   openapi-types@12.1.3: {}
 
@@ -37390,6 +37575,10 @@ snapshots:
       escape-goat: 4.0.0
 
   pure-rand@6.1.0: {}
+
+  pusher-js@8.5.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   pvtsutils@1.3.6:
     dependencies:
@@ -39543,6 +39732,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@1.0.3: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -40940,6 +41131,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@1.5.0(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

PR-A of [EW-684](https://evertech.atlassian.net/browse/EW-684) (Composio full integration epic). Migrates the Composio plugin from the handwritten REST client shipped in #1079 to the official `@composio/core` SDK, per Workspace AGENTS.md **NN #22** (\"always use the official vendor SDK for third-party APIs\").

This is the foundation for PR-B (Settings UX), PR-C (Skills-provider for agent runtime), and PR-D (Webhook triggers) — all of which need SDK calls (`connectedAccounts.initiate`, `triggers.create`, etc.) that didn't exist in the handwritten client.

## Why now

The handwritten client in #1079 already had one wire-format bug (Codex P2: `user_ids` filter encoding). Migrating to the SDK fixes that permanently and ensures we automatically get future wire-format fixes from upstream. Mirroring an existing handwritten-REST plugin (zapier already uses `@zapier/zapier-sdk`, sim-ai already uses `simstudio-ts-sdk`) is the established pattern.

## Public surface — unchanged

`composio.plugin.ts` itself is untouched. The migration lives behind `ComposioClient`'s public methods:

| Method | Before (REST) | After (SDK) |
| --- | --- | --- |
| `listToolkits(limit)` | `GET /toolkits?limit=...` | `composio.toolkits.get({ limit })` |
| `listConnectedAccounts(userId, toolkit)` | `GET /connected_accounts?user_ids=...&toolkit_slugs=...` | `composio.connectedAccounts.list({ userIds, toolkitSlugs })` |
| `executeTool(ref, args)` | `POST /tools/execute/{slug}` body | `composio.tools.execute(slug, { userId, arguments })` |
| `validateConnection(ref)` | composite of above | composite of above |

## Notable preserved behavior

- **Abort-signal support** via `Promise.race` against the signal. The SDK doesn't accept an `AbortSignal` directly — the underlying HTTP request may still complete on the wire after cancellation, but our pipeline discards the result. Documented in the class JSDoc.
- **`successful=false` handling** — the SDK already unwraps the v3 envelope, but Composio still uses `successful: false` for upstream-app failures (gmail quota exceeded, slack rate-limit, …). We surface these as thrown errors with the upstream `error` text + `logId`.
- **Friendly error wrapping** — 401/403 → \"rejected the API key\", 429 → \"rate limit exceeded\", 404 → \"tool slug or toolkit does not exist\", etc.

## Tests

96/96 unit tests still pass:

- `composio-client.spec.ts` (21 tests) — direct SDK injection via a new `sdkOverride` test seam on `ComposioClient`. The `Composio` constructor isn't called in unit tests.
- `composio.spec.ts` (43 tests) — `vi.mock('@composio/core')` with hoisted spies. Simpler than the previous Response-factory + global-fetch-stub pattern.
- `payload-builder.spec.ts` (10), `result-parser.spec.ts` (22) — unchanged.

## Test plan

- [x] `pnpm --filter @ever-works/composio-plugin type-check` (clean)
- [x] `pnpm --filter @ever-works/composio-plugin test` (96/96)
- [x] `pnpm --filter @ever-works/composio-plugin build` (CJS + ESM + DTS)
- [x] `pnpm exec prettier --check packages/plugins/composio/**` (clean)
- [ ] CI green
- [ ] No P2+ bot findings (Codex/CodeRabbit/Greptile)
- [ ] Smoke: run a `GMAIL_LIST_MESSAGES` against a real Composio API key + ACTIVE Gmail account — verify items collected

## Related

- Original Composio PR: #1079
- Workspace NN #22 (official SDKs): https://github.com/ever-works/workspace/blob/develop/AGENTS.md
- Plugin-wide SDK audit: [EW-682](https://evertech.atlassian.net/browse/EW-682)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-684]: https://evertech.atlassian.net/browse/EW-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-682]: https://evertech.atlassian.net/browse/EW-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Composio plugin documentation reflecting the current implementation approach.

* **Chores**
  * Added required dependency for plugin functionality.
  * Internal implementation refactoring.
  * Enhanced test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->