### PR TITLE
feat(notifications-v2): Trigger.dev delivery, quiet-hours deferral, agent email templates, channel SDKs

### DIFF
--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -26,6 +26,10 @@ import {
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { EmailModule } from '../email/email.module';
 import { EmailService } from '../email/email.service';
+import {
+    INBOUND_EMAIL_TASK_SPAWNER,
+    type InboundEmailTaskSpawner,
+} from '@ever-works/agent/notifications';
 
 // Phase 16.6 / 16.7 — commitToRepo / openPullRequest tools.
 // The `AGENT_GIT_FACADE` token (exported from `@ever-works/agent/agents`)
@@ -132,6 +136,35 @@ import { AgentsController } from './agents.controller';
                         force: force ?? false,
                     });
                     return { status: row.status };
+                },
+            }),
+        },
+        // Notifications v2 (EW-670) — INBOUND_EMAIL_TASK_SPAWNER binding.
+        // The inbound-email dispatcher's `task-spawn` mode delegates here:
+        // create a Task from the inbound email (scoped to the address
+        // owner, created-by the receiving agent) and assign that agent so
+        // the task-tracking flow dispatches `agent-task-execute`. When this
+        // token is unbound the dispatcher persists the message but spawns
+        // no Task (graceful no-op).
+        {
+            provide: INBOUND_EMAIL_TASK_SPAWNER,
+            inject: [TasksService],
+            useFactory: (tasks: TasksService): InboundEmailTaskSpawner => ({
+                async spawnTaskForInboundEmail({ agentId, userId, subject, bodyText, from }) {
+                    const title = subject?.trim()
+                        ? subject.trim().slice(0, 200)
+                        : `Inbound email from ${from}`;
+                    const task = await tasks.create(userId, {
+                        title,
+                        description: bodyText?.trim() ? bodyText.trim().slice(0, 8000) : null,
+                        labels: ['inbound-email'],
+                        createdByType: 'agent',
+                        createdById: agentId,
+                    });
+                    // Assign the receiving agent so the task-tracking flow
+                    // fans out agent-task-execute for it.
+                    await tasks.addAssignee(userId, task.id, 'agent', agentId);
+                    return { taskId: task.id };
                 },
             }),
         },
@@ -504,6 +537,7 @@ import { AgentsController } from './agents.controller';
         AGENT_GIT_FACADE,
         AGENT_EMAIL_FACADE,
         AGENT_NOTIFY_CHANNEL_FACADE,
+        INBOUND_EMAIL_TASK_SPAWNER,
     ],
 })
 export class AgentsModule {}

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -419,6 +419,7 @@ import { AgentsController } from './agents.controller';
                     subject,
                     bodyText,
                     bodyHtml,
+                    template,
                     fromAddressId,
                 }) {
                     const result = await email.sendMessage(userId, {
@@ -428,6 +429,7 @@ import { AgentsController } from './agents.controller';
                         subject,
                         bodyText,
                         bodyHtml,
+                        template,
                         fromAddressId,
                     });
                     return {

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -480,8 +480,11 @@ import { AgentsController } from './agents.controller';
                         { text, messageRef: `agent-${agentId}-${Date.now()}` },
                         { userId, agentId },
                     );
+                    // sendDirect is the synchronous inline path (no Trigger
+                    // dispatch), so it only ever resolves delivered/failed —
+                    // narrow the facade's wider union for the agent tool.
                     return {
-                        status: result.status,
+                        status: result.status === 'failed' ? 'failed' : 'delivered',
                         providerMessageId: result.providerMessageId,
                         error: result.error,
                     };

--- a/apps/api/src/notifications/notification-fanout.listener.ts
+++ b/apps/api/src/notifications/notification-fanout.listener.ts
@@ -5,7 +5,10 @@ import {
     type NotificationFanoutEvent,
     UserNotificationSubscriptionService,
 } from '@ever-works/agent/notifications';
-import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
+import {
+    NotificationChannelFacadeService,
+    type ResolvedChannelTarget,
+} from '@ever-works/agent/facades';
 
 /**
  * EW-664 / EW-678 / T20 + T22 — Producer fanout listener.
@@ -70,14 +73,25 @@ export class NotificationFanoutListener {
      * NotificationService.create, so the channel facade treats it as a
      * no-op sentinel).
      */
-    private async resolveChannelIds(userId: string, eventKey: string): Promise<string[]> {
+    private async resolveChannelIds(
+        userId: string,
+        eventKey: string,
+    ): Promise<ResolvedChannelTarget[]> {
         if (!this.subscriptions) return [];
         try {
-            const channels = await this.subscriptions.resolveChannels(userId, eventKey);
+            const plan = await this.subscriptions.resolvePlan(userId, eventKey);
             // Drop the 'in-app' sentinel before fanout — in-app delivery
             // already happened in the v1 producer's create() call; the
-            // channel facade only handles the external channels.
-            return channels.filter((c) => c !== 'in-app');
+            // channel facade only handles the external channels. Deferred
+            // (quiet-hours) channels carry `deferUntil` so the facade
+            // enqueues them on the Trigger.dev delivery task with that delay.
+            const immediate = plan.immediate
+                .filter((c) => c !== 'in-app')
+                .map((channelId) => ({ channelId }));
+            const deferred = plan.deferred
+                .filter((c) => c !== 'in-app')
+                .map((channelId) => ({ channelId, deferUntil: plan.deferUntil }));
+            return [...immediate, ...deferred];
         } catch (err) {
             this.logger.debug(
                 `Subscription resolver fallback to [] for user=${userId} event=${eventKey}: ${String(err)}`,

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -44,7 +44,7 @@ import { TaskRecurrenceDispatcherService } from '@ever-works/agent/tasks-domain'
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
 import { DataSyncDispatcherService } from '../data-sync/data-sync-dispatcher.service';
 import { NotificationService } from '@ever-works/agent/notifications';
-import { GitFacadeService } from '@ever-works/agent/facades';
+import { GitFacadeService, NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { RemoteCallDto } from './dto/remote-call.dto';
 import {
     PluginRepository,
@@ -164,6 +164,10 @@ export class TriggerInternalController implements OnModuleInit {
         private readonly agentRunRepositoryRef: AgentRunRepository,
         // Phase 17 — recurring Task dispatcher.
         private readonly taskRecurrenceDispatcherService: TaskRecurrenceDispatcherService,
+        // Notifications v2 (EW-663) — exposed for the
+        // notification-channel-delivery Trigger task to run a single
+        // channel attempt (plugins are loaded here, not in the worker).
+        private readonly notificationChannelFacade: NotificationChannelFacadeService,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -200,6 +204,9 @@ export class TriggerInternalController implements OnModuleInit {
             AgentRunRepository: this.agentRunRepositoryRef,
             // Phase 17 — recurring Task dispatcher.
             TaskRecurrenceDispatcherService: this.taskRecurrenceDispatcherService,
+            // Notifications v2 (EW-663) — notification-channel-delivery task
+            // calls `deliverToChannelOrThrow` here (allow-list auto-derived).
+            NotificationChannelFacadeService: this.notificationChannelFacade,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/docs/specs/features/event-subscriptions/spec.md
+++ b/docs/specs/features/event-subscriptions/spec.md
@@ -88,7 +88,7 @@ Resolution:
 1. Load `user_notification_subscriptions` rows for `(userId, eventType)`.
 2. If none, fall back to the organisation default → built-in default → `['in-app']`.
 3. Filter out channels the user has disabled.
-4. Apply quiet hours: if now ∈ quiet window AND event.urgent === false AND channel is not `in-app`, queue delivery for end-of-quiet-window via BullMQ delayed job.
+4. Apply quiet hours: if now ∈ quiet window AND event.urgent === false AND channel is not `in-app`, defer delivery to end-of-quiet-window by enqueuing the Trigger.dev `notification-channel-delivery` task with a `delay` (the run waits server-side until the window closes). No BullMQ.
 5. Apply category mute: if `(userId, category)` has an active mute, drop all non-`in-app` channels (in-app still records the notification for retrospective viewing).
 
 Output: a list of `channelId`s. The caller fans out via `NotificationChannelFacadeService.send(channelIds, payload)`.

--- a/docs/specs/features/notification-channels/spec.md
+++ b/docs/specs/features/notification-channels/spec.md
@@ -112,7 +112,7 @@ A new facade in `packages/agent/src/facades/notification-channel.facade.ts` (par
 
 - **`send(userId, eventType, payload)`** — resolves the user's enabled channels for the event (via [`event-subscriptions`](../event-subscriptions/spec.md)), and fans out to each in parallel.
 - **`sendDirect(channelId, payload)`** — bypass the subscription resolver; send to one specific channel (used for "Test" button, direct ad-hoc notifications).
-- **Failover**: per-channel attempt with exponential-backoff retry (3 attempts, 1s/4s/15s); on terminal failure, enqueue a BullMQ `notification-channel-retry` job (24h dead-letter).
+- **Failover**: per-channel delivery runs through a Trigger.dev `notification-channel-delivery` task whose `retry` policy gives exponential backoff (mirrors the existing `webhook-delivery` task). On terminal failure the run exhausts its attempts and the delivery-log row is marked `failed` (that row is the dead-letter). When Trigger.dev is disabled (dev / no token), the facade falls back to a synchronous in-process attempt. No BullMQ/Redis — Trigger.dev is the house job system.
 - **Attribution**: emits a `PluginUsageEvent` per send with `capability='notification-channel'` and `channelId` in metadata.
 
 ### 3.4 In-app channel (special-cased)
@@ -156,7 +156,7 @@ notification_channel_delivery_log
 ### 4.2 Reuses
 
 - `PluginUsageEvent` — adds rows with `capability='notification-channel'`.
-- BullMQ — adds `notification-channel-retry` queue (3 attempts, exponential backoff).
+- Trigger.dev — adds a `notification-channel-delivery` task (exponential-backoff `retry` policy; quiet-hours deferral via the run `delay` option).
 
 ---
 
@@ -214,7 +214,7 @@ The in-app channel is built-in (no plugin package).
 - [x] **I** Plugin-first — each channel ships as its own package under `packages/plugins/`.
 - [x] **II** Capability-driven — selection via `PLUGIN_CAPABILITIES.NOTIFICATION_CHANNEL_*`.
 - [x] **III** Database — new tables go through TypeORM migrations per repo rules.
-- [x] **IV** Trigger.dev / BullMQ — retry queue uses BullMQ (already in use).
+- [x] **IV** Trigger.dev — delivery + retry + quiet-hours deferral use a Trigger.dev task (`delay` for deferral); no BullMQ.
 - [x] **V** Forward-only migrations — additive tables only.
 - [x] **VI** Tests — Vitest unit tests per plugin + Jest integration tests for the facade.
 - [x] **VII** Secret hygiene — bot tokens / API keys marked `x-secret` in the plugin manifest.

--- a/packages/agent/src/agents/__tests__/agent-tool.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool.service.spec.ts
@@ -284,6 +284,51 @@ describe('AgentToolService.resolveAllowedTools', () => {
             expect(facade.sendEmail).toHaveBeenCalledTimes(1);
             expect((ok as { providerMessageId: string }).providerMessageId).toBe('pm-1');
         });
+
+        it('accepts a template instead of bodyText and forwards it to the facade', async () => {
+            const facade = makeEmailFacade();
+            facade.sendEmail.mockResolvedValue({
+                providerMessageId: 'pm-2',
+                accepted: ['b@x.com'],
+                rejected: [],
+            });
+            const withFacade = new AgentToolService(
+                agents,
+                skills,
+                bindings,
+                files,
+                undefined,
+                undefined,
+                facade as any,
+            );
+            const tools = withFacade.resolveAllowedTools(
+                makeAgent({
+                    permissions: { ...makeAgent().permissions, canCallExternalTools: true },
+                }),
+            );
+            const tool = tools.find((t) => t.name === 'sendEmail')!;
+
+            // Neither body nor template → error.
+            const bad = (await tool.invoke({ to: ['b@x.com'], subject: 's' } as any)) as Record<
+                string,
+                unknown
+            >;
+            expect('error' in bad).toBe(true);
+            expect(facade.sendEmail).not.toHaveBeenCalled();
+
+            // Template only → forwarded through to the facade.
+            const ok = await tool.invoke({
+                to: ['b@x.com'],
+                subject: 'Digest',
+                template: { slug: 'agent-summary', props: { agentName: 'Atlas' } },
+            } as any);
+            expect((ok as { providerMessageId: string }).providerMessageId).toBe('pm-2');
+            expect(facade.sendEmail).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    template: { slug: 'agent-summary', props: { agentName: 'Atlas' } },
+                }),
+            );
+        });
     });
 
     describe('messageAgent tool (EW-670 / T24)', () => {

--- a/packages/agent/src/agents/agent-email-facade.ts
+++ b/packages/agent/src/agents/agent-email-facade.ts
@@ -18,6 +18,17 @@
  * resolves the actual from-address + provider from the Agent's
  * `agent_email_assignments` (lowest-priority outbound = default).
  */
+/**
+ * Handle for a registered React-Email template. When provided, the
+ * adapter renders it server-side (via `@ever-works/email-templates`)
+ * into the HTML + text bodies — the Agent supplies structured `props`
+ * instead of raw HTML.
+ */
+export interface AgentEmailTemplateRef {
+    slug: string;
+    props: Record<string, unknown>;
+}
+
 export interface AgentSendEmailInput {
     userId: string;
     agentId: string;
@@ -26,8 +37,11 @@ export interface AgentSendEmailInput {
     to: string[];
     cc?: string[];
     subject: string;
-    bodyText: string;
+    /** Plain-text body. Optional when `template` is supplied (rendered then). */
+    bodyText?: string;
     bodyHtml?: string;
+    /** Render a registered React-Email template instead of raw bodies. */
+    template?: AgentEmailTemplateRef;
     /** Optional explicit from-address id (tenant_email_addresses.id). */
     fromAddressId?: string;
 }

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -606,9 +606,10 @@ export class AgentToolService {
         {
             to: string[];
             subject: string;
-            bodyText: string;
+            bodyText?: string;
             cc?: string[];
             bodyHtml?: string;
+            template?: { slug: string; props: Record<string, unknown> };
             fromAddressId?: string;
         },
         AgentSendEmailResult
@@ -616,7 +617,7 @@ export class AgentToolService {
         return {
             name: 'sendEmail',
             description:
-                "Send an email from one of this agent's assigned outbound addresses. Requires canCallExternalTools AND at least one outbound email address assigned to the agent (Settings → Integrations → Emails). Returns the provider message id plus accepted/rejected recipient lists. Use for agent-authored outbound mail; for messaging a peer agent prefer messageAgent.",
+                "Send an email from one of this agent's assigned outbound addresses. Requires canCallExternalTools AND at least one outbound email address assigned to the agent (Settings → Integrations → Emails). Provide either bodyText (optionally bodyHtml) OR a template to render. Returns the provider message id plus accepted/rejected recipient lists. Use for agent-authored outbound mail; for messaging a peer agent prefer messageAgent.",
             parameters: {
                 type: 'object',
                 properties: {
@@ -626,7 +627,10 @@ export class AgentToolService {
                         description: 'Recipient email addresses (RFC 5321 mailboxes).',
                     },
                     subject: { type: 'string', description: 'Email subject line.' },
-                    bodyText: { type: 'string', description: 'Plain-text body (always required).' },
+                    bodyText: {
+                        type: 'string',
+                        description: 'Plain-text body. Required unless `template` is provided.',
+                    },
                     cc: {
                         type: 'array',
                         items: { type: 'string' },
@@ -636,13 +640,18 @@ export class AgentToolService {
                         type: 'string',
                         description: 'Optional HTML body. When omitted, bodyText is sent as-is.',
                     },
+                    template: {
+                        type: 'object',
+                        description:
+                            'Render a registered React-Email template server-side instead of raw bodies (mutually exclusive with bodyText/bodyHtml). Shape: { slug: string (e.g. "agent-summary" | "agent-message"), props: object (fields depend on the slug) }.',
+                    },
                     fromAddressId: {
                         type: 'string',
                         description:
                             "Optional tenant_email_addresses id to send from. Defaults to the agent's primary (lowest-priority) outbound assignment.",
                     },
                 },
-                required: ['to', 'subject', 'bodyText'],
+                required: ['to', 'subject'],
             },
             invoke: async (args) => {
                 if (!Array.isArray(args?.to) || args.to.length === 0) {
@@ -651,8 +660,10 @@ export class AgentToolService {
                 if (!args?.subject || args.subject.trim().length === 0) {
                     return { error: 'subject is required.' };
                 }
-                if (!args?.bodyText || args.bodyText.trim().length === 0) {
-                    return { error: 'bodyText is required.' };
+                const hasBody = !!args?.bodyText && args.bodyText.trim().length > 0;
+                const hasTemplate = !!args?.template?.slug;
+                if (!hasBody && !hasTemplate) {
+                    return { error: 'Provide bodyText or a template.' };
                 }
                 try {
                     return await this.emailFacade!.sendEmail({
@@ -664,6 +675,7 @@ export class AgentToolService {
                         subject: args.subject,
                         bodyText: args.bodyText,
                         bodyHtml: args.bodyHtml,
+                        template: args.template,
                         fromAddressId: args.fromAddressId,
                     });
                 } catch (err) {

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -217,6 +217,7 @@ describe('FacadesModule + barrel re-exports', () => {
                     'EmailFacadeService',
                     'NotificationChannelFacadeError',
                     'NotificationChannelFacadeService',
+                    'NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER',
                 ].sort(),
             );
         });

--- a/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
@@ -75,4 +75,25 @@ describe('NotificationChannelFacadeService', () => {
             ),
         ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
     });
+
+    it('deliverToChannelOrThrow resolves for the in-app sentinel and throws on failure', async () => {
+        // 'in-app' is a no-op delivered sentinel — resolves.
+        await expect(
+            facade.deliverToChannelOrThrow(
+                'in-app',
+                { text: 'x', messageRef: 'r' },
+                { userId: 'u' },
+            ),
+        ).resolves.toMatchObject({ status: 'delivered' });
+
+        // No channels repo wired here → sendOne yields a failed result →
+        // the throwing variant surfaces it (so Trigger.dev retries).
+        await expect(
+            facade.deliverToChannelOrThrow(
+                'missing',
+                { text: 'x', messageRef: 'r' },
+                { userId: 'u' },
+            ),
+        ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
+    });
 });

--- a/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import {
     NotificationChannelFacadeService,
     NotificationChannelFacadeError,
+    NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
 } from '../notification-channel.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
@@ -95,5 +96,37 @@ describe('NotificationChannelFacadeService', () => {
                 { userId: 'u' },
             ),
         ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
+    });
+
+    it('routes event fanout through the delivery dispatcher when bound (returns queued)', async () => {
+        const enqueue = jest.fn().mockResolvedValue({ runId: 'run-1' });
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                NotificationChannelFacadeService,
+                { provide: PluginRegistryService, useValue: registry },
+                { provide: PluginSettingsService, useValue: settings },
+                { provide: NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER, useValue: { enqueue } },
+            ],
+        }).compile();
+        const f = moduleRef.get(NotificationChannelFacadeService);
+
+        const results = await f.send(
+            'user-1',
+            'work_generation_finished',
+            { text: 'done', messageRef: 'ref-1' },
+            async () => ['ch-1', 'in-app'],
+            { userId: 'user-1' },
+        );
+
+        // ch-1 → enqueued (Trigger handles delivery + retry); in-app stays
+        // inline as a no-op delivered sentinel.
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        expect(results.find((r) => r.channelId === 'ch-1')).toMatchObject({
+            status: 'queued',
+            providerMessageId: 'run-1',
+        });
+        expect(results.find((r) => r.channelId === 'in-app')).toMatchObject({
+            status: 'delivered',
+        });
     });
 });

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -106,6 +106,7 @@ export {
 export {
     NotificationChannelFacadeService,
     NotificationChannelFacadeError,
+    NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
     type NotificationChannelFanoutInput,
     type NotificationChannelFanoutResult,
     type NotificationChannelDeliveryPayload,

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -108,6 +108,8 @@ export {
     NotificationChannelFacadeError,
     type NotificationChannelFanoutInput,
     type NotificationChannelFanoutResult,
+    type NotificationChannelDeliveryPayload,
+    type NotificationChannelDeliveryDispatcher,
 } from './notification-channel.facade';
 
 // Agent-Memory Facade — pluggable persistent memory for agents

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -111,6 +111,7 @@ export {
     type NotificationChannelFanoutResult,
     type NotificationChannelDeliveryPayload,
     type NotificationChannelDeliveryDispatcher,
+    type ResolvedChannelTarget,
 } from './notification-channel.facade';
 
 // Agent-Memory Facade — pluggable persistent memory for agents

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -170,12 +170,18 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
                     options,
                     deferUntil,
                 });
-                return {
-                    channelId,
-                    pluginId: 'queued',
-                    status: 'queued',
-                    providerMessageId: runId ?? undefined,
-                };
+                // A null runId means Trigger.dev is disabled / didn't
+                // enqueue — fall through to in-process delivery so the
+                // notification isn't silently lost. Only a real run id
+                // means the delivery is genuinely queued.
+                if (runId) {
+                    return {
+                        channelId,
+                        pluginId: 'queued',
+                        status: 'queued',
+                        providerMessageId: runId,
+                    };
+                }
             } catch (err) {
                 // Enqueue failed — fall back to an in-process attempt so the
                 // notification isn't silently lost.

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -138,6 +138,32 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         });
     }
 
+    /**
+     * Single delivery attempt that THROWS on failure. This is the
+     * primitive the Trigger.dev `notification-channel-delivery` task
+     * calls (via the trigger-internal RPC) so its `retry` policy re-runs
+     * the attempt on failure — whereas `send()`'s parallel fanout uses
+     * `sendOne` directly, which swallows per-channel failures so one bad
+     * channel doesn't sink its siblings. On terminal retry-exhaustion
+     * the delivery-log row left by `sendOne` is the dead-letter.
+     */
+    async deliverToChannelOrThrow(
+        channelId: string,
+        payload: NotificationChannelFanoutInput,
+        options: FacadeOptions,
+        eventType?: string,
+    ): Promise<NotificationChannelFanoutResult> {
+        const result = await this.sendOne(channelId, payload, options, eventType);
+        if (result.status === 'failed') {
+            throw new NotificationChannelFacadeError(
+                result.error ?? 'channel delivery failed',
+                'deliverToChannelOrThrow',
+                result.pluginId,
+            );
+        }
+        return result;
+    }
+
     private async sendOne(
         channelId: string,
         payload: NotificationChannelFanoutInput,

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { PLUGIN_CAPABILITIES, type FacadeOptions } from '@ever-works/plugin';
 import {
     isNotificationChannelPlugin,
@@ -37,10 +37,44 @@ export interface NotificationChannelFanoutInput {
 export interface NotificationChannelFanoutResult {
     readonly channelId: string;
     readonly pluginId: string;
-    readonly status: 'delivered' | 'failed';
+    /** `queued` = handed to the Trigger.dev delivery task (async outcome). */
+    readonly status: 'delivered' | 'failed' | 'queued';
     readonly providerMessageId?: string;
     readonly error?: string;
 }
+
+/**
+ * Payload handed to the Trigger.dev `notification-channel-delivery`
+ * dispatcher. The Trigger task calls back into
+ * `deliverToChannelOrThrow` (via the trigger-internal RPC) to perform
+ * the actual single attempt under the task's retry policy.
+ */
+export interface NotificationChannelDeliveryPayload {
+    readonly channelId: string;
+    readonly text: string;
+    readonly rich?: ChannelRichPayload;
+    readonly messageRef: string;
+    readonly eventType?: string;
+    readonly options: FacadeOptions;
+    /**
+     * ISO-8601 timestamp. When set, the dispatcher schedules the run
+     * with a Trigger.dev `delay` so it fires then (quiet-hours deferral).
+     */
+    readonly deferUntil?: string;
+}
+
+/**
+ * Producer-side hand-off to Trigger.dev. Bound in apps/api to an
+ * adapter over `TriggerService.dispatchNotificationChannelDelivery`;
+ * left UNBOUND in dev / when Trigger is disabled, in which case the
+ * facade delivers in-process (synchronous fallback).
+ */
+export interface NotificationChannelDeliveryDispatcher {
+    enqueue(payload: NotificationChannelDeliveryPayload): Promise<{ runId: string | null }>;
+}
+
+export const NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER =
+    'NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER' as const;
 
 /**
  * NotificationChannelFacadeService — fan-out point for multi-channel
@@ -60,9 +94,11 @@ export interface NotificationChannelFanoutResult {
  * - Persists a `notification_channel_delivery_log` row (idempotent on `messageRef`).
  * - Emits a `PluginUsageEvent` with `capability='notification_channel'`.
  *
- * Per-channel retry uses BullMQ (queue `notification-channel-retry`, 3
- * attempts exp-backoff, 24h dead-letter) — wired in T12 with the
- * controller layer.
+ * Per-channel retry uses the Trigger.dev `notification-channel-delivery`
+ * task (exponential-backoff `retry` policy; quiet-hours deferral via the
+ * run `delay`). Event fanout enqueues through the optional
+ * {@link NotificationChannelDeliveryDispatcher}; when it's unbound
+ * (dev / Trigger disabled) the facade delivers in-process as a fallback.
  */
 @Injectable()
 export class NotificationChannelFacadeService extends BaseFacadeService {
@@ -76,6 +112,9 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         @Optional() private readonly channels?: NotificationChannelRepository,
         @Optional() private readonly deliveryLog?: NotificationChannelDeliveryLogRepository,
         @Optional() private readonly pluginUsageService?: PluginUsageService,
+        @Optional()
+        @Inject(NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER)
+        private readonly deliveryDispatcher?: NotificationChannelDeliveryDispatcher,
     ) {
         super(registry, settingsService, workPluginRepository);
     }
@@ -98,12 +137,56 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
             this.logger.debug(`No channels resolved for user=${userId} event=${eventType}`);
             return [];
         }
+        const scopedOptions: FacadeOptions = { ...options, userId };
         const attempts = await Promise.all(
             channelIds.map((channelId) =>
-                this.sendOne(channelId, payload, { ...options, userId }, eventType),
+                this.dispatchOrSend(channelId, payload, scopedOptions, eventType),
             ),
         );
         return attempts;
+    }
+
+    /**
+     * Route one channel to the Trigger.dev delivery task when a
+     * dispatcher is bound (async, retry-backed); otherwise deliver
+     * in-process (fallback). `in-app` always stays inline — it's a
+     * no-op sentinel handled by notifications v1.
+     */
+    private async dispatchOrSend(
+        channelId: string,
+        payload: NotificationChannelFanoutInput,
+        options: FacadeOptions,
+        eventType?: string,
+        deferUntil?: string,
+    ): Promise<NotificationChannelFanoutResult> {
+        if (channelId !== 'in-app' && this.deliveryDispatcher) {
+            try {
+                const { runId } = await this.deliveryDispatcher.enqueue({
+                    channelId,
+                    text: payload.text,
+                    rich: payload.rich,
+                    messageRef: payload.messageRef,
+                    eventType,
+                    options,
+                    deferUntil,
+                });
+                return {
+                    channelId,
+                    pluginId: 'queued',
+                    status: 'queued',
+                    providerMessageId: runId ?? undefined,
+                };
+            } catch (err) {
+                // Enqueue failed — fall back to an in-process attempt so the
+                // notification isn't silently lost.
+                this.logger.warn(
+                    `channel ${channelId} enqueue failed, delivering in-process: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
+        }
+        return this.sendOne(channelId, payload, options, eventType);
     }
 
     /**

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -77,6 +77,17 @@ export const NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER =
     'NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER' as const;
 
 /**
+ * A channel to fan out to, optionally deferred. `deferUntil` (ISO-8601)
+ * is set for channels held by quiet hours — the facade enqueues them on
+ * the Trigger.dev delivery task with that `delay`. Plain strings (no
+ * deferral) are accepted too for back-compat with simple resolvers.
+ */
+export interface ResolvedChannelTarget {
+    channelId: string;
+    deferUntil?: string;
+}
+
+/**
  * NotificationChannelFacadeService — fan-out point for multi-channel
  * notification delivery. Mirrors `EmailFacadeService` shape but for the
  * `NOTIFICATION_CHANNEL` umbrella capability.
@@ -129,19 +140,32 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         userId: string,
         eventType: string,
         payload: NotificationChannelFanoutInput,
-        resolveChannelIds: (userId: string, eventType: string) => Promise<readonly string[]>,
+        resolveChannelIds: (
+            userId: string,
+            eventType: string,
+        ) => Promise<readonly (string | ResolvedChannelTarget)[]>,
         options: FacadeOptions,
     ): Promise<readonly NotificationChannelFanoutResult[]> {
-        const channelIds = await resolveChannelIds(userId, eventType);
-        if (channelIds.length === 0) {
+        const resolved = await resolveChannelIds(userId, eventType);
+        if (resolved.length === 0) {
             this.logger.debug(`No channels resolved for user=${userId} event=${eventType}`);
             return [];
         }
         const scopedOptions: FacadeOptions = { ...options, userId };
         const attempts = await Promise.all(
-            channelIds.map((channelId) =>
-                this.dispatchOrSend(channelId, payload, scopedOptions, eventType),
-            ),
+            resolved.map((target) => {
+                const { channelId, deferUntil } =
+                    typeof target === 'string'
+                        ? { channelId: target, deferUntil: undefined }
+                        : target;
+                return this.dispatchOrSend(
+                    channelId,
+                    payload,
+                    scopedOptions,
+                    eventType,
+                    deferUntil,
+                );
+            }),
         );
         return attempts;
     }

--- a/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
@@ -148,6 +148,44 @@ describe('UserNotificationSubscriptionService', () => {
             'in-app',
         ]);
     });
+
+    it('resolvePlan DEFERS non-in-app channels during quiet hours (does not drop them)', async () => {
+        eventTypes.findByKey.mockResolvedValue({
+            key: 'work_generation_finished',
+            category: 'generation',
+            urgent: false,
+            defaultChannels: ['in-app'],
+        });
+        subscriptions.findForEvent.mockResolvedValue({ channelIds: ['in-app', 'channel-1'] });
+        mutes.isMuted.mockResolvedValue(false);
+        preferences.findByUser.mockResolvedValue({
+            quietHoursStart: '00:00:00',
+            quietHoursEnd: '23:59:59',
+            timezone: 'UTC',
+        });
+
+        const plan = await service.resolvePlan('u', 'work_generation_finished');
+        expect(plan.immediate).toEqual(['in-app']);
+        expect(plan.deferred).toEqual(['channel-1']);
+        expect(typeof plan.deferUntil).toBe('string');
+        expect(new Date(plan.deferUntil!).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('resolvePlan leaves deferred empty outside quiet hours', async () => {
+        eventTypes.findByKey.mockResolvedValue({
+            key: 'work_generation_finished',
+            category: 'generation',
+            urgent: false,
+            defaultChannels: ['in-app'],
+        });
+        subscriptions.findForEvent.mockResolvedValue({ channelIds: ['in-app', 'channel-1'] });
+        mutes.isMuted.mockResolvedValue(false);
+        preferences.findByUser.mockResolvedValue(null); // no quiet hours configured
+        const plan = await service.resolvePlan('u', 'work_generation_finished');
+        expect(plan.immediate).toEqual(['in-app', 'channel-1']);
+        expect(plan.deferred).toEqual([]);
+        expect(plan.deferUntil).toBeUndefined();
+    });
 });
 
 describe('isWithinQuietHours', () => {

--- a/packages/agent/src/notifications/user-notification-subscription.service.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.ts
@@ -39,6 +39,17 @@ import {
  * NotificationFanoutListener (replacing its thin stub resolver). The
  * v1 NotificationService.create path remains untouched.
  */
+/**
+ * Outcome of {@link UserNotificationSubscriptionService.resolvePlan}.
+ * `immediate` channels deliver now; `deferred` channels are held until
+ * `deferUntil` (end of the user's quiet-hours window, ISO-8601).
+ */
+export interface ResolvedChannelPlan {
+    immediate: string[];
+    deferred: string[];
+    deferUntil?: string;
+}
+
 @Injectable()
 export class UserNotificationSubscriptionService {
     private readonly logger = new Logger(UserNotificationSubscriptionService.name);
@@ -57,10 +68,24 @@ export class UserNotificationSubscriptionService {
      * the user can review).
      */
     async resolveChannels(userId: string, eventTypeKey: string): Promise<string[]> {
+        const plan = await this.resolvePlan(userId, eventTypeKey);
+        return plan.immediate;
+    }
+
+    /**
+     * Deferral-aware resolution. `immediate` always carries `'in-app'`
+     * (unless muted). For a non-urgent event inside the user's quiet
+     * hours, non-in-app channels move to `deferred` with `deferUntil`
+     * set to the end-of-window instant (ISO) — the producer enqueues
+     * them on the Trigger.dev delivery task with that `delay` instead of
+     * dropping them. Muted categories are silenced (dropped, NOT
+     * deferred) — a mute means "don't tell me", not "tell me later".
+     */
+    async resolvePlan(userId: string, eventTypeKey: string): Promise<ResolvedChannelPlan> {
         const eventType = await this.eventTypes.findByKey(eventTypeKey);
         if (!eventType) {
             this.logger.debug(`Unknown event type ${eventTypeKey}; defaulting to in-app only`);
-            return ['in-app'];
+            return { immediate: ['in-app'], deferred: [] };
         }
 
         let channels = await this.loadInitialChannels(
@@ -78,25 +103,26 @@ export class UserNotificationSubscriptionService {
             }
         }
 
-        // Quiet hours (drops non-in-app for non-urgent events)
+        // Quiet hours: defer (not drop) non-in-app channels for non-urgent
+        // events so they fire at end-of-window.
         if (this.preferences && !eventType.urgent && channels.some((c) => c !== 'in-app')) {
             const pref = await this.preferences.findByUser(userId);
             if (pref?.quietHoursStart && pref?.quietHoursEnd) {
-                const inQuietWindow = isWithinQuietHours(
-                    new Date(),
-                    pref.quietHoursStart,
-                    pref.quietHoursEnd,
-                    pref.timezone ?? 'UTC',
-                );
-                if (inQuietWindow) {
-                    channels = channels.filter((c) => c === 'in-app');
-                    // TODO(EW-677 v2): enqueue non-in-app channels via
-                    // BullMQ delayed job so they fire at end-of-window.
+                const now = new Date();
+                const timeZone = pref.timezone ?? 'UTC';
+                if (isWithinQuietHours(now, pref.quietHoursStart, pref.quietHoursEnd, timeZone)) {
+                    const deferred = channels.filter((c) => c !== 'in-app');
+                    const immediate = channels.filter((c) => c === 'in-app');
+                    return {
+                        immediate,
+                        deferred,
+                        deferUntil: quietHoursEndIso(now, pref.quietHoursEnd, timeZone),
+                    };
                 }
             }
         }
 
-        return channels;
+        return { immediate: channels, deferred: [] };
     }
 
     private async loadInitialChannels(
@@ -163,4 +189,39 @@ function toMinutes(hms: string): number {
     const [h, m, s] = hms.split(':').map((n) => Number.parseInt(n, 10) || 0);
     // Hour 24 (midnight as end-of-day) is allowed in some libs.
     return (h % 24) * 60 + (m % 60) + (s >= 30 ? 1 : 0);
+}
+
+/**
+ * The next instant (ISO-8601) at which the user's quiet-hours window
+ * ends, computed from `now` + the wall-clock minutes until `quietEnd`
+ * in the user's timezone. Used as the Trigger.dev `delay` target for
+ * deferred channels. Assumes the caller has already confirmed `now` is
+ * within the window. DST transitions inside the window may shift the
+ * fire time by ±1h — acceptable for a "fire after quiet hours" signal.
+ */
+export function quietHoursEndIso(now: Date, quietEnd: string, timeZone: string): string {
+    let delayMinutes: number;
+    try {
+        const formatter = new Intl.DateTimeFormat('en-GB', {
+            timeZone,
+            hour12: false,
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        });
+        const parts = formatter.formatToParts(now);
+        const get = (type: Intl.DateTimeFormatPartTypes) =>
+            parts.find((p) => p.type === type)?.value ?? '00';
+        const nowMinutes = toMinutes(`${get('hour')}:${get('minute')}:${get('second')}`);
+        const endMinutes = toMinutes(quietEnd);
+        const diff = (((endMinutes - nowMinutes) % 1440) + 1440) % 1440;
+        // diff === 0 means now is exactly at the boundary — push a full
+        // day rather than firing instantly (shouldn't happen for an
+        // in-window check, but keeps the delay strictly positive).
+        delayMinutes = diff === 0 ? 1440 : diff;
+    } catch {
+        // Fall back to a 1h defer so a bad timezone never drops the send.
+        delayMinutes = 60;
+    }
+    return new Date(now.getTime() + delayMinutes * 60_000).toISOString();
 }

--- a/packages/plugins/discord-channel/README.md
+++ b/packages/plugins/discord-channel/README.md
@@ -4,8 +4,10 @@ Discord notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-discord`
 - **Shape**: `broadcast` (Discord channels = broadcast surfaces)
-- **Transport**: incoming webhook URL (v1)
+- **Transport**: incoming webhook URL (v1) — a plain HTTPS POST via `fetch`
 - **Bot-token mode**: planned for a future iteration
+
+> **SDK note:** intentionally uses `fetch`, not a vendor SDK. Discord incoming webhooks are a bare URL POST with no official SDK; `discord.js` is a full gateway/bot client (WebSocket connection, intents, caches) — far too heavy for a one-shot notification POST. The SDK rule applies where a _sensible_ vendor SDK exists (cf. slack-channel → `@slack/webhook`, telegram-channel → `grammy`).
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/plugins/slack-channel/README.md
+++ b/packages/plugins/slack-channel/README.md
@@ -4,7 +4,7 @@ Slack notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-slack`
 - **Shape**: `broadcast`
-- **Transport**: Slack incoming webhook (Block Kit supported via the `slack-blocks` rich payload kind)
+- **Transport**: official `@slack/webhook` SDK (`IncomingWebhook`) over a Slack incoming webhook (Block Kit supported via the `slack-blocks` rich payload kind)
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/plugins/slack-channel/package.json
+++ b/packages/plugins/slack-channel/package.json
@@ -32,7 +32,8 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@ever-works/plugin": "workspace:*"
+		"@ever-works/plugin": "workspace:*",
+		"@slack/webhook": "^7.0.5"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/packages/plugins/slack-channel/src/slack-channel-plugin.spec.ts
+++ b/packages/plugins/slack-channel/src/slack-channel-plugin.spec.ts
@@ -1,4 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sendMock = vi.fn();
+const ctorMock = vi.fn();
+
+vi.mock('@slack/webhook', () => ({
+	IncomingWebhook: class {
+		constructor(url: string) {
+			ctorMock(url);
+		}
+		send = sendMock;
+	}
+}));
+
 import { SlackChannelPlugin } from './slack-channel-plugin.js';
 
 describe('SlackChannelPlugin', () => {
@@ -6,6 +19,8 @@ describe('SlackChannelPlugin', () => {
 
 	beforeEach(() => {
 		plugin = new SlackChannelPlugin();
+		sendMock.mockReset();
+		ctorMock.mockReset();
 	});
 
 	it('declares notification-channel + notification-channel-slack', () => {
@@ -34,12 +49,8 @@ describe('SlackChannelPlugin', () => {
 	});
 
 	describe('send', () => {
-		it('POSTs text + blocks to the webhook and returns a synthetic id', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				text: async () => 'ok'
-			} as Response);
+		it('sends text + blocks via the @slack/webhook SDK and returns a synthetic id', async () => {
+			sendMock.mockResolvedValueOnce({ text: 'ok' });
 			const res = await plugin.send(
 				{
 					text: 'build is green',
@@ -51,19 +62,17 @@ describe('SlackChannelPlugin', () => {
 				{}
 			);
 			expect(res.providerMessageId).toBe('slack-ref-1');
-			const [, init] = fetchMock.mock.calls[0];
-			const body = JSON.parse((init as RequestInit).body as string);
-			expect(body.text).toBe('build is green');
-			expect(body.blocks).toEqual([{ type: 'section' }]);
-			fetchMock.mockRestore();
+			expect(ctorMock).toHaveBeenCalledWith('https://hooks.slack.com/services/T/B/x');
+			const message = sendMock.mock.calls[0][0];
+			expect(message.text).toBe('build is green');
+			expect(message.blocks).toEqual([{ type: 'section' }]);
 		});
 
-		it('throws on non-2xx Slack response', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: false,
-				status: 400,
-				text: async () => 'invalid_payload'
-			} as Response);
+		it('throws on a Slack SDK send error (surfacing the HTTP status)', async () => {
+			sendMock.mockRejectedValueOnce({
+				message: 'invalid_payload',
+				original: { response: { status: 400 } }
+			});
 			await expect(
 				plugin.send(
 					{
@@ -74,15 +83,11 @@ describe('SlackChannelPlugin', () => {
 					},
 					{}
 				)
-			).rejects.toThrow(/Slack webhook failed/);
+			).rejects.toThrow(/Slack webhook failed \(400\): invalid_payload/);
 		});
 
 		it('hits the idempotency cache on repeated messageRef', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
-				ok: true,
-				status: 200,
-				text: async () => 'ok'
-			} as Response);
+			sendMock.mockResolvedValue({ text: 'ok' });
 			const input = {
 				text: 'x',
 				messageRef: 'ref-cache',
@@ -91,8 +96,7 @@ describe('SlackChannelPlugin', () => {
 			};
 			await plugin.send(input, {});
 			await plugin.send(input, {});
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-			fetchMock.mockRestore();
+			expect(sendMock).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/plugins/slack-channel/src/slack-channel-plugin.ts
+++ b/packages/plugins/slack-channel/src/slack-channel-plugin.ts
@@ -1,3 +1,4 @@
+import { IncomingWebhook } from '@slack/webhook';
 import type {
 	INotificationChannelPlugin,
 	ChannelSendInput,
@@ -26,9 +27,12 @@ function getWebhookUrl(config: ChannelTargetConfig): string {
  * webhook URL. Block Kit blocks are forwarded when the caller supplies
  * the `slack-blocks` rich payload kind.
  *
- * Slack incoming webhooks return the literal string `ok` on success
- * (no message id), so `providerMessageId` is synthesized from the
- * idempotency `messageRef`.
+ * Built on the official `@slack/webhook` SDK (`IncomingWebhook`) — the
+ * vendor SDK for the incoming-webhook mechanism this channel uses
+ * (`@slack/web-api` is the bot-token `chat.postMessage` path, a
+ * different config contract). Incoming webhooks return the literal
+ * string `ok` on success (no message id), so `providerMessageId` is
+ * synthesized from the idempotency `messageRef`.
  */
 export class SlackChannelPlugin implements INotificationChannelPlugin {
 	readonly id = 'slack-channel';
@@ -88,22 +92,19 @@ export class SlackChannelPlugin implements INotificationChannelPlugin {
 			(typeof options.settings?.defaultIconEmoji === 'string' ? options.settings.defaultIconEmoji : undefined) ??
 			(typeof config.iconEmoji === 'string' ? (config.iconEmoji as string) : undefined);
 
-		const body: Record<string, unknown> = { text: payload.text };
-		if (username) body.username = username;
-		if (iconEmoji) body.icon_emoji = iconEmoji;
+		const message: Record<string, unknown> = { text: payload.text };
+		if (username) message.username = username;
+		if (iconEmoji) message.icon_emoji = iconEmoji;
 		if (payload.rich?.kind === 'slack-blocks') {
-			body.blocks = payload.rich.payload;
+			message.blocks = payload.rich.payload;
 		}
 
-		const response = await fetch(webhookUrl, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body)
-		});
-
-		if (!response.ok) {
-			const text = await response.text().catch(() => '');
-			throw new Error(`Slack webhook failed (${response.status}): ${text}`);
+		try {
+			await new IncomingWebhook(webhookUrl).send(message);
+		} catch (err) {
+			const e = err as { message?: string; original?: { response?: { status?: number } } };
+			const status = e.original?.response?.status ?? 'error';
+			throw new Error(`Slack webhook failed (${status}): ${e.message ?? 'unknown error'}`);
 		}
 		// Success body is the literal "ok"; no id to capture.
 		const result: ChannelSendResult = {

--- a/packages/plugins/telegram-channel/README.md
+++ b/packages/plugins/telegram-channel/README.md
@@ -4,7 +4,7 @@ Telegram notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-telegram`
 - **Shape**: `direct` (one chat per channel)
-- **Transport**: Telegram Bot API `sendMessage` (MarkdownV2 via the `telegram-markdown` rich payload kind)
+- **Transport**: official `grammy` SDK (`Api.sendMessage`, a typed Bot-API client with no polling/bot framework; MarkdownV2 via the `telegram-markdown` rich payload kind)
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/plugins/telegram-channel/package.json
+++ b/packages/plugins/telegram-channel/package.json
@@ -32,7 +32,8 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@ever-works/plugin": "workspace:*"
+		"@ever-works/plugin": "workspace:*",
+		"grammy": "^1.30.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/packages/plugins/telegram-channel/src/telegram-channel-plugin.spec.ts
+++ b/packages/plugins/telegram-channel/src/telegram-channel-plugin.spec.ts
@@ -1,4 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sendMessageMock = vi.fn();
+const getMeMock = vi.fn();
+const ctorMock = vi.fn();
+
+vi.mock('grammy', () => ({
+	Api: class {
+		constructor(token: string) {
+			ctorMock(token);
+		}
+		sendMessage = sendMessageMock;
+		getMe = getMeMock;
+	}
+}));
+
 import { TelegramChannelPlugin } from './telegram-channel-plugin.js';
 
 describe('TelegramChannelPlugin', () => {
@@ -6,6 +21,9 @@ describe('TelegramChannelPlugin', () => {
 
 	beforeEach(() => {
 		plugin = new TelegramChannelPlugin();
+		sendMessageMock.mockReset();
+		getMeMock.mockReset();
+		ctorMock.mockReset();
 	});
 
 	it('declares notification-channel + notification-channel-telegram (direct shape)', () => {
@@ -16,22 +34,15 @@ describe('TelegramChannelPlugin', () => {
 
 	describe('verifyTarget', () => {
 		it('returns valid when getMe succeeds', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { id: 42, username: ' everworks_bot' } })
-			} as Response);
+			getMeMock.mockResolvedValueOnce({ id: 42, username: 'everworks_bot' });
 			const res = await plugin.verifyTarget({ botToken: 'tok', chatId: '123' }, {});
 			expect(res.valid).toBe(true);
-			expect(res.details).toMatchObject({ botId: 42, username: ' everworks_bot' });
+			expect(res.details).toMatchObject({ botId: 42, username: 'everworks_bot' });
+			expect(ctorMock).toHaveBeenCalledWith('tok');
 		});
 
 		it('returns invalid when getMe rejects the token', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: false,
-				status: 401,
-				json: async () => ({ ok: false, description: 'Unauthorized' })
-			} as Response);
+			getMeMock.mockRejectedValueOnce({ error_code: 401, description: 'Unauthorized' });
 			const res = await plugin.verifyTarget({ botToken: 'bad', chatId: '123' }, {});
 			expect(res.valid).toBe(false);
 			expect(res.message).toMatch(/Unauthorized/);
@@ -44,12 +55,8 @@ describe('TelegramChannelPlugin', () => {
 	});
 
 	describe('send', () => {
-		it('POSTs sendMessage + returns the telegram message id', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { message_id: 555 } })
-			} as Response);
+		it('sends via the grammy Api and returns the telegram message id', async () => {
+			sendMessageMock.mockResolvedValueOnce({ message_id: 555 });
 			const res = await plugin.send(
 				{
 					text: 'deploy done',
@@ -60,20 +67,14 @@ describe('TelegramChannelPlugin', () => {
 				{}
 			);
 			expect(res.providerMessageId).toBe('555');
-			const [url, init] = fetchMock.mock.calls[0];
-			expect(url).toContain('/bottok/sendMessage');
-			const body = JSON.parse((init as RequestInit).body as string);
-			expect(body.chat_id).toBe('123');
-			expect(body.text).toBe('deploy done');
-			fetchMock.mockRestore();
+			expect(ctorMock).toHaveBeenCalledWith('tok');
+			const [chatId, text] = sendMessageMock.mock.calls[0];
+			expect(chatId).toBe('123');
+			expect(text).toBe('deploy done');
 		});
 
 		it('forwards MarkdownV2 for the telegram-markdown rich kind', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { message_id: 1 } })
-			} as Response);
+			sendMessageMock.mockResolvedValueOnce({ message_id: 1 });
 			await plugin.send(
 				{
 					text: 'fallback',
@@ -84,18 +85,13 @@ describe('TelegramChannelPlugin', () => {
 				},
 				{}
 			);
-			const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
-			expect(body.parse_mode).toBe('MarkdownV2');
-			expect(body.text).toBe('*bold*');
-			fetchMock.mockRestore();
+			const [, text, other] = sendMessageMock.mock.calls[0];
+			expect(text).toBe('*bold*');
+			expect(other.parse_mode).toBe('MarkdownV2');
 		});
 
-		it('throws when Telegram returns ok:false', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: false,
-				status: 400,
-				json: async () => ({ ok: false, error_code: 400, description: 'chat not found' })
-			} as Response);
+		it('throws when the grammy Api send rejects (surfacing error_code + description)', async () => {
+			sendMessageMock.mockRejectedValueOnce({ error_code: 400, description: 'chat not found' });
 			await expect(
 				plugin.send(
 					{
@@ -106,15 +102,11 @@ describe('TelegramChannelPlugin', () => {
 					},
 					{}
 				)
-			).rejects.toThrow(/Telegram sendMessage failed/);
+			).rejects.toThrow(/Telegram sendMessage failed \(400\): chat not found/);
 		});
 
 		it('hits the idempotency cache on repeated messageRef', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { message_id: 9 } })
-			} as Response);
+			sendMessageMock.mockResolvedValue({ message_id: 9 });
 			const input = {
 				text: 'x',
 				messageRef: 'ref-cache',
@@ -123,8 +115,7 @@ describe('TelegramChannelPlugin', () => {
 			};
 			await plugin.send(input, {});
 			await plugin.send(input, {});
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-			fetchMock.mockRestore();
+			expect(sendMessageMock).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/plugins/telegram-channel/src/telegram-channel-plugin.ts
+++ b/packages/plugins/telegram-channel/src/telegram-channel-plugin.ts
@@ -1,3 +1,4 @@
+import { Api } from 'grammy';
 import type {
 	INotificationChannelPlugin,
 	ChannelSendInput,
@@ -10,8 +11,6 @@ import type {
 	JsonSchema
 } from '@ever-works/plugin';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
-
-const TELEGRAM_API_BASE = 'https://api.telegram.org';
 
 interface TelegramTarget {
 	botToken: string;
@@ -30,23 +29,20 @@ function getTarget(config: ChannelTargetConfig): TelegramTarget {
 	return { botToken, chatId };
 }
 
-interface TelegramSendResponse {
-	ok: boolean;
-	result?: { message_id: number };
-	description?: string;
-	error_code?: number;
-}
-
-interface TelegramGetMeResponse {
-	ok: boolean;
-	result?: { id: number; username?: string; first_name?: string };
-	description?: string;
+/** Telegram Bot API errors carry an error_code + description. */
+function describeError(err: unknown): { code: number | string; message: string } {
+	const e = err as { error_code?: number; description?: string; message?: string };
+	return {
+		code: e.error_code ?? 'error',
+		message: e.description ?? e.message ?? 'unknown error'
+	};
 }
 
 /**
- * Telegram notification channel — sends via the Bot API `sendMessage`
- * method. `chatId` is the destination chat; discover it by having the
- * user message the bot then reading `getUpdates` (see README).
+ * Telegram notification channel — sends via the official `grammy`
+ * SDK's lightweight `Api` client (typed Bot API calls, no bot/polling
+ * framework). `chatId` is the destination chat; discover it by having
+ * the user message the bot then reading `getUpdates` (see README).
  *
  * MarkdownV2 is forwarded when the caller supplies the
  * `telegram-markdown` rich payload kind.
@@ -88,22 +84,10 @@ export class TelegramChannelPlugin implements INotificationChannelPlugin {
 			return { valid: false, message: 'chatId is required' };
 		}
 		try {
-			const response = await fetch(`${TELEGRAM_API_BASE}/bot${botToken}/getMe`, {
-				method: 'GET'
-			});
-			const data = (await response.json()) as TelegramGetMeResponse;
-			if (!response.ok || !data.ok) {
-				return {
-					valid: false,
-					message: `Telegram getMe failed: ${data.description ?? response.status}`
-				};
-			}
-			return {
-				valid: true,
-				details: { botId: data.result?.id, username: data.result?.username }
-			};
+			const me = await new Api(botToken).getMe();
+			return { valid: true, details: { botId: me.id, username: me.username } };
 		} catch (err) {
-			return { valid: false, message: err instanceof Error ? err.message : String(err) };
+			return { valid: false, message: `Telegram getMe failed: ${describeError(err).message}` };
 		}
 	}
 
@@ -112,37 +96,26 @@ export class TelegramChannelPlugin implements INotificationChannelPlugin {
 		if (cached) return cached;
 
 		const { botToken, chatId } = getTarget(payload.target ?? {});
-		const disableNotification =
-			typeof options.settings?.disableNotification === 'boolean'
-				? options.settings.disableNotification
-				: undefined;
-
-		const body: Record<string, unknown> = {
-			chat_id: chatId,
-			text: payload.rich?.kind === 'telegram-markdown' ? payload.rich.payload : payload.text
-		};
-		if (payload.rich?.kind === 'telegram-markdown') {
-			body.parse_mode = 'MarkdownV2';
-		}
-		if (disableNotification !== undefined) {
-			body.disable_notification = disableNotification;
+		const isMarkdown = payload.rich?.kind === 'telegram-markdown';
+		const text = isMarkdown ? String(payload.rich.payload) : payload.text;
+		const other: { parse_mode?: 'MarkdownV2'; disable_notification?: boolean } = {};
+		if (isMarkdown) other.parse_mode = 'MarkdownV2';
+		if (typeof options.settings?.disableNotification === 'boolean') {
+			other.disable_notification = options.settings.disableNotification;
 		}
 
-		const response = await fetch(`${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body)
-		});
-		const data = (await response.json()) as TelegramSendResponse;
-		if (!response.ok || !data.ok) {
-			throw new Error(
-				`Telegram sendMessage failed (${response.status} / ${data.error_code ?? '?'}): ${data.description ?? 'unknown error'}`
-			);
+		let messageId: string;
+		try {
+			const message = await new Api(botToken).sendMessage(chatId, text, other);
+			messageId = String(message.message_id);
+		} catch (err) {
+			const { code, message } = describeError(err);
+			throw new Error(`Telegram sendMessage failed (${code}): ${message}`);
 		}
 
 		const result: ChannelSendResult = {
 			provider: this.id,
-			providerMessageId: String(data.result?.message_id ?? `telegram-${payload.messageRef}`),
+			providerMessageId: messageId,
 			deliveredAt: new Date()
 		};
 		this.idempotencyCache.set(payload.messageRef, result);

--- a/packages/plugins/whatsapp-channel/README.md
+++ b/packages/plugins/whatsapp-channel/README.md
@@ -4,7 +4,9 @@ WhatsApp notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-whatsapp`
 - **Shape**: `direct` (one recipient per channel)
-- **Transport**: WhatsApp Business Cloud API (`/{phoneNumberId}/messages`)
+- **Transport**: WhatsApp Business Cloud API (`/{phoneNumberId}/messages`) via `fetch`
+
+> **SDK note:** intentionally uses `fetch`, not a vendor SDK. Meta ships no official Node SDK for the WhatsApp Business Cloud API; the community packages are thin/unmaintained Graph-API wrappers that add no real value over a typed `fetch` call. The SDK rule applies where a _sensible_ vendor SDK exists (cf. slack-channel → `@slack/webhook`, telegram-channel → `grammy`).
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/tasks/src/tasks/trigger/notification-channel-delivery.task.ts
+++ b/packages/tasks/src/tasks/trigger/notification-channel-delivery.task.ts
@@ -1,0 +1,72 @@
+import { task } from '@trigger.dev/sdk';
+import { NestFactory } from '@nestjs/core';
+import {
+    NotificationChannelFacadeService,
+    type NotificationChannelDeliveryPayload,
+} from '@ever-works/agent/facades';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
+
+/**
+ * Notifications v2 (EW-663) — per-channel notification delivery worker.
+ *
+ * One run per (channel, event) pair. The producer-side dispatcher
+ * (`NotificationChannelFacadeService.send` → the bound
+ * `NotificationChannelDeliveryDispatcher` adapter →
+ * `TriggerService.dispatchNotificationChannelDelivery`) enqueues this
+ * task; quiet-hours-deferred sends are enqueued with a `delay` so the
+ * run fires at end-of-window (item D).
+ *
+ * The run boots the lightweight {@link TriggerInternalModule} and calls
+ * the RPC-proxied {@link NotificationChannelFacadeService.deliverToChannelOrThrow}
+ * on the live API (where the channel plugins are already loaded). That
+ * method THROWS on a failed attempt, which surfaces here so the
+ * Trigger.dev retry policy below re-runs it. When attempts exhaust, the
+ * `notification_channel_delivery_log` row left by the facade is the
+ * dead-letter.
+ *
+ * Backoff: 30s → 2m → 8m → 32m → 2h (maxAttempts 5, factor 4) — shorter
+ * tail than webhook delivery; a chat/email notification has little value
+ * a full day late.
+ */
+export const notificationChannelDeliveryTask = task<
+    'notification-channel-delivery',
+    NotificationChannelDeliveryPayload
+>({
+    id: 'notification-channel-delivery',
+    maxDuration: 5 * 60,
+    retry: {
+        maxAttempts: 5,
+        minTimeoutInMs: 30_000, // 30s
+        maxTimeoutInMs: 6 * 60 * 60 * 1000, // 6h cap
+        factor: 4,
+        randomize: true,
+    },
+    run: async (payload: NotificationChannelDeliveryPayload) => {
+        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+        appContext.useLogger(createTriggerLogger('NotificationChannelDelivery'));
+
+        try {
+            const facade = appContext.get(NotificationChannelFacadeService);
+            const result = await facade.deliverToChannelOrThrow(
+                payload.channelId,
+                {
+                    text: payload.text,
+                    rich: payload.rich,
+                    messageRef: payload.messageRef,
+                    eventType: payload.eventType,
+                },
+                payload.options,
+                payload.eventType,
+            );
+            return {
+                channelId: payload.channelId,
+                status: result.status,
+                pluginId: result.pluginId,
+                providerMessageId: result.providerMessageId ?? null,
+            };
+        } finally {
+            await appContext.close();
+        }
+    },
+});

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -10,6 +10,11 @@ import {
     KB_EMBED_DOCUMENT_DISPATCHER,
     KB_ORG_OVERLAY_FANOUT_DISPATCHER,
 } from '@ever-works/agent/tasks';
+import {
+    NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
+    type NotificationChannelDeliveryDispatcher,
+    type NotificationChannelDeliveryPayload,
+} from '@ever-works/agent/facades';
 
 @Global()
 @Module({
@@ -47,6 +52,20 @@ import {
             provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER,
             useExisting: TriggerService,
         },
+        // Notifications v2 (EW-663) — the facade's delivery dispatcher
+        // contract is `enqueue(payload) → { runId }`, so a thin adapter
+        // bridges to TriggerService.dispatchNotificationChannelDelivery
+        // (which returns the run id, or null when Trigger is disabled →
+        // the facade falls back to in-process delivery).
+        {
+            provide: NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
+            useFactory: (trigger: TriggerService): NotificationChannelDeliveryDispatcher => ({
+                async enqueue(payload: NotificationChannelDeliveryPayload) {
+                    return { runId: await trigger.dispatchNotificationChannelDelivery(payload) };
+                },
+            }),
+            inject: [TriggerService],
+        },
     ],
     exports: [
         TriggerService,
@@ -58,6 +77,7 @@ import {
         KB_BACKFILL_SKELETON_DISPATCHER,
         KB_EMBED_DOCUMENT_DISPATCHER,
         KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+        NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
     ],
 })
 export class TriggerModule {}

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -27,6 +27,8 @@ import { kbMirrorDocumentTask } from '../tasks/trigger/kb-mirror-document.task';
 import { kbBackfillSkeletonTask } from '../tasks/trigger/kb-backfill-skeleton.task';
 import { kbEmbedDocumentTask } from '../tasks/trigger/kb-embed-document.task';
 import { kbOrgOverlayFanoutTask } from '../tasks/trigger/kb-org-overlay-fanout.task';
+import { notificationChannelDeliveryTask } from '../tasks/trigger/notification-channel-delivery.task';
+import type { NotificationChannelDeliveryPayload } from '@ever-works/agent/facades';
 
 @Injectable()
 export class TriggerService
@@ -178,6 +180,43 @@ export class TriggerService
             return handle.id;
         } catch (error) {
             this.logger.error('Failed to dispatch webhook-delivery task', error as Error);
+            return null;
+        }
+    }
+
+    /**
+     * Notifications v2 (EW-663) — enqueue one channel delivery to
+     * Trigger.dev. Returns the run id, or `null` when Trigger.dev is
+     * disabled (`shouldUseTrigger()` false) or the dispatch threw — the
+     * facade's in-process fallback handles both. When `payload.deferUntil`
+     * is set (quiet-hours), the run is scheduled with a `delay` so it
+     * fires at end-of-window.
+     */
+    async dispatchNotificationChannelDelivery(
+        payload: NotificationChannelDeliveryPayload,
+    ): Promise<string | null> {
+        if (!this.ensureConfigured()) {
+            return null;
+        }
+
+        try {
+            const delay = payload.deferUntil ? new Date(payload.deferUntil) : undefined;
+            const handle = await notificationChannelDeliveryTask.trigger(payload, {
+                tags: [
+                    'notification-channel-delivery',
+                    `channel:${payload.channelId}`,
+                    ...(payload.eventType ? [`event:${payload.eventType}`] : []),
+                ],
+                machine: this.machine() as any,
+                ...(delay ? { delay } : {}),
+            });
+
+            return handle.id;
+        } catch (error) {
+            this.logger.error(
+                'Failed to dispatch notification-channel-delivery task',
+                error as Error,
+            );
             return null;
         }
     }

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -8,6 +8,7 @@ import { MissionTickService } from '@ever-works/agent/missions';
 import { AgentScheduleDispatcherService } from '@ever-works/agent/agents';
 import { TaskRecurrenceDispatcherService } from '@ever-works/agent/tasks-domain';
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
+import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
 
@@ -88,6 +89,15 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'TaskRecurrenceDispatcherService'),
             inject: [TriggerInternalApiClient],
         },
+        // Notifications v2 (EW-663) — the notification-channel-delivery
+        // task calls `deliverToChannelOrThrow` on this proxy, which RPCs
+        // to the live API where the channel plugins are loaded.
+        {
+            provide: NotificationChannelFacadeService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'NotificationChannelFacadeService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
@@ -100,6 +110,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         AgentRepository,
         AgentRunRepository,
         TaskRecurrenceDispatcherService,
+        NotificationChannelFacadeService,
     ],
 })
 export class TriggerInternalModule {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2344,6 +2344,9 @@ importers:
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
+      '@slack/webhook':
+        specifier: ^7.0.5
+        version: 7.0.9
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -8475,6 +8478,14 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/webhook@7.0.9':
+    resolution: {integrity: sha512-hMfkQ5Y3Y7FtL+ZYhcxFblidx4Z2LPRFrhY1KJb6NqQdnK6kzTzTS1mjH5taVQIB496eqwpg9FE9mq9BFx0DWw==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@slorber/react-helmet-async@1.3.0':
     resolution: {integrity: sha512-e9/OK8VhwUSc67diWI8Rb3I0YgI9/SBQtnhe9aEuK6MhZm7ntZZimXgwXnd8W96YTmSOb9M4d8LwhRZyhWr/1A==}
@@ -26848,6 +26859,16 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@slack/types@2.21.1': {}
+
+  '@slack/webhook@7.0.9':
+    dependencies:
+      '@slack/types': 2.21.1
+      '@types/node': 22.19.11
+      axios: 1.16.0
+    transitivePeerDependencies:
+      - debug
 
   '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2419,6 +2419,9 @@ importers:
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
+      grammy:
+        specifier: ^1.30.0
+        version: 1.43.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -5133,6 +5136,9 @@ packages:
   '@google-cloud/precise-date@4.0.0':
     resolution: {integrity: sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==}
     engines: {node: '>=14.0.0'}
+
+  '@grammyjs/types@3.27.3':
+    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -13194,6 +13200,10 @@ packages:
 
   graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
+
+  grammy@1.43.0:
+    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
+    engines: {node: ^12.20.0 || >=14.13.1}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -23006,6 +23016,8 @@ snapshots:
 
   '@google-cloud/precise-date@4.0.0': {}
 
+  '@grammyjs/types@3.27.3': {}
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -32474,6 +32486,16 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graceful-readlink@1.0.1: {}
+
+  grammy@1.43.0:
+    dependencies:
+      '@grammyjs/types': 3.27.3
+      abort-controller: 3.0.0
+      debug: 4.4.3
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   graphemer@1.4.0: {}
 


### PR DESCRIPTION
## Summary

Final additive slice of **Notifications v2** — closes the deferred items (A–F) from the multichannel epics ([EW-650](https://evertech.atlassian.net/browse/EW-650), [EW-663](https://evertech.atlassian.net/browse/EW-663), [EW-664](https://evertech.atlassian.net/browse/EW-664), [EW-665](https://evertech.atlassian.net/browse/EW-665); child tasks EW-666–EW-681 now Done). Builds on the already-merged plugin + facade groundwork; **no existing routes/services/entities removed** — everything here is additive or an internal SDK swap.

- **Reliable channel delivery (C):** new `deliverToChannelOrThrow` single-attempt primitive + a Trigger.dev `notification-channel-delivery` task (retry 30s→6h ×5, factor 4). Fanout now routes through a delivery dispatcher (status `queued`), falling back to inline send when no run id is available. Worker calls the live API's `NotificationChannelFacadeService` over the existing remote/call RPC.
- **Quiet-hours deferral (D):** non-in-app channels caught inside quiet hours are now **deferred** (delivered at `quietHoursEnd` via Trigger's native `delay`) instead of dropped. `resolvePlan()` returns `{ immediate, deferred, deferUntil }`.
- **Agent email templates (B):** the agent `sendEmail` tool accepts an optional `template { slug, props }` to render the React-Email templates.
- **Inbound email (E):** `INBOUND_EMAIL_TASK_SPAWNER` bound to real Task creation (+ `addAssignee('agent')`).
- **Vendor SDKs (F):** `slack-channel` → `@slack/webhook`; `telegram-channel` → `grammy` `Api`. Replaces hand-written `fetch` calls per the vendor-SDK rule. `discord`/`whatsapp` keep `fetch` (no sensible vendor SDK) with a README note.
- **Docs (A):** retry + quiet-hours specs updated to Trigger.dev (not BullMQ).

## Commits

- docs(notifications-v2): retry + quiet-hours deferral use Trigger.dev, not BullMQ
- feat(notifications-v2): agent sendEmail tool can render React-Email templates
- feat(notifications-v2): add deliverToChannelOrThrow single-attempt primitive (C1)
- feat(notifications-v2): route channel fanout through delivery dispatcher (C2)
- feat(notifications-v2): Trigger.dev notification-channel-delivery task + dispatch (C3)
- feat(notifications-v2): activate Trigger.dev delivery dispatcher end-to-end (C4)
- feat(notifications-v2): defer quiet-hours channels instead of dropping them (D)
- feat(notifications-v2): bind INBOUND_EMAIL_TASK_SPAWNER to real Task creation (E)
- refactor(plugin/slack-channel): use official @slack/webhook SDK instead of fetch (F1)
- refactor(plugin/telegram-channel): use grammy SDK Api instead of fetch (F2)

29 files changed, +779 / −191 (the −191 is slack/telegram `fetch` code replaced by SDK calls).

## Test plan

- [x] `pnpm type-check` — 69/75 packages pass. The one failure (`ever-works-docs`) is a pre-existing Docusaurus `Link`/`bigint`-ReactNode typing conflict; `apps/docs` is untouched by this branch.
- [x] `prettier --check` on all 28 changed files — clean.
- [x] `@ever-works/slack-channel-plugin` — 7/7 Vitest.
- [x] `@ever-works/telegram-channel-plugin` — 8/8 Vitest.
- [x] `@ever-works/agent` targeted Jest — 52/52 (`notification-channel.facade`, `agent-tool.service`, `user-notification-subscription.service`, `facades.module`).
- [ ] CI green on the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-650]: https://evertech.atlassian.net/browse/EW-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-663]: https://evertech.atlassian.net/browse/EW-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-664]: https://evertech.atlassian.net/browse/EW-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-665]: https://evertech.atlassian.net/browse/EW-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added email template support for agent communications.
  * Enabled quiet hours support for non-urgent notifications (deferred delivery).
  * Integrated official Slack and Telegram SDKs for more reliable channel delivery.
  * Introduced per-channel delivery with automatic retries and failure tracking.

* **Improvements**
  * Enhanced notification status reporting and delivery transparency.
  * Improved agent inbound email handling with automatic task creation.

* **Documentation**
  * Updated notification channel and event subscription specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->