### PR TITLE
feat(monitoring): activate Sentry + PostHog in deployed envs and forward logs to PostHog

### DIFF
--- a/.deploy/docker/web/Dockerfile
+++ b/.deploy/docker/web/Dockerfile
@@ -29,6 +29,15 @@ ENV NODE_ENV=build
 ENV NEXT_BUILD_OUTPUT=standalone
 ENV CI=true
 
+# NEXT_PUBLIC_* must be present BEFORE `next build` runs because Next.js
+# inlines them into the client bundle at build time. The docker-build
+# workflows pass them via `--build-arg`; unset values resolve to empty
+# strings and the PostHog browser SDK degrades to a no-op gracefully.
+ARG NEXT_PUBLIC_POSTHOG_KEY=
+ARG NEXT_PUBLIC_POSTHOG_HOST=
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
+ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
+
 # Install python3
 RUN apk add --no-cache python3 pkgconfig build-base
 RUN apk add --no-cache pixman-dev cairo-dev pango-dev jpeg-dev giflib-dev

--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -103,6 +103,18 @@ spec:
             - name: TRIGGER_MACHINE
               value: "$TRIGGER_MACHINE"
 
+            # PostHog (analytics + feature flags) + Sentry (errors + traces).
+            # See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # SDKs are graceful no-ops when the env var is unset.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
+
             # GitHub Auth
             - name: GH_CLIENT_ID
               value: "$GH_CLIENT_ID"
@@ -342,6 +354,22 @@ spec:
               value: "http://ever-works-api-dev:3100"
             - name: NEXT_PUBLIC_WEB_URL
               value: "https://appdev.ever.works"
+
+            # PostHog (server-side: feature flag eval via apps/web/src/lib/feature-flags)
+            # + Sentry (errors + traces). See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # NEXT_PUBLIC_POSTHOG_KEY / NEXT_PUBLIC_POSTHOG_HOST are intentionally NOT
+            # set here — Next.js bakes NEXT_PUBLIC_* into the bundle at BUILD time,
+            # so they're plumbed through the docker-build workflow's build-args
+            # (see .github/workflows/docker-build-publish-dev.yml) and the web
+            # Dockerfile's ARG/ENV declarations.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -108,6 +108,18 @@ spec:
             - name: TRIGGER_MACHINE
               value: "$TRIGGER_MACHINE"
 
+            # PostHog (analytics + feature flags) + Sentry (errors + traces).
+            # See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # SDKs are graceful no-ops when the env var is unset.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
+
             # GitHub Auth
             - name: GH_CLIENT_ID
               value: "$GH_CLIENT_ID"
@@ -375,6 +387,22 @@ spec:
               value: "http://ever-works-api:3100"
             - name: NEXT_PUBLIC_WEB_URL
               value: "https://app.ever.works"
+
+            # PostHog (server-side: feature flag eval via apps/web/src/lib/feature-flags)
+            # + Sentry (errors + traces). See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # NEXT_PUBLIC_POSTHOG_KEY / NEXT_PUBLIC_POSTHOG_HOST are intentionally NOT
+            # set here — Next.js bakes NEXT_PUBLIC_* into the bundle at BUILD time,
+            # so they're plumbed through the docker-build workflow's build-args
+            # (see .github/workflows/docker-build-publish-prod.yml) and the web
+            # Dockerfile's ARG/ENV declarations.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -103,6 +103,18 @@ spec:
             - name: TRIGGER_MACHINE
               value: "$TRIGGER_MACHINE"
 
+            # PostHog (analytics + feature flags) + Sentry (errors + traces).
+            # See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # SDKs are graceful no-ops when the env var is unset.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
+
             # GitHub Auth
             - name: GH_CLIENT_ID
               value: "$GH_CLIENT_ID"
@@ -363,6 +375,22 @@ spec:
               value: "http://ever-works-api-stage:3100"
             - name: NEXT_PUBLIC_WEB_URL
               value: "https://appstage.ever.works"
+
+            # PostHog (server-side: feature flag eval via apps/web/src/lib/feature-flags)
+            # + Sentry (errors + traces). See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # NEXT_PUBLIC_POSTHOG_KEY / NEXT_PUBLIC_POSTHOG_HOST are intentionally NOT
+            # set here — Next.js bakes NEXT_PUBLIC_* into the bundle at BUILD time,
+            # so they're plumbed through the docker-build workflow's build-args
+            # (see .github/workflows/docker-build-publish-stage.yml) and the web
+            # Dockerfile's ARG/ENV declarations.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -123,6 +123,16 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Sentry (errors, traces, profiling). DSN is set repo-wide; absent
+          # DSN -> SDK is a graceful no-op. SENTRY_ENVIRONMENT differentiates
+          # dev / staging / production in the Sentry UI.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: development
+          # PostHog (server-side: analytics events, feature flag eval, logs).
+          # Same phc_* key used by NEXT_PUBLIC_POSTHOG_KEY at docker-build time.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+
           # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -133,6 +133,16 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Sentry (errors, traces, profiling). DSN is set repo-wide; absent
+          # DSN -> SDK is a graceful no-op. SENTRY_ENVIRONMENT differentiates
+          # dev / staging / production in the Sentry UI.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: production
+          # PostHog (server-side: analytics events, feature flag eval, logs).
+          # Same phc_* key used by NEXT_PUBLIC_POSTHOG_KEY at docker-build time.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+
           # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -123,6 +123,16 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Sentry (errors, traces, profiling). DSN is set repo-wide; absent
+          # DSN -> SDK is a graceful no-op. SENTRY_ENVIRONMENT differentiates
+          # dev / staging / production in the Sentry UI.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: staging
+          # PostHog (server-side: analytics events, feature flag eval, logs).
+          # Same phc_* key used by NEXT_PUBLIC_POSTHOG_KEY at docker-build time.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+
           # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -125,8 +125,13 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web-dev:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web-dev:latest
           cache-to: type=inline
+          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # into the client bundle at `next build`, not at container start.
+          # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=development
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -125,8 +125,13 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web:latest
           cache-to: type=inline
+          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # into the client bundle at `next build`, not at container start.
+          # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -125,8 +125,13 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web-stage:latest
           cache-to: type=inline
+          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # into the client bundle at `next build`, not at container start.
+          # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
 
       - name: Docker images list
         run: |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -196,6 +196,29 @@ WEBSITE_TEMPLATE_AUTO_UPDATE_ENABLED=true
 WEBSITE_TEMPLATE_BETA_BRANCH=stage
 
 
+# ============================================
+# Sentry (error tracking, traces, profiling)
+# ============================================
+# Get the DSN from https://sentry.io -> Ever Works project -> Settings ->
+# Client Keys. Without DSN set, Sentry SDK is a no-op (graceful).
+SENTRY_DSN=
+# 'development' / 'staging' / 'production'. Deployed envs override
+# via the k8s manifest; local dev defaults to 'development'.
+SENTRY_ENVIRONMENT=development
+# Override the auto-picked sample rate (default 0.1 in prod, 1.0 elsewhere).
+# SENTRY_TRACES_SAMPLE_RATE=1.0
+
+# ============================================
+# PostHog (server-side analytics + feature flags + logs)
+# ============================================
+# Project (public) API key — same phc_* as the marketing site uses;
+# not a security secret. Without it set, PostHog SDK is a no-op (graceful).
+# When POSTHOG_API_KEY is set, all NestJS Logger emits (log/warn/error/
+# debug/verbose) are also forwarded to PostHog Logs as `$log` events.
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://us.i.posthog.com
+
+
 # ============================== PLUGINS ========================================
 
 # GitHub Plugin (separate from GitHub Auth above)

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,7 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { apiReference } from '@scalar/nestjs-api-reference';
 import { ApiModule } from './api.module';
 import helmet from 'helmet';
-import { initSentry, initPostHog } from '@ever-works/monitoring';
+import { initSentry, initPostHog, PostHogLoggerService } from '@ever-works/monitoring';
 import { IncomingMessage, ServerResponse } from 'http';
 import * as path from 'path';
 import { json, urlencoded } from 'express';
@@ -30,6 +30,12 @@ async function bootstrap() {
     initPostHog();
 
     const app = await NestFactory.create(ApiModule);
+
+    // Forward every NestJS Logger emit (log/warn/error/debug/verbose) to
+    // PostHog Logs as a `$log` event while still writing to stdout. The
+    // PostHogLoggerService fails open — without POSTHOG_API_KEY it degrades
+    // to the default NestJS console logger (no PostHog traffic, no errors).
+    app.useLogger(new PostHogLoggerService());
 
     const captureRawBody = (
         req: IncomingMessage & { rawBody?: string },

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -133,12 +133,21 @@ AUTH_SECRET=your-secret-key-here
 # ============================================
 
 # PostHog project API key. Same key the monitoring package uses.
-# Evaluated SERVER-SIDE only — posthog-js is never shipped to the
-# browser, so this token stays off the client.
-# POSTHOG_API_KEY=phc_your_project_api_key_here
+# Evaluated SERVER-SIDE only — used by apps/web/src/lib/feature-flags
+# for the works-<kind> chip gating below.
+POSTHOG_API_KEY=
 
 # PostHog host. Defaults to https://app.posthog.com when unset.
-# POSTHOG_HOST=https://app.posthog.com
+POSTHOG_HOST=https://us.i.posthog.com
+
+# Client-side (browser) PostHog. NEXT_PUBLIC_* are baked into the
+# Next.js bundle at BUILD time — in deployed envs they're passed as
+# docker --build-arg from the docker-build-publish workflows.
+# Wired up by the platform's frontend posthog-js integration (see
+# the `feat/posthog-frontend-analytics` PR); until that lands these
+# NEXT_PUBLIC_* values are unused but it's harmless to set them.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # Work-kind chips on /new and /works/new are gated by per-kind feature
 # flags named `works-<kind>` (e.g. works-website, works-landing-page,

--- a/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
@@ -20,8 +20,8 @@ jest.mock('posthog-node', () => ({
     PostHog: jest.fn().mockImplementation(() => ({
         capture: captureMock,
         identify: jest.fn(),
-        shutdown: shutdownMock
-    }))
+        shutdown: shutdownMock,
+    })),
 }));
 
 // Mock @sentry/nestjs so we can spy on captureException without ever talking
@@ -36,13 +36,13 @@ jest.mock('@sentry/nestjs', () => ({
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
-        fatal: jest.fn()
-    }
+        fatal: jest.fn(),
+    },
 }));
 
 // Avoid the optional profiling-node native dep blowing up the test.
 jest.mock('@sentry/profiling-node', () => ({
-    nodeProfilingIntegration: () => ({ name: 'mock-profiling' })
+    nodeProfilingIntegration: () => ({ name: 'mock-profiling' }),
 }));
 
 import { initPostHog, shutdownPostHog } from '../posthog.config';
@@ -99,7 +99,7 @@ describe('PostHogLoggerService', () => {
         it.each([
             ['warn', 'warn'],
             ['debug', 'debug'],
-            ['verbose', 'verbose']
+            ['verbose', 'verbose'],
         ])('forwards %s() emits as $log with level=%s', (method, expectedLevel) => {
             const svc = new PostHogLoggerService();
             (svc as any)[method]('hi');

--- a/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for PostHogLoggerService.
+ *
+ * The service has three obligations we exercise here:
+ *   1. forward each NestJS log level to PostHog Logs as a `$log` event with
+ *      the right `level` property + structured metadata;
+ *   2. NEVER throw, even when PostHog is unconfigured or its client raises;
+ *   3. forward `Error` instances logged via `error()` to Sentry's
+ *      `captureException` (but only Error instances — string errors are not
+ *      forwarded, since they would just duplicate request-path exceptions
+ *      caught by SentryInterceptor).
+ */
+
+// Mock posthog-node BEFORE importing anything that touches the posthog
+// singleton, because `initPostHog()` caches the constructed client.
+const captureMock = jest.fn();
+const shutdownMock = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('posthog-node', () => ({
+    PostHog: jest.fn().mockImplementation(() => ({
+        capture: captureMock,
+        identify: jest.fn(),
+        shutdown: shutdownMock
+    }))
+}));
+
+// Mock @sentry/nestjs so we can spy on captureException without ever talking
+// to the real SDK.
+const captureExceptionMock = jest.fn();
+jest.mock('@sentry/nestjs', () => ({
+    captureException: (...args: unknown[]) => captureExceptionMock(...args),
+    init: jest.fn(),
+    logger: {
+        trace: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        fatal: jest.fn()
+    }
+}));
+
+// Avoid the optional profiling-node native dep blowing up the test.
+jest.mock('@sentry/profiling-node', () => ({
+    nodeProfilingIntegration: () => ({ name: 'mock-profiling' })
+}));
+
+import { initPostHog, shutdownPostHog } from '../posthog.config';
+import { PostHogLoggerService } from '../posthog-logger.service';
+
+describe('PostHogLoggerService', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(async () => {
+        originalEnv = { ...process.env };
+        delete process.env.POSTHOG_API_KEY;
+        delete process.env.POSTHOG_HOST;
+        await shutdownPostHog();
+        captureMock.mockReset();
+        captureExceptionMock.mockReset();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    describe('without a PostHog client (POSTHOG_API_KEY unset)', () => {
+        it('does not throw on any level and never calls capture', () => {
+            const svc = new PostHogLoggerService('TestCtx');
+            expect(() => svc.log('hello')).not.toThrow();
+            expect(() => svc.warn('be careful')).not.toThrow();
+            expect(() => svc.error('boom')).not.toThrow();
+            expect(() => svc.debug('debugging')).not.toThrow();
+            expect(() => svc.verbose('verbose')).not.toThrow();
+            expect(captureMock).not.toHaveBeenCalled();
+            expect(captureExceptionMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('with an initialized PostHog client', () => {
+        beforeEach(() => {
+            initPostHog({ apiKey: 'phc_test' });
+            captureMock.mockReset();
+        });
+
+        it('captures a $log event for log() with the right level', () => {
+            const svc = new PostHogLoggerService('MyModule');
+            svc.log('user signed in');
+            expect(captureMock).toHaveBeenCalledTimes(1);
+            const call = captureMock.mock.calls[0][0];
+            expect(call.event).toBe('$log');
+            expect(call.distinctId).toBe('system');
+            expect(call.properties.level).toBe('log');
+            expect(call.properties.message).toBe('user signed in');
+            expect(call.properties.context).toBe('MyModule');
+            expect(call.properties.service).toBe('ever-works-api');
+        });
+
+        it.each([
+            ['warn', 'warn'],
+            ['debug', 'debug'],
+            ['verbose', 'verbose']
+        ])('forwards %s() emits as $log with level=%s', (method, expectedLevel) => {
+            const svc = new PostHogLoggerService();
+            (svc as any)[method]('hi');
+            expect(captureMock).toHaveBeenCalledTimes(1);
+            expect(captureMock.mock.calls[0][0].properties.level).toBe(expectedLevel);
+        });
+
+        it('honours a custom distinctId for grouping', () => {
+            const svc = new PostHogLoggerService('Ctx', 'worker-7');
+            svc.log('working');
+            expect(captureMock.mock.calls[0][0].distinctId).toBe('worker-7');
+        });
+
+        it('serializes Error instances and includes name + stack', () => {
+            const err = new Error('disk full');
+            const svc = new PostHogLoggerService();
+            svc.error(err);
+            const props = captureMock.mock.calls[0][0].properties;
+            expect(props.level).toBe('error');
+            expect(props.message).toBe('disk full');
+            expect(props.error_name).toBe('Error');
+            expect(typeof props.error_stack).toBe('string');
+        });
+
+        it('passes the NestJS trace string through when error() is called as (msg, trace)', () => {
+            const svc = new PostHogLoggerService();
+            const trace = 'Error: x\n    at foo (file.ts:1:1)';
+            svc.error('caught', trace);
+            const props = captureMock.mock.calls[0][0].properties;
+            expect(props.trace).toBe(trace);
+        });
+
+        it('forwards Error instances logged via error() to Sentry captureException', () => {
+            const err = new Error('explode');
+            const svc = new PostHogLoggerService();
+            svc.error(err);
+            expect(captureExceptionMock).toHaveBeenCalledWith(err);
+        });
+
+        it('does NOT call captureException for string error() messages (avoids double-capture with SentryInterceptor)', () => {
+            const svc = new PostHogLoggerService();
+            svc.error('just a string');
+            expect(captureExceptionMock).not.toHaveBeenCalled();
+        });
+
+        it('swallows a thrown capture() and never propagates the error', () => {
+            captureMock.mockImplementationOnce(() => {
+                throw new Error('posthog down');
+            });
+            const svc = new PostHogLoggerService();
+            expect(() => svc.log('still works')).not.toThrow();
+        });
+
+        it('serializes non-string messages via JSON.stringify', () => {
+            const svc = new PostHogLoggerService();
+            svc.log({ event: 'click', userId: 42 });
+            const props = captureMock.mock.calls[0][0].properties;
+            expect(props.message).toBe('{"event":"click","userId":42}');
+        });
+
+        it('uses SENTRY_ENVIRONMENT for the env property when set', () => {
+            process.env.SENTRY_ENVIRONMENT = 'production';
+            const svc = new PostHogLoggerService();
+            svc.log('ping');
+            expect(captureMock.mock.calls[0][0].properties.env).toBe('production');
+        });
+    });
+});

--- a/packages/monitoring/src/posthog/index.ts
+++ b/packages/monitoring/src/posthog/index.ts
@@ -1,2 +1,3 @@
 export * from './posthog.config';
 export * from './posthog.module';
+export * from './posthog-logger.service';

--- a/packages/monitoring/src/posthog/posthog-logger.service.ts
+++ b/packages/monitoring/src/posthog/posthog-logger.service.ts
@@ -1,0 +1,156 @@
+import { Logger, LoggerService } from '@nestjs/common';
+import { getPostHogClient } from './posthog.config';
+import { getSentryInstance } from '../sentry/sentry.config';
+
+/**
+ * Service that converts log emits to a string usable as a PostHog event property.
+ */
+const serializeMessage = (message: unknown): string => {
+    if (message === undefined) return '';
+    if (message === null) return 'null';
+    if (typeof message === 'string') return message;
+    if (message instanceof Error) return message.message;
+    try {
+        return JSON.stringify(message);
+    } catch {
+        // Fallback for cyclic structures and bigints.
+        return String(message);
+    }
+};
+
+const resolveEnv = (): string =>
+    process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development';
+
+type LogLevel = 'log' | 'warn' | 'error' | 'debug' | 'verbose';
+
+/**
+ * NestJS `LoggerService` that forwards every log emit to PostHog Logs as a
+ * `$log` event while still writing to stdout via the default NestJS Logger
+ * (so `kubectl logs` keeps working).
+ *
+ * - Fail-open: any PostHog / Sentry SDK error is swallowed; console output
+ *   is always attempted.
+ * - `error(message, trace, context?)` additionally forwards Error instances
+ *   to Sentry via `captureException`. `SentryInterceptor` already catches
+ *   in-request exceptions, so this only meaningfully fires for errors
+ *   logged outside the request path (bootstrap, background jobs,
+ *   event handlers). Do NOT pass request-path exceptions here — they will
+ *   double-report.
+ *
+ * Wired into the API in `apps/api/src/main.ts` via `app.useLogger(...)`.
+ */
+export class PostHogLoggerService implements LoggerService {
+    private readonly fallbackLogger: Logger;
+    private readonly defaultContext?: string;
+    private readonly distinctId: string;
+
+    constructor(context?: string, distinctId: string = 'system') {
+        this.defaultContext = context;
+        this.distinctId = distinctId;
+        this.fallbackLogger = new Logger(context ?? 'PostHogLogger');
+    }
+
+    log(message: unknown, context?: string): void {
+        this.dispatch('log', message, undefined, context);
+    }
+
+    warn(message: unknown, context?: string): void {
+        this.dispatch('warn', message, undefined, context);
+    }
+
+    /**
+     * NestJS `LoggerService.error` is overloaded in practice: callers may pass
+     * `(message)`, `(message, context)`, or `(message, trace, context)`. We
+     * accept the widest shape so we never reject a legitimate call.
+     */
+    error(message: unknown, traceOrContext?: string, context?: string): void {
+        // Disambiguate the 2-arg form: a value that doesn't look like a stack
+        // trace is treated as a context label, matching NestJS' Logger.
+        const looksLikeTrace =
+            typeof traceOrContext === 'string' &&
+            (traceOrContext.includes('\n') || traceOrContext.includes('    at '));
+        const trace = looksLikeTrace ? traceOrContext : undefined;
+        const ctx = looksLikeTrace ? context : (context ?? traceOrContext);
+        this.dispatch('error', message, trace, ctx);
+    }
+
+    debug(message: unknown, context?: string): void {
+        this.dispatch('debug', message, undefined, context);
+    }
+
+    verbose(message: unknown, context?: string): void {
+        this.dispatch('verbose', message, undefined, context);
+    }
+
+    private dispatch(level: LogLevel, message: unknown, trace?: string, context?: string): void {
+        const ctx = context ?? this.defaultContext;
+
+        // 1) ALWAYS write to the console first so a PostHog/Sentry outage can
+        //    never silently drop a log emit. `fallbackLogger` wraps NestJS'
+        //    default ConsoleLogger.
+        try {
+            switch (level) {
+                case 'log':
+                    this.fallbackLogger.log(message as any, ctx);
+                    break;
+                case 'warn':
+                    this.fallbackLogger.warn(message as any, ctx);
+                    break;
+                case 'error':
+                    this.fallbackLogger.error(message as any, trace, ctx);
+                    break;
+                case 'debug':
+                    this.fallbackLogger.debug(message as any, ctx);
+                    break;
+                case 'verbose':
+                    this.fallbackLogger.verbose(message as any, ctx);
+                    break;
+            }
+        } catch {
+            // Last-resort console.
+            // eslint-disable-next-line no-console
+            console.error('[PostHogLoggerService] fallback logger threw', level, message);
+        }
+
+        // 2) Forward to PostHog Logs as a `$log` event. Swallow any error.
+        try {
+            const client = getPostHogClient();
+            if (client) {
+                const properties: Record<string, unknown> = {
+                    level,
+                    message: serializeMessage(message),
+                    context: ctx,
+                    service: 'ever-works-api',
+                    env: resolveEnv()
+                };
+                if (message instanceof Error) {
+                    properties.error_name = message.name;
+                    properties.error_stack = message.stack;
+                }
+                if (trace) {
+                    properties.trace = trace;
+                }
+                client.capture({
+                    distinctId: this.distinctId,
+                    event: '$log',
+                    properties
+                });
+            }
+        } catch {
+            // Swallow — logs must never break the caller.
+        }
+
+        // 3) For Error-typed `error()` calls, additionally forward to Sentry's
+        //    `captureException`. SentryInterceptor already covers exceptions
+        //    that surface through the request path, so this only meaningfully
+        //    fires for errors logged outside that path.
+        if (level === 'error' && message instanceof Error) {
+            try {
+                const sentry = getSentryInstance();
+                sentry?.captureException(message);
+            } catch {
+                // Swallow.
+            }
+        }
+    }
+}

--- a/packages/monitoring/src/posthog/posthog-logger.service.ts
+++ b/packages/monitoring/src/posthog/posthog-logger.service.ts
@@ -121,7 +121,7 @@ export class PostHogLoggerService implements LoggerService {
                     message: serializeMessage(message),
                     context: ctx,
                     service: 'ever-works-api',
-                    env: resolveEnv()
+                    env: resolveEnv(),
                 };
                 if (message instanceof Error) {
                     properties.error_name = message.name;
@@ -133,7 +133,7 @@ export class PostHogLoggerService implements LoggerService {
                 client.capture({
                     distinctId: this.distinctId,
                     event: '$log',
-                    properties
+                    properties,
                 });
             }
         } catch {


### PR DESCRIPTION
The `@ever-works/monitoring` package (Sentry + PostHog) has been wired into the API since it landed: `MonitoringModule.forRoot()` is in `apps/api/src/api.module.ts` and `initSentry()` + `initPostHog()` run in `apps/api/src/main.ts`. **Today the integration is dead in the deployed pods** — the env vars never reach the container, so prod gets zero Sentry events and zero PostHog data. This PR plumbs the existing GitHub Secrets (`SENTRY_DSN`, `POSTHOG_API_KEY`, `POSTHOG_HOST` — already set on `ever-works/ever-works` since 2025-10-01) through the deploy stack and adds a NestJS-Logger -> PostHog Logs transport on top.

Two commits, intentionally not squashed locally — let GitHub squash on merge if needed.

## Commit 1 — CI/k8s wiring (activate existing code in deployed envs)

`feat(infra): wire SENTRY_DSN + POSTHOG_API_KEY/HOST into deploy workflows and k8s manifests`

- **`.deploy/k8s/k8s-manifest.{dev,stage,prod}.yaml`** — Added `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `POSTHOG_API_KEY`, `POSTHOG_HOST` env entries to BOTH the API and WEB Deployments in each manifest. (Web reads `POSTHOG_API_KEY` / `POSTHOG_HOST` server-side for the fail-open `works-<kind>` chip flags in `apps/web/src/lib/feature-flags/work-kinds.ts`.) `NEXT_PUBLIC_*` are intentionally NOT set on the runtime container — they're baked at build time, see Commit 1 step 3 below.
- **`.github/workflows/deploy-do-{dev,stage,prod}.yml`** — Passes the matching repo secrets through the `envsubst` step. `SENTRY_ENVIRONMENT` is hard-coded per workflow: `development` / `staging` / `production`.
- **`.github/workflows/docker-build-publish-{dev,stage,prod}.yml`** + **`.deploy/docker/web/Dockerfile`** — `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` declared as `ARG`/`ENV` in the web `installer` stage and passed as `--build-arg` from the workflow. Next.js inlines `NEXT_PUBLIC_*` into the client bundle at `next build`, so they MUST be present at build time (not runtime). Same `phc_*` value re-used from `POSTHOG_API_KEY` / `POSTHOG_HOST` — no new secrets required.
- **`apps/api/.env.example`** + **`apps/web/.env.example`** — Documented the new vars and noted that all SDKs are graceful no-ops when their key is unset; in the web example uncommented existing PostHog vars and added the `NEXT_PUBLIC_*` pair with a note about `feat/posthog-frontend-analytics`.

## Commit 2 — NestJS Logger -> PostHog Logs transport

`feat(monitoring): forward NestJS Logger emits to PostHog Logs`

- **New: `packages/monitoring/src/posthog/posthog-logger.service.ts`** — Implements NestJS `LoggerService` (`log` / `warn` / `error` / `debug` / `verbose`). Each emit goes both to the default NestJS Logger (console, so `kubectl logs` keeps working) and to `getPostHogClient()?.capture({ event: '$log', properties: { level, message, context, service, env, error_name?, error_stack?, trace? } })`. Fail-open: throws from PostHog/Sentry are swallowed so logs always reach the console.
- **Sentry forwarding** — `error()` calls additionally forward `Error` instances to `getSentryInstance()?.captureException(...)`. String error messages are NOT forwarded to avoid double-capture with `SentryInterceptor` (which already covers request-path exceptions). Comment in the file calls out the boundary clearly.
- **Exports** — Added to `packages/monitoring/src/posthog/index.ts` (which is already re-exported from the package root `src/index.ts`), so the service is available via `@ever-works/monitoring` and `@ever-works/monitoring/posthog`.
- **Wired in** — `apps/api/src/main.ts` calls `app.useLogger(new PostHogLoggerService())` immediately after `initPostHog()`.
- **New test: `packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts`** — Jest (matching the existing test framework in the package — Jest, not Vitest, despite the original brief's Vitest reference). 12 cases covering event shape per level, custom distinctId, Error serialization with `error_name` + `error_stack`, trace passthrough, Sentry forwarding for Error instances, NO Sentry forwarding for string messages, fail-open on PostHog throw, JSON serialization of object messages, `SENTRY_ENVIRONMENT` honoured in `env` property.
- **Env doc one-liner** — Added in commit 1's `apps/api/.env.example` PostHog section: "When `POSTHOG_API_KEY` is set, all NestJS Logger emits (log/warn/error/debug/verbose) are also forwarded to PostHog Logs as `$log` events."

## Files changed (full list)

Commit 1 (12 files):
- `.deploy/k8s/k8s-manifest.dev.yaml`
- `.deploy/k8s/k8s-manifest.stage.yaml`
- `.deploy/k8s/k8s-manifest.prod.yaml`
- `.github/workflows/deploy-do-dev.yml`
- `.github/workflows/deploy-do-stage.yml`
- `.github/workflows/deploy-do-prod.yml`
- `.github/workflows/docker-build-publish-dev.yml`
- `.github/workflows/docker-build-publish-stage.yml`
- `.github/workflows/docker-build-publish-prod.yml`
- `.deploy/docker/web/Dockerfile`
- `apps/api/.env.example`
- `apps/web/.env.example`

Commit 2 (4 files):
- `packages/monitoring/src/posthog/posthog-logger.service.ts` (new)
- `packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts` (new)
- `packages/monitoring/src/posthog/index.ts`
- `apps/api/src/main.ts`

## Verification (in the worktree)

- `pnpm install` — clean
- `pnpm --filter @ever-works/contracts build` / `@ever-works/plugin build` / `@ever-works/agent build` / `@ever-works/trigger-tasks build` / `@ever-works/email-templates build` / `pnpm build:plugins` — clean
- `cd packages/monitoring && pnpm test` — `Test Suites: 7 passed, 7 total / Tests: 85 passed, 85 total` (12 new spec cases + existing 73)
- `pnpm --filter @ever-works/monitoring type-check` — `Found 0 issues.`
- `pnpm --filter ever-works-api type-check` — clean
- `pnpm --filter ever-works-web type-check` — clean
- YAML parse via `python -c "yaml.safe_load_all(...)"` — all 9 touched YAML files (3 manifests + 6 workflows) parse cleanly
- No lint script exists for the monitoring package (its `package.json` only defines `type-check`); root `pnpm lint` aliases to `turbo run lint`, and the only changed package with a `lint` script is `apps/web` (no `.ts/.tsx` changes there, only `.env.example`).

## Operator notes

- The GitHub Secrets `SENTRY_DSN`, `POSTHOG_API_KEY`, `POSTHOG_HOST` already exist on `ever-works/ever-works` (set 2025-10-01). **No operator action is required beyond merging + the standard `develop` -> `stage` -> `main` cascade.**
- All SDKs (Sentry, PostHog, PostHogLoggerService) are graceful no-ops when their key is unset, so OSS forks and self-hosters who don't set the secrets are unaffected.
- The `NEXT_PUBLIC_*` build args use the same `phc_*` key as the server-side `POSTHOG_API_KEY` (not a security secret — public PostHog project keys are designed for client exposure). The `feat/posthog-frontend-analytics` PR ships the `posthog-js` browser integration; until that lands the bundled values are unused but harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated analytics and error tracking across all environments.
  * Client-side analytics keys are now supplied at build time so web telemetry is accurate.
  * Application logs are forwarded to analytics and error monitoring for improved observability.

* **Documentation**
  * Added observability configuration examples for Sentry and PostHog.

* **Tests**
  * Added tests covering logging and analytics/error-forwarding behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->