### PR TITLE
feat(composio): expose ACTIVE connected accounts as skills-provider (EW-684 PR-C)

### DIFF
--- a/packages/plugins/composio/package.json
+++ b/packages/plugins/composio/package.json
@@ -51,7 +51,8 @@
 			"category": "pipeline",
 			"capabilities": [
 				"pipeline",
-				"form-schema-provider"
+				"form-schema-provider",
+				"skills-provider"
 			],
 			"description": "Pipeline plugin that executes Composio tools across 500+ third-party apps (Gmail, Slack, GitHub, Notion, Linear, Salesforce, …) during Work generation. Composio brokers OAuth so each user connects their own accounts once and the platform reuses them.",
 			"author": {

--- a/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
+++ b/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
@@ -1,21 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ComposioPlugin } from '../composio.plugin.js';
-import {
-	buildSkillCatalogEntries,
-	diffSkillCatalogVersions,
-	filterSkillCatalog
-} from '../skills-provider.js';
+import { buildSkillCatalogEntries, diffSkillCatalogVersions, filterSkillCatalog } from '../skills-provider.js';
+import type { ComposioSdkLike } from '../utils/composio-client.js';
 import type { SkillCatalogEntry } from '@ever-works/plugin';
 
-function jsonResponse(body: unknown): Response {
-	return new Response(JSON.stringify(body), {
-		status: 200,
-		headers: { 'content-type': 'application/json' }
-	});
-}
-
-function mockFetchAccounts(items: unknown[]): typeof fetch {
-	return vi.fn().mockResolvedValue(jsonResponse({ items })) as unknown as typeof fetch;
+function mockSdkWithAccounts(items: unknown[]): ComposioSdkLike {
+	return {
+		toolkits: { get: vi.fn() },
+		connectedAccounts: {
+			list: vi.fn().mockResolvedValue({ items })
+		},
+		tools: { execute: vi.fn() }
+	} as unknown as ComposioSdkLike;
 }
 
 describe('Composio skills-provider — capability surface', () => {
@@ -48,7 +44,7 @@ describe('buildSkillCatalogEntries', () => {
 	});
 
 	it('emits one entry per unique ACTIVE toolkit, skipping INITIATED/EXPIRED', async () => {
-		const fetchImpl = mockFetchAccounts([
+		const sdkOverride = mockSdkWithAccounts([
 			{ id: 'ca_1', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } },
 			{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }, // duplicate toolkit
 			{ id: 'ca_3', status: 'ACTIVE', toolkit: { slug: 'GITHUB' } },
@@ -60,7 +56,7 @@ describe('buildSkillCatalogEntries', () => {
 			apiKey: 'k',
 			baseUrl: 'https://composio.test/api/v3',
 			defaultUserId: 'user-1',
-			fetchImpl
+			sdkOverride
 		});
 
 		expect(entries.map((e) => e.slug)).toEqual(['composio-github', 'composio-gmail']);
@@ -73,13 +69,11 @@ describe('buildSkillCatalogEntries', () => {
 	});
 
 	it('returns empty when the user has no ACTIVE connections', async () => {
-		const fetchImpl = mockFetchAccounts([
-			{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }
-		]);
+		const sdkOverride = mockSdkWithAccounts([{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }]);
 		const entries = await buildSkillCatalogEntries({
 			apiKey: 'k',
 			defaultUserId: 'user-1',
-			fetchImpl
+			sdkOverride
 		});
 		expect(entries).toEqual([]);
 	});
@@ -144,9 +138,7 @@ describe('diffSkillCatalogVersions', () => {
 			}
 		];
 		const result = diffSkillCatalogVersions(entries, { 'composio-gmail': '0.9.0' });
-		expect(result.updated).toEqual([
-			{ slug: 'composio-gmail', oldVersion: '0.9.0', newVersion: '1.0.0' }
-		]);
+		expect(result.updated).toEqual([{ slug: 'composio-gmail', oldVersion: '0.9.0', newVersion: '1.0.0' }]);
 	});
 
 	it('ignores entries the user does not have installed', () => {

--- a/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
+++ b/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ComposioPlugin } from '../composio.plugin.js';
+import {
+	buildSkillCatalogEntries,
+	diffSkillCatalogVersions,
+	filterSkillCatalog
+} from '../skills-provider.js';
+import type { SkillCatalogEntry } from '@ever-works/plugin';
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { 'content-type': 'application/json' }
+	});
+}
+
+function mockFetchAccounts(items: unknown[]): typeof fetch {
+	return vi.fn().mockResolvedValue(jsonResponse({ items })) as unknown as typeof fetch;
+}
+
+describe('Composio skills-provider — capability surface', () => {
+	it('declares the skills-provider capability', () => {
+		const plugin = new ComposioPlugin();
+		expect(plugin.capabilities).toContain('skills-provider');
+		expect(plugin.providerName).toBe('Composio Integrations');
+	});
+
+	it('listEntries returns an empty result when settings are missing', async () => {
+		const plugin = new ComposioPlugin();
+		const result = await plugin.listEntries({ limit: 50, offset: 0 });
+		expect(result).toEqual({ entries: [], total: 0 });
+	});
+
+	it('getEntry returns null when settings are missing', async () => {
+		const plugin = new ComposioPlugin();
+		expect(await plugin.getEntry('composio-gmail')).toBeNull();
+	});
+});
+
+describe('buildSkillCatalogEntries', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns empty when apiKey or defaultUserId is missing', async () => {
+		expect(await buildSkillCatalogEntries({ apiKey: '', defaultUserId: 'u' })).toEqual([]);
+		expect(await buildSkillCatalogEntries({ apiKey: 'k', defaultUserId: '' })).toEqual([]);
+	});
+
+	it('emits one entry per unique ACTIVE toolkit, skipping INITIATED/EXPIRED', async () => {
+		const fetchImpl = mockFetchAccounts([
+			{ id: 'ca_1', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } },
+			{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }, // duplicate toolkit
+			{ id: 'ca_3', status: 'ACTIVE', toolkit: { slug: 'GITHUB' } },
+			{ id: 'ca_4', status: 'INITIATED', toolkit: { slug: 'SLACK' } },
+			{ id: 'ca_5', status: 'EXPIRED', toolkit: { slug: 'NOTION' } }
+		]);
+
+		const entries = await buildSkillCatalogEntries({
+			apiKey: 'k',
+			baseUrl: 'https://composio.test/api/v3',
+			defaultUserId: 'user-1',
+			fetchImpl
+		});
+
+		expect(entries.map((e) => e.slug)).toEqual(['composio-github', 'composio-gmail']);
+		const gmail = entries.find((e) => e.slug === 'composio-gmail');
+		expect(gmail?.title).toBe('Composio: GMAIL');
+		expect(gmail?.frontmatter.tags).toContain('composio');
+		expect(gmail?.frontmatter.tags).toContain('gmail');
+		expect(gmail?.body).toContain('GMAIL');
+		expect(gmail?.body).toContain('user-1');
+	});
+
+	it('returns empty when the user has no ACTIVE connections', async () => {
+		const fetchImpl = mockFetchAccounts([
+			{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }
+		]);
+		const entries = await buildSkillCatalogEntries({
+			apiKey: 'k',
+			defaultUserId: 'user-1',
+			fetchImpl
+		});
+		expect(entries).toEqual([]);
+	});
+});
+
+describe('filterSkillCatalog', () => {
+	const entries: SkillCatalogEntry[] = [
+		{
+			slug: 'composio-gmail',
+			title: 'Composio: GMAIL',
+			description: 'Send email',
+			frontmatter: { name: 'composio-gmail', description: 'Send email', tags: ['composio', 'gmail'] },
+			body: 'body',
+			version: '1.0.0',
+			tags: ['composio', 'gmail', 'integration']
+		},
+		{
+			slug: 'composio-github',
+			title: 'Composio: GITHUB',
+			description: 'Create issues',
+			frontmatter: {
+				name: 'composio-github',
+				description: 'Create issues',
+				tags: ['composio', 'github']
+			},
+			body: 'body',
+			version: '1.0.0',
+			tags: ['composio', 'github', 'integration']
+		}
+	];
+
+	it('paginates', () => {
+		const page1 = filterSkillCatalog(entries, { limit: 1, offset: 0 });
+		const page2 = filterSkillCatalog(entries, { limit: 1, offset: 1 });
+		expect(page1.entries).toHaveLength(1);
+		expect(page1.total).toBe(2);
+		expect(page2.entries[0].slug).not.toBe(page1.entries[0].slug);
+	});
+
+	it('filters by search across slug/title/description', () => {
+		const result = filterSkillCatalog(entries, { limit: 50, offset: 0, search: 'github' });
+		expect(result.entries.map((e) => e.slug)).toEqual(['composio-github']);
+	});
+
+	it('filters by tag (case-insensitive)', () => {
+		const result = filterSkillCatalog(entries, { limit: 50, offset: 0, tags: ['GMAIL'] });
+		expect(result.entries.map((e) => e.slug)).toEqual(['composio-gmail']);
+	});
+});
+
+describe('diffSkillCatalogVersions', () => {
+	it('flags entries whose installed version is older', () => {
+		const entries: SkillCatalogEntry[] = [
+			{
+				slug: 'composio-gmail',
+				title: 'Composio: GMAIL',
+				description: 'd',
+				frontmatter: { name: 'composio-gmail', description: 'd' },
+				body: '',
+				version: '1.0.0',
+				tags: []
+			}
+		];
+		const result = diffSkillCatalogVersions(entries, { 'composio-gmail': '0.9.0' });
+		expect(result.updated).toEqual([
+			{ slug: 'composio-gmail', oldVersion: '0.9.0', newVersion: '1.0.0' }
+		]);
+	});
+
+	it('ignores entries the user does not have installed', () => {
+		const entries: SkillCatalogEntry[] = [
+			{
+				slug: 'composio-gmail',
+				title: 'g',
+				description: 'd',
+				frontmatter: { name: 'composio-gmail', description: 'd' },
+				body: '',
+				version: '1.0.0',
+				tags: []
+			}
+		];
+		const result = diffSkillCatalogVersions(entries, {});
+		expect(result.updated).toEqual([]);
+	});
+});

--- a/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
+++ b/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ComposioPlugin } from '../composio.plugin.js';
 import { buildSkillCatalogEntries, diffSkillCatalogVersions, filterSkillCatalog } from '../skills-provider.js';
+import type { ComposioSdkLike } from '../utils/composio-client.js';
 import type { SkillCatalogEntry } from '@ever-works/plugin';
 
-function jsonResponse(body: unknown): Response {
-	return new Response(JSON.stringify(body), {
-		status: 200,
-		headers: { 'content-type': 'application/json' }
-	});
-}
-
-function mockFetchAccounts(items: unknown[]): typeof fetch {
-	return vi.fn().mockResolvedValue(jsonResponse({ items })) as unknown as typeof fetch;
+function sdkWithAccounts(items: unknown[]): ComposioSdkLike {
+	return {
+		toolkits: { get: vi.fn() },
+		connectedAccounts: {
+			list: vi.fn().mockResolvedValue({ items })
+		},
+		tools: { execute: vi.fn() }
+	} as unknown as ComposioSdkLike;
 }
 
 describe('Composio skills-provider — capability surface', () => {
@@ -44,7 +44,7 @@ describe('buildSkillCatalogEntries', () => {
 	});
 
 	it('emits one entry per unique ACTIVE toolkit, skipping INITIATED/EXPIRED', async () => {
-		const fetchImpl = mockFetchAccounts([
+		const sdkOverride = sdkWithAccounts([
 			{ id: 'ca_1', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } },
 			{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }, // duplicate toolkit
 			{ id: 'ca_3', status: 'ACTIVE', toolkit: { slug: 'GITHUB' } },
@@ -56,7 +56,7 @@ describe('buildSkillCatalogEntries', () => {
 			apiKey: 'k',
 			baseUrl: 'https://composio.test/api/v3',
 			defaultUserId: 'user-1',
-			fetchImpl
+			sdkOverride
 		});
 
 		expect(entries.map((e) => e.slug)).toEqual(['composio-github', 'composio-gmail']);
@@ -69,11 +69,11 @@ describe('buildSkillCatalogEntries', () => {
 	});
 
 	it('returns empty when the user has no ACTIVE connections', async () => {
-		const fetchImpl = mockFetchAccounts([{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }]);
+		const sdkOverride = sdkWithAccounts([{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }]);
 		const entries = await buildSkillCatalogEntries({
 			apiKey: 'k',
 			defaultUserId: 'user-1',
-			fetchImpl
+			sdkOverride
 		});
 		expect(entries).toEqual([]);
 	});

--- a/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
+++ b/packages/plugins/composio/src/__tests__/skills-provider.spec.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ComposioPlugin } from '../composio.plugin.js';
-import {
-	buildSkillCatalogEntries,
-	diffSkillCatalogVersions,
-	filterSkillCatalog
-} from '../skills-provider.js';
+import { buildSkillCatalogEntries, diffSkillCatalogVersions, filterSkillCatalog } from '../skills-provider.js';
 import type { SkillCatalogEntry } from '@ever-works/plugin';
 
 function jsonResponse(body: unknown): Response {
@@ -73,9 +69,7 @@ describe('buildSkillCatalogEntries', () => {
 	});
 
 	it('returns empty when the user has no ACTIVE connections', async () => {
-		const fetchImpl = mockFetchAccounts([
-			{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }
-		]);
+		const fetchImpl = mockFetchAccounts([{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } }]);
 		const entries = await buildSkillCatalogEntries({
 			apiKey: 'k',
 			defaultUserId: 'user-1',
@@ -144,9 +138,7 @@ describe('diffSkillCatalogVersions', () => {
 			}
 		];
 		const result = diffSkillCatalogVersions(entries, { 'composio-gmail': '0.9.0' });
-		expect(result.updated).toEqual([
-			{ slug: 'composio-gmail', oldVersion: '0.9.0', newVersion: '1.0.0' }
-		]);
+		expect(result.updated).toEqual([{ slug: 'composio-gmail', oldVersion: '0.9.0', newVersion: '1.0.0' }]);
 	});
 
 	it('ignores entries the user does not have installed', () => {

--- a/packages/plugins/composio/src/composio.plugin.ts
+++ b/packages/plugins/composio/src/composio.plugin.ts
@@ -77,9 +77,7 @@ import { README } from './readme.js';
  * their accounts once via Composio's hosted flow, and the platform runs
  * tools against `composio.user_id` (defaulted to the Ever Works user id).
  */
-export class ComposioPlugin
-	implements IPlugin, IPipelinePlugin, IFormSchemaProvider, ISkillsProviderPlugin
-{
+export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvider, ISkillsProviderPlugin {
 	readonly id = 'composio';
 	readonly name = 'Composio Integrations';
 	readonly version = '1.0.0';
@@ -310,9 +308,7 @@ export class ComposioPlugin
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			(this.context?.logger ?? console).warn(
-				`Composio skills-provider: failed to load catalog — ${message}`
-			);
+			(this.context?.logger ?? console).warn(`Composio skills-provider: failed to load catalog — ${message}`);
 			return [];
 		}
 	}

--- a/packages/plugins/composio/src/composio.plugin.ts
+++ b/packages/plugins/composio/src/composio.plugin.ts
@@ -2,8 +2,10 @@ import type {
 	IPlugin,
 	IPipelinePlugin,
 	IFormSchemaProvider,
+	ISkillsProviderPlugin,
 	PluginContext,
 	PluginCategory,
+	PluginSettings,
 	JsonSchema,
 	ValidationResult,
 	ConnectionValidationResult,
@@ -17,6 +19,10 @@ import type {
 	ExistingItems,
 	PluginManifest,
 	PluginHealthCheck,
+	SkillCatalogEntry,
+	SkillCatalogListOptions,
+	SkillCatalogListResult,
+	SkillCatalogUpdate,
 	StepStatus,
 	FormFieldDefinition,
 	FormFieldGroup,
@@ -24,6 +30,14 @@ import type {
 	FacadeOptions
 } from '@ever-works/plugin';
 import { buildSuccessPipelineResult } from '@ever-works/plugin';
+import {
+	buildSkillCatalogEntries,
+	diffSkillCatalogVersions,
+	filterSkillCatalog,
+	readApiKey,
+	readBaseUrl,
+	readDefaultUserId
+} from './skills-provider.js';
 
 import type {
 	ComposioStepId,
@@ -63,14 +77,17 @@ import { README } from './readme.js';
  * their accounts once via Composio's hosted flow, and the platform runs
  * tools against `composio.user_id` (defaulted to the Ever Works user id).
  */
-export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvider {
+export class ComposioPlugin
+	implements IPlugin, IPipelinePlugin, IFormSchemaProvider, ISkillsProviderPlugin
+{
 	readonly id = 'composio';
 	readonly name = 'Composio Integrations';
 	readonly version = '1.0.0';
 	readonly category: PluginCategory = 'pipeline';
-	readonly capabilities = ['pipeline', 'form-schema-provider'] as const;
+	readonly capabilities = ['pipeline', 'form-schema-provider', 'skills-provider'] as const;
 	readonly configurationMode = 'user-required' as const;
 	readonly handledConfigFields = ['*'] as const;
+	readonly providerName = 'Composio Integrations';
 
 	readonly settingsSchema: JsonSchema = {
 		type: 'object',
@@ -137,7 +154,7 @@ export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 		};
 	}
 
-	async isAvailable(settings?: Record<string, unknown>): Promise<boolean> {
+	isAvailable(settings?: Record<string, unknown>): boolean {
 		return hasApiKey(settings ?? {});
 	}
 
@@ -252,6 +269,52 @@ export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 
 	getDefaultValues(): Record<string, unknown> {
 		return formDefaults(this.getFormFields());
+	}
+
+	// ── ISkillsProviderPlugin ───────────────────────────────────────────
+	//
+	// Each ACTIVE Composio connected account the user owns surfaces as one
+	// markdown skill entry under `composio-<toolkit>`. The agent reads the
+	// entry's body during planning and learns to dispatch the toolkit via
+	// the composio pipeline plugin. Connection state is read live (cached
+	// per call) — there's no separate ingestion job.
+
+	async listEntries(options: SkillCatalogListOptions): Promise<SkillCatalogListResult> {
+		const entries = await this.loadEntries(options.settings);
+		return filterSkillCatalog(entries, options);
+	}
+
+	async getEntry(slug: string, settings?: PluginSettings): Promise<SkillCatalogEntry | null> {
+		const entries = await this.loadEntries(settings);
+		return entries.find((e) => e.slug === slug) ?? null;
+	}
+
+	async checkForUpdates(
+		installedVersions: Record<string, string>,
+		settings?: PluginSettings
+	): Promise<{ updated: SkillCatalogUpdate[] }> {
+		const entries = await this.loadEntries(settings);
+		return diffSkillCatalogVersions(entries, installedVersions);
+	}
+
+	private async loadEntries(settings?: PluginSettings): Promise<SkillCatalogEntry[]> {
+		const apiKey = readApiKey(settings);
+		const defaultUserId = readDefaultUserId(settings);
+		if (!apiKey || !defaultUserId) return [];
+		try {
+			return await buildSkillCatalogEntries({
+				apiKey,
+				baseUrl: readBaseUrl(settings),
+				defaultUserId,
+				logger: this.context?.logger ?? console
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			(this.context?.logger ?? console).warn(
+				`Composio skills-provider: failed to load catalog — ${message}`
+			);
+			return [];
+		}
 	}
 
 	// ── IPipelinePlugin ─────────────────────────────────────────────────

--- a/packages/plugins/composio/src/skills-provider.ts
+++ b/packages/plugins/composio/src/skills-provider.ts
@@ -116,10 +116,7 @@ export function filterSkillCatalog(
 	if (options.search) {
 		const q = options.search.toLowerCase();
 		filtered = filtered.filter(
-			(e) =>
-				e.slug.includes(q) ||
-				e.title.toLowerCase().includes(q) ||
-				e.description.toLowerCase().includes(q)
+			(e) => e.slug.includes(q) || e.title.toLowerCase().includes(q) || e.description.toLowerCase().includes(q)
 		);
 	}
 	if (options.tags && options.tags.length > 0) {

--- a/packages/plugins/composio/src/skills-provider.ts
+++ b/packages/plugins/composio/src/skills-provider.ts
@@ -6,7 +6,7 @@ import type {
 	SkillCatalogUpdate
 } from '@ever-works/plugin';
 
-import { ComposioClient } from './utils/composio-client.js';
+import { ComposioClient, type ComposioSdkLike } from './utils/composio-client.js';
 
 const SKILL_VERSION = '1.0.0';
 const ACTIVE_STATUS = 'ACTIVE';
@@ -16,7 +16,13 @@ interface BuildEntriesOptions {
 	baseUrl?: string;
 	defaultUserId?: string;
 	logger?: { log(...args: unknown[]): void; warn(...args: unknown[]): void };
-	fetchImpl?: typeof fetch;
+	/**
+	 * Test seam — inject a `Composio`-shaped stub to bypass real SDK
+	 * construction. Mirrors `ComposioClientOptions.sdkOverride`; replaces the
+	 * old `fetchImpl` seam that the v1 handwritten REST client used before the
+	 * `@composio/core` SDK migration (PR-A).
+	 */
+	sdkOverride?: ComposioSdkLike;
 }
 
 /**
@@ -34,7 +40,7 @@ export async function buildSkillCatalogEntries({
 	baseUrl,
 	defaultUserId,
 	logger,
-	fetchImpl
+	sdkOverride
 }: BuildEntriesOptions): Promise<SkillCatalogEntry[]> {
 	if (!apiKey || !defaultUserId) return [];
 
@@ -42,7 +48,7 @@ export async function buildSkillCatalogEntries({
 		apiKey,
 		baseUrl,
 		logger: logger ?? { log: () => undefined, warn: () => undefined },
-		fetchImpl
+		sdkOverride
 	});
 
 	const accounts = await client.listConnectedAccounts(defaultUserId);

--- a/packages/plugins/composio/src/skills-provider.ts
+++ b/packages/plugins/composio/src/skills-provider.ts
@@ -1,0 +1,170 @@
+import type {
+	PluginSettings,
+	SkillCatalogEntry,
+	SkillCatalogListOptions,
+	SkillCatalogListResult,
+	SkillCatalogUpdate
+} from '@ever-works/plugin';
+
+import { ComposioClient } from './utils/composio-client.js';
+
+const SKILL_VERSION = '1.0.0';
+const ACTIVE_STATUS = 'ACTIVE';
+
+interface BuildEntriesOptions {
+	apiKey: string;
+	baseUrl?: string;
+	defaultUserId?: string;
+	logger?: { log(...args: unknown[]): void; warn(...args: unknown[]): void };
+	fetchImpl?: typeof fetch;
+}
+
+/**
+ * Implementation of the `skills-provider` capability for the Composio
+ * plugin. Each ACTIVE Composio connected account the caller owns becomes
+ * one `SkillCatalogEntry`, slugged `composio-<toolkit>`. The body is a
+ * short markdown prompt instructing the agent how to invoke that
+ * toolkit via the composio pipeline plugin during work generation.
+ *
+ * Kept as a free function (not on the plugin class) so it can be tested
+ * standalone with an injected `fetch` and the plugin file stays focused.
+ */
+export async function buildSkillCatalogEntries({
+	apiKey,
+	baseUrl,
+	defaultUserId,
+	logger,
+	fetchImpl
+}: BuildEntriesOptions): Promise<SkillCatalogEntry[]> {
+	if (!apiKey || !defaultUserId) return [];
+
+	const client = new ComposioClient({
+		apiKey,
+		baseUrl,
+		logger: logger ?? { log: () => undefined, warn: () => undefined },
+		fetchImpl
+	});
+
+	const accounts = await client.listConnectedAccounts(defaultUserId);
+	const activeBySlug = new Map<string, { id: string; slug: string }>();
+	for (const account of accounts) {
+		if ((account.status || '').toUpperCase() !== ACTIVE_STATUS) continue;
+		const slug = (account.toolkit?.slug || '').trim().toUpperCase();
+		if (!slug) continue;
+		// First-wins: a user may have multiple connections per toolkit (e.g.
+		// two Gmail accounts). The skill entry is per-toolkit, not per
+		// account — the agent picks which user_id to call with.
+		if (!activeBySlug.has(slug)) {
+			activeBySlug.set(slug, { id: account.id, slug });
+		}
+	}
+
+	const entries: SkillCatalogEntry[] = [];
+	for (const { slug } of activeBySlug.values()) {
+		entries.push(entryFor(slug, defaultUserId));
+	}
+	return entries.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+function entryFor(toolkitSlug: string, defaultUserId: string): SkillCatalogEntry {
+	const slug = `composio-${toolkitSlug.toLowerCase()}`;
+	const title = `Composio: ${toolkitSlug}`;
+	const description =
+		`Call Composio tools in the ${toolkitSlug} toolkit during Work generation. ` +
+		`The user has an ACTIVE Composio connection for this toolkit.`;
+	const body =
+		`# ${title}\n\n` +
+		`This user has an **ACTIVE** Composio connection for the \`${toolkitSlug}\` toolkit.\n\n` +
+		`When the user's task can be served by a ${toolkitSlug} tool (e.g. send an email, ` +
+		`create an issue, read a document), use the **composio** pipeline plugin to execute ` +
+		`the tool. Pass the following config:\n\n` +
+		'```json\n' +
+		JSON.stringify(
+			{
+				toolkit: toolkitSlug,
+				tool_slug: `<TOOL_SLUG_TO_FILL_IN>`,
+				composio_user_id: defaultUserId
+			},
+			null,
+			2
+		) +
+		'\n```\n\n' +
+		`Pick \`tool_slug\` from the toolkit's tool list (search composio.dev for ${toolkitSlug} ` +
+		`tools or call \`GET /api/plugins/composio/toolkits\`). Do NOT invent slugs — Composio ` +
+		`rejects unknown tools with HTTP 404.\n`;
+
+	return {
+		slug,
+		title,
+		description,
+		frontmatter: {
+			name: slug,
+			description,
+			tags: ['composio', toolkitSlug.toLowerCase(), 'integration']
+		},
+		body,
+		version: SKILL_VERSION,
+		tags: ['composio', toolkitSlug.toLowerCase(), 'integration']
+	};
+}
+
+export function filterSkillCatalog(
+	entries: SkillCatalogEntry[],
+	options: SkillCatalogListOptions
+): SkillCatalogListResult {
+	let filtered = entries;
+	if (options.search) {
+		const q = options.search.toLowerCase();
+		filtered = filtered.filter(
+			(e) =>
+				e.slug.includes(q) ||
+				e.title.toLowerCase().includes(q) ||
+				e.description.toLowerCase().includes(q)
+		);
+	}
+	if (options.tags && options.tags.length > 0) {
+		const requested = new Set(options.tags.map((t) => t.toLowerCase()));
+		filtered = filtered.filter((e) => e.tags.some((t) => requested.has(t.toLowerCase())));
+	}
+	const total = filtered.length;
+	const sliced = filtered.slice(options.offset, options.offset + options.limit);
+	return { entries: sliced, total };
+}
+
+export function diffSkillCatalogVersions(
+	entries: SkillCatalogEntry[],
+	installedVersions: Record<string, string>
+): { updated: SkillCatalogUpdate[] } {
+	const updated: SkillCatalogUpdate[] = [];
+	for (const entry of entries) {
+		const installed = installedVersions[entry.slug];
+		if (installed && installed !== entry.version) {
+			updated.push({ slug: entry.slug, oldVersion: installed, newVersion: entry.version });
+		}
+	}
+	return { updated };
+}
+
+export function readApiKey(settings?: PluginSettings): string | undefined {
+	if (!settings) return undefined;
+	const value = settings.apiKey;
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed === '' ? undefined : trimmed;
+}
+
+export function readBaseUrl(settings?: PluginSettings): string | undefined {
+	if (!settings) return undefined;
+	const value = settings.baseUrl;
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed === '' ? undefined : trimmed;
+}
+
+export function readDefaultUserId(settings?: PluginSettings): string | undefined {
+	if (!settings) return undefined;
+	const value = settings.defaultUserId;
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed === '' ? undefined : trimmed;
+}

--- a/packages/plugins/composio/src/skills-provider.ts
+++ b/packages/plugins/composio/src/skills-provider.ts
@@ -6,7 +6,7 @@ import type {
 	SkillCatalogUpdate
 } from '@ever-works/plugin';
 
-import { ComposioClient } from './utils/composio-client.js';
+import { ComposioClient, type ComposioSdkLike } from './utils/composio-client.js';
 
 const SKILL_VERSION = '1.0.0';
 const ACTIVE_STATUS = 'ACTIVE';
@@ -16,7 +16,8 @@ interface BuildEntriesOptions {
 	baseUrl?: string;
 	defaultUserId?: string;
 	logger?: { log(...args: unknown[]): void; warn(...args: unknown[]): void };
-	fetchImpl?: typeof fetch;
+	/** Test seam — inject a mocked SDK to bypass real Composio construction. */
+	sdkOverride?: ComposioSdkLike;
 }
 
 /**
@@ -34,7 +35,7 @@ export async function buildSkillCatalogEntries({
 	baseUrl,
 	defaultUserId,
 	logger,
-	fetchImpl
+	sdkOverride
 }: BuildEntriesOptions): Promise<SkillCatalogEntry[]> {
 	if (!apiKey || !defaultUserId) return [];
 
@@ -42,7 +43,7 @@ export async function buildSkillCatalogEntries({
 		apiKey,
 		baseUrl,
 		logger: logger ?? { log: () => undefined, warn: () => undefined },
-		fetchImpl
+		...(sdkOverride ? { sdkOverride } : {})
 	});
 
 	const accounts = await client.listConnectedAccounts(defaultUserId);
@@ -116,10 +117,7 @@ export function filterSkillCatalog(
 	if (options.search) {
 		const q = options.search.toLowerCase();
 		filtered = filtered.filter(
-			(e) =>
-				e.slug.includes(q) ||
-				e.title.toLowerCase().includes(q) ||
-				e.description.toLowerCase().includes(q)
+			(e) => e.slug.includes(q) || e.title.toLowerCase().includes(q) || e.description.toLowerCase().includes(q)
 		);
 	}
 	if (options.tags && options.tags.length > 0) {


### PR DESCRIPTION
## Summary

EW-684 **PR-C**: makes the Composio plugin a first-party `skills-provider` (ADR-012). Each ACTIVE Composio connected account the user owns surfaces as one agent-callable Skill entry. Builds on **PR-A #1094** (SDK migration) and **PR-B #1101** (settings UX).

- Adds `'skills-provider'` to the plugin's capability list and implements `ISkillsProviderPlugin` (`providerName`, `listEntries`, `getEntry`, `checkForUpdates`).
- Each ACTIVE toolkit connection becomes a `composio-<toolkit>` SkillCatalogEntry whose body is a markdown prompt instructing the agent to dispatch the toolkit via the existing **composio** pipeline plugin (`toolkit` + `tool_slug` + `composio_user_id`), with a hard rule not to invent unknown tool slugs.
- Helpers live in `packages/plugins/composio/src/skills-provider.ts` as pure functions so they can be tested independently with an injected `fetch`.
- 11 new vitest cases (107 total in the plugin now pass) cover capability surface, dedupe across multiple accounts per toolkit, INITIATED / EXPIRED filtering, pagination, search + tag filtering, and version diffing.

## Test plan
- [ ] CI lint-and-test
- [ ] Enable the composio plugin for a user with ACTIVE Gmail + GitHub connections and confirm Skills page shows `composio-gmail` and `composio-github` entries
- [ ] Confirm an INITIATED-only user gets no skill entries
- [ ] Confirm the agent dispatches a Gmail tool via composio when it picks `composio-gmail` during planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composio plugin now exposes a skills provider so users can browse, search, paginate, filter by tags, view skill details, and detect available updates for connected Composio integrations.
  * Provider presents deduplicated, user-scoped skill entries with invocation instructions and version info.

* **Tests**
  * Added comprehensive tests covering catalog building, filtering, pagination, de-duplication, and update detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->