### PR TITLE
feat: add LM Studio and vLLM local AI provider plugins

### DIFF
--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -178,6 +178,8 @@ const sidebars: SidebarsConfig = {
 				'plugin-system/openai-plugin',
 				'plugin-system/anthropic-plugin',
 				'plugin-system/ollama-plugin',
+				'plugin-system/lm-studio-plugin',
+				'plugin-system/vllm-plugin',
 				'plugin-system/groq-plugin',
 				'plugin-system/tavily-plugin',
 				'plugin-system/apify-plugin',

--- a/apps/internal-cli/src/commands/config/__tests__/set.subcommand.spec.ts
+++ b/apps/internal-cli/src/commands/config/__tests__/set.subcommand.spec.ts
@@ -75,6 +75,8 @@ describe('SetSubCommand.run (validation paths)', () => {
             'anthropic',
             'openrouter',
             'ollama',
+            'lm-studio',
+            'vllm',
             'groq',
             'custom',
         ]) {

--- a/apps/internal-cli/src/commands/config/ai-providers/__tests__/ai-provider-registry.service.spec.ts
+++ b/apps/internal-cli/src/commands/config/ai-providers/__tests__/ai-provider-registry.service.spec.ts
@@ -9,16 +9,18 @@ describe('AiProviderRegistryService', () => {
     });
 
     describe('getAllProviders', () => {
-        it('registers exactly the seven default providers', () => {
+        it('registers exactly the nine default providers', () => {
             const providers = service.getAllProviders();
             expect(providers.map((p) => p.name).sort()).toEqual([
                 'anthropic',
                 'custom',
                 'google',
                 'groq',
+                'lm-studio',
                 'ollama',
                 'openai',
                 'openrouter',
+                'vllm',
             ]);
         });
 
@@ -48,14 +50,13 @@ describe('AiProviderRegistryService', () => {
     });
 
     describe('provider properties pinning', () => {
-        it('ollama is the only provider that does NOT require an api key by default', () => {
-            const ollama = service.getProvider('ollama');
-            const custom = service.getProvider('custom');
-            expect(ollama?.requiresApiKey).toBe(false);
-            // custom is also requiresApiKey:false; ollama and custom should both be flagged
-            expect(custom?.requiresApiKey).toBe(false);
+        it('local providers (ollama, lm-studio, vllm) and custom do NOT require an api key by default', () => {
+            const noKeyProviders = ['ollama', 'lm-studio', 'vllm', 'custom'];
+            for (const name of noKeyProviders) {
+                expect(service.getProvider(name)?.requiresApiKey).toBe(false);
+            }
             for (const p of service.getAllProviders()) {
-                if (p.name === 'ollama' || p.name === 'custom') continue;
+                if (noKeyProviders.includes(p.name)) continue;
                 expect(p.requiresApiKey).toBe(true);
             }
         });

--- a/apps/internal-cli/src/commands/config/ai-providers/ai-provider-registry.service.ts
+++ b/apps/internal-cli/src/commands/config/ai-providers/ai-provider-registry.service.ts
@@ -149,6 +149,48 @@ export class AiProviderRegistryService {
             docsUrl: 'https://github.com/ollama/ollama',
         });
 
+        this.providers.set('lm-studio', {
+            name: 'lm-studio',
+            displayName: 'LM Studio',
+            description: 'Local AI models through LM Studio (free)',
+            defaults: {
+                model: 'local-model',
+                temperature: 0.7,
+                maxTokens: 8192,
+                baseUrl: 'http://localhost:1234/v1',
+            },
+            requiresApiKey: false,
+            models: [
+                'qwen2.5-7b-instruct',
+                'llama-3.2-3b-instruct',
+                'mistral-7b-instruct',
+                'gemma-2-9b-it',
+                'phi-4',
+            ],
+            websiteUrl: 'https://lmstudio.ai',
+            docsUrl: 'https://lmstudio.ai/docs',
+        });
+
+        this.providers.set('vllm', {
+            name: 'vllm',
+            displayName: 'vLLM',
+            description: 'Self-hosted high-throughput inference via vLLM',
+            defaults: {
+                model: 'local-model',
+                temperature: 0.7,
+                maxTokens: 8192,
+                baseUrl: 'http://localhost:8000/v1',
+            },
+            requiresApiKey: false,
+            models: [
+                'meta-llama/Llama-3.1-8B-Instruct',
+                'Qwen/Qwen2.5-7B-Instruct',
+                'mistralai/Mistral-7B-Instruct-v0.3',
+            ],
+            websiteUrl: 'https://docs.vllm.ai',
+            docsUrl: 'https://docs.vllm.ai',
+        });
+
         // Groq
         this.providers.set('groq', {
             name: 'groq',

--- a/apps/internal-cli/src/commands/config/ai-providers/ai-provider-registry.service.ts
+++ b/apps/internal-cli/src/commands/config/ai-providers/ai-provider-registry.service.ts
@@ -156,7 +156,7 @@ export class AiProviderRegistryService {
             defaults: {
                 model: 'local-model',
                 temperature: 0.7,
-                maxTokens: 8192,
+                maxTokens: 4096,
                 baseUrl: 'http://localhost:1234/v1',
             },
             requiresApiKey: false,
@@ -178,7 +178,7 @@ export class AiProviderRegistryService {
             defaults: {
                 model: 'local-model',
                 temperature: 0.7,
-                maxTokens: 8192,
+                maxTokens: 4096,
                 baseUrl: 'http://localhost:8000/v1',
             },
             requiresApiKey: false,

--- a/apps/internal-cli/src/commands/config/prompts/ai-provider-prompt.service.ts
+++ b/apps/internal-cli/src/commands/config/prompts/ai-provider-prompt.service.ts
@@ -486,6 +486,9 @@ export class AiProviderPromptService extends BasePromptService {
             openrouter:
                 'Examples: openai/gpt-5.2, openai/gpt-5-mini, anthropic/claude-opus-4.5, google/gemini-3-flash, meta-llama/llama-3.3-70b-instruct:free',
             ollama: 'Examples: llama3.3, llama3.2, qwen2.5, qwen2.5-coder, deepseek-r1, gemma2, phi4',
+            'lm-studio':
+                'Use the model id currently loaded in LM Studio (e.g. qwen2.5-7b-instruct, llama-3.2-3b-instruct)',
+            vllm: 'Use the model id vLLM was launched with via --model (e.g. meta-llama/Llama-3.1-8B-Instruct)',
             groq: 'Examples: openai/gpt-oss-120b, llama-3.3-70b-versatile, llama-3.1-8b-instant, qwen-qwq-32b',
             custom: 'Enter any model name supported by your OpenAI-compatible endpoint',
         };

--- a/apps/internal-cli/src/commands/config/set.subcommand.ts
+++ b/apps/internal-cli/src/commands/config/set.subcommand.ts
@@ -97,6 +97,8 @@ export class SetSubCommand extends CommandRunner {
                 'anthropic',
                 'openrouter',
                 'ollama',
+                'lm-studio',
+                'vllm',
                 'groq',
                 'custom',
             ];

--- a/docs/plugin-system/ai-provider-plugins.md
+++ b/docs/plugin-system/ai-provider-plugins.md
@@ -161,6 +161,38 @@ Groq provides extremely fast inference through custom LPU hardware. Ideal for la
 
 Ollama runs models locally. Users must have Ollama installed and running. The `baseUrl` setting (default: `http://localhost:11434`) points to the local Ollama instance.
 
+### LM Studio
+
+| Property           | Value                          |
+| ------------------ | ------------------------------ |
+| Package            | `@ever-works/lm-studio-plugin` |
+| Provider Type      | `lm-studio`                    |
+| Configuration Mode | `user-required`                |
+| Default Model      | User's loaded model            |
+| Structured Output  | Model dependent                |
+| Streaming          | Yes                            |
+| Tool Calling       | Model dependent                |
+| Vision             | Model dependent                |
+| Embeddings         | Model dependent                |
+
+LM Studio runs models locally and serves them through an OpenAI-compatible API. Start the **Local Server** in the LM Studio app; the `baseUrl` setting (default: `http://localhost:1234/v1`) points to it. No API key is required by default. The model fields have no hardcoded default — they are populated from the currently loaded model via the `model-select` widget.
+
+### vLLM
+
+| Property           | Value                     |
+| ------------------ | ------------------------- |
+| Package            | `@ever-works/vllm-plugin` |
+| Provider Type      | `vllm`                    |
+| Configuration Mode | `user-required`           |
+| Default Model      | Server's `--model`        |
+| Structured Output  | Model dependent           |
+| Streaming          | Yes                       |
+| Tool Calling       | Model dependent           |
+| Vision             | Model dependent           |
+| Embeddings         | Model dependent           |
+
+vLLM is a high-throughput inference server, usually deployed on a GPU host. It exposes an OpenAI-compatible API; the `baseUrl` setting (default: `http://localhost:8000/v1`) points to it. The `apiKey` field defaults to vLLM's `EMPTY` placeholder and is only needed when the server was started with `--api-key` (it is stored encrypted via `x-secret`). For the managed cloud to reach a vLLM server, the base URL must be resolvable from where work generation runs — see the [vLLM plugin page](./vllm-plugin.md) for the networking note.
+
 ### Mistral
 
 | Property           | Value                        |

--- a/docs/plugin-system/built-in-plugins.md
+++ b/docs/plugin-system/built-in-plugins.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 # Built-in Plugins
 
-The platform ships with 40 plugins across the AI provider, search, content extraction, screenshot, git, deployment, pipeline, data source, and utility categories. This page documents each plugin, its configuration, and environment variables.
+The platform ships with 42 plugins across the AI provider, search, content extraction, screenshot, git, deployment, pipeline, data source, and utility categories. This page documents each plugin, its configuration, and environment variables.
 
 ## AI Providers
 
@@ -117,6 +117,42 @@ Use locally running models via Ollama. No API key required.
 | `baseUrl`      | string | —        | Ollama URL (required, e.g., `http://localhost:11434/v1`) |
 | `defaultModel` | string | `llama2` | Default model                                            |
 | `apiKey`       | string | `ollama` | API key (optional, defaults to `ollama`)                 |
+
+### LM Studio
+
+Use locally running models via the LM Studio local server. No API key required.
+
+| Field              | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `lm-studio`     |
+| Configuration Mode | `user-required` |
+| Auto Enable        | No              |
+
+**Settings:**
+
+| Setting        | Type   | Default     | Description                                                      |
+| -------------- | ------ | ----------- | ---------------------------------------------------------------- |
+| `baseUrl`      | string | —           | LM Studio URL (required, e.g., `http://localhost:1234/v1`)       |
+| `apiKey`       | string | `lm-studio` | API key (optional; only for an auth proxy in front of LM Studio) |
+| `defaultModel` | string | —           | Loaded model id (required; populated via the model picker)       |
+
+### vLLM
+
+Use a self-hosted vLLM OpenAI-compatible server (typically GPU-hosted).
+
+| Field              | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `vllm`          |
+| Configuration Mode | `user-required` |
+| Auto Enable        | No              |
+
+**Settings:**
+
+| Setting        | Type   | Default | Description                                                          |
+| -------------- | ------ | ------- | -------------------------------------------------------------------- |
+| `baseUrl`      | string | —       | vLLM URL (required, e.g., `http://localhost:8000/v1`)                |
+| `apiKey`       | string | `EMPTY` | API key (secret; only required if started with `--api-key`)          |
+| `defaultModel` | string | —       | Model id passed to `vllm serve --model` (required; via model picker) |
 
 ### Mistral
 

--- a/docs/plugin-system/lm-studio-plugin.md
+++ b/docs/plugin-system/lm-studio-plugin.md
@@ -1,0 +1,120 @@
+---
+id: lm-studio-plugin
+title: 'LM Studio Plugin'
+sidebar_label: 'LM Studio'
+sidebar_position: 24
+---
+
+# LM Studio AI Provider Plugin
+
+The LM Studio plugin connects Ever Works to a local or remote [LM Studio](https://lmstudio.ai) server for self-hosted AI inference. It extends `BaseAiProvider` and uses the shared `AiOperations` layer that wraps LangChain under the hood.
+
+**Source:** `packages/plugins/lm-studio/src/lm-studio.plugin.ts`
+
+## Overview
+
+| Property           | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `lm-studio`     |
+| Category           | `ai-provider`   |
+| Capabilities       | `ai-provider`   |
+| Version            | `1.0.0`         |
+| Configuration Mode | `user-required` |
+| Provider Type      | `lm-studio`     |
+| Auto-enable        | No              |
+| Built-in           | Yes             |
+| Visibility         | `public`        |
+
+LM Studio runs open-source models (Llama, Qwen, Mistral, Gemma, …) on your own machine and exposes them through an OpenAI-compatible API. Because the server is local, your data never leaves your infrastructure, and there are no per-token costs.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[AiFacadeService] --> B[LmStudioPlugin]
+    B --> C[BaseAiProvider]
+    C --> D[AiOperations]
+    D --> E[LangChain OpenAI-compatible Provider]
+    E --> F[LM Studio Server /v1 endpoint]
+```
+
+The plugin talks to LM Studio through its OpenAI-compatible `/v1` API endpoint, so any model loaded in LM Studio works without additional configuration.
+
+## Configuration
+
+### Settings Schema
+
+| Setting        | Type     | Default     | Scope    | Description                                                       |
+| -------------- | -------- | ----------- | -------- | ----------------------------------------------------------------- |
+| `baseUrl`      | `string` | —           | `user`   | Address of the LM Studio server (e.g. `http://localhost:1234/v1`) |
+| `apiKey`       | `string` | `lm-studio` | `user`   | Only needed if LM Studio is placed behind an auth proxy           |
+| `defaultModel` | `string` | —           | `global` | Used for all AI tasks unless a tier-specific model is set         |
+| `simpleModel`  | `string` | —           | `global` | Handles tags, short descriptions, and quick classifications       |
+| `mediumModel`  | `string` | —           | `global` | Handles listings, summaries, and content reformatting             |
+| `complexModel` | `string` | —           | `global` | Handles full page generation and multi-step analysis              |
+| `temperature`  | `number` | `0.7`       | hidden   | Controls output randomness (0 = deterministic, 2 = creative)      |
+| `maxTokens`    | `number` | `4096`      | hidden   | Maximum length of each AI-generated response                      |
+
+Model fields use the `x-widget: model-select` extension, which renders a model dropdown in the dashboard UI populated by calling `listModels()` against the configured server. Unlike cloud providers, **the model fields ship without a hardcoded default** — LM Studio serves whatever model you have loaded, so you select it after the connection succeeds.
+
+### Required Fields
+
+- `baseUrl` — the LM Studio server address
+- `defaultModel` — at least one model must be selected
+
+## Model Capabilities
+
+```typescript
+getCapabilities(): AiModelCapabilities {
+    return {
+        supportsStructuredOutput: true,
+        supportsStreaming: true,
+        supportsToolCalling: true,
+        supportsVision: true,
+        maxContextLength: 128000
+    };
+}
+```
+
+These are advisory hints — actual support depends on the model you load in LM Studio.
+
+## Lifecycle
+
+### Loading
+
+```typescript
+async onLoad(context: PluginContext): Promise<void> {
+    await super.onLoad(context);
+    this.aiOps = new AiOperations({
+        apiKey: 'lm-studio',
+        model: this.getDefaultModelId(),
+        baseURL: 'http://localhost:1234/v1',
+        temperature: 0.7,
+        maxTokens: 4096,
+        providerType: 'lm-studio'
+    });
+}
+```
+
+On load the plugin creates an `AiOperations` instance with default values. When a request arrives, `resolveConfig()` merges the user's saved settings on top of these defaults before executing.
+
+### Availability Check
+
+`isAvailable()` calls `AiOperations.testConnection()` with the resolved configuration to verify the LM Studio server is reachable. The setup UI uses this (via `validateConnection()`) to detect connectivity before saving.
+
+## Getting Started
+
+1. Install LM Studio from [lmstudio.ai](https://lmstudio.ai) and download at least one model.
+2. Start the **Local Server** in LM Studio (Developer tab) — it listens on `http://localhost:1234` by default.
+3. Enable the LM Studio plugin in **Settings → Plugins**.
+4. Set the **LM Studio Server URL** to your instance address (include the `/v1` suffix).
+5. Select your preferred model for each task complexity tier.
+
+## Troubleshooting
+
+| Issue                    | Cause                        | Solution                                                         |
+| ------------------------ | ---------------------------- | ---------------------------------------------------------------- |
+| Plugin shows unavailable | Local server not started     | Open LM Studio → Developer → **Start Server**                    |
+| No models in dropdown    | No model loaded              | Load a model in the LM Studio app                                |
+| Connection refused       | Wrong base URL               | Verify the URL includes `/v1` (e.g., `http://localhost:1234/v1`) |
+| Slow responses           | Model too large for hardware | Use a smaller / quantized model or increase available RAM/VRAM   |

--- a/docs/plugin-system/lm-studio-plugin.md
+++ b/docs/plugin-system/lm-studio-plugin.md
@@ -44,16 +44,17 @@ The plugin talks to LM Studio through its OpenAI-compatible `/v1` API endpoint, 
 
 ### Settings Schema
 
-| Setting        | Type     | Default     | Scope    | Description                                                       |
-| -------------- | -------- | ----------- | -------- | ----------------------------------------------------------------- |
-| `baseUrl`      | `string` | —           | `user`   | Address of the LM Studio server (e.g. `http://localhost:1234/v1`) |
-| `apiKey`       | `string` | `lm-studio` | `user`   | Only needed if LM Studio is placed behind an auth proxy           |
-| `defaultModel` | `string` | —           | `global` | Used for all AI tasks unless a tier-specific model is set         |
-| `simpleModel`  | `string` | —           | `global` | Handles tags, short descriptions, and quick classifications       |
-| `mediumModel`  | `string` | —           | `global` | Handles listings, summaries, and content reformatting             |
-| `complexModel` | `string` | —           | `global` | Handles full page generation and multi-step analysis              |
-| `temperature`  | `number` | `0.7`       | hidden   | Controls output randomness (0 = deterministic, 2 = creative)      |
-| `maxTokens`    | `number` | `4096`      | hidden   | Maximum length of each AI-generated response                      |
+| Setting          | Type     | Default     | Scope    | Description                                                            |
+| ---------------- | -------- | ----------- | -------- | ---------------------------------------------------------------------- |
+| `baseUrl`        | `string` | —           | `user`   | Address of the LM Studio server (e.g. `http://localhost:1234/v1`)      |
+| `apiKey`         | `string` | `lm-studio` | `user`   | Only needed for an auth proxy in front of LM Studio (stored encrypted) |
+| `defaultModel`   | `string` | —           | `global` | Used for all AI tasks unless a tier-specific model is set              |
+| `simpleModel`    | `string` | —           | `global` | Handles tags, short descriptions, and quick classifications            |
+| `mediumModel`    | `string` | —           | `global` | Handles listings, summaries, and content reformatting                  |
+| `complexModel`   | `string` | —           | `global` | Handles full page generation and multi-step analysis                   |
+| `embeddingModel` | `string` | —           | `global` | Model for semantic-search embeddings (only needed for KB search)       |
+| `temperature`    | `number` | `0.7`       | hidden   | Controls output randomness (0 = deterministic, 2 = creative)           |
+| `maxTokens`      | `number` | `4096`      | hidden   | Maximum length of each AI-generated response                           |
 
 Model fields use the `x-widget: model-select` extension, which renders a model dropdown in the dashboard UI populated by calling `listModels()` against the configured server. Unlike cloud providers, **the model fields ship without a hardcoded default** — LM Studio serves whatever model you have loaded, so you select it after the connection succeeds.
 

--- a/docs/plugin-system/vllm-plugin.md
+++ b/docs/plugin-system/vllm-plugin.md
@@ -44,16 +44,17 @@ The plugin talks to vLLM through its OpenAI-compatible `/v1` API endpoint. vLLM 
 
 ### Settings Schema
 
-| Setting        | Type     | Default | Scope    | Description                                                          |
-| -------------- | -------- | ------- | -------- | -------------------------------------------------------------------- |
-| `baseUrl`      | `string` | —       | `user`   | Address of the vLLM server (e.g. `http://localhost:8000/v1`)         |
-| `apiKey`       | `string` | `EMPTY` | `user`   | Only required if the server was started with `--api-key` (encrypted) |
-| `defaultModel` | `string` | —       | `global` | Used for all AI tasks unless a tier-specific model is set            |
-| `simpleModel`  | `string` | —       | `global` | Handles tags, short descriptions, and quick classifications          |
-| `mediumModel`  | `string` | —       | `global` | Handles listings, summaries, and content reformatting                |
-| `complexModel` | `string` | —       | `global` | Handles full page generation and multi-step analysis                 |
-| `temperature`  | `number` | `0.7`   | hidden   | Controls output randomness (0 = deterministic, 2 = creative)         |
-| `maxTokens`    | `number` | `4096`  | hidden   | Maximum length of each AI-generated response                         |
+| Setting          | Type     | Default | Scope    | Description                                                          |
+| ---------------- | -------- | ------- | -------- | -------------------------------------------------------------------- |
+| `baseUrl`        | `string` | —       | `user`   | Address of the vLLM server (e.g. `http://localhost:8000/v1`)         |
+| `apiKey`         | `string` | `EMPTY` | `user`   | Only required if the server was started with `--api-key` (encrypted) |
+| `defaultModel`   | `string` | —       | `global` | Used for all AI tasks unless a tier-specific model is set            |
+| `simpleModel`    | `string` | —       | `global` | Handles tags, short descriptions, and quick classifications          |
+| `mediumModel`    | `string` | —       | `global` | Handles listings, summaries, and content reformatting                |
+| `complexModel`   | `string` | —       | `global` | Handles full page generation and multi-step analysis                 |
+| `embeddingModel` | `string` | —       | `global` | Model for semantic-search embeddings (only needed for KB search)     |
+| `temperature`    | `number` | `0.7`   | hidden   | Controls output randomness (0 = deterministic, 2 = creative)         |
+| `maxTokens`      | `number` | `4096`  | hidden   | Maximum length of each AI-generated response                         |
 
 The `apiKey` field is marked `x-secret`, so a real token is stored encrypted. It defaults to vLLM's documented `EMPTY` placeholder, which an unsecured server accepts. Model fields use `x-widget: model-select` and have **no hardcoded default** — set them to the model id vLLM was launched with.
 

--- a/docs/plugin-system/vllm-plugin.md
+++ b/docs/plugin-system/vllm-plugin.md
@@ -1,0 +1,124 @@
+---
+id: vllm-plugin
+title: 'vLLM Plugin'
+sidebar_label: 'vLLM'
+sidebar_position: 25
+---
+
+# vLLM AI Provider Plugin
+
+The vLLM plugin connects Ever Works to a self-hosted [vLLM](https://docs.vllm.ai) server for high-throughput, private AI inference. It extends `BaseAiProvider` and uses the shared `AiOperations` layer that wraps LangChain under the hood.
+
+**Source:** `packages/plugins/vllm/src/vllm.plugin.ts`
+
+## Overview
+
+| Property           | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `vllm`          |
+| Category           | `ai-provider`   |
+| Capabilities       | `ai-provider`   |
+| Version            | `1.0.0`         |
+| Configuration Mode | `user-required` |
+| Provider Type      | `vllm`          |
+| Auto-enable        | No              |
+| Built-in           | Yes             |
+| Visibility         | `public`        |
+
+vLLM is a high-throughput inference engine (PagedAttention) for open-source models, usually deployed on a GPU server. It exposes an OpenAI-compatible API, so Ever Works can use it for content generation, conversations, and embeddings while keeping data on your own infrastructure.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[AiFacadeService] --> B[VllmPlugin]
+    B --> C[BaseAiProvider]
+    C --> D[AiOperations]
+    D --> E[LangChain OpenAI-compatible Provider]
+    E --> F[vLLM Server /v1 endpoint]
+```
+
+The plugin talks to vLLM through its OpenAI-compatible `/v1` API endpoint. vLLM serves the model it was launched with (`vllm serve --model ...`).
+
+## Configuration
+
+### Settings Schema
+
+| Setting        | Type     | Default | Scope    | Description                                                          |
+| -------------- | -------- | ------- | -------- | -------------------------------------------------------------------- |
+| `baseUrl`      | `string` | —       | `user`   | Address of the vLLM server (e.g. `http://localhost:8000/v1`)         |
+| `apiKey`       | `string` | `EMPTY` | `user`   | Only required if the server was started with `--api-key` (encrypted) |
+| `defaultModel` | `string` | —       | `global` | Used for all AI tasks unless a tier-specific model is set            |
+| `simpleModel`  | `string` | —       | `global` | Handles tags, short descriptions, and quick classifications          |
+| `mediumModel`  | `string` | —       | `global` | Handles listings, summaries, and content reformatting                |
+| `complexModel` | `string` | —       | `global` | Handles full page generation and multi-step analysis                 |
+| `temperature`  | `number` | `0.7`   | hidden   | Controls output randomness (0 = deterministic, 2 = creative)         |
+| `maxTokens`    | `number` | `4096`  | hidden   | Maximum length of each AI-generated response                         |
+
+The `apiKey` field is marked `x-secret`, so a real token is stored encrypted. It defaults to vLLM's documented `EMPTY` placeholder, which an unsecured server accepts. Model fields use `x-widget: model-select` and have **no hardcoded default** — set them to the model id vLLM was launched with.
+
+### Required Fields
+
+- `baseUrl` — the vLLM server address
+- `defaultModel` — at least one model must be selected
+
+## Networking note (managed cloud vs self-hosted)
+
+The inference HTTP call is made by whoever runs work generation. For the **managed Ever Works cloud** to use your vLLM server, the `baseUrl` must be reachable from where generation runs — i.e. a public or VPN-reachable URL secured with `--api-key`. A `localhost` URL only resolves correctly when Ever Works itself runs on the **same machine or LAN** as the vLLM server (self-hosted deployment). vLLM is the most common "remote endpoint" case because it is typically GPU-hosted rather than on a laptop.
+
+## Model Capabilities
+
+```typescript
+getCapabilities(): AiModelCapabilities {
+    return {
+        supportsStructuredOutput: true,
+        supportsStreaming: true,
+        supportsToolCalling: true,
+        supportsVision: true,
+        maxContextLength: 128000
+    };
+}
+```
+
+These are advisory hints — actual support depends on the served model and the flags vLLM was started with (e.g. tool calling needs `--enable-auto-tool-choice`).
+
+## Lifecycle
+
+### Loading
+
+```typescript
+async onLoad(context: PluginContext): Promise<void> {
+    await super.onLoad(context);
+    this.aiOps = new AiOperations({
+        apiKey: 'EMPTY',
+        model: this.getDefaultModelId(),
+        baseURL: 'http://localhost:8000/v1',
+        temperature: 0.7,
+        maxTokens: 4096,
+        providerType: 'vllm'
+    });
+}
+```
+
+When a request arrives, `resolveConfig()` merges the user's saved settings (base URL, API key, selected model) on top of these defaults before executing.
+
+### Availability Check
+
+`isAvailable()` calls `AiOperations.testConnection()` with the resolved configuration. The setup UI uses this (via `validateConnection()`) to detect connectivity and authentication before saving.
+
+## Getting Started
+
+1. Start a vLLM OpenAI-compatible server: `vllm serve <model>` (listens on `http://localhost:8000` by default).
+2. If you secured it with `--api-key <token>`, have that token ready.
+3. Enable the vLLM plugin in **Settings → Plugins**.
+4. Set the **vLLM Server URL** (include the `/v1` suffix) and, if needed, the **API Key**.
+5. Select the model your server is serving for each task complexity tier.
+
+## Troubleshooting
+
+| Issue                     | Cause                                               | Solution                                                                       |
+| ------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Plugin shows unavailable  | Server not running or unreachable from Ever Works   | Confirm `vllm serve` is up and the base URL is reachable (see networking note) |
+| `401` / `Invalid API key` | Server started with `--api-key` but token missing   | Enter the exact `--api-key` token in the **API Key** field                     |
+| `Model not found`         | Selected model differs from the one vLLM is serving | Set the model fields to the value passed to `vllm serve --model ...`           |
+| No models in dropdown     | Connection failed before `listModels()` could run   | Fix the base URL / API key first, then re-open the model picker                |

--- a/packages/agent/src/services/utils/error-classification.utils.spec.ts
+++ b/packages/agent/src/services/utils/error-classification.utils.spec.ts
@@ -237,6 +237,8 @@ describe('classifyGenerationError', () => {
             ['gemini quota exceeded', 'Google'],
             ['groq insufficient_quota', 'Groq'],
             ['ollama insufficient_quota', 'Ollama'],
+            ['lm-studio insufficient_quota', 'LM Studio'],
+            ['vllm insufficient_quota', 'vLLM'],
             ['openrouter rate_limit', 'OpenRouter'],
         ])('detects provider %p as %p', (input, provider) => {
             const result = classifyGenerationError(input);

--- a/packages/agent/src/services/utils/error-classification.utils.ts
+++ b/packages/agent/src/services/utils/error-classification.utils.ts
@@ -121,6 +121,9 @@ function detectAiProvider(error: string): string {
     if (error.includes('google') || error.includes('gemini')) return 'Google';
     if (error.includes('groq')) return 'Groq';
     if (error.includes('ollama')) return 'Ollama';
+    if (error.includes('lm-studio') || error.includes('lmstudio') || error.includes('lm studio'))
+        return 'LM Studio';
+    if (error.includes('vllm')) return 'vLLM';
     if (error.includes('openrouter')) return 'OpenRouter';
     return 'AI Provider';
 }

--- a/packages/plugins/lm-studio/README.md
+++ b/packages/plugins/lm-studio/README.md
@@ -1,0 +1,82 @@
+# @ever-works/lm-studio-plugin
+
+LM Studio AI provider plugin for Ever Works platform
+
+## Plugin metadata
+
+| Field        | Value           |
+| ------------ | --------------- |
+| ID           | `lm-studio`     |
+| Category     | `ai-provider`   |
+| Capabilities | `ai-provider`   |
+| Author       | Ever Works Team |
+| License      | AGPL-3.0        |
+| Built-in     | yes             |
+| Auto-enable  | no              |
+
+## What is the LM Studio plugin?
+
+This plugin connects Ever Works to an [LM Studio](https://lmstudio.ai) server for AI inference. LM Studio runs open-source models (Llama, Qwen, Mistral, Gemma, and others) locally and exposes them through an OpenAI-compatible API. Because the server runs on your own machine, your data never leaves your infrastructure.
+
+## Why use it?
+
+- **Data privacy** — requests are processed by your LM Studio instance, keeping sensitive content off third-party servers
+- **No API costs** — run unlimited requests against your own hardware
+- **Open-source models** — load any GGUF/MLX model supported by LM Studio
+- **Friendly UI** — manage and download models from the LM Studio desktop app
+
+## How it works in Ever Works
+
+When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your LM Studio server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.
+
+LM Studio exposes the same OpenAI-compatible `/v1` API as the other AI providers, so it reuses the shared `AiOperations` (LangChain) backend with a different base URL.
+
+## Getting started
+
+1. Install LM Studio ([lmstudio.ai](https://lmstudio.ai)) and download at least one model.
+2. Start the **Local Server** in LM Studio (Developer tab) — it listens on `http://localhost:1234` by default.
+3. Enable the LM Studio plugin and set the **Base URL** to your server address (include the `/v1` suffix).
+4. Select your preferred model for each task complexity level.
+
+## Settings
+
+- **LM Studio Server URL** — address of your LM Studio server, e.g. `http://localhost:1234/v1` (per-user, required).
+- **API Key** — usually not needed; only for instances placed behind an auth proxy (per-user).
+- **Default Model** — used for all AI tasks unless a tier-specific model is set. No hardcoded default: pick a model after the connection is established and the model list loads.
+- **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
+- **Standard Tasks Model** — handles listings, summaries, and content reformatting.
+- **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
+- **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
+
+## Troubleshooting
+
+| Symptom                               | Likely cause                                                       | Fix                                                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Plugin shows unavailable              | LM Studio local server not started                                 | Open LM Studio → Developer → **Start Server**, then re-test the connection                                   |
+| No models in the dropdown             | No model loaded in LM Studio                                       | Load a model in the LM Studio app; the server serves whatever model is currently loaded                      |
+| `Connection refused` / wrong base URL | Base URL missing the `/v1` suffix or wrong port                    | Verify the URL is `http://localhost:1234/v1` (or your configured host/port)                                  |
+| Empty / truncated AI output           | **Max Tokens** too low, or context window exceeded                 | Raise **Max Tokens**, or split the input into smaller batches                                                |
+| Plugin not selected during generation | Another AI provider plugin is set as the default for `ai-provider` | In **Settings → Plugins**, set `lm-studio` as the default for `ai-provider`, or disable competing AI plugins |
+| Slow responses                        | Model too large for the available hardware                         | Use a smaller / quantized model, or increase available RAM / VRAM                                            |
+
+## Local development
+
+This plugin ships built-in with the Ever Works platform. To work on it locally from the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter @ever-works/lm-studio-plugin build
+pnpm --filter @ever-works/lm-studio-plugin test
+```
+
+## Documentation
+
+- [Ever Works documentation](https://docs.ever.works)
+- [Ever Works repository](https://github.com/ever-works/ever-works)
+- [Plugin system](../../plugin/README.md)
+- [LM Studio homepage](https://lmstudio.ai)
+
+## License
+
+AGPL-3.0

--- a/packages/plugins/lm-studio/README.md
+++ b/packages/plugins/lm-studio/README.md
@@ -41,11 +41,12 @@ LM Studio exposes the same OpenAI-compatible `/v1` API as the other AI providers
 ## Settings
 
 - **LM Studio Server URL** — address of your LM Studio server, e.g. `http://localhost:1234/v1` (per-user, required).
-- **API Key** — usually not needed; only for instances placed behind an auth proxy (per-user).
+- **API Key** — usually not needed; only for instances placed behind an auth proxy. Stored encrypted (per-user).
 - **Default Model** — used for all AI tasks unless a tier-specific model is set. No hardcoded default: pick a model after the connection is established and the model list loads.
 - **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
 - **Standard Tasks Model** — handles listings, summaries, and content reformatting.
 - **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Embedding Model** — model used for semantic-search embeddings; only needed if you use KB search.
 - **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
 - **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
 

--- a/packages/plugins/lm-studio/package.json
+++ b/packages/plugins/lm-studio/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@ever-works/lm-studio-plugin",
+	"version": "1.0.0",
+	"description": "LM Studio AI provider plugin for Ever Works platform",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@langchain/openai": "^0.6.17",
+		"@langchain/core": "^0.3.80"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^3.2.1"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "lm-studio",
+			"name": "LM Studio",
+			"version": "1.0.0",
+			"category": "ai-provider",
+			"capabilities": [
+				"ai-provider"
+			],
+			"description": "LM Studio AI provider plugin for Ever Works platform",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false
+		}
+	}
+}

--- a/packages/plugins/lm-studio/src/__tests__/lm-studio.plugin.spec.ts
+++ b/packages/plugins/lm-studio/src/__tests__/lm-studio.plugin.spec.ts
@@ -47,11 +47,12 @@ describe('LmStudioPlugin', () => {
 			expect(plugin.settingsSchema.required).toEqual(['baseUrl', 'defaultModel']);
 		});
 
-		it('should have apiKey with placeholder default value', () => {
+		it('should have apiKey as an encrypted secret with a placeholder default', () => {
 			const apiKeySchema = plugin.settingsSchema.properties?.apiKey as any;
 			expect(apiKeySchema).toBeDefined();
 			expect(apiKeySchema.type).toBe('string');
 			expect(apiKeySchema.default).toBe('lm-studio');
+			expect(apiKeySchema['x-secret']).toBe(true);
 			expect(apiKeySchema['x-scope']).toBe('user');
 		});
 
@@ -204,6 +205,29 @@ describe('LmStudioPlugin', () => {
 
 			expect(aiOpsInstance.testConnection).toHaveBeenCalledWith(
 				expect.objectContaining({ baseURL: 'http://custom:1234/v1' })
+			);
+		});
+
+		it('should pass resolved settings (URL, key, embedding model) to AiOperations.createEmbedding', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				settings: {
+					baseUrl: 'http://custom:1234/v1',
+					apiKey: 'proxy-token',
+					embeddingModel: 'nomic-embed-text'
+				}
+			});
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.objectContaining({ input: 'hello' }),
+				expect.objectContaining({
+					baseURL: 'http://custom:1234/v1',
+					apiKey: 'proxy-token',
+					embeddingModel: 'nomic-embed-text'
+				})
 			);
 		});
 	});

--- a/packages/plugins/lm-studio/src/__tests__/lm-studio.plugin.spec.ts
+++ b/packages/plugins/lm-studio/src/__tests__/lm-studio.plugin.spec.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LmStudioPlugin } from '../lm-studio.plugin';
+import type { PluginContext } from '@ever-works/plugin';
+import { AiOperations } from '@ever-works/plugin/ai';
+
+vi.mock('@ever-works/plugin/ai', () => {
+	const MockAiOperations = vi.fn().mockImplementation(() => ({
+		createChatCompletion: vi.fn().mockResolvedValue({ id: 'test', choices: [], model: 'local-model', created: 0 }),
+		createStreamingChatCompletion: vi.fn(),
+		createEmbedding: vi.fn(),
+		askJson: vi.fn().mockResolvedValue({ result: {}, model: 'local-model', usage: undefined }),
+		listModels: vi.fn().mockResolvedValue([]),
+		testConnection: vi.fn().mockResolvedValue({ success: true })
+	}));
+	return { AiOperations: MockAiOperations };
+});
+
+describe('LmStudioPlugin', () => {
+	let plugin: LmStudioPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new LmStudioPlugin();
+	});
+
+	describe('metadata', () => {
+		it('should have correct plugin id and name', () => {
+			expect(plugin.id).toBe('lm-studio');
+			expect(plugin.name).toBe('LM Studio');
+			expect(plugin.version).toBe('1.0.0');
+		});
+
+		it('should have ai-provider category and capability', () => {
+			expect(plugin.category).toBe('ai-provider');
+			expect(plugin.capabilities).toContain('ai-provider');
+		});
+
+		it('should have user-required configuration mode', () => {
+			expect(plugin.configurationMode).toBe('user-required');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('should have required baseUrl and defaultModel fields', () => {
+			expect(plugin.settingsSchema).toBeDefined();
+			expect(plugin.settingsSchema.type).toBe('object');
+			expect(plugin.settingsSchema.required).toEqual(['baseUrl', 'defaultModel']);
+		});
+
+		it('should have apiKey with placeholder default value', () => {
+			const apiKeySchema = plugin.settingsSchema.properties?.apiKey as any;
+			expect(apiKeySchema).toBeDefined();
+			expect(apiKeySchema.type).toBe('string');
+			expect(apiKeySchema.default).toBe('lm-studio');
+			expect(apiKeySchema['x-scope']).toBe('user');
+		});
+
+		it('should have all model settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('defaultModel');
+			expect(props).toHaveProperty('simpleModel');
+			expect(props).toHaveProperty('mediumModel');
+			expect(props).toHaveProperty('complexModel');
+		});
+
+		it('should NOT hardcode a default model (populated via model-select)', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect((props.defaultModel as any).default).toBeUndefined();
+			expect((props.defaultModel as any)['x-widget']).toBe('model-select');
+		});
+
+		it('should have baseUrl setting with the LM Studio title', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('baseUrl');
+			expect((props.baseUrl as any).type).toBe('string');
+			expect((props.baseUrl as any).title).toBe('LM Studio Server URL');
+		});
+
+		it('should have temperature and maxTokens settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('temperature');
+			expect(props).toHaveProperty('maxTokens');
+			expect((props.temperature as any).type).toBe('number');
+			expect((props.maxTokens as any).type).toBe('number');
+		});
+
+		it('should have description on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).description, `${key} should have a description`).toBeDefined();
+				expect((prop as any).description, `${key} description should not be empty`).not.toBe('');
+			}
+		});
+
+		it('should have title on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).title, `${key} should have a title`).toBeDefined();
+			}
+		});
+	});
+
+	describe('lifecycle hooks', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'lm-studio',
+				logger: {
+					log: vi.fn(),
+					debug: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn()
+				},
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should load successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			expect(mockContext.logger.log).toHaveBeenCalledWith('LM Studio Plugin loaded');
+		});
+
+		it('should unload successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			await plugin.onUnload();
+		});
+	});
+
+	describe('manifest', () => {
+		it('should return correct manifest', () => {
+			const manifest = plugin.getManifest();
+			expect(manifest.id).toBe('lm-studio');
+			expect(manifest.name).toBe('LM Studio');
+			expect(manifest.builtIn).toBe(true);
+			expect(manifest.autoEnable).toBe(false);
+			expect(manifest.visibility).toBe('public');
+			expect(manifest.icon).toBeDefined();
+			expect(manifest.icon?.type).toBe('svg');
+		});
+	});
+
+	describe('healthCheck', () => {
+		it('should return healthy status', async () => {
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+			expect(health.message).toBe('LM Studio plugin is ready');
+			expect(health.checkedAt).toBeDefined();
+		});
+	});
+
+	describe('askJson', () => {
+		const createMockContext2 = (): PluginContext =>
+			({
+				pluginId: 'lm-studio',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should delegate to aiOps.askJson with resolved config', async () => {
+			await plugin.onLoad(createMockContext2());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.askJson('Generate JSON', {
+				settings: { apiKey: 'lm-studio' }
+			});
+
+			expect(aiOpsInstance.askJson).toHaveBeenCalledWith(
+				'Generate JSON',
+				expect.any(Object),
+				expect.objectContaining({ apiKey: 'lm-studio' }),
+				expect.any(Object)
+			);
+		});
+
+		it('should throw when plugin not loaded', async () => {
+			await expect(plugin.askJson('test')).rejects.toThrow('Plugin not loaded');
+		});
+	});
+
+	describe('settings threading', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'lm-studio',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should pass settings as configOverrides to AiOperations.listModels', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.listModels({ baseUrl: 'http://custom:1234/v1' });
+
+			expect(aiOpsInstance.listModels).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:1234/v1' })
+			);
+		});
+
+		it('should pass settings as configOverrides to AiOperations.testConnection', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.isAvailable({ baseUrl: 'http://custom:1234/v1' });
+
+			expect(aiOpsInstance.testConnection).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:1234/v1' })
+			);
+		});
+	});
+});

--- a/packages/plugins/lm-studio/src/index.ts
+++ b/packages/plugins/lm-studio/src/index.ts
@@ -1,0 +1,1 @@
+export { LmStudioPlugin, LmStudioPlugin as default } from './lm-studio.plugin.js';

--- a/packages/plugins/lm-studio/src/lm-studio.plugin.ts
+++ b/packages/plugins/lm-studio/src/lm-studio.plugin.ts
@@ -54,6 +54,7 @@ export class LmStudioPlugin extends BaseAiProvider {
 				title: 'API Key',
 				description: 'Usually not needed; only for LM Studio instances placed behind an auth proxy',
 				default: 'lm-studio',
+				'x-secret': true,
 				'x-scope': 'user'
 			},
 			defaultModel: {
@@ -81,6 +82,13 @@ export class LmStudioPlugin extends BaseAiProvider {
 				type: 'string',
 				title: 'Complex Tasks Model',
 				description: 'Handles full page generation and multi-step analysis',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			embeddingModel: {
+				type: 'string',
+				title: 'Embedding Model',
+				description: 'Model used for semantic search embeddings (only needed if you use KB search)',
 				'x-widget': 'model-select',
 				'x-scope': 'global'
 			},
@@ -143,7 +151,7 @@ export class LmStudioPlugin extends BaseAiProvider {
 		if (!this.aiOps) {
 			throw new Error('LM Studio plugin not loaded');
 		}
-		return this.aiOps.createEmbedding(options);
+		return this.aiOps.createEmbedding(options, this.resolveConfig(options.settings));
 	}
 
 	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {

--- a/packages/plugins/lm-studio/src/lm-studio.plugin.ts
+++ b/packages/plugins/lm-studio/src/lm-studio.plugin.ts
@@ -1,0 +1,235 @@
+import { BaseAiProvider } from '@ever-works/plugin/abstract';
+import { AiOperations } from '@ever-works/plugin/ai';
+import type {
+	PluginContext,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema,
+	PluginSettings,
+	ChatCompletionOptions,
+	ChatCompletionResponse,
+	ChatCompletionChunk,
+	EmbeddingOptions,
+	EmbeddingResponse,
+	AiModel,
+	AiModelCapabilities
+} from '@ever-works/plugin';
+
+/**
+ * LM Studio AI provider plugin
+ *
+ * Provides AI capabilities through a local (or remote) LM Studio server.
+ * LM Studio exposes an OpenAI-compatible API on `/v1`, so it reuses the same
+ * `AiOperations` (LangChain) backend as the other AI providers.
+ *
+ * Uses 'user-required' configuration mode - users point the plugin at their
+ * LM Studio server URL. LM Studio does not authenticate by default, but the
+ * OpenAI client requires a non-empty key, so `apiKey` defaults to a placeholder.
+ *
+ * Unlike Ollama, LM Studio has no canonical default model: the served model is
+ * whatever the user has loaded in the app. The model fields therefore ship
+ * without a hardcoded default and are populated by the `model-select` widget
+ * once the connection is established and `listModels()` returns.
+ */
+export class LmStudioPlugin extends BaseAiProvider {
+	readonly id = 'lm-studio';
+	readonly name = 'LM Studio';
+	readonly version = '1.0.0';
+	readonly providerType = 'lm-studio';
+	readonly providerName = 'LM Studio';
+
+	readonly configurationMode: 'admin-only' | 'user-required' | 'hybrid' = 'user-required';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			baseUrl: {
+				type: 'string',
+				title: 'LM Studio Server URL',
+				description: 'Address of your LM Studio server (e.g: http://localhost:1234/v1)',
+				'x-scope': 'user'
+			},
+			apiKey: {
+				type: 'string',
+				title: 'API Key',
+				description: 'Usually not needed; only for LM Studio instances placed behind an auth proxy',
+				default: 'lm-studio',
+				'x-scope': 'user'
+			},
+			defaultModel: {
+				type: 'string',
+				title: 'Default Model',
+				description: 'Used for all AI tasks unless a tier-specific model is set',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			simpleModel: {
+				type: 'string',
+				title: 'Simple Tasks Model',
+				description: 'Handles tags, short descriptions, and quick classifications',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			mediumModel: {
+				type: 'string',
+				title: 'Standard Tasks Model',
+				description: 'Handles listings, summaries, and content reformatting',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			complexModel: {
+				type: 'string',
+				title: 'Complex Tasks Model',
+				description: 'Handles full page generation and multi-step analysis',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+
+			temperature: {
+				type: 'number',
+				title: 'Temperature',
+				description: 'Lower values give consistent output, higher values add variety',
+				default: 0.7,
+				minimum: 0,
+				maximum: 2,
+				'x-hidden': true
+			},
+			maxTokens: {
+				type: 'number',
+				title: 'Max Tokens',
+				description: 'Limits the length of each AI-generated response',
+				default: 4096,
+				'x-hidden': true
+			}
+		},
+		required: ['baseUrl', 'defaultModel']
+	};
+
+	async onLoad(context: PluginContext): Promise<void> {
+		await super.onLoad(context);
+		this.aiOps = new AiOperations({
+			apiKey: 'lm-studio',
+			model: this.getDefaultModelId(),
+			baseURL: 'http://localhost:1234/v1',
+			temperature: 0.7,
+			maxTokens: 4096,
+			providerType: 'lm-studio'
+		});
+		context.logger.log('LM Studio Plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.aiOps = null;
+		await super.onUnload();
+	}
+
+	async createChatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		return this.aiOps.createChatCompletion(options, resolvedConfig);
+	}
+
+	async *createStreamingChatCompletion(options: ChatCompletionOptions): AsyncIterable<ChatCompletionChunk> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		yield* this.aiOps.createStreamingChatCompletion(options, resolvedConfig);
+	}
+
+	async createEmbedding(options: EmbeddingOptions): Promise<EmbeddingResponse> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		return this.aiOps.createEmbedding(options);
+	}
+
+	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		return this.aiOps.listModels(this.resolveConfig(settings));
+	}
+
+	async isAvailable(settings?: PluginSettings): Promise<boolean> {
+		if (!this.aiOps) {
+			return false;
+		}
+		const result = await this.aiOps.testConnection(this.resolveConfig(settings));
+		return result.success;
+	}
+
+	getCapabilities(): AiModelCapabilities {
+		return {
+			supportsStructuredOutput: true,
+			supportsStreaming: true,
+			supportsToolCalling: true,
+			supportsVision: true,
+			maxContextLength: 128000
+		};
+	}
+
+	protected getDefaultModelId(): string {
+		return 'local-model';
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'LM Studio plugin is ready',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Connect to an LM Studio server for private, self-hosted AI inference',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public',
+			uiHints: {
+				completionFields: ['defaultModel']
+			},
+			readme: [
+				'## What is the LM Studio plugin?',
+				'',
+				'This plugin connects Ever Works to an [LM Studio](https://lmstudio.ai) server for AI inference. LM Studio runs open-source models (Llama, Qwen, Mistral, Gemma, and others) locally and exposes them through an OpenAI-compatible API. Because the server runs on your own machine, your data never leaves your infrastructure.',
+				'',
+				'## Why use it?',
+				'',
+				'- **Data privacy** — requests are processed by your LM Studio instance, keeping sensitive content off third-party servers',
+				'- **No API costs** — run unlimited requests against your own hardware',
+				'- **Open-source models** — load any GGUF/MLX model supported by LM Studio',
+				'- **Friendly UI** — manage and download models from the LM Studio desktop app',
+				'',
+				'## How it works in Ever Works',
+				'',
+				'When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your LM Studio server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.',
+				'',
+				'## Getting started',
+				'',
+				'1. Install LM Studio ([lmstudio.ai](https://lmstudio.ai)) and download at least one model',
+				'2. Start the **Local Server** in LM Studio (Developer tab) — it listens on `http://localhost:1234` by default',
+				'3. Enable the LM Studio plugin and set the **Base URL** to your server address (include the `/v1` suffix)',
+				'4. Select your preferred model for each task complexity level'
+			].join('\n'),
+			homepage: 'https://lmstudio.ai',
+			icon: {
+				type: 'svg',
+				value: `<svg fill="#000" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>LM Studio</title><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm4.6 4.7v8.6a.6.6 0 0 0 .92.5l6.9-4.3a.6.6 0 0 0 0-1l-6.9-4.3a.6.6 0 0 0-.92.5z"/></svg>`,
+				darkValue: `<svg fill="#fff" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>LM Studio</title><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm4.6 4.7v8.6a.6.6 0 0 0 .92.5l6.9-4.3a.6.6 0 0 0 0-1l-6.9-4.3a.6.6 0 0 0-.92.5z"/></svg>`
+			}
+		};
+	}
+}
+
+export default LmStudioPlugin;

--- a/packages/plugins/lm-studio/tsconfig.json
+++ b/packages/plugins/lm-studio/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/lm-studio/tsup.config.ts
+++ b/packages/plugins/lm-studio/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/lm-studio/vitest.config.ts
+++ b/packages/plugins/lm-studio/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/vllm/README.md
+++ b/packages/plugins/vllm/README.md
@@ -1,0 +1,87 @@
+# @ever-works/vllm-plugin
+
+vLLM AI provider plugin for Ever Works platform
+
+## Plugin metadata
+
+| Field        | Value           |
+| ------------ | --------------- |
+| ID           | `vllm`          |
+| Category     | `ai-provider`   |
+| Capabilities | `ai-provider`   |
+| Author       | Ever Works Team |
+| License      | AGPL-3.0        |
+| Built-in     | yes             |
+| Auto-enable  | no              |
+
+## What is the vLLM plugin?
+
+This plugin connects Ever Works to a [vLLM](https://docs.vllm.ai) server for AI inference. vLLM is a high-throughput inference engine for open-source models, usually deployed on a GPU server. It exposes an OpenAI-compatible API, so Ever Works can use it for content generation, conversations, and embeddings — and because you run the server, your data stays within your infrastructure.
+
+## Why use it?
+
+- **Data privacy** — requests are processed by your own vLLM server, keeping sensitive content off third-party servers
+- **No API costs** — run unlimited requests against your own GPU infrastructure
+- **High throughput** — vLLM is optimized for concurrent, batched inference (PagedAttention)
+- **Open-source models** — serve any model supported by vLLM
+
+## How it works in Ever Works
+
+When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your vLLM server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.
+
+vLLM exposes the same OpenAI-compatible `/v1` API as the other AI providers, so it reuses the shared `AiOperations` (LangChain) backend with a different base URL.
+
+## Getting started
+
+1. Start a vLLM OpenAI-compatible server: `vllm serve <model>` (listens on `http://localhost:8000` by default).
+2. If you secured it with `--api-key <token>`, have that token ready.
+3. Enable the vLLM plugin and set the **Base URL** to your server address (include the `/v1` suffix).
+4. Enter the **API Key** if your server requires one (otherwise leave it as `EMPTY`).
+5. Select your preferred model for each task complexity level.
+
+## Settings
+
+- **vLLM Server URL** — address of your vLLM server, e.g. `http://localhost:8000/v1` (per-user, required).
+- **API Key** — only required if the server was started with `--api-key`; defaults to `EMPTY` for unsecured servers. Stored encrypted (per-user).
+- **Default Model** — used for all AI tasks unless a tier-specific model is set. No hardcoded default: pick the model your server was launched with (`--model`) after the connection is established.
+- **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
+- **Standard Tasks Model** — handles listings, summaries, and content reformatting.
+- **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
+- **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
+
+## Networking note (managed cloud vs self-hosted)
+
+vLLM is typically deployed on a GPU server rather than a laptop. For the managed Ever Works cloud to reach it, the **Base URL must be resolvable from where work generation runs** — either a self-hosted Ever Works deployment on the same network, or a vLLM server exposed at a reachable (public or VPN) URL secured with `--api-key`. A `localhost` URL only works when Ever Works itself runs on the same machine/LAN as the vLLM server.
+
+## Troubleshooting
+
+| Symptom                                 | Likely cause                                                       | Fix                                                                                                       |
+| --------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Plugin shows unavailable                | vLLM server not running or not reachable from Ever Works           | Confirm `vllm serve` is up and the Base URL is reachable from where generation runs (see networking note) |
+| `401` / `Invalid API key`               | Server started with `--api-key` but no/incorrect token entered     | Enter the exact `--api-key` token in the **API Key** field                                                |
+| `Model not found` / `400 invalid model` | Selected model differs from the one vLLM was launched with         | Set the model fields to the value passed to `vllm serve --model ...` (use the model-select dropdown)      |
+| No models in the dropdown               | Connection failed before `listModels()` could run                  | Fix the Base URL / API key first, then re-open the model picker                                           |
+| Empty / truncated AI output             | **Max Tokens** too low, or context window exceeded                 | Raise **Max Tokens**, or reduce input size                                                                |
+| Plugin not selected during generation   | Another AI provider plugin is set as the default for `ai-provider` | In **Settings → Plugins**, set `vllm` as the default for `ai-provider`, or disable competing AI plugins   |
+
+## Local development
+
+This plugin ships built-in with the Ever Works platform. To work on it locally from the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter @ever-works/vllm-plugin build
+pnpm --filter @ever-works/vllm-plugin test
+```
+
+## Documentation
+
+- [Ever Works documentation](https://docs.ever.works)
+- [Ever Works repository](https://github.com/ever-works/ever-works)
+- [Plugin system](../../plugin/README.md)
+- [vLLM documentation](https://docs.vllm.ai)
+
+## License
+
+AGPL-3.0

--- a/packages/plugins/vllm/README.md
+++ b/packages/plugins/vllm/README.md
@@ -47,6 +47,7 @@ vLLM exposes the same OpenAI-compatible `/v1` API as the other AI providers, so 
 - **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
 - **Standard Tasks Model** — handles listings, summaries, and content reformatting.
 - **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Embedding Model** — model used for semantic-search embeddings; only needed if you use KB search.
 - **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
 - **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
 

--- a/packages/plugins/vllm/package.json
+++ b/packages/plugins/vllm/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@ever-works/vllm-plugin",
+	"version": "1.0.0",
+	"description": "vLLM AI provider plugin for Ever Works platform",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@langchain/openai": "^0.6.17",
+		"@langchain/core": "^0.3.80"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^3.2.1"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "vllm",
+			"name": "vLLM",
+			"version": "1.0.0",
+			"category": "ai-provider",
+			"capabilities": [
+				"ai-provider"
+			],
+			"description": "vLLM AI provider plugin for Ever Works platform",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false
+		}
+	}
+}

--- a/packages/plugins/vllm/src/__tests__/vllm.plugin.spec.ts
+++ b/packages/plugins/vllm/src/__tests__/vllm.plugin.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VllmPlugin } from '../vllm.plugin';
+import type { PluginContext } from '@ever-works/plugin';
+import { AiOperations } from '@ever-works/plugin/ai';
+
+vi.mock('@ever-works/plugin/ai', () => {
+	const MockAiOperations = vi.fn().mockImplementation(() => ({
+		createChatCompletion: vi.fn().mockResolvedValue({ id: 'test', choices: [], model: 'local-model', created: 0 }),
+		createStreamingChatCompletion: vi.fn(),
+		createEmbedding: vi.fn(),
+		askJson: vi.fn().mockResolvedValue({ result: {}, model: 'local-model', usage: undefined }),
+		listModels: vi.fn().mockResolvedValue([]),
+		testConnection: vi.fn().mockResolvedValue({ success: true })
+	}));
+	return { AiOperations: MockAiOperations };
+});
+
+describe('VllmPlugin', () => {
+	let plugin: VllmPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new VllmPlugin();
+	});
+
+	describe('metadata', () => {
+		it('should have correct plugin id and name', () => {
+			expect(plugin.id).toBe('vllm');
+			expect(plugin.name).toBe('vLLM');
+			expect(plugin.version).toBe('1.0.0');
+		});
+
+		it('should have ai-provider category and capability', () => {
+			expect(plugin.category).toBe('ai-provider');
+			expect(plugin.capabilities).toContain('ai-provider');
+		});
+
+		it('should have user-required configuration mode', () => {
+			expect(plugin.configurationMode).toBe('user-required');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('should have required baseUrl and defaultModel fields', () => {
+			expect(plugin.settingsSchema).toBeDefined();
+			expect(plugin.settingsSchema.type).toBe('object');
+			expect(plugin.settingsSchema.required).toEqual(['baseUrl', 'defaultModel']);
+		});
+
+		it('should have apiKey as an encrypted secret with EMPTY default', () => {
+			const apiKeySchema = plugin.settingsSchema.properties?.apiKey as any;
+			expect(apiKeySchema).toBeDefined();
+			expect(apiKeySchema.type).toBe('string');
+			expect(apiKeySchema.default).toBe('EMPTY');
+			expect(apiKeySchema['x-secret']).toBe(true);
+			expect(apiKeySchema['x-scope']).toBe('user');
+		});
+
+		it('should have all model settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('defaultModel');
+			expect(props).toHaveProperty('simpleModel');
+			expect(props).toHaveProperty('mediumModel');
+			expect(props).toHaveProperty('complexModel');
+		});
+
+		it('should NOT hardcode a default model (populated via model-select)', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect((props.defaultModel as any).default).toBeUndefined();
+			expect((props.defaultModel as any)['x-widget']).toBe('model-select');
+		});
+
+		it('should have baseUrl setting with the vLLM title', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('baseUrl');
+			expect((props.baseUrl as any).type).toBe('string');
+			expect((props.baseUrl as any).title).toBe('vLLM Server URL');
+		});
+
+		it('should have temperature and maxTokens settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('temperature');
+			expect(props).toHaveProperty('maxTokens');
+			expect((props.temperature as any).type).toBe('number');
+			expect((props.maxTokens as any).type).toBe('number');
+		});
+
+		it('should have description on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).description, `${key} should have a description`).toBeDefined();
+				expect((prop as any).description, `${key} description should not be empty`).not.toBe('');
+			}
+		});
+
+		it('should have title on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).title, `${key} should have a title`).toBeDefined();
+			}
+		});
+	});
+
+	describe('lifecycle hooks', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'vllm',
+				logger: {
+					log: vi.fn(),
+					debug: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn()
+				},
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should load successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			expect(mockContext.logger.log).toHaveBeenCalledWith('vLLM Plugin loaded');
+		});
+
+		it('should unload successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			await plugin.onUnload();
+		});
+	});
+
+	describe('manifest', () => {
+		it('should return correct manifest', () => {
+			const manifest = plugin.getManifest();
+			expect(manifest.id).toBe('vllm');
+			expect(manifest.name).toBe('vLLM');
+			expect(manifest.builtIn).toBe(true);
+			expect(manifest.autoEnable).toBe(false);
+			expect(manifest.visibility).toBe('public');
+			expect(manifest.icon).toBeDefined();
+			expect(manifest.icon?.type).toBe('svg');
+		});
+	});
+
+	describe('healthCheck', () => {
+		it('should return healthy status', async () => {
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+			expect(health.message).toBe('vLLM plugin is ready');
+			expect(health.checkedAt).toBeDefined();
+		});
+	});
+
+	describe('askJson', () => {
+		const createMockContext2 = (): PluginContext =>
+			({
+				pluginId: 'vllm',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should delegate to aiOps.askJson with resolved config', async () => {
+			await plugin.onLoad(createMockContext2());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.askJson('Generate JSON', {
+				settings: { apiKey: 'EMPTY' }
+			});
+
+			expect(aiOpsInstance.askJson).toHaveBeenCalledWith(
+				'Generate JSON',
+				expect.any(Object),
+				expect.objectContaining({ apiKey: 'EMPTY' }),
+				expect.any(Object)
+			);
+		});
+
+		it('should throw when plugin not loaded', async () => {
+			await expect(plugin.askJson('test')).rejects.toThrow('Plugin not loaded');
+		});
+	});
+
+	describe('settings threading', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'vllm',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should pass settings as configOverrides to AiOperations.listModels', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.listModels({ baseUrl: 'http://custom:8000/v1' });
+
+			expect(aiOpsInstance.listModels).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:8000/v1' })
+			);
+		});
+
+		it('should pass settings as configOverrides to AiOperations.testConnection', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.isAvailable({ baseUrl: 'http://custom:8000/v1' });
+
+			expect(aiOpsInstance.testConnection).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:8000/v1' })
+			);
+		});
+	});
+});

--- a/packages/plugins/vllm/src/__tests__/vllm.plugin.spec.ts
+++ b/packages/plugins/vllm/src/__tests__/vllm.plugin.spec.ts
@@ -207,5 +207,28 @@ describe('VllmPlugin', () => {
 				expect.objectContaining({ baseURL: 'http://custom:8000/v1' })
 			);
 		});
+
+		it('should pass resolved settings (URL, key, embedding model) to AiOperations.createEmbedding', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				settings: {
+					baseUrl: 'http://custom:8000/v1',
+					apiKey: 'sk-vllm-token',
+					embeddingModel: 'intfloat/e5-mistral-7b-instruct'
+				}
+			});
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.objectContaining({ input: 'hello' }),
+				expect.objectContaining({
+					baseURL: 'http://custom:8000/v1',
+					apiKey: 'sk-vllm-token',
+					embeddingModel: 'intfloat/e5-mistral-7b-instruct'
+				})
+			);
+		});
 	});
 });

--- a/packages/plugins/vllm/src/index.ts
+++ b/packages/plugins/vllm/src/index.ts
@@ -1,0 +1,1 @@
+export { VllmPlugin, VllmPlugin as default } from './vllm.plugin.js';

--- a/packages/plugins/vllm/src/vllm.plugin.ts
+++ b/packages/plugins/vllm/src/vllm.plugin.ts
@@ -87,6 +87,13 @@ export class VllmPlugin extends BaseAiProvider {
 				'x-widget': 'model-select',
 				'x-scope': 'global'
 			},
+			embeddingModel: {
+				type: 'string',
+				title: 'Embedding Model',
+				description: 'Model used for semantic search embeddings (only needed if you use KB search)',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
 
 			temperature: {
 				type: 'number',
@@ -146,7 +153,7 @@ export class VllmPlugin extends BaseAiProvider {
 		if (!this.aiOps) {
 			throw new Error('vLLM plugin not loaded');
 		}
-		return this.aiOps.createEmbedding(options);
+		return this.aiOps.createEmbedding(options, this.resolveConfig(options.settings));
 	}
 
 	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {

--- a/packages/plugins/vllm/src/vllm.plugin.ts
+++ b/packages/plugins/vllm/src/vllm.plugin.ts
@@ -1,0 +1,239 @@
+import { BaseAiProvider } from '@ever-works/plugin/abstract';
+import { AiOperations } from '@ever-works/plugin/ai';
+import type {
+	PluginContext,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema,
+	PluginSettings,
+	ChatCompletionOptions,
+	ChatCompletionResponse,
+	ChatCompletionChunk,
+	EmbeddingOptions,
+	EmbeddingResponse,
+	AiModel,
+	AiModelCapabilities
+} from '@ever-works/plugin';
+
+/**
+ * vLLM AI provider plugin
+ *
+ * Provides AI capabilities through a self-hosted vLLM server. vLLM serves an
+ * OpenAI-compatible API on `/v1`, so it reuses the same `AiOperations`
+ * (LangChain) backend as the other AI providers.
+ *
+ * Uses 'user-required' configuration mode - users point the plugin at their
+ * vLLM server URL. An unsecured vLLM server accepts any key, so `apiKey`
+ * defaults to vLLM's documented `EMPTY` placeholder; when the server is
+ * started with `--api-key`, users enter that token (stored encrypted via
+ * `x-secret`).
+ *
+ * vLLM serves whatever model it was launched with (`--model ...`), so there is
+ * no canonical default model. The model fields ship without a hardcoded
+ * default and are populated by the `model-select` widget once the connection
+ * is established and `listModels()` returns.
+ */
+export class VllmPlugin extends BaseAiProvider {
+	readonly id = 'vllm';
+	readonly name = 'vLLM';
+	readonly version = '1.0.0';
+	readonly providerType = 'vllm';
+	readonly providerName = 'vLLM';
+
+	readonly configurationMode: 'admin-only' | 'user-required' | 'hybrid' = 'user-required';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			baseUrl: {
+				type: 'string',
+				title: 'vLLM Server URL',
+				description: 'Address of your vLLM OpenAI-compatible server (e.g: http://localhost:8000/v1)',
+				'x-scope': 'user'
+			},
+			apiKey: {
+				type: 'string',
+				title: 'API Key',
+				description: 'Only required if your vLLM server was started with --api-key; leave as EMPTY otherwise',
+				default: 'EMPTY',
+				'x-secret': true,
+				'x-scope': 'user'
+			},
+			defaultModel: {
+				type: 'string',
+				title: 'Default Model',
+				description: 'Used for all AI tasks unless a tier-specific model is set',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			simpleModel: {
+				type: 'string',
+				title: 'Simple Tasks Model',
+				description: 'Handles tags, short descriptions, and quick classifications',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			mediumModel: {
+				type: 'string',
+				title: 'Standard Tasks Model',
+				description: 'Handles listings, summaries, and content reformatting',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			complexModel: {
+				type: 'string',
+				title: 'Complex Tasks Model',
+				description: 'Handles full page generation and multi-step analysis',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+
+			temperature: {
+				type: 'number',
+				title: 'Temperature',
+				description: 'Lower values give consistent output, higher values add variety',
+				default: 0.7,
+				minimum: 0,
+				maximum: 2,
+				'x-hidden': true
+			},
+			maxTokens: {
+				type: 'number',
+				title: 'Max Tokens',
+				description: 'Limits the length of each AI-generated response',
+				default: 4096,
+				'x-hidden': true
+			}
+		},
+		required: ['baseUrl', 'defaultModel']
+	};
+
+	async onLoad(context: PluginContext): Promise<void> {
+		await super.onLoad(context);
+		this.aiOps = new AiOperations({
+			apiKey: 'EMPTY',
+			model: this.getDefaultModelId(),
+			baseURL: 'http://localhost:8000/v1',
+			temperature: 0.7,
+			maxTokens: 4096,
+			providerType: 'vllm'
+		});
+		context.logger.log('vLLM Plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.aiOps = null;
+		await super.onUnload();
+	}
+
+	async createChatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		return this.aiOps.createChatCompletion(options, resolvedConfig);
+	}
+
+	async *createStreamingChatCompletion(options: ChatCompletionOptions): AsyncIterable<ChatCompletionChunk> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		yield* this.aiOps.createStreamingChatCompletion(options, resolvedConfig);
+	}
+
+	async createEmbedding(options: EmbeddingOptions): Promise<EmbeddingResponse> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		return this.aiOps.createEmbedding(options);
+	}
+
+	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		return this.aiOps.listModels(this.resolveConfig(settings));
+	}
+
+	async isAvailable(settings?: PluginSettings): Promise<boolean> {
+		if (!this.aiOps) {
+			return false;
+		}
+		const result = await this.aiOps.testConnection(this.resolveConfig(settings));
+		return result.success;
+	}
+
+	getCapabilities(): AiModelCapabilities {
+		return {
+			supportsStructuredOutput: true,
+			supportsStreaming: true,
+			supportsToolCalling: true,
+			supportsVision: true,
+			maxContextLength: 128000
+		};
+	}
+
+	protected getDefaultModelId(): string {
+		return 'local-model';
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'vLLM plugin is ready',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Connect to a self-hosted vLLM server for high-throughput, private AI inference',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public',
+			uiHints: {
+				completionFields: ['defaultModel']
+			},
+			readme: [
+				'## What is the vLLM plugin?',
+				'',
+				'This plugin connects Ever Works to a [vLLM](https://docs.vllm.ai) server for AI inference. vLLM is a high-throughput inference engine for open-source models, usually deployed on a GPU server. It exposes an OpenAI-compatible API, so Ever Works can use it for content generation, conversations, and embeddings.',
+				'',
+				'## Why use it?',
+				'',
+				'- **Data privacy** — requests are processed by your own vLLM server, keeping sensitive content off third-party servers',
+				'- **No API costs** — run unlimited requests against your own GPU infrastructure',
+				'- **High throughput** — vLLM is optimized for concurrent, batched inference (PagedAttention)',
+				'- **Open-source models** — serve any model supported by vLLM',
+				'',
+				'## How it works in Ever Works',
+				'',
+				'When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your vLLM server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.',
+				'',
+				'## Getting started',
+				'',
+				'1. Start a vLLM OpenAI-compatible server: `vllm serve <model>` (listens on `http://localhost:8000` by default)',
+				'2. If you secured it with `--api-key <token>`, have that token ready',
+				'3. Enable the vLLM plugin and set the **Base URL** to your server address (include the `/v1` suffix)',
+				'4. Enter the **API Key** if your server requires one (otherwise leave it as `EMPTY`)',
+				'5. Select your preferred model for each task complexity level'
+			].join('\n'),
+			homepage: 'https://docs.vllm.ai',
+			icon: {
+				type: 'svg',
+				value: `<svg fill="#000" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>vLLM</title><path d="M13.1 1.2 4.2 13.3a.7.7 0 0 0 .56 1.11h5.05l-1.02 8.3a.5.5 0 0 0 .9.36l8.9-12.1a.7.7 0 0 0-.56-1.11h-5.05l1.02-8.3a.5.5 0 0 0-.9-.36z"/></svg>`,
+				darkValue: `<svg fill="#fff" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>vLLM</title><path d="M13.1 1.2 4.2 13.3a.7.7 0 0 0 .56 1.11h5.05l-1.02 8.3a.5.5 0 0 0 .9.36l8.9-12.1a.7.7 0 0 0-.56-1.11h-5.05l1.02-8.3a.5.5 0 0 0-.9-.36z"/></svg>`
+			}
+		};
+	}
+}
+
+export default VllmPlugin;

--- a/packages/plugins/vllm/tsconfig.json
+++ b/packages/plugins/vllm/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/vllm/tsup.config.ts
+++ b/packages/plugins/vllm/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/vllm/vitest.config.ts
+++ b/packages/plugins/vllm/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1810,6 +1810,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
+  packages/plugins/lm-studio:
+    dependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@langchain/core':
+        specifier: ^0.3.80
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/openai':
+        specifier: ^0.6.17
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
   packages/plugins/local-content-extractor:
     dependencies:
       '@mozilla/readability':
@@ -2497,6 +2522,31 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/plugins/vercel-ai-gateway:
+    dependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@langchain/core':
+        specifier: ^0.3.80
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/openai':
+        specifier: ^0.6.17
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
+  packages/plugins/vllm:
     dependencies:
       '@ever-works/plugin':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Adds two OpenAI-compatible **local AI provider** plugins alongside the existing Ollama plugin, for users who run inference locally (or on a reachable remote host) instead of via cloud APIs:

- **`@ever-works/lm-studio-plugin`** — default `http://localhost:1234/v1`, placeholder key (no auth by default).
- **`@ever-works/vllm-plugin`** — default `http://localhost:8000/v1`; `apiKey` defaults to vLLM's `EMPTY` and is `x-secret` (encrypted) for `--api-key`-secured servers.

Both extend `BaseAiProvider` and reuse the shared `AiOperations` (LangChain) backend, so setup-time **connection + model detection** comes for free via `validateConnection()` / `listModels()`. Unlike cloud providers, the model fields ship **without a hardcoded default** — LM Studio serves whatever model is loaded and vLLM serves its `--model`, so the fields are populated by the `model-select` widget after the connection is established.

### Wiring (mirrors Ollama everywhere it appears)
- internal-CLI AI provider registry, `AI_DEFAULT_PROVIDER` validation, and model-example hints
- AI-provider error-classification detector (`LM Studio` / `vLLM`)
- Docs: built-in plugins list, AI provider list, two dedicated plugin pages, sidebar
- Specs updated in lockstep (registry / set-subcommand / error-classification)

### Networking note
Local AI works only where the inference call originates: a self-hosted Ever Works on the same machine/LAN, or a remote endpoint reachable from where work generation runs (documented on the vLLM page). The managed-cloud → user's-laptop case needs a separate outbound "Connector" — tracked as a follow-up, not in this PR.

## Test plan

- [x] `@ever-works/lm-studio-plugin` unit tests (19/19)
- [x] `@ever-works/vllm-plugin` unit tests (19/19)
- [x] internal-CLI config specs — registry / set-subcommand / switch-ai (40/40)
- [x] agent `error-classification` spec (70/70)
- [x] both plugins build clean (ESM + CJS + DTS, `tsc --noEmit`)
- [x] `@ever-works/agent` builds with 0 TS issues
- [x] Prettier clean on all changed files
- [ ] CI green
- [ ] Manual: connect to a real Ollama/LM Studio/vLLM server, run a generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)