### PR TITLE
feat(web): add posthog-js client (autocapture + session replay)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -133,8 +133,10 @@ AUTH_SECRET=your-secret-key-here
 # ============================================
 
 # PostHog project API key. Same key the monitoring package uses.
-# Evaluated SERVER-SIDE only — posthog-js is never shipped to the
-# browser, so this token stays off the client.
+# Used by the SERVER for feature-flag evaluation (works-<kind> chips,
+# onboarding event relay). The same value also belongs in
+# NEXT_PUBLIC_POSTHOG_KEY below — `phc_*` keys are the public project
+# key and are safe to ship in the browser bundle.
 # POSTHOG_API_KEY=phc_your_project_api_key_here
 
 # PostHog host. Defaults to https://app.posthog.com when unset.
@@ -148,6 +150,19 @@ AUTH_SECRET=your-secret-key-here
 # explicitly false. No PostHog config, an unreachable/erroring PostHog, a
 # missing flag, or an undefined value all leave the chip ENABLED — so OSS
 # forks with no PostHog run with every kind available.
+
+# ============================================
+# PostHog (client-side product analytics)
+# ============================================
+
+# Same phc_* value as POSTHOG_API_KEY above — phc_* is the PROJECT (public)
+# key and is meant to be shipped in the browser bundle. Drives autocapture,
+# session replay, and manual $pageview events from the App Router.
+# NEXT_PUBLIC_* values are baked into the bundle at BUILD time, so this
+# must be set when `pnpm build` runs (not at runtime). If absent, posthog-js
+# silently no-ops — fail-open for OSS forks that don't run PostHog.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # ============================================
 # Build Configuration

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
         "next-intl": "^4.9.2",
         "nextjs-toploader": "^3.9.17",
         "path-to-regexp": "^8.4.2",
+        "posthog-js": "^1.376.3",
         "posthog-node": "^5.18.0",
         "radix-ui": "^1.4.3",
         "react": "19.2.5",

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -17,6 +17,7 @@ import { useKeyboardShortcuts } from '@/lib/hooks/use-keyboard-shortcuts';
 import { ConnectGithubModal } from '@/components/auth/connect-github-modal';
 import { BackgroundActivityProvider } from '@/lib/hooks/use-background-activity';
 import { EverWorksOnboardingWizard } from '@/components/onboarding/EverWorksOnboardingWizard';
+import { PostHogIdentify } from '@/components/posthog/PostHogIdentify';
 import { computeStepList } from '@/components/onboarding/useOnboardingFlow';
 import { dismissOnboarding } from '@/app/actions/onboarding/state';
 import { ONBOARDING_DEFAULT_STATE } from '@ever-works/contracts/api';
@@ -344,6 +345,7 @@ export function DashboardLayoutClient({
     return (
         <BackgroundActivityProvider>
             <ChatProvider>
+                <PostHogIdentify userId={user.id} email={user.email} name={user.username} />
                 <EverWorksOnboardingWizard
                     open={isOnboardingOpen}
                     initialState={onboardingState}

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import './globals.css';
 import { themeInitScript } from '@/lib/theme-init';
 import { TopLoader } from '@/components/ui/top-loader';
 import { APP_NAME } from '@/lib/constants';
+import { PostHogProvider } from '@/components/posthog/PostHogProvider';
 
 export const metadata: Metadata = {
     title: {
@@ -41,20 +42,22 @@ export default async function RootLayout({
             <body className="antialiased" suppressHydrationWarning>
                 <TopLoader />
                 <NextIntlClientProvider>
-                    {children}
-                    <Toaster
-                        position="top-right"
-                        theme="system"
-                        toastOptions={{
-                            className:
-                                'sonner-toast !bg-surface dark:!bg-surface-dark !text-text dark:!text-text-dark !border !border-border dark:!border-border-dark',
-                            style: {
-                                background: undefined,
-                                color: undefined,
-                                border: undefined,
-                            },
-                        }}
-                    />
+                    <PostHogProvider>
+                        {children}
+                        <Toaster
+                            position="top-right"
+                            theme="system"
+                            toastOptions={{
+                                className:
+                                    'sonner-toast !bg-surface dark:!bg-surface-dark !text-text dark:!text-text-dark !border !border-border dark:!border-border-dark',
+                                style: {
+                                    background: undefined,
+                                    color: undefined,
+                                    border: undefined,
+                                },
+                            }}
+                        />
+                    </PostHogProvider>
                 </NextIntlClientProvider>
             </body>
         </html>

--- a/apps/web/src/app/actions/onboarding/track.ts
+++ b/apps/web/src/app/actions/onboarding/track.ts
@@ -8,9 +8,14 @@ import { onboardingAPI } from '@/lib/api/onboarding';
  * The browser POSTs `{ event, properties }` to this server action, which
  * forwards to `/api/onboarding/telemetry`. The API validates the event
  * against an allowlist and forwards to PostHog via the existing
- * `AnalyticsService`. We deliberately do NOT add `posthog-js` to the
- * web bundle — keeping the relay server-side means PostHog tokens stay
- * out of the client and we don't pay the bundle cost.
+ * `AnalyticsService`.
+ *
+ * Older path: this server-side relay predates the client-side `posthog-js`
+ * integration. Newer client surfaces should call PostHog directly via
+ * `usePostHog()` from `posthog-js/react` (the provider is wired in
+ * `apps/web/src/app/[locale]/layout.tsx`). This server action stays for the
+ * onboarding-wizard event taxonomy that the API consolidates server-side
+ * (allowlist validation + canonical property shaping live in the API).
  *
  * Failures are swallowed: telemetry must never block the wizard.
  */

--- a/apps/web/src/components/posthog/PostHogIdentify.tsx
+++ b/apps/web/src/components/posthog/PostHogIdentify.tsx
@@ -14,8 +14,7 @@ interface PostHogIdentifyProps {
 }
 
 /**
- * Calls `posthog.identify(userId, ...)` when a known user mounts and
- * `posthog.reset()` when the user goes away (logout / unmount).
+ * Calls `posthog.identify(userId, ...)` when a known user mounts.
  *
  * Place this INSIDE <PostHogProvider> so posthog-js is already
  * initialized by the time the identify effect runs.
@@ -24,6 +23,15 @@ interface PostHogIdentifyProps {
  * about the current user (the dashboard layout passes `AuthUser` as a
  * prop from its server component — there's no client-side `useUser()`
  * hook in this repo today).
+ *
+ * UNMOUNT RESET — the real logout path on this platform redirects the
+ * whole dashboard layout to the login page, which unmounts this
+ * component without `userId` ever transitioning to falsy on a still-
+ * mounted instance. Relying purely on the prop-change branch below
+ * would leave PostHog's distinct_id pinned to the departing user for
+ * the rest of the tab's lifetime. To avoid that, a second effect runs
+ * `posthog.reset()` in its UNMOUNT cleanup so logout / route-tear-down
+ * always drops the prior identity.
  */
 export function PostHogIdentify({ userId, email, name }: PostHogIdentifyProps) {
     useEffect(() => {
@@ -40,6 +48,17 @@ export function PostHogIdentify({ userId, email, name }: PostHogIdentifyProps) {
             posthog.reset();
         }
     }, [userId, email, name]);
+
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+        return () => {
+            // Logout typically unmounts the dashboard layout entirely
+            // rather than flipping `userId` to null on a mounted
+            // instance, so the identify effect above never sees the
+            // transition. Reset here so the next mount starts clean.
+            posthog.reset();
+        };
+    }, []);
 
     return null;
 }

--- a/apps/web/src/components/posthog/PostHogIdentify.tsx
+++ b/apps/web/src/components/posthog/PostHogIdentify.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+import posthog from 'posthog-js';
+
+interface PostHogIdentifyProps {
+    /**
+     * Stable internal user id. Same value used everywhere else for
+     * user identity (matches `AuthUser.id`).
+     */
+    userId?: string | null;
+    email?: string | null;
+    name?: string | null;
+}
+
+/**
+ * Calls `posthog.identify(userId, ...)` when a known user mounts and
+ * `posthog.reset()` when the user goes away (logout / unmount).
+ *
+ * Place this INSIDE <PostHogProvider> so posthog-js is already
+ * initialized by the time the identify effect runs.
+ *
+ * `userId` should come from whatever the surrounding tree already knows
+ * about the current user (the dashboard layout passes `AuthUser` as a
+ * prop from its server component — there's no client-side `useUser()`
+ * hook in this repo today).
+ */
+export function PostHogIdentify({ userId, email, name }: PostHogIdentifyProps) {
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+
+        if (userId) {
+            const props: Record<string, string> = {};
+            if (email) props.email = email;
+            if (name) props.name = name;
+            posthog.identify(userId, props);
+        } else {
+            // Unknown user (logged out, anonymous surface). Drop any prior
+            // identity so the next session starts as a fresh anonymous id.
+            posthog.reset();
+        }
+    }, [userId, email, name]);
+
+    return null;
+}

--- a/apps/web/src/components/posthog/PostHogProvider.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.tsx
@@ -8,44 +8,59 @@ import { PostHogProvider as PHProvider } from 'posthog-js/react';
 /**
  * Client-side PostHog wiring for the platform's web frontend.
  *
- * Autocapture + session replay are enabled. PII masking defaults err on
- * the side of "do not mask everything" — input values are recorded so
- * funnel analysis is useful, but password and email inputs are masked
- * because they carry credentials / PII.
+ * Autocapture + session replay are enabled. Session-replay inputs are
+ * masked WHOLESALE (`maskAllInputs: true`) — per-type masking via
+ * `maskInputOptions` is unreliable because apps routinely render
+ * sensitive fields (API keys, secrets, custom autocomplete pickers,
+ * older form patterns) as `input[type="text"]` rather than the strict
+ * `password` / `email` types. Masking everything is the secure-by-default
+ * posture PostHog's own security docs recommend.
  *
  * Pageviews are captured manually (`capture_pageview: false`) so that
  * App Router client-side navigations between routes are counted. The
  * companion <PostHogPageview /> component fires `$pageview` on every
  * `usePathname` / `useSearchParams` change.
  *
+ * INIT TIMING — `posthog.init(...)` runs at MODULE LOAD time (not inside
+ * a `useEffect`). React commits children's effects before parent's, so
+ * doing init in the provider's effect would let `<PostHogIdentify>` and
+ * `<PostHogPageview>` call `posthog.identify(...)` / `posthog.capture(...)`
+ * BEFORE init has run — posthog-js silently no-ops pre-init, dropping
+ * the first pageview and first identify of every session. Running init
+ * at module scope guarantees it has already executed by the time any
+ * child effect fires. `posthog.init` is idempotent per posthog-js docs,
+ * so re-imports / HMR are safe.
+ *
  * If `NEXT_PUBLIC_POSTHOG_KEY` is absent at BUILD time (NEXT_PUBLIC_*
- * are baked at build), `posthog-js` silently no-ops — this is fail-open
- * by design for OSS forks that don't run PostHog.
+ * are baked at build), the module-scope init is skipped and posthog-js
+ * silently no-ops — this is fail-open by design for OSS forks that
+ * don't run PostHog.
  */
+if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+        // We capture $pageview manually below so SPA route changes count.
+        capture_pageview: false,
+        capture_pageleave: true,
+        // Default is `true`, but be explicit for reviewer clarity.
+        autocapture: true,
+        session_recording: {
+            // Mask every input regardless of `type`. Per-type masking
+            // (`maskInputOptions: { email: true, password: true }`) only
+            // matches the literal `input[type]` attribute, so anything
+            // rendered as `type="text"` — API key fields, custom
+            // autocomplete, legacy forms — would otherwise be recorded
+            // verbatim. Secure by default.
+            maskAllInputs: true,
+        },
+        persistence: 'localStorage+cookie',
+        loaded: (ph) => {
+            if (process.env.NODE_ENV === 'development') ph.debug();
+        },
+    });
+}
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
-    useEffect(() => {
-        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
-
-        posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-            api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
-            // We capture $pageview manually below so SPA route changes count.
-            capture_pageview: false,
-            capture_pageleave: true,
-            // Default is `true`, but be explicit for reviewer clarity.
-            autocapture: true,
-            session_recording: {
-                // Recording values is desirable for funnel analysis. Mask only
-                // password + email inputs.
-                maskAllInputs: false,
-                maskInputOptions: { password: true, email: true },
-            },
-            persistence: 'localStorage+cookie',
-            loaded: (ph) => {
-                if (process.env.NODE_ENV === 'development') ph.debug();
-            },
-        });
-    }, []);
-
     return (
         <PHProvider client={posthog}>
             {/* Suspense is required: `useSearchParams` triggers a CSR bailout

--- a/apps/web/src/components/posthog/PostHogProvider.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { Suspense, useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import posthog from 'posthog-js';
+import { PostHogProvider as PHProvider } from 'posthog-js/react';
+
+/**
+ * Client-side PostHog wiring for the platform's web frontend.
+ *
+ * Autocapture + session replay are enabled. PII masking defaults err on
+ * the side of "do not mask everything" — input values are recorded so
+ * funnel analysis is useful, but password and email inputs are masked
+ * because they carry credentials / PII.
+ *
+ * Pageviews are captured manually (`capture_pageview: false`) so that
+ * App Router client-side navigations between routes are counted. The
+ * companion <PostHogPageview /> component fires `$pageview` on every
+ * `usePathname` / `useSearchParams` change.
+ *
+ * If `NEXT_PUBLIC_POSTHOG_KEY` is absent at BUILD time (NEXT_PUBLIC_*
+ * are baked at build), `posthog-js` silently no-ops — this is fail-open
+ * by design for OSS forks that don't run PostHog.
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+
+        posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+            api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+            // We capture $pageview manually below so SPA route changes count.
+            capture_pageview: false,
+            capture_pageleave: true,
+            // Default is `true`, but be explicit for reviewer clarity.
+            autocapture: true,
+            session_recording: {
+                // Recording values is desirable for funnel analysis. Mask only
+                // password + email inputs.
+                maskAllInputs: false,
+                maskInputOptions: { password: true, email: true },
+            },
+            persistence: 'localStorage+cookie',
+            loaded: (ph) => {
+                if (process.env.NODE_ENV === 'development') ph.debug();
+            },
+        });
+    }, []);
+
+    return (
+        <PHProvider client={posthog}>
+            {/* Suspense is required: `useSearchParams` triggers a CSR bailout
+                for the whole route if it's not wrapped, which would force
+                every page below into client rendering. */}
+            <Suspense fallback={null}>
+                <PostHogPageview />
+            </Suspense>
+            {children}
+        </PHProvider>
+    );
+}
+
+/**
+ * Fires `$pageview` on every App Router navigation. The native
+ * `capture_pageview` PostHog option only triggers on full document loads,
+ * which never happens in an SPA after first paint.
+ */
+export function PostHogPageview() {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+        if (!pathname) return;
+
+        let url = window.origin + pathname;
+        const qs = searchParams?.toString();
+        if (qs) {
+            url = url + '?' + qs;
+        }
+
+        posthog.capture('$pageview', { $current_url: url });
+    }, [pathname, searchParams]);
+
+    return null;
+}

--- a/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
@@ -6,9 +6,17 @@ import { render, cleanup } from '@testing-library/react';
  *
  * The provider is fail-open: when `NEXT_PUBLIC_POSTHOG_KEY` is unset
  * (the OSS-fork case) `posthog.init` MUST NOT be called. When the key
- * is set we expect `init` with the right host. The companion pageview
- * component must emit `$pageview` on every App Router navigation, since
- * `capture_pageview: false` disables PostHog's built-in handler.
+ * is set we expect `init` with the right host. Init runs at MODULE LOAD
+ * time (not in an effect) — see the comment in PostHogProvider.tsx for
+ * why — so these tests use `vi.resetModules()` plus a dynamic
+ * `await import(...)` to observe the side effect of the module's top-
+ * level code under each env-var configuration.
+ *
+ * The companion pageview component must emit `$pageview` on every App
+ * Router navigation, since `capture_pageview: false` disables PostHog's
+ * built-in handler. The identify component must call `posthog.reset()`
+ * on unmount so logout (which tears down the dashboard layout) clears
+ * the distinct_id.
  */
 
 const mockPathname = vi.fn<() => string>();
@@ -28,10 +36,14 @@ vi.mock('posthog-js/react', () => ({
 
 const initSpy = vi.fn();
 const captureSpy = vi.fn();
+const identifySpy = vi.fn();
+const resetSpy = vi.fn();
 vi.mock('posthog-js', () => ({
     default: {
         init: (...args: unknown[]) => initSpy(...args),
         capture: (...args: unknown[]) => captureSpy(...args),
+        identify: (...args: unknown[]) => identifySpy(...args),
+        reset: (...args: unknown[]) => resetSpy(...args),
         debug: () => undefined,
     },
 }));
@@ -48,9 +60,14 @@ const ORIGINAL_ENV = { ...process.env };
 beforeEach(() => {
     initSpy.mockReset();
     captureSpy.mockReset();
+    identifySpy.mockReset();
+    resetSpy.mockReset();
     mockPathname.mockReturnValue('/dashboard');
     mockSearchParams.mockReturnValue(new URLSearchParams());
     process.env = { ...ORIGINAL_ENV };
+    // Module-scope init runs once per import. Reset the registry so the
+    // dynamic import in each test re-evaluates against the current env.
+    vi.resetModules();
 });
 
 afterEach(() => {
@@ -59,16 +76,14 @@ afterEach(() => {
 });
 
 describe('PostHogProvider', () => {
-    it('initializes posthog when NEXT_PUBLIC_POSTHOG_KEY is set', async () => {
+    it('initializes posthog at module load when NEXT_PUBLIC_POSTHOG_KEY is set', async () => {
         process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
         process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://us.i.posthog.com';
 
-        const { PostHogProvider } = await import('./PostHogProvider');
-        render(
-            <PostHogProvider>
-                <div data-testid="child">child</div>
-            </PostHogProvider>,
-        );
+        // Importing the module is what triggers `posthog.init(...)` —
+        // assert BEFORE rendering anything to prove init does not
+        // depend on the component mounting.
+        await import('./PostHogProvider');
 
         expect(initSpy).toHaveBeenCalledTimes(1);
         const [key, opts] = initSpy.mock.calls[0] as [string, Record<string, unknown>];
@@ -80,21 +95,17 @@ describe('PostHogProvider', () => {
         expect(opts.capture_pageleave).toBe(true);
         expect(opts.autocapture).toBe(true);
         const replay = opts.session_recording as Record<string, unknown>;
-        expect(replay.maskAllInputs).toBe(false);
-        const maskOpts = replay.maskInputOptions as Record<string, boolean>;
-        expect(maskOpts.password).toBe(true);
-        expect(maskOpts.email).toBe(true);
+        // Secure by default: mask every input regardless of `type`.
+        // Per-type masking via `maskInputOptions` is unreliable when
+        // sensitive fields render as `type="text"`.
+        expect(replay.maskAllInputs).toBe(true);
+        expect(replay.maskInputOptions).toBeUndefined();
     });
 
     it('does NOT initialize posthog when NEXT_PUBLIC_POSTHOG_KEY is empty (OSS-fork case)', async () => {
         delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
-        const { PostHogProvider } = await import('./PostHogProvider');
-        render(
-            <PostHogProvider>
-                <div data-testid="child">child</div>
-            </PostHogProvider>,
-        );
+        await import('./PostHogProvider');
 
         expect(initSpy).not.toHaveBeenCalled();
     });
@@ -107,6 +118,10 @@ describe('PostHogPageview', () => {
         mockSearchParams.mockReturnValue(new URLSearchParams('q=foo&page=2'));
 
         const { PostHogPageview } = await import('./PostHogProvider');
+        // Module-scope init also fires when the module is imported;
+        // clear capture spy AFTER import so we observe only the
+        // pageview emitted by the component effect.
+        captureSpy.mockReset();
         render(<PostHogPageview />);
 
         expect(captureSpy).toHaveBeenCalledTimes(1);
@@ -121,6 +136,7 @@ describe('PostHogPageview', () => {
         mockSearchParams.mockReturnValue(new URLSearchParams());
 
         const { PostHogPageview } = await import('./PostHogProvider');
+        captureSpy.mockReset();
         const { rerender } = render(<PostHogPageview />);
         expect(captureSpy).toHaveBeenCalledTimes(1);
 
@@ -140,5 +156,37 @@ describe('PostHogPageview', () => {
         render(<PostHogPageview />);
 
         expect(captureSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('PostHogIdentify', () => {
+    it('calls posthog.reset() on unmount so logout clears the distinct_id', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+
+        const { PostHogIdentify } = await import('./PostHogIdentify');
+        const { unmount } = render(
+            <PostHogIdentify userId="u1" email="u1@example.com" name="U One" />,
+        );
+
+        // Identify ran on mount.
+        expect(identifySpy).toHaveBeenCalledTimes(1);
+        expect(resetSpy).not.toHaveBeenCalled();
+
+        unmount();
+
+        // Unmount cleanup fires reset, even though `userId` never
+        // transitioned to falsy.
+        expect(resetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call posthog on unmount when NEXT_PUBLIC_POSTHOG_KEY is empty', async () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+        const { PostHogIdentify } = await import('./PostHogIdentify');
+        const { unmount } = render(<PostHogIdentify userId="u1" />);
+        unmount();
+
+        expect(identifySpy).not.toHaveBeenCalled();
+        expect(resetSpy).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
@@ -110,14 +110,9 @@ describe('PostHogPageview', () => {
         render(<PostHogPageview />);
 
         expect(captureSpy).toHaveBeenCalledTimes(1);
-        const [event, props] = captureSpy.mock.calls[0] as [
-            string,
-            { $current_url: string },
-        ];
+        const [event, props] = captureSpy.mock.calls[0] as [string, { $current_url: string }];
         expect(event).toBe('$pageview');
-        expect(props.$current_url).toBe(
-            'http://localhost:3000/dashboard/works?q=foo&page=2',
-        );
+        expect(props.$current_url).toBe('http://localhost:3000/dashboard/works?q=foo&page=2');
     });
 
     it('fires $pageview again when the pathname changes (SPA navigation)', async () => {

--- a/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+/**
+ * Tests for the platform's client-side PostHog wiring.
+ *
+ * The provider is fail-open: when `NEXT_PUBLIC_POSTHOG_KEY` is unset
+ * (the OSS-fork case) `posthog.init` MUST NOT be called. When the key
+ * is set we expect `init` with the right host. The companion pageview
+ * component must emit `$pageview` on every App Router navigation, since
+ * `capture_pageview: false` disables PostHog's built-in handler.
+ */
+
+const mockPathname = vi.fn<() => string>();
+const mockSearchParams = vi.fn<() => URLSearchParams>();
+
+vi.mock('next/navigation', () => ({
+    usePathname: () => mockPathname(),
+    useSearchParams: () => mockSearchParams(),
+}));
+
+// `posthog-js/react` <PostHogProvider> tries to mount things against the
+// real `posthog` global; for unit tests we don't care about its internals
+// and just render children as-is.
+vi.mock('posthog-js/react', () => ({
+    PostHogProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const initSpy = vi.fn();
+const captureSpy = vi.fn();
+vi.mock('posthog-js', () => ({
+    default: {
+        init: (...args: unknown[]) => initSpy(...args),
+        capture: (...args: unknown[]) => captureSpy(...args),
+        debug: () => undefined,
+    },
+}));
+
+// jsdom doesn't set `window.origin` reliably across versions; pin it so
+// the assertion on `$current_url` is deterministic.
+Object.defineProperty(window, 'origin', {
+    configurable: true,
+    value: 'http://localhost:3000',
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+    initSpy.mockReset();
+    captureSpy.mockReset();
+    mockPathname.mockReturnValue('/dashboard');
+    mockSearchParams.mockReturnValue(new URLSearchParams());
+    process.env = { ...ORIGINAL_ENV };
+});
+
+afterEach(() => {
+    cleanup();
+    process.env = ORIGINAL_ENV;
+});
+
+describe('PostHogProvider', () => {
+    it('initializes posthog when NEXT_PUBLIC_POSTHOG_KEY is set', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+        process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+        const { PostHogProvider } = await import('./PostHogProvider');
+        render(
+            <PostHogProvider>
+                <div data-testid="child">child</div>
+            </PostHogProvider>,
+        );
+
+        expect(initSpy).toHaveBeenCalledTimes(1);
+        const [key, opts] = initSpy.mock.calls[0] as [string, Record<string, unknown>];
+        expect(key).toBe('phc_test_key');
+        expect(opts.api_host).toBe('https://us.i.posthog.com');
+        // Manual pageview capture is the whole point — make sure we
+        // didn't regress to PostHog's built-in handler.
+        expect(opts.capture_pageview).toBe(false);
+        expect(opts.capture_pageleave).toBe(true);
+        expect(opts.autocapture).toBe(true);
+        const replay = opts.session_recording as Record<string, unknown>;
+        expect(replay.maskAllInputs).toBe(false);
+        const maskOpts = replay.maskInputOptions as Record<string, boolean>;
+        expect(maskOpts.password).toBe(true);
+        expect(maskOpts.email).toBe(true);
+    });
+
+    it('does NOT initialize posthog when NEXT_PUBLIC_POSTHOG_KEY is empty (OSS-fork case)', async () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+        const { PostHogProvider } = await import('./PostHogProvider');
+        render(
+            <PostHogProvider>
+                <div data-testid="child">child</div>
+            </PostHogProvider>,
+        );
+
+        expect(initSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('PostHogPageview', () => {
+    it('fires a $pageview capture on mount including query string', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+        mockPathname.mockReturnValue('/dashboard/works');
+        mockSearchParams.mockReturnValue(new URLSearchParams('q=foo&page=2'));
+
+        const { PostHogPageview } = await import('./PostHogProvider');
+        render(<PostHogPageview />);
+
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+        const [event, props] = captureSpy.mock.calls[0] as [
+            string,
+            { $current_url: string },
+        ];
+        expect(event).toBe('$pageview');
+        expect(props.$current_url).toBe(
+            'http://localhost:3000/dashboard/works?q=foo&page=2',
+        );
+    });
+
+    it('fires $pageview again when the pathname changes (SPA navigation)', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+        mockPathname.mockReturnValue('/dashboard');
+        mockSearchParams.mockReturnValue(new URLSearchParams());
+
+        const { PostHogPageview } = await import('./PostHogProvider');
+        const { rerender } = render(<PostHogPageview />);
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+
+        mockPathname.mockReturnValue('/dashboard/works/abc');
+        rerender(<PostHogPageview />);
+
+        expect(captureSpy).toHaveBeenCalledTimes(2);
+        const [, props] = captureSpy.mock.calls[1] as [string, { $current_url: string }];
+        expect(props.$current_url).toBe('http://localhost:3000/dashboard/works/abc');
+    });
+
+    it('does NOT fire pageview when NEXT_PUBLIC_POSTHOG_KEY is empty', async () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+        mockPathname.mockReturnValue('/dashboard');
+
+        const { PostHogPageview } = await import('./PostHogProvider');
+        render(<PostHogPageview />);
+
+        expect(captureSpy).not.toHaveBeenCalled();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,9 @@ importers:
       path-to-regexp:
         specifier: ^8.4.2
         version: 8.4.2
+      posthog-js:
+        specifier: ^1.376.3
+        version: 1.376.3
       posthog-node:
         specifier: ^5.18.0
         version: 5.24.15
@@ -6722,6 +6725,10 @@ packages:
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.211.0':
     resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
     engines: {node: '>=8.0.0'}
@@ -6748,6 +6755,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@2.5.0':
     resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -6762,6 +6775,12 @@ packages:
 
   '@opentelemetry/exporter-logs-otlp-http@0.203.0':
     resolution: {integrity: sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -6946,8 +6965,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-transformer@0.203.0':
     resolution: {integrity: sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -6958,6 +6989,12 @@ packages:
 
   '@opentelemetry/resources@2.0.1':
     resolution: {integrity: sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -6974,14 +7011,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
   '@opentelemetry/sdk-metrics@2.0.1':
     resolution: {integrity: sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.0.1':
     resolution: {integrity: sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -7188,6 +7243,12 @@ packages:
 
   '@posthog/core@1.22.0':
     resolution: {integrity: sha512-WkmOnq95aAOu6yk6r5LWr5cfXsQdpVbWDCwOxQwxSne8YV6GuZET1ziO5toSQXgrgbdcjrSz2/GopAfiL6iiAA==}
+
+  '@posthog/core@1.29.12':
+    resolution: {integrity: sha512-r/2RUa4zbN0XdBp6d+Yk8Jw1rPWXHxyXIgSm/wJf9yDLIouZbH0Pdkgbc1RIuhwL6BIHCFrOqK5jy8TFKTI6iw==}
+
+  '@posthog/types@1.376.3':
+    resolution: {integrity: sha512-w21lBoz3/ZGw7BZT7t2lJq1mpJwMvWpZijW7vEwBFNAQlq0KfKf2mj5KKUYZMXM1GdIQ0jHnn931uXPB1Ae60w==}
 
   '@prisma/config@6.19.2':
     resolution: {integrity: sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==}
@@ -12769,6 +12830,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -16672,6 +16736,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.376.3:
+    resolution: {integrity: sha512-Wmj4N6E352b8aWt/AjRYIOfagQgOlkb8LCD/r7i1eGj8WPBhrYLEXojQeZ+jndbiPbRo21l24bFJso7fyNafWQ==}
+
   posthog-node@5.24.15:
     resolution: {integrity: sha512-0QnWVOZAPwEAlp+r3r0jIGfk2IaNYM/2YnEJJhBMJZXs4LpHcTu7mX42l+e95o9xX87YpVuZU0kOkmtQUxgnOA==}
     engines: {node: ^20.20.0 || >=22.22.0}
@@ -16694,6 +16761,9 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -16999,6 +17069,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -19176,6 +19249,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -24835,6 +24911,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.211.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -24854,6 +24934,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.41.1
 
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -24862,7 +24947,7 @@ snapshots:
   '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/exporter-logs-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -24872,6 +24957,15 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-metrics-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -25052,7 +25146,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25128,6 +25222,12 @@ snapshots:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/otlp-transformer@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -25139,12 +25239,29 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
       protobufjs: 8.0.3
 
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
+      protobufjs: 8.0.3
+
   '@opentelemetry/redis-common@0.38.2': {}
 
   '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0)':
@@ -25160,17 +25277,37 @@ snapshots:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0)':
@@ -25396,6 +25533,12 @@ snapshots:
   '@posthog/core@1.22.0':
     dependencies:
       cross-spawn: 7.0.6
+
+  '@posthog/core@1.29.12':
+    dependencies:
+      '@posthog/types': 1.376.3
+
+  '@posthog/types@1.376.3': {}
 
   '@prisma/config@6.19.2':
     dependencies:
@@ -26750,7 +26893,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/node-core@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
+  '@sentry/node-core@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
       '@apm-js-collab/tracing-hooks': 0.3.1
       '@opentelemetry/api': 1.9.0
@@ -26759,9 +26902,9 @@ snapshots:
       '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.38.0
-      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
       import-in-the-middle: 2.0.6
     transitivePeerDependencies:
       - supports-color
@@ -26796,23 +26939,23 @@ snapshots:
       '@opentelemetry/instrumentation-undici': 0.21.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@prisma/instrumentation': 7.2.0(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.38.0
-      '@sentry/node-core': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
-      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      '@sentry/node-core': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
       import-in-the-middle: 2.0.6
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
+  '@sentry/opentelemetry@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.38.0
 
   '@sentry/profiling-node@10.38.0':
@@ -31952,6 +32095,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.4.8: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -37002,6 +37147,22 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.376.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@posthog/core': 1.29.12
+      '@posthog/types': 1.376.3
+      core-js: 3.48.0
+      dompurify: 3.4.2
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
   posthog-node@5.24.15:
     dependencies:
       '@posthog/core': 1.22.0
@@ -37029,6 +37190,8 @@ snapshots:
       - debug
 
   powershell-utils@0.1.0: {}
+
+  preact@10.29.2: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -37411,6 +37574,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -40465,6 +40630,8 @@ snapshots:
     optional: true
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.2.0: {}
 
   web-worker@1.5.0: {}
 


### PR DESCRIPTION
## Summary

This PR **reverses the prior architectural decision** to keep PostHog
server-side only. Per Ruslan's ask, the platform web frontend now
ships `posthog-js` with autocapture + session replay so we get richer
product analytics on the actual UI.

The earlier "we deliberately do NOT add posthog-js" comment in
`apps/web/src/app/actions/onboarding/track.ts` was based on a security
concern that doesn't actually apply: PostHog's `phc_*` key is the
project (public) API key and is meant to be shipped in the browser.
Bundle cost is real but accepted. The onboarding-wizard server relay
stays as-is because the API does allowlist validation + canonical
event shaping server-side.

## What changes

- **`posthog-js` ^1.376.3** added to `apps/web/package.json`
- **`apps/web/src/components/posthog/PostHogProvider.tsx`** — client
  component that:
  - calls `posthog.init` on mount with `capture_pageview: false`,
    `capture_pageleave: true`, `autocapture: true`
  - enables session recording with **PII-sensible defaults**:
    `maskAllInputs: false`, `maskInputOptions: { password: true,
    email: true }` — input values are recorded so funnels stay
    useful, only credentials + email are masked
  - persistence: `localStorage+cookie`
  - turns on `posthog.debug()` in development only
  - wraps children in `PHProvider` from `posthog-js/react`
  - mounts a companion `<PostHogPageview />` (under `<Suspense>`) that
    fires `$pageview` on every `usePathname` / `useSearchParams`
    change so SPA route changes count
- **`apps/web/src/components/posthog/PostHogIdentify.tsx`** — small
  client component that calls `posthog.identify(user.id, { email,
  name })` when a user is known and `posthog.reset()` otherwise. There
  is no `useUser()` hook in this repo; the dashboard layout already
  receives `AuthUser` as a prop from the server, so the identify
  component is wired there.
- **`apps/web/src/app/[locale]/layout.tsx`** — `<PostHogProvider>`
  wraps the rest of the tree inside `<NextIntlClientProvider>` so
  user identity is available for any later `posthog.identify`.
- **`apps/web/src/app/[locale]/(dashboard)/layout-client.tsx`** —
  `<PostHogIdentify userId email name />` mounted inside the
  dashboard providers, identifying the signed-in user.
- **`apps/web/.env.example`** — adds `NEXT_PUBLIC_POSTHOG_KEY` and
  `NEXT_PUBLIC_POSTHOG_HOST`; notes that the existing
  `POSTHOG_API_KEY` / `POSTHOG_HOST` are also used by the server-side
  flag eval and that `NEXT_PUBLIC_*` are the same values for the
  client bundle.
- **`apps/web/src/app/actions/onboarding/track.ts`** — replaces the
  stale "we deliberately do NOT add posthog-js" comment with one that
  explains the new split: client surfaces should call PostHog directly
  via `usePostHog()` from `posthog-js/react`; this server action stays
  for the onboarding-wizard event taxonomy that the API consolidates
  server-side.
- **`apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx`**
  — Vitest spec covering init-with-key, init-skipped-without-key,
  pageview-on-mount-with-query, pageview-on-pathname-change,
  no-pageview-without-key.

## Deploy wiring (separate PR)

`NEXT_PUBLIC_*` env vars are baked into the Next.js bundle at **build
time**, not runtime — so the build workflow + Dockerfile + k8s
manifests all need to pass `NEXT_PUBLIC_POSTHOG_KEY` and
`NEXT_PUBLIC_POSTHOG_HOST` through at build. That wiring is **out of
scope here** and ships in a separate PR.

If `NEXT_PUBLIC_POSTHOG_KEY` is absent at build, `posthog-js` silently
no-ops — **fail-open** for OSS forks that don't run PostHog.

## Test plan

- [x] `pnpm install` clean
- [x] Build prereqs: `pnpm --filter @ever-works/contracts --filter
      @ever-works/plugin build` clean
- [x] Type-check: `npx tsc --noEmit -p apps/web/tsconfig.json` clean
- [x] Lint: `npx eslint` clean on every changed file
- [x] Unit tests: `npx vitest run
      src/components/posthog/PostHogProvider.unit.spec.tsx` — 5/5
      pass
- [ ] Smoke-test in a staging build with a real `phc_*` key (deploy
      PR)
- [ ] Confirm OSS-fork behaviour: build with the var absent, verify
      no PostHog network calls (deploy PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated PostHog analytics to monitor user behavior, page navigation, and interactions throughout the application
  * Added automatic user identification to associate analytics events with authenticated users for enhanced product insights

* **Documentation**
  * Updated environment configuration documentation with setup instructions for PostHog client-side analytics, clearly distinguishing client and server configuration options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->