### PR TITLE
feat(api): Composio settings backend (EW-684 PR-B)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
         "schema:log": "pnpm typeorm -- schema:log -d typeorm.config.ts"
     },
     "dependencies": {
+        "@composio/core": "^0.10.0",
         "@ever-works/agent": "workspace:*",
         "@ever-works/aws-s3-plugin": "workspace:*",
         "@ever-works/contracts": "workspace:*",

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -22,6 +22,7 @@ import { BudgetsModule } from './budgets/budgets.module';
 import { ScreenshotModule } from './plugins-capabilities/screenshot/screenshot.module';
 import { SearchModule } from './plugins-capabilities/search/search.module';
 import { PluginsModule } from './plugins/plugins.module';
+import { ComposioApiModule } from './plugins/composio/composio.module';
 import { GitProviderModule } from './plugins-capabilities/git-provider/git-provider.module';
 import { OAuthModule } from './plugins-capabilities/oauth/oauth.module';
 import { DeviceAuthModule } from './plugins-capabilities/device-auth/device-auth.module';
@@ -104,6 +105,7 @@ import { DatabaseModule } from '@ever-works/agent/database';
             useFactory: () => ({}),
         }),
         PluginsModule,
+        ComposioApiModule,
         GitProviderModule,
         OAuthModule,
         DeviceAuthModule,

--- a/apps/api/src/plugins/composio/composio.controller.ts
+++ b/apps/api/src/plugins/composio/composio.controller.ts
@@ -56,11 +56,9 @@ export class ComposioController {
     async listConnectedAccounts(
         @CurrentUser() auth: AuthenticatedUser,
         @Query('toolkit') toolkit?: string,
-        @Query('composio_user_id') composioUserId?: string,
     ): Promise<ComposioConnectedAccountListDto> {
         const items = await this.composio.listConnectedAccounts(auth.userId, {
             toolkitSlug: toolkit,
-            composioUserId,
         });
         return { items };
     }

--- a/apps/api/src/plugins/composio/composio.controller.ts
+++ b/apps/api/src/plugins/composio/composio.controller.ts
@@ -1,0 +1,82 @@
+import {
+    Body,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Post,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthSessionGuard, CurrentUser } from '../../auth';
+import type { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { ComposioService } from './composio.service';
+import {
+    ComposioConnectedAccountListDto,
+    ComposioToolkitListDto,
+    InitiateConnectionRequestDto,
+    InitiateConnectionResponseDto,
+} from './dto/composio.dto';
+
+@ApiTags('Composio')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/plugins/composio')
+@UseGuards(AuthSessionGuard)
+export class ComposioController {
+    constructor(private readonly composio: ComposioService) {}
+
+    @Get('toolkits')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'List Composio toolkits',
+        description: "Lists toolkits the caller's stored Composio API key has access to.",
+    })
+    @ApiResponse({ status: 200, type: ComposioToolkitListDto })
+    async listToolkits(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query('limit') limit?: string,
+    ): Promise<ComposioToolkitListDto> {
+        const parsed = limit !== undefined ? Number(limit) : 100;
+        const items = await this.composio.listToolkits(
+            auth.userId,
+            Number.isFinite(parsed) ? parsed : 100,
+        );
+        return { items };
+    }
+
+    @Get('connected-accounts')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: "List the caller's Composio connected accounts",
+        description:
+            "Returns the caller's connected accounts on Composio, optionally filtered by toolkit slug. Used by the settings UI to render connection status chips.",
+    })
+    @ApiResponse({ status: 200, type: ComposioConnectedAccountListDto })
+    async listConnectedAccounts(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query('toolkit') toolkit?: string,
+        @Query('composio_user_id') composioUserId?: string,
+    ): Promise<ComposioConnectedAccountListDto> {
+        const items = await this.composio.listConnectedAccounts(auth.userId, {
+            toolkitSlug: toolkit,
+            composioUserId,
+        });
+        return { items };
+    }
+
+    @Post('connect')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Initiate a Composio OAuth connection',
+        description:
+            'Initiates a new connected account via `connectedAccounts.initiate`. Returns the OAuth redirect URL the frontend should open in a popup. The frontend polls `/connected-accounts` to detect the ACTIVE transition.',
+    })
+    @ApiResponse({ status: 200, type: InitiateConnectionResponseDto })
+    async initiateConnection(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: InitiateConnectionRequestDto,
+    ): Promise<InitiateConnectionResponseDto> {
+        return this.composio.initiateConnection(auth.userId, body);
+    }
+}

--- a/apps/api/src/plugins/composio/composio.module.ts
+++ b/apps/api/src/plugins/composio/composio.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { PluginSettingsService } from '@ever-works/agent/plugins';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { AuthModule } from '../../auth';
+import { ComposioController } from './composio.controller';
+import { ComposioService } from './composio.service';
+
+/**
+ * Composio settings API module (PR-B of EW-684).
+ *
+ * Exposes /api/plugins/composio/{toolkits,connected-accounts,connect} for
+ * the web settings UI. Depends on the core PluginsModule (via
+ * `PluginOperationsService`) to resolve the caller's stored Composio API
+ * key from their user_plugin settings.
+ */
+@Module({
+    imports: [DatabaseModule, AuthModule],
+    controllers: [ComposioController],
+    providers: [PluginSettingsService, ComposioService],
+    exports: [ComposioService],
+})
+export class ComposioApiModule {}

--- a/apps/api/src/plugins/composio/composio.service.spec.ts
+++ b/apps/api/src/plugins/composio/composio.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import {
+    BadGatewayException,
+    BadRequestException,
+    NotFoundException,
+    UnauthorizedException,
+} from '@nestjs/common';
 
 // Short-circuit the heavy agent/plugins barrel chain — the only symbol we
 // need from it is the `PluginSettingsService` class token, and we provide
@@ -113,24 +118,13 @@ describe('ComposioService', () => {
     });
 
     describe('listConnectedAccounts', () => {
-        it("scopes the query to the caller's user id by default", async () => {
+        it("hard-pins the user_id filter to the JWT user (no override)", async () => {
             const sdk = buildSdkStub();
             (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({ items: [] });
             injectSdk(service, sdk);
 
             await service.listConnectedAccounts('user-1');
             expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({ userIds: ['user-1'] });
-        });
-
-        it('honors a composioUserId override (typical for email-keyed accounts)', async () => {
-            const sdk = buildSdkStub();
-            (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({ items: [] });
-            injectSdk(service, sdk);
-
-            await service.listConnectedAccounts('user-1', { composioUserId: 'alice@example.com' });
-            expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({
-                userIds: ['alice@example.com'],
-            });
         });
 
         it('passes toolkit filter as an uppercase array', async () => {
@@ -166,13 +160,19 @@ describe('ComposioService', () => {
     describe('initiateConnection', () => {
         it('throws when toolkitSlug is missing', async () => {
             await expect(
-                service.initiateConnection('user-1', { toolkitSlug: '' } as never),
+                service.initiateConnection('user-1', {
+                    toolkitSlug: '',
+                    authConfigId: 'ac_xyz',
+                }),
             ).rejects.toBeInstanceOf(BadRequestException);
         });
 
         it('throws when authConfigId is missing', async () => {
             await expect(
-                service.initiateConnection('user-1', { toolkitSlug: 'GMAIL' } as never),
+                service.initiateConnection('user-1', {
+                    toolkitSlug: 'GMAIL',
+                    authConfigId: '',
+                }),
             ).rejects.toBeInstanceOf(BadRequestException);
         });
 
@@ -210,7 +210,7 @@ describe('ComposioService', () => {
             expect(result.connectedAccountId).toBeUndefined();
         });
 
-        it('forwards composioUserId + callbackUrl to the SDK', async () => {
+        it('forwards callbackUrl to the SDK and always pins user_id to JWT user', async () => {
             const sdk = buildSdkStub();
             (sdk.connectedAccounts.initiate as jest.Mock).mockResolvedValue({
                 redirectUrl: 'https://composio.example/oauth',
@@ -220,14 +220,28 @@ describe('ComposioService', () => {
             await service.initiateConnection('user-1', {
                 toolkitSlug: 'GMAIL',
                 authConfigId: 'ac_xyz',
-                composioUserId: 'alice@example.com',
                 callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback',
             });
             expect(sdk.connectedAccounts.initiate).toHaveBeenCalledWith(
-                'alice@example.com',
+                'user-1',
                 'ac_xyz',
                 { callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback' },
             );
+        });
+
+        it('translates 5xx errors into BadGatewayException', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.initiate as jest.Mock).mockRejectedValue(
+                sdkError(503, 'upstream down'),
+            );
+            injectSdk(service, sdk);
+
+            await expect(
+                service.initiateConnection('user-1', {
+                    toolkitSlug: 'GMAIL',
+                    authConfigId: 'ac_xyz',
+                }),
+            ).rejects.toBeInstanceOf(BadGatewayException);
         });
 
         it('translates 404 errors into NotFoundException', async () => {

--- a/apps/api/src/plugins/composio/composio.service.spec.ts
+++ b/apps/api/src/plugins/composio/composio.service.spec.ts
@@ -118,7 +118,7 @@ describe('ComposioService', () => {
     });
 
     describe('listConnectedAccounts', () => {
-        it("hard-pins the user_id filter to the JWT user (no override)", async () => {
+        it('hard-pins the user_id filter to the JWT user (no override)', async () => {
             const sdk = buildSdkStub();
             (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({ items: [] });
             injectSdk(service, sdk);
@@ -222,11 +222,9 @@ describe('ComposioService', () => {
                 authConfigId: 'ac_xyz',
                 callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback',
             });
-            expect(sdk.connectedAccounts.initiate).toHaveBeenCalledWith(
-                'user-1',
-                'ac_xyz',
-                { callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback' },
-            );
+            expect(sdk.connectedAccounts.initiate).toHaveBeenCalledWith('user-1', 'ac_xyz', {
+                callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback',
+            });
         });
 
         it('translates 5xx errors into BadGatewayException', async () => {

--- a/apps/api/src/plugins/composio/composio.service.spec.ts
+++ b/apps/api/src/plugins/composio/composio.service.spec.ts
@@ -1,0 +1,261 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+// Short-circuit the heavy agent/plugins barrel chain — the only symbol we
+// need from it is the `PluginSettingsService` class token, and we provide
+// the value via NestJS DI rather than calling its methods directly.
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginSettingsService: class PluginSettingsService {},
+}));
+
+jest.mock('@composio/core', () => ({
+    Composio: jest.fn().mockImplementation(() => ({
+        toolkits: { get: jest.fn() },
+        connectedAccounts: { list: jest.fn(), initiate: jest.fn() },
+    })),
+}));
+
+import { PluginSettingsService } from '@ever-works/agent/plugins';
+import { ComposioService, type ComposioSdkLike } from './composio.service';
+
+function buildSdkStub(): ComposioSdkLike {
+    return {
+        toolkits: { get: jest.fn() },
+        connectedAccounts: { list: jest.fn(), initiate: jest.fn() },
+    } as unknown as ComposioSdkLike;
+}
+
+function buildResolvedSettings(overrides: Record<string, unknown> = {}): {
+    settings: Record<string, unknown>;
+} {
+    return { settings: { apiKey: 'test-key', ...overrides } };
+}
+
+function sdkError(status: number, message: string): Error {
+    const err = new Error(message);
+    (err as { status?: number }).status = status;
+    return err;
+}
+
+/**
+ * Replaces the private `getSdk` for direct SDK control in tests. Bypasses the
+ * `@composio/core` constructor (mocked above) and the settings-resolution path,
+ * letting each test isolate the SDK-call assertions.
+ */
+function injectSdk(service: ComposioService, sdk: ComposioSdkLike): void {
+    (service as unknown as { getSdk: jest.Mock }).getSdk = jest.fn().mockResolvedValue(sdk);
+}
+
+describe('ComposioService', () => {
+    let service: ComposioService;
+    let settingsService: { getResolvedSettings: jest.Mock };
+
+    beforeEach(async () => {
+        settingsService = { getResolvedSettings: jest.fn() };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ComposioService,
+                { provide: PluginSettingsService, useValue: settingsService },
+            ],
+        }).compile();
+        service = module.get(ComposioService);
+    });
+
+    describe('listToolkits — settings gating', () => {
+        it('throws BadRequestException when the plugin is not configured', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(null);
+            await expect(service.listToolkits('user-1')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('throws when the API key is missing from settings', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue({ settings: {} });
+            await expect(service.listToolkits('user-1')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+    });
+
+    describe('listToolkits', () => {
+        it('passes the requested limit through to the SDK', async () => {
+            const sdk = buildSdkStub();
+            (sdk.toolkits.get as jest.Mock).mockResolvedValue({
+                items: [{ slug: 'GMAIL', name: 'Gmail' }],
+            });
+            injectSdk(service, sdk);
+
+            const items = await service.listToolkits('user-1', 50);
+            expect(items).toEqual([{ slug: 'GMAIL', name: 'Gmail' }]);
+            expect(sdk.toolkits.get).toHaveBeenCalledWith({ limit: 50 });
+        });
+
+        it('clamps the limit into [1, 200]', async () => {
+            const sdk = buildSdkStub();
+            (sdk.toolkits.get as jest.Mock).mockResolvedValue({ items: [] });
+            injectSdk(service, sdk);
+
+            await service.listToolkits('user-1', 99999);
+            expect(sdk.toolkits.get).toHaveBeenLastCalledWith({ limit: 200 });
+            await service.listToolkits('user-1', 0);
+            expect(sdk.toolkits.get).toHaveBeenLastCalledWith({ limit: 1 });
+        });
+
+        it('translates 401 into UnauthorizedException', async () => {
+            const sdk = buildSdkStub();
+            (sdk.toolkits.get as jest.Mock).mockRejectedValue(sdkError(401, 'no'));
+            injectSdk(service, sdk);
+
+            await expect(service.listToolkits('user-1')).rejects.toBeInstanceOf(
+                UnauthorizedException,
+            );
+        });
+    });
+
+    describe('listConnectedAccounts', () => {
+        it("scopes the query to the caller's user id by default", async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({ items: [] });
+            injectSdk(service, sdk);
+
+            await service.listConnectedAccounts('user-1');
+            expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({ userIds: ['user-1'] });
+        });
+
+        it('honors a composioUserId override (typical for email-keyed accounts)', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({ items: [] });
+            injectSdk(service, sdk);
+
+            await service.listConnectedAccounts('user-1', { composioUserId: 'alice@example.com' });
+            expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({
+                userIds: ['alice@example.com'],
+            });
+        });
+
+        it('passes toolkit filter as an uppercase array', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({ items: [] });
+            injectSdk(service, sdk);
+
+            await service.listConnectedAccounts('user-1', { toolkitSlug: 'gmail' });
+            expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({
+                userIds: ['user-1'],
+                toolkitSlugs: ['GMAIL'],
+            });
+        });
+
+        it('maps SDK records into DTOs with camelCase + raw user_id fallback', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.list as jest.Mock).mockResolvedValue({
+                items: [
+                    { id: 'ca_1', status: 'ACTIVE', toolkit: { slug: 'GMAIL' }, userId: 'alice' },
+                    { id: 'ca_2', status: 'INITIATED', toolkit: { slug: 'GMAIL' }, user_id: 'bob' },
+                ],
+            });
+            injectSdk(service, sdk);
+
+            const result = await service.listConnectedAccounts('user-1');
+            expect(result).toEqual([
+                { id: 'ca_1', status: 'ACTIVE', toolkitSlug: 'GMAIL', userId: 'alice' },
+                { id: 'ca_2', status: 'INITIATED', toolkitSlug: 'GMAIL', userId: 'bob' },
+            ]);
+        });
+    });
+
+    describe('initiateConnection', () => {
+        it('throws when toolkitSlug is missing', async () => {
+            await expect(
+                service.initiateConnection('user-1', { toolkitSlug: '' } as never),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('throws when authConfigId is missing', async () => {
+            await expect(
+                service.initiateConnection('user-1', { toolkitSlug: 'GMAIL' } as never),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('returns the SDK redirect URL + connectedAccountId on success', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.initiate as jest.Mock).mockResolvedValue({
+                id: 'ca_new',
+                connectionRequest: { redirectUrl: 'https://composio.example/oauth/gmail?token=x' },
+            });
+            injectSdk(service, sdk);
+
+            const result = await service.initiateConnection('user-1', {
+                toolkitSlug: 'GMAIL',
+                authConfigId: 'ac_xyz',
+            });
+            expect(result).toEqual({
+                redirectUrl: 'https://composio.example/oauth/gmail?token=x',
+                connectedAccountId: 'ca_new',
+            });
+            expect(sdk.connectedAccounts.initiate).toHaveBeenCalledWith('user-1', 'ac_xyz', {});
+        });
+
+        it('falls back to top-level redirectUrl when connectionRequest is missing', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.initiate as jest.Mock).mockResolvedValue({
+                redirectUrl: 'https://composio.example/oauth/raw',
+            });
+            injectSdk(service, sdk);
+
+            const result = await service.initiateConnection('user-1', {
+                toolkitSlug: 'GMAIL',
+                authConfigId: 'ac_xyz',
+            });
+            expect(result.redirectUrl).toBe('https://composio.example/oauth/raw');
+            expect(result.connectedAccountId).toBeUndefined();
+        });
+
+        it('forwards composioUserId + callbackUrl to the SDK', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.initiate as jest.Mock).mockResolvedValue({
+                redirectUrl: 'https://composio.example/oauth',
+            });
+            injectSdk(service, sdk);
+
+            await service.initiateConnection('user-1', {
+                toolkitSlug: 'GMAIL',
+                authConfigId: 'ac_xyz',
+                composioUserId: 'alice@example.com',
+                callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback',
+            });
+            expect(sdk.connectedAccounts.initiate).toHaveBeenCalledWith(
+                'alice@example.com',
+                'ac_xyz',
+                { callbackUrl: 'https://app.ever.works/settings/plugins/composio/callback' },
+            );
+        });
+
+        it('translates 404 errors into NotFoundException', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.initiate as jest.Mock).mockRejectedValue(
+                sdkError(404, 'no toolkit'),
+            );
+            injectSdk(service, sdk);
+
+            await expect(
+                service.initiateConnection('user-1', {
+                    toolkitSlug: 'GMAIL',
+                    authConfigId: 'ac_xyz',
+                }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('throws when the SDK does not return a redirect URL', async () => {
+            const sdk = buildSdkStub();
+            (sdk.connectedAccounts.initiate as jest.Mock).mockResolvedValue({});
+            injectSdk(service, sdk);
+
+            await expect(
+                service.initiateConnection('user-1', {
+                    toolkitSlug: 'GMAIL',
+                    authConfigId: 'ac_xyz',
+                }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+});

--- a/apps/api/src/plugins/composio/composio.service.ts
+++ b/apps/api/src/plugins/composio/composio.service.ts
@@ -1,0 +1,234 @@
+import {
+    Injectable,
+    Logger,
+    BadRequestException,
+    NotFoundException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { Composio } from '@composio/core';
+import { PluginSettingsService } from '@ever-works/agent/plugins';
+import type {
+    ComposioToolkitDto,
+    ComposioConnectedAccountDto,
+    InitiateConnectionRequestDto,
+    InitiateConnectionResponseDto,
+} from './dto/composio.dto';
+
+const COMPOSIO_PLUGIN_ID = 'composio';
+
+/**
+ * Minimal subset of the official `@composio/core` SDK we use. Mirrors the
+ * shape declared in `packages/plugins/composio/src/utils/composio-client.ts`
+ * so the same mock pattern works in tests across both modules.
+ */
+export interface ComposioSdkLike {
+    toolkits: {
+        get(query?: { limit?: number }): Promise<{ items: ComposioToolkitDto[] }>;
+    };
+    connectedAccounts: {
+        list(query?: { userIds?: string[]; toolkitSlugs?: string[]; limit?: number }): Promise<{
+            items: Array<{
+                id: string;
+                status: string;
+                toolkit?: { slug?: string };
+                user_id?: string;
+                userId?: string;
+            }>;
+        }>;
+        initiate(
+            userId: string,
+            authConfigId: string,
+            options?: { callbackUrl?: string },
+        ): Promise<{
+            id?: string;
+            connectionRequest?: { redirectUrl?: string };
+            redirectUrl?: string;
+        }>;
+    };
+}
+
+/**
+ * Backend service that fronts Composio's catalog + Connected-Accounts APIs
+ * for the Ever Works web UI (PR-B of EW-684).
+ *
+ * Responsibility split:
+ *  - The Composio **plugin** (packages/plugins/composio) drives Composio
+ *    during pipeline execution — its handle on the SDK is per-pipeline-run
+ *    and uses the plugin's resolved settings.
+ *  - This API service drives Composio during **settings UX** — listing
+ *    toolkits, listing the caller's connected accounts, and initiating new
+ *    OAuth connections from the settings page. The two are intentionally
+ *    not shared: the plugin code runs in worker contexts where the NestJS
+ *    DI tree isn't available, and this controller needs request-scoped
+ *    SDK clients built from each caller's stored API key.
+ */
+@Injectable()
+export class ComposioService {
+    private readonly logger = new Logger(ComposioService.name);
+
+    constructor(private readonly settingsService: PluginSettingsService) {}
+
+    /**
+     * Builds a per-request `Composio` SDK client from the caller's stored
+     * `composio` plugin settings. Throws if the plugin is not enabled or
+     * the user hasn't set an API key.
+     *
+     * Override via `sdkFactory` for unit tests.
+     */
+    private async getSdk(
+        userId: string,
+        sdkFactory?: (apiKey: string, baseUrl?: string) => ComposioSdkLike,
+    ): Promise<ComposioSdkLike> {
+        const resolved = await this.settingsService
+            .getResolvedSettings(COMPOSIO_PLUGIN_ID, { userId, includeSecrets: true })
+            .catch(() => null);
+        const settings = (resolved?.settings ?? null) as Record<string, unknown> | null;
+        const apiKey = readString(settings, 'apiKey');
+        if (!apiKey) {
+            throw new BadRequestException(
+                `The Composio plugin is not configured. Set your Composio API key under Settings → Plugins → Composio.`,
+            );
+        }
+        const baseUrl = readString(settings, 'baseUrl') || undefined;
+        if (sdkFactory) return sdkFactory(apiKey, baseUrl);
+        return new Composio({
+            apiKey,
+            ...(baseUrl ? { baseURL: baseUrl } : {}),
+        }) as unknown as ComposioSdkLike;
+    }
+
+    /**
+     * Lists the Composio toolkit catalog the caller's API key has access to.
+     * Used to populate the Connect dropdown / search in the settings UI.
+     */
+    async listToolkits(userId: string, limit = 100): Promise<ComposioToolkitDto[]> {
+        const sdk = await this.getSdk(userId);
+        try {
+            const response = await sdk.toolkits.get({ limit: Math.max(1, Math.min(limit, 200)) });
+            return response.items ?? [];
+        } catch (error) {
+            throw this.wrapComposioError(error, 'list toolkits');
+        }
+    }
+
+    /**
+     * Lists the caller's connected accounts on Composio. Optionally filtered
+     * by toolkit slug to show "is GMAIL connected?" for a single chip.
+     *
+     * `composioUserId` defaults to the JWT user id so each Ever Works user
+     * sees only their own connections. Settings UI may set it to an email
+     * if the upstream account is registered under a different identifier.
+     */
+    async listConnectedAccounts(
+        userId: string,
+        options: { toolkitSlug?: string; composioUserId?: string } = {},
+    ): Promise<ComposioConnectedAccountDto[]> {
+        const sdk = await this.getSdk(userId);
+        const targetUserId = options.composioUserId?.trim() || userId;
+        try {
+            const query: { userIds: string[]; toolkitSlugs?: string[] } = {
+                userIds: [targetUserId],
+            };
+            if (options.toolkitSlug) query.toolkitSlugs = [options.toolkitSlug.toUpperCase()];
+            const response = await sdk.connectedAccounts.list(query);
+            return (response.items ?? []).map((raw) => ({
+                id: raw.id,
+                status: raw.status,
+                toolkitSlug: raw.toolkit?.slug,
+                userId: raw.userId ?? raw.user_id,
+            }));
+        } catch (error) {
+            throw this.wrapComposioError(error, 'list connected accounts');
+        }
+    }
+
+    /**
+     * Initiates an OAuth connection for the caller against a toolkit. Returns
+     * the redirect URL the frontend should open in a popup. The user completes
+     * the OAuth dance on Composio, which redirects to `callbackUrl` (defaults
+     * to the platform's settings page) when done; the frontend then polls
+     * `listConnectedAccounts` until the new account is ACTIVE.
+     *
+     * `authConfigId` is the Composio auth-config nanoid (e.g. `ac_*`). Each
+     * toolkit has a default auth config registered when the Composio
+     * organization is set up; for custom OAuth credentials the operator
+     * creates a separate auth config via Composio dashboard and passes the
+     * id here.
+     */
+    async initiateConnection(
+        userId: string,
+        body: InitiateConnectionRequestDto,
+    ): Promise<InitiateConnectionResponseDto> {
+        if (!body.toolkitSlug) {
+            throw new BadRequestException('toolkitSlug is required');
+        }
+        if (!body.authConfigId) {
+            throw new BadRequestException(
+                'authConfigId is required. Create an auth config for this toolkit in the Composio dashboard or via the auth-configs API and pass its id here.',
+            );
+        }
+        const sdk = await this.getSdk(userId);
+        const targetUserId = body.composioUserId?.trim() || userId;
+        try {
+            const result = await sdk.connectedAccounts.initiate(targetUserId, body.authConfigId, {
+                ...(body.callbackUrl ? { callbackUrl: body.callbackUrl } : {}),
+            });
+            const redirectUrl = result.connectionRequest?.redirectUrl ?? result.redirectUrl;
+            if (!redirectUrl) {
+                throw new Error('Composio did not return a redirect URL for the new connection.');
+            }
+            return {
+                redirectUrl,
+                ...(result.id ? { connectedAccountId: result.id } : {}),
+            };
+        } catch (error) {
+            throw this.wrapComposioError(error, `initiate connection to ${body.toolkitSlug}`);
+        }
+    }
+
+    /**
+     * Translates SDK-thrown errors into NestJS HTTP exceptions so the
+     * controller can pass them through verbatim. Mirrors the friendly
+     * messages in the plugin's `ComposioClient.wrapError` — keep them in
+     * sync; CodeRabbit / Greptile have flagged divergence in the past.
+     */
+    private wrapComposioError(error: unknown, context: string): Error {
+        if (!(error instanceof Error))
+            return new Error(`Unexpected error during ${context}: ${String(error)}`);
+        const status = readNumberProp(error, 'status') ?? readNumberProp(error, 'statusCode');
+        const message = error.message || String(error);
+        if (status === 401 || status === 403) {
+            return new UnauthorizedException(
+                `Composio rejected the API key (HTTP ${status}) during ${context}. Verify it under Settings → Plugins → Composio.`,
+            );
+        }
+        if (status === 404) {
+            return new NotFoundException(
+                `Composio returned 404 during ${context}. Likely causes: the toolkit / tool slug does not exist, or the user has no connected account.`,
+            );
+        }
+        if (status === 429) {
+            return new BadRequestException('Composio rate limit exceeded. Wait and retry.');
+        }
+        if (status !== undefined && status >= 500) {
+            return new BadRequestException(
+                `Composio is returning HTTP ${status} during ${context}. Check https://status.composio.dev. (${message})`,
+            );
+        }
+        this.logger.warn(`Composio SDK error during ${context}: ${message}`);
+        return new BadRequestException(`Composio error during ${context}: ${message}`);
+    }
+}
+
+function readString(source: Record<string, unknown> | null, key: string): string | undefined {
+    if (!source) return undefined;
+    const value = source[key];
+    if (typeof value !== 'string') return undefined;
+    const trimmed = value.trim();
+    return trimmed === '' ? undefined : trimmed;
+}
+
+function readNumberProp(target: object, prop: string): number | undefined {
+    const value = (target as Record<string, unknown>)[prop];
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}

--- a/apps/api/src/plugins/composio/composio.service.ts
+++ b/apps/api/src/plugins/composio/composio.service.ts
@@ -1,6 +1,7 @@
 import {
     Injectable,
     Logger,
+    BadGatewayException,
     BadRequestException,
     NotFoundException,
     UnauthorizedException,
@@ -71,14 +72,9 @@ export class ComposioService {
     /**
      * Builds a per-request `Composio` SDK client from the caller's stored
      * `composio` plugin settings. Throws if the plugin is not enabled or
-     * the user hasn't set an API key.
-     *
-     * Override via `sdkFactory` for unit tests.
+     * the user hasn't set an API key. Tests stub via `jest.spyOn(svc, 'getSdk')`.
      */
-    private async getSdk(
-        userId: string,
-        sdkFactory?: (apiKey: string, baseUrl?: string) => ComposioSdkLike,
-    ): Promise<ComposioSdkLike> {
+    private async getSdk(userId: string): Promise<ComposioSdkLike> {
         const resolved = await this.settingsService
             .getResolvedSettings(COMPOSIO_PLUGIN_ID, { userId, includeSecrets: true })
             .catch(() => null);
@@ -90,7 +86,6 @@ export class ComposioService {
             );
         }
         const baseUrl = readString(settings, 'baseUrl') || undefined;
-        if (sdkFactory) return sdkFactory(apiKey, baseUrl);
         return new Composio({
             apiKey,
             ...(baseUrl ? { baseURL: baseUrl } : {}),
@@ -115,19 +110,18 @@ export class ComposioService {
      * Lists the caller's connected accounts on Composio. Optionally filtered
      * by toolkit slug to show "is GMAIL connected?" for a single chip.
      *
-     * `composioUserId` defaults to the JWT user id so each Ever Works user
-     * sees only their own connections. Settings UI may set it to an email
-     * if the upstream account is registered under a different identifier.
+     * The Composio user_id filter is hard-pinned to the JWT user id so a
+     * shared workspace API key cannot be used to enumerate another user's
+     * connected accounts.
      */
     async listConnectedAccounts(
         userId: string,
-        options: { toolkitSlug?: string; composioUserId?: string } = {},
+        options: { toolkitSlug?: string } = {},
     ): Promise<ComposioConnectedAccountDto[]> {
         const sdk = await this.getSdk(userId);
-        const targetUserId = options.composioUserId?.trim() || userId;
         try {
             const query: { userIds: string[]; toolkitSlugs?: string[] } = {
-                userIds: [targetUserId],
+                userIds: [userId],
             };
             if (options.toolkitSlug) query.toolkitSlugs = [options.toolkitSlug.toUpperCase()];
             const response = await sdk.connectedAccounts.list(query);
@@ -168,9 +162,8 @@ export class ComposioService {
             );
         }
         const sdk = await this.getSdk(userId);
-        const targetUserId = body.composioUserId?.trim() || userId;
         try {
-            const result = await sdk.connectedAccounts.initiate(targetUserId, body.authConfigId, {
+            const result = await sdk.connectedAccounts.initiate(userId, body.authConfigId, {
                 ...(body.callbackUrl ? { callbackUrl: body.callbackUrl } : {}),
             });
             const redirectUrl = result.connectionRequest?.redirectUrl ?? result.redirectUrl;
@@ -211,7 +204,7 @@ export class ComposioService {
             return new BadRequestException('Composio rate limit exceeded. Wait and retry.');
         }
         if (status !== undefined && status >= 500) {
-            return new BadRequestException(
+            return new BadGatewayException(
                 `Composio is returning HTTP ${status} during ${context}. Check https://status.composio.dev. (${message})`,
             );
         }

--- a/apps/api/src/plugins/composio/dto/composio.dto.ts
+++ b/apps/api/src/plugins/composio/dto/composio.dto.ts
@@ -1,0 +1,82 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, IsUrl } from 'class-validator';
+
+export class ComposioToolkitDto {
+    @ApiProperty({ description: 'Toolkit slug (e.g. GMAIL, GITHUB)' })
+    slug!: string;
+
+    @ApiProperty({ description: 'Human-friendly name' })
+    name!: string;
+
+    @ApiPropertyOptional({ description: 'Toolkit description' })
+    description?: string;
+
+    @ApiPropertyOptional({ description: 'Categories the toolkit belongs to', type: [String] })
+    categories?: string[];
+}
+
+export class ComposioToolkitListDto {
+    @ApiProperty({ type: [ComposioToolkitDto] })
+    items!: ComposioToolkitDto[];
+}
+
+export class ComposioConnectedAccountDto {
+    @ApiProperty({ description: 'Composio account id (ca_*)' })
+    id!: string;
+
+    @ApiProperty({ description: 'ACTIVE / INITIATED / EXPIRED / REVOKED / FAILED' })
+    status!: string;
+
+    @ApiPropertyOptional({ description: 'Toolkit slug this connection authenticates' })
+    toolkitSlug?: string;
+
+    @ApiPropertyOptional({ description: 'Composio user id the connection belongs to' })
+    userId?: string;
+}
+
+export class ComposioConnectedAccountListDto {
+    @ApiProperty({ type: [ComposioConnectedAccountDto] })
+    items!: ComposioConnectedAccountDto[];
+}
+
+export class InitiateConnectionRequestDto {
+    @ApiProperty({ description: 'Toolkit to connect (e.g. GMAIL)' })
+    @IsString()
+    @IsNotEmpty()
+    toolkitSlug!: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Composio authConfig id (ac_*) to use for this connection. Omit to fall back to the toolkit default registered in Composio.',
+    })
+    @IsOptional()
+    @IsString()
+    authConfigId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Override the Composio user_id for this connection. Defaults to the Ever Works user id passed via JWT.',
+    })
+    @IsOptional()
+    @IsString()
+    composioUserId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Where Composio should redirect after the OAuth dance completes. Defaults to the platform-configured callback page.',
+    })
+    @IsOptional()
+    @IsUrl({ require_tld: false })
+    callbackUrl?: string;
+}
+
+export class InitiateConnectionResponseDto {
+    @ApiProperty({ description: 'OAuth URL to open in a popup. User completes the flow here.' })
+    redirectUrl!: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Composio connected-account id created by `initiate`. Stays INITIATED until the user completes OAuth, then transitions to ACTIVE. Poll `/connected-accounts` to detect the transition.',
+    })
+    connectedAccountId?: string;
+}

--- a/apps/api/src/plugins/composio/dto/composio.dto.ts
+++ b/apps/api/src/plugins/composio/dto/composio.dto.ts
@@ -45,21 +45,13 @@ export class InitiateConnectionRequestDto {
     @IsNotEmpty()
     toolkitSlug!: string;
 
-    @ApiPropertyOptional({
+    @ApiProperty({
         description:
-            'Composio authConfig id (ac_*) to use for this connection. Omit to fall back to the toolkit default registered in Composio.',
+            'Composio authConfig id (ac_*) to use for this connection. Create an auth config for the toolkit in the Composio dashboard (or via the auth-configs API) and pass its id here.',
     })
-    @IsOptional()
     @IsString()
-    authConfigId?: string;
-
-    @ApiPropertyOptional({
-        description:
-            'Override the Composio user_id for this connection. Defaults to the Ever Works user id passed via JWT.',
-    })
-    @IsOptional()
-    @IsString()
-    composioUserId?: string;
+    @IsNotEmpty()
+    authConfigId!: string;
 
     @ApiPropertyOptional({
         description:

--- a/apps/web/src/app/actions/plugins.ts
+++ b/apps/web/src/app/actions/plugins.ts
@@ -268,7 +268,9 @@ export async function listComposioConnectedAccounts(
         return {
             success: false,
             error:
-                error instanceof Error ? error.message : 'Failed to list Composio connected accounts',
+                error instanceof Error
+                    ? error.message
+                    : 'Failed to list Composio connected accounts',
         };
     }
 }

--- a/apps/web/src/app/actions/plugins.ts
+++ b/apps/web/src/app/actions/plugins.ts
@@ -5,6 +5,13 @@ import {
     deviceAuthAPI,
     type PluginDeviceAuthStatus,
 } from '@/lib/api/plugins-capabilities/device-auth';
+import {
+    composioAPI,
+    type ComposioConnectedAccount,
+    type ComposioToolkit,
+    type InitiateConnectionRequest,
+    type InitiateConnectionResponse,
+} from '@/lib/api/plugins-capabilities/composio';
 import { revalidatePath } from 'next/cache';
 
 export interface ActionResult<T = unknown> {
@@ -233,6 +240,50 @@ export async function startPluginDeviceAuth(
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to start device auth',
+        };
+    }
+}
+
+export async function listComposioToolkits(
+    limit?: number,
+): Promise<ActionResult<ComposioToolkit[]>> {
+    try {
+        const data = await composioAPI.listToolkits(limit);
+        return { success: true, data };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to list Composio toolkits',
+        };
+    }
+}
+
+export async function listComposioConnectedAccounts(
+    toolkitSlug?: string,
+): Promise<ActionResult<ComposioConnectedAccount[]>> {
+    try {
+        const data = await composioAPI.listConnectedAccounts(toolkitSlug);
+        return { success: true, data };
+    } catch (error) {
+        return {
+            success: false,
+            error:
+                error instanceof Error ? error.message : 'Failed to list Composio connected accounts',
+        };
+    }
+}
+
+export async function initiateComposioConnection(
+    body: InitiateConnectionRequest,
+): Promise<ActionResult<InitiateConnectionResponse>> {
+    try {
+        const data = await composioAPI.initiateConnection(body);
+        return { success: true, data };
+    } catch (error) {
+        return {
+            success: false,
+            error:
+                error instanceof Error ? error.message : 'Failed to initiate Composio connection',
         };
     }
 }

--- a/apps/web/src/components/plugins/PluginSettings.tsx
+++ b/apps/web/src/components/plugins/PluginSettings.tsx
@@ -28,6 +28,7 @@ import { PluginDeviceAuthConnection } from '@/components/settings/PluginDeviceAu
 import { PluginOAuthConnection } from '@/components/settings/PluginOAuthConnection';
 import { GitHubOrganizationsSettings } from '@/components/settings/GitHubOrganizationsSettings';
 import { PluginOnboardingWizard } from '@/components/settings/PluginOnboardingWizard';
+import { ComposioConnectionsPanel } from './composio/ComposioConnectionsPanel';
 import { getCategoryLabel, getCapabilityLabel } from '@/lib/utils/plugin-category-icons';
 import { usePluginSettings } from '@/lib/hooks/use-plugin-settings';
 import { usePluginToggle } from '@/lib/hooks/use-plugin-toggle';
@@ -299,6 +300,10 @@ export function PluginSettings({ plugin, oauthConnection, deviceAuthStatus }: Pl
                     plugin={plugin}
                     connected={Boolean(oauthConnection?.connected)}
                 />
+            )}
+
+            {plugin.pluginId === 'composio' && optimisticEnabled && Boolean(displaySettings.apiKey) && (
+                <ComposioConnectionsPanel />
             )}
 
             {/* Settings Form */}

--- a/apps/web/src/components/plugins/PluginSettings.tsx
+++ b/apps/web/src/components/plugins/PluginSettings.tsx
@@ -302,9 +302,9 @@ export function PluginSettings({ plugin, oauthConnection, deviceAuthStatus }: Pl
                 />
             )}
 
-            {plugin.pluginId === 'composio' && optimisticEnabled && Boolean(displaySettings.apiKey) && (
-                <ComposioConnectionsPanel />
-            )}
+            {plugin.pluginId === 'composio' &&
+                optimisticEnabled &&
+                Boolean(displaySettings.apiKey) && <ComposioConnectionsPanel />}
 
             {/* Settings Form */}
             {hasSettings ? (

--- a/apps/web/src/components/plugins/composio/ComposioConnectionsPanel.tsx
+++ b/apps/web/src/components/plugins/composio/ComposioConnectionsPanel.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2, ExternalLink, Loader2, Plug, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+    initiateComposioConnection,
+    listComposioConnectedAccounts,
+    listComposioToolkits,
+} from '@/app/actions/plugins';
+import type {
+    ComposioConnectedAccount,
+    ComposioToolkit,
+} from '@/lib/api/plugins-capabilities/composio';
+
+interface ComposioConnectionsPanelProps {
+    /** Optional callback URL Composio should redirect to after OAuth completes. */
+    callbackUrl?: string;
+}
+
+const ACTIVE_STATUS = 'ACTIVE';
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Settings-page panel that lists the Composio toolkit catalog the caller's
+ * API key has access to and the caller's current connected accounts. For
+ * each toolkit row the user supplies an authConfigId (ac_*) and clicks
+ * **Connect** — we POST `/api/plugins/composio/connect`, open the returned
+ * OAuth URL in a popup, then poll `/api/plugins/composio/connected-accounts`
+ * until the new account flips to ACTIVE.
+ */
+export function ComposioConnectionsPanel({ callbackUrl }: ComposioConnectionsPanelProps) {
+    const [toolkits, setToolkits] = useState<ComposioToolkit[]>([]);
+    const [accounts, setAccounts] = useState<ComposioConnectedAccount[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [authConfigBySlug, setAuthConfigBySlug] = useState<Record<string, string>>({});
+    const [connectingSlug, setConnectingSlug] = useState<string | null>(null);
+    const [pollingSlug, setPollingSlug] = useState<string | null>(null);
+    const pollTimerRef = useRef<number | null>(null);
+
+    const accountsByToolkit = useMemo(() => {
+        const map = new Map<string, ComposioConnectedAccount[]>();
+        for (const a of accounts) {
+            const key = (a.toolkitSlug ?? '').toUpperCase();
+            const list = map.get(key) ?? [];
+            list.push(a);
+            map.set(key, list);
+        }
+        return map;
+    }, [accounts]);
+
+    const refreshAccounts = useCallback(async () => {
+        const result = await listComposioConnectedAccounts();
+        if (result.success && result.data) {
+            setAccounts(result.data);
+            return result.data;
+        }
+        if (!result.success) setError(result.error ?? 'Failed to load connected accounts');
+        return [] as ComposioConnectedAccount[];
+    }, []);
+
+    const refreshAll = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        const [tk, _accs] = await Promise.all([listComposioToolkits(200), refreshAccounts()]);
+        if (tk.success && tk.data) setToolkits(tk.data);
+        else if (!tk.success) setError(tk.error ?? 'Failed to load toolkits');
+        setLoading(false);
+    }, [refreshAccounts]);
+
+    useEffect(() => {
+        void refreshAll();
+    }, [refreshAll]);
+
+    useEffect(() => {
+        return () => {
+            if (pollTimerRef.current !== null) window.clearInterval(pollTimerRef.current);
+        };
+    }, []);
+
+    const startPolling = useCallback(
+        (toolkitSlug: string) => {
+            if (pollTimerRef.current !== null) window.clearInterval(pollTimerRef.current);
+            setPollingSlug(toolkitSlug);
+            const startedAt = Date.now();
+            const upper = toolkitSlug.toUpperCase();
+            pollTimerRef.current = window.setInterval(async () => {
+                const latest = await refreshAccounts();
+                const active = latest.some(
+                    (a) =>
+                        (a.toolkitSlug ?? '').toUpperCase() === upper && a.status === ACTIVE_STATUS,
+                );
+                if (active || Date.now() - startedAt > POLL_TIMEOUT_MS) {
+                    if (pollTimerRef.current !== null) {
+                        window.clearInterval(pollTimerRef.current);
+                        pollTimerRef.current = null;
+                    }
+                    setPollingSlug(null);
+                }
+            }, POLL_INTERVAL_MS);
+        },
+        [refreshAccounts],
+    );
+
+    const handleConnect = useCallback(
+        async (toolkit: ComposioToolkit) => {
+            const authConfigId = (authConfigBySlug[toolkit.slug] ?? '').trim();
+            if (!authConfigId) {
+                setError(
+                    `Enter the authConfig id (ac_*) for ${toolkit.slug} before connecting. Create one in the Composio dashboard.`,
+                );
+                return;
+            }
+            setError(null);
+            setConnectingSlug(toolkit.slug);
+            try {
+                const result = await initiateComposioConnection({
+                    toolkitSlug: toolkit.slug,
+                    authConfigId,
+                    ...(callbackUrl ? { callbackUrl } : {}),
+                });
+                if (!result.success || !result.data) {
+                    setError(result.error ?? 'Failed to initiate connection');
+                    return;
+                }
+                window.open(
+                    result.data.redirectUrl,
+                    '_blank',
+                    'noopener,noreferrer,width=600,height=700',
+                );
+                startPolling(toolkit.slug);
+            } finally {
+                setConnectingSlug(null);
+            }
+        },
+        [authConfigBySlug, callbackUrl, startPolling],
+    );
+
+    if (loading) {
+        return (
+            <div className="rounded-lg border border-border dark:border-border-dark p-6 bg-surface dark:bg-surface-dark flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Loading Composio toolkits…
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark">
+            <div className="flex items-center justify-between gap-2 px-6 py-3 border-b border-border dark:border-border-dark">
+                <div className="flex items-center gap-2">
+                    <Plug className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                    <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                        Composio connections
+                    </h2>
+                </div>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void refreshAll()}
+                    aria-label="Refresh connections"
+                >
+                    <RefreshCw className="w-4 h-4" />
+                </Button>
+            </div>
+
+            {error && (
+                <div className="px-6 py-3 text-sm text-danger border-b border-border dark:border-border-dark">
+                    {error}
+                </div>
+            )}
+
+            {toolkits.length === 0 ? (
+                <div className="p-6 text-sm text-text-muted dark:text-text-muted-dark">
+                    No toolkits returned. Set your Composio API key in plugin settings first.
+                </div>
+            ) : (
+                <ul className="divide-y divide-border dark:divide-border-dark">
+                    {toolkits.map((toolkit) => {
+                        const connected = accountsByToolkit.get(toolkit.slug.toUpperCase()) ?? [];
+                        const isActive = connected.some((a) => a.status === ACTIVE_STATUS);
+                        const isConnecting = connectingSlug === toolkit.slug;
+                        const isPolling = pollingSlug === toolkit.slug;
+                        return (
+                            <li
+                                key={toolkit.slug}
+                                className="px-6 py-4 flex items-start gap-4 flex-wrap"
+                            >
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2">
+                                        <span className="font-medium text-text dark:text-text-dark">
+                                            {toolkit.name}
+                                        </span>
+                                        <span className="font-mono text-xs text-text-muted dark:text-text-muted-dark">
+                                            {toolkit.slug}
+                                        </span>
+                                        {isActive && (
+                                            <span className="inline-flex items-center gap-1 text-xs text-success">
+                                                <CheckCircle2 className="w-3.5 h-3.5" />
+                                                Connected
+                                            </span>
+                                        )}
+                                        {!isActive && connected.length > 0 && (
+                                            <span className="text-xs text-text-muted dark:text-text-muted-dark">
+                                                {connected[0].status}
+                                            </span>
+                                        )}
+                                    </div>
+                                    {toolkit.description && (
+                                        <p className="text-sm text-text-muted dark:text-text-muted-dark mt-1 line-clamp-2">
+                                            {toolkit.description}
+                                        </p>
+                                    )}
+                                </div>
+                                <div className="flex items-center gap-2 w-full sm:w-auto">
+                                    <Input
+                                        type="text"
+                                        placeholder="authConfigId (ac_…)"
+                                        value={authConfigBySlug[toolkit.slug] ?? ''}
+                                        onChange={(e) =>
+                                            setAuthConfigBySlug((prev) => ({
+                                                ...prev,
+                                                [toolkit.slug]: e.target.value,
+                                            }))
+                                        }
+                                        className="w-56 font-mono text-xs"
+                                        aria-label={`authConfigId for ${toolkit.slug}`}
+                                    />
+                                    <Button
+                                        variant="primary"
+                                        size="sm"
+                                        onClick={() => void handleConnect(toolkit)}
+                                        disabled={isConnecting || isPolling}
+                                        loading={isConnecting || isPolling}
+                                    >
+                                        {isPolling ? (
+                                            'Waiting…'
+                                        ) : (
+                                            <>
+                                                <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                                                {isActive ? 'Reconnect' : 'Connect'}
+                                            </>
+                                        )}
+                                    </Button>
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/plugins-capabilities/composio.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/composio.ts
@@ -1,0 +1,55 @@
+import 'server-only';
+import { serverFetch, serverMutation } from '../server-api';
+
+export interface ComposioToolkit {
+    slug: string;
+    name: string;
+    description?: string;
+    categories?: string[];
+}
+
+export interface ComposioConnectedAccount {
+    id: string;
+    status: string;
+    toolkitSlug?: string;
+    userId?: string;
+}
+
+export interface InitiateConnectionRequest {
+    toolkitSlug: string;
+    authConfigId: string;
+    callbackUrl?: string;
+}
+
+export interface InitiateConnectionResponse {
+    redirectUrl: string;
+    connectedAccountId?: string;
+}
+
+export const composioAPI = {
+    listToolkits: async (limit = 100): Promise<ComposioToolkit[]> => {
+        const response = await serverFetch<{ items: ComposioToolkit[] }>(
+            `/plugins/composio/toolkits?limit=${limit}`,
+        );
+        return response.items ?? [];
+    },
+
+    listConnectedAccounts: async (toolkitSlug?: string): Promise<ComposioConnectedAccount[]> => {
+        const query = toolkitSlug ? `?toolkit=${encodeURIComponent(toolkitSlug)}` : '';
+        const response = await serverFetch<{ items: ComposioConnectedAccount[] }>(
+            `/plugins/composio/connected-accounts${query}`,
+        );
+        return response.items ?? [];
+    },
+
+    initiateConnection: async (
+        body: InitiateConnectionRequest,
+    ): Promise<InitiateConnectionResponse> => {
+        return serverMutation<InitiateConnectionResponse>({
+            endpoint: `/plugins/composio/connect`,
+            data: body,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@composio/core':
+        specifier: ^0.10.0
+        version: 0.10.0(ws@8.19.0)(zod@4.4.3)
       '@ever-works/agent':
         specifier: workspace:*
         version: link:../../packages/agent
@@ -771,7 +774,7 @@ importers:
         version: link:../plugin
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
@@ -1133,10 +1136,10 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -1187,7 +1190,7 @@ importers:
         version: 2.0.41(zod@3.25.76)
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       ai:
         specifier: ^6.0.154
         version: 6.0.154(zod@3.25.76)
@@ -1254,10 +1257,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1638,10 +1641,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1663,10 +1666,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1688,10 +1691,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1980,10 +1983,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2049,10 +2052,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2074,10 +2077,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2124,10 +2127,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2362,7 +2365,7 @@ importers:
     dependencies:
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       stopword:
         specifier: ^3.1.5
         version: 3.1.5
@@ -2503,10 +2506,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -3796,6 +3799,19 @@ packages:
   '@commitlint/types@19.8.1':
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
+
+  '@composio/client@0.1.0-alpha.72':
+    resolution: {integrity: sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ==}
+
+  '@composio/core@0.10.0':
+    resolution: {integrity: sha512-dG2BKF4NRiE8HHDzWLLgjMMo3FU4NJ6SxR961EpdLWWEKhkl+yP/mZlIN7p/4WnCR/fuDBKH1Qh+7kBdcHmEHA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  '@composio/json-schema-to-zod@0.1.20':
+    resolution: {integrity: sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q==}
+    peerDependencies:
+      zod: '>=3.25.76 <5'
 
   '@corvu/utils@0.4.2':
     resolution: {integrity: sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==}
@@ -15639,6 +15655,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.39.0:
+    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -16980,6 +17008,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pusher-js@8.5.0:
+    resolution: {integrity: sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -18570,6 +18601,9 @@ packages:
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -21163,6 +21197,26 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
+  '@composio/client@0.1.0-alpha.72': {}
+
+  '@composio/core@0.10.0(ws@8.19.0)(zod@4.4.3)':
+    dependencies:
+      '@composio/client': 0.1.0-alpha.72
+      '@composio/json-schema-to-zod': 0.1.20(zod@4.4.3)
+      '@types/json-schema': 7.0.15
+      chalk: 4.1.2
+      openai: 6.39.0(ws@8.19.0)(zod@4.4.3)
+      pusher-js: 8.5.0
+      semver: 7.8.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+    transitivePeerDependencies:
+      - ws
+
+  '@composio/json-schema-to-zod@0.1.20(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
   '@corvu/utils@0.4.2(solid-js@1.9.13)':
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -23754,14 +23808,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -23775,18 +23829,48 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
       openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
+      js-tiktoken: 1.0.21
+      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
 
   '@langfuse/client@4.6.1(@opentelemetry/api@1.9.0)':
@@ -28289,7 +28373,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.53.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -33893,13 +33977,22 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
+  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      openai: 6.39.0(ws@8.19.0)(zod@3.25.76)
+      ws: 8.19.0
+
+  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      openai: 6.39.0(ws@8.19.0)(zod@4.4.3)
       ws: 8.19.0
 
   language-subtag-registry@0.3.23: {}
@@ -35905,6 +35998,17 @@ snapshots:
       ws: 8.19.0
       zod: 3.25.76
 
+  openai@6.39.0(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
+    optional: true
+
+  openai@6.39.0(ws@8.19.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.4.3
+
   openapi-types@12.1.3: {}
 
   opener@1.5.2: {}
@@ -37390,6 +37494,10 @@ snapshots:
       escape-goat: 4.0.0
 
   pure-rand@6.1.0: {}
+
+  pusher-js@8.5.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   pvtsutils@1.3.6:
     dependencies:
@@ -39543,6 +39651,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@1.0.3: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -40940,6 +41050,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@1.5.0(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

PR-B of [EW-684](https://evertech.atlassian.net/browse/EW-684). Adds the **backend** API surface for in-app Composio onboarding — toolkit browsing, connected-account status, OAuth initiation. The matching frontend `ComposioConnectionsPanel` ships as a follow-up commit on this same branch.

Depends on PR-A ([#1094](https://github.com/ever-works/ever-works/pull/1094)) for the SDK migration, but does NOT block on it — this PR uses `@composio/core` directly from `apps/api` and would still work if PR-A were reverted.

## New endpoints under `/api/plugins/composio`

| Method | Path | Purpose |
| --- | --- | --- |
| `GET` | `/toolkits` | Lists the toolkit catalog the caller's API key has access to. Pagination via `?limit`. |
| `GET` | `/connected-accounts` | Lists the caller's connected accounts. Optional `?toolkit=GMAIL` filter. Frontend polls this after the Connect popup. |
| `POST` | `/connect` | Calls `composio.connectedAccounts.initiate(userId, authConfigId)`. Returns `{ redirectUrl, connectedAccountId }`. Frontend opens `redirectUrl` in a popup. |

## How auth resolution works

`ComposioService` resolves the caller's Composio API key from `user_plugins.secretSettings` via `PluginSettingsService.getResolvedSettings(...)` (the existing admin/user/work cascade with AES-256-GCM decryption). Each request spins up its own `@composio/core` SDK client — settings changes take effect immediately, no warm-up needed.

## Out of scope — follow-ups

- **Auth config CRUD** (`use_custom_auth` with user-provided OAuth client_id/secret). Most users use `use_composio_managed_auth`, which is registered once in the Composio dashboard. We can ship this later under EW-684 if there is demand.
- **Disconnect endpoint.** Composio dashboard handles it today; not a release blocker.
- **Frontend `ComposioConnectionsPanel`** — coming as a follow-up commit on this same branch before merge.

## Test plan

- [x] `pnpm --filter ever-works-api type-check` (clean)
- [x] `pnpm --filter ever-works-api test` — 2542 passing (16 new + 2526 existing), 0 failing
- [x] `pnpm exec prettier --check apps/api/src/plugins/composio` (clean)
- [ ] CI green
- [ ] Frontend panel commit lands on this branch
- [ ] Smoke: hit `/api/plugins/composio/toolkits` with a real Composio API key in user_plugin settings — verify response

## Related

- Epic: [EW-684](https://evertech.atlassian.net/browse/EW-684)
- PR-A (SDK migration): [#1094](https://github.com/ever-works/ever-works/pull/1094)
- Original Composio plugin PR: [#1079](https://github.com/ever-works/ever-works/pull/1079)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-684]: https://evertech.atlassian.net/browse/EW-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-684]: https://evertech.atlassian.net/browse/EW-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composio plugin integration for discovering toolkits, listing connected accounts, and initiating OAuth connections.
  * Plugin settings include a Composio Connections panel with connect, refresh, and real-time status polling.
  * Client/server APIs to list toolkits, list connected accounts, and start connection flows.

* **Tests**
  * Unit tests covering toolkit listing, connected-account mapping, and connection initiation/error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->