### PR TITLE
docs: spec dual-mode plugin distribution (bundled + runtime npm install)

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -28,6 +28,7 @@ docs/specs/
 │   ├── pipeline-executor.md        # Executor / step / modifier substrate
 │   ├── trigger-integration.md      # Trigger.dev wiring
 │   ├── plugin-sdk.md               # @ever-works/plugin SDK deep-dive
+│   ├── runtime-plugins.md          # Dual-mode distribution + runtime installer
 │   ├── settings-system.md          # 3-tier resolution + secret hygiene
 │   ├── ai-facade.md                # AiFacadeService routing & model catalog
 │   ├── auth.md                     # JWT + OAuth + API keys + device flow
@@ -56,6 +57,7 @@ docs/specs/
     ├── comparisons/
     ├── creating-a-work/
     ├── custom-domains/
+    ├── dynamic-plugin-distribution/
     ├── data-generator/
     ├── data-management/
     ├── work-changelog/
@@ -94,6 +96,7 @@ which now live folded into `tasks.md`).
 | [`custom-domains`](features/custom-domains/spec)                   | Retrospective | Branded domain assignment with provider sync                   |
 | [`data-generator`](features/data-generator/spec)                   | Retrospective | Data repository management and item persistence                |
 | [`data-management`](features/data-management/spec)                 | Retrospective | Export / Import / GitHub Sync with secret hygiene              |
+| [`dynamic-plugin-distribution`](features/dynamic-plugin-distribution/spec) | Draft         | Dual-mode plugins: bundle all, or core-only + runtime npm install |
 | [`work-changelog`](features/work-changelog/spec)                   | Retrospective | Audit trail of all work mutations                              |
 | [`work-import`](features/work-import/spec)                         | Retrospective | Bootstrap from existing repo or Awesome List                   |
 | [`work-members`](features/work-members/spec)                       | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)   |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -89,32 +89,32 @@ full Spec Kit format and retain their deeper architectural `spec.md`
 (see also their `acceptance.md` for the original acceptance criteria
 which now live folded into `tasks.md`).
 
-| Feature                                                            | Status        | Description                                                                                   |
-| ------------------------------------------------------------------ | ------------- | --------------------------------------------------------------------------------------------- |
-| [`advanced-prompts`](features/advanced-prompts/spec)               | Retrospective | Per-work prompt overrides per pipeline step                                                   |
-| [`api-keys`](features/api-keys/spec)                               | Retrospective | Long-lived auth tokens for CI / CLI / MCP                                                     |
-| [`collections`](features/collections/spec)                         | Retrospective | Editorial groupings cutting across categories                                                 |
-| [`community-pr-processing`](features/community-pr-processing/spec) | Retrospective | AI-driven processing of community-contributed PRs                                             |
-| [`comparisons`](features/comparisons/spec)                         | Retrospective | A vs B comparison page generator                                                              |
-| [`creating-a-work`](features/creating-a-work/spec)                 | Retrospective | Three creation methods: AI / Manual / Import                                                  |
-| [`custom-domains`](features/custom-domains/spec)                   | Retrospective | Branded domain assignment with provider sync                                                  |
-| [`data-generator`](features/data-generator/spec)                   | Retrospective | Data repository management and item persistence                                               |
-| [`data-management`](features/data-management/spec)                 | Retrospective | Export / Import / GitHub Sync with secret hygiene                                             |
-| [`dynamic-plugin-distribution`](features/dynamic-plugin-distribution/spec) | Draft         | Dual-mode plugins: bundle all, or core-only + runtime npm install                       |
-| [`work-changelog`](features/work-changelog/spec)                   | Retrospective | Audit trail of all work mutations                                                             |
-| [`work-import`](features/work-import/spec)                         | Retrospective | Bootstrap from existing repo or Awesome List                                                  |
-| [`work-members`](features/work-members/spec)                       | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)                                  |
-| [`generation-cancellation`](features/generation-cancellation/spec) | Retrospective | Mid-flight generation cancel with four mode paths                                             |
-| [`git-operations`](features/git-operations/spec)                   | Retrospective | `GitFacadeService` and provider plugin contract                                               |
-| [`job-runtime-providers`](features/job-runtime-providers/spec)     | Draft         | Pluggable background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) |
-| [`item-source-validation`](features/item-source-validation/spec)   | Retrospective | Reachability + AI accuracy checks per item                                                    |
-| [`markdown-generator`](features/markdown-generator/spec)           | Retrospective | Markdown rendering pipeline                                                                   |
-| [`mcp-server`](features/mcp-server/spec)                           | Retrospective | OpenAPI-derived MCP tool surface                                                              |
-| [`plugin-system`](features/plugin-system/spec)                     | Retrospective | Capability-driven plugin architecture (39 first-party plugins)                                |
-| [`scheduled-updates`](features/scheduled-updates/spec)             | Retrospective | Cron-driven generation with CAS claim and drift correction                                    |
-| [`taxonomy-system`](features/taxonomy-system/spec)                 | Retrospective | Categories, tags, and collections in the data repo                                            |
-| [`website-generator`](features/website-generator/spec)             | Retrospective | Static site generation pipeline                                                               |
-| [`works-config`](features/works-config/spec)                       | Retrospective | `.works/works.yml` source-controlled work configuration                                       |
+| Feature                                                                    | Status        | Description                                                                                   |
+| -------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| [`advanced-prompts`](features/advanced-prompts/spec)                       | Retrospective | Per-work prompt overrides per pipeline step                                                   |
+| [`api-keys`](features/api-keys/spec)                                       | Retrospective | Long-lived auth tokens for CI / CLI / MCP                                                     |
+| [`collections`](features/collections/spec)                                 | Retrospective | Editorial groupings cutting across categories                                                 |
+| [`community-pr-processing`](features/community-pr-processing/spec)         | Retrospective | AI-driven processing of community-contributed PRs                                             |
+| [`comparisons`](features/comparisons/spec)                                 | Retrospective | A vs B comparison page generator                                                              |
+| [`creating-a-work`](features/creating-a-work/spec)                         | Retrospective | Three creation methods: AI / Manual / Import                                                  |
+| [`custom-domains`](features/custom-domains/spec)                           | Retrospective | Branded domain assignment with provider sync                                                  |
+| [`data-generator`](features/data-generator/spec)                           | Retrospective | Data repository management and item persistence                                               |
+| [`data-management`](features/data-management/spec)                         | Retrospective | Export / Import / GitHub Sync with secret hygiene                                             |
+| [`dynamic-plugin-distribution`](features/dynamic-plugin-distribution/spec) | Draft         | Dual-mode plugins: bundle all, or core-only + runtime npm install                             |
+| [`work-changelog`](features/work-changelog/spec)                           | Retrospective | Audit trail of all work mutations                                                             |
+| [`work-import`](features/work-import/spec)                                 | Retrospective | Bootstrap from existing repo or Awesome List                                                  |
+| [`work-members`](features/work-members/spec)                               | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)                                  |
+| [`generation-cancellation`](features/generation-cancellation/spec)         | Retrospective | Mid-flight generation cancel with four mode paths                                             |
+| [`git-operations`](features/git-operations/spec)                           | Retrospective | `GitFacadeService` and provider plugin contract                                               |
+| [`job-runtime-providers`](features/job-runtime-providers/spec)             | Draft         | Pluggable background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) |
+| [`item-source-validation`](features/item-source-validation/spec)           | Retrospective | Reachability + AI accuracy checks per item                                                    |
+| [`markdown-generator`](features/markdown-generator/spec)                   | Retrospective | Markdown rendering pipeline                                                                   |
+| [`mcp-server`](features/mcp-server/spec)                                   | Retrospective | OpenAPI-derived MCP tool surface                                                              |
+| [`plugin-system`](features/plugin-system/spec)                             | Retrospective | Capability-driven plugin architecture (39 first-party plugins)                                |
+| [`scheduled-updates`](features/scheduled-updates/spec)                     | Retrospective | Cron-driven generation with CAS claim and drift correction                                    |
+| [`taxonomy-system`](features/taxonomy-system/spec)                         | Retrospective | Categories, tags, and collections in the data repo                                            |
+| [`website-generator`](features/website-generator/spec)                     | Retrospective | Static site generation pipeline                                                               |
+| [`works-config`](features/works-config/spec)                               | Retrospective | `.works/works.yml` source-controlled work configuration                                       |
 
 ## Reading order for new contributors
 

--- a/docs/specs/architecture/runtime-plugins.md
+++ b/docs/specs/architecture/runtime-plugins.md
@@ -105,22 +105,43 @@ Key properties:
   `await import(entryPath)`, and `DEFAULT_PLUGIN_PATHS` already includes
   `./plugins` and `./node_modules/@ever-works`.
 
-## 6. Boot reconcile
+## 6. Install propagation across replicas & workers
 
 Pods are ephemeral and replicas scale horizontally; the **database is the source
-of truth** for which distributable plugins are installed/enabled. On
-`onApplicationBootstrap` in dynamic mode, `PluginBootstrapService` reconciles:
+of truth** for which distributable plugins are installed/enabled. With a
+per-replica store, two mechanisms keep every node consistent **without** a shared
+volume:
+
+**(a) Lazy install-on-use — the correctness guarantee.** Before any node (an API
+replica *or* a job-runtime worker) invokes a distributable plugin, it ensures the
+package is present locally and installs it if not:
+
+```
+ensurePluginAvailable(pluginId):
+    rec = DB row for pluginId            # source, registrySpec, integrity
+    if rec.source == 'registry' and (not present in store OR integrity mismatch):
+        PluginInstallerService.install(rec.registrySpec, rec.integrity)  # idempotent, per-id lock
+    load + register if not already in this process's registry
+```
+
+This closes the gap Codex flagged: when pod A handles the first enable and marks
+the plugin `installed` in the DB, pod B (and the worker) do **not** need a restart
+— the first request that reaches them lazily installs the package before use. The
+per-id concurrency lock + integrity pin make concurrent lazy installs safe.
+
+**(b) Boot reconcile — a warmup optimisation.** On `onApplicationBootstrap` in
+dynamic mode, `PluginBootstrapService` pre-installs the DB-recorded
+installed/enabled set so a freshly-started replica is warm before taking traffic:
 
 ```
 for each DB plugin where source='registry' and (installed or enabled):
-    if not present in PLUGIN_INSTALL_DIR (or integrity mismatch):
-        PluginInstallerService.install(pinned version + integrity)
-mark ready only after reconcile completes (readiness gate)
+    ensurePluginAvailable(pluginId)
+optionally gate readiness until warmup completes
 ```
 
-This makes a fresh replica converge to its peers without shared storage. A
-shared RWX volume or a "bake popular plugins into the image" optimisation can
-reduce cold-start cost later, but is not required for correctness.
+Reconcile is **not** the correctness mechanism (lazy install-on-use is) — it just
+avoids a first-request latency spike. A shared RWX volume or "bake popular plugins
+into the image" can further reduce cold-start cost, but neither is required.
 
 ## 7. Execution model
 
@@ -134,6 +155,16 @@ operation's `executionProfile`:
   **pluggable job runtime** (Trigger.dev today). Plugin code imported inside the
   task process is **already isolated** there, and the result returns through the
   existing job result channel.
+
+> **The worker is a separate runtime with its own store.** The Trigger.dev worker
+> is deployed independently from the API and prepares its own `./plugins` bundle
+> at deploy time — so a plugin *installed at runtime in the API* does **not**
+> exist in the worker. The long-running path therefore calls the same
+> `ensurePluginAvailable()` (§6 lazy install-on-use) inside the task **before**
+> invoking the plugin, installing into the worker's own store on first use. The
+> installer (`@ever-works/agent` plugins module) runs in the worker just as it
+> does in the API. Without this, an enable that succeeds in the API would fail the
+> first long-running call in the worker — the second P1 Codex flagged.
 
 This is why v1 needs no bespoke sandbox: long-running third-party work inherits
 the job runtime's isolation, and the install allowlist limits what can run at

--- a/docs/specs/architecture/runtime-plugins.md
+++ b/docs/specs/architecture/runtime-plugins.md
@@ -43,15 +43,17 @@ Classification is declared on the plugin via the manifest field `distribution`
 (`'core' | 'registry'`), defaulting from `systemPlugin`:
 
 - **Core** (`distribution: 'core'`) — always bundled, present in both modes,
-  never fetched from a registry. Comprises:
-  - every `systemPlugin: true` plugin: `agent-pipeline`, `comparison-generator`,
-    `github`, `k8s`, `local-content-extractor`, `local-fs`, `openrouter`,
-    `standard-pipeline`, `tavily`, `vercel`;
-  - plugins the API cannot boot without — today the storage plugins imported
-    directly in `apps/api/package.json`: `aws-s3`, `github-storage`, `minio`
-    (see Open Question on whether these stay core or lose the hard import).
-- **Distributable** (`distribution: 'registry'`) — everything else; published
-  and runtime-installable.
+  never fetched from a registry. Comprises **every `systemPlugin: true` plugin**:
+  `agent-pipeline`, `comparison-generator`, `github`, `k8s`,
+  `local-content-extractor`, `local-fs`, `openrouter`, `standard-pipeline`,
+  `tavily`, `vercel`. `local-fs` doubles as the **default storage backend** so the
+  API boots with working storage even when no distributable storage plugin is
+  enabled.
+- **Distributable** (`distribution: 'registry'`) — everything else, **including**
+  the storage plugins `aws-s3`, `github-storage`, and `minio`. The API today hard
+  imports those three in `apps/api/package.json`; that coupling is **removed** and
+  storage is resolved through the capability facade/registry, which is what lets
+  them be distributable (see EW-693 T8b).
 
 The manifest is the source of truth; the value is denormalised onto the
 `plugins` row for listing.

--- a/docs/specs/architecture/runtime-plugins.md
+++ b/docs/specs/architecture/runtime-plugins.md
@@ -1,0 +1,211 @@
+# Architecture: Runtime Plugin Distribution
+
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+**Audience**: AI agents and engineers implementing dual-mode plugin distribution.
+
+> Companion to [`plugin-sdk`](./plugin-sdk.md) (the SDK plugins build against)
+> and the feature spec [`dynamic-plugin-distribution`](../features/dynamic-plugin-distribution/spec.md).
+> This doc describes **how plugins are distributed, installed, and executed** at
+> runtime — `plugin-sdk.md` describes the contract; this describes the supply chain.
+
+---
+
+## 1. Purpose
+
+The platform supports two distribution modes that share one code path:
+
+- **`bundled`** (default, today): every plugin in `packages/plugins/*` is built
+  into the image and discovered from disk at boot. No registry, no enable-time
+  network.
+- **`dynamic`**: only **core** plugins ship in the image; **distributable**
+  plugins are published to npm + GitHub Packages and pulled, verified, and
+  loaded at runtime when first enabled.
+
+This decouples "what code exists in the repo" (always all of it) from "what gets
+installed and shipped" (all, or core-only + on-demand). The selector is
+`PLUGIN_DISTRIBUTION_MODE`; default `bundled` so existing deployments are inert
+to this feature.
+
+## 2. Why this exists
+
+In bundled mode, `pnpm install` resolves the dependency closure of all ~49
+plugins, and the image carries every plugin's third-party SDK whether or not it
+is enabled. Adding integrations (Principle I + the official-SDK rule, EW-682)
+therefore grows install time and image size linearly with the unique SDK trees
+each plugin drags in (e.g. `@kubernetes/client-node`, `@vercel/sdk`,
+`@notionhq/client`, `@aws-sdk/*`). Dynamic mode lets a deployment pay only for
+the plugins it uses.
+
+## 3. Core vs distributable
+
+Classification is declared on the plugin via the manifest field `distribution`
+(`'core' | 'registry'`), defaulting from `systemPlugin`:
+
+- **Core** (`distribution: 'core'`) — always bundled, present in both modes,
+  never fetched from a registry. Comprises:
+  - every `systemPlugin: true` plugin: `agent-pipeline`, `comparison-generator`,
+    `github`, `k8s`, `local-content-extractor`, `local-fs`, `openrouter`,
+    `standard-pipeline`, `tavily`, `vercel`;
+  - plugins the API cannot boot without — today the storage plugins imported
+    directly in `apps/api/package.json`: `aws-s3`, `github-storage`, `minio`
+    (see Open Question on whether these stay core or lose the hard import).
+- **Distributable** (`distribution: 'registry'`) — everything else; published
+  and runtime-installable.
+
+The manifest is the source of truth; the value is denormalised onto the
+`plugins` row for listing.
+
+## 4. Build & publish
+
+Plugins build with **tsup** exactly as today (ESM `index.js` + CJS `index.cjs` +
+`index.d.ts`, deps external, `@ever-works/plugin` as peer). Distribution adds a
+**publish** step:
+
+- **Versioning**: Changesets, **independent** per plugin — a plugin release does
+  not require a platform release (today all plugins are lockstep `1.0.0`).
+- **Targets**: each distributable plugin is published to **both** the public npm
+  registry and the **GitHub Packages** `@ever-works` registry on release, via a
+  CI workflow mirroring the auth pattern of `.github/workflows/publish-cli.yml`.
+- **Privacy**: distributable plugins flip `private: true → false` with
+  `publishConfig`; core plugins may remain unpublished.
+- **Provenance**: rely on npm package integrity (sha512) and first-party npm
+  provenance; no bespoke signing in v1.
+
+## 5. Runtime install path (dynamic mode)
+
+```
+User clicks Enable (plugin not installed)
+  → plugins.controller → PluginOperationsService.enable
+    → PluginInstallerService.install(pluginId)
+        1. resolve pkg@exactVersion from registry (PLUGIN_REGISTRY_URL / GitHub)
+        2. allowlist check FIRST (first-party @ever-works/* implicit; else
+           must match an enabled plugin_allowlist row) — refuse before download
+        3. download + verify integrity (sha512) — mismatch ⇒ refuse
+        4. place into PLUGIN_INSTALL_DIR (default /app/plugins)
+        5. PluginLoaderService.load(installPath)  ← existing dynamic import()
+        6. PluginRegistryService.register + persist (source='registry',
+           installedVersion, integrity, installState='installed')
+    → existing enable (UserPluginEntity/WorkPluginEntity flip)
+```
+
+Key properties:
+
+- **Install ≠ enable ≠ load** stay distinct (the SDK already separates
+  load/enable). Dynamic mode inserts *install + load* in front of *enable* only
+  when the plugin is absent.
+- **Idempotent + concurrency-guarded** per plugin id (two simultaneous enables
+  of the same plugin install once).
+- **Failure isolation**: a failed install records a reason on the plugin row
+  (`installState='error'`) and registers nothing partial; the rest of the system
+  is unaffected (spec FR-14).
+- The loader is unchanged — it already resolves `main`/`module` and
+  `await import(entryPath)`, and `DEFAULT_PLUGIN_PATHS` already includes
+  `./plugins` and `./node_modules/@ever-works`.
+
+## 6. Boot reconcile
+
+Pods are ephemeral and replicas scale horizontally; the **database is the source
+of truth** for which distributable plugins are installed/enabled. On
+`onApplicationBootstrap` in dynamic mode, `PluginBootstrapService` reconciles:
+
+```
+for each DB plugin where source='registry' and (installed or enabled):
+    if not present in PLUGIN_INSTALL_DIR (or integrity mismatch):
+        PluginInstallerService.install(pinned version + integrity)
+mark ready only after reconcile completes (readiness gate)
+```
+
+This makes a fresh replica converge to its peers without shared storage. A
+shared RWX volume or a "bake popular plugins into the image" optimisation can
+reduce cold-start cost later, but is not required for correctness.
+
+## 7. Execution model
+
+The base mechanism is the same dynamic `import()` everywhere; **where** a
+capability call runs is decided by `PluginExecutionRouterService` from the
+operation's `executionProfile`:
+
+- **`sync` / short calls** (e.g. list models, resolve config): run **in-process**
+  in the API via dynamic import. No job-runtime hop, lowest latency.
+- **`long-running` calls** (e.g. a generation pipeline step): dispatched to the
+  **pluggable job runtime** (Trigger.dev today). Plugin code imported inside the
+  task process is **already isolated** there, and the result returns through the
+  existing job result channel.
+
+This is why v1 needs no bespoke sandbox: long-running third-party work inherits
+the job runtime's isolation, and the install allowlist limits what can run at
+all. Making the job-runtime provider itself swappable (Temporal / BullMQ /
+others) is tracked in **EW-683** and is a dependency of the long-running path,
+not part of this feature.
+
+## 8. Security model
+
+- **Supply chain**: install restricted to first-party `@ever-works/*` +
+  admin-managed allowlist (`plugin_allowlist`); refusal happens before any
+  network fetch. Exact-version pinning + integrity verification before `import()`.
+- **Secrets**: registry auth tokens (GitHub Packages / private mirrors) are
+  secrets sourced from env/secret store, never logged or returned. Plugin
+  settings keep `x-secret` redaction (Principle VII / [settings-system](./settings-system.md)).
+- **Isolation**: long-running plugin execution runs in the isolated job runtime;
+  in-process execution is reserved for short calls and (in v1) trusted/allowlisted
+  code. Full sandboxing (isolated-vm / microVM) is a documented future phase.
+
+## 9. Deployment & filesystem
+
+- The API image WORKDIR is `/app`; root FS is writable today
+  (`readOnlyRootFilesystem: false`), and `/tmp` is an emptyDir. The runtime store
+  defaults to `PLUGIN_INSTALL_DIR=/app/plugins`.
+- **k8s**: mount a writable volume for the store (emptyDir per-replica with boot
+  reconcile, or an optional PVC); gate readiness on reconcile completion.
+- **bundled image** keeps shipping all plugins (current Dockerfile). The
+  **dynamic image** variant ships core-only via a build arg.
+- **Read-only-FS serverless** (Vercel, currently disabled) cannot install at
+  runtime — those targets support `bundled` only.
+
+## 10. Observability
+
+- Events/activity-log: `plugin.install.requested|succeeded|failed`,
+  `plugin.upgrade.*`, `plugin.uninstall.*` with id, version, source, duration,
+  reason.
+- Metrics: install latency/error-rate per plugin, boot-reconcile duration,
+  catalog-fetch failures.
+- Sentry tags: `plugin_id`, `plugin_source`, `distribution_mode`.
+
+## 11. Failure modes
+
+| Failure | Behaviour |
+| ------- | --------- |
+| Registry unreachable | New installs fail cleanly + retryable; installed plugins keep working; reconcile retries on next boot. |
+| Package not permitted | Refused before download (allowlist), 409. |
+| Integrity mismatch | Refused, nothing loaded, 424. |
+| Invalid manifest / incompatible version | Recorded `installState='error'` + reason, 422; nothing registered. |
+| Throwing plugin constructor | Same as load failure today — caught, recorded, isolated. |
+| Mode switch (bundled↔dynamic) | Reconcile on restart; user enable choices preserved in DB. |
+
+## 12. Constitution Reconciliation
+
+| Principle | How this design respects it |
+| --------- | --------------------------- |
+| I — Plugin-first | Plugins stay the integration unit; this is supply-chain plumbing. |
+| II — Capability-driven | Resolution/enable unchanged; install precedes them. |
+| III — Source-of-truth repos | Unaffected. |
+| IV — Trigger.dev | Long-running plugin execution routed through the job runtime. |
+| V — Forward-only migrations | New columns/table additive with defaults. |
+| VI — Tests | Installer/allowlist/reconcile/router/publish all tested. |
+| VII — Secret hygiene | Registry tokens + plugin creds are secrets; `x-secret` preserved. |
+| VIII — Plugin counts | Canonical built-in-plugins doc carries core vs distributable split. |
+| IX — Behaviour-first | Behaviour in the feature spec; this is architecture. |
+| X — Backwards-compat | Default `bundled` preserves current behaviour; all additions additive. |
+
+## 13. References
+
+- Feature spec: [`features/dynamic-plugin-distribution/spec`](../features/dynamic-plugin-distribution/spec.md)
+- Plan: [`features/dynamic-plugin-distribution/plan`](../features/dynamic-plugin-distribution/plan.md)
+- ADR: [`decisions/015-dynamic-plugin-distribution`](../decisions/015-dynamic-plugin-distribution.md)
+- SDK: [`plugin-sdk`](./plugin-sdk.md)
+- Deployment: [`deployment`](./deployment.md)
+- Trigger.dev: [`trigger-integration`](./trigger-integration.md)
+- Source today: `packages/agent/src/plugins/`, `packages/agent/src/plugins/plugins.constants.ts`
+  (`DEFAULT_PLUGIN_PATHS`), `apps/api/src/config/constants.ts`
+- Jira: EW epic (this feature), [EW-683] (job-runtime pluggability)

--- a/docs/specs/architecture/runtime-plugins.md
+++ b/docs/specs/architecture/runtime-plugins.md
@@ -94,7 +94,7 @@ User clicks Enable (plugin not installed)
 Key properties:
 
 - **Install ≠ enable ≠ load** stay distinct (the SDK already separates
-  load/enable). Dynamic mode inserts *install + load* in front of *enable* only
+  load/enable). Dynamic mode inserts _install + load_ in front of _enable_ only
   when the plugin is absent.
 - **Idempotent + concurrency-guarded** per plugin id (two simultaneous enables
   of the same plugin install once).
@@ -113,7 +113,7 @@ per-replica store, two mechanisms keep every node consistent **without** a share
 volume:
 
 **(a) Lazy install-on-use — the correctness guarantee.** Before any node (an API
-replica *or* a job-runtime worker) invokes a distributable plugin, it ensures the
+replica _or_ a job-runtime worker) invokes a distributable plugin, it ensures the
 package is present locally and installs it if not:
 
 ```
@@ -158,7 +158,7 @@ operation's `executionProfile`:
 
 > **The worker is a separate runtime with its own store.** The Trigger.dev worker
 > is deployed independently from the API and prepares its own `./plugins` bundle
-> at deploy time — so a plugin *installed at runtime in the API* does **not**
+> at deploy time — so a plugin _installed at runtime in the API_ does **not**
 > exist in the worker. The long-running path therefore calls the same
 > `ensurePluginAvailable()` (§6 lazy install-on-use) inside the task **before**
 > invoking the plugin, installing into the worker's own store on first use. The
@@ -207,29 +207,29 @@ not part of this feature.
 
 ## 11. Failure modes
 
-| Failure | Behaviour |
-| ------- | --------- |
-| Registry unreachable | New installs fail cleanly + retryable; installed plugins keep working; reconcile retries on next boot. |
-| Package not permitted | Refused before download (allowlist), 409. |
-| Integrity mismatch | Refused, nothing loaded, 424. |
-| Invalid manifest / incompatible version | Recorded `installState='error'` + reason, 422; nothing registered. |
-| Throwing plugin constructor | Same as load failure today — caught, recorded, isolated. |
-| Mode switch (bundled↔dynamic) | Reconcile on restart; user enable choices preserved in DB. |
+| Failure                                 | Behaviour                                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Registry unreachable                    | New installs fail cleanly + retryable; installed plugins keep working; reconcile retries on next boot. |
+| Package not permitted                   | Refused before download (allowlist), 409.                                                              |
+| Integrity mismatch                      | Refused, nothing loaded, 424.                                                                          |
+| Invalid manifest / incompatible version | Recorded `installState='error'` + reason, 422; nothing registered.                                     |
+| Throwing plugin constructor             | Same as load failure today — caught, recorded, isolated.                                               |
+| Mode switch (bundled↔dynamic)           | Reconcile on restart; user enable choices preserved in DB.                                             |
 
 ## 12. Constitution Reconciliation
 
-| Principle | How this design respects it |
-| --------- | --------------------------- |
-| I — Plugin-first | Plugins stay the integration unit; this is supply-chain plumbing. |
-| II — Capability-driven | Resolution/enable unchanged; install precedes them. |
-| III — Source-of-truth repos | Unaffected. |
-| IV — Trigger.dev | Long-running plugin execution routed through the job runtime. |
-| V — Forward-only migrations | New columns/table additive with defaults. |
-| VI — Tests | Installer/allowlist/reconcile/router/publish all tested. |
-| VII — Secret hygiene | Registry tokens + plugin creds are secrets; `x-secret` preserved. |
-| VIII — Plugin counts | Canonical built-in-plugins doc carries core vs distributable split. |
-| IX — Behaviour-first | Behaviour in the feature spec; this is architecture. |
-| X — Backwards-compat | Default `bundled` preserves current behaviour; all additions additive. |
+| Principle                   | How this design respects it                                            |
+| --------------------------- | ---------------------------------------------------------------------- |
+| I — Plugin-first            | Plugins stay the integration unit; this is supply-chain plumbing.      |
+| II — Capability-driven      | Resolution/enable unchanged; install precedes them.                    |
+| III — Source-of-truth repos | Unaffected.                                                            |
+| IV — Trigger.dev            | Long-running plugin execution routed through the job runtime.          |
+| V — Forward-only migrations | New columns/table additive with defaults.                              |
+| VI — Tests                  | Installer/allowlist/reconcile/router/publish all tested.               |
+| VII — Secret hygiene        | Registry tokens + plugin creds are secrets; `x-secret` preserved.      |
+| VIII — Plugin counts        | Canonical built-in-plugins doc carries core vs distributable split.    |
+| IX — Behaviour-first        | Behaviour in the feature spec; this is architecture.                   |
+| X — Backwards-compat        | Default `bundled` preserves current behaviour; all additions additive. |
 
 ## 13. References
 

--- a/docs/specs/architecture/runtime-plugins.md
+++ b/docs/specs/architecture/runtime-plugins.md
@@ -204,7 +204,7 @@ not part of this feature.
 
 - Feature spec: [`features/dynamic-plugin-distribution/spec`](../features/dynamic-plugin-distribution/spec.md)
 - Plan: [`features/dynamic-plugin-distribution/plan`](../features/dynamic-plugin-distribution/plan.md)
-- ADR: [`decisions/015-dynamic-plugin-distribution`](../decisions/015-dynamic-plugin-distribution.md)
+- ADR: [`decisions/016-dynamic-plugin-distribution`](../decisions/016-dynamic-plugin-distribution.md)
 - SDK: [`plugin-sdk`](./plugin-sdk.md)
 - Deployment: [`deployment`](./deployment.md)
 - Trigger.dev: [`trigger-integration`](./trigger-integration.md)

--- a/docs/specs/decisions/015-dynamic-plugin-distribution.md
+++ b/docs/specs/decisions/015-dynamic-plugin-distribution.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Proposed**
+**Accepted** — decisions locked with @evereq 2026-05-28; implementation tracked under EW-693.
 
 ## Date
 
@@ -72,10 +72,13 @@ Supporting decisions:
 - Cold-start install cost on fresh replicas (mitigated by boot reconcile +
   optional baking/PVC).
 - Dynamic mode requires a writable runtime store, so read-only-FS serverless
-  targets (Vercel) remain `bundled`-only.
-- The API's current hard imports of storage plugins (`aws-s3`, `minio`,
-  `github-storage`) must either stay core-bundled or be refactored to resolve via
-  the loader (tracked as an open question).
+  targets (Vercel) remain `bundled`-only. The store is just a writable directory
+  (default `/app/plugins`), per-replica with boot reconcile — no shared volume or
+  external service required.
+- The API's hard imports of storage plugins (`aws-s3`, `minio`, `github-storage`)
+  are **removed**; storage is resolved via the capability facade and those three
+  become distributable. `local-fs` stays core as the default storage so the API
+  boots without any distributable plugin (EW-693 T8b).
 
 **Neutral**
 

--- a/docs/specs/decisions/015-dynamic-plugin-distribution.md
+++ b/docs/specs/decisions/015-dynamic-plugin-distribution.md
@@ -1,0 +1,104 @@
+# ADR-015: Dual-Mode Plugin Distribution (bundled + runtime npm install)
+
+## Status
+
+**Proposed**
+
+## Date
+
+2026-05-28
+
+## Context
+
+Every plugin under `packages/plugins/*` is part of the pnpm workspace and is
+built into the platform image. Consequences today:
+
+- A clone + `pnpm install` resolves the dependency closure of **all** ~49
+  plugins, pulling every plugin's third-party SDK even for plugins that will
+  never be enabled.
+- The deployed artifact (and image) carries every plugin and its SDK regardless
+  of what any tenant enables. Plugins are discovered from disk
+  (`DEFAULT_PLUGIN_PATHS`) and dynamically `import()`-ed; there is no
+  tree-shaking by enable-state.
+- "Enable" is purely a DB flag flip today — all plugins are pre-loaded at boot.
+- The official-SDK rule (EW-682, AGENTS.md NN #22) means each new integration
+  adds a real runtime dependency, so install time and image size grow linearly
+  with the unique SDK trees plugins introduce.
+
+We want to keep the simple "everything bundled" model **and** add a mode where a
+deployment ships only core plugins and pulls the rest at runtime when enabled.
+
+## Decision
+
+Introduce a platform setting **`PLUGIN_DISTRIBUTION_MODE`** with two values:
+
+- **`bundled`** (default): current behaviour — all plugins in the image,
+  discovered from disk, no registry. Existing deployments are unaffected.
+- **`dynamic`**: only **core** plugins are bundled; **distributable** plugins are
+  published to a registry and pulled, integrity-verified, and loaded at runtime
+  on first enable, then reconciled from the database on every boot.
+
+Supporting decisions:
+
+1. **Core vs distributable is declared on the plugin** via a new manifest field
+   `distribution: 'core' | 'registry'`, defaulting from `systemPlugin`. Core =
+   all `systemPlugin: true` plugins + any plugin the API cannot boot without.
+2. **Publish to BOTH public npm and GitHub Packages** (`@ever-works` org), with
+   **independent per-plugin versioning** via Changesets. Registry endpoints are
+   configurable so self-hosters can use a mirror/private registry.
+3. **Trust model: first-party + allowlist.** Only `@ever-works/*` (implicit) or
+   admin-allowlisted packages are installable; verify integrity before load. No
+   arbitrary-npm execution and no bespoke sandbox in v1.
+4. **Execution location is routed per operation.** Short/`sync` calls run
+   in-process via dynamic import; `long-running` calls run inside the pluggable
+   job runtime (Trigger.dev today), which already isolates plugin code. This
+   depends on, but does not duplicate, the job-runtime-pluggability work
+   (EW-683).
+
+## Consequences
+
+**Positive**
+
+- Lean installs/images for deployments that enable few plugins.
+- Plugin releases decouple from platform releases (independent versions).
+- Clear path to a future community/third-party plugin ecosystem (allowlist →
+  marketplace) without re-architecting.
+- Isolation for long-running third-party code reuses existing infrastructure.
+
+**Negative / costs**
+
+- New supply-chain surface: registry availability, auth, integrity, allowlist
+  administration.
+- Cold-start install cost on fresh replicas (mitigated by boot reconcile +
+  optional baking/PVC).
+- Dynamic mode requires a writable runtime store, so read-only-FS serverless
+  targets (Vercel) remain `bundled`-only.
+- The API's current hard imports of storage plugins (`aws-s3`, `minio`,
+  `github-storage`) must either stay core-bundled or be refactored to resolve via
+  the loader (tracked as an open question).
+
+**Neutral**
+
+- The loader, registry, lifecycle, and per-user/per-work enable model are reused
+  unchanged; this is additive plumbing, not a rewrite.
+
+## Alternatives considered
+
+- **Public npm only** — simpler, but loses the GitHub-native auth/mirroring story
+  for self-hosters and private plugins. Rejected in favour of dual-publish.
+- **Self-hosted Verdaccio only** — maximum control but new infra to operate;
+  kept as an optional self-host mirror behind the configurable registry URL.
+- **First-party only** (no third-party) — simplest trust model, but forecloses
+  the ecosystem; rejected in favour of first-party + allowlist.
+- **Open to any npm package** — requires signing + sandboxing + review pipeline
+  up front; deferred to a future phase.
+- **In-process sandbox (isolated-vm/microVM) for all plugin code** — heavy; not
+  needed in v1 given allowlist + job-runtime isolation for long-running work.
+
+## References
+
+- Feature spec: [`features/dynamic-plugin-distribution/spec`](../features/dynamic-plugin-distribution/spec.md)
+- Plan: [`features/dynamic-plugin-distribution/plan`](../features/dynamic-plugin-distribution/plan.md)
+- Architecture: [`architecture/runtime-plugins`](../architecture/runtime-plugins.md)
+- Related: [`plugin-sdk`](../architecture/plugin-sdk.md), [`deployment`](../architecture/deployment.md)
+- Jira: EW epic (this feature), EW-683 (job-runtime pluggability), EW-682 (official-SDK audit)

--- a/docs/specs/decisions/016-dynamic-plugin-distribution.md
+++ b/docs/specs/decisions/016-dynamic-plugin-distribution.md
@@ -1,4 +1,4 @@
-# ADR-015: Dual-Mode Plugin Distribution (bundled + runtime npm install)
+# ADR-016: Dual-Mode Plugin Distribution (bundled + runtime npm install)
 
 ## Status
 

--- a/docs/specs/decisions/016-dynamic-plugin-distribution.md
+++ b/docs/specs/decisions/016-dynamic-plugin-distribution.md
@@ -69,8 +69,11 @@ Supporting decisions:
 
 - New supply-chain surface: registry availability, auth, integrity, allowlist
   administration.
-- Cold-start install cost on fresh replicas (mitigated by boot reconcile +
-  optional baking/PVC).
+- Cold-start install cost on fresh replicas (mitigated by boot warmup + optional
+  baking/PVC). Cross-replica/worker correctness relies on **lazy install-on-use**
+  (`ensurePluginAvailable` runs on every node — API replicas and the job-runtime
+  worker — before invoking a plugin), not boot reconcile alone; the worker
+  installs into its own store on first use. (Resolves Codex P1 ×2 on PR #1098.)
 - Dynamic mode requires a writable runtime store, so read-only-FS serverless
   targets (Vercel) remain `bundled`-only. The store is just a writable directory
   (default `/app/plugins`), per-replica with boot reconcile — no shared volume or

--- a/docs/specs/features/dynamic-plugin-distribution/plan.md
+++ b/docs/specs/features/dynamic-plugin-distribution/plan.md
@@ -279,7 +279,7 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 
 - Spec: `./spec.md`
 - Tasks: `./tasks.md`
-- ADR: [`015-dynamic-plugin-distribution`](../../decisions/015-dynamic-plugin-distribution.md)
+- ADR: [`016-dynamic-plugin-distribution`](../../decisions/016-dynamic-plugin-distribution.md)
 - Architecture: [`runtime-plugins`](../../architecture/runtime-plugins.md),
   [`plugin-sdk`](../../architecture/plugin-sdk.md),
   [`deployment`](../../architecture/deployment.md)

--- a/docs/specs/features/dynamic-plugin-distribution/plan.md
+++ b/docs/specs/features/dynamic-plugin-distribution/plan.md
@@ -1,0 +1,275 @@
+# Implementation Plan: Dynamic Plugin Distribution (dual-mode)
+
+> Translates [`spec.md`](./spec.md) into architecture and tech choices.
+> The plan owns implementation details; the spec owns behaviour.
+
+**Feature ID**: `dynamic-plugin-distribution`
+**Spec**: `./spec.md`
+**Tasks**: `./tasks.md`
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+
+---
+
+## 1. Architecture Summary
+
+```mermaid
+flowchart TD
+    subgraph Build["Build / CI"]
+        SRC[packages/plugins/*] -->|tsup build| DIST[dist per plugin]
+        DIST -->|changesets release| PUB{publish}
+        PUB --> NPM[(public npm)]
+        PUB --> GHP[(GitHub Packages)]
+    end
+
+    subgraph Image["Platform image"]
+        CORE[core plugins bundled in /app/plugins] --> LOADER
+    end
+
+    subgraph Runtime["API process (dynamic mode)"]
+        UI[Web: Enable] --> CTRL[plugins.controller]
+        CTRL --> OPS[PluginOperationsService.enable]
+        OPS -->|not installed?| INST[PluginInstallerService]
+        INST -->|allowlist + integrity| RESOLVE[resolve pkg@version]
+        RESOLVE --> NPM
+        RESOLVE --> GHP
+        INST -->|install to store| STORE[(Runtime plugin store
+/app/plugins or PVC)]
+        STORE --> LOADER[PluginLoaderService.load]
+        LOADER --> REG[PluginRegistryService]
+        REG --> DB[(plugins / plugin_allowlist)]
+        OPS --> DB
+    end
+
+    subgraph Boot["Boot (every replica)"]
+        BS[PluginBootstrapService] --> RECON[reconcile store from DB]
+        RECON --> INST
+    end
+
+    subgraph Exec["Capability execution"]
+        FAC[Facade call] --> ROUTER{execution location}
+        ROUTER -->|short / sync| INPROC[dynamic import in API]
+        ROUTER -->|long-running| JOB[Job runtime: Trigger.dev task
+imports plugin, isolated]
+    end
+```
+
+The design is **additive**: it layers a publish pipeline, an installer, a
+boot reconciler, an allowlist, and an execution-location router on top of the
+existing discover → load → register → enable machinery. The existing loader
+(`await import(entryPath)`), registry, lifecycle manager, and per-user/per-work
+enable model are reused unchanged. `bundled` mode is the current code path with
+the new pieces inert.
+
+## 2. Tech Choices
+
+| Concern | Choice | Rationale |
+| ------- | ------ | --------- |
+| Distribution flag | `config` constant + env (`PLUGIN_DISTRIBUTION_MODE`) | Matches `apps/api/src/config/constants.ts` lazy-fn + `FEATURE_*` pattern; fail-fast validation. |
+| Core vs distributable | New `distribution` manifest field in `everworks.plugin` | Declared on the plugin, not hard-coded (FR-3). Default derived from `systemPlugin`. |
+| Publish | **Changesets** → npm + GitHub Packages | Independent per-plugin versioning (FR-7); no platform release coupling; mirrors `publish-cli.yml` auth pattern. |
+| Runtime fetch | `npm`/`pnpm` programmatic install (pinned exact version, `--no-save`) into the store, then `import()` | Reuses Node module resolution + integrity; loader already scans `node_modules/@ever-works` and `./plugins`. |
+| Integrity | npm package integrity (sha512) + first-party npm provenance | No bespoke signing in v1; verify-before-load (FR-10). |
+| Persistence | TypeORM columns on `PluginEntity` + new `PluginAllowlistEntity` | Existing pattern in `packages/agent/src/plugins`. |
+| Long-running execution | Pluggable job runtime (Trigger.dev today) | Principle IV; isolation comes "for free" inside the task process. Depends on EW-683. |
+| Store location | `PLUGIN_INSTALL_DIR` (default `/app/plugins`); k8s writable volume | API root FS is writable today (`readOnlyRootFilesystem: false`); per-replica reconcile avoids requiring RWX. |
+
+## 3. Data Model
+
+### Changed entity — `PluginEntity` (`packages/agent/src/plugins/entities/plugin.entity.ts`)
+
+Additive columns (all nullable / defaulted — forward-only):
+
+```ts
+// Where the plugin came from on this deployment.
+@Column({ type: 'varchar', default: 'bundled' })
+source: 'bundled' | 'registry';
+
+// npm spec actually installed, e.g. "@ever-works/notion-extractor-plugin@1.2.0".
+@Column({ type: 'varchar', nullable: true })
+registrySpec?: string;
+
+// Resolved version present on disk (may differ from manifest until upgraded).
+@Column({ type: 'varchar', nullable: true })
+installedVersion?: string;
+
+// Integrity used to verify the install (sha512 from the registry).
+@Column({ type: 'varchar', nullable: true })
+integrity?: string;
+
+// Install lifecycle, distinct from the existing load `state`.
+@Column({ type: 'varchar', default: 'available' })
+installState: 'available' | 'installing' | 'installed' | 'error';
+```
+
+`distribution` (core vs registry) is read from the manifest at discovery time;
+it is denormalised onto the row for listing convenience but the manifest is the
+source of truth.
+
+### New entity — `PluginAllowlistEntity` (`packages/agent/src/plugins/entities/plugin-allowlist.entity.ts`)
+
+```ts
+@Entity('plugin_allowlist')
+export class PluginAllowlistEntity {
+    @PrimaryGeneratedColumn('uuid') id: string;
+    @Column({ type: 'varchar', unique: true }) packageName: string; // npm name
+    @Column({ type: 'varchar' }) versionRange: string;             // pinned/semver
+    @Column({ type: 'varchar', nullable: true }) integrity?: string;
+    @Column({ type: 'varchar', default: 'npm' }) source: 'npm' | 'github-packages';
+    @Column({ type: 'boolean', default: true }) enabled: boolean;
+    @CreateDateColumn() createdAt: Date;
+}
+```
+
+First-party `@ever-works/*` is implicitly allowed (no row required).
+
+### Migrations
+
+- `apps/api/src/migrations/<unix-millis>-AddPluginDistributionColumns.ts` —
+  add the five `PluginEntity` columns. Additive, forward-only, defaults set so
+  existing rows become `source='bundled'`, `installState='installed'`.
+- `apps/api/src/migrations/<unix-millis>-CreatePluginAllowlist.ts` — create
+  `plugin_allowlist`.
+- **NN #16 / Principle V**: generated with `pnpm typeorm migration:generate`,
+  SQL read by hand, no `DROP`/`ALTER TYPE`. Ship in the same PR as the entity change.
+
+### DTOs / contracts (`packages/contracts`)
+
+- `PluginInstallStateDto`, extend the plugin list/response DTOs with
+  `source`, `installState`, `installedVersion`, `available` (catalog) fields.
+- Allowlist admin DTOs (`CreateAllowlistEntryDto`, etc.).
+
+## 4. API Surface
+
+| Method | Endpoint | Description | Status |
+| ------ | -------- | ----------- | ------ |
+| `GET` | `/plugins/catalog` | List distributable plugins available from the registry (manifest summaries), with install state. | New |
+| `POST` | `/plugins/:pluginId/install` | Install (resolve+verify+load) a distributable plugin without enabling. | New |
+| `POST` | `/plugins/:pluginId/enable` | Existing; in dynamic mode installs first if absent, then enables. | Changed |
+| `DELETE` | `/plugins/:pluginId/install` | Uninstall a distributable plugin (refused for core). | New |
+| `GET` | `/plugins/:pluginId/install-status` | Poll install progress/state. | New |
+| `GET`/`POST`/`DELETE` | `/admin/plugins/allowlist` | Manage the third-party allowlist (admin-gated). | New |
+
+- Auth: user-scoped endpoints use existing `@CurrentUser()`; allowlist endpoints
+  are admin-gated. Install is rate-limited (registry protection).
+- Errors: `409` plugin not permitted (allowlist), `424` integrity mismatch,
+  `502/504` registry unreachable, `422` invalid manifest / version incompatible.
+
+## 5. Plugin Surface
+
+- **SDK (`packages/plugin`)**: add `distribution?: 'core' | 'registry'` and an
+  optional execution hint (e.g. `executionProfile?: 'sync' | 'long-running'` at
+  capability/operation granularity) to `PluginManifest`
+  (`src/contracts/plugin-manifest.types.ts`) + JSON-schema validator update.
+  Additive; default derivation keeps old manifests valid.
+- **All plugin `package.json`s**: set `distribution` (core for `systemPlugin`
+  + API-boot-critical; `registry` for the rest); flip `private: true → false`
+  with `publishConfig` for distributable plugins; add per-plugin `release` wiring.
+- **Loader (`plugin-loader.service.ts`)**: accept an explicit install path from
+  the installer (reuse `loadPluginModule`); no behaviour change in bundled mode.
+- **New `PluginInstallerService`** (`packages/agent/src/plugins/services/`):
+  resolve → allowlist-check → download → integrity-verify → place in store →
+  hand path to loader. Idempotent; concurrency-guarded per plugin id.
+- **New `PluginExecutionRouterService`**: given a capability/operation, decide
+  in-process vs job-runtime dispatch; reused by facades.
+
+## 6. Web / CLI Surface
+
+- `apps/web/src/app/[locale]/(dashboard)/settings/plugins/[category]/page.tsx`
+  and `apps/web/src/lib/api/plugins.ts`: add catalog listing, install state
+  chips (available/installing/installed/error), Install action + progress, and
+  error surfacing. Enable button triggers install-then-enable in dynamic mode.
+- Admin allowlist management page (basic table + add/remove).
+- Optional CLI: `ever-works plugins install <id>` mirroring the API.
+
+## 7. Background Jobs
+
+| Trigger | When | What it does | Idempotency strategy |
+| ------- | ---- | ------------ | -------------------- |
+| Boot reconcile (on `onApplicationBootstrap`) | Every API start in dynamic mode | Install any DB-recorded installed/enabled distributable plugins missing from the local store. | Per-plugin install is idempotent (version+integrity pinned); skip if present. |
+| Long-running capability dispatch | Per pipeline/long op | Run plugin call inside the job runtime task that imports the plugin. | Existing job idempotency / CAS in the task layer. |
+| Optional GC (later) | Cron | Remove store files for long-unused disabled plugins. | Guarded by retention policy; out of v1 unless cheap. |
+
+## 8. Security & Permissions
+
+- Install is gated: first-party `@ever-works/*` OR allowlisted package only
+  (FR-11); refusal happens **before** any network fetch.
+- Integrity verified before `import()` (FR-10); mismatch → refuse.
+- Registry auth tokens (GitHub Packages, private mirrors) are secrets — sourced
+  from env/secret store, never logged, never returned by APIs.
+- Plugin settings/credentials keep `x-secret` redaction (Principle VII).
+- Long-running third-party code executes in the isolated job runtime, limiting
+  blast radius inside the API process.
+- Allowlist mutation endpoints are admin-only.
+
+## 9. Observability
+
+- Activity-log/events: `plugin.install.requested|succeeded|failed`,
+  `plugin.upgrade.*`, `plugin.uninstall.*`, with plugin id, version, source,
+  duration, and failure reason.
+- Metrics: install count/latency/error-rate per plugin; reconcile duration on
+  boot; catalog-fetch failures.
+- Sentry tags: `plugin_id`, `plugin_source`, `distribution_mode`.
+
+## 10. Phased Rollout
+
+1. **Phase 1 — SDK & data model**: manifest `distribution`/exec fields + JSON
+   schema; `PluginEntity` columns + `PluginAllowlistEntity` + migrations; DTOs.
+   Behind the flag; default `bundled`; no behaviour change.
+2. **Phase 2 — Publish pipeline**: Changesets + dual-publish CI (npm + GitHub
+   Packages); flip `private` + `publishConfig` on distributable plugins;
+   dry-run, then first real publishes. Independent of runtime mode.
+3. **Phase 3 — Installer & reconcile**: `PluginInstallerService`, allowlist
+   enforcement, integrity verify, boot reconcile; wire into enable flow gated by
+   dynamic mode. Still default `bundled`.
+4. **Phase 4 — Execution router**: classify operations; route long-running plugin
+   calls through the job runtime; in-process for short. Depends on EW-683 for
+   full provider-pluggability but works against Trigger.dev directly meanwhile.
+5. **Phase 5 — Deployment**: dynamic-mode image variant (core-only) + writable
+   store/volume + k8s manifest + entrypoint reconcile hook; document Vercel
+   read-only-FS limitation (dynamic mode unsupported on read-only serverless).
+6. **Phase 6 — UI & catalog**: catalog listing, install states, progress,
+   errors, admin allowlist UI.
+7. **Phase 7 — Soak & default**: enable dynamic mode on a staging/SaaS target,
+   soak, then decide per-target defaults (Open Question).
+
+## 11. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| Registry outage blocks enabling new plugins | Med | Med | Installed plugins unaffected; clean retryable failures; optional warm cache/mirror. |
+| Cold-start install cost on new replicas | Med | Med | Per-replica reconcile in parallel; consider baking "popular" plugins; readiness gate until reconcile done. |
+| Running untrusted-ish 3rd-party code in API process | Low (allowlist) | High | Allowlist + integrity; long-running paths in isolated job runtime; sandbox is a documented future phase. |
+| Read-only FS targets (Vercel) can't install at runtime | Med | Low | Dynamic mode requires writable store; Vercel/serverless documented as bundled-only. |
+| API hard-deps on storage plugins block making them distributable | High | Low | Keep aws-s3/minio/github-storage core for v1 (Open Question), or remove direct import. |
+| Version drift between manifest and installed dist | Med | Low | Persist `installedVersion`+`integrity`; reconcile pins exact version. |
+
+## 12. Constitution Reconciliation
+
+- **I — Plugin-first**: Plugins remain the integration unit; registry/installer
+  is platform plumbing.
+- **II — Capability-driven**: Resolution/enable semantics unchanged; install is
+  a precondition step.
+- **III — Source-of-truth repos**: Unaffected.
+- **IV — Trigger.dev**: Long-running plugin execution explicitly routed through
+  the job runtime; ties to EW-683.
+- **V — Forward-only migrations**: New columns/table additive; defaults backfill.
+- **VI — Tests**: Installer, allowlist, reconcile, router, publish dry-run all
+  ship tests; e2e for both execution paths.
+- **VII — Secret hygiene**: Registry tokens + plugin creds are secrets;
+  `x-secret` preserved.
+- **VIII — Plugin counts**: Canonical built-in-plugins doc updated with core vs
+  distributable split.
+- **IX — Behaviour-first**: Behaviour in spec; this file holds implementation.
+- **X — Backwards-compat**: Default `bundled` preserves current behaviour; SDK,
+  manifest, schema, and API additions are additive.
+
+## 13. References
+
+- Spec: `./spec.md`
+- Tasks: `./tasks.md`
+- ADR: [`015-dynamic-plugin-distribution`](../../decisions/015-dynamic-plugin-distribution.md)
+- Architecture: [`runtime-plugins`](../../architecture/runtime-plugins.md),
+  [`plugin-sdk`](../../architecture/plugin-sdk.md),
+  [`deployment`](../../architecture/deployment.md)
+- Jira: EW epic (this feature); [EW-683] job-runtime pluggability (dependency)

--- a/docs/specs/features/dynamic-plugin-distribution/plan.md
+++ b/docs/specs/features/dynamic-plugin-distribution/plan.md
@@ -193,9 +193,10 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 
 | Trigger | When | What it does | Idempotency strategy |
 | ------- | ---- | ------------ | -------------------- |
-| Boot reconcile (on `onApplicationBootstrap`) | Every API start in dynamic mode | Install any DB-recorded installed/enabled distributable plugins missing from the local store. | Per-plugin install is idempotent (version+integrity pinned); skip if present. |
-| Long-running capability dispatch | Per pipeline/long op | Run plugin call inside the job runtime task that imports the plugin. | Existing job idempotency / CAS in the task layer. |
-| Optional GC (later) | Cron | Remove store files for long-unused disabled plugins. | Guarded by retention policy; out of v1 unless cheap. |
+| **Lazy install-on-use** (`ensurePluginAvailable`) | Before *any* node invokes a distributable plugin (API replica or worker) | Install the pinned package into the local store if missing, then load+register. **The correctness guarantee** — a plugin enabled on one replica works on all replicas/worker with no restart or shared volume. | Per-id concurrency lock + version/integrity pin; skip if present. |
+| Boot reconcile (on `onApplicationBootstrap`) | Every API/worker start in dynamic mode | Warm the store by pre-installing the DB-recorded installed/enabled set. Optimisation only (avoids first-request latency), not correctness. | Same `ensurePluginAvailable`; idempotent. |
+| Long-running capability dispatch | Per pipeline/long op | In the job-runtime worker, call `ensurePluginAvailable` then run the plugin inside the isolated task. The worker has its own store, so it installs on first use just like the API. | Existing job idempotency / CAS in the task layer. |
+| GC | — | Out of scope for v1 (decided: keep installed files on disable, no GC). | n/a |
 
 ## 8. Security & Permissions
 
@@ -248,7 +249,8 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 | Risk | Likelihood | Impact | Mitigation |
 | ---- | ---------- | ------ | ---------- |
 | Registry outage blocks enabling new plugins | Med | Med | Installed plugins unaffected; clean retryable failures; optional warm cache/mirror. |
-| Cold-start install cost on new replicas | Med | Med | Per-replica reconcile in parallel; consider baking "popular" plugins; readiness gate until reconcile done. |
+| Cold-start install cost on new replicas | Med | Med | Boot warmup pre-installs in parallel; lazy install-on-use covers anything not warmed; consider baking "popular" plugins. |
+| Plugin enabled on replica A not present on replica B / worker | High | High | **Lazy install-on-use** (`ensurePluginAvailable`) on every node before invocation — not boot-only reconcile. Worker installs into its own store too. (Codex P1 ×2.) |
 | Running untrusted-ish 3rd-party code in API process | Low (allowlist) | High | Allowlist + integrity; long-running paths in isolated job runtime; sandbox is a documented future phase. |
 | Read-only FS targets (Vercel) can't install at runtime | Med | Low | Dynamic mode requires writable store; Vercel/serverless documented as bundled-only. |
 | API hard-deps on storage plugins block making them distributable | High | Low | **Decided**: remove the direct imports, resolve storage via the facade, keep `local-fs` as core default (so the API boots storage-less of any distributable plugin). |

--- a/docs/specs/features/dynamic-plugin-distribution/plan.md
+++ b/docs/specs/features/dynamic-plugin-distribution/plan.md
@@ -162,9 +162,16 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
   capability/operation granularity) to `PluginManifest`
   (`src/contracts/plugin-manifest.types.ts`) + JSON-schema validator update.
   Additive; default derivation keeps old manifests valid.
-- **All plugin `package.json`s**: set `distribution` (core for `systemPlugin`
-  + API-boot-critical; `registry` for the rest); flip `private: true → false`
-  with `publishConfig` for distributable plugins; add per-plugin `release` wiring.
+- **All plugin `package.json`s**: set `distribution` (core for every
+  `systemPlugin`; `registry` for the rest, **including** `aws-s3`, `minio`,
+  `github-storage`); flip `private: true → false` with `publishConfig` for
+  distributable plugins; add per-plugin `release` wiring.
+- **Decouple the API from storage plugins**: remove the direct
+  `@ever-works/{aws-s3,minio,github-storage}-plugin` dependencies from
+  `apps/api/package.json` and resolve storage through the capability
+  facade/registry instead of static imports. Keep `local-fs` (a `systemPlugin`)
+  bundled as the core default storage so the API boots without any distributable
+  storage plugin present. This is what makes those three plugins distributable.
 - **Loader (`plugin-loader.service.ts`)**: accept an explicit install path from
   the installer (reuse `loadPluginModule`); no behaviour change in bundled mode.
 - **New `PluginInstallerService`** (`packages/agent/src/plugins/services/`):
@@ -214,8 +221,10 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 ## 10. Phased Rollout
 
 1. **Phase 1 — SDK & data model**: manifest `distribution`/exec fields + JSON
-   schema; `PluginEntity` columns + `PluginAllowlistEntity` + migrations; DTOs.
-   Behind the flag; default `bundled`; no behaviour change.
+   schema; `PluginEntity` columns + `PluginAllowlistEntity` + migrations; DTOs;
+   **decouple the API from storage plugins** (remove hard imports, resolve via
+   facade, keep `local-fs` core). Behind the flag; default `bundled`; no
+   behaviour change.
 2. **Phase 2 — Publish pipeline**: Changesets + dual-publish CI (npm + GitHub
    Packages); flip `private` + `publishConfig` on distributable plugins;
    dry-run, then first real publishes. Independent of runtime mode.
@@ -230,8 +239,9 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
    read-only-FS limitation (dynamic mode unsupported on read-only serverless).
 6. **Phase 6 — UI & catalog**: catalog listing, install states, progress,
    errors, admin allowlist UI.
-7. **Phase 7 — Soak & default**: enable dynamic mode on a staging/SaaS target,
-   soak, then decide per-target defaults (Open Question).
+7. **Phase 7 — Soak**: enable dynamic mode on a staging target and soak. The
+   shipped default stays `bundled` everywhere (SaaS + self-host); `dynamic` is
+   opt-in per deployment — no default flip planned for v1.
 
 ## 11. Risks & Mitigations
 
@@ -241,7 +251,8 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 | Cold-start install cost on new replicas | Med | Med | Per-replica reconcile in parallel; consider baking "popular" plugins; readiness gate until reconcile done. |
 | Running untrusted-ish 3rd-party code in API process | Low (allowlist) | High | Allowlist + integrity; long-running paths in isolated job runtime; sandbox is a documented future phase. |
 | Read-only FS targets (Vercel) can't install at runtime | Med | Low | Dynamic mode requires writable store; Vercel/serverless documented as bundled-only. |
-| API hard-deps on storage plugins block making them distributable | High | Low | Keep aws-s3/minio/github-storage core for v1 (Open Question), or remove direct import. |
+| API hard-deps on storage plugins block making them distributable | High | Low | **Decided**: remove the direct imports, resolve storage via the facade, keep `local-fs` as core default (so the API boots storage-less of any distributable plugin). |
+| Default storage (`local-fs`) not shared across replicas | Med | Low | Pre-existing concern, not new; production enables a distributable shared backend (s3/minio/github-storage). `local-fs` only guarantees the API boots. |
 | Version drift between manifest and installed dist | Med | Low | Persist `installedVersion`+`integrity`; reconcile pins exact version. |
 
 ## 12. Constitution Reconciliation

--- a/docs/specs/features/dynamic-plugin-distribution/plan.md
+++ b/docs/specs/features/dynamic-plugin-distribution/plan.md
@@ -63,16 +63,16 @@ the new pieces inert.
 
 ## 2. Tech Choices
 
-| Concern | Choice | Rationale |
-| ------- | ------ | --------- |
-| Distribution flag | `config` constant + env (`PLUGIN_DISTRIBUTION_MODE`) | Matches `apps/api/src/config/constants.ts` lazy-fn + `FEATURE_*` pattern; fail-fast validation. |
-| Core vs distributable | New `distribution` manifest field in `everworks.plugin` | Declared on the plugin, not hard-coded (FR-3). Default derived from `systemPlugin`. |
-| Publish | **Changesets** → npm + GitHub Packages | Independent per-plugin versioning (FR-7); no platform release coupling; mirrors `publish-cli.yml` auth pattern. |
-| Runtime fetch | `npm`/`pnpm` programmatic install (pinned exact version, `--no-save`) into the store, then `import()` | Reuses Node module resolution + integrity; loader already scans `node_modules/@ever-works` and `./plugins`. |
-| Integrity | npm package integrity (sha512) + first-party npm provenance | No bespoke signing in v1; verify-before-load (FR-10). |
-| Persistence | TypeORM columns on `PluginEntity` + new `PluginAllowlistEntity` | Existing pattern in `packages/agent/src/plugins`. |
-| Long-running execution | Pluggable job runtime (Trigger.dev today) | Principle IV; isolation comes "for free" inside the task process. Depends on EW-683. |
-| Store location | `PLUGIN_INSTALL_DIR` (default `/app/plugins`); k8s writable volume | API root FS is writable today (`readOnlyRootFilesystem: false`); per-replica reconcile avoids requiring RWX. |
+| Concern                | Choice                                                                                                | Rationale                                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Distribution flag      | `config` constant + env (`PLUGIN_DISTRIBUTION_MODE`)                                                  | Matches `apps/api/src/config/constants.ts` lazy-fn + `FEATURE_*` pattern; fail-fast validation.                 |
+| Core vs distributable  | New `distribution` manifest field in `everworks.plugin`                                               | Declared on the plugin, not hard-coded (FR-3). Default derived from `systemPlugin`.                             |
+| Publish                | **Changesets** → npm + GitHub Packages                                                                | Independent per-plugin versioning (FR-7); no platform release coupling; mirrors `publish-cli.yml` auth pattern. |
+| Runtime fetch          | `npm`/`pnpm` programmatic install (pinned exact version, `--no-save`) into the store, then `import()` | Reuses Node module resolution + integrity; loader already scans `node_modules/@ever-works` and `./plugins`.     |
+| Integrity              | npm package integrity (sha512) + first-party npm provenance                                           | No bespoke signing in v1; verify-before-load (FR-10).                                                           |
+| Persistence            | TypeORM columns on `PluginEntity` + new `PluginAllowlistEntity`                                       | Existing pattern in `packages/agent/src/plugins`.                                                               |
+| Long-running execution | Pluggable job runtime (Trigger.dev today)                                                             | Principle IV; isolation comes "for free" inside the task process. Depends on EW-683.                            |
+| Store location         | `PLUGIN_INSTALL_DIR` (default `/app/plugins`); k8s writable volume                                    | API root FS is writable today (`readOnlyRootFilesystem: false`); per-replica reconcile avoids requiring RWX.    |
 
 ## 3. Data Model
 
@@ -111,13 +111,13 @@ source of truth.
 ```ts
 @Entity('plugin_allowlist')
 export class PluginAllowlistEntity {
-    @PrimaryGeneratedColumn('uuid') id: string;
-    @Column({ type: 'varchar', unique: true }) packageName: string; // npm name
-    @Column({ type: 'varchar' }) versionRange: string;             // pinned/semver
-    @Column({ type: 'varchar', nullable: true }) integrity?: string;
-    @Column({ type: 'varchar', default: 'npm' }) source: 'npm' | 'github-packages';
-    @Column({ type: 'boolean', default: true }) enabled: boolean;
-    @CreateDateColumn() createdAt: Date;
+	@PrimaryGeneratedColumn('uuid') id: string;
+	@Column({ type: 'varchar', unique: true }) packageName: string; // npm name
+	@Column({ type: 'varchar' }) versionRange: string; // pinned/semver
+	@Column({ type: 'varchar', nullable: true }) integrity?: string;
+	@Column({ type: 'varchar', default: 'npm' }) source: 'npm' | 'github-packages';
+	@Column({ type: 'boolean', default: true }) enabled: boolean;
+	@CreateDateColumn() createdAt: Date;
 }
 ```
 
@@ -141,14 +141,14 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 
 ## 4. API Surface
 
-| Method | Endpoint | Description | Status |
-| ------ | -------- | ----------- | ------ |
-| `GET` | `/plugins/catalog` | List distributable plugins available from the registry (manifest summaries), with install state. | New |
-| `POST` | `/plugins/:pluginId/install` | Install (resolve+verify+load) a distributable plugin without enabling. | New |
-| `POST` | `/plugins/:pluginId/enable` | Existing; in dynamic mode installs first if absent, then enables. | Changed |
-| `DELETE` | `/plugins/:pluginId/install` | Uninstall a distributable plugin (refused for core). | New |
-| `GET` | `/plugins/:pluginId/install-status` | Poll install progress/state. | New |
-| `GET`/`POST`/`DELETE` | `/admin/plugins/allowlist` | Manage the third-party allowlist (admin-gated). | New |
+| Method                | Endpoint                            | Description                                                                                      | Status  |
+| --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------ | ------- |
+| `GET`                 | `/plugins/catalog`                  | List distributable plugins available from the registry (manifest summaries), with install state. | New     |
+| `POST`                | `/plugins/:pluginId/install`        | Install (resolve+verify+load) a distributable plugin without enabling.                           | New     |
+| `POST`                | `/plugins/:pluginId/enable`         | Existing; in dynamic mode installs first if absent, then enables.                                | Changed |
+| `DELETE`              | `/plugins/:pluginId/install`        | Uninstall a distributable plugin (refused for core).                                             | New     |
+| `GET`                 | `/plugins/:pluginId/install-status` | Poll install progress/state.                                                                     | New     |
+| `GET`/`POST`/`DELETE` | `/admin/plugins/allowlist`          | Manage the third-party allowlist (admin-gated).                                                  | New     |
 
 - Auth: user-scoped endpoints use existing `@CurrentUser()`; allowlist endpoints
   are admin-gated. Install is rate-limited (registry protection).
@@ -191,12 +191,12 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 
 ## 7. Background Jobs
 
-| Trigger | When | What it does | Idempotency strategy |
-| ------- | ---- | ------------ | -------------------- |
-| **Lazy install-on-use** (`ensurePluginAvailable`) | Before *any* node invokes a distributable plugin (API replica or worker) | Install the pinned package into the local store if missing, then load+register. **The correctness guarantee** — a plugin enabled on one replica works on all replicas/worker with no restart or shared volume. | Per-id concurrency lock + version/integrity pin; skip if present. |
-| Boot reconcile (on `onApplicationBootstrap`) | Every API/worker start in dynamic mode | Warm the store by pre-installing the DB-recorded installed/enabled set. Optimisation only (avoids first-request latency), not correctness. | Same `ensurePluginAvailable`; idempotent. |
-| Long-running capability dispatch | Per pipeline/long op | In the job-runtime worker, call `ensurePluginAvailable` then run the plugin inside the isolated task. The worker has its own store, so it installs on first use just like the API. | Existing job idempotency / CAS in the task layer. |
-| GC | — | Out of scope for v1 (decided: keep installed files on disable, no GC). | n/a |
+| Trigger                                           | When                                                                     | What it does                                                                                                                                                                                                   | Idempotency strategy                                              |
+| ------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Lazy install-on-use** (`ensurePluginAvailable`) | Before _any_ node invokes a distributable plugin (API replica or worker) | Install the pinned package into the local store if missing, then load+register. **The correctness guarantee** — a plugin enabled on one replica works on all replicas/worker with no restart or shared volume. | Per-id concurrency lock + version/integrity pin; skip if present. |
+| Boot reconcile (on `onApplicationBootstrap`)      | Every API/worker start in dynamic mode                                   | Warm the store by pre-installing the DB-recorded installed/enabled set. Optimisation only (avoids first-request latency), not correctness.                                                                     | Same `ensurePluginAvailable`; idempotent.                         |
+| Long-running capability dispatch                  | Per pipeline/long op                                                     | In the job-runtime worker, call `ensurePluginAvailable` then run the plugin inside the isolated task. The worker has its own store, so it installs on first use just like the API.                             | Existing job idempotency / CAS in the task layer.                 |
+| GC                                                | —                                                                        | Out of scope for v1 (decided: keep installed files on disable, no GC).                                                                                                                                         | n/a                                                               |
 
 ## 8. Security & Permissions
 
@@ -246,16 +246,16 @@ First-party `@ever-works/*` is implicitly allowed (no row required).
 
 ## 11. Risks & Mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-| ---- | ---------- | ------ | ---------- |
-| Registry outage blocks enabling new plugins | Med | Med | Installed plugins unaffected; clean retryable failures; optional warm cache/mirror. |
-| Cold-start install cost on new replicas | Med | Med | Boot warmup pre-installs in parallel; lazy install-on-use covers anything not warmed; consider baking "popular" plugins. |
-| Plugin enabled on replica A not present on replica B / worker | High | High | **Lazy install-on-use** (`ensurePluginAvailable`) on every node before invocation — not boot-only reconcile. Worker installs into its own store too. (Codex P1 ×2.) |
-| Running untrusted-ish 3rd-party code in API process | Low (allowlist) | High | Allowlist + integrity; long-running paths in isolated job runtime; sandbox is a documented future phase. |
-| Read-only FS targets (Vercel) can't install at runtime | Med | Low | Dynamic mode requires writable store; Vercel/serverless documented as bundled-only. |
-| API hard-deps on storage plugins block making them distributable | High | Low | **Decided**: remove the direct imports, resolve storage via the facade, keep `local-fs` as core default (so the API boots storage-less of any distributable plugin). |
-| Default storage (`local-fs`) not shared across replicas | Med | Low | Pre-existing concern, not new; production enables a distributable shared backend (s3/minio/github-storage). `local-fs` only guarantees the API boots. |
-| Version drift between manifest and installed dist | Med | Low | Persist `installedVersion`+`integrity`; reconcile pins exact version. |
+| Risk                                                             | Likelihood      | Impact | Mitigation                                                                                                                                                           |
+| ---------------------------------------------------------------- | --------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Registry outage blocks enabling new plugins                      | Med             | Med    | Installed plugins unaffected; clean retryable failures; optional warm cache/mirror.                                                                                  |
+| Cold-start install cost on new replicas                          | Med             | Med    | Boot warmup pre-installs in parallel; lazy install-on-use covers anything not warmed; consider baking "popular" plugins.                                             |
+| Plugin enabled on replica A not present on replica B / worker    | High            | High   | **Lazy install-on-use** (`ensurePluginAvailable`) on every node before invocation — not boot-only reconcile. Worker installs into its own store too. (Codex P1 ×2.)  |
+| Running untrusted-ish 3rd-party code in API process              | Low (allowlist) | High   | Allowlist + integrity; long-running paths in isolated job runtime; sandbox is a documented future phase.                                                             |
+| Read-only FS targets (Vercel) can't install at runtime           | Med             | Low    | Dynamic mode requires writable store; Vercel/serverless documented as bundled-only.                                                                                  |
+| API hard-deps on storage plugins block making them distributable | High            | Low    | **Decided**: remove the direct imports, resolve storage via the facade, keep `local-fs` as core default (so the API boots storage-less of any distributable plugin). |
+| Default storage (`local-fs`) not shared across replicas          | Med             | Low    | Pre-existing concern, not new; production enables a distributable shared backend (s3/minio/github-storage). `local-fs` only guarantees the API boots.                |
+| Version drift between manifest and installed dist                | Med             | Low    | Persist `installedVersion`+`integrity`; reconcile pins exact version.                                                                                                |
 
 ## 12. Constitution Reconciliation
 

--- a/docs/specs/features/dynamic-plugin-distribution/spec.md
+++ b/docs/specs/features/dynamic-plugin-distribution/spec.md
@@ -63,7 +63,7 @@ isn't present yet.
   inside the isolated task process, returning the result through the existing
   job result channel.
 - **Given** a plugin was enabled on one API replica, **when** a later request
-  for it is routed to a *different* replica (or the worker) that has not yet
+  for it is routed to a _different_ replica (or the worker) that has not yet
   installed it, **then** that node lazily installs it on first use and serves the
   request — no restart or shared volume required.
 - **Given** a fresh pod / new replica in dynamic mode, **when** it boots,
@@ -210,18 +210,18 @@ Compatibility:
 
 ## 5. Key Entities & Domain Concepts
 
-| Entity / concept | Description |
-| ---------------- | ----------- |
-| Distribution mode | Platform setting selecting `bundled` (all in image) vs `dynamic` (core in image, rest from registry). |
-| Core plugin | A plugin always shipped in the image and present in both modes (every `systemPlugin`, incl. `local-fs` as the boot default storage). Distributable storage (`aws-s3`/`minio`/`github-storage`) is NOT core. |
-| Runtime plugin store | A writable directory on a node (default `/app/plugins`) where pulled plugins are written so Node can `import()` them — per-replica, reconciled on boot; not external infrastructure. |
-| Distributable plugin | A plugin published to a registry and installable at runtime in dynamic mode. |
-| Plugin registry | The npm source(s) plugins are published to and pulled from — public npm + GitHub Packages, configurable. |
-| Plugin catalog | The listable set of distributable plugins (manifest summaries) shown in the UI before install. |
-| Install state | Lifecycle of a plugin's presence on a node: available → installing → installed / error (distinct from enabled). |
-| Plugin allowlist | Admin-managed set of non-first-party packages permitted for runtime install, with version/integrity pinning. |
-| Boot reconcile | Start-up routine that makes a node's plugin store match the DB record of installed/enabled plugins. |
-| Execution location | Where a capability call runs: in-process (short) vs job runtime (long-running). |
+| Entity / concept     | Description                                                                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Distribution mode    | Platform setting selecting `bundled` (all in image) vs `dynamic` (core in image, rest from registry).                                                                                                       |
+| Core plugin          | A plugin always shipped in the image and present in both modes (every `systemPlugin`, incl. `local-fs` as the boot default storage). Distributable storage (`aws-s3`/`minio`/`github-storage`) is NOT core. |
+| Runtime plugin store | A writable directory on a node (default `/app/plugins`) where pulled plugins are written so Node can `import()` them — per-replica, reconciled on boot; not external infrastructure.                        |
+| Distributable plugin | A plugin published to a registry and installable at runtime in dynamic mode.                                                                                                                                |
+| Plugin registry      | The npm source(s) plugins are published to and pulled from — public npm + GitHub Packages, configurable.                                                                                                    |
+| Plugin catalog       | The listable set of distributable plugins (manifest summaries) shown in the UI before install.                                                                                                              |
+| Install state        | Lifecycle of a plugin's presence on a node: available → installing → installed / error (distinct from enabled).                                                                                             |
+| Plugin allowlist     | Admin-managed set of non-first-party packages permitted for runtime install, with version/integrity pinning.                                                                                                |
+| Boot reconcile       | Start-up routine that makes a node's plugin store match the DB record of installed/enabled plugins.                                                                                                         |
+| Execution location   | Where a capability call runs: in-process (short) vs job runtime (long-running).                                                                                                                             |
 
 ## 6. Out of Scope
 
@@ -265,18 +265,18 @@ Compatibility:
 All initial open questions were resolved with @evereq on 2026-05-28:
 
 - **Default mode** — `bundled` everywhere (hosted SaaS and self-host alike);
-  `dynamic` is strictly opt-in. *(Resolved: bundled default.)*
+  `dynamic` is strictly opt-in. _(Resolved: bundled default.)_
 - **Multi-replica plugin store** — per-replica ephemeral store + boot reconcile;
   **no shared RWX volume required**. A shared PVC is an optional optimization,
-  not a prerequisite. *(Resolved: per-replica reconcile.)*
+  not a prerequisite. _(Resolved: per-replica reconcile.)_
 - **Disable retention** — keep installed files on disable; **no garbage
-  collection** in v1. *(Resolved: keep installed.)*
+  collection** in v1. _(Resolved: keep installed.)_
 - **API storage plugins** — **remove** the API's hard imports of `aws-s3`,
   `minio`, `github-storage` and make them **distributable**; resolve storage via
-  the capability facade; keep `local-fs` as the core default. *(Resolved:
-  decouple + distributable.)*
+  the capability facade; keep `local-fs` as the core default. _(Resolved:
+  decouple + distributable.)_
 - **Allowlist administration** — **both** env/config and an admin API.
-  *(Resolved: both surfaces.)*
+  _(Resolved: both surfaces.)_
 
 ## 9. Constitution Gates
 

--- a/docs/specs/features/dynamic-plugin-distribution/spec.md
+++ b/docs/specs/features/dynamic-plugin-distribution/spec.md
@@ -92,6 +92,9 @@ isn't present yet.
 - **Given** a core plugin, **when** any user attempts to "uninstall" it in
   dynamic mode, **then** the action is refused — core plugins are always present
   and (for `systemPlugin`) cannot be disabled.
+- **Given** dynamic mode and no distributable storage plugin enabled, **when**
+  the platform boots, **then** the core default storage (`local-fs`) is available
+  so storage-dependent features still function.
 
 ## 3. Functional Requirements
 
@@ -105,9 +108,13 @@ Distribution mode & core set:
   bundled in the image, present in both modes) or **distributable** (published
   to a registry, runtime-installable in dynamic mode). The classification MUST
   be declared on the plugin (manifest), not hard-coded in the platform.
-- **FR-4** Core MUST include every plugin marked `systemPlugin: true` and every
-  plugin that the API directly depends on to boot. The system MUST NOT allow a
-  distributable plugin to be one the API cannot start without.
+- **FR-4** Core MUST include every plugin marked `systemPlugin: true`, and the
+  API MUST NOT statically depend on any **distributable** plugin to boot.
+  Storage plugins `aws-s3`, `minio`, and `github-storage` are **distributable**;
+  the API's current hard imports of them MUST be removed and storage resolved via
+  the capability facade/registry. `local-fs` (a `systemPlugin`) remains core and
+  is the default storage backend so the platform boots with working storage even
+  when no distributable storage plugin is enabled.
 - **FR-5** The system MUST NOT require core plugins to be fetched from a
   registry in either mode.
 
@@ -196,13 +203,13 @@ Compatibility:
 | Entity / concept | Description |
 | ---------------- | ----------- |
 | Distribution mode | Platform setting selecting `bundled` (all in image) vs `dynamic` (core in image, rest from registry). |
-| Core plugin | A plugin always shipped in the image and present in both modes (system plugins + boot-critical plugins). |
+| Core plugin | A plugin always shipped in the image and present in both modes (every `systemPlugin`, incl. `local-fs` as the boot default storage). Distributable storage (`aws-s3`/`minio`/`github-storage`) is NOT core. |
+| Runtime plugin store | A writable directory on a node (default `/app/plugins`) where pulled plugins are written so Node can `import()` them — per-replica, reconciled on boot; not external infrastructure. |
 | Distributable plugin | A plugin published to a registry and installable at runtime in dynamic mode. |
 | Plugin registry | The npm source(s) plugins are published to and pulled from — public npm + GitHub Packages, configurable. |
 | Plugin catalog | The listable set of distributable plugins (manifest summaries) shown in the UI before install. |
 | Install state | Lifecycle of a plugin's presence on a node: available → installing → installed / error (distinct from enabled). |
 | Plugin allowlist | Admin-managed set of non-first-party packages permitted for runtime install, with version/integrity pinning. |
-| Runtime plugin store | Writable location on a node where dynamically-installed plugins live and are imported from. |
 | Boot reconcile | Start-up routine that makes a node's plugin store match the DB record of installed/enabled plugins. |
 | Execution location | Where a capability call runs: in-process (short) vs job runtime (long-running). |
 
@@ -243,11 +250,21 @@ Compatibility:
 
 ## 8. Open Questions
 
-- `[NEEDS CLARIFICATION: default for the hosted SaaS (apps.ever.works) — ship dynamic mode there while self-host defaults to bundled, or both default bundled until dynamic soaks?]`
-- `[NEEDS CLARIFICATION: multi-replica plugin store — shared RWX volume vs per-replica ephemeral store with boot reconcile (plan recommends per-replica reconcile; confirm acceptable cold-start cost)?]`
-- `[NEEDS CLARIFICATION: retention policy on disable — keep installed files (recommended) vs garbage-collect after N days unused?]`
-- `[NEEDS CLARIFICATION: do the API-imported storage plugins (aws-s3, minio, github-storage) become core-bundled, or is the API's direct dependency removed so they can be distributable?]`
-- `[NEEDS CLARIFICATION: allowlist administration surface — env/config only, admin API, or both for v1?]`
+All initial open questions were resolved with @evereq on 2026-05-28:
+
+- **Default mode** — `bundled` everywhere (hosted SaaS and self-host alike);
+  `dynamic` is strictly opt-in. *(Resolved: bundled default.)*
+- **Multi-replica plugin store** — per-replica ephemeral store + boot reconcile;
+  **no shared RWX volume required**. A shared PVC is an optional optimization,
+  not a prerequisite. *(Resolved: per-replica reconcile.)*
+- **Disable retention** — keep installed files on disable; **no garbage
+  collection** in v1. *(Resolved: keep installed.)*
+- **API storage plugins** — **remove** the API's hard imports of `aws-s3`,
+  `minio`, `github-storage` and make them **distributable**; resolve storage via
+  the capability facade; keep `local-fs` as the core default. *(Resolved:
+  decouple + distributable.)*
+- **Allowlist administration** — **both** env/config and an admin API.
+  *(Resolved: both surfaces.)*
 
 ## 9. Constitution Gates
 

--- a/docs/specs/features/dynamic-plugin-distribution/spec.md
+++ b/docs/specs/features/dynamic-plugin-distribution/spec.md
@@ -1,0 +1,281 @@
+# Feature Specification: Dynamic Plugin Distribution (dual-mode)
+
+> Behaviour-first spec per [Constitution Principle IX](../../../../.specify/memory/constitution.md#ix-specs-are-behaviour-first).
+> Describe **what** the system does, not how it's structured. Implementation
+> lives in [`plan.md`](./plan.md); execution in [`tasks.md`](./tasks.md).
+
+**Feature ID**: `dynamic-plugin-distribution`
+**Branch**: `feat/dynamic-plugin-distribution`
+**Status**: `Draft`
+**Created**: 2026-05-28
+**Last updated**: 2026-05-28
+**Owner**: @evereq
+
+---
+
+## 1. Overview
+
+Today every plugin in `packages/plugins/*` is built and shipped inside the
+platform image. A clone installs all ~49 plugins' third-party SDKs at
+`pnpm install`, and the deployed artifact carries every plugin whether or not
+an operator ever enables it. This feature makes plugin distribution **dual-mode**
+so an operator can choose between:
+
+- **Bundled mode** (today's behaviour, default): all plugins built into the
+  image and discovered from disk at boot. No registry, no network at enable-time.
+- **Dynamic mode**: only **core** plugins are bundled; every other plugin is
+  published to an npm registry and **pulled, validated, and loaded at runtime**
+  the first time a user enables it. The platform image and a fresh install stay
+  lean, and operators add only the plugins they actually use.
+
+The two modes coexist permanently and are selected by a single platform
+setting. Bundled mode remains the default so existing deployments are unaffected.
+The capability/enable/settings model the user already sees does not change —
+"Enable" simply gains an install-and-load step when a dynamic-mode plugin
+isn't present yet.
+
+## 2. User Scenarios
+
+### 2.1 Primary scenarios
+
+- **Given** an operator running in bundled mode (the default), **when** they
+  deploy the platform, **then** all plugins are available exactly as today and
+  no registry network calls occur at enable-time.
+- **Given** an operator running in dynamic mode, **when** a user opens the
+  plugins page, **then** core plugins show as installed and every other
+  published plugin shows as **available** (listed from the registry catalog)
+  with an Install/Enable action.
+- **Given** a user in dynamic mode, **when** they click **Enable** on an
+  available non-core plugin (e.g. `notion-extractor`), **then** the platform
+  resolves the package from the configured registry, verifies it, installs it
+  into the runtime plugin store, loads it, registers its capabilities, and the
+  plugin transitions to enabled — without an operator redeploy.
+- **Given** a plugin's source changes and a new version is released, **when**
+  CI publishes it, **then** the new version is available in **both** the public
+  npm registry and the GitHub Packages org registry, and dynamic-mode
+  deployments can pick it up on next install/upgrade.
+- **Given** a short, synchronous capability call (e.g. resolving an AI
+  provider's model list), **when** it runs, **then** the dynamically-installed
+  plugin executes in-process via dynamic import with no extra hop.
+- **Given** a long-running capability call (e.g. a full generation pipeline
+  step), **when** it runs, **then** the plugin executes inside the pluggable
+  job runtime (Trigger.dev today) where third-party code is already isolated,
+  and the result is returned through the existing job result channel.
+- **Given** a fresh pod / new replica in dynamic mode, **when** it boots,
+  **then** it reconciles its local plugin store against the set of
+  installed/enabled plugins recorded in the database, re-installing any that
+  are missing, before serving traffic.
+
+### 2.2 Edge cases & failures
+
+- **Given** the registry is unreachable, **when** a user clicks Enable in
+  dynamic mode, **then** the install fails with a clear, user-visible error,
+  the plugin stays in an `error`/not-installed state, and no partial/half-loaded
+  plugin is registered. Already-installed plugins keep working.
+- **Given** a requested package is **not** first-party and **not** on the
+  allowlist, **when** install is attempted, **then** it is rejected before any
+  download with an "package not permitted" error.
+- **Given** a package's downloaded integrity hash does not match the pinned
+  expectation, **when** install runs, **then** it is rejected and nothing is
+  loaded.
+- **Given** a plugin fails to load (invalid manifest, version incompatibility,
+  throwing constructor), **when** install runs, **then** the failure is recorded
+  against that plugin with a reason, the user sees it, and the rest of the
+  system is unaffected.
+- **Given** a user disables a dynamically-installed plugin, **when** they do so,
+  **then** it stops being used immediately (per existing enable/disable rules);
+  whether its files are removed from the store is governed by a retention policy
+  (default: keep installed, just disabled).
+- **Given** an operator switches a running deployment from bundled to dynamic
+  mode (or back), **when** the platform restarts, **then** it reconciles to the
+  new mode without losing any user's enabled-plugin choices.
+- **Given** a core plugin, **when** any user attempts to "uninstall" it in
+  dynamic mode, **then** the action is refused — core plugins are always present
+  and (for `systemPlugin`) cannot be disabled.
+
+## 3. Functional Requirements
+
+Distribution mode & core set:
+
+- **FR-1** The system MUST support a platform-level distribution mode with at
+  least the values `bundled` and `dynamic`, defaulting to `bundled`.
+- **FR-2** In `bundled` mode the system MUST behave exactly as today: all
+  plugins discovered from disk at boot, no registry access required.
+- **FR-3** The system MUST classify every plugin as either **core** (always
+  bundled in the image, present in both modes) or **distributable** (published
+  to a registry, runtime-installable in dynamic mode). The classification MUST
+  be declared on the plugin (manifest), not hard-coded in the platform.
+- **FR-4** Core MUST include every plugin marked `systemPlugin: true` and every
+  plugin that the API directly depends on to boot. The system MUST NOT allow a
+  distributable plugin to be one the API cannot start without.
+- **FR-5** The system MUST NOT require core plugins to be fetched from a
+  registry in either mode.
+
+Publishing:
+
+- **FR-6** The system MUST publish each distributable plugin to **both** the
+  public npm registry and the GitHub Packages org registry on release.
+- **FR-7** Publishing MUST be automated in CI and triggered by plugin source
+  changes / releases, and MUST version plugins independently (a plugin release
+  MUST NOT require a platform release).
+- **FR-8** The platform MUST read the registry endpoint(s) and any auth from
+  configuration so self-hosters can point at their own mirror or private
+  registry.
+
+Runtime install / enable:
+
+- **FR-9** In dynamic mode, when a user enables a distributable plugin that is
+  not yet installed, the system MUST resolve, verify, install, load, register,
+  and then enable it as a single user-observable action.
+- **FR-10** The system MUST verify a downloaded plugin's integrity (pinned
+  version + integrity hash) before loading it.
+- **FR-11** The system MUST only install packages that are first-party
+  (`@ever-works/*`) or present on an admin-managed allowlist; any other package
+  MUST be refused before download.
+- **FR-12** The system MUST persist, per plugin, its distribution source
+  (`bundled` | `registry`), the installed package spec, the installed version,
+  and the integrity value used.
+- **FR-13** On boot in dynamic mode, the system MUST reconcile the local plugin
+  store against the database record of installed/enabled distributable plugins,
+  re-installing any missing ones before marking itself ready.
+- **FR-14** A failed install MUST leave the plugin in a clearly-failed state
+  with a recorded reason and MUST NOT register a partially-loaded plugin.
+
+Execution model:
+
+- **FR-15** The system MUST be able to execute a dynamically-installed plugin's
+  capability call in-process via dynamic import (for short/synchronous calls).
+- **FR-16** The system MUST be able to execute a dynamically-installed plugin's
+  capability call inside the pluggable job runtime (long-running calls), reusing
+  the existing job-dispatch and result channel.
+- **FR-17** The choice of execution location MUST be driven by the
+  operation/capability (declared classification), not hard-coded per plugin id.
+
+Catalog & UI:
+
+- **FR-18** The plugins UI MUST show, per plugin, an install state distinct
+  from enable state: at minimum **available** (not installed), **installing**,
+  **installed**, and **error**.
+- **FR-19** In dynamic mode the plugins UI MUST list distributable plugins that
+  are available from the registry catalog even when not yet installed (the
+  manifest summary is listable without instantiating the plugin).
+- **FR-20** The system MUST surface install progress and install failures to
+  the user who triggered them.
+
+Compatibility:
+
+- **FR-21** Enabling/disabling and per-user / per-work scoping rules MUST remain
+  unchanged from today; dynamic mode only adds an install/load step in front of
+  enable when the plugin is absent.
+- **FR-22** The system MUST NOT change behaviour for existing bundled-mode
+  deployments that take no action (default stays `bundled`).
+
+## 4. Non-Functional Requirements
+
+- **Performance**: In-process enable-and-install of a single first-party plugin
+  SHOULD complete within a few seconds on a warm registry connection; the call
+  MUST be async/non-blocking from the user's perspective with progress feedback.
+  Short capability calls MUST NOT incur a job-runtime round-trip.
+- **Reliability**: A registry outage MUST degrade gracefully — already-installed
+  plugins keep working; new installs fail cleanly and are retryable. Boot-time
+  reconcile MUST be idempotent and safe to run on every replica.
+- **Security & privacy**: Only allowlisted/first-party packages are installable
+  (no arbitrary npm execution in v1). Integrity is verified before load. Plugin
+  credentials continue to follow `x-secret` rules. Registry auth tokens are
+  treated as secrets. Long-running third-party code runs in the isolated job
+  runtime.
+- **Observability**: Plugin install attempts, successes, failures, version, and
+  source MUST emit activity-log/events and metrics; install failures MUST be
+  visible in monitoring.
+- **Compatibility**: Requires `@ever-works/plugin` SDK additions to be additive
+  and semver-compatible. Plugin manifests gaining new fields MUST remain valid
+  under the existing validator (forward-compatible).
+
+## 5. Key Entities & Domain Concepts
+
+| Entity / concept | Description |
+| ---------------- | ----------- |
+| Distribution mode | Platform setting selecting `bundled` (all in image) vs `dynamic` (core in image, rest from registry). |
+| Core plugin | A plugin always shipped in the image and present in both modes (system plugins + boot-critical plugins). |
+| Distributable plugin | A plugin published to a registry and installable at runtime in dynamic mode. |
+| Plugin registry | The npm source(s) plugins are published to and pulled from — public npm + GitHub Packages, configurable. |
+| Plugin catalog | The listable set of distributable plugins (manifest summaries) shown in the UI before install. |
+| Install state | Lifecycle of a plugin's presence on a node: available → installing → installed / error (distinct from enabled). |
+| Plugin allowlist | Admin-managed set of non-first-party packages permitted for runtime install, with version/integrity pinning. |
+| Runtime plugin store | Writable location on a node where dynamically-installed plugins live and are imported from. |
+| Boot reconcile | Start-up routine that makes a node's plugin store match the DB record of installed/enabled plugins. |
+| Execution location | Where a capability call runs: in-process (short) vs job runtime (long-running). |
+
+## 6. Out of Scope
+
+- A public third-party plugin **marketplace** with self-serve submission,
+  ratings, or billing (this v1 is first-party + admin allowlist only).
+- Strong per-plugin sandboxing beyond what the job runtime already provides
+  (no isolated-vm / microVM execution in v1).
+- Plugin code signing beyond npm integrity + first-party provenance.
+- Hot **unload** / live in-process re-instantiation of a plugin without a
+  process restart (today the platform never re-instantiates in-process; dynamic
+  install adds first-load, not hot-swap).
+- Making the job-runtime provider itself pluggable — that is tracked separately
+  in [EW-683] and is a dependency, not part of this feature.
+- Per-tenant private registries (single configurable registry set in v1).
+
+## 7. Acceptance Criteria
+
+- [ ] With no configuration change, an existing deployment runs in `bundled`
+      mode and behaves identically to today (no registry calls at enable-time).
+- [ ] Setting distribution mode to `dynamic` ships an image containing only core
+      plugins; non-core plugins are absent from the image.
+- [ ] In dynamic mode, enabling a first-party distributable plugin installs and
+      loads it at runtime and it becomes usable without a redeploy.
+- [ ] Each distributable plugin is published to both public npm and GitHub
+      Packages by CI on release, with independent versions.
+- [ ] A non-allowlisted third-party package is refused before download.
+- [ ] A corrupted/integrity-mismatched download is refused and nothing loads.
+- [ ] A registry outage fails new installs cleanly while installed plugins keep
+      working; retry succeeds when the registry returns.
+- [ ] A new replica reconciles its plugin store from the DB on boot and serves
+      the same enabled plugins as its peers.
+- [ ] Short capability calls run in-process; long-running ones run in the job
+      runtime — verified by an integration test of each path.
+- [ ] Core/`systemPlugin` plugins cannot be uninstalled or disabled.
+- [ ] All functional requirements have a passing test (unit or e2e).
+
+## 8. Open Questions
+
+- `[NEEDS CLARIFICATION: default for the hosted SaaS (apps.ever.works) — ship dynamic mode there while self-host defaults to bundled, or both default bundled until dynamic soaks?]`
+- `[NEEDS CLARIFICATION: multi-replica plugin store — shared RWX volume vs per-replica ephemeral store with boot reconcile (plan recommends per-replica reconcile; confirm acceptable cold-start cost)?]`
+- `[NEEDS CLARIFICATION: retention policy on disable — keep installed files (recommended) vs garbage-collect after N days unused?]`
+- `[NEEDS CLARIFICATION: do the API-imported storage plugins (aws-s3, minio, github-storage) become core-bundled, or is the API's direct dependency removed so they can be distributable?]`
+- `[NEEDS CLARIFICATION: allowlist administration surface — env/config only, admin API, or both for v1?]`
+
+## 9. Constitution Gates
+
+- [x] Plugin-first if introducing an external integration (Principle I) — the
+      registry/installer is platform infrastructure; plugins stay the integration unit.
+- [x] Capability-driven resolution if touching cross-plugin behaviour
+      (Principle II) — resolution/enable semantics unchanged; install precedes them.
+- [x] Source-of-truth repos preserved (Principle III) — unaffected.
+- [x] Long-running work via Trigger.dev (Principle IV) — long-running plugin
+      execution is explicitly routed through the job runtime.
+- [x] Schema changes ship as forward-only migrations (Principle V) — new plugin
+      columns + allowlist table are additive.
+- [x] Tests accompany the change (Principle VI).
+- [x] Secrets handled per `x-secret` rules (Principle VII) — plugin creds and
+      registry tokens are secrets.
+- [x] Plugin counts touch the canonical doc only (Principle VIII) — counts and
+      core/distributable split documented in the canonical built-in-plugins doc.
+- [x] Behaviour-first — no implementation in this spec (Principle IX).
+- [x] Backwards-compatible API/SDK/schema changes (Principle X) — default
+      `bundled` keeps current behaviour; SDK/manifest additions are additive.
+
+## 10. References
+
+- Related features: [`plugin-system`](../plugin-system/spec.md)
+- Related ADRs: [`015-dynamic-plugin-distribution`](../../decisions/015-dynamic-plugin-distribution.md)
+- Related architecture: [`runtime-plugins`](../../architecture/runtime-plugins.md),
+  [`plugin-sdk`](../../architecture/plugin-sdk.md),
+  [`deployment`](../../architecture/deployment.md),
+  [`trigger-integration`](../../architecture/trigger-integration.md)
+- Related Jira: EW epic (this feature), [EW-683] (job-runtime pluggability — dependency),
+  [EW-682] (official-SDK audit — related)

--- a/docs/specs/features/dynamic-plugin-distribution/spec.md
+++ b/docs/specs/features/dynamic-plugin-distribution/spec.md
@@ -289,7 +289,7 @@ All initial open questions were resolved with @evereq on 2026-05-28:
 ## 10. References
 
 - Related features: [`plugin-system`](../plugin-system/spec.md)
-- Related ADRs: [`015-dynamic-plugin-distribution`](../../decisions/015-dynamic-plugin-distribution.md)
+- Related ADRs: [`016-dynamic-plugin-distribution`](../../decisions/016-dynamic-plugin-distribution.md)
 - Related architecture: [`runtime-plugins`](../../architecture/runtime-plugins.md),
   [`plugin-sdk`](../../architecture/plugin-sdk.md),
   [`deployment`](../../architecture/deployment.md),

--- a/docs/specs/features/dynamic-plugin-distribution/spec.md
+++ b/docs/specs/features/dynamic-plugin-distribution/spec.md
@@ -58,13 +58,17 @@ isn't present yet.
   provider's model list), **when** it runs, **then** the dynamically-installed
   plugin executes in-process via dynamic import with no extra hop.
 - **Given** a long-running capability call (e.g. a full generation pipeline
-  step), **when** it runs, **then** the plugin executes inside the pluggable
-  job runtime (Trigger.dev today) where third-party code is already isolated,
-  and the result is returned through the existing job result channel.
+  step), **when** it runs, **then** the job-runtime worker first ensures the
+  plugin is installed in its own store (lazy install-on-use), then executes it
+  inside the isolated task process, returning the result through the existing
+  job result channel.
+- **Given** a plugin was enabled on one API replica, **when** a later request
+  for it is routed to a *different* replica (or the worker) that has not yet
+  installed it, **then** that node lazily installs it on first use and serves the
+  request — no restart or shared volume required.
 - **Given** a fresh pod / new replica in dynamic mode, **when** it boots,
-  **then** it reconciles its local plugin store against the set of
-  installed/enabled plugins recorded in the database, re-installing any that
-  are missing, before serving traffic.
+  **then** it warms its local store by pre-installing the DB-recorded
+  installed/enabled set, and in any case lazily installs any plugin on first use.
 
 ### 2.2 Edge cases & failures
 
@@ -142,9 +146,15 @@ Runtime install / enable:
 - **FR-12** The system MUST persist, per plugin, its distribution source
   (`bundled` | `registry`), the installed package spec, the installed version,
   and the integrity value used.
-- **FR-13** On boot in dynamic mode, the system MUST reconcile the local plugin
-  store against the database record of installed/enabled distributable plugins,
-  re-installing any missing ones before marking itself ready.
+- **FR-13** Every node — each API replica **and** each job-runtime worker — MUST
+  ensure a distributable plugin is installed in its own local store before
+  invoking it (**lazy install-on-use**), so a plugin enabled on one replica is
+  usable on all replicas and in the worker **without** requiring a restart or a
+  shared volume. This is the correctness guarantee for per-replica stores.
+- **FR-13a** On boot in dynamic mode, a node SHOULD pre-install (warm) the
+  DB-recorded installed/enabled distributable set to avoid a first-request
+  latency spike. Boot reconcile is an optimisation, not the correctness
+  mechanism (FR-13 is).
 - **FR-14** A failed install MUST leave the plugin in a clearly-failed state
   with a recorded reason and MUST NOT register a partially-loaded plugin.
 
@@ -241,8 +251,10 @@ Compatibility:
 - [ ] A corrupted/integrity-mismatched download is refused and nothing loads.
 - [ ] A registry outage fails new installs cleanly while installed plugins keep
       working; retry succeeds when the registry returns.
-- [ ] A new replica reconciles its plugin store from the DB on boot and serves
-      the same enabled plugins as its peers.
+- [ ] A plugin enabled on one API replica is served by a different replica that
+      never handled the enable, via lazy install-on-use, with no restart.
+- [ ] A long-running call for a runtime-installed plugin succeeds in the
+      job-runtime worker (worker lazily installs it into its own store first).
 - [ ] Short capability calls run in-process; long-running ones run in the job
       runtime — verified by an integration test of each path.
 - [ ] Core/`systemPlugin` plugins cannot be uninstalled or disabled.

--- a/docs/specs/features/dynamic-plugin-distribution/tasks.md
+++ b/docs/specs/features/dynamic-plugin-distribution/tasks.md
@@ -1,0 +1,187 @@
+# Task Breakdown: Dynamic Plugin Distribution (dual-mode)
+
+> Ordered, granular tasks derived from [`plan.md`](./plan.md). Each task is small
+> enough to land in a single PR and ships with tests per Constitution Principle VI.
+
+**Feature ID**: `dynamic-plugin-distribution`
+**Plan**: `./plan.md`
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+
+---
+
+## How to use
+
+- Tasks are sequential by default. `(parallel)` tasks can run alongside their predecessor.
+- Each task has explicit file paths so an implementer can pick it up cold.
+- Jira mapping: the parent Epic groups these into child Tasks named
+  `[EW-<epic> Tn-Tm] …` (see the Epic for the live keys).
+
+## Phase 1 — SDK & manifest (T1–T4)
+
+- [ ] **T1**. Add `distribution?: 'core' | 'registry'` and
+      `executionProfile?: 'sync' | 'long-running'` to `PluginManifest` at
+      `packages/plugin/src/contracts/plugin-manifest.types.ts`.
+    - Document default derivation: `systemPlugin === true ⇒ 'core'`, else `'registry'`.
+    - **Test**: manifest type + default-derivation unit test in `packages/plugin`.
+- [ ] **T2**. Update the manifest JSON-schema validator
+      (`packages/agent/src/plugins/services/plugin-manifest-validator.service.ts`)
+      to accept and validate the new fields; keep old manifests valid (forward-compat).
+    - **Test**: validator spec covering present/absent/invalid values.
+- [ ] **T3** (parallel with T2). Add install/catalog DTOs in
+      `packages/contracts/src/api/plugins/` (`PluginInstallStateDto`, catalog
+      entry, allowlist DTOs); export from the package index.
+- [ ] **T4**. Bump `@ever-works/plugin` minor; note additive change in its
+      changelog. Confirm `pnpm build:plugins` + type-check green.
+
+## Phase 2 — Data model & migrations (T5–T8)
+
+- [ ] **T5**. Add columns to `PluginEntity` at
+      `packages/agent/src/plugins/entities/plugin.entity.ts`: `source`,
+      `registrySpec`, `installedVersion`, `integrity`, `installState`.
+    - **Test**: entity spec.
+- [ ] **T6**. Add `PluginAllowlistEntity` at
+      `packages/agent/src/plugins/entities/plugin-allowlist.entity.ts`; register
+      in `PLUGIN_ENTITIES` and the agent entities index.
+- [ ] **T7**. Add `PluginAllowlistRepository` +
+      `PluginRepository` methods for install-state transitions at
+      `packages/agent/src/plugins/repositories/`.
+    - **Test**: repository specs.
+- [ ] **T8**. Generate migrations from `apps/api/`:
+      `AddPluginDistributionColumns` + `CreatePluginAllowlist`
+      (`pnpm typeorm migration:generate -d typeorm.config.ts src/migrations/<Name>`).
+      Read the SQL by hand — additive, forward-only, no `DROP`. (NN #16)
+
+## Phase 3 — Publish pipeline (T9–T13)
+
+- [ ] **T9**. Add Changesets (`.changeset/config.json`) configured for
+      independent versioning of `packages/plugins/*` + `packages/plugin`.
+- [ ] **T10**. Flip `private: true → false` and add `publishConfig` (access +
+      registry) to each **distributable** plugin `package.json`. Leave core
+      plugins as-is. Verify the core/distributable split against T1's rule.
+- [ ] **T11**. Add a dual-publish GitHub Actions workflow at
+      `.github/workflows/publish-plugins.yml` mirroring the auth pattern in
+      `.github/workflows/publish-cli.yml`: build changed plugins, publish to
+      **public npm** and **GitHub Packages** (`@ever-works` scope), gated on
+      release/changeset.
+- [ ] **T12**. Add a `release`/`publish` script per distributable plugin (or a
+      root orchestration script) and wire into the workflow; include a `--dry-run`.
+- [ ] **T13**. CI dry-run publish on a PR; confirm both registries resolve the
+      package and that `npm view` / GitHub Packages show the version.
+
+## Phase 4 — Config & feature flag (T14–T15)
+
+- [ ] **T14**. Add config to `apps/api/src/config/constants.ts` (lazy-fn pattern):
+      `PLUGIN_DISTRIBUTION_MODE` (`bundled`|`dynamic`, default `bundled`),
+      `PLUGIN_REGISTRY_URL`, `PLUGIN_REGISTRY_GITHUB_URL`, `PLUGIN_REGISTRY_TOKEN`
+      (secret), `PLUGIN_INSTALL_DIR` (default `/app/plugins`),
+      `FEATURE_DYNAMIC_PLUGINS`. Fail-fast validation when dynamic + no registry.
+    - **Test**: config validation spec.
+- [ ] **T15**. Thread the mode/paths into `PluginsModule.forRootAsync` options
+      (`packages/agent/src/plugins/plugins.module.ts`,
+      `apps/api/src/api.module.ts`) so `pluginPaths`/install dir derive from config.
+
+## Phase 5 — Installer & boot reconcile (T16–T20)
+
+- [ ] **T16**. Implement `PluginInstallerService` at
+      `packages/agent/src/plugins/services/plugin-installer.service.ts`:
+      resolve `pkg@version` from the registry, **allowlist-check first**,
+      download, **verify integrity**, place into `PLUGIN_INSTALL_DIR`. Per-id
+      concurrency guard; idempotent (skip if present + integrity matches).
+    - **Test**: installer spec with mocked registry + allowlist + integrity paths.
+- [ ] **T17**. Allowlist enforcement: first-party `@ever-works/*` implicitly
+      allowed; everything else must match an enabled `plugin_allowlist` row;
+      refuse before download (FR-11). **Test**: allow/deny matrix.
+- [ ] **T18**. Wire installer into the enable flow in
+      `packages/agent/src/plugins/services/plugin-operations.service.ts`
+      (`enablePluginForUser`): in dynamic mode, if not installed →
+      install → `PluginLoaderService.load(path)` → register → then enable.
+      Bundled mode unchanged. Update `installState` transitions + failure reason.
+    - **Test**: enable-installs-then-enables; failure leaves no partial registration (FR-14).
+- [ ] **T19**. Boot reconcile in
+      `packages/agent/src/plugins/services/plugin-bootstrap.service.ts`: in
+      dynamic mode, install any DB-recorded installed/enabled distributable
+      plugins missing from the store before marking ready (FR-13). Idempotent.
+    - **Test**: reconcile installs missing, skips present, is safe to re-run.
+- [ ] **T20**. Uninstall path (`DELETE /plugins/:id/install` service method);
+      refuse for core/`systemPlugin`; default retention = keep files, mark
+      not-installed. **Test**: core refusal + non-core uninstall.
+
+## Phase 6 — API surface (T21–T24)
+
+- [ ] **T21**. Add controller methods in
+      `apps/api/src/plugins/plugins.controller.ts`: `GET /plugins/catalog`,
+      `POST /plugins/:id/install`, `DELETE /plugins/:id/install`,
+      `GET /plugins/:id/install-status`. Swagger decorators + error mapping
+      (409/424/502/422).
+- [ ] **T22**. Catalog service: list distributable plugins (manifest summaries)
+      from the registry/catalog source, merged with local install state.
+    - **Test**: catalog merge + registry-down degradation.
+- [ ] **T23**. Admin allowlist endpoints `GET/POST/DELETE /admin/plugins/allowlist`
+      (admin-gated) in a new `apps/api/src/plugins/allowlist.controller.ts`.
+- [ ] **T24**. e2e: `apps/api/test/plugins-dynamic.e2e-spec.ts` — install →
+      enable → use, non-allowlisted refusal, integrity mismatch, registry-down.
+
+## Phase 7 — Execution router (T25–T28)
+
+- [ ] **T25**. Implement `PluginExecutionRouterService` at
+      `packages/agent/src/plugins/services/plugin-execution-router.service.ts`:
+      decide in-process vs job-runtime per capability/operation from
+      `executionProfile` + operation classification (FR-17).
+    - **Test**: routing matrix.
+- [ ] **T26**. In-process path: facades (`packages/agent/src/facades/*`) call the
+      dynamically-loaded plugin directly for `sync` operations (FR-15). No change
+      for bundled/core. **Test**: short call stays in-process (no job dispatch).
+- [ ] **T27**. Long-running path: route `long-running` plugin calls through the
+      job runtime (Trigger.dev task in `packages/tasks/src/tasks/trigger/`) that
+      imports the plugin and returns via the existing result channel (FR-16).
+      Coordinate with [EW-683] for provider abstraction. **Test**: long call dispatched.
+- [ ] **T28**. Result/error propagation + timeout/retry parity between paths.
+
+## Phase 8 — Deployment (T29–T32)
+
+- [ ] **T29**. Dynamic-mode image: build a core-only plugin set into the image
+      (build arg / variant) at `.deploy/docker/api/Dockerfile`; keep the current
+      all-bundled image as the `bundled` default. Confirm only core plugins land
+      in `/app/plugins`.
+- [ ] **T30**. Writable runtime store: ensure `PLUGIN_INSTALL_DIR` is writable
+      in k8s (`.deploy/k8s/k8s-manifest.prod.yaml`) — emptyDir (per-replica) or
+      optional PVC; readiness gate until boot reconcile completes.
+- [ ] **T31**. Entrypoint/boot wiring (`.deploy/docker/api/entrypoint.sh`) so
+      reconcile runs before serving; document ordering vs migrations.
+- [ ] **T32**. Document that read-only-FS serverless targets (Vercel) support
+      `bundled` only; dynamic mode requires a writable store.
+
+## Phase 9 — Web / CLI (T33–T36)
+
+- [ ] **T33**. Extend `apps/web/src/lib/api/plugins.ts` with catalog, install,
+      install-status, uninstall calls + types.
+- [ ] **T34**. Plugins settings page
+      (`apps/web/src/app/[locale]/(dashboard)/settings/plugins/[category]/page.tsx`):
+      install-state chips, Install action, progress, error surfacing; Enable
+      triggers install-then-enable in dynamic mode (FR-18/19/20).
+- [ ] **T35**. Admin allowlist management page + components.
+- [ ] **T36** (optional). CLI `ever-works plugins install|uninstall|list`
+      under `apps/cli/src/commands/`.
+
+## Phase 10 — Observability, docs & rollout (T37–T40)
+
+- [ ] **T37**. Activity-log events + metrics for install/upgrade/uninstall/reconcile
+      (`plugin.install.*`), Sentry tags (`plugin_source`, `distribution_mode`).
+- [ ] **T38**. Update canonical `docs/plugin-system/built-in-plugins.md` with the
+      core vs distributable split (Principle VIII); update
+      `docs/specs/architecture/runtime-plugins.md` cross-links and
+      `docs/specs/README.md` index.
+- [ ] **T39**. Operator runbook: enabling dynamic mode, registry config, store
+      volume, troubleshooting failed installs (under `docs/` + Workspace KB).
+- [ ] **T40**. Flip spec `Status: Implemented`, mark plan/tasks `Done`; run
+      `pnpm format && pnpm lint && pnpm type-check && pnpm test && pnpm build` green.
+
+## Definition of Done
+
+- All checkboxes ticked; all new code tested and green in CI.
+- `pnpm format:check` and `pnpm lint` green.
+- `pnpm --filter ever-works-docs build` produces no broken-link warnings.
+- Bundled-mode behaviour is byte-for-byte unchanged for a no-config deployment.
+- Both execution paths (in-process + job-runtime) covered by integration tests.
+- Constitution gates in `spec.md` §9 all confirmed satisfied.

--- a/docs/specs/features/dynamic-plugin-distribution/tasks.md
+++ b/docs/specs/features/dynamic-plugin-distribution/tasks.md
@@ -107,11 +107,15 @@
       install → `PluginLoaderService.load(path)` → register → then enable.
       Bundled mode unchanged. Update `installState` transitions + failure reason.
     - **Test**: enable-installs-then-enables; failure leaves no partial registration (FR-14).
-- [ ] **T19**. Boot reconcile in
-      `packages/agent/src/plugins/services/plugin-bootstrap.service.ts`: in
-      dynamic mode, install any DB-recorded installed/enabled distributable
-      plugins missing from the store before marking ready (FR-13). Idempotent.
-    - **Test**: reconcile installs missing, skips present, is safe to re-run.
+- [ ] **T19**. **Lazy install-on-use** `ensurePluginAvailable(pluginId)` on the
+      installer/loader path: before any node invokes a distributable plugin,
+      install-if-missing (pinned version+integrity, per-id lock) then load+register.
+      This is the correctness guarantee (FR-13) — a plugin enabled on replica A is
+      usable on replica B and in the worker with no restart/shared volume. Also add
+      **boot warmup** in `plugin-bootstrap.service.ts` that pre-installs the
+      DB-recorded set (FR-13a, optimisation only). Idempotent.
+    - **Test**: enable on one registry instance → second instance with empty store
+      lazily installs on first use; warmup pre-installs; both safe to re-run.
 - [ ] **T20**. Uninstall path (`DELETE /plugins/:id/install` service method);
       refuse for core/`systemPlugin`; default retention = keep files, mark
       not-installed. **Test**: core refusal + non-core uninstall.
@@ -142,9 +146,13 @@
       dynamically-loaded plugin directly for `sync` operations (FR-15). No change
       for bundled/core. **Test**: short call stays in-process (no job dispatch).
 - [ ] **T27**. Long-running path: route `long-running` plugin calls through the
-      job runtime (Trigger.dev task in `packages/tasks/src/tasks/trigger/`) that
-      imports the plugin and returns via the existing result channel (FR-16).
-      Coordinate with [EW-683] for provider abstraction. **Test**: long call dispatched.
+      job runtime (Trigger.dev task in `packages/tasks/src/tasks/trigger/`). The
+      task MUST call `ensurePluginAvailable` (T19) **first** — the worker is a
+      separate runtime with its own store, so a runtime-installed plugin is absent
+      there until installed — then import the plugin and return via the existing
+      result channel (FR-16). Coordinate with [EW-683] for provider abstraction.
+    - **Test**: long call for a runtime-installed plugin succeeds in the worker
+      (worker installs into its own store first), not just the API.
 - [ ] **T28**. Result/error propagation + timeout/retry parity between paths.
 
 ## Phase 8 — Deployment (T29–T32)

--- a/docs/specs/features/dynamic-plugin-distribution/tasks.md
+++ b/docs/specs/features/dynamic-plugin-distribution/tasks.md
@@ -34,7 +34,7 @@
 - [ ] **T4**. Bump `@ever-works/plugin` minor; note additive change in its
       changelog. Confirm `pnpm build:plugins` + type-check green.
 
-## Phase 2 — Data model & migrations (T5–T8)
+## Phase 2 — Data model & migrations (T5–T8b)
 
 - [ ] **T5**. Add columns to `PluginEntity` at
       `packages/agent/src/plugins/entities/plugin.entity.ts`: `source`,
@@ -51,6 +51,15 @@
       `AddPluginDistributionColumns` + `CreatePluginAllowlist`
       (`pnpm typeorm migration:generate -d typeorm.config.ts src/migrations/<Name>`).
       Read the SQL by hand — additive, forward-only, no `DROP`. (NN #16)
+- [ ] **T8b**. Decouple the API from storage plugins: remove
+      `@ever-works/{aws-s3,minio,github-storage}-plugin` from
+      `apps/api/package.json`; resolve storage via the capability facade/registry
+      instead of static imports. Set those three plugins' manifest
+      `distribution: 'registry'`. Keep `local-fs` (`systemPlugin`) bundled as the
+      core default so the API boots with working storage and no distributable
+      plugin is boot-critical (FR-4).
+    - **Test**: API boots with only `local-fs`; s3/minio/github-storage resolve
+      via facade when enabled; e2e for default-storage path.
 
 ## Phase 3 — Publish pipeline (T9–T13)
 


### PR DESCRIPTION
## Summary

Specs only (no code) for making **plugin distribution dual-mode**:

- **`bundled`** (default, unchanged): all plugins built into the image, discovered from disk at boot.
- **`dynamic`**: only **core** plugins bundled; **distributable** plugins are published to a registry and pulled, integrity-verified, and loaded at runtime when a user clicks Enable — then reconciled from the DB on every boot.

Decisions baked in (per @evereq):
- Registry = **public npm + GitHub Packages** (configurable URL for self-host).
- Trust = **first-party `@ever-works/*` + admin allowlist** (integrity/version pinned).
- Execution = dynamic `import()`; short calls in-process, **long-running calls via the job runtime** (Trigger.dev today → ties to EW-683).
- Default stays `bundled` so existing deployments are unaffected (additive).

## Files

- `docs/specs/features/dynamic-plugin-distribution/{spec,plan,tasks}.md`
- `docs/specs/architecture/runtime-plugins.md`
- `docs/specs/decisions/015-dynamic-plugin-distribution.md`
- `docs/specs/README.md` index wiring

`tasks.md` enumerates T1–T40 across 10 phases with explicit file paths, mapped to a Jira EW Epic + child Tasks.

## Test plan

- [ ] Docs render: `pnpm --filter ever-works-docs build` produces no broken-link warnings
- [ ] Spec/plan/tasks reviewed for the dual-mode behaviour + core/distributable split
- [ ] Confirm open questions in spec §8 (SaaS default, multi-replica store, API storage-plugin hard-deps, allowlist admin surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for dynamic plugin distribution capability, including architecture decisions, implementation plans, and feature specifications outlining a dual-mode system where plugins can be bundled (default) or dynamically installed from a registry at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->