### PR TITLE
release: develop → stage cascade (security fixes + Item #18 + docs)

### DIFF
--- a/apps/api/src/email/email.service.spec.ts
+++ b/apps/api/src/email/email.service.spec.ts
@@ -1,0 +1,112 @@
+// Stub the agent subpaths so their transitive `@ever-works/agent/database` →
+// `database.config.ts` (api-only `@src/config`) is never pulled into this spec.
+jest.mock('@ever-works/agent/database', () => ({
+    TenantEmailAddressRepository: class TenantEmailAddressRepository {},
+    AgentEmailAssignmentRepository: class AgentEmailAssignmentRepository {},
+    EmailMessageRepository: class EmailMessageRepository {},
+}));
+jest.mock('@ever-works/agent/facades', () => ({
+    EmailFacadeService: class EmailFacadeService {},
+}));
+jest.mock('./templates/render', () => ({
+    renderTemplate: jest.fn(),
+    listTemplates: jest.fn(() => []),
+}));
+
+import { NotFoundException } from '@nestjs/common';
+import { EmailService } from './email.service';
+
+/**
+ * EmailService — security-scoped behaviour around `sendMessage`.
+ *
+ * Covers the Codex P1 finding on PR #1085: when `fromAddressId` is omitted,
+ * the resolved primary-outbound address MUST belong to the calling user.
+ * Otherwise an authenticated caller who knows another user's `agentId` could
+ * send mail from that user's outbound address.
+ */
+describe('EmailService.sendMessage authorization', () => {
+    let addresses: {
+        findByIdForUser: jest.Mock;
+        findById: jest.Mock;
+    };
+    let assignments: { findPrimaryOutboundForAgent: jest.Mock };
+    let messages: Record<string, jest.Mock>;
+    let emailFacade: { send: jest.Mock };
+    let service: EmailService;
+
+    beforeEach(() => {
+        addresses = {
+            findByIdForUser: jest.fn(),
+            findById: jest.fn(),
+        };
+        assignments = { findPrimaryOutboundForAgent: jest.fn() };
+        messages = {};
+        emailFacade = { send: jest.fn().mockResolvedValue({ providerMessageId: 'pm-1' }) };
+        service = new EmailService(
+            addresses as never,
+            assignments as never,
+            messages as never,
+            emailFacade as never,
+        );
+    });
+
+    it('default path: scopes the resolved address to the caller (findByIdForUser)', async () => {
+        assignments.findPrimaryOutboundForAgent.mockResolvedValue({
+            emailAddressId: 'addr-foreign',
+        });
+        addresses.findByIdForUser.mockResolvedValue({
+            id: 'addr-foreign',
+            address: 'me@x.com',
+            userId: 'user-1',
+        });
+
+        await service.sendMessage('user-1', {
+            agentId: 'agent-foreign',
+            to: ['to@x.com'],
+            subject: 's',
+            bodyText: 'b',
+        });
+
+        expect(addresses.findByIdForUser).toHaveBeenCalledWith('addr-foreign', 'user-1');
+        expect(addresses.findById).not.toHaveBeenCalled();
+    });
+
+    it('default path: throws NotFound when the resolved address belongs to a different user', async () => {
+        assignments.findPrimaryOutboundForAgent.mockResolvedValue({
+            emailAddressId: 'addr-foreign',
+        });
+        // findByIdForUser returns null when (id, userId) does not match — i.e. the
+        // address belongs to another user. We must not fall through to findById.
+        addresses.findByIdForUser.mockResolvedValue(null);
+
+        await expect(
+            service.sendMessage('user-1', {
+                agentId: 'agent-foreign',
+                to: ['to@x.com'],
+                subject: 's',
+                bodyText: 'b',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundException);
+
+        expect(emailFacade.send).not.toHaveBeenCalled();
+    });
+
+    it('explicit fromAddressId path remains user-scoped (no regression)', async () => {
+        addresses.findByIdForUser.mockResolvedValue({
+            id: 'addr-1',
+            address: 'me@x.com',
+            userId: 'user-1',
+        });
+
+        await service.sendMessage('user-1', {
+            agentId: 'agent-1',
+            to: ['to@x.com'],
+            subject: 's',
+            bodyText: 'b',
+            fromAddressId: 'addr-1',
+        });
+
+        expect(addresses.findByIdForUser).toHaveBeenCalledWith('addr-1', 'user-1');
+        expect(assignments.findPrimaryOutboundForAgent).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -148,7 +148,10 @@ export class EmailService {
         } else {
             const assignment = await this.assignments.findPrimaryOutboundForAgent(input.agentId);
             if (assignment) {
-                address = await this.addresses.findById(assignment.emailAddressId);
+                // Codex P1 (PR #1085): scope the resolved address to the caller. Otherwise
+                // an authenticated user who knows another user's agentId could send from
+                // that user's outbound address.
+                address = await this.addresses.findByIdForUser(assignment.emailAddressId, userId);
             }
         }
         if (!address) {

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -21,9 +21,11 @@ docs/specs/
 ├── decisions/                      # Architecture Decision Records (ADRs)
 │   ├── 001-pipeline-checkpointing.md
 │   ├── 002-trigger-worker-callback-channel.md
-│   └── 003-pnpm-overrides-strategy.md
+│   ├── 003-pnpm-overrides-strategy.md
+│   └── 015-job-runtime-provider-pluggability.md  # Pluggable background-job runtime
 ├── architecture/                   # Cross-feature architecture docs
 │   ├── README.md                   # Reading order + companion-pair index
+│   ├── job-runtime-providers.md    # Pluggable runtime contract + worker models
 │   ├── pipeline-overview.md        # High-level generation flow
 │   ├── pipeline-executor.md        # Executor / step / modifier substrate
 │   ├── trigger-integration.md      # Trigger.dev wiring
@@ -63,6 +65,7 @@ docs/specs/
     ├── work-members/
     ├── generation-cancellation/
     ├── git-operations/
+    ├── job-runtime-providers/   # Pluggable background-job runtime (proposed)
     ├── item-source-validation/
     ├── markdown-generator/
     ├── mcp-server/
@@ -99,6 +102,7 @@ which now live folded into `tasks.md`).
 | [`work-members`](features/work-members/spec)                       | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)   |
 | [`generation-cancellation`](features/generation-cancellation/spec) | Retrospective | Mid-flight generation cancel with four mode paths              |
 | [`git-operations`](features/git-operations/spec)                   | Retrospective | `GitFacadeService` and provider plugin contract                |
+| [`job-runtime-providers`](features/job-runtime-providers/spec)     | Draft         | Pluggable background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) |
 | [`item-source-validation`](features/item-source-validation/spec)   | Retrospective | Reachability + AI accuracy checks per item                     |
 | [`markdown-generator`](features/markdown-generator/spec)           | Retrospective | Markdown rendering pipeline                                    |
 | [`mcp-server`](features/mcp-server/spec)                           | Retrospective | OpenAPI-derived MCP tool surface                               |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -86,31 +86,31 @@ full Spec Kit format and retain their deeper architectural `spec.md`
 (see also their `acceptance.md` for the original acceptance criteria
 which now live folded into `tasks.md`).
 
-| Feature                                                            | Status        | Description                                                    |
-| ------------------------------------------------------------------ | ------------- | -------------------------------------------------------------- |
-| [`advanced-prompts`](features/advanced-prompts/spec)               | Retrospective | Per-work prompt overrides per pipeline step                    |
-| [`api-keys`](features/api-keys/spec)                               | Retrospective | Long-lived auth tokens for CI / CLI / MCP                      |
-| [`collections`](features/collections/spec)                         | Retrospective | Editorial groupings cutting across categories                  |
-| [`community-pr-processing`](features/community-pr-processing/spec) | Retrospective | AI-driven processing of community-contributed PRs              |
-| [`comparisons`](features/comparisons/spec)                         | Retrospective | A vs B comparison page generator                               |
-| [`creating-a-work`](features/creating-a-work/spec)                 | Retrospective | Three creation methods: AI / Manual / Import                   |
-| [`custom-domains`](features/custom-domains/spec)                   | Retrospective | Branded domain assignment with provider sync                   |
-| [`data-generator`](features/data-generator/spec)                   | Retrospective | Data repository management and item persistence                |
-| [`data-management`](features/data-management/spec)                 | Retrospective | Export / Import / GitHub Sync with secret hygiene              |
-| [`work-changelog`](features/work-changelog/spec)                   | Retrospective | Audit trail of all work mutations                              |
-| [`work-import`](features/work-import/spec)                         | Retrospective | Bootstrap from existing repo or Awesome List                   |
-| [`work-members`](features/work-members/spec)                       | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)   |
-| [`generation-cancellation`](features/generation-cancellation/spec) | Retrospective | Mid-flight generation cancel with four mode paths              |
-| [`git-operations`](features/git-operations/spec)                   | Retrospective | `GitFacadeService` and provider plugin contract                |
+| Feature                                                            | Status        | Description                                                                                   |
+| ------------------------------------------------------------------ | ------------- | --------------------------------------------------------------------------------------------- |
+| [`advanced-prompts`](features/advanced-prompts/spec)               | Retrospective | Per-work prompt overrides per pipeline step                                                   |
+| [`api-keys`](features/api-keys/spec)                               | Retrospective | Long-lived auth tokens for CI / CLI / MCP                                                     |
+| [`collections`](features/collections/spec)                         | Retrospective | Editorial groupings cutting across categories                                                 |
+| [`community-pr-processing`](features/community-pr-processing/spec) | Retrospective | AI-driven processing of community-contributed PRs                                             |
+| [`comparisons`](features/comparisons/spec)                         | Retrospective | A vs B comparison page generator                                                              |
+| [`creating-a-work`](features/creating-a-work/spec)                 | Retrospective | Three creation methods: AI / Manual / Import                                                  |
+| [`custom-domains`](features/custom-domains/spec)                   | Retrospective | Branded domain assignment with provider sync                                                  |
+| [`data-generator`](features/data-generator/spec)                   | Retrospective | Data repository management and item persistence                                               |
+| [`data-management`](features/data-management/spec)                 | Retrospective | Export / Import / GitHub Sync with secret hygiene                                             |
+| [`work-changelog`](features/work-changelog/spec)                   | Retrospective | Audit trail of all work mutations                                                             |
+| [`work-import`](features/work-import/spec)                         | Retrospective | Bootstrap from existing repo or Awesome List                                                  |
+| [`work-members`](features/work-members/spec)                       | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)                                  |
+| [`generation-cancellation`](features/generation-cancellation/spec) | Retrospective | Mid-flight generation cancel with four mode paths                                             |
+| [`git-operations`](features/git-operations/spec)                   | Retrospective | `GitFacadeService` and provider plugin contract                                               |
 | [`job-runtime-providers`](features/job-runtime-providers/spec)     | Draft         | Pluggable background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) |
-| [`item-source-validation`](features/item-source-validation/spec)   | Retrospective | Reachability + AI accuracy checks per item                     |
-| [`markdown-generator`](features/markdown-generator/spec)           | Retrospective | Markdown rendering pipeline                                    |
-| [`mcp-server`](features/mcp-server/spec)                           | Retrospective | OpenAPI-derived MCP tool surface                               |
-| [`plugin-system`](features/plugin-system/spec)                     | Retrospective | Capability-driven plugin architecture (39 first-party plugins) |
-| [`scheduled-updates`](features/scheduled-updates/spec)             | Retrospective | Cron-driven generation with CAS claim and drift correction     |
-| [`taxonomy-system`](features/taxonomy-system/spec)                 | Retrospective | Categories, tags, and collections in the data repo             |
-| [`website-generator`](features/website-generator/spec)             | Retrospective | Static site generation pipeline                                |
-| [`works-config`](features/works-config/spec)                       | Retrospective | `.works/works.yml` source-controlled work configuration        |
+| [`item-source-validation`](features/item-source-validation/spec)   | Retrospective | Reachability + AI accuracy checks per item                                                    |
+| [`markdown-generator`](features/markdown-generator/spec)           | Retrospective | Markdown rendering pipeline                                                                   |
+| [`mcp-server`](features/mcp-server/spec)                           | Retrospective | OpenAPI-derived MCP tool surface                                                              |
+| [`plugin-system`](features/plugin-system/spec)                     | Retrospective | Capability-driven plugin architecture (39 first-party plugins)                                |
+| [`scheduled-updates`](features/scheduled-updates/spec)             | Retrospective | Cron-driven generation with CAS claim and drift correction                                    |
+| [`taxonomy-system`](features/taxonomy-system/spec)                 | Retrospective | Categories, tags, and collections in the data repo                                            |
+| [`website-generator`](features/website-generator/spec)             | Retrospective | Static site generation pipeline                                                               |
+| [`works-config`](features/works-config/spec)                       | Retrospective | `.works/works.yml` source-controlled work configuration                                       |
 
 ## Reading order for new contributors
 

--- a/docs/specs/architecture/README.md
+++ b/docs/specs/architecture/README.md
@@ -41,6 +41,7 @@ wide-angle first.
 | ------------------------------------------------- | --------------------------------------------------------------------- |
 | [`trigger-integration`](./trigger-integration.md) | API → Trigger.dev dispatch, payload contract, callback channel        |
 | [`trigger-worker`](./trigger-worker.md)           | Internals: per-task NestJS bootstrap, plugin hydration, logger bridge |
+| [`job-runtime-providers`](./job-runtime-providers.md) | Proposed: pluggable runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) — [ADR-015](../decisions/015-job-runtime-provider-pluggability.md) |
 
 ### Plugins & capabilities
 

--- a/docs/specs/architecture/README.md
+++ b/docs/specs/architecture/README.md
@@ -37,10 +37,10 @@ wide-angle first.
 
 ### Trigger.dev & background work
 
-| Spec                                              | Focus                                                                 |
-| ------------------------------------------------- | --------------------------------------------------------------------- |
-| [`trigger-integration`](./trigger-integration.md) | API → Trigger.dev dispatch, payload contract, callback channel        |
-| [`trigger-worker`](./trigger-worker.md)           | Internals: per-task NestJS bootstrap, plugin hydration, logger bridge |
+| Spec                                                  | Focus                                                                                                                                                       |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`trigger-integration`](./trigger-integration.md)     | API → Trigger.dev dispatch, payload contract, callback channel                                                                                              |
+| [`trigger-worker`](./trigger-worker.md)               | Internals: per-task NestJS bootstrap, plugin hydration, logger bridge                                                                                       |
 | [`job-runtime-providers`](./job-runtime-providers.md) | Proposed: pluggable runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) — [ADR-015](../decisions/015-job-runtime-provider-pluggability.md) |
 
 ### Plugins & capabilities

--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -10,7 +10,7 @@
 
 ## 1. Purpose
 
-Long-running operations (work generation, import, onboarding, scheduled dispatch, KB embedding, webhook delivery, agent heartbeats, deploy-ready polling, mission ticks) cannot run inside an HTTP request. Today they all run on **Trigger.dev SaaS**. This spec defines the **`job-runtime` capability**: a provider contract that lets a deployment choose *which* runtime executes that work, while the rest of the platform — the API, the agent business logic, the dispatcher call sites — stays identical regardless of choice.
+Long-running operations (work generation, import, onboarding, scheduled dispatch, KB embedding, webhook delivery, agent heartbeats, deploy-ready polling, mission ticks) cannot run inside an HTTP request. Today they all run on **Trigger.dev SaaS**. This spec defines the **`job-runtime` capability**: a provider contract that lets a deployment choose _which_ runtime executes that work, while the rest of the platform — the API, the agent business logic, the dispatcher call sites — stays identical regardless of choice.
 
 The runtime owns exactly six concerns, and **only** these six:
 
@@ -21,7 +21,7 @@ The runtime owns exactly six concerns, and **only** these six:
 5. **Retry / idempotency** — re-run safely with stable identity.
 6. **Worker hosting** — run the process that executes `@ever-works/agent` orchestrators.
 
-Everything else — what the work *does*, the SuperJSON callback channel, the pre-created `historyId`, secret hygiene — is provider-neutral and unchanged.
+Everything else — what the work _does_, the SuperJSON callback channel, the pre-created `historyId`, secret hygiene — is provider-neutral and unchanged.
 
 ## 2. The seam that makes this possible
 
@@ -38,17 +38,17 @@ export const WORK_GENERATION_DISPATCHER = Symbol('WORK_GENERATION_DISPATCHER');
 
 The API depends only on these symbols; it has **no** `@trigger.dev/sdk` import. `TriggerService` (`packages/tasks/src/trigger/trigger.service.ts`) implements all of them today. The eight dispatcher seams in use:
 
-| Dispatcher symbol | Payload | Used by |
-| --- | --- | --- |
-| `WORK_GENERATION_DISPATCHER` | `WorkGenerationPayload` | `WorkGenerationService` |
-| `WORK_IMPORT_DISPATCHER` | `WorkImportPayload` | `WorkImportService` |
-| `TEMPLATE_CUSTOMIZATION_DISPATCHER` | `TemplateCustomizationPayload` | template customization |
-| `WEBHOOK_DELIVERY_DISPATCHER` | `WebhookDeliveryPayload` | webhook delivery |
-| `KB_MIRROR_DOCUMENT_DISPATCHER` | `KbMirrorDocumentPayload` | KB mirror |
-| `KB_BACKFILL_SKELETON_DISPATCHER` | `KbBackfillSkeletonPayload` | KB backfill |
-| `KB_EMBED_DOCUMENT_DISPATCHER` | `KbEmbedDocumentPayload` | KB embed |
-| `KB_ORG_OVERLAY_FANOUT_DISPATCHER` | `KbOrgOverlayFanoutPayload` | KB org overlay |
-| (+ `AGENT_TASK_EXECUTE_DISPATCHER`, `AGENT_CHAT_REPLY_DISPATCHER` wired in `apps/api/src/tasks/tasks.module.ts`) | | agents |
+| Dispatcher symbol                                                                                                | Payload                        | Used by                 |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------------------- |
+| `WORK_GENERATION_DISPATCHER`                                                                                     | `WorkGenerationPayload`        | `WorkGenerationService` |
+| `WORK_IMPORT_DISPATCHER`                                                                                         | `WorkImportPayload`            | `WorkImportService`     |
+| `TEMPLATE_CUSTOMIZATION_DISPATCHER`                                                                              | `TemplateCustomizationPayload` | template customization  |
+| `WEBHOOK_DELIVERY_DISPATCHER`                                                                                    | `WebhookDeliveryPayload`       | webhook delivery        |
+| `KB_MIRROR_DOCUMENT_DISPATCHER`                                                                                  | `KbMirrorDocumentPayload`      | KB mirror               |
+| `KB_BACKFILL_SKELETON_DISPATCHER`                                                                                | `KbBackfillSkeletonPayload`    | KB backfill             |
+| `KB_EMBED_DOCUMENT_DISPATCHER`                                                                                   | `KbEmbedDocumentPayload`       | KB embed                |
+| `KB_ORG_OVERLAY_FANOUT_DISPATCHER`                                                                               | `KbOrgOverlayFanoutPayload`    | KB org overlay          |
+| (+ `AGENT_TASK_EXECUTE_DISPATCHER`, `AGENT_CHAT_REPLY_DISPATCHER` wired in `apps/api/src/tasks/tasks.module.ts`) |                                | agents                  |
 
 **The refactor's premise:** instead of binding these symbols to `TriggerService`, bind them to whichever `IJobRuntimeProvider` is active. Call sites do not change.
 
@@ -81,21 +81,20 @@ export interface IJobRuntimeProvider {
 	startWorkerHost?(opts: WorkerHostOptions): Promise<WorkerHostHandle>;
 }
 
-export type JobRunStatus =
-	| 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown';
+export type JobRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown';
 
 export interface ScheduleSpec {
-	id: string;            // e.g. 'work-schedule-dispatcher'
-	cron: string;          // standard 5-field cron
-	payload?: unknown;     // optional static payload
+	id: string; // e.g. 'work-schedule-dispatcher'
+	cron: string; // standard 5-field cron
+	payload?: unknown; // optional static payload
 }
 
 export interface JobEnqueueOptions {
 	tags?: string[];
-	idempotencyKey?: string;   // stable identity across retries
-	concurrencyKey?: string;   // serialise per key (e.g. per workId/orgId)
+	idempotencyKey?: string; // stable identity across retries
+	concurrencyKey?: string; // serialise per key (e.g. per workId/orgId)
 	maxDurationSeconds?: number;
-	machineHint?: string;      // provider maps to its own sizing
+	machineHint?: string; // provider maps to its own sizing
 }
 ```
 
@@ -122,10 +121,15 @@ Binding (proposed) lives where the dispatcher symbols are provided. A factory re
 // packages/agent/src/tasks/job-runtime.providers.ts (proposed shape)
 const provider = jobRuntimeRegistry.getActive(); // by EVER_WORKS_JOB_RUNTIME
 [
-	WORK_GENERATION_DISPATCHER, WORK_IMPORT_DISPATCHER, TEMPLATE_CUSTOMIZATION_DISPATCHER,
-	WEBHOOK_DELIVERY_DISPATCHER, KB_MIRROR_DOCUMENT_DISPATCHER, KB_BACKFILL_SKELETON_DISPATCHER,
-	KB_EMBED_DOCUMENT_DISPATCHER, KB_ORG_OVERLAY_FANOUT_DISPATCHER,
-].forEach(sym => bind(sym, () => provider.dispatchers));
+	WORK_GENERATION_DISPATCHER,
+	WORK_IMPORT_DISPATCHER,
+	TEMPLATE_CUSTOMIZATION_DISPATCHER,
+	WEBHOOK_DELIVERY_DISPATCHER,
+	KB_MIRROR_DOCUMENT_DISPATCHER,
+	KB_BACKFILL_SKELETON_DISPATCHER,
+	KB_EMBED_DOCUMENT_DISPATCHER,
+	KB_ORG_OVERLAY_FANOUT_DISPATCHER
+].forEach((sym) => bind(sym, () => provider.dispatchers));
 ```
 
 Provider-specific credentials/options use the **standard plugin settings system** (`x-secret`, `x-envVar`, JSON-Schema, admin scope). The selector (`EVER_WORKS_JOB_RUNTIME`) is the only "which provider" knob; everything else is the chosen provider's settings.
@@ -152,13 +156,13 @@ Provider-specific credentials/options use the **standard plugin settings system*
 
 Enqueue is the easy half. The genuinely different part is **how each runtime hosts and invokes the worker** that runs the agent orchestrators. The contract abstracts dispatch; it cannot fully abstract hosting, so each provider documents its model and ships its own worker entrypoint + deploy artifacts. The agent orchestrator code (`TriggerGenerationOrchestrator` → generalise to `JobOrchestrator`) and the SuperJSON callback channel are reused unchanged.
 
-| Provider | Worker-hosting model | Who invokes the worker | Cron mechanism |
-| --- | --- | --- | --- |
-| **Trigger.dev** | Tasks deployed to Trigger.dev (`pnpm deploy:trigger`); Trigger.dev runs them on its machines (cloud or self-hosted). | Trigger.dev platform | `schedules.task` |
-| **Temporal** | Long-running **Worker** process polls a task queue; we run it as a deployment/sidecar. Orchestrator = a Temporal **Workflow**; agent work = **Activities**. | Temporal Service hands tasks to polling workers | Temporal **Schedules** API |
-| **BullMQ** | In-process or sidecar `Worker` consuming a Redis queue; we run N worker replicas. | The worker process pulls jobs from Redis | BullMQ **repeatable jobs** (`JobScheduler`) |
-| **pg-boss** | In-process or sidecar pg-boss instance polling Postgres; `boss.work(name, handler)`. | pg-boss polling Postgres | pg-boss **`schedule()`** (cron) |
-| **Inngest** | Functions served over **HTTP** (`serve()` handler mounted in the API or a small service); **Inngest Cloud invokes them** via webhook. | Inngest Cloud calls our HTTP endpoint | Inngest **cron functions** |
+| Provider        | Worker-hosting model                                                                                                                                        | Who invokes the worker                          | Cron mechanism                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------- |
+| **Trigger.dev** | Tasks deployed to Trigger.dev (`pnpm deploy:trigger`); Trigger.dev runs them on its machines (cloud or self-hosted).                                        | Trigger.dev platform                            | `schedules.task`                            |
+| **Temporal**    | Long-running **Worker** process polls a task queue; we run it as a deployment/sidecar. Orchestrator = a Temporal **Workflow**; agent work = **Activities**. | Temporal Service hands tasks to polling workers | Temporal **Schedules** API                  |
+| **BullMQ**      | In-process or sidecar `Worker` consuming a Redis queue; we run N worker replicas.                                                                           | The worker process pulls jobs from Redis        | BullMQ **repeatable jobs** (`JobScheduler`) |
+| **pg-boss**     | In-process or sidecar pg-boss instance polling Postgres; `boss.work(name, handler)`.                                                                        | pg-boss polling Postgres                        | pg-boss **`schedule()`** (cron)             |
+| **Inngest**     | Functions served over **HTTP** (`serve()` handler mounted in the API or a small service); **Inngest Cloud invokes them** via webhook.                       | Inngest Cloud calls our HTTP endpoint           | Inngest **cron functions**                  |
 
 Key implications captured for the plan:
 

--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -1,6 +1,6 @@
 # Architecture: Job-Runtime Providers (pluggable background-job runtime)
 
-**Status**: `Proposed` (tracking [EW-685](https://evertech.atlassian.net/browse/EW-685))
+**Status**: `Proposed` (tracking [EW-683](https://evertech.atlassian.net/browse/EW-683))
 **Last updated**: 2026-05-28
 **Audience**: AI agents and engineers who need to understand how the platform's long-running work is dispatched, scheduled, cancelled, and executed — and how that runtime becomes a **swappable provider** (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest optional).
 

--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -1,0 +1,254 @@
+# Architecture: Job-Runtime Providers (pluggable background-job runtime)
+
+**Status**: `Proposed` (tracking [EW-685](https://evertech.atlassian.net/browse/EW-685))
+**Last updated**: 2026-05-28
+**Audience**: AI agents and engineers who need to understand how the platform's long-running work is dispatched, scheduled, cancelled, and executed — and how that runtime becomes a **swappable provider** (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest optional).
+
+> This spec describes the **target architecture**. Nothing here is built yet. It generalises the existing [`trigger-integration`](./trigger-integration.md) and [`trigger-worker`](./trigger-worker.md) specs into a provider-neutral form. Read those two first — this spec assumes them. Decision rationale: [ADR-015](../decisions/015-job-runtime-provider-pluggability.md). Per-provider detail: [`features/job-runtime-providers/providers.md`](../features/job-runtime-providers/providers.md).
+
+---
+
+## 1. Purpose
+
+Long-running operations (work generation, import, onboarding, scheduled dispatch, KB embedding, webhook delivery, agent heartbeats, deploy-ready polling, mission ticks) cannot run inside an HTTP request. Today they all run on **Trigger.dev SaaS**. This spec defines the **`job-runtime` capability**: a provider contract that lets a deployment choose *which* runtime executes that work, while the rest of the platform — the API, the agent business logic, the dispatcher call sites — stays identical regardless of choice.
+
+The runtime owns exactly six concerns, and **only** these six:
+
+1. **Enqueue** — accept a typed payload and durably hand it to a worker.
+2. **Schedule** — fire recurring/cron work (e.g. the schedule dispatcher every N minutes).
+3. **Cancel** — abort an in-flight run by id.
+4. **Status** — report run lifecycle (queued → running → completed/failed/cancelled) back so the API can mirror it onto `WorkGenerationHistory` etc.
+5. **Retry / idempotency** — re-run safely with stable identity.
+6. **Worker hosting** — run the process that executes `@ever-works/agent` orchestrators.
+
+Everything else — what the work *does*, the SuperJSON callback channel, the pre-created `historyId`, secret hygiene — is provider-neutral and unchanged.
+
+## 2. The seam that makes this possible
+
+The platform already isolates the runtime behind **dispatcher interfaces** owned by the agent package. This is the entire reason a swap is tractable. Each is a tiny interface plus a DI `Symbol`:
+
+```ts
+// packages/agent/src/tasks/work-generation-dispatcher.ts (exists today)
+export interface WorkGenerationDispatcher {
+	dispatchWorkGeneration(payload: WorkGenerationPayload): Promise<string | null>;
+	cancelWorkGeneration(runId: string): Promise<boolean>;
+}
+export const WORK_GENERATION_DISPATCHER = Symbol('WORK_GENERATION_DISPATCHER');
+```
+
+The API depends only on these symbols; it has **no** `@trigger.dev/sdk` import. `TriggerService` (`packages/tasks/src/trigger/trigger.service.ts`) implements all of them today. The eight dispatcher seams in use:
+
+| Dispatcher symbol | Payload | Used by |
+| --- | --- | --- |
+| `WORK_GENERATION_DISPATCHER` | `WorkGenerationPayload` | `WorkGenerationService` |
+| `WORK_IMPORT_DISPATCHER` | `WorkImportPayload` | `WorkImportService` |
+| `TEMPLATE_CUSTOMIZATION_DISPATCHER` | `TemplateCustomizationPayload` | template customization |
+| `WEBHOOK_DELIVERY_DISPATCHER` | `WebhookDeliveryPayload` | webhook delivery |
+| `KB_MIRROR_DOCUMENT_DISPATCHER` | `KbMirrorDocumentPayload` | KB mirror |
+| `KB_BACKFILL_SKELETON_DISPATCHER` | `KbBackfillSkeletonPayload` | KB backfill |
+| `KB_EMBED_DOCUMENT_DISPATCHER` | `KbEmbedDocumentPayload` | KB embed |
+| `KB_ORG_OVERLAY_FANOUT_DISPATCHER` | `KbOrgOverlayFanoutPayload` | KB org overlay |
+| (+ `AGENT_TASK_EXECUTE_DISPATCHER`, `AGENT_CHAT_REPLY_DISPATCHER` wired in `apps/api/src/tasks/tasks.module.ts`) | | agents |
+
+**The refactor's premise:** instead of binding these symbols to `TriggerService`, bind them to whichever `IJobRuntimeProvider` is active. Call sites do not change.
+
+## 3. The `IJobRuntimeProvider` contract
+
+A new capability `job-runtime` is registered in `packages/plugin/src/job-runtime/`. A provider plugin extends `BasePlugin` (category `job-runtime`, `configurationMode: 'admin-only'`) and exposes:
+
+```ts
+// packages/plugin/src/job-runtime/job-runtime.contract.ts (proposed)
+export interface IJobRuntimeProvider {
+	/** Stable provider id: 'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest' */
+	readonly runtimeId: JobRuntimeId;
+
+	/** One object that implements every agent dispatcher interface (enqueue + cancel). */
+	readonly dispatchers: JobRuntimeDispatchers;
+
+	/** Register/lifecycle the recurring jobs the platform needs (cron). */
+	registerSchedules(schedules: ScheduleSpec[]): Promise<void>;
+
+	/** Cancel an in-flight run by the id returned at enqueue time. */
+	cancel(runId: string): Promise<boolean>;
+
+	/** Look up live run status (used where webhooks/callbacks aren't available). */
+	getRunStatus(runId: string): Promise<JobRunStatus>;
+
+	/** True when this provider is configured & reachable in the current env. */
+	isEnabled(): boolean;
+
+	/** Optional: stand up / connect the worker host (see §5). */
+	startWorkerHost?(opts: WorkerHostOptions): Promise<WorkerHostHandle>;
+}
+
+export type JobRunStatus =
+	| 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown';
+
+export interface ScheduleSpec {
+	id: string;            // e.g. 'work-schedule-dispatcher'
+	cron: string;          // standard 5-field cron
+	payload?: unknown;     // optional static payload
+}
+
+export interface JobEnqueueOptions {
+	tags?: string[];
+	idempotencyKey?: string;   // stable identity across retries
+	concurrencyKey?: string;   // serialise per key (e.g. per workId/orgId)
+	maxDurationSeconds?: number;
+	machineHint?: string;      // provider maps to its own sizing
+}
+```
+
+`JobRuntimeDispatchers` is the union of the existing dispatcher interfaces (`WorkGenerationDispatcher & WorkImportDispatcher & … `). The contract deliberately keeps the dispatch signature identical to today (`Promise<string | null>` — run id or "runtime disabled, fall back in-process").
+
+### Design constraints the contract must hold
+
+- **`string | null` enqueue return is preserved.** A disabled/unreachable runtime returns `null`; the API's existing in-process dev fallback is the provider-neutral safety net.
+- **Idempotency is first-class.** The pre-created `historyId` already gives every dispatch a stable identity. Providers MUST map `idempotencyKey` onto their native mechanism (Trigger.dev `idempotencyKey`, Temporal workflow id, BullMQ/pg-boss job id, Inngest event idempotency) so retries write to the same `WorkGenerationHistory` row.
+- **Concurrency keys are preserved.** Today some tasks are concurrency-keyed (KB mirror/embed on `workId`, org overlay on `organizationId`). The contract carries `concurrencyKey`; each provider maps it (Trigger.dev `queue.concurrencyKey`, BullMQ groups / job ids, Temporal workflow id namespacing, pg-boss singleton keys).
+- **Cancellation must propagate an `AbortSignal` into the orchestrator** so in-flight AI/search/git calls abort — exactly as the Trigger.dev `onCancel`/`signal` path does today (see [`trigger-integration`](./trigger-integration.md) §8).
+
+## 4. Selection: one active runtime per deployment, env-driven
+
+Unlike per-user/per-work plugins (AI, search, deployment), the job runtime is **deployment infrastructure** — there is exactly **one** active runtime per deployment, chosen by the operator, scoped global/admin. This matches the `k8s` deployment plugin's `admin-only` config and ADR-005's cache/lock backend selection.
+
+```bash
+EVER_WORKS_JOB_RUNTIME=trigger   # trigger (default) | temporal | bullmq | pgboss | inngest
+```
+
+Binding (proposed) lives where the dispatcher symbols are provided. A factory reads `EVER_WORKS_JOB_RUNTIME`, resolves the matching registered `job-runtime` plugin from `PluginRegistryService`, and binds its `.dispatchers` to all `*_DISPATCHER` symbols:
+
+```ts
+// packages/agent/src/tasks/job-runtime.providers.ts (proposed shape)
+const provider = jobRuntimeRegistry.getActive(); // by EVER_WORKS_JOB_RUNTIME
+[
+	WORK_GENERATION_DISPATCHER, WORK_IMPORT_DISPATCHER, TEMPLATE_CUSTOMIZATION_DISPATCHER,
+	WEBHOOK_DELIVERY_DISPATCHER, KB_MIRROR_DOCUMENT_DISPATCHER, KB_BACKFILL_SKELETON_DISPATCHER,
+	KB_EMBED_DOCUMENT_DISPATCHER, KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+].forEach(sym => bind(sym, () => provider.dispatchers));
+```
+
+Provider-specific credentials/options use the **standard plugin settings system** (`x-secret`, `x-envVar`, JSON-Schema, admin scope). The selector (`EVER_WORKS_JOB_RUNTIME`) is the only "which provider" knob; everything else is the chosen provider's settings.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ apps/api  — dispatch call sites depend ONLY on *_DISPATCHER    │
+│            symbols (provider-neutral, unchanged)               │
+└───────────────┬────────────────────────────────────────────────┘
+                │  EVER_WORKS_JOB_RUNTIME selects ONE provider
+        ┌───────┴────────┬─────────┬──────────┬──────────┐
+        ▼                ▼         ▼          ▼          ▼
+   trigger (default)  temporal   bullmq     pgboss    inngest
+   SaaS / self-host   self/Cloud Redis      Postgres  SaaS only
+        │                │         │          │          │
+        ▼                ▼         ▼          ▼          ▼
+   ┌────────────────────────────────────────────────────────────┐
+   │ Worker host runs @ever-works/agent orchestrators            │
+   │ (same SuperJSON callback channel to /internal/* for DB)     │
+   └────────────────────────────────────────────────────────────┘
+```
+
+## 5. Worker-hosting models (the hard part)
+
+Enqueue is the easy half. The genuinely different part is **how each runtime hosts and invokes the worker** that runs the agent orchestrators. The contract abstracts dispatch; it cannot fully abstract hosting, so each provider documents its model and ships its own worker entrypoint + deploy artifacts. The agent orchestrator code (`TriggerGenerationOrchestrator` → generalise to `JobOrchestrator`) and the SuperJSON callback channel are reused unchanged.
+
+| Provider | Worker-hosting model | Who invokes the worker | Cron mechanism |
+| --- | --- | --- | --- |
+| **Trigger.dev** | Tasks deployed to Trigger.dev (`pnpm deploy:trigger`); Trigger.dev runs them on its machines (cloud or self-hosted). | Trigger.dev platform | `schedules.task` |
+| **Temporal** | Long-running **Worker** process polls a task queue; we run it as a deployment/sidecar. Orchestrator = a Temporal **Workflow**; agent work = **Activities**. | Temporal Service hands tasks to polling workers | Temporal **Schedules** API |
+| **BullMQ** | In-process or sidecar `Worker` consuming a Redis queue; we run N worker replicas. | The worker process pulls jobs from Redis | BullMQ **repeatable jobs** (`JobScheduler`) |
+| **pg-boss** | In-process or sidecar pg-boss instance polling Postgres; `boss.work(name, handler)`. | pg-boss polling Postgres | pg-boss **`schedule()`** (cron) |
+| **Inngest** | Functions served over **HTTP** (`serve()` handler mounted in the API or a small service); **Inngest Cloud invokes them** via webhook. | Inngest Cloud calls our HTTP endpoint | Inngest **cron functions** |
+
+Key implications captured for the plan:
+
+- **Trigger.dev and Inngest are "push" (the platform invokes our code)**; **Temporal/BullMQ/pg-boss are "pull" (our worker polls)**. The contract's optional `startWorkerHost()` exists for the pull model (Temporal/BullMQ/pg-boss start a long-lived worker); push providers (Trigger.dev, Inngest) implement it as a no-op or as the HTTP `serve()` mount.
+- **The agent orchestrator must be runtime-agnostic.** Today it's `withWorkerContext()` + a NestJS application context bootstrap. That bootstrap is reused by every pull-model worker; the push-model providers wrap the same bootstrap inside their task/function handler.
+- **Cancellation differs sharply.** Trigger.dev/Temporal have first-class cancel with signal propagation; BullMQ/pg-boss need a cooperative cancel (a cancellation flag the orchestrator polls at each `throwIfGenerationCancelled` checkpoint — the checkpoints already exist). Inngest cancels via its `cancelOn`/event model. The contract's `cancel(runId)` hides this; each provider implements it natively.
+- **`maxDuration` (5h generation).** Trigger.dev supports it directly. Temporal supports arbitrarily long workflows. BullMQ/pg-boss have no hard cap but need lock-renewal/visibility-timeout tuning for multi-hour jobs (documented per provider). Inngest steps have per-step limits — long pipelines must be expressed as multiple steps.
+
+## 6. Status reporting back to the API
+
+Today the worker writes terminal state itself (orchestrator + `onFailure`/`onCancel`) and the API mirrors run ids. The contract keeps this: **the orchestrator remains the source of truth for `WorkGenerationHistory` status**, so most status flows are provider-neutral. `getRunStatus(runId)` is only needed where a provider lacks worker-side terminal writes or where the API polls (e.g. a future UI "live runtime status" panel). Providers that support webhooks (Trigger.dev, Inngest) may push status; pull providers expose `getRunStatus` by querying their store (BullMQ `Job.getState()`, pg-boss `getJobById`, Temporal `DescribeWorkflowExecution`).
+
+## 7. Conformance suite (parity guarantee)
+
+A provider-agnostic contract test in `packages/plugin/src/job-runtime/testing/` exercises every provider identically (mirrors ADR-005's `LockProvider` contract suite):
+
+- enqueue returns an id; the worker runs and writes terminal state
+- idempotency: same `idempotencyKey` → one logical run, retries reuse the history row
+- concurrency: same `concurrencyKey` serialises
+- cancel: in-flight run aborts; orchestrator observes the signal/flag and writes `CANCELLED`
+- schedule: a registered cron fires on cadence
+- disabled/unreachable runtime: enqueue returns `null`, API falls back in-process (dev)
+
+A provider is not "supported" until green on this suite. Until then it ships behind an `experimental` flag.
+
+## 8. Configuration contract
+
+Selector + per-provider settings (full matrix in [`providers.md`](../features/job-runtime-providers/providers.md)). Illustrative:
+
+```bash
+# Selector (default trigger — existing deployments need nothing)
+EVER_WORKS_JOB_RUNTIME=trigger
+
+# trigger  (unchanged — see trigger-integration.md §12)
+TRIGGER_SECRET_KEY=...           TRIGGER_API_URL=https://api.trigger.dev
+TRIGGER_INTERNAL_SECRET=...      TRIGGER_MACHINE=medium-1x
+
+# temporal
+TEMPORAL_ADDRESS=temporal.internal:7233   TEMPORAL_NAMESPACE=ever-works
+TEMPORAL_TASK_QUEUE=ever-works-jobs
+TEMPORAL_TLS_CERT / TEMPORAL_TLS_KEY      # for Temporal Cloud (mTLS)
+
+# bullmq (Redis-only)
+BULLMQ_REDIS_URL=redis://...     BULLMQ_PREFIX=ew  BULLMQ_CONCURRENCY=5
+
+# pgboss (Postgres-native — can reuse the platform DB)
+PGBOSS_DATABASE_URL=postgres://... (defaults to platform DATABASE_URL)
+PGBOSS_SCHEMA=pgboss
+
+# inngest (SaaS only)
+INNGEST_EVENT_KEY=...   INNGEST_SIGNING_KEY=...   INNGEST_APP_ID=ever-works
+```
+
+The internal SuperJSON callback channel (`TRIGGER_INTERNAL_SECRET`, internal base URL) is **provider-neutral** — every pull-model worker still calls back to `/internal/*` over the same authenticated RPC. The env names may be generalised (`EVER_WORKS_INTERNAL_SECRET`) with the `TRIGGER_*` names kept as aliases for back-compat.
+
+## 9. Coexistence & migration
+
+- **Default path is byte-for-byte unchanged.** No `EVER_WORKS_JOB_RUNTIME` → `trigger`. The `trigger` provider IS the current `TriggerService`, re-housed.
+- **Switching runtimes is a deploy-time action**, not a live migration. In-flight runs drain on the old runtime (or are re-enqueued idempotently). Documented in the per-provider deploy guide.
+- **Self-hosted Trigger.dev** ([EW-592](https://evertech.atlassian.net/browse/EW-592)) = `trigger` provider with `TRIGGER_API_URL` pointed at the self-hosted instance. No new provider needed for that case.
+
+## 10. File index (proposed)
+
+```
+packages/plugin/src/job-runtime/
+├── job-runtime.contract.ts          # IJobRuntimeProvider, JobRunStatus, ScheduleSpec, options
+├── job-runtime.category.ts          # capability registration ('job-runtime')
+└── testing/
+    └── job-runtime.contract.spec.ts # provider-agnostic conformance suite
+
+packages/agent/src/tasks/
+├── *.dispatcher.ts                  # EXISTING dispatcher interfaces (unchanged)
+└── job-runtime.providers.ts         # NEW factory: EVER_WORKS_JOB_RUNTIME → bind symbols
+
+packages/plugins/
+├── job-runtime-trigger/             # re-housed TriggerService (default)
+├── job-runtime-temporal/            # @temporalio/* worker + workflows + activities
+├── job-runtime-bullmq/              # bullmq Queue + Worker + JobScheduler
+├── job-runtime-pgboss/              # pg-boss boss.work + schedule
+└── job-runtime-inngest/             # inngest serve() + functions (SaaS)
+
+packages/tasks/                      # remains the trigger provider's worker package
+                                     # (other pull providers get sibling worker entrypoints)
+```
+
+## 11. See Also
+
+- [ADR-015](../decisions/015-job-runtime-provider-pluggability.md) — decision + rationale.
+- [`features/job-runtime-providers/spec.md`](../features/job-runtime-providers/spec.md) · [`plan.md`](../features/job-runtime-providers/plan.md) · [`tasks.md`](../features/job-runtime-providers/tasks.md) · [`providers.md`](../features/job-runtime-providers/providers.md)
+- [`trigger-integration.md`](./trigger-integration.md) · [`trigger-worker.md`](./trigger-worker.md) — the current integration, generalised here.
+- [`plugin-sdk.md`](./plugin-sdk.md) — the plugin contract every provider extends.
+- [ADR-005](../decisions/005-cache-and-lock-pluggability.md) — the sibling env-selected-backend pattern.
+- [`features/scheduled-updates/spec.md`](../features/scheduled-updates/spec.md) — the CAS-claim contract the cron dispatcher relies on, runtime-neutral.

--- a/docs/specs/decisions/015-job-runtime-provider-pluggability.md
+++ b/docs/specs/decisions/015-job-runtime-provider-pluggability.md
@@ -1,0 +1,109 @@
+# ADR-015: Job-Runtime Provider Pluggability — Keep Trigger.dev default, make the background-job runtime a swappable provider (Temporal / BullMQ / pg-boss / Inngest)
+
+## Status
+
+**Proposed** — Tracking implementation in [EW-685](https://evertech.atlassian.net/browse/EW-685). This ADR is forward-looking; **nothing changes today**. Trigger.dev (SaaS) stays the default background-job runtime and remains fully supported. No deployment is forced to change anything.
+
+## Date
+
+- 2026-05-28 — Initial.
+
+## Context
+
+Every long-running operation on the platform — work generation, work import, onboarding, scheduled dispatch, KB embedding, webhook delivery, agent heartbeats, the deploy-ready poller, mission ticks — runs on **Trigger.dev**, today exclusively against the Trigger.dev **SaaS cloud** (`api.trigger.dev`, project `proj_uevrbfmpvojzzazvhffy`). See [`architecture/trigger-integration.md`](../architecture/trigger-integration.md) and [`architecture/trigger-worker.md`](../architecture/trigger-worker.md).
+
+The integration is already cleanly layered (this is the key enabling fact for this ADR):
+
+- The **agent package owns dispatcher interfaces** — `WorkGenerationDispatcher`, `WorkImportDispatcher`, `TemplateCustomizationDispatcher`, `WebhookDeliveryDispatcher`, the four KB dispatchers, the agent dispatchers — each a small interface + a DI `Symbol` (`packages/agent/src/tasks/*.dispatcher.ts`). The API depends only on these symbols and **never imports `@trigger.dev/sdk` directly**.
+- The **tasks package implements them** — `TriggerService` (`packages/tasks/src/trigger/trigger.service.ts`) implements all dispatcher interfaces, lazy-configures `@trigger.dev/sdk`, and returns `null` when Trigger.dev is disabled so the API can fall back to in-process execution.
+- Business logic lives in `@ever-works/agent`, orthogonal to the runtime. Tasks are thin orchestration; the worker calls back to the API over a narrow SuperJSON RPC channel (`/internal/trigger/*`). The runtime only owns **enqueue, schedule, retry, cancel, run status, and worker hosting** — not the work itself.
+
+This was built deliberately as a "Background Job Manager Abstraction Layer" ([EW-169](https://evertech.atlassian.net/browse/EW-169), Done, under [EW-168](https://evertech.atlassian.net/browse/EW-168) "Conditional Trigger.dev Support"). The dispatcher seam is exactly the right place to make the runtime swappable.
+
+**Why make the runtime pluggable now?** Ever Works is an **open-source, self-hostable** product as much as a hosted SaaS ("runs on your machine, your cloud, or ours"). The single hard dependency on Trigger.dev SaaS is the one piece of the long-running-work story that a self-hoster cannot fully own:
+
+1. **Self-hosting / data residency / air-gap.** Operators running the OSS distribution in their own cloud (or fully offline) want a runtime they control end-to-end, without sending payloads to a third-party SaaS. Trigger.dev *can* be self-hosted on Kubernetes ([EW-592](https://evertech.atlassian.net/browse/EW-592)), but it is operationally heavy, and some operators would rather use a runtime they already run.
+2. **Reuse existing infrastructure investments.** Operators who already run **Temporal**, a **Redis + BullMQ** tier, or just **PostgreSQL** want to point Ever Works at what they have rather than stand up Trigger.dev.
+3. **"Just PostgreSQL" deployments.** Mirroring [ADR-005](./005-cache-and-lock-pluggability.md) (cache/lock pluggability), a small self-hoster should be able to run the whole platform on a single PostgreSQL instance with **no Redis and no external SaaS** — which means a Postgres-native queue option (pg-boss) for background jobs.
+4. **Durability / workflow semantics at scale.** Larger deployments may want Temporal's durable-execution and long-history guarantees for the multi-hour generation pipeline.
+5. **Avoid lock-in as a product principle.** "You own everything, nothing is locked in" is a load-bearing brand claim. Locking the runtime to one SaaS undercuts it.
+
+The question is not "Trigger.dev vs X" — it is whether we **lock the runtime to one option** or make it a **selectable provider** so each deployment chooses, exactly as we decided for cache/lock in ADR-005.
+
+## Decision
+
+The background-job runtime becomes a **pluggable provider** selected at deployment time, expressed through the platform's existing **plugin system** (a new `job-runtime` capability) and selected by environment, **defaulting to Trigger.dev**. Concretely:
+
+1. **Introduce a `job-runtime` capability + `IJobRuntimeProvider` contract** in `packages/plugin/`. A job-runtime provider supplies: enqueue (one provider object implementing all agent dispatcher interfaces), scheduling (cron/recurring), cancellation, run-status reporting back to the API, and a worker-hosting model. See [`architecture/job-runtime-providers.md`](../architecture/job-runtime-providers.md) for the full contract.
+
+2. **Refactor the current Trigger.dev integration into the first provider** — `@ever-works/plugin-job-runtime-trigger` — by moving `TriggerService` behind `IJobRuntimeProvider`. **No behaviour change** for existing deployments; this is a pure re-housing of working code.
+
+3. **Add four sibling providers**, each enable/disable-able and configurable through the standard plugin settings system (`x-secret`, `x-envVar`, JSON-Schema), and each documenting its self-host vs SaaS story:
+   - **Temporal** (`@ever-works/plugin-job-runtime-temporal`) — self-hosted (the platform stands up / connects to a Temporal Service) **or** remote self-managed cluster **or** Temporal Cloud (mTLS). Server is MIT-licensed and free to self-host.
+   - **BullMQ** (`@ever-works/plugin-job-runtime-bullmq`) — Redis-backed queue. Connects to a local, remote, or managed Redis (ElastiCache / Upstash / Redis Cloud). BullMQ is **Redis-only** by design.
+   - **pg-boss** (`@ever-works/plugin-job-runtime-pgboss`) — **PostgreSQL-native** queue. Reuses the platform's existing PostgreSQL with no Redis and no SaaS. This is the "just Postgres" answer to the "BullMQ with Redis *or* PostgreSQL" requirement (BullMQ cannot use Postgres; pg-boss is the Postgres path).
+   - **Inngest** (`@ever-works/plugin-job-runtime-inngest`) — **SaaS only** (Inngest Cloud). Inngest *is* technically self-hostable, but its server + CLI ship under the **SSPL** (converting to Apache-2.0 only after a 3-year delay), which is legally incompatible with offering it inside a commercial multi-tenant SaaS. We therefore scope Inngest to its managed cloud and document the licensing rationale rather than the technical one. See [`features/job-runtime-providers/providers.md`](../features/job-runtime-providers/providers.md#inngest).
+
+4. **Selection is instance-global, env-driven, with exactly one active runtime per deployment** — a new `EVER_WORKS_JOB_RUNTIME={trigger,temporal,bullmq,pgboss,inngest}` (default `trigger`), mirroring ADR-005's `EVER_WORKS_CACHE_BACKEND` / `EVER_WORKS_LOCK_BACKEND`. Unlike AI/search/deployment plugins (which resolve per-user/per-work), the job runtime is **deployment infrastructure**: one active provider, chosen by the operator, scoped global/admin — like the cache and lock backends, and like the `k8s` deployment plugin's admin-only config.
+
+5. **All providers pass one shared conformance suite.** A provider-agnostic contract test (enqueue → run → status → cancel → schedule → retry/idempotency) runs against every provider; a provider is not "done" until it passes identically. Mirrors ADR-005's shared `LockProvider` contract suite.
+
+### What does NOT change
+
+- **Trigger.dev (SaaS) remains the default and is fully supported.** Existing dev/stage/prod deployments need **zero** config change — absent `EVER_WORKS_JOB_RUNTIME`, the platform behaves exactly as today.
+- The dispatcher interfaces (`packages/agent/src/tasks/*.dispatcher.ts`), the SuperJSON internal callback channel, the pre-created `historyId` contract, the in-process dev fallback, and the agent business logic all stay as-is. They become **provider-neutral** rather than Trigger.dev-specific.
+- Self-hosted **Trigger.dev** on Kubernetes ([EW-592](https://evertech.atlassian.net/browse/EW-592)) remains a valid path — it is just "the Trigger.dev provider pointed at a self-hosted `TRIGGER_API_URL`," now one option among several.
+
+### Out of scope for this ADR
+
+- Running **multiple** job runtimes simultaneously / per-work runtime routing. v1 is one active runtime per deployment. A later ADR can add routing if a real need appears.
+- Replacing cache/lock backends — that is [ADR-005](./005-cache-and-lock-pluggability.md)'s concern. (The two compose: a "just Postgres" deployment = pg-boss runtime + TypeORM cache + Postgres lock.)
+- Migrating *in-flight* runs between providers. Switching runtime is a deploy-time decision; in-flight runs drain on the old runtime or are re-enqueued.
+- Changing what the tasks *do*. Business logic in `@ever-works/agent` is untouched.
+
+### Constitution note
+
+[Constitution](https://github.com/ever-works/ever-works/blob/develop/.specify/memory/constitution.md) **Principle IV** currently reads "Long-running work via Trigger.dev." This ADR generalises it to "Long-running work via the **configured job-runtime provider** (Trigger.dev default)." That is a constitution amendment and must land as part of this initiative's first PR (Principle IV text + this ADR cross-link). Flagged here so the gate check in the feature spec (`spec.md` §9 / `plan.md` §12) is honest rather than silently in conflict.
+
+## Consequences
+
+**Positive**
+
+- Self-hosters and air-gapped operators get a runtime they fully own (Temporal self-host, BullMQ-on-own-Redis, or pure pg-boss-on-Postgres) — strengthens the "you own everything, nothing locked in" promise.
+- "Just PostgreSQL" deployments become possible end-to-end (pg-boss runtime + ADR-005 Postgres cache/lock = zero external dependencies).
+- The hosted SaaS keeps Trigger.dev with no disruption; large operators can opt into Temporal for durable-execution semantics.
+- The dispatcher seam gets a real second (third, fourth, fifth) implementation, which validates and hardens the abstraction that EW-169 introduced.
+
+**Negative**
+
+- Five runtime providers to keep at feature parity in the conformance suite, docs, and CI. Mitigated by: (a) the shared contract test, (b) staging providers behind "experimental" flags until they pass, (c) only Trigger.dev being a supported-default — others are opt-in and best-effort until proven.
+- Each provider has a genuinely different **worker-hosting** model (Trigger.dev deploys tasks to its cloud; Temporal runs polling workers; BullMQ/pg-boss run in-process or sidecar workers; Inngest serves functions over HTTP that Inngest invokes). This is the hard part and is the bulk of the implementation effort — see [`architecture/job-runtime-providers.md`](../architecture/job-runtime-providers.md) §"Worker-hosting models."
+- Operators choosing a non-default runtime pick up its operational concerns (Redis persistence/eviction, Temporal cluster ops, etc.) — their explicit choice.
+
+**Neutral**
+
+- No new dependency on the default path. Each non-Trigger provider's SDK is isolated in its own optional plugin package (`peerDependencies` for `@ever-works/plugin`, runtime deps for the vendor SDK), installed only when that provider is enabled. Per workstation Non-Negotiable #22 and CLAUDE.md, each provider uses the **official vendor SDK** (`@trigger.dev/sdk`, `@temporalio/*`, `bullmq`, `pg-boss`, `inngest`) — never a hand-rolled client.
+
+## Implementation outline
+
+Tracked in [EW-685](https://evertech.atlassian.net/browse/EW-685). Full detail in the feature spec set under [`features/job-runtime-providers/`](../features/job-runtime-providers/spec.md). High-level shape:
+
+1. Define the `job-runtime` capability + `IJobRuntimeProvider` contract in `packages/plugin/src/job-runtime/`.
+2. Generalise the dispatcher wiring so the active provider is bound to all `*_DISPATCHER` symbols via a factory that reads `EVER_WORKS_JOB_RUNTIME`.
+3. Re-house the current Trigger.dev integration as the `trigger` provider (no behaviour change) and prove the conformance suite green against it.
+4. Build the provider conformance test harness (`packages/plugin/src/job-runtime/testing/`).
+5. Implement Temporal, BullMQ, pg-boss, Inngest providers behind experimental flags, each green on the conformance suite.
+6. Worker-hosting: define how each provider hosts the worker that runs `@ever-works/agent` orchestrators (Docker/compose + k8s manifests + `pnpm` scripts per provider).
+7. Docs: provider matrix, per-provider deploy guides, `EVER_WORKS_JOB_RUNTIME` env, and amend Principle IV in the constitution.
+
+## References
+
+- [EW-685 — Job-runtime provider pluggability (epic)](https://evertech.atlassian.net/browse/EW-685)
+- [`architecture/job-runtime-providers.md`](../architecture/job-runtime-providers.md) — the provider contract + worker-hosting models.
+- [`features/job-runtime-providers/spec.md`](../features/job-runtime-providers/spec.md) · [`plan.md`](../features/job-runtime-providers/plan.md) · [`tasks.md`](../features/job-runtime-providers/tasks.md) · [`providers.md`](../features/job-runtime-providers/providers.md)
+- [ADR-005 — Cache and Lock Pluggability](./005-cache-and-lock-pluggability.md) — the sibling pattern this ADR mirrors (env-selected, Postgres-default, additive).
+- [ADR-002 — Trigger worker callback channel](./002-trigger-worker-callback-channel.md) — the SuperJSON RPC seam that every provider must preserve.
+- [`architecture/trigger-integration.md`](../architecture/trigger-integration.md) · [`architecture/trigger-worker.md`](../architecture/trigger-worker.md) — current integration this ADR generalises.
+- [EW-168](https://evertech.atlassian.net/browse/EW-168) / [EW-169](https://evertech.atlassian.net/browse/EW-169) — original conditional-Trigger.dev + background-job abstraction layer (Done) this builds on.
+- [EW-592](https://evertech.atlassian.net/browse/EW-592) — self-hosted Trigger.dev on Kubernetes (subsumed as "the trigger provider, self-hosted URL").
+- [EW-475](https://evertech.atlassian.net/browse/EW-475) — Ever Works Plugin System (the host for the new capability).

--- a/docs/specs/decisions/015-job-runtime-provider-pluggability.md
+++ b/docs/specs/decisions/015-job-runtime-provider-pluggability.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Proposed** — Tracking implementation in [EW-685](https://evertech.atlassian.net/browse/EW-685). This ADR is forward-looking; **nothing changes today**. Trigger.dev (SaaS) stays the default background-job runtime and remains fully supported. No deployment is forced to change anything.
+**Proposed** — Tracking implementation in [EW-683](https://evertech.atlassian.net/browse/EW-683). This ADR is forward-looking; **nothing changes today**. Trigger.dev (SaaS) stays the default background-job runtime and remains fully supported. No deployment is forced to change anything.
 
 ## Date
 
@@ -86,7 +86,7 @@ The background-job runtime becomes a **pluggable provider** selected at deployme
 
 ## Implementation outline
 
-Tracked in [EW-685](https://evertech.atlassian.net/browse/EW-685). Full detail in the feature spec set under [`features/job-runtime-providers/`](../features/job-runtime-providers/spec.md). High-level shape:
+Tracked in [EW-683](https://evertech.atlassian.net/browse/EW-683). Full detail in the feature spec set under [`features/job-runtime-providers/`](../features/job-runtime-providers/spec.md). High-level shape:
 
 1. Define the `job-runtime` capability + `IJobRuntimeProvider` contract in `packages/plugin/src/job-runtime/`.
 2. Generalise the dispatcher wiring so the active provider is bound to all `*_DISPATCHER` symbols via a factory that reads `EVER_WORKS_JOB_RUNTIME`.
@@ -98,7 +98,7 @@ Tracked in [EW-685](https://evertech.atlassian.net/browse/EW-685). Full detail i
 
 ## References
 
-- [EW-685 — Job-runtime provider pluggability (epic)](https://evertech.atlassian.net/browse/EW-685)
+- [EW-683 — Job-runtime provider pluggability (epic)](https://evertech.atlassian.net/browse/EW-683)
 - [`architecture/job-runtime-providers.md`](../architecture/job-runtime-providers.md) — the provider contract + worker-hosting models.
 - [`features/job-runtime-providers/spec.md`](../features/job-runtime-providers/spec.md) · [`plan.md`](../features/job-runtime-providers/plan.md) · [`tasks.md`](../features/job-runtime-providers/tasks.md) · [`providers.md`](../features/job-runtime-providers/providers.md)
 - [ADR-005 — Cache and Lock Pluggability](./005-cache-and-lock-pluggability.md) — the sibling pattern this ADR mirrors (env-selected, Postgres-default, additive).

--- a/docs/specs/decisions/015-job-runtime-provider-pluggability.md
+++ b/docs/specs/decisions/015-job-runtime-provider-pluggability.md
@@ -22,7 +22,7 @@ This was built deliberately as a "Background Job Manager Abstraction Layer" ([EW
 
 **Why make the runtime pluggable now?** Ever Works is an **open-source, self-hostable** product as much as a hosted SaaS ("runs on your machine, your cloud, or ours"). The single hard dependency on Trigger.dev SaaS is the one piece of the long-running-work story that a self-hoster cannot fully own:
 
-1. **Self-hosting / data residency / air-gap.** Operators running the OSS distribution in their own cloud (or fully offline) want a runtime they control end-to-end, without sending payloads to a third-party SaaS. Trigger.dev *can* be self-hosted on Kubernetes ([EW-592](https://evertech.atlassian.net/browse/EW-592)), but it is operationally heavy, and some operators would rather use a runtime they already run.
+1. **Self-hosting / data residency / air-gap.** Operators running the OSS distribution in their own cloud (or fully offline) want a runtime they control end-to-end, without sending payloads to a third-party SaaS. Trigger.dev _can_ be self-hosted on Kubernetes ([EW-592](https://evertech.atlassian.net/browse/EW-592)), but it is operationally heavy, and some operators would rather use a runtime they already run.
 2. **Reuse existing infrastructure investments.** Operators who already run **Temporal**, a **Redis + BullMQ** tier, or just **PostgreSQL** want to point Ever Works at what they have rather than stand up Trigger.dev.
 3. **"Just PostgreSQL" deployments.** Mirroring [ADR-005](./005-cache-and-lock-pluggability.md) (cache/lock pluggability), a small self-hoster should be able to run the whole platform on a single PostgreSQL instance with **no Redis and no external SaaS** — which means a Postgres-native queue option (pg-boss) for background jobs.
 4. **Durability / workflow semantics at scale.** Larger deployments may want Temporal's durable-execution and long-history guarantees for the multi-hour generation pipeline.
@@ -39,10 +39,10 @@ The background-job runtime becomes a **pluggable provider** selected at deployme
 2. **Refactor the current Trigger.dev integration into the first provider** — `@ever-works/plugin-job-runtime-trigger` — by moving `TriggerService` behind `IJobRuntimeProvider`. **No behaviour change** for existing deployments; this is a pure re-housing of working code.
 
 3. **Add four sibling providers**, each enable/disable-able and configurable through the standard plugin settings system (`x-secret`, `x-envVar`, JSON-Schema), and each documenting its self-host vs SaaS story:
-   - **Temporal** (`@ever-works/plugin-job-runtime-temporal`) — self-hosted (the platform stands up / connects to a Temporal Service) **or** remote self-managed cluster **or** Temporal Cloud (mTLS). Server is MIT-licensed and free to self-host.
-   - **BullMQ** (`@ever-works/plugin-job-runtime-bullmq`) — Redis-backed queue. Connects to a local, remote, or managed Redis (ElastiCache / Upstash / Redis Cloud). BullMQ is **Redis-only** by design.
-   - **pg-boss** (`@ever-works/plugin-job-runtime-pgboss`) — **PostgreSQL-native** queue. Reuses the platform's existing PostgreSQL with no Redis and no SaaS. This is the "just Postgres" answer to the "BullMQ with Redis *or* PostgreSQL" requirement (BullMQ cannot use Postgres; pg-boss is the Postgres path).
-   - **Inngest** (`@ever-works/plugin-job-runtime-inngest`) — **SaaS only** (Inngest Cloud). Inngest *is* technically self-hostable, but its server + CLI ship under the **SSPL** (converting to Apache-2.0 only after a 3-year delay), which is legally incompatible with offering it inside a commercial multi-tenant SaaS. We therefore scope Inngest to its managed cloud and document the licensing rationale rather than the technical one. See [`features/job-runtime-providers/providers.md`](../features/job-runtime-providers/providers.md#inngest).
+    - **Temporal** (`@ever-works/plugin-job-runtime-temporal`) — self-hosted (the platform stands up / connects to a Temporal Service) **or** remote self-managed cluster **or** Temporal Cloud (mTLS). Server is MIT-licensed and free to self-host.
+    - **BullMQ** (`@ever-works/plugin-job-runtime-bullmq`) — Redis-backed queue. Connects to a local, remote, or managed Redis (ElastiCache / Upstash / Redis Cloud). BullMQ is **Redis-only** by design.
+    - **pg-boss** (`@ever-works/plugin-job-runtime-pgboss`) — **PostgreSQL-native** queue. Reuses the platform's existing PostgreSQL with no Redis and no SaaS. This is the "just Postgres" answer to the "BullMQ with Redis _or_ PostgreSQL" requirement (BullMQ cannot use Postgres; pg-boss is the Postgres path).
+    - **Inngest** (`@ever-works/plugin-job-runtime-inngest`) — **SaaS only** (Inngest Cloud). Inngest _is_ technically self-hostable, but its server + CLI ship under the **SSPL** (converting to Apache-2.0 only after a 3-year delay), which is legally incompatible with offering it inside a commercial multi-tenant SaaS. We therefore scope Inngest to its managed cloud and document the licensing rationale rather than the technical one. See [`features/job-runtime-providers/providers.md`](../features/job-runtime-providers/providers.md#inngest).
 
 4. **Selection is instance-global, env-driven, with exactly one active runtime per deployment** — a new `EVER_WORKS_JOB_RUNTIME={trigger,temporal,bullmq,pgboss,inngest}` (default `trigger`), mirroring ADR-005's `EVER_WORKS_CACHE_BACKEND` / `EVER_WORKS_LOCK_BACKEND`. Unlike AI/search/deployment plugins (which resolve per-user/per-work), the job runtime is **deployment infrastructure**: one active provider, chosen by the operator, scoped global/admin — like the cache and lock backends, and like the `k8s` deployment plugin's admin-only config.
 
@@ -58,8 +58,8 @@ The background-job runtime becomes a **pluggable provider** selected at deployme
 
 - Running **multiple** job runtimes simultaneously / per-work runtime routing. v1 is one active runtime per deployment. A later ADR can add routing if a real need appears.
 - Replacing cache/lock backends — that is [ADR-005](./005-cache-and-lock-pluggability.md)'s concern. (The two compose: a "just Postgres" deployment = pg-boss runtime + TypeORM cache + Postgres lock.)
-- Migrating *in-flight* runs between providers. Switching runtime is a deploy-time decision; in-flight runs drain on the old runtime or are re-enqueued.
-- Changing what the tasks *do*. Business logic in `@ever-works/agent` is untouched.
+- Migrating _in-flight_ runs between providers. Switching runtime is a deploy-time decision; in-flight runs drain on the old runtime or are re-enqueued.
+- Changing what the tasks _do_. Business logic in `@ever-works/agent` is untouched.
 
 ### Constitution note
 

--- a/docs/specs/features/job-runtime-providers/plan.md
+++ b/docs/specs/features/job-runtime-providers/plan.md
@@ -1,0 +1,154 @@
+# Implementation Plan: Job-Runtime Provider Pluggability
+
+> Translates [`spec.md`](./spec.md) into architecture and tech choices. Behaviour lives in the spec; this owns the "how." Provider research: [`providers.md`](./providers.md). Rationale: [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md). Deep architecture: [`architecture/job-runtime-providers.md`](../../architecture/job-runtime-providers.md).
+
+**Feature ID**: `job-runtime-providers`
+**Spec**: `./spec.md`
+**Tasks**: `./tasks.md`
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+
+---
+
+## 1. Architecture Summary
+
+```mermaid
+flowchart LR
+    A[API dispatch call sites] -->|*_DISPATCHER symbols| B[Active IJobRuntimeProvider]
+    B -. EVER_WORKS_JOB_RUNTIME .-> T[trigger]
+    B --> TE[temporal]
+    B --> BU[bullmq]
+    B --> PG[pgboss]
+    B --> IN[inngest]
+    T --> W[Worker host: @ever-works/agent orchestrators]
+    TE --> W
+    BU --> W
+    PG --> W
+    IN --> W
+    W -->|SuperJSON RPC /internal/*| A
+    W --> DB[(WorkGenerationHistory status)]
+```
+
+The seam already exists (dispatcher interfaces + DI symbols, [`architecture/job-runtime-providers.md`](../../architecture/job-runtime-providers.md) §2). The plan binds those symbols to the active provider instead of `TriggerService`, builds the contract + conformance harness, re-houses Trigger.dev, then adds four providers.
+
+## 2. Tech Choices
+
+| Concern | Choice | Rationale |
+| --- | --- | --- |
+| Abstraction | New `job-runtime` capability + `IJobRuntimeProvider` in `packages/plugin/` | Plugin-first (Principle I); mirrors existing capabilities. |
+| Selection | `EVER_WORKS_JOB_RUNTIME` env, default `trigger` | Mirrors ADR-005 `EVER_WORKS_*_BACKEND`; infra is global, not per-user. |
+| Trigger provider | Re-house existing `TriggerService` | Zero behaviour change; lowest risk. |
+| Temporal | `@temporalio/{client,worker,workflow,activity}` | Official SDK (NN #22); MIT server, free self-host + Cloud. |
+| BullMQ | `bullmq` | Official SDK; already a transitive dep; Redis-native. |
+| Postgres queue | `pg-boss` | Postgres-native (BullMQ can't do Postgres); reuses platform DB. |
+| Inngest | `inngest` | Official SDK; SaaS-only (SSPL). |
+| Conformance | Shared Vitest/Jest suite against `IJobRuntimeProvider` | Mirrors ADR-005 `LockProvider` contract suite. |
+| Worker hosting | Per-provider entrypoints + compose/k8s artifacts | Models genuinely differ (push vs pull); cannot fully abstract. |
+
+## 3. Data Model
+
+### New entities
+
+None required on the platform schema for the core abstraction. Run state continues to live in `WorkGenerationHistory` (`triggerRunId` generalised to `runtimeRunId`, with `triggerRunId` kept as an alias column read-path for back-compat).
+
+Optional (later): a small `job_runtime_runs` mirror table if we want a provider-neutral run index for an admin UI. **Not** in v1.
+
+### Migrations
+
+- If `triggerRunId` → `runtimeRunId` rename is adopted: **forward-only, two-phase** (add `runtimeRunId`, backfill from `triggerRunId`, dual-write, switch reads, drop later) per [`database.md`](../../architecture/database.md) §6.2 and workstation NN #16. Default plan: **keep `triggerRunId` as-is**, treat it as the opaque run id for all providers (cheaper, no migration). Decide in tasks T2.
+- **pg-boss** creates its own `pgboss` schema in the platform DB on `boss.start()` — isolated, additive, not a platform migration.
+
+### DTOs / contracts
+
+`@ever-works/contracts` unchanged for external API consumers. New internal types (`JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`) live in `packages/plugin/src/job-runtime/`.
+
+## 4. API Surface
+
+No new public endpoints. The internal callback controller (`/internal/trigger/*`) is generalised to `/internal/jobs/*` with `/internal/trigger/*` kept as an alias route (back-compat for the in-flight Trigger.dev worker during rollout). Auth header generalised `x-trigger-secret` → `x-internal-secret` (alias retained).
+
+| Method | Endpoint | Description | Status |
+| --- | --- | --- | --- |
+| `POST` | `/internal/jobs/remote/call` | SuperJSON RPC (was `/internal/trigger/remote/call`) | Generalised |
+| `GET` | `/internal/jobs/works/:id/context` | Worker work/user/token context | Generalised |
+
+## 5. Plugin Surface
+
+- **New capability** `job-runtime` → declare in `packages/plugin/src/job-runtime/job-runtime.category.ts` + `IJobRuntimeProvider` contract.
+- **New plugins** under `packages/plugins/`: `job-runtime-trigger` (re-house), `job-runtime-temporal`, `job-runtime-bullmq`, `job-runtime-pgboss`, `job-runtime-inngest`. Each: `package.json` with `everworks.plugin` (category `job-runtime`, `configurationMode: 'admin-only'`), tsup build, vitest, settings JSON-Schema with `x-secret`/`x-envVar`/`x-scope: global`.
+- **Binding factory** `packages/agent/src/tasks/job-runtime.providers.ts` resolves the active provider and binds all `*_DISPATCHER` symbols to it.
+
+## 6. Web / CLI Surface
+
+- **Web**: none for v1 (no end-user runtime picker). Optionally, an admin read-only "active runtime" badge in settings (nice-to-have, not required).
+- **CLI / internal-cli**: a `job-runtime status` diagnostic (which provider is active + reachability) — optional.
+- **MCP**: none.
+
+## 7. Background Jobs
+
+The recurring jobs that exist today must be expressed per provider (each provider's native cron):
+
+| Trigger | When | What it does | Idempotency strategy |
+| --- | --- | --- | --- |
+| schedule dispatcher | every N min | claim + dispatch due `WorkSchedule`s | runtime-neutral CAS claim ([`scheduled-updates`](../scheduled-updates/spec.md)) |
+| deploy-ready poller | every 2 min | flip mid-deploy works to READY | idempotent poll |
+| agent heartbeat dispatcher | every N min | dispatch agent heartbeats | CAS claim |
+| data-repo-sync / recurrence / mission-tick / research-rerun | various | existing cron tasks | existing idempotency |
+
+Each provider implements these via its scheduler (Trigger.dev `schedules.task`, Temporal Schedules, BullMQ repeatable, pg-boss `schedule`, Inngest cron). The CAS claim makes "exactly one firing per tick" a non-load-bearing convenience, so providers with weaker single-firing guarantees remain correct.
+
+## 8. Security & Permissions
+
+- All provider credentials are `x-secret: true`, `x-scope: global`, resolved through the settings hierarchy; never returned in API responses.
+- The internal callback channel stays authenticated (constant-time secret compare, allow-listed RPC targets, `@SkipThrottle`) — provider-neutral.
+- Self-host/air-gap providers (Temporal/BullMQ/pg-boss) MUST NOT contact any SaaS; verified by the air-gap compose profile test.
+- Inngest's signing-key webhook is the trust boundary for the push model; validate signatures on the `serve()` endpoint.
+
+## 9. Observability
+
+- `WorkGenerationHistory` remains the canonical status surface (status, recentLogs, durationInSeconds) — provider-neutral.
+- Each provider bridges run logs to its native dashboard and to the shared MonitoringModule (Sentry/PostHog), exactly as the Trigger.dev worker does today ([`monitoring.md`](../../architecture/monitoring.md)).
+- Startup logs the active runtime + `experimental` warning when applicable.
+
+## 10. Phased Rollout
+
+1. **Phase 0 — Contract & seam (no behaviour change).** Define `job-runtime` capability + `IJobRuntimeProvider`; build the binding factory bound to `trigger` by default; amend Constitution Principle IV. Ship dark.
+2. **Phase 1 — Re-house Trigger.dev.** Move `TriggerService` into `job-runtime-trigger` behind the contract. Existing trigger e2e suite must pass unchanged. This is the proof the abstraction is faithful.
+3. **Phase 2 — Conformance harness.** Build the provider-agnostic suite; run it green against `trigger`.
+4. **Phase 3 — pg-boss (first new provider).** Highest value (enables "just Postgres" OSS deploys). Worker entrypoint + compose profile + conformance green. GA-track.
+5. **Phase 4 — BullMQ.** Redis worker + compose profile + conformance green. Experimental → GA.
+6. **Phase 5 — Temporal.** Workflow/Activity split + worker deployment + `start-dev` CI + conformance green. Experimental → GA. (Largest lift.)
+7. **Phase 6 — Inngest (SaaS).** `serve()` functions + cron + cancel; documented SaaS-only. Experimental.
+8. **Phase 7 — Docs & matrix.** Provider deploy guides, env reference, plugin-count canonical doc, ADR/architecture cross-links finalised.
+
+Each provider stays behind an `experimental` flag (startup warning) until its conformance suite is green in CI.
+
+## 11. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Re-housing Trigger.dev subtly changes behaviour | Med | High | Phase 1 gate = existing trigger e2e passes unchanged; diff is mechanical move. |
+| Worker-hosting models too different to share orchestrator | Med | High | Keep agent orchestrator + SuperJSON channel reused; only the host wrapper differs per provider; prove with pg-boss first. |
+| Cooperative cancel (BullMQ/pg-boss) leaves zombie runs | Med | Med | Reuse existing `throwIfGenerationCancelled` checkpoints + the three-layer terminal-write defense. |
+| Multi-hour jobs trip BullMQ/pg-boss timeouts | Med | Med | Tune lock renewal / visibility timeout; document; conformance includes a long-job case. |
+| Inngest per-step limits break the long pipeline | Med | Med | Express pipeline as steps under Inngest; keep Inngest experimental; document the constraint. |
+| Five providers rot at different rates | High | Med | Shared conformance suite in CI; non-default = experimental + best-effort; only `trigger` is supported-default. |
+| Maintenance/CI cost | High | Low-Med | Matrix CI runs conformance per provider; providers are independently installable plugins. |
+
+## 12. Constitution Reconciliation
+
+- **I Plugin-first** — providers are plugins. ✓
+- **II Capability-driven** — `job-runtime` capability resolved from registry. ✓
+- **III Source-of-truth repos** — untouched. ✓
+- **IV Long-running work via Trigger.dev** — **AMEND** to "via the configured job-runtime provider (Trigger.dev default)"; ships in Phase 0 PR with ADR-015 cross-link. ⚠️→✓
+- **V Forward-only migrations** — pg-boss schema additive; any `triggerRunId` rename two-phase. ✓
+- **VI Tests** — conformance suite + per-provider e2e. ✓
+- **VII Secrets** — all runtime creds `x-secret`. ✓
+- **VIII Plugin-count canonical doc** — updated as providers land. ✓
+- **IX Behaviour-first** — behaviour in spec, impl here. ✓
+- **X Backwards-compatible** — default path unchanged; additive. ✓
+
+## 13. References
+
+- Spec: [`./spec.md`](./spec.md) · Tasks: [`./tasks.md`](./tasks.md) · Providers: [`./providers.md`](./providers.md)
+- ADRs: [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md), [ADR-005](../../decisions/005-cache-and-lock-pluggability.md), [ADR-002](../../decisions/002-trigger-worker-callback-channel.md)
+- Architecture: [`job-runtime-providers.md`](../../architecture/job-runtime-providers.md), [`trigger-integration.md`](../../architecture/trigger-integration.md), [`trigger-worker.md`](../../architecture/trigger-worker.md)

--- a/docs/specs/features/job-runtime-providers/plan.md
+++ b/docs/specs/features/job-runtime-providers/plan.md
@@ -33,17 +33,17 @@ The seam already exists (dispatcher interfaces + DI symbols, [`architecture/job-
 
 ## 2. Tech Choices
 
-| Concern | Choice | Rationale |
-| --- | --- | --- |
-| Abstraction | New `job-runtime` capability + `IJobRuntimeProvider` in `packages/plugin/` | Plugin-first (Principle I); mirrors existing capabilities. |
-| Selection | `EVER_WORKS_JOB_RUNTIME` env, default `trigger` | Mirrors ADR-005 `EVER_WORKS_*_BACKEND`; infra is global, not per-user. |
-| Trigger provider | Re-house existing `TriggerService` | Zero behaviour change; lowest risk. |
-| Temporal | `@temporalio/{client,worker,workflow,activity}` | Official SDK (NN #22); MIT server, free self-host + Cloud. |
-| BullMQ | `bullmq` | Official SDK; already a transitive dep; Redis-native. |
-| Postgres queue | `pg-boss` | Postgres-native (BullMQ can't do Postgres); reuses platform DB. |
-| Inngest | `inngest` | Official SDK; SaaS-only (SSPL). |
-| Conformance | Shared Vitest/Jest suite against `IJobRuntimeProvider` | Mirrors ADR-005 `LockProvider` contract suite. |
-| Worker hosting | Per-provider entrypoints + compose/k8s artifacts | Models genuinely differ (push vs pull); cannot fully abstract. |
+| Concern          | Choice                                                                     | Rationale                                                              |
+| ---------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Abstraction      | New `job-runtime` capability + `IJobRuntimeProvider` in `packages/plugin/` | Plugin-first (Principle I); mirrors existing capabilities.             |
+| Selection        | `EVER_WORKS_JOB_RUNTIME` env, default `trigger`                            | Mirrors ADR-005 `EVER_WORKS_*_BACKEND`; infra is global, not per-user. |
+| Trigger provider | Re-house existing `TriggerService`                                         | Zero behaviour change; lowest risk.                                    |
+| Temporal         | `@temporalio/{client,worker,workflow,activity}`                            | Official SDK (NN #22); MIT server, free self-host + Cloud.             |
+| BullMQ           | `bullmq`                                                                   | Official SDK; already a transitive dep; Redis-native.                  |
+| Postgres queue   | `pg-boss`                                                                  | Postgres-native (BullMQ can't do Postgres); reuses platform DB.        |
+| Inngest          | `inngest`                                                                  | Official SDK; SaaS-only (SSPL).                                        |
+| Conformance      | Shared Vitest/Jest suite against `IJobRuntimeProvider`                     | Mirrors ADR-005 `LockProvider` contract suite.                         |
+| Worker hosting   | Per-provider entrypoints + compose/k8s artifacts                           | Models genuinely differ (push vs pull); cannot fully abstract.         |
 
 ## 3. Data Model
 
@@ -66,10 +66,10 @@ Optional (later): a small `job_runtime_runs` mirror table if we want a provider-
 
 No new public endpoints. The internal callback controller (`/internal/trigger/*`) is generalised to `/internal/jobs/*` with `/internal/trigger/*` kept as an alias route (back-compat for the in-flight Trigger.dev worker during rollout). Auth header generalised `x-trigger-secret` → `x-internal-secret` (alias retained).
 
-| Method | Endpoint | Description | Status |
-| --- | --- | --- | --- |
-| `POST` | `/internal/jobs/remote/call` | SuperJSON RPC (was `/internal/trigger/remote/call`) | Generalised |
-| `GET` | `/internal/jobs/works/:id/context` | Worker work/user/token context | Generalised |
+| Method | Endpoint                           | Description                                         | Status      |
+| ------ | ---------------------------------- | --------------------------------------------------- | ----------- |
+| `POST` | `/internal/jobs/remote/call`       | SuperJSON RPC (was `/internal/trigger/remote/call`) | Generalised |
+| `GET`  | `/internal/jobs/works/:id/context` | Worker work/user/token context                      | Generalised |
 
 ## 5. Plugin Surface
 
@@ -87,12 +87,12 @@ No new public endpoints. The internal callback controller (`/internal/trigger/*`
 
 The recurring jobs that exist today must be expressed per provider (each provider's native cron):
 
-| Trigger | When | What it does | Idempotency strategy |
-| --- | --- | --- | --- |
-| schedule dispatcher | every N min | claim + dispatch due `WorkSchedule`s | runtime-neutral CAS claim ([`scheduled-updates`](../scheduled-updates/spec.md)) |
-| deploy-ready poller | every 2 min | flip mid-deploy works to READY | idempotent poll |
-| agent heartbeat dispatcher | every N min | dispatch agent heartbeats | CAS claim |
-| data-repo-sync / recurrence / mission-tick / research-rerun | various | existing cron tasks | existing idempotency |
+| Trigger                                                     | When        | What it does                         | Idempotency strategy                                                            |
+| ----------------------------------------------------------- | ----------- | ------------------------------------ | ------------------------------------------------------------------------------- |
+| schedule dispatcher                                         | every N min | claim + dispatch due `WorkSchedule`s | runtime-neutral CAS claim ([`scheduled-updates`](../scheduled-updates/spec.md)) |
+| deploy-ready poller                                         | every 2 min | flip mid-deploy works to READY       | idempotent poll                                                                 |
+| agent heartbeat dispatcher                                  | every N min | dispatch agent heartbeats            | CAS claim                                                                       |
+| data-repo-sync / recurrence / mission-tick / research-rerun | various     | existing cron tasks                  | existing idempotency                                                            |
 
 Each provider implements these via its scheduler (Trigger.dev `schedules.task`, Temporal Schedules, BullMQ repeatable, pg-boss `schedule`, Inngest cron). The CAS claim makes "exactly one firing per tick" a non-load-bearing convenience, so providers with weaker single-firing guarantees remain correct.
 
@@ -124,15 +124,15 @@ Each provider stays behind an `experimental` flag (startup warning) until its co
 
 ## 11. Risks & Mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-| --- | --- | --- | --- |
-| Re-housing Trigger.dev subtly changes behaviour | Med | High | Phase 1 gate = existing trigger e2e passes unchanged; diff is mechanical move. |
-| Worker-hosting models too different to share orchestrator | Med | High | Keep agent orchestrator + SuperJSON channel reused; only the host wrapper differs per provider; prove with pg-boss first. |
-| Cooperative cancel (BullMQ/pg-boss) leaves zombie runs | Med | Med | Reuse existing `throwIfGenerationCancelled` checkpoints + the three-layer terminal-write defense. |
-| Multi-hour jobs trip BullMQ/pg-boss timeouts | Med | Med | Tune lock renewal / visibility timeout; document; conformance includes a long-job case. |
-| Inngest per-step limits break the long pipeline | Med | Med | Express pipeline as steps under Inngest; keep Inngest experimental; document the constraint. |
-| Five providers rot at different rates | High | Med | Shared conformance suite in CI; non-default = experimental + best-effort; only `trigger` is supported-default. |
-| Maintenance/CI cost | High | Low-Med | Matrix CI runs conformance per provider; providers are independently installable plugins. |
+| Risk                                                      | Likelihood | Impact  | Mitigation                                                                                                                |
+| --------------------------------------------------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Re-housing Trigger.dev subtly changes behaviour           | Med        | High    | Phase 1 gate = existing trigger e2e passes unchanged; diff is mechanical move.                                            |
+| Worker-hosting models too different to share orchestrator | Med        | High    | Keep agent orchestrator + SuperJSON channel reused; only the host wrapper differs per provider; prove with pg-boss first. |
+| Cooperative cancel (BullMQ/pg-boss) leaves zombie runs    | Med        | Med     | Reuse existing `throwIfGenerationCancelled` checkpoints + the three-layer terminal-write defense.                         |
+| Multi-hour jobs trip BullMQ/pg-boss timeouts              | Med        | Med     | Tune lock renewal / visibility timeout; document; conformance includes a long-job case.                                   |
+| Inngest per-step limits break the long pipeline           | Med        | Med     | Express pipeline as steps under Inngest; keep Inngest experimental; document the constraint.                              |
+| Five providers rot at different rates                     | High       | Med     | Shared conformance suite in CI; non-default = experimental + best-effort; only `trigger` is supported-default.            |
+| Maintenance/CI cost                                       | High       | Low-Med | Matrix CI runs conformance per provider; providers are independently installable plugins.                                 |
 
 ## 12. Constitution Reconciliation
 

--- a/docs/specs/features/job-runtime-providers/providers.md
+++ b/docs/specs/features/job-runtime-providers/providers.md
@@ -11,27 +11,27 @@
 
 ## 1. Capability matrix
 
-| Dimension | **Trigger.dev** (default) | **Temporal** | **BullMQ** | **pg-boss** | **Inngest** |
-| --- | --- | --- | --- | --- | --- |
-| Primary store | Trigger.dev cloud / self-host (Postgres+Redis under the hood) | Temporal Service (Cassandra/Postgres/MySQL) | **Redis only** | **PostgreSQL only** | Inngest cloud |
-| Self-host? | ✅ (k8s, heavy) | ✅ (free, MIT) | ✅ (you run Redis) | ✅ (you run Postgres) | ⚠️ technically yes, but **SSPL** — see §6 |
-| Remote self-managed? | ✅ (`TRIGGER_API_URL`) | ✅ (any cluster) | ✅ (managed Redis) | ✅ (managed Postgres) | n/a |
-| SaaS / managed? | ✅ (default today) | ✅ (Temporal Cloud, mTLS) | via managed Redis only | via managed Postgres only | ✅ (the only supported mode) |
-| Licence (engine) | Apache-2.0 (self-host components) | **MIT** | MIT | MIT | **SSPL** → Apache-2.0 after 3y delay |
-| Official SDK (TS) | `@trigger.dev/sdk` | `@temporalio/{client,worker,workflow,activity}` | `bullmq` | `pg-boss` | `inngest` |
-| Worker model | Tasks deployed to platform; platform runs them | Long-running worker polls task queue | Worker process consumes Redis | In-process/sidecar polls Postgres | Functions served over HTTP; cloud invokes |
-| Push or pull | Push (platform invokes) | Pull (worker polls) | Pull (worker polls) | Pull (worker polls) | Push (cloud invokes via HTTP) |
-| Native cron | `schedules.task` | Schedules API | repeatable jobs / `JobScheduler` | `schedule()` | cron functions |
-| Native cancel | ✅ signal | ✅ signal | cooperative (flag) | cooperative (flag) | `cancelOn` / events |
-| Durable multi-hour run | ✅ (`maxDuration` 5h) | ✅ (best-in-class) | ⚠️ tune lock renewal | ⚠️ tune visibility timeout | ⚠️ express as steps |
-| Idempotency primitive | `idempotencyKey` | workflow id | job id | job id / singleton key | event idempotency id |
-| "Just Postgres" deploy | ❌ | ❌ (needs its DB) | ❌ (needs Redis) | ✅ **reuses platform DB** | ❌ |
-| Recommended for | hosted SaaS (default) | large self-host needing durability | teams already on Redis | minimal self-host, OSS distro | hosted teams wanting Inngest |
+| Dimension              | **Trigger.dev** (default)                                     | **Temporal**                                    | **BullMQ**                       | **pg-boss**                       | **Inngest**                               |
+| ---------------------- | ------------------------------------------------------------- | ----------------------------------------------- | -------------------------------- | --------------------------------- | ----------------------------------------- |
+| Primary store          | Trigger.dev cloud / self-host (Postgres+Redis under the hood) | Temporal Service (Cassandra/Postgres/MySQL)     | **Redis only**                   | **PostgreSQL only**               | Inngest cloud                             |
+| Self-host?             | ✅ (k8s, heavy)                                               | ✅ (free, MIT)                                  | ✅ (you run Redis)               | ✅ (you run Postgres)             | ⚠️ technically yes, but **SSPL** — see §6 |
+| Remote self-managed?   | ✅ (`TRIGGER_API_URL`)                                        | ✅ (any cluster)                                | ✅ (managed Redis)               | ✅ (managed Postgres)             | n/a                                       |
+| SaaS / managed?        | ✅ (default today)                                            | ✅ (Temporal Cloud, mTLS)                       | via managed Redis only           | via managed Postgres only         | ✅ (the only supported mode)              |
+| Licence (engine)       | Apache-2.0 (self-host components)                             | **MIT**                                         | MIT                              | MIT                               | **SSPL** → Apache-2.0 after 3y delay      |
+| Official SDK (TS)      | `@trigger.dev/sdk`                                            | `@temporalio/{client,worker,workflow,activity}` | `bullmq`                         | `pg-boss`                         | `inngest`                                 |
+| Worker model           | Tasks deployed to platform; platform runs them                | Long-running worker polls task queue            | Worker process consumes Redis    | In-process/sidecar polls Postgres | Functions served over HTTP; cloud invokes |
+| Push or pull           | Push (platform invokes)                                       | Pull (worker polls)                             | Pull (worker polls)              | Pull (worker polls)               | Push (cloud invokes via HTTP)             |
+| Native cron            | `schedules.task`                                              | Schedules API                                   | repeatable jobs / `JobScheduler` | `schedule()`                      | cron functions                            |
+| Native cancel          | ✅ signal                                                     | ✅ signal                                       | cooperative (flag)               | cooperative (flag)                | `cancelOn` / events                       |
+| Durable multi-hour run | ✅ (`maxDuration` 5h)                                         | ✅ (best-in-class)                              | ⚠️ tune lock renewal             | ⚠️ tune visibility timeout        | ⚠️ express as steps                       |
+| Idempotency primitive  | `idempotencyKey`                                              | workflow id                                     | job id                           | job id / singleton key            | event idempotency id                      |
+| "Just Postgres" deploy | ❌                                                            | ❌ (needs its DB)                               | ❌ (needs Redis)                 | ✅ **reuses platform DB**         | ❌                                        |
+| Recommended for        | hosted SaaS (default)                                         | large self-host needing durability              | teams already on Redis           | minimal self-host, OSS distro     | hosted teams wanting Inngest              |
 
 **Two headline corrections to the original request, carried from research:**
 
 1. **"BullMQ with Redis or PostgreSQL if possible"** — BullMQ is **Redis-only**; it is built directly on Redis data structures and has no Postgres backend. The "PostgreSQL if possible" need is met by a **separate** provider, **pg-boss** (Postgres-native), per the decision in ADR-015. We ship both: BullMQ (Redis) and pg-boss (Postgres).
-2. **Inngest "not allowed to self-host"** — Inngest *is* technically self-hostable, but under **SSPL**, which is the real blocker for a commercial multi-tenant SaaS. We scope Inngest to **SaaS only** for that licensing reason (documented in §6), which matches the original intent on firmer grounds.
+2. **Inngest "not allowed to self-host"** — Inngest _is_ technically self-hostable, but under **SSPL**, which is the real blocker for a commercial multi-tenant SaaS. We scope Inngest to **SaaS only** for that licensing reason (documented in §6), which matches the original intent on firmer grounds.
 
 ---
 
@@ -40,6 +40,7 @@
 **What it is.** The current runtime. Durable task queue with retries, cancellation, machines, and a run dashboard. The platform's tasks live in `packages/tasks/` (`@ever-works/trigger-tasks`) and deploy via `pnpm deploy:trigger`.
 
 **Deployment modes.**
+
 - **SaaS** (today): `api.trigger.dev`, project `proj_uevrbfmpvojzzazvhffy`.
 - **Self-hosted**: Trigger.dev can run on Kubernetes (tracked separately in [EW-592](https://evertech.atlassian.net/browse/EW-592)); selected by pointing `TRIGGER_API_URL` at the self-hosted instance. This is "the trigger provider, self-hosted URL" — **not** a separate provider.
 
@@ -47,7 +48,7 @@
 
 **Official SDK.** `@trigger.dev/sdk` (v4.x). Already a workspace dependency.
 
-**Worker model.** *Push*: tasks are deployed to Trigger.dev; the platform runs them on its machines (`micro`…`large-2x`). Cron via `schedules.task`. The worker bootstraps a NestJS app context (`withWorkerContext`) and calls back to the API over the SuperJSON channel.
+**Worker model.** _Push_: tasks are deployed to Trigger.dev; the platform runs them on its machines (`micro`…`large-2x`). Cron via `schedules.task`. The worker bootstraps a NestJS app context (`withWorkerContext`) and calls back to the API over the SuperJSON channel.
 
 **Cancellation.** First-class: `runs.cancel(runId)` → `AbortSignal` into the task → orchestrator observes `signal.aborted` at checkpoints.
 
@@ -64,6 +65,7 @@
 **What it is.** A durable-execution engine. Workflows are deterministic, replayable functions; side effects run in Activities. Best-in-class for long, reliable, observable processes — a natural fit for the multi-hour generation pipeline.
 
 **Deployment modes.**
+
 - **Local/dev**: `temporal server start-dev` (Temporal CLI) runs a full service + Web UI (`:8233`) on an in-memory DB; gRPC on `:7233`. Ideal for the plugin's dev mode.
 - **Self-hosted (prod)**: run the Temporal Service backed by Cassandra/PostgreSQL/MySQL, on k8s or VMs. **Free, MIT-licensed, no limits.**
 - **Remote self-managed**: connect to an existing cluster via `TEMPORAL_ADDRESS`.
@@ -73,7 +75,7 @@
 
 **Official SDK (TS).** `@temporalio/client` (enqueue/signal/cancel), `@temporalio/worker` (host workers), `@temporalio/workflow` (workflow code — sandboxed/deterministic), `@temporalio/activity` (side-effecting work).
 
-**Worker model.** *Pull*: a long-running **Worker** process polls a **task queue** and executes Workflows + Activities. The platform runs ≥1 worker deployment/sidecar. The generation orchestrator becomes a **Workflow**; the actual agent work (AI calls, git, search) becomes **Activities** (activities may call back to the API over the existing SuperJSON channel, or run in-process given the worker hosts the agent module). Cron via the **Schedules** API.
+**Worker model.** _Pull_: a long-running **Worker** process polls a **task queue** and executes Workflows + Activities. The platform runs ≥1 worker deployment/sidecar. The generation orchestrator becomes a **Workflow**; the actual agent work (AI calls, git, search) becomes **Activities** (activities may call back to the API over the existing SuperJSON channel, or run in-process given the worker hosts the agent module). Cron via the **Schedules** API.
 
 **Cancellation.** First-class workflow cancellation; cancellation scopes propagate to activities → maps to the orchestrator `AbortSignal` checkpoints.
 
@@ -89,7 +91,7 @@
 
 ## 4. BullMQ (Redis-backed)
 
-**What it is.** A fast, robust Node.js queue built on Redis. Already a transitive dependency of `@ever-works/agent` (used today by the `agent-pipeline` plugin's internal worker pool — a *narrow* use; this provider is a broader, platform-wide use).
+**What it is.** A fast, robust Node.js queue built on Redis. Already a transitive dependency of `@ever-works/agent` (used today by the `agent-pipeline` plugin's internal worker pool — a _narrow_ use; this provider is a broader, platform-wide use).
 
 **Deployment modes.** Needs a **Redis** (local, self-hosted, or managed — ElastiCache / Upstash / Redis Cloud). **No SaaS** of its own; "managed" means managed Redis.
 
@@ -97,9 +99,9 @@
 
 **Official SDK.** `bullmq` (v5.x). `Queue` (producer), `Worker` (consumer), `JobScheduler`/repeatable jobs (cron), `QueueEvents` (status), flows (parent/child).
 
-**Worker model.** *Pull*: a `Worker` consumes jobs from Redis; run N replicas for throughput. Workers can run in-process in a dedicated worker app or as a sidecar. Cron via repeatable jobs.
+**Worker model.** _Pull_: a `Worker` consumes jobs from Redis; run N replicas for throughput. Workers can run in-process in a dedicated worker app or as a sidecar. Cron via repeatable jobs.
 
-**Cancellation.** No native cancel of a *running* job. Implement **cooperative cancellation**: a Redis flag (or the existing DB cancellation flag) the orchestrator polls at each `throwIfGenerationCancelled` checkpoint. Pending (not-yet-started) jobs can be removed directly.
+**Cancellation.** No native cancel of a _running_ job. Implement **cooperative cancellation**: a Redis flag (or the existing DB cancellation flag) the orchestrator polls at each `throwIfGenerationCancelled` checkpoint. Pending (not-yet-started) jobs can be removed directly.
 
 **Idempotency / concurrency.** Custom **job id** = idempotency key (duplicate id is ignored). Concurrency via worker `concurrency`, named groups, and rate limits; `concurrencyKey` maps to grouped queues / job-id namespacing.
 
@@ -121,7 +123,7 @@
 
 **Official SDK.** `pg-boss` (v10.x). `boss.send(name, data, options)` (enqueue), `boss.work(name, handler)` (consume), `boss.schedule(name, cron, data)` (cron), singleton/throttle options.
 
-**Worker model.** *Pull*: a pg-boss instance polls Postgres and dispatches to handlers; run in-process in a worker app or sidecar. Cron via `schedule()`.
+**Worker model.** _Pull_: a pg-boss instance polls Postgres and dispatches to handlers; run in-process in a worker app or sidecar. Cron via `schedule()`.
 
 **Cancellation.** Cooperative, same pattern as BullMQ (cancel flag polled at orchestrator checkpoints); `cancel(jobId)` removes pending jobs.
 
@@ -139,13 +141,13 @@
 
 **What it is.** Event-driven durable functions / step functions, strong for AI workflows and fan-out. Functions are defined in code and **served over HTTP**; Inngest invokes them.
 
-**Why SaaS only.** Inngest's server + CLI are released under the **SSPL** (Server Side Public License), converting to Apache-2.0 only after a **3-year delay** (fair-source/DOSP model). SSPL's "offering the software as a service" clause makes **self-hosting Inngest inside a commercial multi-tenant SaaS legally fraught** — the same reason MongoDB's SSPL deters embedding in SaaS. Technically Inngest *can* be self-hosted (single binary, dev server, air-gapped), but for Ever Works' hosted/commercial posture we deliberately scope Inngest to **Inngest Cloud only** and record the reason here. This matches the original "SaaS only" intent on a firmer (legal, not technical) basis. Self-hosting Inngest is therefore **explicitly out of scope** for this provider; operators who want a self-owned runtime use Temporal, BullMQ, or pg-boss.
+**Why SaaS only.** Inngest's server + CLI are released under the **SSPL** (Server Side Public License), converting to Apache-2.0 only after a **3-year delay** (fair-source/DOSP model). SSPL's "offering the software as a service" clause makes **self-hosting Inngest inside a commercial multi-tenant SaaS legally fraught** — the same reason MongoDB's SSPL deters embedding in SaaS. Technically Inngest _can_ be self-hosted (single binary, dev server, air-gapped), but for Ever Works' hosted/commercial posture we deliberately scope Inngest to **Inngest Cloud only** and record the reason here. This matches the original "SaaS only" intent on a firmer (legal, not technical) basis. Self-hosting Inngest is therefore **explicitly out of scope** for this provider; operators who want a self-owned runtime use Temporal, BullMQ, or pg-boss.
 
 **Deployment mode.** **Inngest Cloud** only. The platform serves functions at an HTTP endpoint (`serve()` handler, mounted in the API or a small service); Inngest Cloud calls that endpoint to run steps.
 
 **Official SDK.** `inngest` (TS). `Inngest` client (send events), `createFunction` (define), `serve` (HTTP handler), steps (`step.run`, `step.sleep`, `step.waitForEvent`), `cancelOn`.
 
-**Worker model.** *Push*: no long-running worker we operate; Inngest Cloud invokes our HTTP functions. Cron via cron functions. **The signing-key-authenticated webhook is the trust boundary** — analogous to (and reusing the posture of) the `x-trigger-secret` internal channel.
+**Worker model.** _Push_: no long-running worker we operate; Inngest Cloud invokes our HTTP functions. Cron via cron functions. **The signing-key-authenticated webhook is the trust boundary** — analogous to (and reusing the posture of) the `x-trigger-secret` internal channel.
 
 **Cancellation.** Via `cancelOn` events / the cancel API; map `cancel(runId)` to sending the cancel event or calling the REST cancel.
 

--- a/docs/specs/features/job-runtime-providers/providers.md
+++ b/docs/specs/features/job-runtime-providers/providers.md
@@ -1,0 +1,175 @@
+# Job-Runtime Providers — capability matrix & per-provider deep dive
+
+**Feature ID**: `job-runtime-providers`
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+**Companion to**: [`spec.md`](./spec.md) · [`plan.md`](./plan.md) · [`tasks.md`](./tasks.md) · [`architecture/job-runtime-providers.md`](../../architecture/job-runtime-providers.md) · [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md)
+
+> This is the **research appendix**: what each runtime is, how it deploys (self-host / remote / SaaS), its licence, its official SDK, its worker-hosting model, and how it maps onto the `IJobRuntimeProvider` contract. Facts current as of 2026-05. Where a fact materially shapes scope (Inngest SSPL, BullMQ Redis-only) it is called out explicitly.
+
+---
+
+## 1. Capability matrix
+
+| Dimension | **Trigger.dev** (default) | **Temporal** | **BullMQ** | **pg-boss** | **Inngest** |
+| --- | --- | --- | --- | --- | --- |
+| Primary store | Trigger.dev cloud / self-host (Postgres+Redis under the hood) | Temporal Service (Cassandra/Postgres/MySQL) | **Redis only** | **PostgreSQL only** | Inngest cloud |
+| Self-host? | ✅ (k8s, heavy) | ✅ (free, MIT) | ✅ (you run Redis) | ✅ (you run Postgres) | ⚠️ technically yes, but **SSPL** — see §6 |
+| Remote self-managed? | ✅ (`TRIGGER_API_URL`) | ✅ (any cluster) | ✅ (managed Redis) | ✅ (managed Postgres) | n/a |
+| SaaS / managed? | ✅ (default today) | ✅ (Temporal Cloud, mTLS) | via managed Redis only | via managed Postgres only | ✅ (the only supported mode) |
+| Licence (engine) | Apache-2.0 (self-host components) | **MIT** | MIT | MIT | **SSPL** → Apache-2.0 after 3y delay |
+| Official SDK (TS) | `@trigger.dev/sdk` | `@temporalio/{client,worker,workflow,activity}` | `bullmq` | `pg-boss` | `inngest` |
+| Worker model | Tasks deployed to platform; platform runs them | Long-running worker polls task queue | Worker process consumes Redis | In-process/sidecar polls Postgres | Functions served over HTTP; cloud invokes |
+| Push or pull | Push (platform invokes) | Pull (worker polls) | Pull (worker polls) | Pull (worker polls) | Push (cloud invokes via HTTP) |
+| Native cron | `schedules.task` | Schedules API | repeatable jobs / `JobScheduler` | `schedule()` | cron functions |
+| Native cancel | ✅ signal | ✅ signal | cooperative (flag) | cooperative (flag) | `cancelOn` / events |
+| Durable multi-hour run | ✅ (`maxDuration` 5h) | ✅ (best-in-class) | ⚠️ tune lock renewal | ⚠️ tune visibility timeout | ⚠️ express as steps |
+| Idempotency primitive | `idempotencyKey` | workflow id | job id | job id / singleton key | event idempotency id |
+| "Just Postgres" deploy | ❌ | ❌ (needs its DB) | ❌ (needs Redis) | ✅ **reuses platform DB** | ❌ |
+| Recommended for | hosted SaaS (default) | large self-host needing durability | teams already on Redis | minimal self-host, OSS distro | hosted teams wanting Inngest |
+
+**Two headline corrections to the original request, carried from research:**
+
+1. **"BullMQ with Redis or PostgreSQL if possible"** — BullMQ is **Redis-only**; it is built directly on Redis data structures and has no Postgres backend. The "PostgreSQL if possible" need is met by a **separate** provider, **pg-boss** (Postgres-native), per the decision in ADR-015. We ship both: BullMQ (Redis) and pg-boss (Postgres).
+2. **Inngest "not allowed to self-host"** — Inngest *is* technically self-hostable, but under **SSPL**, which is the real blocker for a commercial multi-tenant SaaS. We scope Inngest to **SaaS only** for that licensing reason (documented in §6), which matches the original intent on firmer grounds.
+
+---
+
+## 2. Trigger.dev (default — re-housed, no behaviour change)
+
+**What it is.** The current runtime. Durable task queue with retries, cancellation, machines, and a run dashboard. The platform's tasks live in `packages/tasks/` (`@ever-works/trigger-tasks`) and deploy via `pnpm deploy:trigger`.
+
+**Deployment modes.**
+- **SaaS** (today): `api.trigger.dev`, project `proj_uevrbfmpvojzzazvhffy`.
+- **Self-hosted**: Trigger.dev can run on Kubernetes (tracked separately in [EW-592](https://evertech.atlassian.net/browse/EW-592)); selected by pointing `TRIGGER_API_URL` at the self-hosted instance. This is "the trigger provider, self-hosted URL" — **not** a separate provider.
+
+**Licence.** Self-host components Apache-2.0.
+
+**Official SDK.** `@trigger.dev/sdk` (v4.x). Already a workspace dependency.
+
+**Worker model.** *Push*: tasks are deployed to Trigger.dev; the platform runs them on its machines (`micro`…`large-2x`). Cron via `schedules.task`. The worker bootstraps a NestJS app context (`withWorkerContext`) and calls back to the API over the SuperJSON channel.
+
+**Cancellation.** First-class: `runs.cancel(runId)` → `AbortSignal` into the task → orchestrator observes `signal.aborted` at checkpoints.
+
+**Idempotency / concurrency.** `idempotencyKey` + `queue.concurrencyKey`. The pre-created `historyId` provides stable identity across retries.
+
+**Mapping to contract.** `dispatchers` = the existing `TriggerService` methods; `registerSchedules` = the existing `schedules.task` definitions; `cancel` = `runs.cancel`; `startWorkerHost` = no-op (deploy-time). Effectively a re-housing: move `TriggerService` into `packages/plugins/job-runtime-trigger/` behind `IJobRuntimeProvider`.
+
+**Fit.** Stays the default; lowest risk; no migration for any existing deployment.
+
+---
+
+## 3. Temporal (self-host / remote / Temporal Cloud)
+
+**What it is.** A durable-execution engine. Workflows are deterministic, replayable functions; side effects run in Activities. Best-in-class for long, reliable, observable processes — a natural fit for the multi-hour generation pipeline.
+
+**Deployment modes.**
+- **Local/dev**: `temporal server start-dev` (Temporal CLI) runs a full service + Web UI (`:8233`) on an in-memory DB; gRPC on `:7233`. Ideal for the plugin's dev mode.
+- **Self-hosted (prod)**: run the Temporal Service backed by Cassandra/PostgreSQL/MySQL, on k8s or VMs. **Free, MIT-licensed, no limits.**
+- **Remote self-managed**: connect to an existing cluster via `TEMPORAL_ADDRESS`.
+- **Temporal Cloud**: managed, connect over **mTLS** (cert/key), namespace-isolated; consumption pricing (~$25/M actions Standard; free Dev tier).
+
+**Licence.** Temporal Server is **MIT** (`temporalio/temporal`). Self-host is free with no limits.
+
+**Official SDK (TS).** `@temporalio/client` (enqueue/signal/cancel), `@temporalio/worker` (host workers), `@temporalio/workflow` (workflow code — sandboxed/deterministic), `@temporalio/activity` (side-effecting work).
+
+**Worker model.** *Pull*: a long-running **Worker** process polls a **task queue** and executes Workflows + Activities. The platform runs ≥1 worker deployment/sidecar. The generation orchestrator becomes a **Workflow**; the actual agent work (AI calls, git, search) becomes **Activities** (activities may call back to the API over the existing SuperJSON channel, or run in-process given the worker hosts the agent module). Cron via the **Schedules** API.
+
+**Cancellation.** First-class workflow cancellation; cancellation scopes propagate to activities → maps to the orchestrator `AbortSignal` checkpoints.
+
+**Idempotency / concurrency.** **Workflow id** is the idempotency key (reuse `work:{workId}:{historyId}` to dedupe); workflow-id uniqueness gives concurrency control per key.
+
+**Mapping to contract.** `dispatchers.*` → `client.workflow.start(..., { workflowId, taskQueue })`; `registerSchedules` → Schedules API; `cancel` → `handle.cancel()`; `startWorkerHost` → boot a `@temporalio/worker` Worker bound to the task queue.
+
+**Gotchas.** Workflow code must be deterministic (no direct I/O — that's what Activities are for); the generation pipeline's I/O must sit in Activities. The biggest implementation lift of the five.
+
+**Fit.** The recommended option for large self-hosters needing durability and deep observability.
+
+---
+
+## 4. BullMQ (Redis-backed)
+
+**What it is.** A fast, robust Node.js queue built on Redis. Already a transitive dependency of `@ever-works/agent` (used today by the `agent-pipeline` plugin's internal worker pool — a *narrow* use; this provider is a broader, platform-wide use).
+
+**Deployment modes.** Needs a **Redis** (local, self-hosted, or managed — ElastiCache / Upstash / Redis Cloud). **No SaaS** of its own; "managed" means managed Redis.
+
+**Licence.** MIT.
+
+**Official SDK.** `bullmq` (v5.x). `Queue` (producer), `Worker` (consumer), `JobScheduler`/repeatable jobs (cron), `QueueEvents` (status), flows (parent/child).
+
+**Worker model.** *Pull*: a `Worker` consumes jobs from Redis; run N replicas for throughput. Workers can run in-process in a dedicated worker app or as a sidecar. Cron via repeatable jobs.
+
+**Cancellation.** No native cancel of a *running* job. Implement **cooperative cancellation**: a Redis flag (or the existing DB cancellation flag) the orchestrator polls at each `throwIfGenerationCancelled` checkpoint. Pending (not-yet-started) jobs can be removed directly.
+
+**Idempotency / concurrency.** Custom **job id** = idempotency key (duplicate id is ignored). Concurrency via worker `concurrency`, named groups, and rate limits; `concurrencyKey` maps to grouped queues / job-id namespacing.
+
+**`maxDuration`.** No hard cap, but multi-hour jobs need **lock renewal** (`lockDuration` + `lockRenewTime`) tuned so the job isn't considered stalled. Documented in the deploy guide.
+
+**Mapping to contract.** `dispatchers.*` → `queue.add(name, payload, { jobId, ... })`; `registerSchedules` → `queue.add` repeatable / `JobScheduler`; `cancel` → set cancel flag (+ remove if pending); `getRunStatus` → `Job.getState()`; `startWorkerHost` → boot `Worker`s.
+
+**Fit.** Teams already running Redis; high-throughput, low-ceremony.
+
+---
+
+## 5. pg-boss (PostgreSQL-native) — the "just Postgres" answer
+
+**What it is.** A queue built **entirely on PostgreSQL** (SKIP LOCKED), no extra infrastructure. This is the provider that satisfies the "runs on PostgreSQL" half of the original BullMQ request — because BullMQ itself cannot use Postgres.
+
+**Deployment modes.** Needs only **PostgreSQL** — and can **reuse the platform's existing `DATABASE_URL`** (its own `pgboss` schema). A complete Ever Works deployment can then run on a single Postgres instance with **no Redis and no SaaS**, composing with ADR-005's Postgres cache/lock backends.
+
+**Licence.** MIT.
+
+**Official SDK.** `pg-boss` (v10.x). `boss.send(name, data, options)` (enqueue), `boss.work(name, handler)` (consume), `boss.schedule(name, cron, data)` (cron), singleton/throttle options.
+
+**Worker model.** *Pull*: a pg-boss instance polls Postgres and dispatches to handlers; run in-process in a worker app or sidecar. Cron via `schedule()`.
+
+**Cancellation.** Cooperative, same pattern as BullMQ (cancel flag polled at orchestrator checkpoints); `cancel(jobId)` removes pending jobs.
+
+**Idempotency / concurrency.** Singleton keys + custom job id; `singletonKey`/`singletonSeconds` map `concurrencyKey`. Idempotency via deterministic job id.
+
+**`maxDuration`.** Governed by `expireInHours` / visibility; tune for multi-hour jobs (set generous expiry + heartbeat-style re-fetch). Documented.
+
+**Mapping to contract.** `dispatchers.*` → `boss.send(name, payload, { id, singletonKey })`; `registerSchedules` → `boss.schedule`; `cancel` → cancel flag + `boss.cancel(id)`; `getRunStatus` → `boss.getJobById`; `startWorkerHost` → `boss.start()` + register `boss.work(...)` handlers.
+
+**Fit.** The default recommendation for minimal self-hosters and the OSS distribution — zero external dependencies beyond the database we already require.
+
+---
+
+## 6. Inngest (SaaS only — licensing-bounded)
+
+**What it is.** Event-driven durable functions / step functions, strong for AI workflows and fan-out. Functions are defined in code and **served over HTTP**; Inngest invokes them.
+
+**Why SaaS only.** Inngest's server + CLI are released under the **SSPL** (Server Side Public License), converting to Apache-2.0 only after a **3-year delay** (fair-source/DOSP model). SSPL's "offering the software as a service" clause makes **self-hosting Inngest inside a commercial multi-tenant SaaS legally fraught** — the same reason MongoDB's SSPL deters embedding in SaaS. Technically Inngest *can* be self-hosted (single binary, dev server, air-gapped), but for Ever Works' hosted/commercial posture we deliberately scope Inngest to **Inngest Cloud only** and record the reason here. This matches the original "SaaS only" intent on a firmer (legal, not technical) basis. Self-hosting Inngest is therefore **explicitly out of scope** for this provider; operators who want a self-owned runtime use Temporal, BullMQ, or pg-boss.
+
+**Deployment mode.** **Inngest Cloud** only. The platform serves functions at an HTTP endpoint (`serve()` handler, mounted in the API or a small service); Inngest Cloud calls that endpoint to run steps.
+
+**Official SDK.** `inngest` (TS). `Inngest` client (send events), `createFunction` (define), `serve` (HTTP handler), steps (`step.run`, `step.sleep`, `step.waitForEvent`), `cancelOn`.
+
+**Worker model.** *Push*: no long-running worker we operate; Inngest Cloud invokes our HTTP functions. Cron via cron functions. **The signing-key-authenticated webhook is the trust boundary** — analogous to (and reusing the posture of) the `x-trigger-secret` internal channel.
+
+**Cancellation.** Via `cancelOn` events / the cancel API; map `cancel(runId)` to sending the cancel event or calling the REST cancel.
+
+**Idempotency / concurrency.** Event **idempotency id** + function concurrency keys; map directly.
+
+**`maxDuration`.** Long pipelines must be expressed as **multiple steps** (per-step limits apply) — the orchestrator may need step-boundary checkpoints when run under Inngest. Documented as an Inngest-specific constraint.
+
+**Mapping to contract.** `dispatchers.*` → `inngest.send({ name, data, id })`; `registerSchedules` → cron functions; `cancel` → cancel event/REST; `startWorkerHost` → mount the `serve()` HTTP handler (no polling worker).
+
+**Fit.** Hosted teams that specifically want Inngest's event/step model; opt-in, SaaS-bound.
+
+---
+
+## 7. Cross-provider notes
+
+- **Official SDKs only.** Per the platform's official-SDK convention (root `CLAUDE.md` "Key Dependencies"; Workspace AGENTS.md NN #22), every provider uses the vendor's official SDK — never a hand-rolled REST client. Each SDK is a runtime dep of its own plugin package; `@ever-works/plugin` stays a peer dep.
+- **The SuperJSON callback channel is provider-neutral.** Pull-model workers (Temporal/BullMQ/pg-boss) call back to `/internal/*` exactly like the Trigger.dev worker; push-model providers (Trigger.dev/Inngest) run our code that does the same. The internal secret may be generalised to `EVER_WORKS_INTERNAL_SECRET` with `TRIGGER_INTERNAL_SECRET` kept as an alias.
+- **Secret hygiene.** All credentials (`TRIGGER_SECRET_KEY`, `TEMPORAL_TLS_KEY`, `BULLMQ_REDIS_URL` auth, `PGBOSS_DATABASE_URL`, `INNGEST_SIGNING_KEY`) are `x-secret: true` settings, resolved through the standard plugin settings hierarchy and never returned in API responses.
+- **Conformance parity.** No provider is "supported" until green on the shared conformance suite (`architecture/job-runtime-providers.md` §7). Non-default providers ship `experimental` until then.
+
+## 8. Sources
+
+- Trigger.dev: <https://trigger.dev/docs>
+- Temporal (MIT, self-host, CLI dev server, Cloud/mTLS): <https://docs.temporal.io/self-hosted-guide>, <https://docs.temporal.io/develop/typescript>, <https://github.com/temporalio/temporal/blob/main/LICENSE>
+- BullMQ (Redis-only): <https://docs.bullmq.io/>, <https://github.com/taskforcesh/bullmq>
+- pg-boss (Postgres-native): <https://github.com/timgit/pg-boss>
+- Inngest (self-hosting + SSPL/DOSP): <https://www.inngest.com/docs/self-hosting>, <https://github.com/inngest/inngest>

--- a/docs/specs/features/job-runtime-providers/spec.md
+++ b/docs/specs/features/job-runtime-providers/spec.md
@@ -68,15 +68,15 @@ The "user" here is primarily the **operator** deploying Ever Works, plus the **e
 
 ## 5. Key Entities & Domain Concepts
 
-| Entity / concept | Description |
-| --- | --- |
-| `job-runtime` capability | New plugin capability category for background-job runtimes. |
-| `IJobRuntimeProvider` | Contract a runtime plugin implements: dispatchers + schedule + cancel + status + worker host. |
-| Job-runtime provider | A plugin (`trigger`/`temporal`/`bullmq`/`pgboss`/`inngest`) implementing the contract. |
-| Active runtime | The single provider selected by `EVER_WORKS_JOB_RUNTIME` for a deployment. |
-| Dispatcher | Existing per-job-type interface (`WorkGenerationDispatcher`, …) the active provider fulfils. |
-| Worker host | The process/model that executes agent orchestrators for a given runtime (push vs. pull). |
-| Conformance suite | Provider-agnostic test all providers must pass to be "supported." |
+| Entity / concept         | Description                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| `job-runtime` capability | New plugin capability category for background-job runtimes.                                   |
+| `IJobRuntimeProvider`    | Contract a runtime plugin implements: dispatchers + schedule + cancel + status + worker host. |
+| Job-runtime provider     | A plugin (`trigger`/`temporal`/`bullmq`/`pgboss`/`inngest`) implementing the contract.        |
+| Active runtime           | The single provider selected by `EVER_WORKS_JOB_RUNTIME` for a deployment.                    |
+| Dispatcher               | Existing per-job-type interface (`WorkGenerationDispatcher`, …) the active provider fulfils.  |
+| Worker host              | The process/model that executes agent orchestrators for a given runtime (push vs. pull).      |
+| Conformance suite        | Provider-agnostic test all providers must pass to be "supported."                             |
 
 ## 6. Out of Scope
 

--- a/docs/specs/features/job-runtime-providers/spec.md
+++ b/docs/specs/features/job-runtime-providers/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Job-Runtime Provider Pluggability
+
+> Behaviour-first spec. Describes **what** the system does once the background-job runtime is a swappable provider — not how it's wired. Implementation lives in [`plan.md`](./plan.md); provider detail in [`providers.md`](./providers.md); rationale in [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md).
+
+**Feature ID**: `job-runtime-providers`
+**Branch**: `feat/job-runtime-providers`
+**Status**: `Draft`
+**Created**: 2026-05-28
+**Last updated**: 2026-05-28
+**Owner**: Ever Works Team
+**Epic**: [EW-685](https://evertech.atlassian.net/browse/EW-685)
+
+---
+
+## 1. Overview
+
+An operator can choose **which background-job runtime** powers all long-running work (generation, import, onboarding, scheduled dispatch, KB embedding, webhook delivery, agent jobs) on their deployment, by setting a single environment selector. Trigger.dev (SaaS) remains the default and behaves exactly as today; operators may instead select **Trigger.dev self-hosted**, **Temporal** (self-hosted, remote, or Temporal Cloud), **BullMQ** (on Redis), **pg-boss** (on PostgreSQL — no Redis, no SaaS), or **Inngest** (SaaS only). The choice is invisible to users of the platform: a work generates, cancels, schedules, and reports status identically regardless of runtime.
+
+## 2. User Scenarios
+
+The "user" here is primarily the **operator** deploying Ever Works, plus the **end user** whose work runs (who should notice nothing).
+
+### 2.1 Primary scenarios
+
+- **Given** I deploy Ever Works with no runtime config, **when** the API starts, **then** it uses Trigger.dev SaaS exactly as today (zero config change vs. the current release).
+- **Given** I set `EVER_WORKS_JOB_RUNTIME=pgboss` and a `DATABASE_URL`, **when** I start the API and a worker with no Redis and no external SaaS, **then** work generation runs end-to-end on PostgreSQL alone.
+- **Given** I set `EVER_WORKS_JOB_RUNTIME=temporal` pointing at my Temporal cluster, **when** a user generates a work, **then** the run executes on my Temporal workers and the user sees the same status/logs UI as on Trigger.dev.
+- **Given** I select `bullmq` with a Redis URL, **when** a user triggers generation, **then** the job runs on a BullMQ worker and is visible in the same `WorkGenerationHistory` UI.
+- **Given** I select `inngest` with Inngest Cloud keys, **when** scheduled updates are due, **then** an Inngest cron function dispatches them.
+- **Given** any runtime, **when** a user clicks "Cancel" mid-generation, **then** the in-flight run aborts and the work transitions to `CANCELLED`.
+
+### 2.2 Edge cases & failures
+
+- **Given** the selected runtime is misconfigured/unreachable, **when** the API tries to enqueue, **then** dispatch returns `null` and (in dev) the work runs in-process, or (in prod) surfaces a friendly "background runtime unavailable" error — never a 500 with a stack trace.
+- **Given** a run is retried by the runtime, **when** it re-executes, **then** it writes to the **same** `WorkGenerationHistory` row (stable `historyId`/idempotency) rather than creating a duplicate.
+- **Given** two scheduled-dispatcher ticks overlap, **when** both try to claim the same due schedule, **then** exactly one wins (the CAS claim is runtime-neutral) regardless of provider.
+- **Given** an operator switches `EVER_WORKS_JOB_RUNTIME` between deploys, **when** runs were in-flight on the old runtime, **then** those drain on the old runtime (or are safely re-enqueued); no run is silently lost or double-executed.
+- **Given** a non-default provider is still `experimental`, **when** an operator selects it, **then** startup logs a clear "experimental runtime" warning.
+- **Given** Inngest, **when** an operator tries to self-host it, **then** the docs explicitly state Inngest is SaaS-only here and why (SSPL), pointing them to Temporal/BullMQ/pg-boss for self-owned runtimes.
+
+## 3. Functional Requirements
+
+- **FR-1** The system MUST select the active job runtime from `EVER_WORKS_JOB_RUNTIME` ∈ {`trigger`,`temporal`,`bullmq`,`pgboss`,`inngest`}, defaulting to `trigger` when unset.
+- **FR-2** The system MUST expose every background job through the existing agent **dispatcher interfaces**; call sites MUST NOT depend on any specific runtime SDK.
+- **FR-3** The system MUST run exactly **one** active runtime per deployment (no per-work runtime routing in v1).
+- **FR-4** Each runtime provider MUST implement enqueue, schedule (cron), cancel, and run-status reporting for all dispatched job types.
+- **FR-5** The system MUST preserve idempotency: a retried run MUST reuse the pre-created `historyId` and write to the same history row.
+- **FR-6** The system MUST preserve concurrency keys currently in use (KB mirror/embed per `workId`, org overlay per `organizationId`).
+- **FR-7** Cancellation MUST propagate an abort to the running orchestrator so in-flight AI/search/git work stops (native signal where available; cooperative cancel flag otherwise).
+- **FR-8** Provider credentials/options MUST be declared via the standard plugin settings schema with `x-secret`/`x-envVar`/`x-scope: global`, resolved through the existing settings hierarchy, and never returned in API responses.
+- **FR-9** The Trigger.dev provider MUST be a behaviour-preserving re-housing of the current `TriggerService` — no observable change for existing deployments.
+- **FR-10** Every provider MUST pass one shared **conformance suite** (enqueue → run → status → cancel → schedule → idempotency) before being marked supported.
+- **FR-11** The system MUST keep the in-process dev fallback when the runtime is disabled/unreachable (dispatch returns `null`).
+- **FR-12** The pg-boss provider MUST be able to reuse the platform's existing PostgreSQL (`DATABASE_URL`), requiring no Redis and no external SaaS.
+- **FR-13** The Inngest provider MUST be SaaS-only; the system MUST NOT ship a self-host path for Inngest, and docs MUST state the SSPL rationale.
+- **FR-14** Each provider MUST use the **official vendor SDK** (`@trigger.dev/sdk`, `@temporalio/*`, `bullmq`, `pg-boss`, `inngest`); hand-rolled REST clients are forbidden (NN #22).
+- **FR-15** Non-default providers MUST ship behind an `experimental` flag and log a warning on selection until they pass the conformance suite in CI.
+- **FR-16** The system SHOULD preserve the SuperJSON internal callback channel as provider-neutral (`/internal/*`), so any pull-model worker reads/writes DB state through the API.
+- **FR-17** The system MUST NOT remove or weaken self-hosted Trigger.dev support — it remains "the trigger provider with a self-hosted `TRIGGER_API_URL`."
+
+## 4. Non-Functional Requirements
+
+- **Performance**: enqueue latency overhead from the abstraction layer MUST be negligible (< 5 ms p95 vs. direct SDK call). Schedule-dispatch cadence accuracy unchanged.
+- **Reliability**: switching providers MUST NOT lose or duplicate runs; idempotency + the CAS schedule claim guarantee at-most-once logical execution per due schedule.
+- **Security & privacy**: all runtime credentials are `x-secret`; the internal callback channel stays authenticated; self-host/air-gap modes must not phone home to any SaaS.
+- **Observability**: run status continues to flow to `WorkGenerationHistory`; each provider surfaces run logs to its native dashboard (Trigger.dev UI / Temporal Web / BullMQ board / pg-boss table / Inngest dashboard) and to the platform's existing Sentry/PostHog.
+- **Compatibility**: default path unchanged; requires `@ever-works/plugin` ≥ the version introducing the `job-runtime` capability; each provider plugin is independently installable.
+
+## 5. Key Entities & Domain Concepts
+
+| Entity / concept | Description |
+| --- | --- |
+| `job-runtime` capability | New plugin capability category for background-job runtimes. |
+| `IJobRuntimeProvider` | Contract a runtime plugin implements: dispatchers + schedule + cancel + status + worker host. |
+| Job-runtime provider | A plugin (`trigger`/`temporal`/`bullmq`/`pgboss`/`inngest`) implementing the contract. |
+| Active runtime | The single provider selected by `EVER_WORKS_JOB_RUNTIME` for a deployment. |
+| Dispatcher | Existing per-job-type interface (`WorkGenerationDispatcher`, …) the active provider fulfils. |
+| Worker host | The process/model that executes agent orchestrators for a given runtime (push vs. pull). |
+| Conformance suite | Provider-agnostic test all providers must pass to be "supported." |
+
+## 6. Out of Scope
+
+- Running multiple runtimes at once or routing jobs per-work to different runtimes (possible later ADR).
+- Live migration of in-flight runs between runtimes (switch is deploy-time).
+- Changing what any job does (agent business logic untouched).
+- Cache/lock backend selection — that's [ADR-005](../../decisions/005-cache-and-lock-pluggability.md) (composes with this, separate work).
+- Self-hosting Inngest (deliberately excluded — SSPL; see [`providers.md`](./providers.md#6-inngest-saas-only--licensing-bounded)).
+- A UI for picking the runtime — selection is an operator/env concern, not an end-user setting.
+
+## 7. Acceptance Criteria
+
+- [ ] With no new env, behaviour is identical to the current release (Trigger.dev SaaS), proven by the existing trigger e2e suite passing unchanged.
+- [ ] `EVER_WORKS_JOB_RUNTIME=pgboss` runs work generation end-to-end on PostgreSQL only (no Redis, no SaaS) in a compose profile.
+- [ ] `EVER_WORKS_JOB_RUNTIME=temporal` runs generation against a `temporal server start-dev` instance in CI.
+- [ ] `EVER_WORKS_JOB_RUNTIME=bullmq` runs generation against a Redis service in CI.
+- [ ] `EVER_WORKS_JOB_RUNTIME=inngest` dispatches via Inngest (mocked/dev) and is documented SaaS-only.
+- [ ] Cancellation aborts an in-flight run and writes `CANCELLED` on every provider.
+- [ ] A retried run reuses its `WorkGenerationHistory` row on every provider.
+- [ ] The shared conformance suite passes for every provider marked non-experimental.
+- [ ] All FRs have a passing test (unit, conformance, or e2e).
+- [ ] Constitution Principle IV amended to reference the configured runtime (Trigger.dev default).
+
+## 8. Open Questions
+
+- `[NEEDS CLARIFICATION: Should the pull-model workers (Temporal/BullMQ/pg-boss) call back to the API over the SuperJSON channel like the Trigger.dev worker, or run the agent module fully in-process against the DB? Trade-off: callback = one source of truth + audit hooks (today's invariant); in-process = fewer hops. Default assumption: keep the callback channel for parity.]`
+- `[NEEDS CLARIFICATION: For Inngest's per-step limits, does the generation pipeline need explicit step boundaries, or is a single long function acceptable within Inngest limits for our p95 generation duration?]`
+- `[NEEDS CLARIFICATION: Do we generalise TRIGGER_INTERNAL_SECRET → EVER_WORKS_INTERNAL_SECRET now (with alias) or defer?]`
+- `[NEEDS CLARIFICATION: Which providers ship in the first GA cut vs. stay experimental — proposal: trigger GA; pgboss GA next; temporal/bullmq/inngest experimental first.]`
+
+## 9. Constitution Gates
+
+- [x] **Plugin-first (Principle I)** — every runtime is a plugin under `packages/plugins/job-runtime-*`.
+- [x] **Capability-driven resolution (Principle II)** — new `job-runtime` capability; active provider resolved from the registry.
+- [x] **Source-of-truth repos preserved (Principle III)** — no change to code/content-in-Git.
+- [ ] **Long-running work via Trigger.dev (Principle IV)** — **AMENDMENT REQUIRED**: generalise to "via the configured job-runtime provider (Trigger.dev default)." Must land in the first PR. See [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md) §Constitution note.
+- [x] **Forward-only migrations (Principle V)** — pg-boss creates its own schema; no destructive platform-schema change.
+- [x] **Tests accompany the change (Principle VI)** — shared conformance suite + per-provider e2e.
+- [x] **Secrets per `x-secret` (Principle VII)** — all runtime creds `x-secret`.
+- [x] **Plugin counts touch canonical doc only (Principle VIII)** — update the canonical plugin count/category doc when providers land.
+- [x] **Behaviour-first (Principle IX)** — this spec describes behaviour; implementation in `plan.md`.
+- [x] **Backwards-compatible (Principle X)** — default path unchanged; additive capability + optional plugins.
+
+## 10. References
+
+- ADR: [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md)
+- Architecture: [`job-runtime-providers.md`](../../architecture/job-runtime-providers.md), [`trigger-integration.md`](../../architecture/trigger-integration.md), [`trigger-worker.md`](../../architecture/trigger-worker.md), [`plugin-sdk.md`](../../architecture/plugin-sdk.md)
+- Provider detail: [`providers.md`](./providers.md)
+- Related ADRs: [ADR-005](../../decisions/005-cache-and-lock-pluggability.md), [ADR-002](../../decisions/002-trigger-worker-callback-channel.md)
+- Related features: [`scheduled-updates`](../scheduled-updates/spec.md), [`generation-cancellation`](../generation-cancellation/spec.md), [`plugin-system`](../plugin-system/spec.md)
+- Jira: [EW-685](https://evertech.atlassian.net/browse/EW-685) (epic), [EW-168](https://evertech.atlassian.net/browse/EW-168)/[EW-169](https://evertech.atlassian.net/browse/EW-169) (prior abstraction), [EW-592](https://evertech.atlassian.net/browse/EW-592) (self-hosted Trigger.dev)

--- a/docs/specs/features/job-runtime-providers/spec.md
+++ b/docs/specs/features/job-runtime-providers/spec.md
@@ -8,7 +8,7 @@
 **Created**: 2026-05-28
 **Last updated**: 2026-05-28
 **Owner**: Ever Works Team
-**Epic**: [EW-685](https://evertech.atlassian.net/browse/EW-685)
+**Epic**: [EW-683](https://evertech.atlassian.net/browse/EW-683)
 
 ---
 
@@ -127,4 +127,4 @@ The "user" here is primarily the **operator** deploying Ever Works, plus the **e
 - Provider detail: [`providers.md`](./providers.md)
 - Related ADRs: [ADR-005](../../decisions/005-cache-and-lock-pluggability.md), [ADR-002](../../decisions/002-trigger-worker-callback-channel.md)
 - Related features: [`scheduled-updates`](../scheduled-updates/spec.md), [`generation-cancellation`](../generation-cancellation/spec.md), [`plugin-system`](../plugin-system/spec.md)
-- Jira: [EW-685](https://evertech.atlassian.net/browse/EW-685) (epic), [EW-168](https://evertech.atlassian.net/browse/EW-168)/[EW-169](https://evertech.atlassian.net/browse/EW-169) (prior abstraction), [EW-592](https://evertech.atlassian.net/browse/EW-592) (self-hosted Trigger.dev)
+- Jira: [EW-683](https://evertech.atlassian.net/browse/EW-683) (epic), [EW-168](https://evertech.atlassian.net/browse/EW-168)/[EW-169](https://evertech.atlassian.net/browse/EW-169) (prior abstraction), [EW-592](https://evertech.atlassian.net/browse/EW-592) (self-hosted Trigger.dev)

--- a/docs/specs/features/job-runtime-providers/tasks.md
+++ b/docs/specs/features/job-runtime-providers/tasks.md
@@ -3,13 +3,13 @@
 **Feature ID**: `job-runtime-providers`
 **Status**: `Draft` (not started)
 **Last updated**: 2026-05-28
-**Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-685](https://evertech.atlassian.net/browse/EW-685)
+**Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-683](https://evertech.atlassian.net/browse/EW-683)
 
-> Ordered, granular tasks with explicit paths. Phases map to `plan.md` §10. Each phase is a candidate sub-PR. Mark `[x]` as landed. Suggested Jira child-issue grouping noted per phase (e.g. `[EW-685 T1–T6]`).
+> Ordered, granular tasks with explicit paths. Phases map to `plan.md` §10. Each phase is a candidate sub-PR. Mark `[x]` as landed. Suggested Jira child-issue grouping noted per phase (e.g. `[EW-683 T1–T6]`).
 
 ---
 
-## Phase 0 — Contract & seam (no behaviour change) · `[EW-685 P0]`
+## Phase 0 — Contract & seam (no behaviour change) · `[EW-683 P0]`
 
 - [ ] **T1.** Define the `job-runtime` capability: `packages/plugin/src/job-runtime/job-runtime.category.ts` (register capability) + export from `packages/plugin` entrypoint.
 - [ ] **T2.** Define `IJobRuntimeProvider`, `JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`, `JobRuntimeDispatchers` in `packages/plugin/src/job-runtime/job-runtime.contract.ts`. Decide `triggerRunId` (keep) vs `runtimeRunId` (rename, two-phase migration) — default: keep `triggerRunId` as the opaque run id.
@@ -18,19 +18,19 @@
 - [ ] **T5.** Amend Constitution Principle IV (`.specify/memory/constitution.md`) → "via the configured job-runtime provider (Trigger.dev default)"; cross-link [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md). (Lands in this phase's PR.)
 - [ ] **T6.** Startup log: active runtime id + `experimental` warning when non-default & not yet conformance-green.
 
-## Phase 1 — Re-house Trigger.dev as the `trigger` provider · `[EW-685 P1]`
+## Phase 1 — Re-house Trigger.dev as the `trigger` provider · `[EW-683 P1]`
 
 - [ ] **T7.** Scaffold `packages/plugins/job-runtime-trigger/` (package.json `everworks.plugin` category `job-runtime`, tsup, vitest).
 - [ ] **T8.** Move `TriggerService` (`packages/tasks/src/trigger/trigger.service.ts`) behind `IJobRuntimeProvider` in the new plugin (or adapter that wraps it). `dispatchers` = existing methods; `cancel` = `runs.cancel`; `registerSchedules` = existing `schedules.task`; `startWorkerHost` = no-op.
 - [ ] **T9.** Keep `packages/tasks/` as the trigger worker package; wire it to the provider. Generalise `/internal/trigger/*` → `/internal/jobs/*` with alias routes; `x-trigger-secret` → `x-internal-secret` with alias.
 - [ ] **T10.** **Gate:** existing Trigger.dev e2e suite (`apps/web/e2e/*` trigger/worker tests) passes unchanged. No behaviour diff.
 
-## Phase 2 — Conformance harness · `[EW-685 P2]`
+## Phase 2 — Conformance harness · `[EW-683 P2]`
 
 - [ ] **T11.** Provider-agnostic suite `packages/plugin/src/job-runtime/testing/job-runtime.contract.spec.ts`: enqueue→run→status, idempotency (same key → one logical run), concurrency (same key serialises), cancel (in-flight aborts → `CANCELLED`), schedule fires, disabled→`null`+in-process fallback.
 - [ ] **T12.** Run harness green against `trigger`. Add a CI matrix axis `JOB_RUNTIME={trigger}` (extend per provider in later phases).
 
-## Phase 3 — pg-boss provider (Postgres-native, GA-track) · `[EW-685 P3]`
+## Phase 3 — pg-boss provider (Postgres-native, GA-track) · `[EW-683 P3]`
 
 - [ ] **T13.** Scaffold `packages/plugins/job-runtime-pgboss/`; runtime dep `pg-boss`; settings: `PGBOSS_DATABASE_URL` (defaults to platform `DATABASE_URL`), `PGBOSS_SCHEMA` (`pgboss`).
 - [ ] **T14.** Implement `dispatchers.*` via `boss.send(name, payload, { id, singletonKey })`; `cancel` = cancel-flag + `boss.cancel`; `getRunStatus` = `boss.getJobById`; `registerSchedules` = `boss.schedule(cron)`.
@@ -38,14 +38,14 @@
 - [ ] **T16.** Cooperative cancel: reuse `throwIfGenerationCancelled` checkpoints against a cancel flag; tune `expireInHours` for multi-hour jobs.
 - [ ] **T17.** Compose profile `pgboss` (no Redis, no SaaS); CI matrix axis `JOB_RUNTIME=pgboss`; conformance green. Mark GA-track.
 
-## Phase 4 — BullMQ provider (Redis) · `[EW-685 P4]`
+## Phase 4 — BullMQ provider (Redis) · `[EW-683 P4]`
 
 - [ ] **T18.** Scaffold `packages/plugins/job-runtime-bullmq/`; runtime dep `bullmq`; settings: `BULLMQ_REDIS_URL`, `BULLMQ_PREFIX`, `BULLMQ_CONCURRENCY`.
 - [ ] **T19.** Implement `dispatchers.*` via `queue.add(name, payload, { jobId })`; `registerSchedules` via repeatable jobs / `JobScheduler`; `getRunStatus` via `Job.getState()`; `cancel` via cancel-flag (+ remove if pending).
 - [ ] **T20.** Worker host: `Worker(name, handler, { concurrency, lockDuration, lockRenewTime })` running the orchestrator; replicas; tune lock renewal for multi-hour jobs.
 - [ ] **T21.** Compose profile `bullmq` (+ Redis service); CI matrix `JOB_RUNTIME=bullmq`; conformance green. Experimental→GA.
 
-## Phase 5 — Temporal provider (self-host / remote / Cloud) · `[EW-685 P5]`
+## Phase 5 — Temporal provider (self-host / remote / Cloud) · `[EW-683 P5]`
 
 - [ ] **T22.** Scaffold `packages/plugins/job-runtime-temporal/`; runtime deps `@temporalio/{client,worker,workflow,activity}`; settings: `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, `TEMPORAL_TASK_QUEUE`, `TEMPORAL_TLS_CERT`/`TEMPORAL_TLS_KEY` (Cloud mTLS, `x-secret`).
 - [ ] **T23.** Express the generation/import orchestrators as **Workflows**; agent I/O (AI/search/git) as **Activities** (calling back over SuperJSON or in-process). Keep workflow code deterministic.
@@ -53,13 +53,13 @@
 - [ ] **T25.** Worker host: `@temporalio/worker` Worker bound to the task queue; deployment/sidecar + `pnpm` script.
 - [ ] **T26.** CI: `temporal server start-dev` service; matrix `JOB_RUNTIME=temporal`; conformance green. Experimental→GA.
 
-## Phase 6 — Inngest provider (SaaS only) · `[EW-685 P6]`
+## Phase 6 — Inngest provider (SaaS only) · `[EW-683 P6]`
 
 - [ ] **T27.** Scaffold `packages/plugins/job-runtime-inngest/`; runtime dep `inngest`; settings: `INNGEST_EVENT_KEY`, `INNGEST_SIGNING_KEY` (`x-secret`), `INNGEST_APP_ID`. **No self-host path** — doc SSPL rationale in plugin README + [`providers.md`](./providers.md#6-inngest-saas-only--licensing-bounded).
 - [ ] **T28.** Define functions with `createFunction`; mount `serve()` HTTP handler (in API or small service) with signing-key verification; `dispatchers.*` → `inngest.send({ name, data, id })`; cron functions for schedules; `cancel` via `cancelOn`/REST.
 - [ ] **T29.** Address per-step limits: express long pipeline as steps where needed; document. CI with Inngest dev/mocked; conformance (push-model variant) green. Experimental.
 
-## Phase 7 — Docs, matrix & cleanup · `[EW-685 P7]`
+## Phase 7 — Docs, matrix & cleanup · `[EW-683 P7]`
 
 - [ ] **T30.** Provider deploy guides under `docs/devops/` (one per provider: env, worker host, compose/k8s, switch-runtime runbook + in-flight-drain note).
 - [ ] **T31.** Env reference: add `EVER_WORKS_JOB_RUNTIME` + per-provider vars to `docs/environment-variables.md`.

--- a/docs/specs/features/job-runtime-providers/tasks.md
+++ b/docs/specs/features/job-runtime-providers/tasks.md
@@ -1,0 +1,76 @@
+# Task Breakdown: Job-Runtime Provider Pluggability
+
+**Feature ID**: `job-runtime-providers`
+**Status**: `Draft` (not started)
+**Last updated**: 2026-05-28
+**Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-685](https://evertech.atlassian.net/browse/EW-685)
+
+> Ordered, granular tasks with explicit paths. Phases map to `plan.md` §10. Each phase is a candidate sub-PR. Mark `[x]` as landed. Suggested Jira child-issue grouping noted per phase (e.g. `[EW-685 T1–T6]`).
+
+---
+
+## Phase 0 — Contract & seam (no behaviour change) · `[EW-685 P0]`
+
+- [ ] **T1.** Define the `job-runtime` capability: `packages/plugin/src/job-runtime/job-runtime.category.ts` (register capability) + export from `packages/plugin` entrypoint.
+- [ ] **T2.** Define `IJobRuntimeProvider`, `JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`, `JobRuntimeDispatchers` in `packages/plugin/src/job-runtime/job-runtime.contract.ts`. Decide `triggerRunId` (keep) vs `runtimeRunId` (rename, two-phase migration) — default: keep `triggerRunId` as the opaque run id.
+- [ ] **T3.** Add `EVER_WORKS_JOB_RUNTIME` to config (`packages/agent/src/config/index.ts`): `getJobRuntime()` default `'trigger'`, validated enum.
+- [ ] **T4.** Binding factory `packages/agent/src/tasks/job-runtime.providers.ts`: resolve active provider from registry by `EVER_WORKS_JOB_RUNTIME`, bind all `*_DISPATCHER` symbols to `provider.dispatchers`. Bound to `trigger` by default.
+- [ ] **T5.** Amend Constitution Principle IV (`.specify/memory/constitution.md`) → "via the configured job-runtime provider (Trigger.dev default)"; cross-link [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md). (Lands in this phase's PR.)
+- [ ] **T6.** Startup log: active runtime id + `experimental` warning when non-default & not yet conformance-green.
+
+## Phase 1 — Re-house Trigger.dev as the `trigger` provider · `[EW-685 P1]`
+
+- [ ] **T7.** Scaffold `packages/plugins/job-runtime-trigger/` (package.json `everworks.plugin` category `job-runtime`, tsup, vitest).
+- [ ] **T8.** Move `TriggerService` (`packages/tasks/src/trigger/trigger.service.ts`) behind `IJobRuntimeProvider` in the new plugin (or adapter that wraps it). `dispatchers` = existing methods; `cancel` = `runs.cancel`; `registerSchedules` = existing `schedules.task`; `startWorkerHost` = no-op.
+- [ ] **T9.** Keep `packages/tasks/` as the trigger worker package; wire it to the provider. Generalise `/internal/trigger/*` → `/internal/jobs/*` with alias routes; `x-trigger-secret` → `x-internal-secret` with alias.
+- [ ] **T10.** **Gate:** existing Trigger.dev e2e suite (`apps/web/e2e/*` trigger/worker tests) passes unchanged. No behaviour diff.
+
+## Phase 2 — Conformance harness · `[EW-685 P2]`
+
+- [ ] **T11.** Provider-agnostic suite `packages/plugin/src/job-runtime/testing/job-runtime.contract.spec.ts`: enqueue→run→status, idempotency (same key → one logical run), concurrency (same key serialises), cancel (in-flight aborts → `CANCELLED`), schedule fires, disabled→`null`+in-process fallback.
+- [ ] **T12.** Run harness green against `trigger`. Add a CI matrix axis `JOB_RUNTIME={trigger}` (extend per provider in later phases).
+
+## Phase 3 — pg-boss provider (Postgres-native, GA-track) · `[EW-685 P3]`
+
+- [ ] **T13.** Scaffold `packages/plugins/job-runtime-pgboss/`; runtime dep `pg-boss`; settings: `PGBOSS_DATABASE_URL` (defaults to platform `DATABASE_URL`), `PGBOSS_SCHEMA` (`pgboss`).
+- [ ] **T14.** Implement `dispatchers.*` via `boss.send(name, payload, { id, singletonKey })`; `cancel` = cancel-flag + `boss.cancel`; `getRunStatus` = `boss.getJobById`; `registerSchedules` = `boss.schedule(cron)`.
+- [ ] **T15.** Worker host: `boss.start()` + `boss.work(name, handler)` running the agent orchestrator; worker entrypoint + `pnpm` script.
+- [ ] **T16.** Cooperative cancel: reuse `throwIfGenerationCancelled` checkpoints against a cancel flag; tune `expireInHours` for multi-hour jobs.
+- [ ] **T17.** Compose profile `pgboss` (no Redis, no SaaS); CI matrix axis `JOB_RUNTIME=pgboss`; conformance green. Mark GA-track.
+
+## Phase 4 — BullMQ provider (Redis) · `[EW-685 P4]`
+
+- [ ] **T18.** Scaffold `packages/plugins/job-runtime-bullmq/`; runtime dep `bullmq`; settings: `BULLMQ_REDIS_URL`, `BULLMQ_PREFIX`, `BULLMQ_CONCURRENCY`.
+- [ ] **T19.** Implement `dispatchers.*` via `queue.add(name, payload, { jobId })`; `registerSchedules` via repeatable jobs / `JobScheduler`; `getRunStatus` via `Job.getState()`; `cancel` via cancel-flag (+ remove if pending).
+- [ ] **T20.** Worker host: `Worker(name, handler, { concurrency, lockDuration, lockRenewTime })` running the orchestrator; replicas; tune lock renewal for multi-hour jobs.
+- [ ] **T21.** Compose profile `bullmq` (+ Redis service); CI matrix `JOB_RUNTIME=bullmq`; conformance green. Experimental→GA.
+
+## Phase 5 — Temporal provider (self-host / remote / Cloud) · `[EW-685 P5]`
+
+- [ ] **T22.** Scaffold `packages/plugins/job-runtime-temporal/`; runtime deps `@temporalio/{client,worker,workflow,activity}`; settings: `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, `TEMPORAL_TASK_QUEUE`, `TEMPORAL_TLS_CERT`/`TEMPORAL_TLS_KEY` (Cloud mTLS, `x-secret`).
+- [ ] **T23.** Express the generation/import orchestrators as **Workflows**; agent I/O (AI/search/git) as **Activities** (calling back over SuperJSON or in-process). Keep workflow code deterministic.
+- [ ] **T24.** `dispatchers.*` → `client.workflow.start(..., { workflowId, taskQueue })`; `cancel` → `handle.cancel()`; `registerSchedules` → Schedules API; `getRunStatus` → `DescribeWorkflowExecution`.
+- [ ] **T25.** Worker host: `@temporalio/worker` Worker bound to the task queue; deployment/sidecar + `pnpm` script.
+- [ ] **T26.** CI: `temporal server start-dev` service; matrix `JOB_RUNTIME=temporal`; conformance green. Experimental→GA.
+
+## Phase 6 — Inngest provider (SaaS only) · `[EW-685 P6]`
+
+- [ ] **T27.** Scaffold `packages/plugins/job-runtime-inngest/`; runtime dep `inngest`; settings: `INNGEST_EVENT_KEY`, `INNGEST_SIGNING_KEY` (`x-secret`), `INNGEST_APP_ID`. **No self-host path** — doc SSPL rationale in plugin README + [`providers.md`](./providers.md#6-inngest-saas-only--licensing-bounded).
+- [ ] **T28.** Define functions with `createFunction`; mount `serve()` HTTP handler (in API or small service) with signing-key verification; `dispatchers.*` → `inngest.send({ name, data, id })`; cron functions for schedules; `cancel` via `cancelOn`/REST.
+- [ ] **T29.** Address per-step limits: express long pipeline as steps where needed; document. CI with Inngest dev/mocked; conformance (push-model variant) green. Experimental.
+
+## Phase 7 — Docs, matrix & cleanup · `[EW-685 P7]`
+
+- [ ] **T30.** Provider deploy guides under `docs/devops/` (one per provider: env, worker host, compose/k8s, switch-runtime runbook + in-flight-drain note).
+- [ ] **T31.** Env reference: add `EVER_WORKS_JOB_RUNTIME` + per-provider vars to `docs/environment-variables.md`.
+- [ ] **T32.** Update canonical plugin count/category doc (`docs/plugin-system/built-in-plugins.md` / `plugin-categories.md`) with the `job-runtime` category + 5 providers (Principle VIII).
+- [ ] **T33.** k8s manifests: parameterise the worker deployment per active runtime (`.deploy/k8s/k8s-manifest.{dev,stage,prod}.yaml`).
+- [ ] **T34.** Finalise GA vs experimental labels per `plan.md` §10; flip CI gates accordingly.
+
+## Dependency notes
+
+- T1–T6 block everything (the contract).
+- T7–T10 (re-house trigger) block T11–T12 (conformance needs a reference provider).
+- T11–T12 block every provider phase (each must pass the suite).
+- Phases 3–6 are independent of each other and can parallelise after Phase 2.
+- T30–T34 (docs/matrix) trail each provider as it lands.

--- a/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../notification-channel.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { NotificationChannelRepository } from '../../database/repositories/notification-channel.repository';
 
 /**
  * EW-672 / T11 — NotificationChannelFacadeService construction + fan-out
@@ -74,5 +75,73 @@ describe('NotificationChannelFacadeService', () => {
                 { userId: 'user-1' },
             ),
         ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
+    });
+});
+
+/**
+ * Codex P2 (PR #1085) — scoping the channel lookup to the caller.
+ *
+ * Without this, an authenticated user could pass a leaked channel UUID owned
+ * by another user and have their text fan out to that user's webhook.
+ */
+describe('NotificationChannelFacadeService channel-ownership scoping', () => {
+    let registry: jest.Mocked<PluginRegistryService>;
+    let settings: jest.Mocked<PluginSettingsService>;
+    let channels: jest.Mocked<NotificationChannelRepository>;
+    let facade: NotificationChannelFacadeService;
+
+    beforeEach(async () => {
+        registry = {
+            getByCapability: jest.fn().mockReturnValue([]),
+        } as unknown as jest.Mocked<PluginRegistryService>;
+        settings = {
+            getResolvedSettings: jest.fn().mockResolvedValue({}),
+        } as unknown as jest.Mocked<PluginSettingsService>;
+        channels = {
+            findById: jest.fn(),
+            findByIdForUser: jest.fn(),
+        } as unknown as jest.Mocked<NotificationChannelRepository>;
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                NotificationChannelFacadeService,
+                { provide: PluginRegistryService, useValue: registry },
+                { provide: PluginSettingsService, useValue: settings },
+                { provide: NotificationChannelRepository, useValue: channels },
+            ],
+        }).compile();
+
+        facade = moduleRef.get(NotificationChannelFacadeService);
+    });
+
+    it('uses findByIdForUser when options.userId is set', async () => {
+        channels.findByIdForUser.mockResolvedValue(null);
+
+        const result = await facade.sendDirect(
+            'channel-foreign',
+            { text: 'pwned', messageRef: 'ref-1' },
+            { userId: 'user-1' },
+        );
+
+        expect(channels.findByIdForUser).toHaveBeenCalledWith('channel-foreign', 'user-1');
+        expect(channels.findById).not.toHaveBeenCalled();
+        // Foreign / missing channel is reported as failed without leaking which.
+        expect(result.status).toBe('failed');
+        expect(result.error).toContain('not found');
+    });
+
+    it('returns "not found" failure when the channel exists but belongs to another user', async () => {
+        // The user-scoped repo method returns null for "exists but foreign" — the
+        // facade must NOT fall back to an unscoped lookup in that case.
+        channels.findByIdForUser.mockResolvedValue(null);
+
+        const result = await facade.sendDirect(
+            'channel-foreign',
+            { text: 'pwned', messageRef: 'ref-1' },
+            { userId: 'user-1' },
+        );
+
+        expect(result.status).toBe('failed');
+        expect(channels.findById).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -157,7 +157,14 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
                 error: 'channels repository not injected',
             };
         }
-        const channel = await this.channels.findById(channelId);
+        // Codex P2 (PR #1085): scope channel lookup to the caller when a userId is
+        // available. Otherwise a caller could supply a leaked channel UUID owned by
+        // another user and have their text fan out to that user's webhook. We
+        // intentionally return the same "not found" shape for "doesn't exist" and
+        // "belongs to someone else" so we don't leak channel existence across users.
+        const channel = options.userId
+            ? await this.channels.findByIdForUser(channelId, options.userId)
+            : await this.channels.findById(channelId);
         if (!channel) {
             return {
                 channelId,

--- a/packages/agent/src/pipeline/pipeline-facade.service.spec.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.spec.ts
@@ -181,6 +181,27 @@ describe('PipelineFacadeService', () => {
             expect(ctx.kbContext?.alwaysInjected.map((d) => d.id)).toEqual(['always-doc']);
             expect(ctx.kbContext?.queryRetrieved.map((d) => d.id)).toEqual(['query-doc']);
         });
+
+        // Item #18 — `memorySessionId` carrier so orchestrators (e.g.
+        // `AgentRunService`) can hand the open session through to the
+        // memory-pipeline-modifier.
+        it('forwards the provided memorySessionId into the StepExecutionContext', () => {
+            const ctx = service.createStepExecutionContext(
+                makeWork() as any,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                'sess-orchestrator-1',
+            );
+            expect(ctx.memorySessionId).toBe('sess-orchestrator-1');
+        });
+
+        it('leaves memorySessionId undefined when no orchestrator session is supplied', () => {
+            const ctx = service.createStepExecutionContext(makeWork() as any);
+            expect(ctx.memorySessionId).toBeUndefined();
+        });
     });
 
     describe('logger prefix', () => {

--- a/packages/agent/src/pipeline/pipeline-facade.service.ts
+++ b/packages/agent/src/pipeline/pipeline-facade.service.ts
@@ -105,6 +105,7 @@ export class PipelineFacadeService {
         signal?: AbortSignal,
         kbContext?: KbContextBundleData,
         kbTools?: IKbToolsFacade,
+        memorySessionId?: string,
     ): StepExecutionContext {
         const stepLogger: StepLogger = {
             log: (msg: string, ...args: unknown[]) =>
@@ -146,6 +147,7 @@ export class PipelineFacadeService {
             signal,
             kbContext,
             kbTools,
+            memorySessionId,
         };
     }
 

--- a/packages/plugin/src/pipeline/step-execution-context.interface.ts
+++ b/packages/plugin/src/pipeline/step-execution-context.interface.ts
@@ -138,4 +138,21 @@ export interface StepExecutionContext {
 	 * responsible for null-checking before use.
 	 */
 	readonly agentMemoryFacade?: IAgentMemoryStepFacade;
+
+	/**
+	 * Optional agent-memory session id supplied by the orchestrator that
+	 * invoked the pipeline (e.g. `AgentRunService` already opens a
+	 * session per run via `AgentMemoryFacadeService.openSession`). When
+	 * set, pipeline modifiers/steps that touch agent-memory MUST associate
+	 * their `saveMemory` / `buildContext` calls with this session instead
+	 * of opening one of their own, so the orchestrator and pipeline share
+	 * the same `agent_memory_sessions` row.
+	 *
+	 * Carrier-only — populated by `PipelineFacadeService.createStepExecutionContext`.
+	 * Optional: pipelines run from non-agent surfaces (Work generation
+	 * tasks, manual triggers, OSS builds without `agentmemory-plugin`)
+	 * leave it `undefined` and the memory modifier falls back to its
+	 * default per-run association (no explicit session id).
+	 */
+	readonly memorySessionId?: string;
 }

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -375,4 +375,79 @@ describe('MemoryPipelineModifierPlugin', () => {
 			expect(result.errors?.[0].path).toBe('maxContextTokens');
 		});
 	});
+
+	// Item #18 — `memorySessionId` plumbing from the orchestrator
+	// (e.g. AgentRunService) through StepExecutionContext into the
+	// modifier's buildContext / saveMemory / rollback paths.
+	describe('memorySessionId propagation from execContext', () => {
+		function makeExecContextWithSession(sessionId?: string): StepExecutionContext {
+			return {
+				agentMemoryFacade: memoryFacade,
+				logger,
+				work: { id: 'work-1', slug: 'best-react-tools', name: 'Best React Tools', user: { id: 'u-1' } },
+				...(sessionId ? { memorySessionId: sessionId } : {})
+			} as unknown as StepExecutionContext;
+		}
+
+		it('threads execContext.memorySessionId into buildContext on the fetch step', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({
+				content: 'prior notes',
+				approxTokens: 42
+			});
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: {
+					stepId: FETCH_CONTEXT_STEP_ID,
+					execContext: makeExecContextWithSession('sess-orchestrator-1')
+				}
+			});
+			expect(memoryFacade.buildContext).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-orchestrator-1' }),
+				expect.anything()
+			);
+		});
+
+		it('omits sessionId from buildContext when execContext does not carry one', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({
+				content: 'prior notes',
+				approxTokens: 42
+			});
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContextWithSession() }
+			});
+			const buildArg = (memoryFacade.buildContext as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(buildArg).not.toHaveProperty('sessionId');
+		});
+
+		it('threads execContext.memorySessionId into saveMemory on the save step', async () => {
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-1' });
+			const context = makeContext();
+			// Prime the stash so the save step's lookup works.
+			(context as Record<string, unknown>).__memoryModifierExecContext =
+				makeExecContextWithSession('sess-orchestrator-2');
+			await plugin.execute(context, {
+				settings: {
+					stepId: SAVE_MEMORY_STEP_ID,
+					execContext: makeExecContextWithSession('sess-orchestrator-2')
+				}
+			});
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-orchestrator-2' }),
+				expect.anything()
+			);
+		});
+
+		it('threads execContext.memorySessionId into rollback saveMemory', async () => {
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-rb-1' });
+			const context = makeContext();
+			(context as Record<string, unknown>).__memoryModifierExecContext =
+				makeExecContextWithSession('sess-orchestrator-3');
+			await plugin.rollback(context, new Error('boom'));
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-orchestrator-3' }),
+				expect.anything()
+			);
+		});
+	});
 });

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -315,12 +315,14 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 			const summary = this.buildFailureSummary(work, items, error, isCancellation);
 			const tags = this.buildFailureTags(work, isCancellation);
+			const sessionId = execContext?.memorySessionId;
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
 					content: summary,
 					tags,
 					projectId: work?.slug ?? work?.id,
+					...(sessionId ? { sessionId } : {}),
 					metadata: {
 						workId: work?.id,
 						workSlug: work?.slug,
@@ -357,12 +359,22 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			const work = (context as { work?: { id?: string; name?: string; slug?: string } }).work;
 			const request = (context as { request?: { prompt?: string } }).request;
 
+			// Honour a session id supplied by the orchestrator (e.g.
+			// AgentRunService opens a session per agent run and propagates
+			// it via StepExecutionContext.memorySessionId). When absent —
+			// the usual case for plain Work-generation pipelines — the
+			// backend associates the record with no specific session.
+			const sessionId = (context as ContextBag).__memoryModifierExecContext
+				? ((context as ContextBag).__memoryModifierExecContext as StepExecutionContext).memorySessionId
+				: undefined;
+
 			const ctx: AgentMemoryContext = await memoryFacade.buildContext(
 				{
 					query: request?.prompt,
 					purpose: settings.purpose ?? DEFAULT_PURPOSE,
 					projectId: work?.slug ?? work?.id,
-					maxTokens: settings.maxContextTokens ?? DEFAULT_MAX_CONTEXT_TOKENS
+					maxTokens: settings.maxContextTokens ?? DEFAULT_MAX_CONTEXT_TOKENS,
+					...(sessionId ? { sessionId } : {})
 				},
 				// Bound facade ignores its facadeOptions — pass placeholder.
 				{ userId: 'bound', workId: 'bound' }
@@ -408,12 +420,16 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			// unreachable at this step's call site.
 			const summary = this.buildSummary(work, items);
 			const tags = this.buildTags(work);
+			const sessionId = (context as ContextBag).__memoryModifierExecContext
+				? ((context as ContextBag).__memoryModifierExecContext as StepExecutionContext).memorySessionId
+				: undefined;
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
 					content: summary,
 					tags,
 					projectId: work?.slug ?? work?.id,
+					...(sessionId ? { sessionId } : {}),
 					metadata: {
 						workId: work?.id,
 						workSlug: work?.slug,


### PR DESCRIPTION
## Summary

Routine develop → stage cascade. Brings stage to parity with develop's 8 new commits:

- **#1093** — fix(email,notify): scope outbound address + channel lookups to caller (Codex P1+P2 security fixes raised against the in-flight stage→main cascade #1085)
- **#1095** — feat(pipeline): pipe `memorySessionId` orchestrator→`StepExecutionContext`→`memory-pipeline-modifier` (Item #18 follow-up to #1090)
- **#1092** — docs: job-runtime provider pluggability spec (Trigger.dev default + Temporal/BullMQ/pg-boss/Inngest, epic EW-683)

Once this lands, the open stage → main cascade PR #1085 auto-absorbs all three.

## Test plan

- [ ] `lint-and-test (22.x)` green on the cascade
- [ ] CodeRabbit summary clean (auto-reviews disabled on non-default base — informational)