### PR TITLE
feat(api,web): Composio triggers — entity, webhook, CRUD, UI list (EW-684 PR-D)

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -22,6 +22,7 @@ import { BudgetsModule } from './budgets/budgets.module';
 import { ScreenshotModule } from './plugins-capabilities/screenshot/screenshot.module';
 import { SearchModule } from './plugins-capabilities/search/search.module';
 import { PluginsModule } from './plugins/plugins.module';
+import { ComposioTriggersModule } from './plugins/composio-triggers/composio-triggers.module';
 import { GitProviderModule } from './plugins-capabilities/git-provider/git-provider.module';
 import { OAuthModule } from './plugins-capabilities/oauth/oauth.module';
 import { DeviceAuthModule } from './plugins-capabilities/device-auth/device-auth.module';
@@ -104,6 +105,7 @@ import { DatabaseModule } from '@ever-works/agent/database';
             useFactory: () => ({}),
         }),
         PluginsModule,
+        ComposioTriggersModule,
         GitProviderModule,
         OAuthModule,
         DeviceAuthModule,

--- a/apps/api/src/migrations/1780100000000-AddComposioTriggerSubscriptions.ts
+++ b/apps/api/src/migrations/1780100000000-AddComposioTriggerSubscriptions.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * EW-684 PR-D — Composio Triggers.
+ *
+ * Creates the `composio_trigger_subscriptions` table, which stores one
+ * row per user-installed Composio trigger (the webhook event surface —
+ * `GMAIL_NEW_EMAIL`, `SLACK_NEW_MESSAGE`, …). Each row carries a
+ * server-generated HMAC secret used to verify `x-composio-signature`
+ * on inbound webhook deliveries.
+ *
+ * Forward-only, idempotent (`ifNotExists`). Tier C-shaped: nullable
+ * tenant/org FKs, no entity-level @ManyToOne for those (cycle
+ * avoidance per EW-654).
+ */
+export class AddComposioTriggerSubscriptions1780100000000 implements MigrationInterface {
+    name = 'AddComposioTriggerSubscriptions1780100000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'composio_trigger_subscriptions',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'toolkitSlug', type: 'varchar', length: '64' },
+                    { name: 'triggerSlug', type: 'varchar', length: '128' },
+                    { name: 'composioTriggerId', type: 'varchar', length: '64' },
+                    { name: 'composioConnectedAccountId', type: 'varchar', length: '64' },
+                    { name: 'webhookSecret', type: 'varchar', length: '128' },
+                    { name: 'config', type: 'text', isNullable: true },
+                    { name: 'enabled', type: 'boolean', default: true },
+                    { name: 'lastFiredAt', type: 'bigint', isNullable: true },
+                    { name: 'deliveriesReceived', type: 'integer', default: 0 },
+                    { name: 'deliveriesRejected', type: 'integer', default: 0 },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createForeignKey(
+            'composio_trigger_subscriptions',
+            new TableForeignKey({
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'composio_trigger_subscriptions',
+            new TableIndex({
+                name: 'uq_composio_trigger_subscription',
+                columnNames: ['userId', 'toolkitSlug', 'triggerSlug'],
+                isUnique: true,
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'composio_trigger_subscriptions',
+            new TableIndex({
+                name: 'uq_composio_trigger_subscription_remote',
+                columnNames: ['composioTriggerId'],
+                isUnique: true,
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'composio_trigger_subscriptions',
+            new TableIndex({
+                name: 'idx_composio_trigger_subscription_user',
+                columnNames: ['userId'],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('composio_trigger_subscriptions', true);
+    }
+}

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.controller.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.controller.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto';
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Headers,
+    HttpCode,
+    HttpStatus,
+    NotFoundException,
+    Param,
+    ParseUUIDPipe,
+    Post,
+    Req,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthSessionGuard, CurrentUser } from '../../auth';
+import { Public } from '@src/auth/decorators/public.decorator';
+import type { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { ComposioTriggersService } from './composio-triggers.service';
+import {
+    ComposioTriggerDto,
+    ComposioTriggerListDto,
+    CreateComposioTriggerDto,
+} from './dto/composio-trigger.dto';
+import type { ComposioTriggerSubscription } from '@ever-works/agent/entities';
+
+@ApiTags('Composio Triggers')
+@Controller('api/plugins/composio')
+export class ComposioTriggersController {
+    constructor(private readonly triggers: ComposioTriggersService) {}
+
+    @Get('triggers')
+    @ApiBearerAuth('JWT-auth')
+    @UseGuards(AuthSessionGuard)
+    @ApiOperation({ summary: "List the caller's Composio triggers" })
+    @ApiResponse({ status: 200, type: ComposioTriggerListDto })
+    async list(@CurrentUser() auth: AuthenticatedUser): Promise<ComposioTriggerListDto> {
+        const rows = await this.triggers.list(auth.userId);
+        return { items: rows.map((row) => toDto(row)) };
+    }
+
+    @Post('triggers')
+    @ApiBearerAuth('JWT-auth')
+    @UseGuards(AuthSessionGuard)
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({
+        summary: 'Create a Composio trigger subscription',
+        description:
+            "Allocates a server-generated HMAC secret and stores the subscription. The created `webhookSecret` is returned in the response **once** — store it client-side if you need to register the same trigger on a different platform. Subsequent GETs never include it. (Follow-up PR will also call Composio's `POST /triggers` to enable the trigger upstream and persist the returned `tg_*` id.)",
+    })
+    @ApiResponse({ status: 201, type: ComposioTriggerDto })
+    async create(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: CreateComposioTriggerDto,
+    ): Promise<ComposioTriggerDto> {
+        // Until the upstream Composio enable-trigger call is wired,
+        // we mint a placeholder composioTriggerId so the row is uniquely
+        // queryable. Once enabled, this is replaced with the real
+        // `tg_*` returned by Composio in the same transaction.
+        const placeholderTriggerId = `local_${randomUUID()}`;
+        const row = await this.triggers.create(auth.userId, placeholderTriggerId, body);
+        return { ...toDto(row), webhookSecret: row.webhookSecret };
+    }
+
+    @Delete('triggers/:id')
+    @ApiBearerAuth('JWT-auth')
+    @UseGuards(AuthSessionGuard)
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Delete a Composio trigger subscription' })
+    async remove(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ): Promise<void> {
+        await this.triggers.remove(auth.userId, id);
+    }
+
+    @Public()
+    @Post('webhook')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Composio webhook receiver',
+        description:
+            'Inbound Composio webhook deliveries land here. Composio signs the JSON body with HMAC-SHA256 of the per-subscription secret; the digest arrives as `x-composio-signature`. The handler resolves the subscription by the `tg_*` trigger id in the payload, verifies the signature in constant time, and records the outcome. Returns 200 even on no-op outcomes so Composio does not retry; 401 only when signature verification fails.',
+    })
+    async webhook(
+        @Req() req: { rawBody?: string },
+        @Body() body: ComposioWebhookPayload,
+        @Headers('x-composio-signature') signature: string | undefined,
+    ): Promise<{ ok: true }> {
+        const triggerId = body?.trigger_id ?? body?.triggerId;
+        if (!triggerId || typeof triggerId !== 'string') {
+            throw new BadRequestException('Missing trigger_id in webhook payload');
+        }
+        if (!req.rawBody) {
+            throw new BadRequestException('Missing raw webhook payload');
+        }
+
+        const subscription = await this.triggers.findByComposioTriggerId(triggerId);
+        if (!subscription) {
+            // Hide trigger existence — return 404 without a body. Composio
+            // treats 4xx as a permanent failure and will not retry.
+            throw new NotFoundException();
+        }
+
+        try {
+            this.triggers.verifyDelivery(subscription, req.rawBody, signature);
+        } catch (error) {
+            await this.triggers.recordDelivery(subscription.id, 'rejected');
+            throw error;
+        }
+
+        await this.triggers.recordDelivery(subscription.id, 'accepted');
+        // Hand-off to downstream fanout happens in a follow-up PR. For now
+        // the row's `lastFiredAt` + `deliveriesReceived` counters give the
+        // UI enough to render an "active" state.
+        return { ok: true };
+    }
+}
+
+interface ComposioWebhookPayload {
+    trigger_id?: string;
+    triggerId?: string;
+    [key: string]: unknown;
+}
+
+function toDto(row: ComposioTriggerSubscription): ComposioTriggerDto {
+    return {
+        id: row.id,
+        toolkitSlug: row.toolkitSlug,
+        triggerSlug: row.triggerSlug,
+        composioTriggerId: row.composioTriggerId,
+        composioConnectedAccountId: row.composioConnectedAccountId,
+        enabled: row.enabled,
+        deliveriesReceived: row.deliveriesReceived,
+        deliveriesRejected: row.deliveriesRejected,
+        lastFiredAt: row.lastFiredAt ? row.lastFiredAt.toISOString() : null,
+        createdAt: row.createdAt.toISOString(),
+    };
+}

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../../auth/auth.module';
+import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
+import { ComposioTriggersController } from './composio-triggers.controller';
+import { ComposioTriggersService } from './composio-triggers.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule],
+    controllers: [ComposioTriggersController],
+    providers: [ComposioTriggersService],
+    exports: [ComposioTriggersService],
+})
+export class ComposioTriggersModule {}

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
@@ -78,21 +78,13 @@ describe('ComposioTriggersService', () => {
 
         it('accepts a valid signature with the `sha256=` prefix', () => {
             expect(() =>
-                service.verifyDelivery(
-                    { webhookSecret: secret },
-                    rawBody,
-                    `sha256=${validSig}`,
-                ),
+                service.verifyDelivery({ webhookSecret: secret }, rawBody, `sha256=${validSig}`),
             ).not.toThrow();
         });
 
         it('rejects a tampered body', () => {
             expect(() =>
-                service.verifyDelivery(
-                    { webhookSecret: secret },
-                    rawBody + 'tampered',
-                    validSig,
-                ),
+                service.verifyDelivery({ webhookSecret: secret }, rawBody + 'tampered', validSig),
             ).toThrow(UnauthorizedException);
         });
 
@@ -112,11 +104,7 @@ describe('ComposioTriggersService', () => {
     describe('recordDelivery', () => {
         it('increments deliveriesReceived and sets lastFiredAt on accepted', async () => {
             await service.recordDelivery('sub-1', 'accepted');
-            expect(repo.increment).toHaveBeenCalledWith(
-                { id: 'sub-1' },
-                'deliveriesReceived',
-                1,
-            );
+            expect(repo.increment).toHaveBeenCalledWith({ id: 'sub-1' }, 'deliveriesReceived', 1);
             expect(repo.update).toHaveBeenCalled();
             const updateArgs = repo.update.mock.calls[0][1];
             expect(updateArgs.lastFiredAt).toBeInstanceOf(Date);
@@ -124,11 +112,7 @@ describe('ComposioTriggersService', () => {
 
         it('increments deliveriesRejected (and does not touch lastFiredAt) on rejected', async () => {
             await service.recordDelivery('sub-1', 'rejected');
-            expect(repo.increment).toHaveBeenCalledWith(
-                { id: 'sub-1' },
-                'deliveriesRejected',
-                1,
-            );
+            expect(repo.increment).toHaveBeenCalledWith({ id: 'sub-1' }, 'deliveriesRejected', 1);
             expect(repo.update).not.toHaveBeenCalled();
         });
     });

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
@@ -1,0 +1,135 @@
+import { createHmac } from 'node:crypto';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
+import { ComposioTriggersService } from './composio-triggers.service';
+
+function buildRepoStub() {
+    return {
+        find: jest.fn(),
+        findOne: jest.fn(),
+        create: jest.fn((data: Partial<ComposioTriggerSubscription>) => data),
+        save: jest.fn((row: Partial<ComposioTriggerSubscription>) => ({
+            ...row,
+            id: 'sub-1',
+        })),
+        delete: jest.fn(),
+        increment: jest.fn(),
+        update: jest.fn(),
+    };
+}
+
+describe('ComposioTriggersService', () => {
+    let service: ComposioTriggersService;
+    let repo: ReturnType<typeof buildRepoStub>;
+
+    beforeEach(async () => {
+        repo = buildRepoStub();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ComposioTriggersService,
+                { provide: getRepositoryToken(ComposioTriggerSubscription), useValue: repo },
+            ],
+        }).compile();
+        service = module.get(ComposioTriggersService);
+    });
+
+    describe('create', () => {
+        it('mints a 64-hex-char webhook secret and uppercases toolkit + trigger slugs', async () => {
+            await service.create('user-1', 'tg_abc', {
+                toolkitSlug: 'gmail',
+                triggerSlug: 'gmail_new_email',
+                composioConnectedAccountId: 'ca_1',
+            });
+            const saved = repo.save.mock.calls[0][0];
+            expect(saved.toolkitSlug).toBe('GMAIL');
+            expect(saved.triggerSlug).toBe('GMAIL_NEW_EMAIL');
+            expect(saved.composioTriggerId).toBe('tg_abc');
+            expect(saved.webhookSecret).toMatch(/^[0-9a-f]{64}$/);
+        });
+    });
+
+    describe('remove', () => {
+        it('throws NotFoundException when the subscription is not owned by the caller', async () => {
+            repo.findOne.mockResolvedValue(null);
+            await expect(service.remove('user-1', 'sub-x')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('deletes when found', async () => {
+            repo.findOne.mockResolvedValue({ id: 'sub-1', userId: 'user-1' });
+            await service.remove('user-1', 'sub-1');
+            expect(repo.delete).toHaveBeenCalledWith({ id: 'sub-1' });
+        });
+    });
+
+    describe('verifyDelivery', () => {
+        const secret = 'a'.repeat(64);
+        const rawBody = '{"trigger_id":"tg_1","data":{"foo":"bar"}}';
+        const validSig = createHmac('sha256', secret).update(rawBody).digest('hex');
+
+        it('accepts a valid signature', () => {
+            expect(() =>
+                service.verifyDelivery({ webhookSecret: secret }, rawBody, validSig),
+            ).not.toThrow();
+        });
+
+        it('accepts a valid signature with the `sha256=` prefix', () => {
+            expect(() =>
+                service.verifyDelivery(
+                    { webhookSecret: secret },
+                    rawBody,
+                    `sha256=${validSig}`,
+                ),
+            ).not.toThrow();
+        });
+
+        it('rejects a tampered body', () => {
+            expect(() =>
+                service.verifyDelivery(
+                    { webhookSecret: secret },
+                    rawBody + 'tampered',
+                    validSig,
+                ),
+            ).toThrow(UnauthorizedException);
+        });
+
+        it('rejects when the signature is missing', () => {
+            expect(() =>
+                service.verifyDelivery({ webhookSecret: secret }, rawBody, undefined),
+            ).toThrow(UnauthorizedException);
+        });
+
+        it('rejects when the signature length is wrong (defeats truncation oracle)', () => {
+            expect(() =>
+                service.verifyDelivery({ webhookSecret: secret }, rawBody, validSig.slice(0, 32)),
+            ).toThrow(UnauthorizedException);
+        });
+    });
+
+    describe('recordDelivery', () => {
+        it('increments deliveriesReceived and sets lastFiredAt on accepted', async () => {
+            await service.recordDelivery('sub-1', 'accepted');
+            expect(repo.increment).toHaveBeenCalledWith(
+                { id: 'sub-1' },
+                'deliveriesReceived',
+                1,
+            );
+            expect(repo.update).toHaveBeenCalled();
+            const updateArgs = repo.update.mock.calls[0][1];
+            expect(updateArgs.lastFiredAt).toBeInstanceOf(Date);
+        });
+
+        it('increments deliveriesRejected (and does not touch lastFiredAt) on rejected', async () => {
+            await service.recordDelivery('sub-1', 'rejected');
+            expect(repo.increment).toHaveBeenCalledWith(
+                { id: 'sub-1' },
+                'deliveriesRejected',
+                1,
+            );
+            expect(repo.update).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
@@ -1,0 +1,132 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import {
+    Injectable,
+    Logger,
+    NotFoundException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
+import type { CreateComposioTriggerDto } from './dto/composio-trigger.dto';
+
+/**
+ * CRUD + webhook-verification service for `composio_trigger_subscriptions`.
+ *
+ * Triggers are created via `POST /api/plugins/composio/triggers`. The
+ * service generates a per-subscription HMAC secret server-side and
+ * returns it ONCE in the create response. Subsequent reads never
+ * include the secret.
+ *
+ * Webhook deliveries arrive at `POST /api/plugins/composio/webhook`
+ * with the Composio trigger id in the JSON body (`tg_*`) plus an
+ * `x-composio-signature` header — the controller resolves the
+ * subscription by trigger id, then `verifyDelivery` HMAC-checks the
+ * raw request body against the stored secret in constant time.
+ */
+@Injectable()
+export class ComposioTriggersService {
+    private readonly logger = new Logger(ComposioTriggersService.name);
+
+    constructor(
+        @InjectRepository(ComposioTriggerSubscription)
+        private readonly repo: Repository<ComposioTriggerSubscription>,
+    ) {}
+
+    async list(userId: string): Promise<ComposioTriggerSubscription[]> {
+        return this.repo.find({
+            where: { userId },
+            order: { createdAt: 'DESC' as const },
+        });
+    }
+
+    /**
+     * Creates a trigger subscription row. In a follow-up PR this will
+     * also call Composio's `POST /triggers` to enable the trigger
+     * upstream — for now the controller layer wires the upstream call
+     * and passes us the resulting `composioTriggerId`.
+     */
+    async create(
+        userId: string,
+        composioTriggerId: string,
+        body: CreateComposioTriggerDto,
+    ): Promise<ComposioTriggerSubscription> {
+        const webhookSecret = randomBytes(32).toString('hex');
+        const entity = this.repo.create({
+            userId,
+            toolkitSlug: body.toolkitSlug.toUpperCase(),
+            triggerSlug: body.triggerSlug.toUpperCase(),
+            composioTriggerId,
+            composioConnectedAccountId: body.composioConnectedAccountId,
+            webhookSecret,
+            config: body.config ?? null,
+            enabled: true,
+            deliveriesReceived: 0,
+            deliveriesRejected: 0,
+        });
+        return this.repo.save(entity);
+    }
+
+    async remove(userId: string, id: string): Promise<void> {
+        const subscription = await this.repo.findOne({ where: { id, userId } });
+        if (!subscription) throw new NotFoundException('Trigger subscription not found');
+        await this.repo.delete({ id });
+    }
+
+    async findByComposioTriggerId(
+        composioTriggerId: string,
+    ): Promise<ComposioTriggerSubscription | null> {
+        return this.repo.findOne({ where: { composioTriggerId } });
+    }
+
+    /**
+     * Verifies an inbound Composio webhook delivery against the stored
+     * per-subscription HMAC secret. Composio signs deliveries with
+     * HMAC-SHA256 of the raw JSON body; the signature is sent as the
+     * hex digest in the `x-composio-signature` header.
+     *
+     * Uses `crypto.timingSafeEqual` to defeat timing attacks. Throws
+     * `UnauthorizedException` on mismatch.
+     */
+    verifyDelivery(
+        subscription: Pick<ComposioTriggerSubscription, 'webhookSecret'>,
+        rawBody: string,
+        signature: string | undefined,
+    ): void {
+        if (!signature || typeof signature !== 'string') {
+            throw new UnauthorizedException('Missing x-composio-signature header');
+        }
+
+        const computed = createHmac('sha256', subscription.webhookSecret)
+            .update(rawBody)
+            .digest('hex');
+
+        const provided = signature.trim().toLowerCase().replace(/^sha256=/, '');
+        if (provided.length !== computed.length) {
+            throw new UnauthorizedException('Invalid Composio webhook signature');
+        }
+
+        let equal = false;
+        try {
+            equal = timingSafeEqual(Buffer.from(provided, 'hex'), Buffer.from(computed, 'hex'));
+        } catch {
+            equal = false;
+        }
+        if (!equal) {
+            throw new UnauthorizedException('Invalid Composio webhook signature');
+        }
+    }
+
+    async recordDelivery(
+        subscriptionId: string,
+        outcome: 'accepted' | 'rejected',
+    ): Promise<void> {
+        const column = outcome === 'accepted' ? 'deliveriesReceived' : 'deliveriesRejected';
+        const updates: Partial<ComposioTriggerSubscription> = {};
+        if (outcome === 'accepted') updates.lastFiredAt = new Date();
+        await this.repo.increment({ id: subscriptionId }, column, 1);
+        if (Object.keys(updates).length > 0) {
+            await this.repo.update({ id: subscriptionId }, updates);
+        }
+    }
+}

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
@@ -1,10 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import {
-    Injectable,
-    Logger,
-    NotFoundException,
-    UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
@@ -101,7 +96,10 @@ export class ComposioTriggersService {
             .update(rawBody)
             .digest('hex');
 
-        const provided = signature.trim().toLowerCase().replace(/^sha256=/, '');
+        const provided = signature
+            .trim()
+            .toLowerCase()
+            .replace(/^sha256=/, '');
         if (provided.length !== computed.length) {
             throw new UnauthorizedException('Invalid Composio webhook signature');
         }
@@ -117,10 +115,7 @@ export class ComposioTriggersService {
         }
     }
 
-    async recordDelivery(
-        subscriptionId: string,
-        outcome: 'accepted' | 'rejected',
-    ): Promise<void> {
+    async recordDelivery(subscriptionId: string, outcome: 'accepted' | 'rejected'): Promise<void> {
         const column = outcome === 'accepted' ? 'deliveriesReceived' : 'deliveriesRejected';
         const updates: Partial<ComposioTriggerSubscription> = {};
         if (outcome === 'accepted') updates.lastFiredAt = new Date();

--- a/apps/api/src/plugins/composio-triggers/dto/composio-trigger.dto.ts
+++ b/apps/api/src/plugins/composio-triggers/dto/composio-trigger.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsObject, IsOptional, IsString, IsNotEmpty } from 'class-validator';
+
+export class CreateComposioTriggerDto {
+    @ApiProperty({ description: 'Composio toolkit slug (e.g. GMAIL).' })
+    @IsString()
+    @IsNotEmpty()
+    toolkitSlug!: string;
+
+    @ApiProperty({ description: 'Composio trigger slug (e.g. GMAIL_NEW_EMAIL).' })
+    @IsString()
+    @IsNotEmpty()
+    triggerSlug!: string;
+
+    @ApiProperty({ description: 'Composio connected-account id (`ca_*`) the trigger binds to.' })
+    @IsString()
+    @IsNotEmpty()
+    composioConnectedAccountId!: string;
+
+    @ApiPropertyOptional({
+        description: 'Per-trigger config (filters, polling cadence) — passed through to Composio.',
+    })
+    @IsOptional()
+    @IsObject()
+    config?: Record<string, unknown>;
+}
+
+export class ComposioTriggerDto {
+    @ApiProperty() id!: string;
+    @ApiProperty() toolkitSlug!: string;
+    @ApiProperty() triggerSlug!: string;
+    @ApiProperty() composioTriggerId!: string;
+    @ApiProperty() composioConnectedAccountId!: string;
+    @ApiProperty() enabled!: boolean;
+    @ApiProperty() deliveriesReceived!: number;
+    @ApiProperty() deliveriesRejected!: number;
+    @ApiPropertyOptional({ type: String }) lastFiredAt?: string | null;
+    @ApiProperty() createdAt!: string;
+
+    /** Only returned on initial creation. Never re-fetched. */
+    @ApiPropertyOptional() webhookSecret?: string;
+}
+
+export class ComposioTriggerListDto {
+    @ApiProperty({ type: [ComposioTriggerDto] })
+    items!: ComposioTriggerDto[];
+}

--- a/apps/web/src/app/actions/plugins.ts
+++ b/apps/web/src/app/actions/plugins.ts
@@ -5,6 +5,11 @@ import {
     deviceAuthAPI,
     type PluginDeviceAuthStatus,
 } from '@/lib/api/plugins-capabilities/device-auth';
+import {
+    composioTriggersAPI,
+    type ComposioTrigger,
+    type CreateComposioTriggerInput,
+} from '@/lib/api/plugins-capabilities/composio-triggers';
 import { revalidatePath } from 'next/cache';
 
 export interface ActionResult<T = unknown> {
@@ -233,6 +238,44 @@ export async function startPluginDeviceAuth(
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to start device auth',
+        };
+    }
+}
+
+export async function listComposioTriggers(): Promise<ActionResult<ComposioTrigger[]>> {
+    try {
+        const data = await composioTriggersAPI.list();
+        return { success: true, data };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to list Composio triggers',
+        };
+    }
+}
+
+export async function createComposioTrigger(
+    input: CreateComposioTriggerInput,
+): Promise<ActionResult<ComposioTrigger>> {
+    try {
+        const data = await composioTriggersAPI.create(input);
+        return { success: true, data };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to create Composio trigger',
+        };
+    }
+}
+
+export async function deleteComposioTrigger(id: string): Promise<ActionResult<void>> {
+    try {
+        await composioTriggersAPI.remove(id);
+        return { success: true };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to delete Composio trigger',
         };
     }
 }

--- a/apps/web/src/components/plugins/PluginSettings.tsx
+++ b/apps/web/src/components/plugins/PluginSettings.tsx
@@ -28,6 +28,7 @@ import { PluginDeviceAuthConnection } from '@/components/settings/PluginDeviceAu
 import { PluginOAuthConnection } from '@/components/settings/PluginOAuthConnection';
 import { GitHubOrganizationsSettings } from '@/components/settings/GitHubOrganizationsSettings';
 import { PluginOnboardingWizard } from '@/components/settings/PluginOnboardingWizard';
+import { ComposioTriggersPanel } from './composio/ComposioTriggersPanel';
 import { getCategoryLabel, getCapabilityLabel } from '@/lib/utils/plugin-category-icons';
 import { usePluginSettings } from '@/lib/hooks/use-plugin-settings';
 import { usePluginToggle } from '@/lib/hooks/use-plugin-toggle';
@@ -299,6 +300,10 @@ export function PluginSettings({ plugin, oauthConnection, deviceAuthStatus }: Pl
                     plugin={plugin}
                     connected={Boolean(oauthConnection?.connected)}
                 />
+            )}
+
+            {plugin.pluginId === 'composio' && optimisticEnabled && (
+                <ComposioTriggersPanel />
             )}
 
             {/* Settings Form */}

--- a/apps/web/src/components/plugins/composio/ComposioTriggersPanel.tsx
+++ b/apps/web/src/components/plugins/composio/ComposioTriggersPanel.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, RefreshCw, Trash2, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    deleteComposioTrigger,
+    listComposioTriggers,
+} from '@/app/actions/plugins';
+import type { ComposioTrigger } from '@/lib/api/plugins-capabilities/composio-triggers';
+
+/**
+ * Settings-page panel that lists the caller's Composio trigger subscriptions
+ * (each row = one enabled trigger event surface like `GMAIL_NEW_EMAIL`).
+ *
+ * Create flow is intentionally out of this MVP — triggers are minted via
+ * `POST /api/plugins/composio/triggers` (the API also returns the
+ * per-subscription HMAC secret once). UI for "Create trigger" lands with
+ * the upstream Composio enable-trigger call in a follow-up PR — until
+ * then operators provision via API and this panel surfaces the result.
+ */
+export function ComposioTriggersPanel() {
+    const [items, setItems] = useState<ComposioTrigger[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [deletingId, setDeletingId] = useState<string | null>(null);
+
+    const refresh = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        const result = await listComposioTriggers();
+        if (result.success && result.data) setItems(result.data);
+        else if (!result.success) setError(result.error ?? 'Failed to load triggers');
+        setLoading(false);
+    }, []);
+
+    useEffect(() => {
+        void refresh();
+    }, [refresh]);
+
+    const handleDelete = useCallback(
+        async (id: string) => {
+            setDeletingId(id);
+            try {
+                const result = await deleteComposioTrigger(id);
+                if (!result.success) {
+                    setError(result.error ?? 'Failed to delete trigger');
+                    return;
+                }
+                setItems((prev) => prev.filter((t) => t.id !== id));
+            } finally {
+                setDeletingId(null);
+            }
+        },
+        [],
+    );
+
+    if (loading) {
+        return (
+            <div className="rounded-lg border border-border dark:border-border-dark p-6 bg-surface dark:bg-surface-dark flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Loading Composio triggers…
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark">
+            <div className="flex items-center justify-between gap-2 px-6 py-3 border-b border-border dark:border-border-dark">
+                <div className="flex items-center gap-2">
+                    <Zap className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                    <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                        Composio triggers
+                    </h2>
+                </div>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void refresh()}
+                    aria-label="Refresh triggers"
+                >
+                    <RefreshCw className="w-4 h-4" />
+                </Button>
+            </div>
+
+            {error && (
+                <div className="px-6 py-3 text-sm text-danger border-b border-border dark:border-border-dark">
+                    {error}
+                </div>
+            )}
+
+            {items.length === 0 ? (
+                <div className="p-6 text-sm text-text-muted dark:text-text-muted-dark">
+                    No triggers yet. Create one via{' '}
+                    <code className="font-mono">POST /api/plugins/composio/triggers</code> — UI is
+                    coming in a follow-up.
+                </div>
+            ) : (
+                <ul className="divide-y divide-border dark:divide-border-dark">
+                    {items.map((trigger) => (
+                        <li key={trigger.id} className="px-6 py-4 flex items-start gap-4">
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <span className="font-mono text-sm text-text dark:text-text-dark">
+                                        {trigger.triggerSlug}
+                                    </span>
+                                    <span className="text-xs text-text-muted dark:text-text-muted-dark">
+                                        {trigger.toolkitSlug}
+                                    </span>
+                                    {trigger.enabled ? (
+                                        <span className="inline-flex items-center gap-1 text-xs text-success">
+                                            <span className="w-1.5 h-1.5 rounded-full bg-success" />
+                                            Enabled
+                                        </span>
+                                    ) : (
+                                        <span className="text-xs text-text-muted dark:text-text-muted-dark">
+                                            Disabled
+                                        </span>
+                                    )}
+                                </div>
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                                    Deliveries: {trigger.deliveriesReceived} received,{' '}
+                                    {trigger.deliveriesRejected} rejected
+                                    {trigger.lastFiredAt
+                                        ? ` · last fired ${new Date(trigger.lastFiredAt).toLocaleString()}`
+                                        : ''}
+                                </p>
+                            </div>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => void handleDelete(trigger.id)}
+                                disabled={deletingId === trigger.id}
+                                loading={deletingId === trigger.id}
+                                aria-label={`Delete trigger ${trigger.triggerSlug}`}
+                                className="text-danger hover:text-danger hover:bg-danger/10"
+                            >
+                                <Trash2 className="w-4 h-4" />
+                            </Button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/plugins/composio/ComposioTriggersPanel.tsx
+++ b/apps/web/src/components/plugins/composio/ComposioTriggersPanel.tsx
@@ -3,10 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, RefreshCw, Trash2, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-    deleteComposioTrigger,
-    listComposioTriggers,
-} from '@/app/actions/plugins';
+import { deleteComposioTrigger, listComposioTriggers } from '@/app/actions/plugins';
 import type { ComposioTrigger } from '@/lib/api/plugins-capabilities/composio-triggers';
 
 /**
@@ -38,22 +35,19 @@ export function ComposioTriggersPanel() {
         void refresh();
     }, [refresh]);
 
-    const handleDelete = useCallback(
-        async (id: string) => {
-            setDeletingId(id);
-            try {
-                const result = await deleteComposioTrigger(id);
-                if (!result.success) {
-                    setError(result.error ?? 'Failed to delete trigger');
-                    return;
-                }
-                setItems((prev) => prev.filter((t) => t.id !== id));
-            } finally {
-                setDeletingId(null);
+    const handleDelete = useCallback(async (id: string) => {
+        setDeletingId(id);
+        try {
+            const result = await deleteComposioTrigger(id);
+            if (!result.success) {
+                setError(result.error ?? 'Failed to delete trigger');
+                return;
             }
-        },
-        [],
-    );
+            setItems((prev) => prev.filter((t) => t.id !== id));
+        } finally {
+            setDeletingId(null);
+        }
+    }, []);
 
     if (loading) {
         return (

--- a/apps/web/src/lib/api/plugins-capabilities/composio-triggers.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/composio-triggers.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+import { serverFetch, serverMutation } from '../server-api';
+
+export interface ComposioTrigger {
+    id: string;
+    toolkitSlug: string;
+    triggerSlug: string;
+    composioTriggerId: string;
+    composioConnectedAccountId: string;
+    enabled: boolean;
+    deliveriesReceived: number;
+    deliveriesRejected: number;
+    lastFiredAt?: string | null;
+    createdAt: string;
+    /** Returned only on create — never on subsequent reads. */
+    webhookSecret?: string;
+}
+
+export interface CreateComposioTriggerInput {
+    toolkitSlug: string;
+    triggerSlug: string;
+    composioConnectedAccountId: string;
+    config?: Record<string, unknown>;
+}
+
+export const composioTriggersAPI = {
+    list: async (): Promise<ComposioTrigger[]> => {
+        const response = await serverFetch<{ items: ComposioTrigger[] }>(
+            '/plugins/composio/triggers',
+        );
+        return response.items ?? [];
+    },
+
+    create: async (input: CreateComposioTriggerInput): Promise<ComposioTrigger> => {
+        return serverMutation<ComposioTrigger>({
+            endpoint: '/plugins/composio/triggers',
+            data: input,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    remove: async (id: string): Promise<void> => {
+        await serverMutation<void>({
+            endpoint: `/plugins/composio/triggers/${id}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+};

--- a/packages/agent/src/entities/composio-trigger-subscription.entity.ts
+++ b/packages/agent/src/entities/composio-trigger-subscription.entity.ts
@@ -1,0 +1,98 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+import { PortableDateColumn } from './_types';
+
+/**
+ * One row per user-installed Composio trigger.
+ *
+ * A *trigger* is Composio's webhook event surface (`GMAIL_NEW_EMAIL`,
+ * `SLACK_NEW_MESSAGE`, `GITHUB_NEW_STAR`, …). Each enabled trigger
+ * fires HTTP POSTs to `/api/plugins/composio/webhook`. This table
+ * tracks which triggers the user has enabled, plus the per-trigger
+ * HMAC secret used to verify inbound deliveries.
+ *
+ * `composioTriggerId` is the Composio-assigned nanoid (`tg_*`) — it
+ * is the primary lookup key when verifying a webhook delivery. A
+ * Composio account can only subscribe to a given (toolkit, trigger)
+ * pair once per user, hence the unique index.
+ *
+ * See `docs/specs/features/composio-triggers/spec.md` (EW-684 PR-D).
+ */
+@Entity({ name: 'composio_trigger_subscriptions' })
+@Index('uq_composio_trigger_subscription', ['userId', 'toolkitSlug', 'triggerSlug'], {
+    unique: true,
+})
+@Index('uq_composio_trigger_subscription_remote', ['composioTriggerId'], { unique: true })
+@Index('idx_composio_trigger_subscription_user', ['userId'])
+export class ComposioTriggerSubscription {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    @ManyToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'userId' })
+    user?: User;
+
+    /** Composio toolkit slug, uppercase (`GMAIL`, `SLACK`, …). */
+    @Column({ type: 'varchar', length: 64 })
+    toolkitSlug: string;
+
+    /** Composio trigger slug, uppercase (`GMAIL_NEW_EMAIL`, …). */
+    @Column({ type: 'varchar', length: 128 })
+    triggerSlug: string;
+
+    /** Composio trigger nanoid (`tg_*`). Stable identifier for webhook lookup. */
+    @Column({ type: 'varchar', length: 64 })
+    composioTriggerId: string;
+
+    /** Composio connected-account id (`ca_*`) the trigger was bound to. */
+    @Column({ type: 'varchar', length: 64 })
+    composioConnectedAccountId: string;
+
+    /**
+     * HMAC-SHA256 key used to verify the `x-composio-signature` header
+     * on every webhook delivery. Generated server-side at subscription
+     * creation time, never re-shown after creation.
+     */
+    @Column({ type: 'varchar', length: 128 })
+    webhookSecret: string;
+
+    /** Per-trigger config (filters, polling cadence, …) — passthrough to Composio. */
+    @Column({ type: 'simple-json', nullable: true })
+    config?: Record<string, unknown> | null;
+
+    @Column({ type: 'boolean', default: true })
+    enabled: boolean;
+
+    @PortableDateColumn({ nullable: true })
+    lastFiredAt?: Date | null;
+
+    @Column({ type: 'integer', default: 0 })
+    deliveriesReceived: number;
+
+    @Column({ type: 'integer', default: 0 })
+    deliveriesRejected: number;
+
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -84,3 +84,6 @@ export * from './user-notification-subscription.entity';
 export * from './user-notification-preference.entity';
 export * from './user-notification-category-mute.entity';
 export * from './organization-notification-default.entity';
+
+// Composio triggers (EW-684 PR-D)
+export * from './composio-trigger-subscription.entity';


### PR DESCRIPTION
## Summary

EW-684 **PR-D**: lands the Composio triggers surface. Pairs with **PR-A #1094** (SDK migration), **PR-B #1101** (settings UX backend + connections panel), and **PR-C #1102** (skills-provider). Independent of those three — no merge order required.

### Database
- New `ComposioTriggerSubscription` TypeORM entity + migration `1780100000000-AddComposioTriggerSubscriptions.ts` (NN #16). Stores toolkit + trigger slugs, Composio `tg_*` id, bound `ca_*`, a server-minted HMAC secret, per-row delivery counters, and Tier-C tenant/org FKs.

### API (mounted at `api/plugins/composio`)
- `GET /triggers` — list the caller's triggers
- `POST /triggers` — create a subscription, returns the per-row `webhookSecret` **once**
- `DELETE /triggers/:id` — remove
- `@Public()` `POST /webhook` — resolves the subscription by the `tg_*` in the payload, HMAC-SHA256-verifies the raw body (constant-time, supports bare hex + `sha256=` prefix), bumps delivery counters

### Web
- `ComposioTriggersPanel` listing each trigger with delivery counts + delete, rendered on the composio plugin settings page when the plugin is enabled
- Server actions + `composioTriggersAPI` client

### Tests
- 10 new jest cases (apps/api): slug uppercasing, secret format, NotFound on cross-user remove, valid signature (bare + prefixed), tampered body, missing header, wrong length, delivery counter behavior

### Out of scope (follow-up PR)
- Calling Composio's `POST /triggers` to enable the trigger upstream (controller currently mints a placeholder `composioTriggerId`)
- A "Create trigger" form in the panel — operators provision via API for now and the panel surfaces the result

## Test plan
- [ ] CI lint-and-test
- [ ] Create a trigger via API and confirm the panel renders it after refresh
- [ ] POST a delivery to `/api/plugins/composio/webhook` with a valid `x-composio-signature` → 200, `deliveriesReceived` increments, `lastFiredAt` updates
- [ ] POST with a tampered body → 401, `deliveriesRejected` increments
- [ ] Delete the trigger from the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composio Triggers panel to list, create, and delete trigger subscriptions; per-subscription webhook secret shown once at creation.
  * UI shows enabled state, delivery counters, last-fired timestamp, refresh/loading/empty states.
  * Webhook endpoints to receive and verify Composio deliveries.

* **Bug Fixes**
  * Improved webhook delivery verification and more accurate delivery tracking.

* **Tests**
  * Added unit tests for trigger handling, verification, and delivery recording.

* **Chores**
  * Database migration to persist trigger subscriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->