### PR TITLE
release: develop → stage cascade (notifications-v2-finish + composio SDK + monitoring + local AI providers)

### DIFF
--- a/.deploy/docker/web/Dockerfile
+++ b/.deploy/docker/web/Dockerfile
@@ -29,6 +29,15 @@ ENV NODE_ENV=build
 ENV NEXT_BUILD_OUTPUT=standalone
 ENV CI=true
 
+# NEXT_PUBLIC_* must be present BEFORE `next build` runs because Next.js
+# inlines them into the client bundle at build time. The docker-build
+# workflows pass them via `--build-arg`; unset values resolve to empty
+# strings and the PostHog browser SDK degrades to a no-op gracefully.
+ARG NEXT_PUBLIC_POSTHOG_KEY=
+ARG NEXT_PUBLIC_POSTHOG_HOST=
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
+ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
+
 # Install python3
 RUN apk add --no-cache python3 pkgconfig build-base
 RUN apk add --no-cache pixman-dev cairo-dev pango-dev jpeg-dev giflib-dev

--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -103,6 +103,18 @@ spec:
             - name: TRIGGER_MACHINE
               value: "$TRIGGER_MACHINE"
 
+            # PostHog (analytics + feature flags) + Sentry (errors + traces).
+            # See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # SDKs are graceful no-ops when the env var is unset.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
+
             # GitHub Auth
             - name: GH_CLIENT_ID
               value: "$GH_CLIENT_ID"
@@ -342,6 +354,22 @@ spec:
               value: "http://ever-works-api-dev:3100"
             - name: NEXT_PUBLIC_WEB_URL
               value: "https://appdev.ever.works"
+
+            # PostHog (server-side: feature flag eval via apps/web/src/lib/feature-flags)
+            # + Sentry (errors + traces). See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # NEXT_PUBLIC_POSTHOG_KEY / NEXT_PUBLIC_POSTHOG_HOST are intentionally NOT
+            # set here — Next.js bakes NEXT_PUBLIC_* into the bundle at BUILD time,
+            # so they're plumbed through the docker-build workflow's build-args
+            # (see .github/workflows/docker-build-publish-dev.yml) and the web
+            # Dockerfile's ARG/ENV declarations.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -108,6 +108,18 @@ spec:
             - name: TRIGGER_MACHINE
               value: "$TRIGGER_MACHINE"
 
+            # PostHog (analytics + feature flags) + Sentry (errors + traces).
+            # See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # SDKs are graceful no-ops when the env var is unset.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
+
             # GitHub Auth
             - name: GH_CLIENT_ID
               value: "$GH_CLIENT_ID"
@@ -375,6 +387,22 @@ spec:
               value: "http://ever-works-api:3100"
             - name: NEXT_PUBLIC_WEB_URL
               value: "https://app.ever.works"
+
+            # PostHog (server-side: feature flag eval via apps/web/src/lib/feature-flags)
+            # + Sentry (errors + traces). See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # NEXT_PUBLIC_POSTHOG_KEY / NEXT_PUBLIC_POSTHOG_HOST are intentionally NOT
+            # set here — Next.js bakes NEXT_PUBLIC_* into the bundle at BUILD time,
+            # so they're plumbed through the docker-build workflow's build-args
+            # (see .github/workflows/docker-build-publish-prod.yml) and the web
+            # Dockerfile's ARG/ENV declarations.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -103,6 +103,18 @@ spec:
             - name: TRIGGER_MACHINE
               value: "$TRIGGER_MACHINE"
 
+            # PostHog (analytics + feature flags) + Sentry (errors + traces).
+            # See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # SDKs are graceful no-ops when the env var is unset.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
+
             # GitHub Auth
             - name: GH_CLIENT_ID
               value: "$GH_CLIENT_ID"
@@ -363,6 +375,22 @@ spec:
               value: "http://ever-works-api-stage:3100"
             - name: NEXT_PUBLIC_WEB_URL
               value: "https://appstage.ever.works"
+
+            # PostHog (server-side: feature flag eval via apps/web/src/lib/feature-flags)
+            # + Sentry (errors + traces). See knowledge/infrastructure/EVER_WORKS_POSTHOG.md.
+            # NEXT_PUBLIC_POSTHOG_KEY / NEXT_PUBLIC_POSTHOG_HOST are intentionally NOT
+            # set here — Next.js bakes NEXT_PUBLIC_* into the bundle at BUILD time,
+            # so they're plumbed through the docker-build workflow's build-args
+            # (see .github/workflows/docker-build-publish-stage.yml) and the web
+            # Dockerfile's ARG/ENV declarations.
+            - name: SENTRY_DSN
+              value: "$SENTRY_DSN"
+            - name: SENTRY_ENVIRONMENT
+              value: "$SENTRY_ENVIRONMENT"
+            - name: POSTHOG_API_KEY
+              value: "$POSTHOG_API_KEY"
+            - name: POSTHOG_HOST
+              value: "$POSTHOG_HOST"
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -123,6 +123,16 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Sentry (errors, traces, profiling). DSN is set repo-wide; absent
+          # DSN -> SDK is a graceful no-op. SENTRY_ENVIRONMENT differentiates
+          # dev / staging / production in the Sentry UI.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: development
+          # PostHog (server-side: analytics events, feature flag eval, logs).
+          # Same phc_* key used by NEXT_PUBLIC_POSTHOG_KEY at docker-build time.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+
           # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -133,6 +133,16 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Sentry (errors, traces, profiling). DSN is set repo-wide; absent
+          # DSN -> SDK is a graceful no-op. SENTRY_ENVIRONMENT differentiates
+          # dev / staging / production in the Sentry UI.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: production
+          # PostHog (server-side: analytics events, feature flag eval, logs).
+          # Same phc_* key used by NEXT_PUBLIC_POSTHOG_KEY at docker-build time.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+
           # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -123,6 +123,16 @@ jobs:
           RESEND_APIKEY: ${{ secrets.RESEND_APIKEY }}
           RESEND_EMAIL_FROM: ${{ secrets.RESEND_EMAIL_FROM }}
 
+          # Sentry (errors, traces, profiling). DSN is set repo-wide; absent
+          # DSN -> SDK is a graceful no-op. SENTRY_ENVIRONMENT differentiates
+          # dev / staging / production in the Sentry UI.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: staging
+          # PostHog (server-side: analytics events, feature flag eval, logs).
+          # Same phc_* key used by NEXT_PUBLIC_POSTHOG_KEY at docker-build time.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+
           # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -125,8 +125,13 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web-dev:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web-dev:latest
           cache-to: type=inline
+          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # into the client bundle at `next build`, not at container start.
+          # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=development
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -125,8 +125,13 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web:latest
           cache-to: type=inline
+          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # into the client bundle at `next build`, not at container start.
+          # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -125,8 +125,13 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web-stage:latest
           cache-to: type=inline
+          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # into the client bundle at `next build`, not at container start.
+          # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
 
       - name: Docker images list
         run: |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -196,6 +196,29 @@ WEBSITE_TEMPLATE_AUTO_UPDATE_ENABLED=true
 WEBSITE_TEMPLATE_BETA_BRANCH=stage
 
 
+# ============================================
+# Sentry (error tracking, traces, profiling)
+# ============================================
+# Get the DSN from https://sentry.io -> Ever Works project -> Settings ->
+# Client Keys. Without DSN set, Sentry SDK is a no-op (graceful).
+SENTRY_DSN=
+# 'development' / 'staging' / 'production'. Deployed envs override
+# via the k8s manifest; local dev defaults to 'development'.
+SENTRY_ENVIRONMENT=development
+# Override the auto-picked sample rate (default 0.1 in prod, 1.0 elsewhere).
+# SENTRY_TRACES_SAMPLE_RATE=1.0
+
+# ============================================
+# PostHog (server-side analytics + feature flags + logs)
+# ============================================
+# Project (public) API key — same phc_* as the marketing site uses;
+# not a security secret. Without it set, PostHog SDK is a no-op (graceful).
+# When POSTHOG_API_KEY is set, all NestJS Logger emits (log/warn/error/
+# debug/verbose) are also forwarded to PostHog Logs as `$log` events.
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://us.i.posthog.com
+
+
 # ============================== PLUGINS ========================================
 
 # GitHub Plugin (separate from GitHub Auth above)

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -26,6 +26,10 @@ import {
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { EmailModule } from '../email/email.module';
 import { EmailService } from '../email/email.service';
+import {
+    INBOUND_EMAIL_TASK_SPAWNER,
+    type InboundEmailTaskSpawner,
+} from '@ever-works/agent/notifications';
 
 // Phase 16.6 / 16.7 — commitToRepo / openPullRequest tools.
 // The `AGENT_GIT_FACADE` token (exported from `@ever-works/agent/agents`)
@@ -132,6 +136,35 @@ import { AgentsController } from './agents.controller';
                         force: force ?? false,
                     });
                     return { status: row.status };
+                },
+            }),
+        },
+        // Notifications v2 (EW-670) — INBOUND_EMAIL_TASK_SPAWNER binding.
+        // The inbound-email dispatcher's `task-spawn` mode delegates here:
+        // create a Task from the inbound email (scoped to the address
+        // owner, created-by the receiving agent) and assign that agent so
+        // the task-tracking flow dispatches `agent-task-execute`. When this
+        // token is unbound the dispatcher persists the message but spawns
+        // no Task (graceful no-op).
+        {
+            provide: INBOUND_EMAIL_TASK_SPAWNER,
+            inject: [TasksService],
+            useFactory: (tasks: TasksService): InboundEmailTaskSpawner => ({
+                async spawnTaskForInboundEmail({ agentId, userId, subject, bodyText, from }) {
+                    const title = subject?.trim()
+                        ? subject.trim().slice(0, 200)
+                        : `Inbound email from ${from}`;
+                    const task = await tasks.create(userId, {
+                        title,
+                        description: bodyText?.trim() ? bodyText.trim().slice(0, 8000) : null,
+                        labels: ['inbound-email'],
+                        createdByType: 'agent',
+                        createdById: agentId,
+                    });
+                    // Assign the receiving agent so the task-tracking flow
+                    // fans out agent-task-execute for it.
+                    await tasks.addAssignee(userId, task.id, 'agent', agentId);
+                    return { taskId: task.id };
                 },
             }),
         },
@@ -504,6 +537,7 @@ import { AgentsController } from './agents.controller';
         AGENT_GIT_FACADE,
         AGENT_EMAIL_FACADE,
         AGENT_NOTIFY_CHANNEL_FACADE,
+        INBOUND_EMAIL_TASK_SPAWNER,
     ],
 })
 export class AgentsModule {}

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -419,6 +419,7 @@ import { AgentsController } from './agents.controller';
                     subject,
                     bodyText,
                     bodyHtml,
+                    template,
                     fromAddressId,
                 }) {
                     const result = await email.sendMessage(userId, {
@@ -428,6 +429,7 @@ import { AgentsController } from './agents.controller';
                         subject,
                         bodyText,
                         bodyHtml,
+                        template,
                         fromAddressId,
                     });
                     return {

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -480,8 +480,11 @@ import { AgentsController } from './agents.controller';
                         { text, messageRef: `agent-${agentId}-${Date.now()}` },
                         { userId, agentId },
                     );
+                    // sendDirect is the synchronous inline path (no Trigger
+                    // dispatch), so it only ever resolves delivered/failed —
+                    // narrow the facade's wider union for the agent tool.
                     return {
-                        status: result.status,
+                        status: result.status === 'failed' ? 'failed' : 'delivered',
                         providerMessageId: result.providerMessageId,
                         error: result.error,
                     };

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,7 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { apiReference } from '@scalar/nestjs-api-reference';
 import { ApiModule } from './api.module';
 import helmet from 'helmet';
-import { initSentry, initPostHog } from '@ever-works/monitoring';
+import { initSentry, initPostHog, PostHogLoggerService } from '@ever-works/monitoring';
 import { IncomingMessage, ServerResponse } from 'http';
 import * as path from 'path';
 import { json, urlencoded } from 'express';
@@ -30,6 +30,12 @@ async function bootstrap() {
     initPostHog();
 
     const app = await NestFactory.create(ApiModule);
+
+    // Forward every NestJS Logger emit (log/warn/error/debug/verbose) to
+    // PostHog Logs as a `$log` event while still writing to stdout. The
+    // PostHogLoggerService fails open — without POSTHOG_API_KEY it degrades
+    // to the default NestJS console logger (no PostHog traffic, no errors).
+    app.useLogger(new PostHogLoggerService());
 
     const captureRawBody = (
         req: IncomingMessage & { rawBody?: string },

--- a/apps/api/src/notifications/notification-fanout.listener.ts
+++ b/apps/api/src/notifications/notification-fanout.listener.ts
@@ -5,7 +5,10 @@ import {
     type NotificationFanoutEvent,
     UserNotificationSubscriptionService,
 } from '@ever-works/agent/notifications';
-import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
+import {
+    NotificationChannelFacadeService,
+    type ResolvedChannelTarget,
+} from '@ever-works/agent/facades';
 
 /**
  * EW-664 / EW-678 / T20 + T22 — Producer fanout listener.
@@ -70,14 +73,25 @@ export class NotificationFanoutListener {
      * NotificationService.create, so the channel facade treats it as a
      * no-op sentinel).
      */
-    private async resolveChannelIds(userId: string, eventKey: string): Promise<string[]> {
+    private async resolveChannelIds(
+        userId: string,
+        eventKey: string,
+    ): Promise<ResolvedChannelTarget[]> {
         if (!this.subscriptions) return [];
         try {
-            const channels = await this.subscriptions.resolveChannels(userId, eventKey);
+            const plan = await this.subscriptions.resolvePlan(userId, eventKey);
             // Drop the 'in-app' sentinel before fanout — in-app delivery
             // already happened in the v1 producer's create() call; the
-            // channel facade only handles the external channels.
-            return channels.filter((c) => c !== 'in-app');
+            // channel facade only handles the external channels. Deferred
+            // (quiet-hours) channels carry `deferUntil` so the facade
+            // enqueues them on the Trigger.dev delivery task with that delay.
+            const immediate = plan.immediate
+                .filter((c) => c !== 'in-app')
+                .map((channelId) => ({ channelId }));
+            const deferred = plan.deferred
+                .filter((c) => c !== 'in-app')
+                .map((channelId) => ({ channelId, deferUntil: plan.deferUntil }));
+            return [...immediate, ...deferred];
         } catch (err) {
             this.logger.debug(
                 `Subscription resolver fallback to [] for user=${userId} event=${eventKey}: ${String(err)}`,

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -209,6 +209,25 @@ describe('DeployController', () => {
             });
         });
 
+        it('treats ever-works as available when the k8s plugin is loaded', async () => {
+            deployFacade.getAvailableProviders.mockReturnValue([
+                { id: 'k8s', name: 'Kubernetes', enabled: true },
+            ]);
+            deployFacade.isProviderConfigured.mockResolvedValue(true);
+
+            const result = await controller.isProviderConfigured(auth, 'ever-works');
+
+            expect(deployFacade.isProviderConfigured).toHaveBeenCalledWith(
+                'ever-works',
+                'caller-1',
+            );
+            expect(result).toMatchObject({
+                configured: true,
+                available: true,
+                enabled: true,
+            });
+        });
+
         it('returns configured:false with the not-configured-message when enabled but unconfigured', async () => {
             deployFacade.getAvailableProviders.mockReturnValue([
                 { id: 'vercel', name: 'Vercel', enabled: true },

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -27,6 +27,15 @@ import { DeployWorkDto, RollbackDto } from './dto/deploy.dto';
 import { BatchDeployDto, BatchDeployResponseDto } from './dto/batch-deploy.dto';
 import { AddDomainDto } from './dto/domain.dto';
 
+const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
+const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
+
+function resolveDeployProviderId(providerId: string): string {
+    return providerId === EVER_WORKS_DEPLOY_PROVIDER_ID
+        ? KUBERNETES_DEPLOY_PROVIDER_ID
+        : providerId;
+}
+
 @ApiTags('Deploy')
 @ApiBearerAuth('JWT-auth')
 @Controller('api/deploy')
@@ -43,8 +52,9 @@ export class DeployController {
 
     private getProviderName(deployProvider: string | undefined): string {
         if (!deployProvider) return 'Deployment';
+        const resolvedProviderId = resolveDeployProviderId(deployProvider);
         const providers = this.deployFacade.getAvailableProviders();
-        const provider = providers.find((p) => p.id === deployProvider);
+        const provider = providers.find((p) => p.id === resolvedProviderId);
         return provider?.name || deployProvider;
     }
 
@@ -80,7 +90,8 @@ export class DeployController {
         @Param('providerId') providerId: string,
     ) {
         const providers = this.deployFacade.getAvailableProviders();
-        const provider = providers.find((p) => p.id === providerId);
+        const resolvedProviderId = resolveDeployProviderId(providerId);
+        const provider = providers.find((p) => p.id === resolvedProviderId);
 
         if (!provider) {
             return {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -62,6 +62,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         /** EW-120 dual-mode Activity Feed sync. Defaults to `push` to keep
          *  pre-dual-mode tests behaving as before. */
         activitySyncMode?: 'pull' | 'push' | 'disabled';
+        githubPluginOverrides?: Record<string, unknown>;
     }) => {
         const websiteOwner = overrides.websiteOwner ?? 'acme';
         const work = {
@@ -112,6 +113,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             dispatchWorkflow: jest.fn().mockResolvedValue(undefined),
             getRepositoryPublicKey: jest.fn().mockResolvedValue({ key_id: 'k', key: 'pubkey' }),
             enableDeploymentWorkflows: jest.fn().mockResolvedValue(undefined),
+            ...(overrides.githubPluginOverrides ?? {}),
         };
 
         const pluginRegistry = {
@@ -222,6 +224,36 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         const { dispatches } = captureCalls(githubPlugin);
         const workflows = dispatches.map((d: any) => d.workflow);
         expect(workflows).toEqual(['deploy_k8s.yaml']);
+    });
+
+    it('syncs the website template before dispatch when the required workflow is missing', async () => {
+        const notFound = Object.assign(new Error('Not found'), { status: 404 });
+        const getFileContent = jest
+            .fn()
+            .mockRejectedValueOnce(notFound)
+            .mockResolvedValueOnce('name: Kubernetes deploy');
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+            },
+            githubPluginOverrides: { getFileContent },
+        });
+        jest.spyOn(service as any, 'delay').mockResolvedValue(undefined);
+
+        const result = await service.deploy('work-1', 'user-1', {});
+
+        expect(result.dispatched).toBe(true);
+        expect(getFileContent).toHaveBeenNthCalledWith(
+            1,
+            'acme',
+            'acme-site',
+            '.github/workflows/deploy_k8s.yaml',
+            'gh-token',
+            'main',
+        );
+        expect(githubPlugin.dispatchWorkflow).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to deploy_prod.yaml for plugins without getWorkflowFilenames', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -870,6 +870,87 @@ export class DeployService {
         return randomBytes(this.CRON_SECRET_LENGTH).toString('hex');
     }
 
+    private async findMissingWorkflowFiles(
+        owner: string,
+        repo: string,
+        token: string,
+        branch: string,
+        workflowFiles: readonly string[],
+    ): Promise<string[] | null> {
+        const plugin = this.getGitHubPlugin();
+        if (typeof plugin.getFileContent !== 'function') {
+            return null;
+        }
+
+        const missing: string[] = [];
+        for (const workflowFile of workflowFiles) {
+            const workflowPath = `.github/workflows/${workflowFile}`;
+            try {
+                await plugin.getFileContent(owner, repo, workflowPath, token, branch);
+            } catch (error: any) {
+                if (this.isRepositoryFileNotFound(error)) {
+                    missing.push(workflowFile);
+                    continue;
+                }
+
+                this.logger.warn(
+                    `Could not preflight workflow file "${workflowPath}" in ${owner}/${repo}@${branch}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                return null;
+            }
+        }
+
+        return missing;
+    }
+
+    private isRepositoryFileNotFound(error: unknown): boolean {
+        const maybeError = error as {
+            status?: number;
+            response?: { status?: number };
+            message?: string;
+        };
+        const status = maybeError?.status ?? maybeError?.response?.status;
+        if (status === 404) return true;
+
+        return typeof maybeError?.message === 'string' && /not found/i.test(maybeError.message);
+    }
+
+    private async areAllWorkflowFilesMissing(params: {
+        owner: string;
+        repo: string;
+        token: string;
+        branch: string;
+        workflowFiles: readonly string[];
+        phase: 'initial' | 'post-update';
+    }): Promise<boolean> {
+        const missing = await this.findMissingWorkflowFiles(
+            params.owner,
+            params.repo,
+            params.token,
+            params.branch,
+            params.workflowFiles,
+        );
+
+        if (!missing || missing.length === 0) {
+            return false;
+        }
+
+        const missingList = missing.join(', ');
+        if (missing.length === params.workflowFiles.length) {
+            this.logger.warn(
+                `Deployment workflow preflight (${params.phase}) found no configured workflow files in ${params.owner}/${params.repo}@${params.branch}: ${missingList}`,
+            );
+            return true;
+        }
+
+        this.logger.warn(
+            `Deployment workflow preflight (${params.phase}) found missing optional workflow file(s) in ${params.owner}/${params.repo}@${params.branch}: ${missingList}`,
+        );
+        return false;
+    }
+
     private async dispatchWithRetry(
         work: Work,
         user: User,
@@ -927,8 +1008,17 @@ export class DeployService {
             return false;
         };
 
-        // First attempt
-        const firstAttemptSuccess = await tryDispatch();
+        // First attempt. If the repo is missing every expected workflow,
+        // skip the doomed dispatch and sync from the selected template first.
+        const skipFirstAttempt = await this.areAllWorkflowFilesMissing({
+            owner,
+            repo,
+            token: gitToken,
+            branch: dispatchBranch,
+            workflowFiles: workflowFilesToTry,
+            phase: 'initial',
+        });
+        const firstAttemptSuccess = skipFirstAttempt ? false : await tryDispatch();
         if (firstAttemptSuccess) {
             return true;
         }
@@ -939,6 +1029,21 @@ export class DeployService {
             await this.websiteUpdateService.updateRepository(work, user);
             await this.createTriggerCommit(work, user);
             await this.delay(3000);
+
+            const stillMissingAllWorkflows = await this.areAllWorkflowFilesMissing({
+                owner,
+                repo,
+                token: gitToken,
+                branch: dispatchBranch,
+                workflowFiles: workflowFilesToTry,
+                phase: 'post-update',
+            });
+            if (stillMissingAllWorkflows) {
+                this.logger.error(
+                    `Deployment cannot continue because ${owner}/${repo}@${dispatchBranch} does not contain any expected deployment workflow: ${workflowFilesToTry.join(', ')}`,
+                );
+                return false;
+            }
 
             const retrySuccess = await tryDispatch();
             if (retrySuccess) {

--- a/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.spec.ts
@@ -419,6 +419,29 @@ describe('DeploymentVerifierService', () => {
             expect((completedEvent as any).payload.providerName).toBe('Vercel');
         });
 
+        it('resolves ever-works through the k8s plugin for terminal event metadata', async () => {
+            deployFacade.lookupExistingDeployment.mockResolvedValueOnce({
+                found: true,
+                deploymentState: 'READY',
+            });
+            pluginRegistry.get.mockReturnValueOnce({
+                plugin: { providerName: 'Kubernetes', name: 'Kubernetes' },
+            } as any);
+
+            await service.startVerification(
+                buildWork({ deployProvider: 'ever-works' }) as any,
+                'user-1',
+            );
+            await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+            expect(pluginRegistry.get).toHaveBeenCalledWith('k8s');
+            const completedEvent = eventEmitter.emit.mock.calls.find(
+                (c) => c[0] === DeploymentCompletedEvent.EVENT_NAME,
+            )![1];
+            expect((completedEvent as any).payload.providerId).toBe('ever-works');
+            expect((completedEvent as any).payload.providerName).toBe('Kubernetes');
+        });
+
         it('falls back to plugin.name when providerName is missing', async () => {
             deployFacade.lookupExistingDeployment.mockResolvedValueOnce({
                 found: true,

--- a/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/tasks/deployment-verifier.service.ts
@@ -22,6 +22,15 @@ type DeploymentTerminalState = 'READY' | 'ERROR' | 'CANCELED' | 'TIMEOUT';
 const isTerminalState = (state: DeploymentReadyState): state is DeploymentTerminalState =>
     state === 'READY' || state === 'ERROR' || state === 'CANCELED' || state === 'TIMEOUT';
 
+const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
+const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
+
+function resolveDeployProviderId(providerId: string): string {
+    return providerId === EVER_WORKS_DEPLOY_PROVIDER_ID
+        ? KUBERNETES_DEPLOY_PROVIDER_ID
+        : providerId;
+}
+
 /**
  * DeploymentVerifierService monitors deployment progress and updates work status.
  *
@@ -224,7 +233,7 @@ export class DeploymentVerifierService {
         const providerId = work.deployProvider;
         if (!providerId) return;
 
-        const registered = this.pluginRegistry.get(providerId);
+        const registered = this.pluginRegistry.get(resolveDeployProviderId(providerId));
         const plugin = registered?.plugin as IDeploymentPlugin | undefined;
         const providerName = plugin?.providerName ?? plugin?.name ?? providerId;
 

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -44,7 +44,7 @@ import { TaskRecurrenceDispatcherService } from '@ever-works/agent/tasks-domain'
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
 import { DataSyncDispatcherService } from '../data-sync/data-sync-dispatcher.service';
 import { NotificationService } from '@ever-works/agent/notifications';
-import { GitFacadeService } from '@ever-works/agent/facades';
+import { GitFacadeService, NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { RemoteCallDto } from './dto/remote-call.dto';
 import {
     PluginRepository,
@@ -164,6 +164,10 @@ export class TriggerInternalController implements OnModuleInit {
         private readonly agentRunRepositoryRef: AgentRunRepository,
         // Phase 17 — recurring Task dispatcher.
         private readonly taskRecurrenceDispatcherService: TaskRecurrenceDispatcherService,
+        // Notifications v2 (EW-663) — exposed for the
+        // notification-channel-delivery Trigger task to run a single
+        // channel attempt (plugins are loaded here, not in the worker).
+        private readonly notificationChannelFacade: NotificationChannelFacadeService,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -200,6 +204,9 @@ export class TriggerInternalController implements OnModuleInit {
             AgentRunRepository: this.agentRunRepositoryRef,
             // Phase 17 — recurring Task dispatcher.
             TaskRecurrenceDispatcherService: this.taskRecurrenceDispatcherService,
+            // Notifications v2 (EW-663) — notification-channel-delivery task
+            // calls `deliverToChannelOrThrow` here (allow-list auto-derived).
+            NotificationChannelFacadeService: this.notificationChannelFacade,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -178,6 +178,8 @@ const sidebars: SidebarsConfig = {
 				'plugin-system/openai-plugin',
 				'plugin-system/anthropic-plugin',
 				'plugin-system/ollama-plugin',
+				'plugin-system/lm-studio-plugin',
+				'plugin-system/vllm-plugin',
 				'plugin-system/groq-plugin',
 				'plugin-system/tavily-plugin',
 				'plugin-system/apify-plugin',

--- a/apps/internal-cli/src/commands/config/__tests__/set.subcommand.spec.ts
+++ b/apps/internal-cli/src/commands/config/__tests__/set.subcommand.spec.ts
@@ -75,6 +75,8 @@ describe('SetSubCommand.run (validation paths)', () => {
             'anthropic',
             'openrouter',
             'ollama',
+            'lm-studio',
+            'vllm',
             'groq',
             'custom',
         ]) {

--- a/apps/internal-cli/src/commands/config/ai-providers/__tests__/ai-provider-registry.service.spec.ts
+++ b/apps/internal-cli/src/commands/config/ai-providers/__tests__/ai-provider-registry.service.spec.ts
@@ -9,16 +9,18 @@ describe('AiProviderRegistryService', () => {
     });
 
     describe('getAllProviders', () => {
-        it('registers exactly the seven default providers', () => {
+        it('registers exactly the nine default providers', () => {
             const providers = service.getAllProviders();
             expect(providers.map((p) => p.name).sort()).toEqual([
                 'anthropic',
                 'custom',
                 'google',
                 'groq',
+                'lm-studio',
                 'ollama',
                 'openai',
                 'openrouter',
+                'vllm',
             ]);
         });
 
@@ -48,14 +50,13 @@ describe('AiProviderRegistryService', () => {
     });
 
     describe('provider properties pinning', () => {
-        it('ollama is the only provider that does NOT require an api key by default', () => {
-            const ollama = service.getProvider('ollama');
-            const custom = service.getProvider('custom');
-            expect(ollama?.requiresApiKey).toBe(false);
-            // custom is also requiresApiKey:false; ollama and custom should both be flagged
-            expect(custom?.requiresApiKey).toBe(false);
+        it('local providers (ollama, lm-studio, vllm) and custom do NOT require an api key by default', () => {
+            const noKeyProviders = ['ollama', 'lm-studio', 'vllm', 'custom'];
+            for (const name of noKeyProviders) {
+                expect(service.getProvider(name)?.requiresApiKey).toBe(false);
+            }
             for (const p of service.getAllProviders()) {
-                if (p.name === 'ollama' || p.name === 'custom') continue;
+                if (noKeyProviders.includes(p.name)) continue;
                 expect(p.requiresApiKey).toBe(true);
             }
         });

--- a/apps/internal-cli/src/commands/config/ai-providers/ai-provider-registry.service.ts
+++ b/apps/internal-cli/src/commands/config/ai-providers/ai-provider-registry.service.ts
@@ -149,6 +149,48 @@ export class AiProviderRegistryService {
             docsUrl: 'https://github.com/ollama/ollama',
         });
 
+        this.providers.set('lm-studio', {
+            name: 'lm-studio',
+            displayName: 'LM Studio',
+            description: 'Local AI models through LM Studio (free)',
+            defaults: {
+                model: 'local-model',
+                temperature: 0.7,
+                maxTokens: 4096,
+                baseUrl: 'http://localhost:1234/v1',
+            },
+            requiresApiKey: false,
+            models: [
+                'qwen2.5-7b-instruct',
+                'llama-3.2-3b-instruct',
+                'mistral-7b-instruct',
+                'gemma-2-9b-it',
+                'phi-4',
+            ],
+            websiteUrl: 'https://lmstudio.ai',
+            docsUrl: 'https://lmstudio.ai/docs',
+        });
+
+        this.providers.set('vllm', {
+            name: 'vllm',
+            displayName: 'vLLM',
+            description: 'Self-hosted high-throughput inference via vLLM',
+            defaults: {
+                model: 'local-model',
+                temperature: 0.7,
+                maxTokens: 4096,
+                baseUrl: 'http://localhost:8000/v1',
+            },
+            requiresApiKey: false,
+            models: [
+                'meta-llama/Llama-3.1-8B-Instruct',
+                'Qwen/Qwen2.5-7B-Instruct',
+                'mistralai/Mistral-7B-Instruct-v0.3',
+            ],
+            websiteUrl: 'https://docs.vllm.ai',
+            docsUrl: 'https://docs.vllm.ai',
+        });
+
         // Groq
         this.providers.set('groq', {
             name: 'groq',

--- a/apps/internal-cli/src/commands/config/prompts/ai-provider-prompt.service.ts
+++ b/apps/internal-cli/src/commands/config/prompts/ai-provider-prompt.service.ts
@@ -486,6 +486,9 @@ export class AiProviderPromptService extends BasePromptService {
             openrouter:
                 'Examples: openai/gpt-5.2, openai/gpt-5-mini, anthropic/claude-opus-4.5, google/gemini-3-flash, meta-llama/llama-3.3-70b-instruct:free',
             ollama: 'Examples: llama3.3, llama3.2, qwen2.5, qwen2.5-coder, deepseek-r1, gemma2, phi4',
+            'lm-studio':
+                'Use the model id currently loaded in LM Studio (e.g. qwen2.5-7b-instruct, llama-3.2-3b-instruct)',
+            vllm: 'Use the model id vLLM was launched with via --model (e.g. meta-llama/Llama-3.1-8B-Instruct)',
             groq: 'Examples: openai/gpt-oss-120b, llama-3.3-70b-versatile, llama-3.1-8b-instant, qwen-qwq-32b',
             custom: 'Enter any model name supported by your OpenAI-compatible endpoint',
         };

--- a/apps/internal-cli/src/commands/config/set.subcommand.ts
+++ b/apps/internal-cli/src/commands/config/set.subcommand.ts
@@ -97,6 +97,8 @@ export class SetSubCommand extends CommandRunner {
                 'anthropic',
                 'openrouter',
                 'ollama',
+                'lm-studio',
+                'vllm',
                 'groq',
                 'custom',
             ];

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -140,7 +140,7 @@ AUTH_SECRET=your-secret-key-here
 # POSTHOG_API_KEY=phc_your_project_api_key_here
 
 # PostHog host. Defaults to https://app.posthog.com when unset.
-# POSTHOG_HOST=https://app.posthog.com
+POSTHOG_HOST=https://us.i.posthog.com
 
 # Work-kind chips on /new and /works/new are gated by per-kind feature
 # flags named `works-<kind>` (e.g. works-website, works-landing-page,

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -133,8 +133,10 @@ AUTH_SECRET=your-secret-key-here
 # ============================================
 
 # PostHog project API key. Same key the monitoring package uses.
-# Evaluated SERVER-SIDE only — posthog-js is never shipped to the
-# browser, so this token stays off the client.
+# Used by the SERVER for feature-flag evaluation (works-<kind> chips,
+# onboarding event relay). The same value also belongs in
+# NEXT_PUBLIC_POSTHOG_KEY below — `phc_*` keys are the public project
+# key and are safe to ship in the browser bundle.
 # POSTHOG_API_KEY=phc_your_project_api_key_here
 
 # PostHog host. Defaults to https://app.posthog.com when unset.
@@ -148,6 +150,19 @@ AUTH_SECRET=your-secret-key-here
 # explicitly false. No PostHog config, an unreachable/erroring PostHog, a
 # missing flag, or an undefined value all leave the chip ENABLED — so OSS
 # forks with no PostHog run with every kind available.
+
+# ============================================
+# PostHog (client-side product analytics)
+# ============================================
+
+# Same phc_* value as POSTHOG_API_KEY above — phc_* is the PROJECT (public)
+# key and is meant to be shipped in the browser bundle. Drives autocapture,
+# session replay, and manual $pageview events from the App Router.
+# NEXT_PUBLIC_* values are baked into the bundle at BUILD time, so this
+# must be set when `pnpm build` runs (not at runtime). If absent, posthog-js
+# silently no-ops — fail-open for OSS forks that don't run PostHog.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # ============================================
 # Build Configuration

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
         "next-intl": "^4.9.2",
         "nextjs-toploader": "^3.9.17",
         "path-to-regexp": "^8.4.2",
+        "posthog-js": "^1.376.3",
         "posthog-node": "^5.18.0",
         "radix-ui": "^1.4.3",
         "react": "19.2.5",

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -17,6 +17,7 @@ import { useKeyboardShortcuts } from '@/lib/hooks/use-keyboard-shortcuts';
 import { ConnectGithubModal } from '@/components/auth/connect-github-modal';
 import { BackgroundActivityProvider } from '@/lib/hooks/use-background-activity';
 import { EverWorksOnboardingWizard } from '@/components/onboarding/EverWorksOnboardingWizard';
+import { PostHogIdentify } from '@/components/posthog/PostHogIdentify';
 import { computeStepList } from '@/components/onboarding/useOnboardingFlow';
 import { dismissOnboarding } from '@/app/actions/onboarding/state';
 import { ONBOARDING_DEFAULT_STATE } from '@ever-works/contracts/api';
@@ -344,6 +345,7 @@ export function DashboardLayoutClient({
     return (
         <BackgroundActivityProvider>
             <ChatProvider>
+                <PostHogIdentify userId={user.id} email={user.email} name={user.username} />
                 <EverWorksOnboardingWizard
                     open={isOnboardingOpen}
                     initialState={onboardingState}

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import './globals.css';
 import { themeInitScript } from '@/lib/theme-init';
 import { TopLoader } from '@/components/ui/top-loader';
 import { APP_NAME } from '@/lib/constants';
+import { PostHogProvider } from '@/components/posthog/PostHogProvider';
 
 export const metadata: Metadata = {
     title: {
@@ -41,20 +42,22 @@ export default async function RootLayout({
             <body className="antialiased" suppressHydrationWarning>
                 <TopLoader />
                 <NextIntlClientProvider>
-                    {children}
-                    <Toaster
-                        position="top-right"
-                        theme="system"
-                        toastOptions={{
-                            className:
-                                'sonner-toast !bg-surface dark:!bg-surface-dark !text-text dark:!text-text-dark !border !border-border dark:!border-border-dark',
-                            style: {
-                                background: undefined,
-                                color: undefined,
-                                border: undefined,
-                            },
-                        }}
-                    />
+                    <PostHogProvider>
+                        {children}
+                        <Toaster
+                            position="top-right"
+                            theme="system"
+                            toastOptions={{
+                                className:
+                                    'sonner-toast !bg-surface dark:!bg-surface-dark !text-text dark:!text-text-dark !border !border-border dark:!border-border-dark',
+                                style: {
+                                    background: undefined,
+                                    color: undefined,
+                                    border: undefined,
+                                },
+                            }}
+                        />
+                    </PostHogProvider>
                 </NextIntlClientProvider>
             </body>
         </html>

--- a/apps/web/src/app/actions/onboarding/track.ts
+++ b/apps/web/src/app/actions/onboarding/track.ts
@@ -8,9 +8,14 @@ import { onboardingAPI } from '@/lib/api/onboarding';
  * The browser POSTs `{ event, properties }` to this server action, which
  * forwards to `/api/onboarding/telemetry`. The API validates the event
  * against an allowlist and forwards to PostHog via the existing
- * `AnalyticsService`. We deliberately do NOT add `posthog-js` to the
- * web bundle — keeping the relay server-side means PostHog tokens stay
- * out of the client and we don't pay the bundle cost.
+ * `AnalyticsService`.
+ *
+ * Older path: this server-side relay predates the client-side `posthog-js`
+ * integration. Newer client surfaces should call PostHog directly via
+ * `usePostHog()` from `posthog-js/react` (the provider is wired in
+ * `apps/web/src/app/[locale]/layout.tsx`). This server action stays for the
+ * onboarding-wizard event taxonomy that the API consolidates server-side
+ * (allowlist validation + canonical property shaping live in the API).
  *
  * Failures are swallowed: telemetry must never block the wizard.
  */

--- a/apps/web/src/components/posthog/PostHogIdentify.tsx
+++ b/apps/web/src/components/posthog/PostHogIdentify.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect } from 'react';
+import posthog from 'posthog-js';
+
+interface PostHogIdentifyProps {
+    /**
+     * Stable internal user id. Same value used everywhere else for
+     * user identity (matches `AuthUser.id`).
+     */
+    userId?: string | null;
+    email?: string | null;
+    name?: string | null;
+}
+
+/**
+ * Calls `posthog.identify(userId, ...)` when a known user mounts.
+ *
+ * Place this INSIDE <PostHogProvider> so posthog-js is already
+ * initialized by the time the identify effect runs.
+ *
+ * `userId` should come from whatever the surrounding tree already knows
+ * about the current user (the dashboard layout passes `AuthUser` as a
+ * prop from its server component — there's no client-side `useUser()`
+ * hook in this repo today).
+ *
+ * UNMOUNT RESET — the real logout path on this platform redirects the
+ * whole dashboard layout to the login page, which unmounts this
+ * component without `userId` ever transitioning to falsy on a still-
+ * mounted instance. Relying purely on the prop-change branch below
+ * would leave PostHog's distinct_id pinned to the departing user for
+ * the rest of the tab's lifetime. To avoid that, a second effect runs
+ * `posthog.reset()` in its UNMOUNT cleanup so logout / route-tear-down
+ * always drops the prior identity.
+ */
+export function PostHogIdentify({ userId, email, name }: PostHogIdentifyProps) {
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+
+        if (userId) {
+            const props: Record<string, string> = {};
+            if (email) props.email = email;
+            if (name) props.name = name;
+            posthog.identify(userId, props);
+        } else {
+            // Unknown user (logged out, anonymous surface). Drop any prior
+            // identity so the next session starts as a fresh anonymous id.
+            posthog.reset();
+        }
+    }, [userId, email, name]);
+
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+        return () => {
+            // Logout typically unmounts the dashboard layout entirely
+            // rather than flipping `userId` to null on a mounted
+            // instance, so the identify effect above never sees the
+            // transition. Reset here so the next mount starts clean.
+            posthog.reset();
+        };
+    }, []);
+
+    return null;
+}

--- a/apps/web/src/components/posthog/PostHogProvider.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Suspense, useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import posthog from 'posthog-js';
+import { PostHogProvider as PHProvider } from 'posthog-js/react';
+
+/**
+ * Client-side PostHog wiring for the platform's web frontend.
+ *
+ * Autocapture + session replay are enabled. Session-replay inputs are
+ * masked WHOLESALE (`maskAllInputs: true`) — per-type masking via
+ * `maskInputOptions` is unreliable because apps routinely render
+ * sensitive fields (API keys, secrets, custom autocomplete pickers,
+ * older form patterns) as `input[type="text"]` rather than the strict
+ * `password` / `email` types. Masking everything is the secure-by-default
+ * posture PostHog's own security docs recommend.
+ *
+ * Pageviews are captured manually (`capture_pageview: false`) so that
+ * App Router client-side navigations between routes are counted. The
+ * companion <PostHogPageview /> component fires `$pageview` on every
+ * `usePathname` / `useSearchParams` change.
+ *
+ * INIT TIMING — `posthog.init(...)` runs at MODULE LOAD time (not inside
+ * a `useEffect`). React commits children's effects before parent's, so
+ * doing init in the provider's effect would let `<PostHogIdentify>` and
+ * `<PostHogPageview>` call `posthog.identify(...)` / `posthog.capture(...)`
+ * BEFORE init has run — posthog-js silently no-ops pre-init, dropping
+ * the first pageview and first identify of every session. Running init
+ * at module scope guarantees it has already executed by the time any
+ * child effect fires. `posthog.init` is idempotent per posthog-js docs,
+ * so re-imports / HMR are safe.
+ *
+ * If `NEXT_PUBLIC_POSTHOG_KEY` is absent at BUILD time (NEXT_PUBLIC_*
+ * are baked at build), the module-scope init is skipped and posthog-js
+ * silently no-ops — this is fail-open by design for OSS forks that
+ * don't run PostHog.
+ */
+if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+        // We capture $pageview manually below so SPA route changes count.
+        capture_pageview: false,
+        capture_pageleave: true,
+        // Default is `true`, but be explicit for reviewer clarity.
+        autocapture: true,
+        session_recording: {
+            // Mask every input regardless of `type`. Per-type masking
+            // (`maskInputOptions: { email: true, password: true }`) only
+            // matches the literal `input[type]` attribute, so anything
+            // rendered as `type="text"` — API key fields, custom
+            // autocomplete, legacy forms — would otherwise be recorded
+            // verbatim. Secure by default.
+            maskAllInputs: true,
+        },
+        persistence: 'localStorage+cookie',
+        loaded: (ph) => {
+            if (process.env.NODE_ENV === 'development') ph.debug();
+        },
+    });
+}
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+    return (
+        <PHProvider client={posthog}>
+            {/* Suspense is required: `useSearchParams` triggers a CSR bailout
+                for the whole route if it's not wrapped, which would force
+                every page below into client rendering. */}
+            <Suspense fallback={null}>
+                <PostHogPageview />
+            </Suspense>
+            {children}
+        </PHProvider>
+    );
+}
+
+/**
+ * Fires `$pageview` on every App Router navigation. The native
+ * `capture_pageview` PostHog option only triggers on full document loads,
+ * which never happens in an SPA after first paint.
+ */
+export function PostHogPageview() {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+        if (!pathname) return;
+
+        let url = window.origin + pathname;
+        const qs = searchParams?.toString();
+        if (qs) {
+            url = url + '?' + qs;
+        }
+
+        posthog.capture('$pageview', { $current_url: url });
+    }, [pathname, searchParams]);
+
+    return null;
+}

--- a/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
+++ b/apps/web/src/components/posthog/PostHogProvider.unit.spec.tsx
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+/**
+ * Tests for the platform's client-side PostHog wiring.
+ *
+ * The provider is fail-open: when `NEXT_PUBLIC_POSTHOG_KEY` is unset
+ * (the OSS-fork case) `posthog.init` MUST NOT be called. When the key
+ * is set we expect `init` with the right host. Init runs at MODULE LOAD
+ * time (not in an effect) — see the comment in PostHogProvider.tsx for
+ * why — so these tests use `vi.resetModules()` plus a dynamic
+ * `await import(...)` to observe the side effect of the module's top-
+ * level code under each env-var configuration.
+ *
+ * The companion pageview component must emit `$pageview` on every App
+ * Router navigation, since `capture_pageview: false` disables PostHog's
+ * built-in handler. The identify component must call `posthog.reset()`
+ * on unmount so logout (which tears down the dashboard layout) clears
+ * the distinct_id.
+ */
+
+const mockPathname = vi.fn<() => string>();
+const mockSearchParams = vi.fn<() => URLSearchParams>();
+
+vi.mock('next/navigation', () => ({
+    usePathname: () => mockPathname(),
+    useSearchParams: () => mockSearchParams(),
+}));
+
+// `posthog-js/react` <PostHogProvider> tries to mount things against the
+// real `posthog` global; for unit tests we don't care about its internals
+// and just render children as-is.
+vi.mock('posthog-js/react', () => ({
+    PostHogProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const initSpy = vi.fn();
+const captureSpy = vi.fn();
+const identifySpy = vi.fn();
+const resetSpy = vi.fn();
+vi.mock('posthog-js', () => ({
+    default: {
+        init: (...args: unknown[]) => initSpy(...args),
+        capture: (...args: unknown[]) => captureSpy(...args),
+        identify: (...args: unknown[]) => identifySpy(...args),
+        reset: (...args: unknown[]) => resetSpy(...args),
+        debug: () => undefined,
+    },
+}));
+
+// jsdom doesn't set `window.origin` reliably across versions; pin it so
+// the assertion on `$current_url` is deterministic.
+Object.defineProperty(window, 'origin', {
+    configurable: true,
+    value: 'http://localhost:3000',
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+    initSpy.mockReset();
+    captureSpy.mockReset();
+    identifySpy.mockReset();
+    resetSpy.mockReset();
+    mockPathname.mockReturnValue('/dashboard');
+    mockSearchParams.mockReturnValue(new URLSearchParams());
+    process.env = { ...ORIGINAL_ENV };
+    // Module-scope init runs once per import. Reset the registry so the
+    // dynamic import in each test re-evaluates against the current env.
+    vi.resetModules();
+});
+
+afterEach(() => {
+    cleanup();
+    process.env = ORIGINAL_ENV;
+});
+
+describe('PostHogProvider', () => {
+    it('initializes posthog at module load when NEXT_PUBLIC_POSTHOG_KEY is set', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+        process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+        // Importing the module is what triggers `posthog.init(...)` —
+        // assert BEFORE rendering anything to prove init does not
+        // depend on the component mounting.
+        await import('./PostHogProvider');
+
+        expect(initSpy).toHaveBeenCalledTimes(1);
+        const [key, opts] = initSpy.mock.calls[0] as [string, Record<string, unknown>];
+        expect(key).toBe('phc_test_key');
+        expect(opts.api_host).toBe('https://us.i.posthog.com');
+        // Manual pageview capture is the whole point — make sure we
+        // didn't regress to PostHog's built-in handler.
+        expect(opts.capture_pageview).toBe(false);
+        expect(opts.capture_pageleave).toBe(true);
+        expect(opts.autocapture).toBe(true);
+        const replay = opts.session_recording as Record<string, unknown>;
+        // Secure by default: mask every input regardless of `type`.
+        // Per-type masking via `maskInputOptions` is unreliable when
+        // sensitive fields render as `type="text"`.
+        expect(replay.maskAllInputs).toBe(true);
+        expect(replay.maskInputOptions).toBeUndefined();
+    });
+
+    it('does NOT initialize posthog when NEXT_PUBLIC_POSTHOG_KEY is empty (OSS-fork case)', async () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+        await import('./PostHogProvider');
+
+        expect(initSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('PostHogPageview', () => {
+    it('fires a $pageview capture on mount including query string', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+        mockPathname.mockReturnValue('/dashboard/works');
+        mockSearchParams.mockReturnValue(new URLSearchParams('q=foo&page=2'));
+
+        const { PostHogPageview } = await import('./PostHogProvider');
+        // Module-scope init also fires when the module is imported;
+        // clear capture spy AFTER import so we observe only the
+        // pageview emitted by the component effect.
+        captureSpy.mockReset();
+        render(<PostHogPageview />);
+
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+        const [event, props] = captureSpy.mock.calls[0] as [string, { $current_url: string }];
+        expect(event).toBe('$pageview');
+        expect(props.$current_url).toBe('http://localhost:3000/dashboard/works?q=foo&page=2');
+    });
+
+    it('fires $pageview again when the pathname changes (SPA navigation)', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+        mockPathname.mockReturnValue('/dashboard');
+        mockSearchParams.mockReturnValue(new URLSearchParams());
+
+        const { PostHogPageview } = await import('./PostHogProvider');
+        captureSpy.mockReset();
+        const { rerender } = render(<PostHogPageview />);
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+
+        mockPathname.mockReturnValue('/dashboard/works/abc');
+        rerender(<PostHogPageview />);
+
+        expect(captureSpy).toHaveBeenCalledTimes(2);
+        const [, props] = captureSpy.mock.calls[1] as [string, { $current_url: string }];
+        expect(props.$current_url).toBe('http://localhost:3000/dashboard/works/abc');
+    });
+
+    it('does NOT fire pageview when NEXT_PUBLIC_POSTHOG_KEY is empty', async () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+        mockPathname.mockReturnValue('/dashboard');
+
+        const { PostHogPageview } = await import('./PostHogProvider');
+        render(<PostHogPageview />);
+
+        expect(captureSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('PostHogIdentify', () => {
+    it('calls posthog.reset() on unmount so logout clears the distinct_id', async () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+
+        const { PostHogIdentify } = await import('./PostHogIdentify');
+        const { unmount } = render(
+            <PostHogIdentify userId="u1" email="u1@example.com" name="U One" />,
+        );
+
+        // Identify ran on mount.
+        expect(identifySpy).toHaveBeenCalledTimes(1);
+        expect(resetSpy).not.toHaveBeenCalled();
+
+        unmount();
+
+        // Unmount cleanup fires reset, even though `userId` never
+        // transitioned to falsy.
+        expect(resetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call posthog on unmount when NEXT_PUBLIC_POSTHOG_KEY is empty', async () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+        const { PostHogIdentify } = await import('./PostHogIdentify');
+        const { unmount } = render(<PostHogIdentify userId="u1" />);
+        unmount();
+
+        expect(identifySpy).not.toHaveBeenCalled();
+        expect(resetSpy).not.toHaveBeenCalled();
+    });
+});

--- a/docs/plugin-system/ai-provider-plugins.md
+++ b/docs/plugin-system/ai-provider-plugins.md
@@ -161,6 +161,38 @@ Groq provides extremely fast inference through custom LPU hardware. Ideal for la
 
 Ollama runs models locally. Users must have Ollama installed and running. The `baseUrl` setting (default: `http://localhost:11434`) points to the local Ollama instance.
 
+### LM Studio
+
+| Property           | Value                          |
+| ------------------ | ------------------------------ |
+| Package            | `@ever-works/lm-studio-plugin` |
+| Provider Type      | `lm-studio`                    |
+| Configuration Mode | `user-required`                |
+| Default Model      | User's loaded model            |
+| Structured Output  | Model dependent                |
+| Streaming          | Yes                            |
+| Tool Calling       | Model dependent                |
+| Vision             | Model dependent                |
+| Embeddings         | Model dependent                |
+
+LM Studio runs models locally and serves them through an OpenAI-compatible API. Start the **Local Server** in the LM Studio app; the `baseUrl` setting (default: `http://localhost:1234/v1`) points to it. No API key is required by default. The model fields have no hardcoded default — they are populated from the currently loaded model via the `model-select` widget.
+
+### vLLM
+
+| Property           | Value                     |
+| ------------------ | ------------------------- |
+| Package            | `@ever-works/vllm-plugin` |
+| Provider Type      | `vllm`                    |
+| Configuration Mode | `user-required`           |
+| Default Model      | Server's `--model`        |
+| Structured Output  | Model dependent           |
+| Streaming          | Yes                       |
+| Tool Calling       | Model dependent           |
+| Vision             | Model dependent           |
+| Embeddings         | Model dependent           |
+
+vLLM is a high-throughput inference server, usually deployed on a GPU host. It exposes an OpenAI-compatible API; the `baseUrl` setting (default: `http://localhost:8000/v1`) points to it. The `apiKey` field defaults to vLLM's `EMPTY` placeholder and is only needed when the server was started with `--api-key` (it is stored encrypted via `x-secret`). For the managed cloud to reach a vLLM server, the base URL must be resolvable from where work generation runs — see the [vLLM plugin page](./vllm-plugin.md) for the networking note.
+
 ### Mistral
 
 | Property           | Value                        |

--- a/docs/plugin-system/built-in-plugins.md
+++ b/docs/plugin-system/built-in-plugins.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 # Built-in Plugins
 
-The platform ships with 40 plugins across the AI provider, search, content extraction, screenshot, git, deployment, pipeline, data source, and utility categories. This page documents each plugin, its configuration, and environment variables.
+The platform ships with 42 plugins across the AI provider, search, content extraction, screenshot, git, deployment, pipeline, data source, and utility categories. This page documents each plugin, its configuration, and environment variables.
 
 ## AI Providers
 
@@ -117,6 +117,42 @@ Use locally running models via Ollama. No API key required.
 | `baseUrl`      | string | —        | Ollama URL (required, e.g., `http://localhost:11434/v1`) |
 | `defaultModel` | string | `llama2` | Default model                                            |
 | `apiKey`       | string | `ollama` | API key (optional, defaults to `ollama`)                 |
+
+### LM Studio
+
+Use locally running models via the LM Studio local server. No API key required.
+
+| Field              | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `lm-studio`     |
+| Configuration Mode | `user-required` |
+| Auto Enable        | No              |
+
+**Settings:**
+
+| Setting        | Type   | Default     | Description                                                      |
+| -------------- | ------ | ----------- | ---------------------------------------------------------------- |
+| `baseUrl`      | string | —           | LM Studio URL (required, e.g., `http://localhost:1234/v1`)       |
+| `apiKey`       | string | `lm-studio` | API key (optional; only for an auth proxy in front of LM Studio) |
+| `defaultModel` | string | —           | Loaded model id (required; populated via the model picker)       |
+
+### vLLM
+
+Use a self-hosted vLLM OpenAI-compatible server (typically GPU-hosted).
+
+| Field              | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `vllm`          |
+| Configuration Mode | `user-required` |
+| Auto Enable        | No              |
+
+**Settings:**
+
+| Setting        | Type   | Default | Description                                                          |
+| -------------- | ------ | ------- | -------------------------------------------------------------------- |
+| `baseUrl`      | string | —       | vLLM URL (required, e.g., `http://localhost:8000/v1`)                |
+| `apiKey`       | string | `EMPTY` | API key (secret; only required if started with `--api-key`)          |
+| `defaultModel` | string | —       | Model id passed to `vllm serve --model` (required; via model picker) |
 
 ### Mistral
 

--- a/docs/plugin-system/lm-studio-plugin.md
+++ b/docs/plugin-system/lm-studio-plugin.md
@@ -1,0 +1,121 @@
+---
+id: lm-studio-plugin
+title: 'LM Studio Plugin'
+sidebar_label: 'LM Studio'
+sidebar_position: 24
+---
+
+# LM Studio AI Provider Plugin
+
+The LM Studio plugin connects Ever Works to a local or remote [LM Studio](https://lmstudio.ai) server for self-hosted AI inference. It extends `BaseAiProvider` and uses the shared `AiOperations` layer that wraps LangChain under the hood.
+
+**Source:** `packages/plugins/lm-studio/src/lm-studio.plugin.ts`
+
+## Overview
+
+| Property           | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `lm-studio`     |
+| Category           | `ai-provider`   |
+| Capabilities       | `ai-provider`   |
+| Version            | `1.0.0`         |
+| Configuration Mode | `user-required` |
+| Provider Type      | `lm-studio`     |
+| Auto-enable        | No              |
+| Built-in           | Yes             |
+| Visibility         | `public`        |
+
+LM Studio runs open-source models (Llama, Qwen, Mistral, Gemma, …) on your own machine and exposes them through an OpenAI-compatible API. Because the server is local, your data never leaves your infrastructure, and there are no per-token costs.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[AiFacadeService] --> B[LmStudioPlugin]
+    B --> C[BaseAiProvider]
+    C --> D[AiOperations]
+    D --> E[LangChain OpenAI-compatible Provider]
+    E --> F[LM Studio Server /v1 endpoint]
+```
+
+The plugin talks to LM Studio through its OpenAI-compatible `/v1` API endpoint, so any model loaded in LM Studio works without additional configuration.
+
+## Configuration
+
+### Settings Schema
+
+| Setting          | Type     | Default     | Scope    | Description                                                            |
+| ---------------- | -------- | ----------- | -------- | ---------------------------------------------------------------------- |
+| `baseUrl`        | `string` | —           | `user`   | Address of the LM Studio server (e.g. `http://localhost:1234/v1`)      |
+| `apiKey`         | `string` | `lm-studio` | `user`   | Only needed for an auth proxy in front of LM Studio (stored encrypted) |
+| `defaultModel`   | `string` | —           | `global` | Used for all AI tasks unless a tier-specific model is set              |
+| `simpleModel`    | `string` | —           | `global` | Handles tags, short descriptions, and quick classifications            |
+| `mediumModel`    | `string` | —           | `global` | Handles listings, summaries, and content reformatting                  |
+| `complexModel`   | `string` | —           | `global` | Handles full page generation and multi-step analysis                   |
+| `embeddingModel` | `string` | —           | `global` | Model for semantic-search embeddings (only needed for KB search)       |
+| `temperature`    | `number` | `0.7`       | hidden   | Controls output randomness (0 = deterministic, 2 = creative)           |
+| `maxTokens`      | `number` | `4096`      | hidden   | Maximum length of each AI-generated response                           |
+
+Model fields use the `x-widget: model-select` extension, which renders a model dropdown in the dashboard UI populated by calling `listModels()` against the configured server. Unlike cloud providers, **the model fields ship without a hardcoded default** — LM Studio serves whatever model you have loaded, so you select it after the connection succeeds.
+
+### Required Fields
+
+- `baseUrl` — the LM Studio server address
+- `defaultModel` — at least one model must be selected
+
+## Model Capabilities
+
+```typescript
+getCapabilities(): AiModelCapabilities {
+    return {
+        supportsStructuredOutput: true,
+        supportsStreaming: true,
+        supportsToolCalling: true,
+        supportsVision: true,
+        maxContextLength: 128000
+    };
+}
+```
+
+These are advisory hints — actual support depends on the model you load in LM Studio.
+
+## Lifecycle
+
+### Loading
+
+```typescript
+async onLoad(context: PluginContext): Promise<void> {
+    await super.onLoad(context);
+    this.aiOps = new AiOperations({
+        apiKey: 'lm-studio',
+        model: this.getDefaultModelId(),
+        baseURL: 'http://localhost:1234/v1',
+        temperature: 0.7,
+        maxTokens: 4096,
+        providerType: 'lm-studio'
+    });
+}
+```
+
+On load the plugin creates an `AiOperations` instance with default values. When a request arrives, `resolveConfig()` merges the user's saved settings on top of these defaults before executing.
+
+### Availability Check
+
+`isAvailable()` calls `AiOperations.testConnection()` with the resolved configuration to verify the LM Studio server is reachable. The setup UI uses this (via `validateConnection()`) to detect connectivity before saving.
+
+## Getting Started
+
+1. Install LM Studio from [lmstudio.ai](https://lmstudio.ai) and download at least one model.
+2. Start the **Local Server** in LM Studio (Developer tab) — it listens on `http://localhost:1234` by default.
+3. Enable the LM Studio plugin in **Settings → Plugins**.
+4. Set the **LM Studio Server URL** to your instance address (include the `/v1` suffix).
+5. Select your preferred model for each task complexity tier.
+
+## Troubleshooting
+
+| Issue                    | Cause                        | Solution                                                         |
+| ------------------------ | ---------------------------- | ---------------------------------------------------------------- |
+| Plugin shows unavailable | Local server not started     | Open LM Studio → Developer → **Start Server**                    |
+| No models in dropdown    | No model loaded              | Load a model in the LM Studio app                                |
+| Connection refused       | Wrong base URL               | Verify the URL includes `/v1` (e.g., `http://localhost:1234/v1`) |
+| Slow responses           | Model too large for hardware | Use a smaller / quantized model or increase available RAM/VRAM   |

--- a/docs/plugin-system/vllm-plugin.md
+++ b/docs/plugin-system/vllm-plugin.md
@@ -1,0 +1,125 @@
+---
+id: vllm-plugin
+title: 'vLLM Plugin'
+sidebar_label: 'vLLM'
+sidebar_position: 25
+---
+
+# vLLM AI Provider Plugin
+
+The vLLM plugin connects Ever Works to a self-hosted [vLLM](https://docs.vllm.ai) server for high-throughput, private AI inference. It extends `BaseAiProvider` and uses the shared `AiOperations` layer that wraps LangChain under the hood.
+
+**Source:** `packages/plugins/vllm/src/vllm.plugin.ts`
+
+## Overview
+
+| Property           | Value           |
+| ------------------ | --------------- |
+| Plugin ID          | `vllm`          |
+| Category           | `ai-provider`   |
+| Capabilities       | `ai-provider`   |
+| Version            | `1.0.0`         |
+| Configuration Mode | `user-required` |
+| Provider Type      | `vllm`          |
+| Auto-enable        | No              |
+| Built-in           | Yes             |
+| Visibility         | `public`        |
+
+vLLM is a high-throughput inference engine (PagedAttention) for open-source models, usually deployed on a GPU server. It exposes an OpenAI-compatible API, so Ever Works can use it for content generation, conversations, and embeddings while keeping data on your own infrastructure.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[AiFacadeService] --> B[VllmPlugin]
+    B --> C[BaseAiProvider]
+    C --> D[AiOperations]
+    D --> E[LangChain OpenAI-compatible Provider]
+    E --> F[vLLM Server /v1 endpoint]
+```
+
+The plugin talks to vLLM through its OpenAI-compatible `/v1` API endpoint. vLLM serves the model it was launched with (`vllm serve --model ...`).
+
+## Configuration
+
+### Settings Schema
+
+| Setting          | Type     | Default | Scope    | Description                                                          |
+| ---------------- | -------- | ------- | -------- | -------------------------------------------------------------------- |
+| `baseUrl`        | `string` | —       | `user`   | Address of the vLLM server (e.g. `http://localhost:8000/v1`)         |
+| `apiKey`         | `string` | `EMPTY` | `user`   | Only required if the server was started with `--api-key` (encrypted) |
+| `defaultModel`   | `string` | —       | `global` | Used for all AI tasks unless a tier-specific model is set            |
+| `simpleModel`    | `string` | —       | `global` | Handles tags, short descriptions, and quick classifications          |
+| `mediumModel`    | `string` | —       | `global` | Handles listings, summaries, and content reformatting                |
+| `complexModel`   | `string` | —       | `global` | Handles full page generation and multi-step analysis                 |
+| `embeddingModel` | `string` | —       | `global` | Model for semantic-search embeddings (only needed for KB search)     |
+| `temperature`    | `number` | `0.7`   | hidden   | Controls output randomness (0 = deterministic, 2 = creative)         |
+| `maxTokens`      | `number` | `4096`  | hidden   | Maximum length of each AI-generated response                         |
+
+The `apiKey` field is marked `x-secret`, so a real token is stored encrypted. It defaults to vLLM's documented `EMPTY` placeholder, which an unsecured server accepts. Model fields use `x-widget: model-select` and have **no hardcoded default** — set them to the model id vLLM was launched with.
+
+### Required Fields
+
+- `baseUrl` — the vLLM server address
+- `defaultModel` — at least one model must be selected
+
+## Networking note (managed cloud vs self-hosted)
+
+The inference HTTP call is made by whoever runs work generation. For the **managed Ever Works cloud** to use your vLLM server, the `baseUrl` must be reachable from where generation runs — i.e. a public or VPN-reachable URL secured with `--api-key`. A `localhost` URL only resolves correctly when Ever Works itself runs on the **same machine or LAN** as the vLLM server (self-hosted deployment). vLLM is the most common "remote endpoint" case because it is typically GPU-hosted rather than on a laptop.
+
+## Model Capabilities
+
+```typescript
+getCapabilities(): AiModelCapabilities {
+    return {
+        supportsStructuredOutput: true,
+        supportsStreaming: true,
+        supportsToolCalling: true,
+        supportsVision: true,
+        maxContextLength: 128000
+    };
+}
+```
+
+These are advisory hints — actual support depends on the served model and the flags vLLM was started with (e.g. tool calling needs `--enable-auto-tool-choice`).
+
+## Lifecycle
+
+### Loading
+
+```typescript
+async onLoad(context: PluginContext): Promise<void> {
+    await super.onLoad(context);
+    this.aiOps = new AiOperations({
+        apiKey: 'EMPTY',
+        model: this.getDefaultModelId(),
+        baseURL: 'http://localhost:8000/v1',
+        temperature: 0.7,
+        maxTokens: 4096,
+        providerType: 'vllm'
+    });
+}
+```
+
+When a request arrives, `resolveConfig()` merges the user's saved settings (base URL, API key, selected model) on top of these defaults before executing.
+
+### Availability Check
+
+`isAvailable()` calls `AiOperations.testConnection()` with the resolved configuration. The setup UI uses this (via `validateConnection()`) to detect connectivity and authentication before saving.
+
+## Getting Started
+
+1. Start a vLLM OpenAI-compatible server: `vllm serve <model>` (listens on `http://localhost:8000` by default).
+2. If you secured it with `--api-key <token>`, have that token ready.
+3. Enable the vLLM plugin in **Settings → Plugins**.
+4. Set the **vLLM Server URL** (include the `/v1` suffix) and, if needed, the **API Key**.
+5. Select the model your server is serving for each task complexity tier.
+
+## Troubleshooting
+
+| Issue                     | Cause                                               | Solution                                                                       |
+| ------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Plugin shows unavailable  | Server not running or unreachable from Ever Works   | Confirm `vllm serve` is up and the base URL is reachable (see networking note) |
+| `401` / `Invalid API key` | Server started with `--api-key` but token missing   | Enter the exact `--api-key` token in the **API Key** field                     |
+| `Model not found`         | Selected model differs from the one vLLM is serving | Set the model fields to the value passed to `vllm serve --model ...`           |
+| No models in dropdown     | Connection failed before `listModels()` could run   | Fix the base URL / API key first, then re-open the model picker                |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -22,7 +22,8 @@ docs/specs/
 │   ├── 001-pipeline-checkpointing.md
 │   ├── 002-trigger-worker-callback-channel.md
 │   ├── 003-pnpm-overrides-strategy.md
-│   └── 015-job-runtime-provider-pluggability.md  # Pluggable background-job runtime
+│   ├── 015-job-runtime-provider-pluggability.md  # Pluggable background-job runtime
+│   └── 016-dynamic-plugin-distribution.md  # Dual-mode bundled + runtime npm
 ├── architecture/                   # Cross-feature architecture docs
 │   ├── README.md                   # Reading order + companion-pair index
 │   ├── job-runtime-providers.md    # Pluggable runtime contract + worker models
@@ -30,6 +31,7 @@ docs/specs/
 │   ├── pipeline-executor.md        # Executor / step / modifier substrate
 │   ├── trigger-integration.md      # Trigger.dev wiring
 │   ├── plugin-sdk.md               # @ever-works/plugin SDK deep-dive
+│   ├── runtime-plugins.md          # Dual-mode distribution + runtime installer
 │   ├── settings-system.md          # 3-tier resolution + secret hygiene
 │   ├── ai-facade.md                # AiFacadeService routing & model catalog
 │   ├── auth.md                     # JWT + OAuth + API keys + device flow
@@ -58,6 +60,7 @@ docs/specs/
     ├── comparisons/
     ├── creating-a-work/
     ├── custom-domains/
+    ├── dynamic-plugin-distribution/
     ├── data-generator/
     ├── data-management/
     ├── work-changelog/
@@ -86,31 +89,32 @@ full Spec Kit format and retain their deeper architectural `spec.md`
 (see also their `acceptance.md` for the original acceptance criteria
 which now live folded into `tasks.md`).
 
-| Feature                                                            | Status        | Description                                                                                   |
-| ------------------------------------------------------------------ | ------------- | --------------------------------------------------------------------------------------------- |
-| [`advanced-prompts`](features/advanced-prompts/spec)               | Retrospective | Per-work prompt overrides per pipeline step                                                   |
-| [`api-keys`](features/api-keys/spec)                               | Retrospective | Long-lived auth tokens for CI / CLI / MCP                                                     |
-| [`collections`](features/collections/spec)                         | Retrospective | Editorial groupings cutting across categories                                                 |
-| [`community-pr-processing`](features/community-pr-processing/spec) | Retrospective | AI-driven processing of community-contributed PRs                                             |
-| [`comparisons`](features/comparisons/spec)                         | Retrospective | A vs B comparison page generator                                                              |
-| [`creating-a-work`](features/creating-a-work/spec)                 | Retrospective | Three creation methods: AI / Manual / Import                                                  |
-| [`custom-domains`](features/custom-domains/spec)                   | Retrospective | Branded domain assignment with provider sync                                                  |
-| [`data-generator`](features/data-generator/spec)                   | Retrospective | Data repository management and item persistence                                               |
-| [`data-management`](features/data-management/spec)                 | Retrospective | Export / Import / GitHub Sync with secret hygiene                                             |
-| [`work-changelog`](features/work-changelog/spec)                   | Retrospective | Audit trail of all work mutations                                                             |
-| [`work-import`](features/work-import/spec)                         | Retrospective | Bootstrap from existing repo or Awesome List                                                  |
-| [`work-members`](features/work-members/spec)                       | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)                                  |
-| [`generation-cancellation`](features/generation-cancellation/spec) | Retrospective | Mid-flight generation cancel with four mode paths                                             |
-| [`git-operations`](features/git-operations/spec)                   | Retrospective | `GitFacadeService` and provider plugin contract                                               |
-| [`job-runtime-providers`](features/job-runtime-providers/spec)     | Draft         | Pluggable background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) |
-| [`item-source-validation`](features/item-source-validation/spec)   | Retrospective | Reachability + AI accuracy checks per item                                                    |
-| [`markdown-generator`](features/markdown-generator/spec)           | Retrospective | Markdown rendering pipeline                                                                   |
-| [`mcp-server`](features/mcp-server/spec)                           | Retrospective | OpenAPI-derived MCP tool surface                                                              |
-| [`plugin-system`](features/plugin-system/spec)                     | Retrospective | Capability-driven plugin architecture (39 first-party plugins)                                |
-| [`scheduled-updates`](features/scheduled-updates/spec)             | Retrospective | Cron-driven generation with CAS claim and drift correction                                    |
-| [`taxonomy-system`](features/taxonomy-system/spec)                 | Retrospective | Categories, tags, and collections in the data repo                                            |
-| [`website-generator`](features/website-generator/spec)             | Retrospective | Static site generation pipeline                                                               |
-| [`works-config`](features/works-config/spec)                       | Retrospective | `.works/works.yml` source-controlled work configuration                                       |
+| Feature                                                                    | Status        | Description                                                                                   |
+| -------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| [`advanced-prompts`](features/advanced-prompts/spec)                       | Retrospective | Per-work prompt overrides per pipeline step                                                   |
+| [`api-keys`](features/api-keys/spec)                                       | Retrospective | Long-lived auth tokens for CI / CLI / MCP                                                     |
+| [`collections`](features/collections/spec)                                 | Retrospective | Editorial groupings cutting across categories                                                 |
+| [`community-pr-processing`](features/community-pr-processing/spec)         | Retrospective | AI-driven processing of community-contributed PRs                                             |
+| [`comparisons`](features/comparisons/spec)                                 | Retrospective | A vs B comparison page generator                                                              |
+| [`creating-a-work`](features/creating-a-work/spec)                         | Retrospective | Three creation methods: AI / Manual / Import                                                  |
+| [`custom-domains`](features/custom-domains/spec)                           | Retrospective | Branded domain assignment with provider sync                                                  |
+| [`data-generator`](features/data-generator/spec)                           | Retrospective | Data repository management and item persistence                                               |
+| [`data-management`](features/data-management/spec)                         | Retrospective | Export / Import / GitHub Sync with secret hygiene                                             |
+| [`dynamic-plugin-distribution`](features/dynamic-plugin-distribution/spec) | Draft         | Dual-mode plugins: bundle all, or core-only + runtime npm install                             |
+| [`work-changelog`](features/work-changelog/spec)                           | Retrospective | Audit trail of all work mutations                                                             |
+| [`work-import`](features/work-import/spec)                                 | Retrospective | Bootstrap from existing repo or Awesome List                                                  |
+| [`work-members`](features/work-members/spec)                               | Retrospective | Role-based collaboration (Owner / Manager / Editor / Viewer)                                  |
+| [`generation-cancellation`](features/generation-cancellation/spec)         | Retrospective | Mid-flight generation cancel with four mode paths                                             |
+| [`git-operations`](features/git-operations/spec)                           | Retrospective | `GitFacadeService` and provider plugin contract                                               |
+| [`job-runtime-providers`](features/job-runtime-providers/spec)             | Draft         | Pluggable background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest) |
+| [`item-source-validation`](features/item-source-validation/spec)           | Retrospective | Reachability + AI accuracy checks per item                                                    |
+| [`markdown-generator`](features/markdown-generator/spec)                   | Retrospective | Markdown rendering pipeline                                                                   |
+| [`mcp-server`](features/mcp-server/spec)                                   | Retrospective | OpenAPI-derived MCP tool surface                                                              |
+| [`plugin-system`](features/plugin-system/spec)                             | Retrospective | Capability-driven plugin architecture (39 first-party plugins)                                |
+| [`scheduled-updates`](features/scheduled-updates/spec)                     | Retrospective | Cron-driven generation with CAS claim and drift correction                                    |
+| [`taxonomy-system`](features/taxonomy-system/spec)                         | Retrospective | Categories, tags, and collections in the data repo                                            |
+| [`website-generator`](features/website-generator/spec)                     | Retrospective | Static site generation pipeline                                                               |
+| [`works-config`](features/works-config/spec)                               | Retrospective | `.works/works.yml` source-controlled work configuration                                       |
 
 ## Reading order for new contributors
 

--- a/docs/specs/architecture/runtime-plugins.md
+++ b/docs/specs/architecture/runtime-plugins.md
@@ -1,0 +1,244 @@
+# Architecture: Runtime Plugin Distribution
+
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+**Audience**: AI agents and engineers implementing dual-mode plugin distribution.
+
+> Companion to [`plugin-sdk`](./plugin-sdk.md) (the SDK plugins build against)
+> and the feature spec [`dynamic-plugin-distribution`](../features/dynamic-plugin-distribution/spec.md).
+> This doc describes **how plugins are distributed, installed, and executed** at
+> runtime — `plugin-sdk.md` describes the contract; this describes the supply chain.
+
+---
+
+## 1. Purpose
+
+The platform supports two distribution modes that share one code path:
+
+- **`bundled`** (default, today): every plugin in `packages/plugins/*` is built
+  into the image and discovered from disk at boot. No registry, no enable-time
+  network.
+- **`dynamic`**: only **core** plugins ship in the image; **distributable**
+  plugins are published to npm + GitHub Packages and pulled, verified, and
+  loaded at runtime when first enabled.
+
+This decouples "what code exists in the repo" (always all of it) from "what gets
+installed and shipped" (all, or core-only + on-demand). The selector is
+`PLUGIN_DISTRIBUTION_MODE`; default `bundled` so existing deployments are inert
+to this feature.
+
+## 2. Why this exists
+
+In bundled mode, `pnpm install` resolves the dependency closure of all ~49
+plugins, and the image carries every plugin's third-party SDK whether or not it
+is enabled. Adding integrations (Principle I + the official-SDK rule, EW-682)
+therefore grows install time and image size linearly with the unique SDK trees
+each plugin drags in (e.g. `@kubernetes/client-node`, `@vercel/sdk`,
+`@notionhq/client`, `@aws-sdk/*`). Dynamic mode lets a deployment pay only for
+the plugins it uses.
+
+## 3. Core vs distributable
+
+Classification is declared on the plugin via the manifest field `distribution`
+(`'core' | 'registry'`), defaulting from `systemPlugin`:
+
+- **Core** (`distribution: 'core'`) — always bundled, present in both modes,
+  never fetched from a registry. Comprises **every `systemPlugin: true` plugin**:
+  `agent-pipeline`, `comparison-generator`, `github`, `k8s`,
+  `local-content-extractor`, `local-fs`, `openrouter`, `standard-pipeline`,
+  `tavily`, `vercel`. `local-fs` doubles as the **default storage backend** so the
+  API boots with working storage even when no distributable storage plugin is
+  enabled.
+- **Distributable** (`distribution: 'registry'`) — everything else, **including**
+  the storage plugins `aws-s3`, `github-storage`, and `minio`. The API today hard
+  imports those three in `apps/api/package.json`; that coupling is **removed** and
+  storage is resolved through the capability facade/registry, which is what lets
+  them be distributable (see EW-693 T8b).
+
+The manifest is the source of truth; the value is denormalised onto the
+`plugins` row for listing.
+
+## 4. Build & publish
+
+Plugins build with **tsup** exactly as today (ESM `index.js` + CJS `index.cjs` +
+`index.d.ts`, deps external, `@ever-works/plugin` as peer). Distribution adds a
+**publish** step:
+
+- **Versioning**: Changesets, **independent** per plugin — a plugin release does
+  not require a platform release (today all plugins are lockstep `1.0.0`).
+- **Targets**: each distributable plugin is published to **both** the public npm
+  registry and the **GitHub Packages** `@ever-works` registry on release, via a
+  CI workflow mirroring the auth pattern of `.github/workflows/publish-cli.yml`.
+- **Privacy**: distributable plugins flip `private: true → false` with
+  `publishConfig`; core plugins may remain unpublished.
+- **Provenance**: rely on npm package integrity (sha512) and first-party npm
+  provenance; no bespoke signing in v1.
+
+## 5. Runtime install path (dynamic mode)
+
+```
+User clicks Enable (plugin not installed)
+  → plugins.controller → PluginOperationsService.enable
+    → PluginInstallerService.install(pluginId)
+        1. resolve pkg@exactVersion from registry (PLUGIN_REGISTRY_URL / GitHub)
+        2. allowlist check FIRST (first-party @ever-works/* implicit; else
+           must match an enabled plugin_allowlist row) — refuse before download
+        3. download + verify integrity (sha512) — mismatch ⇒ refuse
+        4. place into PLUGIN_INSTALL_DIR (default /app/plugins)
+        5. PluginLoaderService.load(installPath)  ← existing dynamic import()
+        6. PluginRegistryService.register + persist (source='registry',
+           installedVersion, integrity, installState='installed')
+    → existing enable (UserPluginEntity/WorkPluginEntity flip)
+```
+
+Key properties:
+
+- **Install ≠ enable ≠ load** stay distinct (the SDK already separates
+  load/enable). Dynamic mode inserts _install + load_ in front of _enable_ only
+  when the plugin is absent.
+- **Idempotent + concurrency-guarded** per plugin id (two simultaneous enables
+  of the same plugin install once).
+- **Failure isolation**: a failed install records a reason on the plugin row
+  (`installState='error'`) and registers nothing partial; the rest of the system
+  is unaffected (spec FR-14).
+- The loader is unchanged — it already resolves `main`/`module` and
+  `await import(entryPath)`, and `DEFAULT_PLUGIN_PATHS` already includes
+  `./plugins` and `./node_modules/@ever-works`.
+
+## 6. Install propagation across replicas & workers
+
+Pods are ephemeral and replicas scale horizontally; the **database is the source
+of truth** for which distributable plugins are installed/enabled. With a
+per-replica store, two mechanisms keep every node consistent **without** a shared
+volume:
+
+**(a) Lazy install-on-use — the correctness guarantee.** Before any node (an API
+replica _or_ a job-runtime worker) invokes a distributable plugin, it ensures the
+package is present locally and installs it if not:
+
+```
+ensurePluginAvailable(pluginId):
+    rec = DB row for pluginId            # source, registrySpec, integrity
+    if rec.source == 'registry' and (not present in store OR integrity mismatch):
+        PluginInstallerService.install(rec.registrySpec, rec.integrity)  # idempotent, per-id lock
+    load + register if not already in this process's registry
+```
+
+This closes the gap Codex flagged: when pod A handles the first enable and marks
+the plugin `installed` in the DB, pod B (and the worker) do **not** need a restart
+— the first request that reaches them lazily installs the package before use. The
+per-id concurrency lock + integrity pin make concurrent lazy installs safe.
+
+**(b) Boot reconcile — a warmup optimisation.** On `onApplicationBootstrap` in
+dynamic mode, `PluginBootstrapService` pre-installs the DB-recorded
+installed/enabled set so a freshly-started replica is warm before taking traffic:
+
+```
+for each DB plugin where source='registry' and (installed or enabled):
+    ensurePluginAvailable(pluginId)
+optionally gate readiness until warmup completes
+```
+
+Reconcile is **not** the correctness mechanism (lazy install-on-use is) — it just
+avoids a first-request latency spike. A shared RWX volume or "bake popular plugins
+into the image" can further reduce cold-start cost, but neither is required.
+
+## 7. Execution model
+
+The base mechanism is the same dynamic `import()` everywhere; **where** a
+capability call runs is decided by `PluginExecutionRouterService` from the
+operation's `executionProfile`:
+
+- **`sync` / short calls** (e.g. list models, resolve config): run **in-process**
+  in the API via dynamic import. No job-runtime hop, lowest latency.
+- **`long-running` calls** (e.g. a generation pipeline step): dispatched to the
+  **pluggable job runtime** (Trigger.dev today). Plugin code imported inside the
+  task process is **already isolated** there, and the result returns through the
+  existing job result channel.
+
+> **The worker is a separate runtime with its own store.** The Trigger.dev worker
+> is deployed independently from the API and prepares its own `./plugins` bundle
+> at deploy time — so a plugin _installed at runtime in the API_ does **not**
+> exist in the worker. The long-running path therefore calls the same
+> `ensurePluginAvailable()` (§6 lazy install-on-use) inside the task **before**
+> invoking the plugin, installing into the worker's own store on first use. The
+> installer (`@ever-works/agent` plugins module) runs in the worker just as it
+> does in the API. Without this, an enable that succeeds in the API would fail the
+> first long-running call in the worker — the second P1 Codex flagged.
+
+This is why v1 needs no bespoke sandbox: long-running third-party work inherits
+the job runtime's isolation, and the install allowlist limits what can run at
+all. Making the job-runtime provider itself swappable (Temporal / BullMQ /
+others) is tracked in **EW-683** and is a dependency of the long-running path,
+not part of this feature.
+
+## 8. Security model
+
+- **Supply chain**: install restricted to first-party `@ever-works/*` +
+  admin-managed allowlist (`plugin_allowlist`); refusal happens before any
+  network fetch. Exact-version pinning + integrity verification before `import()`.
+- **Secrets**: registry auth tokens (GitHub Packages / private mirrors) are
+  secrets sourced from env/secret store, never logged or returned. Plugin
+  settings keep `x-secret` redaction (Principle VII / [settings-system](./settings-system.md)).
+- **Isolation**: long-running plugin execution runs in the isolated job runtime;
+  in-process execution is reserved for short calls and (in v1) trusted/allowlisted
+  code. Full sandboxing (isolated-vm / microVM) is a documented future phase.
+
+## 9. Deployment & filesystem
+
+- The API image WORKDIR is `/app`; root FS is writable today
+  (`readOnlyRootFilesystem: false`), and `/tmp` is an emptyDir. The runtime store
+  defaults to `PLUGIN_INSTALL_DIR=/app/plugins`.
+- **k8s**: mount a writable volume for the store (emptyDir per-replica with boot
+  reconcile, or an optional PVC); gate readiness on reconcile completion.
+- **bundled image** keeps shipping all plugins (current Dockerfile). The
+  **dynamic image** variant ships core-only via a build arg.
+- **Read-only-FS serverless** (Vercel, currently disabled) cannot install at
+  runtime — those targets support `bundled` only.
+
+## 10. Observability
+
+- Events/activity-log: `plugin.install.requested|succeeded|failed`,
+  `plugin.upgrade.*`, `plugin.uninstall.*` with id, version, source, duration,
+  reason.
+- Metrics: install latency/error-rate per plugin, boot-reconcile duration,
+  catalog-fetch failures.
+- Sentry tags: `plugin_id`, `plugin_source`, `distribution_mode`.
+
+## 11. Failure modes
+
+| Failure                                 | Behaviour                                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Registry unreachable                    | New installs fail cleanly + retryable; installed plugins keep working; reconcile retries on next boot. |
+| Package not permitted                   | Refused before download (allowlist), 409.                                                              |
+| Integrity mismatch                      | Refused, nothing loaded, 424.                                                                          |
+| Invalid manifest / incompatible version | Recorded `installState='error'` + reason, 422; nothing registered.                                     |
+| Throwing plugin constructor             | Same as load failure today — caught, recorded, isolated.                                               |
+| Mode switch (bundled↔dynamic)           | Reconcile on restart; user enable choices preserved in DB.                                             |
+
+## 12. Constitution Reconciliation
+
+| Principle                   | How this design respects it                                            |
+| --------------------------- | ---------------------------------------------------------------------- |
+| I — Plugin-first            | Plugins stay the integration unit; this is supply-chain plumbing.      |
+| II — Capability-driven      | Resolution/enable unchanged; install precedes them.                    |
+| III — Source-of-truth repos | Unaffected.                                                            |
+| IV — Trigger.dev            | Long-running plugin execution routed through the job runtime.          |
+| V — Forward-only migrations | New columns/table additive with defaults.                              |
+| VI — Tests                  | Installer/allowlist/reconcile/router/publish all tested.               |
+| VII — Secret hygiene        | Registry tokens + plugin creds are secrets; `x-secret` preserved.      |
+| VIII — Plugin counts        | Canonical built-in-plugins doc carries core vs distributable split.    |
+| IX — Behaviour-first        | Behaviour in the feature spec; this is architecture.                   |
+| X — Backwards-compat        | Default `bundled` preserves current behaviour; all additions additive. |
+
+## 13. References
+
+- Feature spec: [`features/dynamic-plugin-distribution/spec`](../features/dynamic-plugin-distribution/spec.md)
+- Plan: [`features/dynamic-plugin-distribution/plan`](../features/dynamic-plugin-distribution/plan.md)
+- ADR: [`decisions/016-dynamic-plugin-distribution`](../decisions/016-dynamic-plugin-distribution.md)
+- SDK: [`plugin-sdk`](./plugin-sdk.md)
+- Deployment: [`deployment`](./deployment.md)
+- Trigger.dev: [`trigger-integration`](./trigger-integration.md)
+- Source today: `packages/agent/src/plugins/`, `packages/agent/src/plugins/plugins.constants.ts`
+  (`DEFAULT_PLUGIN_PATHS`), `apps/api/src/config/constants.ts`
+- Jira: EW epic (this feature), [EW-683] (job-runtime pluggability)

--- a/docs/specs/decisions/016-dynamic-plugin-distribution.md
+++ b/docs/specs/decisions/016-dynamic-plugin-distribution.md
@@ -1,0 +1,110 @@
+# ADR-016: Dual-Mode Plugin Distribution (bundled + runtime npm install)
+
+## Status
+
+**Accepted** — decisions locked with @evereq 2026-05-28; implementation tracked under EW-693.
+
+## Date
+
+2026-05-28
+
+## Context
+
+Every plugin under `packages/plugins/*` is part of the pnpm workspace and is
+built into the platform image. Consequences today:
+
+- A clone + `pnpm install` resolves the dependency closure of **all** ~49
+  plugins, pulling every plugin's third-party SDK even for plugins that will
+  never be enabled.
+- The deployed artifact (and image) carries every plugin and its SDK regardless
+  of what any tenant enables. Plugins are discovered from disk
+  (`DEFAULT_PLUGIN_PATHS`) and dynamically `import()`-ed; there is no
+  tree-shaking by enable-state.
+- "Enable" is purely a DB flag flip today — all plugins are pre-loaded at boot.
+- The official-SDK rule (EW-682, AGENTS.md NN #22) means each new integration
+  adds a real runtime dependency, so install time and image size grow linearly
+  with the unique SDK trees plugins introduce.
+
+We want to keep the simple "everything bundled" model **and** add a mode where a
+deployment ships only core plugins and pulls the rest at runtime when enabled.
+
+## Decision
+
+Introduce a platform setting **`PLUGIN_DISTRIBUTION_MODE`** with two values:
+
+- **`bundled`** (default): current behaviour — all plugins in the image,
+  discovered from disk, no registry. Existing deployments are unaffected.
+- **`dynamic`**: only **core** plugins are bundled; **distributable** plugins are
+  published to a registry and pulled, integrity-verified, and loaded at runtime
+  on first enable, then reconciled from the database on every boot.
+
+Supporting decisions:
+
+1. **Core vs distributable is declared on the plugin** via a new manifest field
+   `distribution: 'core' | 'registry'`, defaulting from `systemPlugin`. Core =
+   all `systemPlugin: true` plugins + any plugin the API cannot boot without.
+2. **Publish to BOTH public npm and GitHub Packages** (`@ever-works` org), with
+   **independent per-plugin versioning** via Changesets. Registry endpoints are
+   configurable so self-hosters can use a mirror/private registry.
+3. **Trust model: first-party + allowlist.** Only `@ever-works/*` (implicit) or
+   admin-allowlisted packages are installable; verify integrity before load. No
+   arbitrary-npm execution and no bespoke sandbox in v1.
+4. **Execution location is routed per operation.** Short/`sync` calls run
+   in-process via dynamic import; `long-running` calls run inside the pluggable
+   job runtime (Trigger.dev today), which already isolates plugin code. This
+   depends on, but does not duplicate, the job-runtime-pluggability work
+   (EW-683).
+
+## Consequences
+
+**Positive**
+
+- Lean installs/images for deployments that enable few plugins.
+- Plugin releases decouple from platform releases (independent versions).
+- Clear path to a future community/third-party plugin ecosystem (allowlist →
+  marketplace) without re-architecting.
+- Isolation for long-running third-party code reuses existing infrastructure.
+
+**Negative / costs**
+
+- New supply-chain surface: registry availability, auth, integrity, allowlist
+  administration.
+- Cold-start install cost on fresh replicas (mitigated by boot warmup + optional
+  baking/PVC). Cross-replica/worker correctness relies on **lazy install-on-use**
+  (`ensurePluginAvailable` runs on every node — API replicas and the job-runtime
+  worker — before invoking a plugin), not boot reconcile alone; the worker
+  installs into its own store on first use. (Resolves Codex P1 ×2 on PR #1098.)
+- Dynamic mode requires a writable runtime store, so read-only-FS serverless
+  targets (Vercel) remain `bundled`-only. The store is just a writable directory
+  (default `/app/plugins`), per-replica with boot reconcile — no shared volume or
+  external service required.
+- The API's hard imports of storage plugins (`aws-s3`, `minio`, `github-storage`)
+  are **removed**; storage is resolved via the capability facade and those three
+  become distributable. `local-fs` stays core as the default storage so the API
+  boots without any distributable plugin (EW-693 T8b).
+
+**Neutral**
+
+- The loader, registry, lifecycle, and per-user/per-work enable model are reused
+  unchanged; this is additive plumbing, not a rewrite.
+
+## Alternatives considered
+
+- **Public npm only** — simpler, but loses the GitHub-native auth/mirroring story
+  for self-hosters and private plugins. Rejected in favour of dual-publish.
+- **Self-hosted Verdaccio only** — maximum control but new infra to operate;
+  kept as an optional self-host mirror behind the configurable registry URL.
+- **First-party only** (no third-party) — simplest trust model, but forecloses
+  the ecosystem; rejected in favour of first-party + allowlist.
+- **Open to any npm package** — requires signing + sandboxing + review pipeline
+  up front; deferred to a future phase.
+- **In-process sandbox (isolated-vm/microVM) for all plugin code** — heavy; not
+  needed in v1 given allowlist + job-runtime isolation for long-running work.
+
+## References
+
+- Feature spec: [`features/dynamic-plugin-distribution/spec`](../features/dynamic-plugin-distribution/spec.md)
+- Plan: [`features/dynamic-plugin-distribution/plan`](../features/dynamic-plugin-distribution/plan.md)
+- Architecture: [`architecture/runtime-plugins`](../architecture/runtime-plugins.md)
+- Related: [`plugin-sdk`](../architecture/plugin-sdk.md), [`deployment`](../architecture/deployment.md)
+- Jira: EW epic (this feature), EW-683 (job-runtime pluggability), EW-682 (official-SDK audit)

--- a/docs/specs/features/dynamic-plugin-distribution/plan.md
+++ b/docs/specs/features/dynamic-plugin-distribution/plan.md
@@ -1,0 +1,288 @@
+# Implementation Plan: Dynamic Plugin Distribution (dual-mode)
+
+> Translates [`spec.md`](./spec.md) into architecture and tech choices.
+> The plan owns implementation details; the spec owns behaviour.
+
+**Feature ID**: `dynamic-plugin-distribution`
+**Spec**: `./spec.md`
+**Tasks**: `./tasks.md`
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+
+---
+
+## 1. Architecture Summary
+
+```mermaid
+flowchart TD
+    subgraph Build["Build / CI"]
+        SRC[packages/plugins/*] -->|tsup build| DIST[dist per plugin]
+        DIST -->|changesets release| PUB{publish}
+        PUB --> NPM[(public npm)]
+        PUB --> GHP[(GitHub Packages)]
+    end
+
+    subgraph Image["Platform image"]
+        CORE[core plugins bundled in /app/plugins] --> LOADER
+    end
+
+    subgraph Runtime["API process (dynamic mode)"]
+        UI[Web: Enable] --> CTRL[plugins.controller]
+        CTRL --> OPS[PluginOperationsService.enable]
+        OPS -->|not installed?| INST[PluginInstallerService]
+        INST -->|allowlist + integrity| RESOLVE[resolve pkg@version]
+        RESOLVE --> NPM
+        RESOLVE --> GHP
+        INST -->|install to store| STORE[(Runtime plugin store
+/app/plugins or PVC)]
+        STORE --> LOADER[PluginLoaderService.load]
+        LOADER --> REG[PluginRegistryService]
+        REG --> DB[(plugins / plugin_allowlist)]
+        OPS --> DB
+    end
+
+    subgraph Boot["Boot (every replica)"]
+        BS[PluginBootstrapService] --> RECON[reconcile store from DB]
+        RECON --> INST
+    end
+
+    subgraph Exec["Capability execution"]
+        FAC[Facade call] --> ROUTER{execution location}
+        ROUTER -->|short / sync| INPROC[dynamic import in API]
+        ROUTER -->|long-running| JOB[Job runtime: Trigger.dev task
+imports plugin, isolated]
+    end
+```
+
+The design is **additive**: it layers a publish pipeline, an installer, a
+boot reconciler, an allowlist, and an execution-location router on top of the
+existing discover → load → register → enable machinery. The existing loader
+(`await import(entryPath)`), registry, lifecycle manager, and per-user/per-work
+enable model are reused unchanged. `bundled` mode is the current code path with
+the new pieces inert.
+
+## 2. Tech Choices
+
+| Concern                | Choice                                                                                                | Rationale                                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Distribution flag      | `config` constant + env (`PLUGIN_DISTRIBUTION_MODE`)                                                  | Matches `apps/api/src/config/constants.ts` lazy-fn + `FEATURE_*` pattern; fail-fast validation.                 |
+| Core vs distributable  | New `distribution` manifest field in `everworks.plugin`                                               | Declared on the plugin, not hard-coded (FR-3). Default derived from `systemPlugin`.                             |
+| Publish                | **Changesets** → npm + GitHub Packages                                                                | Independent per-plugin versioning (FR-7); no platform release coupling; mirrors `publish-cli.yml` auth pattern. |
+| Runtime fetch          | `npm`/`pnpm` programmatic install (pinned exact version, `--no-save`) into the store, then `import()` | Reuses Node module resolution + integrity; loader already scans `node_modules/@ever-works` and `./plugins`.     |
+| Integrity              | npm package integrity (sha512) + first-party npm provenance                                           | No bespoke signing in v1; verify-before-load (FR-10).                                                           |
+| Persistence            | TypeORM columns on `PluginEntity` + new `PluginAllowlistEntity`                                       | Existing pattern in `packages/agent/src/plugins`.                                                               |
+| Long-running execution | Pluggable job runtime (Trigger.dev today)                                                             | Principle IV; isolation comes "for free" inside the task process. Depends on EW-683.                            |
+| Store location         | `PLUGIN_INSTALL_DIR` (default `/app/plugins`); k8s writable volume                                    | API root FS is writable today (`readOnlyRootFilesystem: false`); per-replica reconcile avoids requiring RWX.    |
+
+## 3. Data Model
+
+### Changed entity — `PluginEntity` (`packages/agent/src/plugins/entities/plugin.entity.ts`)
+
+Additive columns (all nullable / defaulted — forward-only):
+
+```ts
+// Where the plugin came from on this deployment.
+@Column({ type: 'varchar', default: 'bundled' })
+source: 'bundled' | 'registry';
+
+// npm spec actually installed, e.g. "@ever-works/notion-extractor-plugin@1.2.0".
+@Column({ type: 'varchar', nullable: true })
+registrySpec?: string;
+
+// Resolved version present on disk (may differ from manifest until upgraded).
+@Column({ type: 'varchar', nullable: true })
+installedVersion?: string;
+
+// Integrity used to verify the install (sha512 from the registry).
+@Column({ type: 'varchar', nullable: true })
+integrity?: string;
+
+// Install lifecycle, distinct from the existing load `state`.
+@Column({ type: 'varchar', default: 'available' })
+installState: 'available' | 'installing' | 'installed' | 'error';
+```
+
+`distribution` (core vs registry) is read from the manifest at discovery time;
+it is denormalised onto the row for listing convenience but the manifest is the
+source of truth.
+
+### New entity — `PluginAllowlistEntity` (`packages/agent/src/plugins/entities/plugin-allowlist.entity.ts`)
+
+```ts
+@Entity('plugin_allowlist')
+export class PluginAllowlistEntity {
+	@PrimaryGeneratedColumn('uuid') id: string;
+	@Column({ type: 'varchar', unique: true }) packageName: string; // npm name
+	@Column({ type: 'varchar' }) versionRange: string; // pinned/semver
+	@Column({ type: 'varchar', nullable: true }) integrity?: string;
+	@Column({ type: 'varchar', default: 'npm' }) source: 'npm' | 'github-packages';
+	@Column({ type: 'boolean', default: true }) enabled: boolean;
+	@CreateDateColumn() createdAt: Date;
+}
+```
+
+First-party `@ever-works/*` is implicitly allowed (no row required).
+
+### Migrations
+
+- `apps/api/src/migrations/<unix-millis>-AddPluginDistributionColumns.ts` —
+  add the five `PluginEntity` columns. Additive, forward-only, defaults set so
+  existing rows become `source='bundled'`, `installState='installed'`.
+- `apps/api/src/migrations/<unix-millis>-CreatePluginAllowlist.ts` — create
+  `plugin_allowlist`.
+- **NN #16 / Principle V**: generated with `pnpm typeorm migration:generate`,
+  SQL read by hand, no `DROP`/`ALTER TYPE`. Ship in the same PR as the entity change.
+
+### DTOs / contracts (`packages/contracts`)
+
+- `PluginInstallStateDto`, extend the plugin list/response DTOs with
+  `source`, `installState`, `installedVersion`, `available` (catalog) fields.
+- Allowlist admin DTOs (`CreateAllowlistEntryDto`, etc.).
+
+## 4. API Surface
+
+| Method                | Endpoint                            | Description                                                                                      | Status  |
+| --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------ | ------- |
+| `GET`                 | `/plugins/catalog`                  | List distributable plugins available from the registry (manifest summaries), with install state. | New     |
+| `POST`                | `/plugins/:pluginId/install`        | Install (resolve+verify+load) a distributable plugin without enabling.                           | New     |
+| `POST`                | `/plugins/:pluginId/enable`         | Existing; in dynamic mode installs first if absent, then enables.                                | Changed |
+| `DELETE`              | `/plugins/:pluginId/install`        | Uninstall a distributable plugin (refused for core).                                             | New     |
+| `GET`                 | `/plugins/:pluginId/install-status` | Poll install progress/state.                                                                     | New     |
+| `GET`/`POST`/`DELETE` | `/admin/plugins/allowlist`          | Manage the third-party allowlist (admin-gated).                                                  | New     |
+
+- Auth: user-scoped endpoints use existing `@CurrentUser()`; allowlist endpoints
+  are admin-gated. Install is rate-limited (registry protection).
+- Errors: `409` plugin not permitted (allowlist), `424` integrity mismatch,
+  `502/504` registry unreachable, `422` invalid manifest / version incompatible.
+
+## 5. Plugin Surface
+
+- **SDK (`packages/plugin`)**: add `distribution?: 'core' | 'registry'` and an
+  optional execution hint (e.g. `executionProfile?: 'sync' | 'long-running'` at
+  capability/operation granularity) to `PluginManifest`
+  (`src/contracts/plugin-manifest.types.ts`) + JSON-schema validator update.
+  Additive; default derivation keeps old manifests valid.
+- **All plugin `package.json`s**: set `distribution` (core for every
+  `systemPlugin`; `registry` for the rest, **including** `aws-s3`, `minio`,
+  `github-storage`); flip `private: true → false` with `publishConfig` for
+  distributable plugins; add per-plugin `release` wiring.
+- **Decouple the API from storage plugins**: remove the direct
+  `@ever-works/{aws-s3,minio,github-storage}-plugin` dependencies from
+  `apps/api/package.json` and resolve storage through the capability
+  facade/registry instead of static imports. Keep `local-fs` (a `systemPlugin`)
+  bundled as the core default storage so the API boots without any distributable
+  storage plugin present. This is what makes those three plugins distributable.
+- **Loader (`plugin-loader.service.ts`)**: accept an explicit install path from
+  the installer (reuse `loadPluginModule`); no behaviour change in bundled mode.
+- **New `PluginInstallerService`** (`packages/agent/src/plugins/services/`):
+  resolve → allowlist-check → download → integrity-verify → place in store →
+  hand path to loader. Idempotent; concurrency-guarded per plugin id.
+- **New `PluginExecutionRouterService`**: given a capability/operation, decide
+  in-process vs job-runtime dispatch; reused by facades.
+
+## 6. Web / CLI Surface
+
+- `apps/web/src/app/[locale]/(dashboard)/settings/plugins/[category]/page.tsx`
+  and `apps/web/src/lib/api/plugins.ts`: add catalog listing, install state
+  chips (available/installing/installed/error), Install action + progress, and
+  error surfacing. Enable button triggers install-then-enable in dynamic mode.
+- Admin allowlist management page (basic table + add/remove).
+- Optional CLI: `ever-works plugins install <id>` mirroring the API.
+
+## 7. Background Jobs
+
+| Trigger                                           | When                                                                     | What it does                                                                                                                                                                                                   | Idempotency strategy                                              |
+| ------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Lazy install-on-use** (`ensurePluginAvailable`) | Before _any_ node invokes a distributable plugin (API replica or worker) | Install the pinned package into the local store if missing, then load+register. **The correctness guarantee** — a plugin enabled on one replica works on all replicas/worker with no restart or shared volume. | Per-id concurrency lock + version/integrity pin; skip if present. |
+| Boot reconcile (on `onApplicationBootstrap`)      | Every API/worker start in dynamic mode                                   | Warm the store by pre-installing the DB-recorded installed/enabled set. Optimisation only (avoids first-request latency), not correctness.                                                                     | Same `ensurePluginAvailable`; idempotent.                         |
+| Long-running capability dispatch                  | Per pipeline/long op                                                     | In the job-runtime worker, call `ensurePluginAvailable` then run the plugin inside the isolated task. The worker has its own store, so it installs on first use just like the API.                             | Existing job idempotency / CAS in the task layer.                 |
+| GC                                                | —                                                                        | Out of scope for v1 (decided: keep installed files on disable, no GC).                                                                                                                                         | n/a                                                               |
+
+## 8. Security & Permissions
+
+- Install is gated: first-party `@ever-works/*` OR allowlisted package only
+  (FR-11); refusal happens **before** any network fetch.
+- Integrity verified before `import()` (FR-10); mismatch → refuse.
+- Registry auth tokens (GitHub Packages, private mirrors) are secrets — sourced
+  from env/secret store, never logged, never returned by APIs.
+- Plugin settings/credentials keep `x-secret` redaction (Principle VII).
+- Long-running third-party code executes in the isolated job runtime, limiting
+  blast radius inside the API process.
+- Allowlist mutation endpoints are admin-only.
+
+## 9. Observability
+
+- Activity-log/events: `plugin.install.requested|succeeded|failed`,
+  `plugin.upgrade.*`, `plugin.uninstall.*`, with plugin id, version, source,
+  duration, and failure reason.
+- Metrics: install count/latency/error-rate per plugin; reconcile duration on
+  boot; catalog-fetch failures.
+- Sentry tags: `plugin_id`, `plugin_source`, `distribution_mode`.
+
+## 10. Phased Rollout
+
+1. **Phase 1 — SDK & data model**: manifest `distribution`/exec fields + JSON
+   schema; `PluginEntity` columns + `PluginAllowlistEntity` + migrations; DTOs;
+   **decouple the API from storage plugins** (remove hard imports, resolve via
+   facade, keep `local-fs` core). Behind the flag; default `bundled`; no
+   behaviour change.
+2. **Phase 2 — Publish pipeline**: Changesets + dual-publish CI (npm + GitHub
+   Packages); flip `private` + `publishConfig` on distributable plugins;
+   dry-run, then first real publishes. Independent of runtime mode.
+3. **Phase 3 — Installer & reconcile**: `PluginInstallerService`, allowlist
+   enforcement, integrity verify, boot reconcile; wire into enable flow gated by
+   dynamic mode. Still default `bundled`.
+4. **Phase 4 — Execution router**: classify operations; route long-running plugin
+   calls through the job runtime; in-process for short. Depends on EW-683 for
+   full provider-pluggability but works against Trigger.dev directly meanwhile.
+5. **Phase 5 — Deployment**: dynamic-mode image variant (core-only) + writable
+   store/volume + k8s manifest + entrypoint reconcile hook; document Vercel
+   read-only-FS limitation (dynamic mode unsupported on read-only serverless).
+6. **Phase 6 — UI & catalog**: catalog listing, install states, progress,
+   errors, admin allowlist UI.
+7. **Phase 7 — Soak**: enable dynamic mode on a staging target and soak. The
+   shipped default stays `bundled` everywhere (SaaS + self-host); `dynamic` is
+   opt-in per deployment — no default flip planned for v1.
+
+## 11. Risks & Mitigations
+
+| Risk                                                             | Likelihood      | Impact | Mitigation                                                                                                                                                           |
+| ---------------------------------------------------------------- | --------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Registry outage blocks enabling new plugins                      | Med             | Med    | Installed plugins unaffected; clean retryable failures; optional warm cache/mirror.                                                                                  |
+| Cold-start install cost on new replicas                          | Med             | Med    | Boot warmup pre-installs in parallel; lazy install-on-use covers anything not warmed; consider baking "popular" plugins.                                             |
+| Plugin enabled on replica A not present on replica B / worker    | High            | High   | **Lazy install-on-use** (`ensurePluginAvailable`) on every node before invocation — not boot-only reconcile. Worker installs into its own store too. (Codex P1 ×2.)  |
+| Running untrusted-ish 3rd-party code in API process              | Low (allowlist) | High   | Allowlist + integrity; long-running paths in isolated job runtime; sandbox is a documented future phase.                                                             |
+| Read-only FS targets (Vercel) can't install at runtime           | Med             | Low    | Dynamic mode requires writable store; Vercel/serverless documented as bundled-only.                                                                                  |
+| API hard-deps on storage plugins block making them distributable | High            | Low    | **Decided**: remove the direct imports, resolve storage via the facade, keep `local-fs` as core default (so the API boots storage-less of any distributable plugin). |
+| Default storage (`local-fs`) not shared across replicas          | Med             | Low    | Pre-existing concern, not new; production enables a distributable shared backend (s3/minio/github-storage). `local-fs` only guarantees the API boots.                |
+| Version drift between manifest and installed dist                | Med             | Low    | Persist `installedVersion`+`integrity`; reconcile pins exact version.                                                                                                |
+
+## 12. Constitution Reconciliation
+
+- **I — Plugin-first**: Plugins remain the integration unit; registry/installer
+  is platform plumbing.
+- **II — Capability-driven**: Resolution/enable semantics unchanged; install is
+  a precondition step.
+- **III — Source-of-truth repos**: Unaffected.
+- **IV — Trigger.dev**: Long-running plugin execution explicitly routed through
+  the job runtime; ties to EW-683.
+- **V — Forward-only migrations**: New columns/table additive; defaults backfill.
+- **VI — Tests**: Installer, allowlist, reconcile, router, publish dry-run all
+  ship tests; e2e for both execution paths.
+- **VII — Secret hygiene**: Registry tokens + plugin creds are secrets;
+  `x-secret` preserved.
+- **VIII — Plugin counts**: Canonical built-in-plugins doc updated with core vs
+  distributable split.
+- **IX — Behaviour-first**: Behaviour in spec; this file holds implementation.
+- **X — Backwards-compat**: Default `bundled` preserves current behaviour; SDK,
+  manifest, schema, and API additions are additive.
+
+## 13. References
+
+- Spec: `./spec.md`
+- Tasks: `./tasks.md`
+- ADR: [`016-dynamic-plugin-distribution`](../../decisions/016-dynamic-plugin-distribution.md)
+- Architecture: [`runtime-plugins`](../../architecture/runtime-plugins.md),
+  [`plugin-sdk`](../../architecture/plugin-sdk.md),
+  [`deployment`](../../architecture/deployment.md)
+- Jira: EW epic (this feature); [EW-683] job-runtime pluggability (dependency)

--- a/docs/specs/features/dynamic-plugin-distribution/spec.md
+++ b/docs/specs/features/dynamic-plugin-distribution/spec.md
@@ -1,0 +1,310 @@
+# Feature Specification: Dynamic Plugin Distribution (dual-mode)
+
+> Behaviour-first spec per [Constitution Principle IX](../../../../.specify/memory/constitution.md#ix-specs-are-behaviour-first).
+> Describe **what** the system does, not how it's structured. Implementation
+> lives in [`plan.md`](./plan.md); execution in [`tasks.md`](./tasks.md).
+
+**Feature ID**: `dynamic-plugin-distribution`
+**Branch**: `feat/dynamic-plugin-distribution`
+**Status**: `Draft`
+**Created**: 2026-05-28
+**Last updated**: 2026-05-28
+**Owner**: @evereq
+
+---
+
+## 1. Overview
+
+Today every plugin in `packages/plugins/*` is built and shipped inside the
+platform image. A clone installs all ~49 plugins' third-party SDKs at
+`pnpm install`, and the deployed artifact carries every plugin whether or not
+an operator ever enables it. This feature makes plugin distribution **dual-mode**
+so an operator can choose between:
+
+- **Bundled mode** (today's behaviour, default): all plugins built into the
+  image and discovered from disk at boot. No registry, no network at enable-time.
+- **Dynamic mode**: only **core** plugins are bundled; every other plugin is
+  published to an npm registry and **pulled, validated, and loaded at runtime**
+  the first time a user enables it. The platform image and a fresh install stay
+  lean, and operators add only the plugins they actually use.
+
+The two modes coexist permanently and are selected by a single platform
+setting. Bundled mode remains the default so existing deployments are unaffected.
+The capability/enable/settings model the user already sees does not change —
+"Enable" simply gains an install-and-load step when a dynamic-mode plugin
+isn't present yet.
+
+## 2. User Scenarios
+
+### 2.1 Primary scenarios
+
+- **Given** an operator running in bundled mode (the default), **when** they
+  deploy the platform, **then** all plugins are available exactly as today and
+  no registry network calls occur at enable-time.
+- **Given** an operator running in dynamic mode, **when** a user opens the
+  plugins page, **then** core plugins show as installed and every other
+  published plugin shows as **available** (listed from the registry catalog)
+  with an Install/Enable action.
+- **Given** a user in dynamic mode, **when** they click **Enable** on an
+  available non-core plugin (e.g. `notion-extractor`), **then** the platform
+  resolves the package from the configured registry, verifies it, installs it
+  into the runtime plugin store, loads it, registers its capabilities, and the
+  plugin transitions to enabled — without an operator redeploy.
+- **Given** a plugin's source changes and a new version is released, **when**
+  CI publishes it, **then** the new version is available in **both** the public
+  npm registry and the GitHub Packages org registry, and dynamic-mode
+  deployments can pick it up on next install/upgrade.
+- **Given** a short, synchronous capability call (e.g. resolving an AI
+  provider's model list), **when** it runs, **then** the dynamically-installed
+  plugin executes in-process via dynamic import with no extra hop.
+- **Given** a long-running capability call (e.g. a full generation pipeline
+  step), **when** it runs, **then** the job-runtime worker first ensures the
+  plugin is installed in its own store (lazy install-on-use), then executes it
+  inside the isolated task process, returning the result through the existing
+  job result channel.
+- **Given** a plugin was enabled on one API replica, **when** a later request
+  for it is routed to a _different_ replica (or the worker) that has not yet
+  installed it, **then** that node lazily installs it on first use and serves the
+  request — no restart or shared volume required.
+- **Given** a fresh pod / new replica in dynamic mode, **when** it boots,
+  **then** it warms its local store by pre-installing the DB-recorded
+  installed/enabled set, and in any case lazily installs any plugin on first use.
+
+### 2.2 Edge cases & failures
+
+- **Given** the registry is unreachable, **when** a user clicks Enable in
+  dynamic mode, **then** the install fails with a clear, user-visible error,
+  the plugin stays in an `error`/not-installed state, and no partial/half-loaded
+  plugin is registered. Already-installed plugins keep working.
+- **Given** a requested package is **not** first-party and **not** on the
+  allowlist, **when** install is attempted, **then** it is rejected before any
+  download with an "package not permitted" error.
+- **Given** a package's downloaded integrity hash does not match the pinned
+  expectation, **when** install runs, **then** it is rejected and nothing is
+  loaded.
+- **Given** a plugin fails to load (invalid manifest, version incompatibility,
+  throwing constructor), **when** install runs, **then** the failure is recorded
+  against that plugin with a reason, the user sees it, and the rest of the
+  system is unaffected.
+- **Given** a user disables a dynamically-installed plugin, **when** they do so,
+  **then** it stops being used immediately (per existing enable/disable rules);
+  whether its files are removed from the store is governed by a retention policy
+  (default: keep installed, just disabled).
+- **Given** an operator switches a running deployment from bundled to dynamic
+  mode (or back), **when** the platform restarts, **then** it reconciles to the
+  new mode without losing any user's enabled-plugin choices.
+- **Given** a core plugin, **when** any user attempts to "uninstall" it in
+  dynamic mode, **then** the action is refused — core plugins are always present
+  and (for `systemPlugin`) cannot be disabled.
+- **Given** dynamic mode and no distributable storage plugin enabled, **when**
+  the platform boots, **then** the core default storage (`local-fs`) is available
+  so storage-dependent features still function.
+
+## 3. Functional Requirements
+
+Distribution mode & core set:
+
+- **FR-1** The system MUST support a platform-level distribution mode with at
+  least the values `bundled` and `dynamic`, defaulting to `bundled`.
+- **FR-2** In `bundled` mode the system MUST behave exactly as today: all
+  plugins discovered from disk at boot, no registry access required.
+- **FR-3** The system MUST classify every plugin as either **core** (always
+  bundled in the image, present in both modes) or **distributable** (published
+  to a registry, runtime-installable in dynamic mode). The classification MUST
+  be declared on the plugin (manifest), not hard-coded in the platform.
+- **FR-4** Core MUST include every plugin marked `systemPlugin: true`, and the
+  API MUST NOT statically depend on any **distributable** plugin to boot.
+  Storage plugins `aws-s3`, `minio`, and `github-storage` are **distributable**;
+  the API's current hard imports of them MUST be removed and storage resolved via
+  the capability facade/registry. `local-fs` (a `systemPlugin`) remains core and
+  is the default storage backend so the platform boots with working storage even
+  when no distributable storage plugin is enabled.
+- **FR-5** The system MUST NOT require core plugins to be fetched from a
+  registry in either mode.
+
+Publishing:
+
+- **FR-6** The system MUST publish each distributable plugin to **both** the
+  public npm registry and the GitHub Packages org registry on release.
+- **FR-7** Publishing MUST be automated in CI and triggered by plugin source
+  changes / releases, and MUST version plugins independently (a plugin release
+  MUST NOT require a platform release).
+- **FR-8** The platform MUST read the registry endpoint(s) and any auth from
+  configuration so self-hosters can point at their own mirror or private
+  registry.
+
+Runtime install / enable:
+
+- **FR-9** In dynamic mode, when a user enables a distributable plugin that is
+  not yet installed, the system MUST resolve, verify, install, load, register,
+  and then enable it as a single user-observable action.
+- **FR-10** The system MUST verify a downloaded plugin's integrity (pinned
+  version + integrity hash) before loading it.
+- **FR-11** The system MUST only install packages that are first-party
+  (`@ever-works/*`) or present on an admin-managed allowlist; any other package
+  MUST be refused before download.
+- **FR-12** The system MUST persist, per plugin, its distribution source
+  (`bundled` | `registry`), the installed package spec, the installed version,
+  and the integrity value used.
+- **FR-13** Every node — each API replica **and** each job-runtime worker — MUST
+  ensure a distributable plugin is installed in its own local store before
+  invoking it (**lazy install-on-use**), so a plugin enabled on one replica is
+  usable on all replicas and in the worker **without** requiring a restart or a
+  shared volume. This is the correctness guarantee for per-replica stores.
+- **FR-13a** On boot in dynamic mode, a node SHOULD pre-install (warm) the
+  DB-recorded installed/enabled distributable set to avoid a first-request
+  latency spike. Boot reconcile is an optimisation, not the correctness
+  mechanism (FR-13 is).
+- **FR-14** A failed install MUST leave the plugin in a clearly-failed state
+  with a recorded reason and MUST NOT register a partially-loaded plugin.
+
+Execution model:
+
+- **FR-15** The system MUST be able to execute a dynamically-installed plugin's
+  capability call in-process via dynamic import (for short/synchronous calls).
+- **FR-16** The system MUST be able to execute a dynamically-installed plugin's
+  capability call inside the pluggable job runtime (long-running calls), reusing
+  the existing job-dispatch and result channel.
+- **FR-17** The choice of execution location MUST be driven by the
+  operation/capability (declared classification), not hard-coded per plugin id.
+
+Catalog & UI:
+
+- **FR-18** The plugins UI MUST show, per plugin, an install state distinct
+  from enable state: at minimum **available** (not installed), **installing**,
+  **installed**, and **error**.
+- **FR-19** In dynamic mode the plugins UI MUST list distributable plugins that
+  are available from the registry catalog even when not yet installed (the
+  manifest summary is listable without instantiating the plugin).
+- **FR-20** The system MUST surface install progress and install failures to
+  the user who triggered them.
+
+Compatibility:
+
+- **FR-21** Enabling/disabling and per-user / per-work scoping rules MUST remain
+  unchanged from today; dynamic mode only adds an install/load step in front of
+  enable when the plugin is absent.
+- **FR-22** The system MUST NOT change behaviour for existing bundled-mode
+  deployments that take no action (default stays `bundled`).
+
+## 4. Non-Functional Requirements
+
+- **Performance**: In-process enable-and-install of a single first-party plugin
+  SHOULD complete within a few seconds on a warm registry connection; the call
+  MUST be async/non-blocking from the user's perspective with progress feedback.
+  Short capability calls MUST NOT incur a job-runtime round-trip.
+- **Reliability**: A registry outage MUST degrade gracefully — already-installed
+  plugins keep working; new installs fail cleanly and are retryable. Boot-time
+  reconcile MUST be idempotent and safe to run on every replica.
+- **Security & privacy**: Only allowlisted/first-party packages are installable
+  (no arbitrary npm execution in v1). Integrity is verified before load. Plugin
+  credentials continue to follow `x-secret` rules. Registry auth tokens are
+  treated as secrets. Long-running third-party code runs in the isolated job
+  runtime.
+- **Observability**: Plugin install attempts, successes, failures, version, and
+  source MUST emit activity-log/events and metrics; install failures MUST be
+  visible in monitoring.
+- **Compatibility**: Requires `@ever-works/plugin` SDK additions to be additive
+  and semver-compatible. Plugin manifests gaining new fields MUST remain valid
+  under the existing validator (forward-compatible).
+
+## 5. Key Entities & Domain Concepts
+
+| Entity / concept     | Description                                                                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Distribution mode    | Platform setting selecting `bundled` (all in image) vs `dynamic` (core in image, rest from registry).                                                                                                       |
+| Core plugin          | A plugin always shipped in the image and present in both modes (every `systemPlugin`, incl. `local-fs` as the boot default storage). Distributable storage (`aws-s3`/`minio`/`github-storage`) is NOT core. |
+| Runtime plugin store | A writable directory on a node (default `/app/plugins`) where pulled plugins are written so Node can `import()` them — per-replica, reconciled on boot; not external infrastructure.                        |
+| Distributable plugin | A plugin published to a registry and installable at runtime in dynamic mode.                                                                                                                                |
+| Plugin registry      | The npm source(s) plugins are published to and pulled from — public npm + GitHub Packages, configurable.                                                                                                    |
+| Plugin catalog       | The listable set of distributable plugins (manifest summaries) shown in the UI before install.                                                                                                              |
+| Install state        | Lifecycle of a plugin's presence on a node: available → installing → installed / error (distinct from enabled).                                                                                             |
+| Plugin allowlist     | Admin-managed set of non-first-party packages permitted for runtime install, with version/integrity pinning.                                                                                                |
+| Boot reconcile       | Start-up routine that makes a node's plugin store match the DB record of installed/enabled plugins.                                                                                                         |
+| Execution location   | Where a capability call runs: in-process (short) vs job runtime (long-running).                                                                                                                             |
+
+## 6. Out of Scope
+
+- A public third-party plugin **marketplace** with self-serve submission,
+  ratings, or billing (this v1 is first-party + admin allowlist only).
+- Strong per-plugin sandboxing beyond what the job runtime already provides
+  (no isolated-vm / microVM execution in v1).
+- Plugin code signing beyond npm integrity + first-party provenance.
+- Hot **unload** / live in-process re-instantiation of a plugin without a
+  process restart (today the platform never re-instantiates in-process; dynamic
+  install adds first-load, not hot-swap).
+- Making the job-runtime provider itself pluggable — that is tracked separately
+  in [EW-683] and is a dependency, not part of this feature.
+- Per-tenant private registries (single configurable registry set in v1).
+
+## 7. Acceptance Criteria
+
+- [ ] With no configuration change, an existing deployment runs in `bundled`
+      mode and behaves identically to today (no registry calls at enable-time).
+- [ ] Setting distribution mode to `dynamic` ships an image containing only core
+      plugins; non-core plugins are absent from the image.
+- [ ] In dynamic mode, enabling a first-party distributable plugin installs and
+      loads it at runtime and it becomes usable without a redeploy.
+- [ ] Each distributable plugin is published to both public npm and GitHub
+      Packages by CI on release, with independent versions.
+- [ ] A non-allowlisted third-party package is refused before download.
+- [ ] A corrupted/integrity-mismatched download is refused and nothing loads.
+- [ ] A registry outage fails new installs cleanly while installed plugins keep
+      working; retry succeeds when the registry returns.
+- [ ] A plugin enabled on one API replica is served by a different replica that
+      never handled the enable, via lazy install-on-use, with no restart.
+- [ ] A long-running call for a runtime-installed plugin succeeds in the
+      job-runtime worker (worker lazily installs it into its own store first).
+- [ ] Short capability calls run in-process; long-running ones run in the job
+      runtime — verified by an integration test of each path.
+- [ ] Core/`systemPlugin` plugins cannot be uninstalled or disabled.
+- [ ] All functional requirements have a passing test (unit or e2e).
+
+## 8. Open Questions
+
+All initial open questions were resolved with @evereq on 2026-05-28:
+
+- **Default mode** — `bundled` everywhere (hosted SaaS and self-host alike);
+  `dynamic` is strictly opt-in. _(Resolved: bundled default.)_
+- **Multi-replica plugin store** — per-replica ephemeral store + boot reconcile;
+  **no shared RWX volume required**. A shared PVC is an optional optimization,
+  not a prerequisite. _(Resolved: per-replica reconcile.)_
+- **Disable retention** — keep installed files on disable; **no garbage
+  collection** in v1. _(Resolved: keep installed.)_
+- **API storage plugins** — **remove** the API's hard imports of `aws-s3`,
+  `minio`, `github-storage` and make them **distributable**; resolve storage via
+  the capability facade; keep `local-fs` as the core default. _(Resolved:
+  decouple + distributable.)_
+- **Allowlist administration** — **both** env/config and an admin API.
+  _(Resolved: both surfaces.)_
+
+## 9. Constitution Gates
+
+- [x] Plugin-first if introducing an external integration (Principle I) — the
+      registry/installer is platform infrastructure; plugins stay the integration unit.
+- [x] Capability-driven resolution if touching cross-plugin behaviour
+      (Principle II) — resolution/enable semantics unchanged; install precedes them.
+- [x] Source-of-truth repos preserved (Principle III) — unaffected.
+- [x] Long-running work via Trigger.dev (Principle IV) — long-running plugin
+      execution is explicitly routed through the job runtime.
+- [x] Schema changes ship as forward-only migrations (Principle V) — new plugin
+      columns + allowlist table are additive.
+- [x] Tests accompany the change (Principle VI).
+- [x] Secrets handled per `x-secret` rules (Principle VII) — plugin creds and
+      registry tokens are secrets.
+- [x] Plugin counts touch the canonical doc only (Principle VIII) — counts and
+      core/distributable split documented in the canonical built-in-plugins doc.
+- [x] Behaviour-first — no implementation in this spec (Principle IX).
+- [x] Backwards-compatible API/SDK/schema changes (Principle X) — default
+      `bundled` keeps current behaviour; SDK/manifest additions are additive.
+
+## 10. References
+
+- Related features: [`plugin-system`](../plugin-system/spec.md)
+- Related ADRs: [`016-dynamic-plugin-distribution`](../../decisions/016-dynamic-plugin-distribution.md)
+- Related architecture: [`runtime-plugins`](../../architecture/runtime-plugins.md),
+  [`plugin-sdk`](../../architecture/plugin-sdk.md),
+  [`deployment`](../../architecture/deployment.md),
+  [`trigger-integration`](../../architecture/trigger-integration.md)
+- Related Jira: EW epic (this feature), [EW-683] (job-runtime pluggability — dependency),
+  [EW-682] (official-SDK audit — related)

--- a/docs/specs/features/dynamic-plugin-distribution/tasks.md
+++ b/docs/specs/features/dynamic-plugin-distribution/tasks.md
@@ -1,0 +1,204 @@
+# Task Breakdown: Dynamic Plugin Distribution (dual-mode)
+
+> Ordered, granular tasks derived from [`plan.md`](./plan.md). Each task is small
+> enough to land in a single PR and ships with tests per Constitution Principle VI.
+
+**Feature ID**: `dynamic-plugin-distribution`
+**Plan**: `./plan.md`
+**Status**: `Draft`
+**Last updated**: 2026-05-28
+
+---
+
+## How to use
+
+- Tasks are sequential by default. `(parallel)` tasks can run alongside their predecessor.
+- Each task has explicit file paths so an implementer can pick it up cold.
+- Jira mapping: the parent Epic groups these into child Tasks named
+  `[EW-<epic> Tn-Tm] …` (see the Epic for the live keys).
+
+## Phase 1 — SDK & manifest (T1–T4)
+
+- [ ] **T1**. Add `distribution?: 'core' | 'registry'` and
+      `executionProfile?: 'sync' | 'long-running'` to `PluginManifest` at
+      `packages/plugin/src/contracts/plugin-manifest.types.ts`.
+    - Document default derivation: `systemPlugin === true ⇒ 'core'`, else `'registry'`.
+    - **Test**: manifest type + default-derivation unit test in `packages/plugin`.
+- [ ] **T2**. Update the manifest JSON-schema validator
+      (`packages/agent/src/plugins/services/plugin-manifest-validator.service.ts`)
+      to accept and validate the new fields; keep old manifests valid (forward-compat).
+    - **Test**: validator spec covering present/absent/invalid values.
+- [ ] **T3** (parallel with T2). Add install/catalog DTOs in
+      `packages/contracts/src/api/plugins/` (`PluginInstallStateDto`, catalog
+      entry, allowlist DTOs); export from the package index.
+- [ ] **T4**. Bump `@ever-works/plugin` minor; note additive change in its
+      changelog. Confirm `pnpm build:plugins` + type-check green.
+
+## Phase 2 — Data model & migrations (T5–T8b)
+
+- [ ] **T5**. Add columns to `PluginEntity` at
+      `packages/agent/src/plugins/entities/plugin.entity.ts`: `source`,
+      `registrySpec`, `installedVersion`, `integrity`, `installState`.
+    - **Test**: entity spec.
+- [ ] **T6**. Add `PluginAllowlistEntity` at
+      `packages/agent/src/plugins/entities/plugin-allowlist.entity.ts`; register
+      in `PLUGIN_ENTITIES` and the agent entities index.
+- [ ] **T7**. Add `PluginAllowlistRepository` +
+      `PluginRepository` methods for install-state transitions at
+      `packages/agent/src/plugins/repositories/`.
+    - **Test**: repository specs.
+- [ ] **T8**. Generate migrations from `apps/api/`:
+      `AddPluginDistributionColumns` + `CreatePluginAllowlist`
+      (`pnpm typeorm migration:generate -d typeorm.config.ts src/migrations/<Name>`).
+      Read the SQL by hand — additive, forward-only, no `DROP`. (NN #16)
+- [ ] **T8b**. Decouple the API from storage plugins: remove
+      `@ever-works/{aws-s3,minio,github-storage}-plugin` from
+      `apps/api/package.json`; resolve storage via the capability facade/registry
+      instead of static imports. Set those three plugins' manifest
+      `distribution: 'registry'`. Keep `local-fs` (`systemPlugin`) bundled as the
+      core default so the API boots with working storage and no distributable
+      plugin is boot-critical (FR-4).
+    - **Test**: API boots with only `local-fs`; s3/minio/github-storage resolve
+      via facade when enabled; e2e for default-storage path.
+
+## Phase 3 — Publish pipeline (T9–T13)
+
+- [ ] **T9**. Add Changesets (`.changeset/config.json`) configured for
+      independent versioning of `packages/plugins/*` + `packages/plugin`.
+- [ ] **T10**. Flip `private: true → false` and add `publishConfig` (access +
+      registry) to each **distributable** plugin `package.json`. Leave core
+      plugins as-is. Verify the core/distributable split against T1's rule.
+- [ ] **T11**. Add a dual-publish GitHub Actions workflow at
+      `.github/workflows/publish-plugins.yml` mirroring the auth pattern in
+      `.github/workflows/publish-cli.yml`: build changed plugins, publish to
+      **public npm** and **GitHub Packages** (`@ever-works` scope), gated on
+      release/changeset.
+- [ ] **T12**. Add a `release`/`publish` script per distributable plugin (or a
+      root orchestration script) and wire into the workflow; include a `--dry-run`.
+- [ ] **T13**. CI dry-run publish on a PR; confirm both registries resolve the
+      package and that `npm view` / GitHub Packages show the version.
+
+## Phase 4 — Config & feature flag (T14–T15)
+
+- [ ] **T14**. Add config to `apps/api/src/config/constants.ts` (lazy-fn pattern):
+      `PLUGIN_DISTRIBUTION_MODE` (`bundled`|`dynamic`, default `bundled`),
+      `PLUGIN_REGISTRY_URL`, `PLUGIN_REGISTRY_GITHUB_URL`, `PLUGIN_REGISTRY_TOKEN`
+      (secret), `PLUGIN_INSTALL_DIR` (default `/app/plugins`),
+      `FEATURE_DYNAMIC_PLUGINS`. Fail-fast validation when dynamic + no registry.
+    - **Test**: config validation spec.
+- [ ] **T15**. Thread the mode/paths into `PluginsModule.forRootAsync` options
+      (`packages/agent/src/plugins/plugins.module.ts`,
+      `apps/api/src/api.module.ts`) so `pluginPaths`/install dir derive from config.
+
+## Phase 5 — Installer & boot reconcile (T16–T20)
+
+- [ ] **T16**. Implement `PluginInstallerService` at
+      `packages/agent/src/plugins/services/plugin-installer.service.ts`:
+      resolve `pkg@version` from the registry, **allowlist-check first**,
+      download, **verify integrity**, place into `PLUGIN_INSTALL_DIR`. Per-id
+      concurrency guard; idempotent (skip if present + integrity matches).
+    - **Test**: installer spec with mocked registry + allowlist + integrity paths.
+- [ ] **T17**. Allowlist enforcement: first-party `@ever-works/*` implicitly
+      allowed; everything else must match an enabled `plugin_allowlist` row;
+      refuse before download (FR-11). **Test**: allow/deny matrix.
+- [ ] **T18**. Wire installer into the enable flow in
+      `packages/agent/src/plugins/services/plugin-operations.service.ts`
+      (`enablePluginForUser`): in dynamic mode, if not installed →
+      install → `PluginLoaderService.load(path)` → register → then enable.
+      Bundled mode unchanged. Update `installState` transitions + failure reason.
+    - **Test**: enable-installs-then-enables; failure leaves no partial registration (FR-14).
+- [ ] **T19**. **Lazy install-on-use** `ensurePluginAvailable(pluginId)` on the
+      installer/loader path: before any node invokes a distributable plugin,
+      install-if-missing (pinned version+integrity, per-id lock) then load+register.
+      This is the correctness guarantee (FR-13) — a plugin enabled on replica A is
+      usable on replica B and in the worker with no restart/shared volume. Also add
+      **boot warmup** in `plugin-bootstrap.service.ts` that pre-installs the
+      DB-recorded set (FR-13a, optimisation only). Idempotent.
+    - **Test**: enable on one registry instance → second instance with empty store
+      lazily installs on first use; warmup pre-installs; both safe to re-run.
+- [ ] **T20**. Uninstall path (`DELETE /plugins/:id/install` service method);
+      refuse for core/`systemPlugin`; default retention = keep files, mark
+      not-installed. **Test**: core refusal + non-core uninstall.
+
+## Phase 6 — API surface (T21–T24)
+
+- [ ] **T21**. Add controller methods in
+      `apps/api/src/plugins/plugins.controller.ts`: `GET /plugins/catalog`,
+      `POST /plugins/:id/install`, `DELETE /plugins/:id/install`,
+      `GET /plugins/:id/install-status`. Swagger decorators + error mapping
+      (409/424/502/422).
+- [ ] **T22**. Catalog service: list distributable plugins (manifest summaries)
+      from the registry/catalog source, merged with local install state.
+    - **Test**: catalog merge + registry-down degradation.
+- [ ] **T23**. Admin allowlist endpoints `GET/POST/DELETE /admin/plugins/allowlist`
+      (admin-gated) in a new `apps/api/src/plugins/allowlist.controller.ts`.
+- [ ] **T24**. e2e: `apps/api/test/plugins-dynamic.e2e-spec.ts` — install →
+      enable → use, non-allowlisted refusal, integrity mismatch, registry-down.
+
+## Phase 7 — Execution router (T25–T28)
+
+- [ ] **T25**. Implement `PluginExecutionRouterService` at
+      `packages/agent/src/plugins/services/plugin-execution-router.service.ts`:
+      decide in-process vs job-runtime per capability/operation from
+      `executionProfile` + operation classification (FR-17).
+    - **Test**: routing matrix.
+- [ ] **T26**. In-process path: facades (`packages/agent/src/facades/*`) call the
+      dynamically-loaded plugin directly for `sync` operations (FR-15). No change
+      for bundled/core. **Test**: short call stays in-process (no job dispatch).
+- [ ] **T27**. Long-running path: route `long-running` plugin calls through the
+      job runtime (Trigger.dev task in `packages/tasks/src/tasks/trigger/`). The
+      task MUST call `ensurePluginAvailable` (T19) **first** — the worker is a
+      separate runtime with its own store, so a runtime-installed plugin is absent
+      there until installed — then import the plugin and return via the existing
+      result channel (FR-16). Coordinate with [EW-683] for provider abstraction.
+    - **Test**: long call for a runtime-installed plugin succeeds in the worker
+      (worker installs into its own store first), not just the API.
+- [ ] **T28**. Result/error propagation + timeout/retry parity between paths.
+
+## Phase 8 — Deployment (T29–T32)
+
+- [ ] **T29**. Dynamic-mode image: build a core-only plugin set into the image
+      (build arg / variant) at `.deploy/docker/api/Dockerfile`; keep the current
+      all-bundled image as the `bundled` default. Confirm only core plugins land
+      in `/app/plugins`.
+- [ ] **T30**. Writable runtime store: ensure `PLUGIN_INSTALL_DIR` is writable
+      in k8s (`.deploy/k8s/k8s-manifest.prod.yaml`) — emptyDir (per-replica) or
+      optional PVC; readiness gate until boot reconcile completes.
+- [ ] **T31**. Entrypoint/boot wiring (`.deploy/docker/api/entrypoint.sh`) so
+      reconcile runs before serving; document ordering vs migrations.
+- [ ] **T32**. Document that read-only-FS serverless targets (Vercel) support
+      `bundled` only; dynamic mode requires a writable store.
+
+## Phase 9 — Web / CLI (T33–T36)
+
+- [ ] **T33**. Extend `apps/web/src/lib/api/plugins.ts` with catalog, install,
+      install-status, uninstall calls + types.
+- [ ] **T34**. Plugins settings page
+      (`apps/web/src/app/[locale]/(dashboard)/settings/plugins/[category]/page.tsx`):
+      install-state chips, Install action, progress, error surfacing; Enable
+      triggers install-then-enable in dynamic mode (FR-18/19/20).
+- [ ] **T35**. Admin allowlist management page + components.
+- [ ] **T36** (optional). CLI `ever-works plugins install|uninstall|list`
+      under `apps/cli/src/commands/`.
+
+## Phase 10 — Observability, docs & rollout (T37–T40)
+
+- [ ] **T37**. Activity-log events + metrics for install/upgrade/uninstall/reconcile
+      (`plugin.install.*`), Sentry tags (`plugin_source`, `distribution_mode`).
+- [ ] **T38**. Update canonical `docs/plugin-system/built-in-plugins.md` with the
+      core vs distributable split (Principle VIII); update
+      `docs/specs/architecture/runtime-plugins.md` cross-links and
+      `docs/specs/README.md` index.
+- [ ] **T39**. Operator runbook: enabling dynamic mode, registry config, store
+      volume, troubleshooting failed installs (under `docs/` + Workspace KB).
+- [ ] **T40**. Flip spec `Status: Implemented`, mark plan/tasks `Done`; run
+      `pnpm format && pnpm lint && pnpm type-check && pnpm test && pnpm build` green.
+
+## Definition of Done
+
+- All checkboxes ticked; all new code tested and green in CI.
+- `pnpm format:check` and `pnpm lint` green.
+- `pnpm --filter ever-works-docs build` produces no broken-link warnings.
+- Bundled-mode behaviour is byte-for-byte unchanged for a no-config deployment.
+- Both execution paths (in-process + job-runtime) covered by integration tests.
+- Constitution gates in `spec.md` §9 all confirmed satisfied.

--- a/docs/specs/features/event-subscriptions/spec.md
+++ b/docs/specs/features/event-subscriptions/spec.md
@@ -88,7 +88,7 @@ Resolution:
 1. Load `user_notification_subscriptions` rows for `(userId, eventType)`.
 2. If none, fall back to the organisation default → built-in default → `['in-app']`.
 3. Filter out channels the user has disabled.
-4. Apply quiet hours: if now ∈ quiet window AND event.urgent === false AND channel is not `in-app`, queue delivery for end-of-quiet-window via BullMQ delayed job.
+4. Apply quiet hours: if now ∈ quiet window AND event.urgent === false AND channel is not `in-app`, defer delivery to end-of-quiet-window by enqueuing the Trigger.dev `notification-channel-delivery` task with a `delay` (the run waits server-side until the window closes). No BullMQ.
 5. Apply category mute: if `(userId, category)` has an active mute, drop all non-`in-app` channels (in-app still records the notification for retrospective viewing).
 
 Output: a list of `channelId`s. The caller fans out via `NotificationChannelFacadeService.send(channelIds, payload)`.

--- a/docs/specs/features/notification-channels/spec.md
+++ b/docs/specs/features/notification-channels/spec.md
@@ -112,7 +112,7 @@ A new facade in `packages/agent/src/facades/notification-channel.facade.ts` (par
 
 - **`send(userId, eventType, payload)`** — resolves the user's enabled channels for the event (via [`event-subscriptions`](../event-subscriptions/spec.md)), and fans out to each in parallel.
 - **`sendDirect(channelId, payload)`** — bypass the subscription resolver; send to one specific channel (used for "Test" button, direct ad-hoc notifications).
-- **Failover**: per-channel attempt with exponential-backoff retry (3 attempts, 1s/4s/15s); on terminal failure, enqueue a BullMQ `notification-channel-retry` job (24h dead-letter).
+- **Failover**: per-channel delivery runs through a Trigger.dev `notification-channel-delivery` task whose `retry` policy gives exponential backoff (mirrors the existing `webhook-delivery` task). On terminal failure the run exhausts its attempts and the delivery-log row is marked `failed` (that row is the dead-letter). When Trigger.dev is disabled (dev / no token), the facade falls back to a synchronous in-process attempt. No BullMQ/Redis — Trigger.dev is the house job system.
 - **Attribution**: emits a `PluginUsageEvent` per send with `capability='notification-channel'` and `channelId` in metadata.
 
 ### 3.4 In-app channel (special-cased)
@@ -156,7 +156,7 @@ notification_channel_delivery_log
 ### 4.2 Reuses
 
 - `PluginUsageEvent` — adds rows with `capability='notification-channel'`.
-- BullMQ — adds `notification-channel-retry` queue (3 attempts, exponential backoff).
+- Trigger.dev — adds a `notification-channel-delivery` task (exponential-backoff `retry` policy; quiet-hours deferral via the run `delay` option).
 
 ---
 
@@ -214,7 +214,7 @@ The in-app channel is built-in (no plugin package).
 - [x] **I** Plugin-first — each channel ships as its own package under `packages/plugins/`.
 - [x] **II** Capability-driven — selection via `PLUGIN_CAPABILITIES.NOTIFICATION_CHANNEL_*`.
 - [x] **III** Database — new tables go through TypeORM migrations per repo rules.
-- [x] **IV** Trigger.dev / BullMQ — retry queue uses BullMQ (already in use).
+- [x] **IV** Trigger.dev — delivery + retry + quiet-hours deferral use a Trigger.dev task (`delay` for deferral); no BullMQ.
 - [x] **V** Forward-only migrations — additive tables only.
 - [x] **VI** Tests — Vitest unit tests per plugin + Jest integration tests for the facade.
 - [x] **VII** Secret hygiene — bot tokens / API keys marked `x-secret` in the plugin manifest.

--- a/packages/agent/src/agents/__tests__/agent-tool.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool.service.spec.ts
@@ -284,6 +284,51 @@ describe('AgentToolService.resolveAllowedTools', () => {
             expect(facade.sendEmail).toHaveBeenCalledTimes(1);
             expect((ok as { providerMessageId: string }).providerMessageId).toBe('pm-1');
         });
+
+        it('accepts a template instead of bodyText and forwards it to the facade', async () => {
+            const facade = makeEmailFacade();
+            facade.sendEmail.mockResolvedValue({
+                providerMessageId: 'pm-2',
+                accepted: ['b@x.com'],
+                rejected: [],
+            });
+            const withFacade = new AgentToolService(
+                agents,
+                skills,
+                bindings,
+                files,
+                undefined,
+                undefined,
+                facade as any,
+            );
+            const tools = withFacade.resolveAllowedTools(
+                makeAgent({
+                    permissions: { ...makeAgent().permissions, canCallExternalTools: true },
+                }),
+            );
+            const tool = tools.find((t) => t.name === 'sendEmail')!;
+
+            // Neither body nor template → error.
+            const bad = (await tool.invoke({ to: ['b@x.com'], subject: 's' } as any)) as Record<
+                string,
+                unknown
+            >;
+            expect('error' in bad).toBe(true);
+            expect(facade.sendEmail).not.toHaveBeenCalled();
+
+            // Template only → forwarded through to the facade.
+            const ok = await tool.invoke({
+                to: ['b@x.com'],
+                subject: 'Digest',
+                template: { slug: 'agent-summary', props: { agentName: 'Atlas' } },
+            } as any);
+            expect((ok as { providerMessageId: string }).providerMessageId).toBe('pm-2');
+            expect(facade.sendEmail).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    template: { slug: 'agent-summary', props: { agentName: 'Atlas' } },
+                }),
+            );
+        });
     });
 
     describe('messageAgent tool (EW-670 / T24)', () => {

--- a/packages/agent/src/agents/agent-email-facade.ts
+++ b/packages/agent/src/agents/agent-email-facade.ts
@@ -18,6 +18,17 @@
  * resolves the actual from-address + provider from the Agent's
  * `agent_email_assignments` (lowest-priority outbound = default).
  */
+/**
+ * Handle for a registered React-Email template. When provided, the
+ * adapter renders it server-side (via `@ever-works/email-templates`)
+ * into the HTML + text bodies — the Agent supplies structured `props`
+ * instead of raw HTML.
+ */
+export interface AgentEmailTemplateRef {
+    slug: string;
+    props: Record<string, unknown>;
+}
+
 export interface AgentSendEmailInput {
     userId: string;
     agentId: string;
@@ -26,8 +37,11 @@ export interface AgentSendEmailInput {
     to: string[];
     cc?: string[];
     subject: string;
-    bodyText: string;
+    /** Plain-text body. Optional when `template` is supplied (rendered then). */
+    bodyText?: string;
     bodyHtml?: string;
+    /** Render a registered React-Email template instead of raw bodies. */
+    template?: AgentEmailTemplateRef;
     /** Optional explicit from-address id (tenant_email_addresses.id). */
     fromAddressId?: string;
 }

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -606,9 +606,10 @@ export class AgentToolService {
         {
             to: string[];
             subject: string;
-            bodyText: string;
+            bodyText?: string;
             cc?: string[];
             bodyHtml?: string;
+            template?: { slug: string; props: Record<string, unknown> };
             fromAddressId?: string;
         },
         AgentSendEmailResult
@@ -616,7 +617,7 @@ export class AgentToolService {
         return {
             name: 'sendEmail',
             description:
-                "Send an email from one of this agent's assigned outbound addresses. Requires canCallExternalTools AND at least one outbound email address assigned to the agent (Settings → Integrations → Emails). Returns the provider message id plus accepted/rejected recipient lists. Use for agent-authored outbound mail; for messaging a peer agent prefer messageAgent.",
+                "Send an email from one of this agent's assigned outbound addresses. Requires canCallExternalTools AND at least one outbound email address assigned to the agent (Settings → Integrations → Emails). Provide either bodyText (optionally bodyHtml) OR a template to render. Returns the provider message id plus accepted/rejected recipient lists. Use for agent-authored outbound mail; for messaging a peer agent prefer messageAgent.",
             parameters: {
                 type: 'object',
                 properties: {
@@ -626,7 +627,10 @@ export class AgentToolService {
                         description: 'Recipient email addresses (RFC 5321 mailboxes).',
                     },
                     subject: { type: 'string', description: 'Email subject line.' },
-                    bodyText: { type: 'string', description: 'Plain-text body (always required).' },
+                    bodyText: {
+                        type: 'string',
+                        description: 'Plain-text body. Required unless `template` is provided.',
+                    },
                     cc: {
                         type: 'array',
                         items: { type: 'string' },
@@ -636,13 +640,18 @@ export class AgentToolService {
                         type: 'string',
                         description: 'Optional HTML body. When omitted, bodyText is sent as-is.',
                     },
+                    template: {
+                        type: 'object',
+                        description:
+                            'Render a registered React-Email template server-side instead of raw bodies (mutually exclusive with bodyText/bodyHtml). Shape: { slug: string (e.g. "agent-summary" | "agent-message"), props: object (fields depend on the slug) }.',
+                    },
                     fromAddressId: {
                         type: 'string',
                         description:
                             "Optional tenant_email_addresses id to send from. Defaults to the agent's primary (lowest-priority) outbound assignment.",
                     },
                 },
-                required: ['to', 'subject', 'bodyText'],
+                required: ['to', 'subject'],
             },
             invoke: async (args) => {
                 if (!Array.isArray(args?.to) || args.to.length === 0) {
@@ -651,8 +660,10 @@ export class AgentToolService {
                 if (!args?.subject || args.subject.trim().length === 0) {
                     return { error: 'subject is required.' };
                 }
-                if (!args?.bodyText || args.bodyText.trim().length === 0) {
-                    return { error: 'bodyText is required.' };
+                const hasBody = !!args?.bodyText && args.bodyText.trim().length > 0;
+                const hasTemplate = !!args?.template?.slug;
+                if (!hasBody && !hasTemplate) {
+                    return { error: 'Provide bodyText or a template.' };
                 }
                 try {
                     return await this.emailFacade!.sendEmail({
@@ -664,6 +675,7 @@ export class AgentToolService {
                         subject: args.subject,
                         bodyText: args.bodyText,
                         bodyHtml: args.bodyHtml,
+                        template: args.template,
                         fromAddressId: args.fromAddressId,
                     });
                 } catch (err) {

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -88,6 +88,32 @@ describe('DeployFacadeService', () => {
         ]);
     });
 
+    it('checks configured state for the ever-works alias against k8s settings', async () => {
+        const { service, registry, settingsService } = createService({
+            deployProvider: 'ever-works',
+            pluginId: 'k8s',
+            settings: { clusterSource: { value: 'k8s-works' } },
+        });
+
+        await expect(service.isProviderConfigured('ever-works', 'user-1', 'work-1')).resolves.toBe(
+            true,
+        );
+
+        expect(registry.get).toHaveBeenCalledWith('k8s');
+        expect(settingsService.getResolvedSettings).toHaveBeenCalledWith('k8s', {
+            userId: 'user-1',
+            workId: 'work-1',
+            includeSecrets: true,
+        });
+    });
+
+    it('uses the resolved plugin display name for the ever-works alias', () => {
+        const { service } = createService({ deployProvider: 'ever-works', pluginId: 'k8s' });
+
+        expect(service.resolveProviderId('ever-works')).toBe('k8s');
+        expect(service.getProviderName('ever-works')).toBe('Kubernetes');
+    });
+
     it('does not report an unconfigured loaded provider as configured', async () => {
         const { service } = createService({
             deployProvider: 'k8s',
@@ -100,6 +126,34 @@ describe('DeployFacadeService', () => {
             id: 'k8s',
             enabled: true,
             configured: false,
+        });
+    });
+
+    describe('auto-assigned deployment domains', () => {
+        const originalDomain = process.env.EVER_WORKS_DOMAIN;
+
+        afterEach(() => {
+            if (originalDomain === undefined) {
+                delete process.env.EVER_WORKS_DOMAIN;
+            } else {
+                process.env.EVER_WORKS_DOMAIN = originalDomain;
+            }
+        });
+
+        it('treats Ever Works subdomains as auto-assigned', () => {
+            const { service } = createService({ deployProvider: 'k8s' });
+
+            expect((service as any).isAutoAssignedDomain('my-site.ever.works')).toBe(true);
+            expect((service as any).isAutoAssignedDomain('my-site.vercel.app')).toBe(true);
+            expect((service as any).isAutoAssignedDomain('www.customer.com')).toBe(false);
+        });
+
+        it('respects EVER_WORKS_DOMAIN overrides for auto-assigned domains', () => {
+            process.env.EVER_WORKS_DOMAIN = 'preview.ever.works';
+            const { service } = createService({ deployProvider: 'k8s' });
+
+            expect((service as any).isAutoAssignedDomain('my-site.preview.ever.works')).toBe(true);
+            expect((service as any).isAutoAssignedDomain('my-site.ever.works')).toBe(false);
         });
     });
 

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -217,6 +217,7 @@ describe('FacadesModule + barrel re-exports', () => {
                     'EmailFacadeService',
                     'NotificationChannelFacadeError',
                     'NotificationChannelFacadeService',
+                    'NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER',
                 ].sort(),
             );
         });

--- a/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
@@ -75,4 +75,25 @@ describe('NotificationChannelFacadeService', () => {
             ),
         ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
     });
+
+    it('deliverToChannelOrThrow resolves for the in-app sentinel and throws on failure', async () => {
+        // 'in-app' is a no-op delivered sentinel — resolves.
+        await expect(
+            facade.deliverToChannelOrThrow(
+                'in-app',
+                { text: 'x', messageRef: 'r' },
+                { userId: 'u' },
+            ),
+        ).resolves.toMatchObject({ status: 'delivered' });
+
+        // No channels repo wired here → sendOne yields a failed result →
+        // the throwing variant surfaces it (so Trigger.dev retries).
+        await expect(
+            facade.deliverToChannelOrThrow(
+                'missing',
+                { text: 'x', messageRef: 'r' },
+                { userId: 'u' },
+            ),
+        ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
+    });
 });

--- a/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/notification-channel.facade.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import {
     NotificationChannelFacadeService,
     NotificationChannelFacadeError,
+    NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
 } from '../notification-channel.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
@@ -95,5 +96,37 @@ describe('NotificationChannelFacadeService', () => {
                 { userId: 'u' },
             ),
         ).rejects.toBeInstanceOf(NotificationChannelFacadeError);
+    });
+
+    it('routes event fanout through the delivery dispatcher when bound (returns queued)', async () => {
+        const enqueue = jest.fn().mockResolvedValue({ runId: 'run-1' });
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                NotificationChannelFacadeService,
+                { provide: PluginRegistryService, useValue: registry },
+                { provide: PluginSettingsService, useValue: settings },
+                { provide: NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER, useValue: { enqueue } },
+            ],
+        }).compile();
+        const f = moduleRef.get(NotificationChannelFacadeService);
+
+        const results = await f.send(
+            'user-1',
+            'work_generation_finished',
+            { text: 'done', messageRef: 'ref-1' },
+            async () => ['ch-1', 'in-app'],
+            { userId: 'user-1' },
+        );
+
+        // ch-1 → enqueued (Trigger handles delivery + retry); in-app stays
+        // inline as a no-op delivered sentinel.
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        expect(results.find((r) => r.channelId === 'ch-1')).toMatchObject({
+            status: 'queued',
+            providerMessageId: 'run-1',
+        });
+        expect(results.find((r) => r.channelId === 'in-app')).toMatchObject({
+            status: 'delivered',
+        });
     });
 });

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -94,6 +94,20 @@ export class DeployFacadeService implements IDeployFacade {
         private readonly workPluginRepository?: WorkPluginRepository,
     ) {}
 
+    resolveProviderId(providerId: string): string {
+        return resolvePluginProviderId(providerId);
+    }
+
+    getProviderName(providerId: string | undefined): string {
+        if (!providerId) return 'Deployment';
+
+        const resolvedProviderId = resolvePluginProviderId(providerId);
+        const registered = this.registry.get(resolvedProviderId);
+        const plugin = registered?.plugin as IDeploymentPlugin | undefined;
+
+        return plugin?.name || plugin?.providerName || providerId;
+    }
+
     /**
      * Check if deployment is configured for a work
      */
@@ -132,14 +146,15 @@ export class DeployFacadeService implements IDeployFacade {
         userId: string,
         workId?: string,
     ): Promise<boolean> {
-        const registered = this.registry.get(providerId);
+        const resolvedProviderId = resolvePluginProviderId(providerId);
+        const registered = this.registry.get(resolvedProviderId);
         if (!registered || registered.state !== 'loaded') {
             return false;
         }
         if (!registered.manifest.capabilities.includes(this.CAPABILITY)) {
             return false;
         }
-        return !!(await this.getTokenFromSettings(providerId, userId, workId));
+        return !!(await this.getTokenFromSettings(resolvedProviderId, userId, workId));
     }
 
     /**
@@ -574,7 +589,8 @@ export class DeployFacadeService implements IDeployFacade {
         if (!domain.verified) return;
 
         // Only promote to primary URL if current website is auto-assigned or unset
-        const isAutoAssigned = !work.website || work.website.endsWith('.vercel.app');
+        const currentHost = this.extractHostname(work.website);
+        const isAutoAssigned = !currentHost || this.isAutoAssignedDomain(currentHost);
         if (!isAutoAssigned) return;
 
         await this.workRepository.update(work.id, {
@@ -582,8 +598,34 @@ export class DeployFacadeService implements IDeployFacade {
         });
     }
 
+    private extractHostname(value?: string | null): string | undefined {
+        if (!value) return undefined;
+        try {
+            return new URL(value).hostname.toLowerCase();
+        } catch {
+            return (
+                value
+                    .replace(/^https?:\/\//, '')
+                    .split('/')[0]
+                    ?.toLowerCase() || undefined
+            );
+        }
+    }
+
     private isAutoAssignedDomain(domain: string): boolean {
-        return domain.endsWith('.vercel.app');
+        const host = this.extractHostname(domain);
+        if (!host) return false;
+
+        const everWorksDomain = (process.env.EVER_WORKS_DOMAIN || 'ever.works')
+            .trim()
+            .replace(/^\.+|\.+$/g, '')
+            .toLowerCase();
+
+        return (
+            host.endsWith('.vercel.app') ||
+            (Boolean(everWorksDomain) &&
+                (host === everWorksDomain || host.endsWith(`.${everWorksDomain}`)))
+        );
     }
 
     private sortDomainsForDisplay(domains: DeploymentDomain[]): DeploymentDomain[] {

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -106,6 +106,7 @@ export {
 export {
     NotificationChannelFacadeService,
     NotificationChannelFacadeError,
+    NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
     type NotificationChannelFanoutInput,
     type NotificationChannelFanoutResult,
     type NotificationChannelDeliveryPayload,

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -108,6 +108,8 @@ export {
     NotificationChannelFacadeError,
     type NotificationChannelFanoutInput,
     type NotificationChannelFanoutResult,
+    type NotificationChannelDeliveryPayload,
+    type NotificationChannelDeliveryDispatcher,
 } from './notification-channel.facade';
 
 // Agent-Memory Facade — pluggable persistent memory for agents

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -111,6 +111,7 @@ export {
     type NotificationChannelFanoutResult,
     type NotificationChannelDeliveryPayload,
     type NotificationChannelDeliveryDispatcher,
+    type ResolvedChannelTarget,
 } from './notification-channel.facade';
 
 // Agent-Memory Facade — pluggable persistent memory for agents

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -170,12 +170,18 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
                     options,
                     deferUntil,
                 });
-                return {
-                    channelId,
-                    pluginId: 'queued',
-                    status: 'queued',
-                    providerMessageId: runId ?? undefined,
-                };
+                // A null runId means Trigger.dev is disabled / didn't
+                // enqueue — fall through to in-process delivery so the
+                // notification isn't silently lost. Only a real run id
+                // means the delivery is genuinely queued.
+                if (runId) {
+                    return {
+                        channelId,
+                        pluginId: 'queued',
+                        status: 'queued',
+                        providerMessageId: runId,
+                    };
+                }
             } catch (err) {
                 // Enqueue failed — fall back to an in-process attempt so the
                 // notification isn't silently lost.

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -138,6 +138,32 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         });
     }
 
+    /**
+     * Single delivery attempt that THROWS on failure. This is the
+     * primitive the Trigger.dev `notification-channel-delivery` task
+     * calls (via the trigger-internal RPC) so its `retry` policy re-runs
+     * the attempt on failure — whereas `send()`'s parallel fanout uses
+     * `sendOne` directly, which swallows per-channel failures so one bad
+     * channel doesn't sink its siblings. On terminal retry-exhaustion
+     * the delivery-log row left by `sendOne` is the dead-letter.
+     */
+    async deliverToChannelOrThrow(
+        channelId: string,
+        payload: NotificationChannelFanoutInput,
+        options: FacadeOptions,
+        eventType?: string,
+    ): Promise<NotificationChannelFanoutResult> {
+        const result = await this.sendOne(channelId, payload, options, eventType);
+        if (result.status === 'failed') {
+            throw new NotificationChannelFacadeError(
+                result.error ?? 'channel delivery failed',
+                'deliverToChannelOrThrow',
+                result.pluginId,
+            );
+        }
+        return result;
+    }
+
     private async sendOne(
         channelId: string,
         payload: NotificationChannelFanoutInput,

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { PLUGIN_CAPABILITIES, type FacadeOptions } from '@ever-works/plugin';
 import {
     isNotificationChannelPlugin,
@@ -37,10 +37,44 @@ export interface NotificationChannelFanoutInput {
 export interface NotificationChannelFanoutResult {
     readonly channelId: string;
     readonly pluginId: string;
-    readonly status: 'delivered' | 'failed';
+    /** `queued` = handed to the Trigger.dev delivery task (async outcome). */
+    readonly status: 'delivered' | 'failed' | 'queued';
     readonly providerMessageId?: string;
     readonly error?: string;
 }
+
+/**
+ * Payload handed to the Trigger.dev `notification-channel-delivery`
+ * dispatcher. The Trigger task calls back into
+ * `deliverToChannelOrThrow` (via the trigger-internal RPC) to perform
+ * the actual single attempt under the task's retry policy.
+ */
+export interface NotificationChannelDeliveryPayload {
+    readonly channelId: string;
+    readonly text: string;
+    readonly rich?: ChannelRichPayload;
+    readonly messageRef: string;
+    readonly eventType?: string;
+    readonly options: FacadeOptions;
+    /**
+     * ISO-8601 timestamp. When set, the dispatcher schedules the run
+     * with a Trigger.dev `delay` so it fires then (quiet-hours deferral).
+     */
+    readonly deferUntil?: string;
+}
+
+/**
+ * Producer-side hand-off to Trigger.dev. Bound in apps/api to an
+ * adapter over `TriggerService.dispatchNotificationChannelDelivery`;
+ * left UNBOUND in dev / when Trigger is disabled, in which case the
+ * facade delivers in-process (synchronous fallback).
+ */
+export interface NotificationChannelDeliveryDispatcher {
+    enqueue(payload: NotificationChannelDeliveryPayload): Promise<{ runId: string | null }>;
+}
+
+export const NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER =
+    'NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER' as const;
 
 /**
  * NotificationChannelFacadeService — fan-out point for multi-channel
@@ -60,9 +94,11 @@ export interface NotificationChannelFanoutResult {
  * - Persists a `notification_channel_delivery_log` row (idempotent on `messageRef`).
  * - Emits a `PluginUsageEvent` with `capability='notification_channel'`.
  *
- * Per-channel retry uses BullMQ (queue `notification-channel-retry`, 3
- * attempts exp-backoff, 24h dead-letter) — wired in T12 with the
- * controller layer.
+ * Per-channel retry uses the Trigger.dev `notification-channel-delivery`
+ * task (exponential-backoff `retry` policy; quiet-hours deferral via the
+ * run `delay`). Event fanout enqueues through the optional
+ * {@link NotificationChannelDeliveryDispatcher}; when it's unbound
+ * (dev / Trigger disabled) the facade delivers in-process as a fallback.
  */
 @Injectable()
 export class NotificationChannelFacadeService extends BaseFacadeService {
@@ -76,6 +112,9 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         @Optional() private readonly channels?: NotificationChannelRepository,
         @Optional() private readonly deliveryLog?: NotificationChannelDeliveryLogRepository,
         @Optional() private readonly pluginUsageService?: PluginUsageService,
+        @Optional()
+        @Inject(NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER)
+        private readonly deliveryDispatcher?: NotificationChannelDeliveryDispatcher,
     ) {
         super(registry, settingsService, workPluginRepository);
     }
@@ -98,12 +137,56 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
             this.logger.debug(`No channels resolved for user=${userId} event=${eventType}`);
             return [];
         }
+        const scopedOptions: FacadeOptions = { ...options, userId };
         const attempts = await Promise.all(
             channelIds.map((channelId) =>
-                this.sendOne(channelId, payload, { ...options, userId }, eventType),
+                this.dispatchOrSend(channelId, payload, scopedOptions, eventType),
             ),
         );
         return attempts;
+    }
+
+    /**
+     * Route one channel to the Trigger.dev delivery task when a
+     * dispatcher is bound (async, retry-backed); otherwise deliver
+     * in-process (fallback). `in-app` always stays inline — it's a
+     * no-op sentinel handled by notifications v1.
+     */
+    private async dispatchOrSend(
+        channelId: string,
+        payload: NotificationChannelFanoutInput,
+        options: FacadeOptions,
+        eventType?: string,
+        deferUntil?: string,
+    ): Promise<NotificationChannelFanoutResult> {
+        if (channelId !== 'in-app' && this.deliveryDispatcher) {
+            try {
+                const { runId } = await this.deliveryDispatcher.enqueue({
+                    channelId,
+                    text: payload.text,
+                    rich: payload.rich,
+                    messageRef: payload.messageRef,
+                    eventType,
+                    options,
+                    deferUntil,
+                });
+                return {
+                    channelId,
+                    pluginId: 'queued',
+                    status: 'queued',
+                    providerMessageId: runId ?? undefined,
+                };
+            } catch (err) {
+                // Enqueue failed — fall back to an in-process attempt so the
+                // notification isn't silently lost.
+                this.logger.warn(
+                    `channel ${channelId} enqueue failed, delivering in-process: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
+        }
+        return this.sendOne(channelId, payload, options, eventType);
     }
 
     /**

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -77,6 +77,17 @@ export const NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER =
     'NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER' as const;
 
 /**
+ * A channel to fan out to, optionally deferred. `deferUntil` (ISO-8601)
+ * is set for channels held by quiet hours — the facade enqueues them on
+ * the Trigger.dev delivery task with that `delay`. Plain strings (no
+ * deferral) are accepted too for back-compat with simple resolvers.
+ */
+export interface ResolvedChannelTarget {
+    channelId: string;
+    deferUntil?: string;
+}
+
+/**
  * NotificationChannelFacadeService — fan-out point for multi-channel
  * notification delivery. Mirrors `EmailFacadeService` shape but for the
  * `NOTIFICATION_CHANNEL` umbrella capability.
@@ -129,19 +140,32 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         userId: string,
         eventType: string,
         payload: NotificationChannelFanoutInput,
-        resolveChannelIds: (userId: string, eventType: string) => Promise<readonly string[]>,
+        resolveChannelIds: (
+            userId: string,
+            eventType: string,
+        ) => Promise<readonly (string | ResolvedChannelTarget)[]>,
         options: FacadeOptions,
     ): Promise<readonly NotificationChannelFanoutResult[]> {
-        const channelIds = await resolveChannelIds(userId, eventType);
-        if (channelIds.length === 0) {
+        const resolved = await resolveChannelIds(userId, eventType);
+        if (resolved.length === 0) {
             this.logger.debug(`No channels resolved for user=${userId} event=${eventType}`);
             return [];
         }
         const scopedOptions: FacadeOptions = { ...options, userId };
         const attempts = await Promise.all(
-            channelIds.map((channelId) =>
-                this.dispatchOrSend(channelId, payload, scopedOptions, eventType),
-            ),
+            resolved.map((target) => {
+                const { channelId, deferUntil } =
+                    typeof target === 'string'
+                        ? { channelId: target, deferUntil: undefined }
+                        : target;
+                return this.dispatchOrSend(
+                    channelId,
+                    payload,
+                    scopedOptions,
+                    eventType,
+                    deferUntil,
+                );
+            }),
         );
         return attempts;
     }

--- a/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
@@ -148,6 +148,44 @@ describe('UserNotificationSubscriptionService', () => {
             'in-app',
         ]);
     });
+
+    it('resolvePlan DEFERS non-in-app channels during quiet hours (does not drop them)', async () => {
+        eventTypes.findByKey.mockResolvedValue({
+            key: 'work_generation_finished',
+            category: 'generation',
+            urgent: false,
+            defaultChannels: ['in-app'],
+        });
+        subscriptions.findForEvent.mockResolvedValue({ channelIds: ['in-app', 'channel-1'] });
+        mutes.isMuted.mockResolvedValue(false);
+        preferences.findByUser.mockResolvedValue({
+            quietHoursStart: '00:00:00',
+            quietHoursEnd: '23:59:59',
+            timezone: 'UTC',
+        });
+
+        const plan = await service.resolvePlan('u', 'work_generation_finished');
+        expect(plan.immediate).toEqual(['in-app']);
+        expect(plan.deferred).toEqual(['channel-1']);
+        expect(typeof plan.deferUntil).toBe('string');
+        expect(new Date(plan.deferUntil!).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('resolvePlan leaves deferred empty outside quiet hours', async () => {
+        eventTypes.findByKey.mockResolvedValue({
+            key: 'work_generation_finished',
+            category: 'generation',
+            urgent: false,
+            defaultChannels: ['in-app'],
+        });
+        subscriptions.findForEvent.mockResolvedValue({ channelIds: ['in-app', 'channel-1'] });
+        mutes.isMuted.mockResolvedValue(false);
+        preferences.findByUser.mockResolvedValue(null); // no quiet hours configured
+        const plan = await service.resolvePlan('u', 'work_generation_finished');
+        expect(plan.immediate).toEqual(['in-app', 'channel-1']);
+        expect(plan.deferred).toEqual([]);
+        expect(plan.deferUntil).toBeUndefined();
+    });
 });
 
 describe('isWithinQuietHours', () => {

--- a/packages/agent/src/notifications/user-notification-subscription.service.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.ts
@@ -39,6 +39,17 @@ import {
  * NotificationFanoutListener (replacing its thin stub resolver). The
  * v1 NotificationService.create path remains untouched.
  */
+/**
+ * Outcome of {@link UserNotificationSubscriptionService.resolvePlan}.
+ * `immediate` channels deliver now; `deferred` channels are held until
+ * `deferUntil` (end of the user's quiet-hours window, ISO-8601).
+ */
+export interface ResolvedChannelPlan {
+    immediate: string[];
+    deferred: string[];
+    deferUntil?: string;
+}
+
 @Injectable()
 export class UserNotificationSubscriptionService {
     private readonly logger = new Logger(UserNotificationSubscriptionService.name);
@@ -57,10 +68,24 @@ export class UserNotificationSubscriptionService {
      * the user can review).
      */
     async resolveChannels(userId: string, eventTypeKey: string): Promise<string[]> {
+        const plan = await this.resolvePlan(userId, eventTypeKey);
+        return plan.immediate;
+    }
+
+    /**
+     * Deferral-aware resolution. `immediate` always carries `'in-app'`
+     * (unless muted). For a non-urgent event inside the user's quiet
+     * hours, non-in-app channels move to `deferred` with `deferUntil`
+     * set to the end-of-window instant (ISO) — the producer enqueues
+     * them on the Trigger.dev delivery task with that `delay` instead of
+     * dropping them. Muted categories are silenced (dropped, NOT
+     * deferred) — a mute means "don't tell me", not "tell me later".
+     */
+    async resolvePlan(userId: string, eventTypeKey: string): Promise<ResolvedChannelPlan> {
         const eventType = await this.eventTypes.findByKey(eventTypeKey);
         if (!eventType) {
             this.logger.debug(`Unknown event type ${eventTypeKey}; defaulting to in-app only`);
-            return ['in-app'];
+            return { immediate: ['in-app'], deferred: [] };
         }
 
         let channels = await this.loadInitialChannels(
@@ -78,25 +103,26 @@ export class UserNotificationSubscriptionService {
             }
         }
 
-        // Quiet hours (drops non-in-app for non-urgent events)
+        // Quiet hours: defer (not drop) non-in-app channels for non-urgent
+        // events so they fire at end-of-window.
         if (this.preferences && !eventType.urgent && channels.some((c) => c !== 'in-app')) {
             const pref = await this.preferences.findByUser(userId);
             if (pref?.quietHoursStart && pref?.quietHoursEnd) {
-                const inQuietWindow = isWithinQuietHours(
-                    new Date(),
-                    pref.quietHoursStart,
-                    pref.quietHoursEnd,
-                    pref.timezone ?? 'UTC',
-                );
-                if (inQuietWindow) {
-                    channels = channels.filter((c) => c === 'in-app');
-                    // TODO(EW-677 v2): enqueue non-in-app channels via
-                    // BullMQ delayed job so they fire at end-of-window.
+                const now = new Date();
+                const timeZone = pref.timezone ?? 'UTC';
+                if (isWithinQuietHours(now, pref.quietHoursStart, pref.quietHoursEnd, timeZone)) {
+                    const deferred = channels.filter((c) => c !== 'in-app');
+                    const immediate = channels.filter((c) => c === 'in-app');
+                    return {
+                        immediate,
+                        deferred,
+                        deferUntil: quietHoursEndIso(now, pref.quietHoursEnd, timeZone),
+                    };
                 }
             }
         }
 
-        return channels;
+        return { immediate: channels, deferred: [] };
     }
 
     private async loadInitialChannels(
@@ -163,4 +189,39 @@ function toMinutes(hms: string): number {
     const [h, m, s] = hms.split(':').map((n) => Number.parseInt(n, 10) || 0);
     // Hour 24 (midnight as end-of-day) is allowed in some libs.
     return (h % 24) * 60 + (m % 60) + (s >= 30 ? 1 : 0);
+}
+
+/**
+ * The next instant (ISO-8601) at which the user's quiet-hours window
+ * ends, computed from `now` + the wall-clock minutes until `quietEnd`
+ * in the user's timezone. Used as the Trigger.dev `delay` target for
+ * deferred channels. Assumes the caller has already confirmed `now` is
+ * within the window. DST transitions inside the window may shift the
+ * fire time by ±1h — acceptable for a "fire after quiet hours" signal.
+ */
+export function quietHoursEndIso(now: Date, quietEnd: string, timeZone: string): string {
+    let delayMinutes: number;
+    try {
+        const formatter = new Intl.DateTimeFormat('en-GB', {
+            timeZone,
+            hour12: false,
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        });
+        const parts = formatter.formatToParts(now);
+        const get = (type: Intl.DateTimeFormatPartTypes) =>
+            parts.find((p) => p.type === type)?.value ?? '00';
+        const nowMinutes = toMinutes(`${get('hour')}:${get('minute')}:${get('second')}`);
+        const endMinutes = toMinutes(quietEnd);
+        const diff = (((endMinutes - nowMinutes) % 1440) + 1440) % 1440;
+        // diff === 0 means now is exactly at the boundary — push a full
+        // day rather than firing instantly (shouldn't happen for an
+        // in-window check, but keeps the delay strictly positive).
+        delayMinutes = diff === 0 ? 1440 : diff;
+    } catch {
+        // Fall back to a 1h defer so a bad timezone never drops the send.
+        delayMinutes = 60;
+    }
+    return new Date(now.getTime() + delayMinutes * 60_000).toISOString();
 }

--- a/packages/agent/src/services/utils/error-classification.utils.spec.ts
+++ b/packages/agent/src/services/utils/error-classification.utils.spec.ts
@@ -237,6 +237,8 @@ describe('classifyGenerationError', () => {
             ['gemini quota exceeded', 'Google'],
             ['groq insufficient_quota', 'Groq'],
             ['ollama insufficient_quota', 'Ollama'],
+            ['lm-studio insufficient_quota', 'LM Studio'],
+            ['vllm insufficient_quota', 'vLLM'],
             ['openrouter rate_limit', 'OpenRouter'],
         ])('detects provider %p as %p', (input, provider) => {
             const result = classifyGenerationError(input);

--- a/packages/agent/src/services/utils/error-classification.utils.ts
+++ b/packages/agent/src/services/utils/error-classification.utils.ts
@@ -121,6 +121,9 @@ function detectAiProvider(error: string): string {
     if (error.includes('google') || error.includes('gemini')) return 'Google';
     if (error.includes('groq')) return 'Groq';
     if (error.includes('ollama')) return 'Ollama';
+    if (error.includes('lm-studio') || error.includes('lmstudio') || error.includes('lm studio'))
+        return 'LM Studio';
+    if (error.includes('vllm')) return 'vLLM';
     if (error.includes('openrouter')) return 'OpenRouter';
     return 'AI Provider';
 }

--- a/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/posthog-logger.service.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for PostHogLoggerService.
+ *
+ * The service has three obligations we exercise here:
+ *   1. forward each NestJS log level to PostHog Logs as a `$log` event with
+ *      the right `level` property + structured metadata;
+ *   2. NEVER throw, even when PostHog is unconfigured or its client raises;
+ *   3. forward `Error` instances logged via `error()` to Sentry's
+ *      `captureException` (but only Error instances — string errors are not
+ *      forwarded, since they would just duplicate request-path exceptions
+ *      caught by SentryInterceptor).
+ */
+
+// Mock posthog-node BEFORE importing anything that touches the posthog
+// singleton, because `initPostHog()` caches the constructed client.
+const captureMock = jest.fn();
+const shutdownMock = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('posthog-node', () => ({
+    PostHog: jest.fn().mockImplementation(() => ({
+        capture: captureMock,
+        identify: jest.fn(),
+        shutdown: shutdownMock,
+    })),
+}));
+
+// Mock @sentry/nestjs so we can spy on captureException without ever talking
+// to the real SDK.
+const captureExceptionMock = jest.fn();
+jest.mock('@sentry/nestjs', () => ({
+    captureException: (...args: unknown[]) => captureExceptionMock(...args),
+    init: jest.fn(),
+    logger: {
+        trace: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        fatal: jest.fn(),
+    },
+}));
+
+// Avoid the optional profiling-node native dep blowing up the test.
+jest.mock('@sentry/profiling-node', () => ({
+    nodeProfilingIntegration: () => ({ name: 'mock-profiling' }),
+}));
+
+import { initPostHog, shutdownPostHog } from '../posthog.config';
+import { PostHogLoggerService } from '../posthog-logger.service';
+
+describe('PostHogLoggerService', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(async () => {
+        originalEnv = { ...process.env };
+        delete process.env.POSTHOG_API_KEY;
+        delete process.env.POSTHOG_HOST;
+        await shutdownPostHog();
+        captureMock.mockReset();
+        captureExceptionMock.mockReset();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    describe('without a PostHog client (POSTHOG_API_KEY unset)', () => {
+        it('does not throw on any level and never calls capture', () => {
+            const svc = new PostHogLoggerService('TestCtx');
+            expect(() => svc.log('hello')).not.toThrow();
+            expect(() => svc.warn('be careful')).not.toThrow();
+            expect(() => svc.error('boom')).not.toThrow();
+            expect(() => svc.debug('debugging')).not.toThrow();
+            expect(() => svc.verbose('verbose')).not.toThrow();
+            expect(captureMock).not.toHaveBeenCalled();
+            expect(captureExceptionMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('with an initialized PostHog client', () => {
+        beforeEach(() => {
+            initPostHog({ apiKey: 'phc_test' });
+            captureMock.mockReset();
+        });
+
+        it('captures a $log event for log() with the right level', () => {
+            const svc = new PostHogLoggerService('MyModule');
+            svc.log('user signed in');
+            expect(captureMock).toHaveBeenCalledTimes(1);
+            const call = captureMock.mock.calls[0][0];
+            expect(call.event).toBe('$log');
+            expect(call.distinctId).toBe('system');
+            expect(call.properties.level).toBe('log');
+            expect(call.properties.message).toBe('user signed in');
+            expect(call.properties.context).toBe('MyModule');
+            expect(call.properties.service).toBe('ever-works-api');
+        });
+
+        it.each([
+            ['warn', 'warn'],
+            ['debug', 'debug'],
+            ['verbose', 'verbose'],
+        ])('forwards %s() emits as $log with level=%s', (method, expectedLevel) => {
+            const svc = new PostHogLoggerService();
+            (svc as any)[method]('hi');
+            expect(captureMock).toHaveBeenCalledTimes(1);
+            expect(captureMock.mock.calls[0][0].properties.level).toBe(expectedLevel);
+        });
+
+        it('honours a custom distinctId for grouping', () => {
+            const svc = new PostHogLoggerService('Ctx', 'worker-7');
+            svc.log('working');
+            expect(captureMock.mock.calls[0][0].distinctId).toBe('worker-7');
+        });
+
+        it('serializes Error instances and includes name + stack', () => {
+            const err = new Error('disk full');
+            const svc = new PostHogLoggerService();
+            svc.error(err);
+            const props = captureMock.mock.calls[0][0].properties;
+            expect(props.level).toBe('error');
+            expect(props.message).toBe('disk full');
+            expect(props.error_name).toBe('Error');
+            expect(typeof props.error_stack).toBe('string');
+        });
+
+        it('passes the NestJS trace string through when error() is called as (msg, trace)', () => {
+            const svc = new PostHogLoggerService();
+            const trace = 'Error: x\n    at foo (file.ts:1:1)';
+            svc.error('caught', trace);
+            const props = captureMock.mock.calls[0][0].properties;
+            expect(props.trace).toBe(trace);
+        });
+
+        it('forwards Error instances logged via error() to Sentry captureException', () => {
+            const err = new Error('explode');
+            const svc = new PostHogLoggerService();
+            svc.error(err);
+            expect(captureExceptionMock).toHaveBeenCalledWith(err);
+        });
+
+        it('does NOT call captureException for string error() messages (avoids double-capture with SentryInterceptor)', () => {
+            const svc = new PostHogLoggerService();
+            svc.error('just a string');
+            expect(captureExceptionMock).not.toHaveBeenCalled();
+        });
+
+        it('swallows a thrown capture() and never propagates the error', () => {
+            captureMock.mockImplementationOnce(() => {
+                throw new Error('posthog down');
+            });
+            const svc = new PostHogLoggerService();
+            expect(() => svc.log('still works')).not.toThrow();
+        });
+
+        it('serializes non-string messages via JSON.stringify', () => {
+            const svc = new PostHogLoggerService();
+            svc.log({ event: 'click', userId: 42 });
+            const props = captureMock.mock.calls[0][0].properties;
+            expect(props.message).toBe('{"event":"click","userId":42}');
+        });
+
+        it('uses SENTRY_ENVIRONMENT for the env property when set', () => {
+            process.env.SENTRY_ENVIRONMENT = 'production';
+            const svc = new PostHogLoggerService();
+            svc.log('ping');
+            expect(captureMock.mock.calls[0][0].properties.env).toBe('production');
+        });
+    });
+});

--- a/packages/monitoring/src/posthog/index.ts
+++ b/packages/monitoring/src/posthog/index.ts
@@ -1,2 +1,3 @@
 export * from './posthog.config';
 export * from './posthog.module';
+export * from './posthog-logger.service';

--- a/packages/monitoring/src/posthog/posthog-logger.service.ts
+++ b/packages/monitoring/src/posthog/posthog-logger.service.ts
@@ -1,0 +1,156 @@
+import { Logger, LoggerService } from '@nestjs/common';
+import { getPostHogClient } from './posthog.config';
+import { getSentryInstance } from '../sentry/sentry.config';
+
+/**
+ * Service that converts log emits to a string usable as a PostHog event property.
+ */
+const serializeMessage = (message: unknown): string => {
+    if (message === undefined) return '';
+    if (message === null) return 'null';
+    if (typeof message === 'string') return message;
+    if (message instanceof Error) return message.message;
+    try {
+        return JSON.stringify(message);
+    } catch {
+        // Fallback for cyclic structures and bigints.
+        return String(message);
+    }
+};
+
+const resolveEnv = (): string =>
+    process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development';
+
+type LogLevel = 'log' | 'warn' | 'error' | 'debug' | 'verbose';
+
+/**
+ * NestJS `LoggerService` that forwards every log emit to PostHog Logs as a
+ * `$log` event while still writing to stdout via the default NestJS Logger
+ * (so `kubectl logs` keeps working).
+ *
+ * - Fail-open: any PostHog / Sentry SDK error is swallowed; console output
+ *   is always attempted.
+ * - `error(message, trace, context?)` additionally forwards Error instances
+ *   to Sentry via `captureException`. `SentryInterceptor` already catches
+ *   in-request exceptions, so this only meaningfully fires for errors
+ *   logged outside the request path (bootstrap, background jobs,
+ *   event handlers). Do NOT pass request-path exceptions here — they will
+ *   double-report.
+ *
+ * Wired into the API in `apps/api/src/main.ts` via `app.useLogger(...)`.
+ */
+export class PostHogLoggerService implements LoggerService {
+    private readonly fallbackLogger: Logger;
+    private readonly defaultContext?: string;
+    private readonly distinctId: string;
+
+    constructor(context?: string, distinctId: string = 'system') {
+        this.defaultContext = context;
+        this.distinctId = distinctId;
+        this.fallbackLogger = new Logger(context ?? 'PostHogLogger');
+    }
+
+    log(message: unknown, context?: string): void {
+        this.dispatch('log', message, undefined, context);
+    }
+
+    warn(message: unknown, context?: string): void {
+        this.dispatch('warn', message, undefined, context);
+    }
+
+    /**
+     * NestJS `LoggerService.error` is overloaded in practice: callers may pass
+     * `(message)`, `(message, context)`, or `(message, trace, context)`. We
+     * accept the widest shape so we never reject a legitimate call.
+     */
+    error(message: unknown, traceOrContext?: string, context?: string): void {
+        // Disambiguate the 2-arg form: a value that doesn't look like a stack
+        // trace is treated as a context label, matching NestJS' Logger.
+        const looksLikeTrace =
+            typeof traceOrContext === 'string' &&
+            (traceOrContext.includes('\n') || traceOrContext.includes('    at '));
+        const trace = looksLikeTrace ? traceOrContext : undefined;
+        const ctx = looksLikeTrace ? context : (context ?? traceOrContext);
+        this.dispatch('error', message, trace, ctx);
+    }
+
+    debug(message: unknown, context?: string): void {
+        this.dispatch('debug', message, undefined, context);
+    }
+
+    verbose(message: unknown, context?: string): void {
+        this.dispatch('verbose', message, undefined, context);
+    }
+
+    private dispatch(level: LogLevel, message: unknown, trace?: string, context?: string): void {
+        const ctx = context ?? this.defaultContext;
+
+        // 1) ALWAYS write to the console first so a PostHog/Sentry outage can
+        //    never silently drop a log emit. `fallbackLogger` wraps NestJS'
+        //    default ConsoleLogger.
+        try {
+            switch (level) {
+                case 'log':
+                    this.fallbackLogger.log(message as any, ctx);
+                    break;
+                case 'warn':
+                    this.fallbackLogger.warn(message as any, ctx);
+                    break;
+                case 'error':
+                    this.fallbackLogger.error(message as any, trace, ctx);
+                    break;
+                case 'debug':
+                    this.fallbackLogger.debug(message as any, ctx);
+                    break;
+                case 'verbose':
+                    this.fallbackLogger.verbose(message as any, ctx);
+                    break;
+            }
+        } catch {
+            // Last-resort console.
+            // eslint-disable-next-line no-console
+            console.error('[PostHogLoggerService] fallback logger threw', level, message);
+        }
+
+        // 2) Forward to PostHog Logs as a `$log` event. Swallow any error.
+        try {
+            const client = getPostHogClient();
+            if (client) {
+                const properties: Record<string, unknown> = {
+                    level,
+                    message: serializeMessage(message),
+                    context: ctx,
+                    service: 'ever-works-api',
+                    env: resolveEnv(),
+                };
+                if (message instanceof Error) {
+                    properties.error_name = message.name;
+                    properties.error_stack = message.stack;
+                }
+                if (trace) {
+                    properties.trace = trace;
+                }
+                client.capture({
+                    distinctId: this.distinctId,
+                    event: '$log',
+                    properties,
+                });
+            }
+        } catch {
+            // Swallow — logs must never break the caller.
+        }
+
+        // 3) For Error-typed `error()` calls, additionally forward to Sentry's
+        //    `captureException`. SentryInterceptor already covers exceptions
+        //    that surface through the request path, so this only meaningfully
+        //    fires for errors logged outside that path.
+        if (level === 'error' && message instanceof Error) {
+            try {
+                const sentry = getSentryInstance();
+                sentry?.captureException(message);
+            } catch {
+                // Swallow.
+            }
+        }
+    }
+}

--- a/packages/plugins/composio/README.md
+++ b/packages/plugins/composio/README.md
@@ -18,7 +18,7 @@ Composio Integrations Pipeline Plugin - Executes Composio tools across 500+ thir
 
 This plugin lets Ever Works call any of [Composio](https://composio.dev)'s 500+ third-party integrations (Gmail, Slack, GitHub, Notion, Linear, Salesforce, HubSpot, Stripe, Shopify, Airtable, …) during work generation. Composio brokers OAuth on your behalf — each user connects an app once through Composio's hosted flow, and the platform reuses that connection to execute tools.
 
-Instead of writing a per-app connector for every service your users want to integrate, you ship one plugin (this one) and your users get the entire Composio catalog. The plugin invokes tools via the Composio v3 REST API (`POST /api/v3/tools/execute/{tool_slug}`) and returns the result as pipeline outputs in one of three shapes: structured `{ items: [...] }`, native records with a field mapping, or side-effect only (fire-and-forget).
+Instead of writing a per-app connector for every service your users want to integrate, you ship one plugin (this one) and your users get the entire Composio catalog. The plugin invokes tools through the official [`@composio/core`](https://www.npmjs.com/package/@composio/core) SDK (per Workspace AGENTS.md NN #22 — always use the official vendor SDK) and returns the result as pipeline outputs in one of three shapes: structured `{ items: [...] }`, native records with a field mapping, or side-effect only (fire-and-forget).
 
 ## Why use it?
 
@@ -30,11 +30,11 @@ Instead of writing a per-app connector for every service your users want to inte
 
 ## How it works in Ever Works
 
-When this plugin is selected as the active pipeline, the platform calls the Composio v3 REST API. The 6 sequential steps:
+When this plugin is selected as the active pipeline, the platform drives a `Composio` client from `@composio/core` through 6 sequential steps:
 
-1. **Validate Composio Connection** — verifies the API key is accepted and the user has an ACTIVE connected account for the requested toolkit.
+1. **Validate Composio Connection** — `composio.toolkits.get(...)` confirms the API key is accepted, then `composio.connectedAccounts.list({ userIds, toolkitSlugs })` confirms the user has an ACTIVE connected account for the requested toolkit.
 2. **Prepare Tool Payload** — builds the `arguments` object with work metadata, an optional existing-items summary, an optional GitHub data repository, and any user-supplied tool params.
-3. **Execute Composio Tool** — `POST /tools/execute/{tool_slug}` with `{ user_id, arguments }`.
+3. **Execute Composio Tool** — `composio.tools.execute(toolSlug, { userId, arguments })`. The SDK unwraps the v3 response envelope (`{ successful, data, error, log_id }`) for us.
 4. **Collect & Validate Results** — parses the response, projects records onto work items if needed, deduplicates against existing items.
 5. **Capture Screenshots** (optional) — uses the configured screenshot plugin to fetch images for items without them.
 6. **Cleanup** — releases resources.
@@ -50,7 +50,7 @@ The plugin treats the **tool slug** as the unique identifier of an action (`GMAI
 
 ## Settings
 
-- `apiKey` (**secret**, required) — Composio API key, sent as `x-api-key` on every Composio v3 call.
+- `apiKey` (**secret**, required) — Composio API key, passed to the `@composio/core` SDK at construction time.
 - `baseUrl` — Override the Composio API base URL (leave empty for the default `https://backend.composio.dev/api/v3`).
 - `defaultUserId` — Composio `user_id` to run tools against. Defaults to your Ever Works user id.
 - `defaultToolkit` — Default toolkit slug (e.g. `GMAIL`).

--- a/packages/plugins/composio/package.json
+++ b/packages/plugins/composio/package.json
@@ -32,7 +32,9 @@
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"@composio/core": "^0.10.0"
+	},
 	"peerDependencies": {
 		"@ever-works/plugin": "workspace:*"
 	},

--- a/packages/plugins/composio/src/__tests__/composio-client.spec.ts
+++ b/packages/plugins/composio/src/__tests__/composio-client.spec.ts
@@ -1,29 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ComposioClient } from '../utils/composio-client.js';
+import { ComposioClient, type ComposioSdkLike } from '../utils/composio-client.js';
 import type { ComposioToolRef } from '../types.js';
 
-function jsonResponse(body: unknown, init?: ResponseInit): Response {
-	return new Response(JSON.stringify(body), {
-		status: 200,
-		headers: { 'content-type': 'application/json' },
-		...init
-	});
+/**
+ * Builds a minimal `ComposioSdkLike` stub that satisfies the SDK contract
+ * the plugin uses. Tests then `vi.mocked(stub.tools.execute).mockResolvedValue(...)`.
+ */
+function buildSdkStub(): ComposioSdkLike {
+	return {
+		toolkits: {
+			get: vi.fn()
+		},
+		connectedAccounts: {
+			list: vi.fn()
+		},
+		tools: {
+			execute: vi.fn()
+		}
+	} as unknown as ComposioSdkLike;
 }
 
-function errorResponse(status: number, body: string | object = ''): Response {
-	const text = typeof body === 'string' ? body : JSON.stringify(body);
-	return new Response(text, {
-		status,
-		headers: { 'content-type': typeof body === 'string' ? 'text/plain' : 'application/json' }
-	});
-}
-
-function createClient(fetchImpl: typeof fetch): ComposioClient {
+function createClient(sdk: ComposioSdkLike): ComposioClient {
 	return new ComposioClient({
 		apiKey: 'test-key',
 		baseUrl: 'https://composio.test/api/v3',
 		logger: { log: vi.fn(), warn: vi.fn() },
-		fetchImpl
+		sdkOverride: sdk
 	});
 }
 
@@ -36,7 +38,14 @@ function createRef(overrides: Partial<ComposioToolRef> = {}): ComposioToolRef {
 	};
 }
 
-describe('ComposioClient', () => {
+/** Builds a vendor-shaped error with a numeric `status` field, mirroring how the SDK surfaces HTTP errors. */
+function sdkError(status: number, message: string): Error {
+	const err = new Error(message);
+	(err as { status?: number }).status = status;
+	return err;
+}
+
+describe('ComposioClient (SDK-backed)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -52,223 +61,211 @@ describe('ComposioClient', () => {
 			).toThrow(/API key is required/i);
 		});
 
-		it('strips trailing slashes from the base URL', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [] }));
-			const client = new ComposioClient({
-				apiKey: 'k',
-				baseUrl: 'https://composio.test/api/v3///',
-				logger: { log: vi.fn(), warn: vi.fn() },
-				fetchImpl
-			});
-			await client.listToolkits();
-			const url = (fetchImpl.mock.calls[0][0] as string).split('?')[0];
-			expect(url).toBe('https://composio.test/api/v3/toolkits');
+		it('accepts an sdkOverride to bypass real SDK construction in tests', () => {
+			const sdk = buildSdkStub();
+			expect(() => createClient(sdk)).not.toThrow();
 		});
 	});
 
 	describe('listToolkits', () => {
-		it('sends GET with x-api-key and accept headers', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [{ slug: 'GMAIL', name: 'Gmail' }] }));
-			const client = createClient(fetchImpl);
+		it('calls sdk.toolkits.get with the requested limit', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockResolvedValue({
+				items: [{ slug: 'GMAIL', name: 'Gmail' }]
+			});
 
-			const result = await client.listToolkits(50);
+			const result = await createClient(sdk).listToolkits(50);
 
 			expect(result).toEqual([{ slug: 'GMAIL', name: 'Gmail' }]);
-			const [url, init] = fetchImpl.mock.calls[0];
-			expect((url as string).startsWith('https://composio.test/api/v3/toolkits')).toBe(true);
-			expect(url as string).toContain('limit=50');
-			const headers = new Headers((init as RequestInit).headers);
-			expect(headers.get('x-api-key')).toBe('test-key');
-			expect(headers.get('accept')).toBe('application/json');
+			expect(sdk.toolkits.get).toHaveBeenCalledWith({ limit: 50 });
 		});
 
 		it('clamps the limit into [1, 200]', async () => {
-			// Response bodies are single-use streams — make a fresh one per call.
-			const fetchImpl = vi.fn().mockImplementation(async () => jsonResponse({ items: [] }));
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockResolvedValue({ items: [] });
+			const client = createClient(sdk);
 
 			await client.listToolkits(99999);
-			expect(fetchImpl.mock.calls[0][0] as string).toContain('limit=200');
+			expect(sdk.toolkits.get).toHaveBeenLastCalledWith({ limit: 200 });
 
 			await client.listToolkits(0);
-			expect(fetchImpl.mock.calls[1][0] as string).toContain('limit=1');
+			expect(sdk.toolkits.get).toHaveBeenLastCalledWith({ limit: 1 });
 		});
 
-		it('extracts the array under .items', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [{ slug: 'A' }, { slug: 'B' }] }));
-			const client = createClient(fetchImpl);
-			expect(await client.listToolkits()).toHaveLength(2);
+		it('returns [] when the SDK response has no items', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockResolvedValue({ items: [] });
+
+			expect(await createClient(sdk).listToolkits()).toEqual([]);
 		});
 
-		it('falls back to .data envelope', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [{ slug: 'A' }] }));
-			const client = createClient(fetchImpl);
-			expect(await client.listToolkits()).toHaveLength(1);
-		});
+		it('translates 401 into an actionable API-key error', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(sdkError(401, 'unauthorized'));
 
-		it('returns [] for an unrecognized envelope', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ foo: 'bar' }));
-			const client = createClient(fetchImpl);
-			expect(await client.listToolkits()).toEqual([]);
-		});
-
-		it('translates 401 into an actionable error', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(401, 'bad key'));
-			const client = createClient(fetchImpl);
-
-			await expect(client.listToolkits()).rejects.toThrow(/rejected the API key.*HTTP 401/i);
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/rejected the API key.*HTTP 401/i);
 		});
 
 		it('translates 429 into a rate-limit error', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(429));
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(sdkError(429, 'throttled'));
 
-			await expect(client.listToolkits()).rejects.toThrow(/rate limit/i);
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/rate limit/i);
 		});
 
-		it('translates 5xx into a Composio status error', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(503, 'maintenance'));
-			const client = createClient(fetchImpl);
+		it('translates 5xx into a Composio-status error', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(sdkError(503, 'maintenance'));
 
-			await expect(client.listToolkits()).rejects.toThrow(/HTTP 503/);
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/HTTP 503/);
+		});
+
+		it('preserves the original message for non-HTTP errors', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.toolkits.get).mockRejectedValue(new Error('network down'));
+
+			await expect(createClient(sdk).listToolkits()).rejects.toThrow(/network down/);
 		});
 	});
 
 	describe('listConnectedAccounts', () => {
-		it('sends user_ids and toolkit_slugs (uppercased)', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [] }));
-			const client = createClient(fetchImpl);
+		it('sends userIds and toolkitSlugs as arrays (toolkit uppercased)', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({ items: [] });
 
-			await client.listConnectedAccounts('user-123', 'gmail');
+			await createClient(sdk).listConnectedAccounts('user-123', 'gmail');
 
-			const url = fetchImpl.mock.calls[0][0] as string;
-			expect(url).toContain('user_ids=user-123');
-			expect(url).toContain('toolkit_slugs=GMAIL');
+			expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({
+				userIds: ['user-123'],
+				toolkitSlugs: ['GMAIL']
+			});
 		});
 
-		it('omits toolkit_slugs when toolkit is undefined', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ items: [] }));
-			const client = createClient(fetchImpl);
+		it('omits toolkitSlugs when toolkit is undefined', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({ items: [] });
 
-			await client.listConnectedAccounts('user-123');
+			await createClient(sdk).listConnectedAccounts('user-123');
 
-			const url = fetchImpl.mock.calls[0][0] as string;
-			expect(url).not.toContain('toolkit_slugs=');
+			expect(sdk.connectedAccounts.list).toHaveBeenCalledWith({ userIds: ['user-123'] });
+		});
+
+		it('translates a 401 from the SDK with the friendly API-key message', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockRejectedValue(sdkError(401, 'unauthorized'));
+
+			await expect(createClient(sdk).listConnectedAccounts('user-123')).rejects.toThrow(/rejected the API key/i);
 		});
 	});
 
 	describe('validateConnection', () => {
 		it('succeeds when an ACTIVE account exists', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(
-				jsonResponse({
-					items: [
-						{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } },
-						{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }
-					]
-				})
-			);
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({
+				items: [
+					{ id: 'ca_1', status: 'INITIATED', toolkit: { slug: 'GMAIL' } },
+					{ id: 'ca_2', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }
+				]
+			});
 
-			const account = await client.validateConnection(createRef());
+			const account = await createClient(sdk).validateConnection(createRef());
 			expect(account.id).toBe('ca_2');
 		});
 
 		it('normalizes status to upper-case before matching', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(
-					jsonResponse({ items: [{ id: 'ca_x', status: 'active', toolkit: { slug: 'GMAIL' } }] })
-				);
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({
+				items: [{ id: 'ca_x', status: 'active', toolkit: { slug: 'GMAIL' } }]
+			});
 
-			const account = await client.validateConnection(createRef());
+			const account = await createClient(sdk).validateConnection(createRef());
 			expect(account.id).toBe('ca_x');
 		});
 
 		it('throws a friendly error when no ACTIVE account exists', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(
-					jsonResponse({ items: [{ id: 'ca_1', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }] })
-				);
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.connectedAccounts.list).mockResolvedValue({
+				items: [{ id: 'ca_1', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }]
+			});
 
-			await expect(client.validateConnection(createRef())).rejects.toThrow(
+			await expect(createClient(sdk).validateConnection(createRef())).rejects.toThrow(
 				/No active Composio connected account/i
 			);
 		});
 	});
 
 	describe('executeTool', () => {
-		it('POSTs to /tools/execute/{slug} with { user_id, arguments }', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(jsonResponse({ successful: true, data: { items: [{ name: 'A' }] } }));
-			const client = createClient(fetchImpl);
+		it('calls sdk.tools.execute with the slug, userId, and arguments', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockResolvedValue({
+				successful: true,
+				data: { items: [{ name: 'A' }] }
+			});
 
-			const result = await client.executeTool(createRef(), { to: 'a@b.c', subject: 'hi' });
+			const result = await createClient(sdk).executeTool(createRef(), { to: 'a@b.c', subject: 'hi' });
 
 			expect((result.data as { items: unknown[] }).items).toHaveLength(1);
 			expect(result.composioDuration).toBeGreaterThanOrEqual(0);
-
-			const [url, init] = fetchImpl.mock.calls[0];
-			expect(url).toBe('https://composio.test/api/v3/tools/execute/GMAIL_SEND_EMAIL');
-			expect((init as RequestInit).method).toBe('POST');
-			const body = JSON.parse((init as { body: string }).body);
-			expect(body.user_id).toBe('user-123');
-			expect(body.arguments).toEqual({ to: 'a@b.c', subject: 'hi' });
+			expect(sdk.tools.execute).toHaveBeenCalledWith('GMAIL_SEND_EMAIL', {
+				userId: 'user-123',
+				arguments: { to: 'a@b.c', subject: 'hi' }
+			});
 		});
 
-		it('URL-encodes the tool slug', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ successful: true, data: {} }));
-			const client = createClient(fetchImpl);
+		it('throws when the SDK envelope reports successful=false', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockResolvedValue({
+				successful: false,
+				error: 'gmail quota exceeded',
+				logId: 'log_42'
+			});
 
-			await client.executeTool(createRef({ toolSlug: 'TOOL/WITH SPACE' }), {});
-
-			const url = fetchImpl.mock.calls[0][0] as string;
-			expect(url).toBe('https://composio.test/api/v3/tools/execute/TOOL%2FWITH%20SPACE');
-		});
-
-		it('converts timeoutMs to seconds in the request body', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ successful: true, data: {} }));
-			const client = createClient(fetchImpl);
-
-			await client.executeTool(createRef(), {}, { timeoutMs: 90_000 });
-
-			const body = JSON.parse((fetchImpl.mock.calls[0][1] as { body: string }).body);
-			expect(body.timeout).toBe(90);
-		});
-
-		it('throws when successful=false even on HTTP 200', async () => {
-			const fetchImpl = vi
-				.fn()
-				.mockResolvedValue(
-					jsonResponse({ successful: false, error: 'gmail quota exceeded', log_id: 'log_42' })
-				);
-			const client = createClient(fetchImpl);
-
-			await expect(client.executeTool(createRef(), {})).rejects.toThrow(/gmail quota exceeded.*log_42/i);
+			await expect(createClient(sdk).executeTool(createRef(), {})).rejects.toThrow(
+				/gmail quota exceeded.*log_42/i
+			);
 		});
 
 		it('rejects pre-aborted signals before issuing a request', async () => {
-			const fetchImpl = vi.fn();
-			const client = createClient(fetchImpl);
+			const sdk = buildSdkStub();
 			const controller = new AbortController();
 			controller.abort();
 
-			await expect(client.executeTool(createRef(), {}, { signal: controller.signal })).rejects.toThrow(
+			await expect(createClient(sdk).executeTool(createRef(), {}, { signal: controller.signal })).rejects.toThrow(
 				/cancelled/i
 			);
-			expect(fetchImpl).not.toHaveBeenCalled();
+			expect(sdk.tools.execute).not.toHaveBeenCalled();
 		});
 
-		it('translates 404 into a tool-or-account-not-found message', async () => {
-			const fetchImpl = vi.fn().mockResolvedValue(errorResponse(404, 'not found'));
-			const client = createClient(fetchImpl);
+		it('rejects when the signal aborts after the SDK call starts but before it resolves', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockImplementation(
+				() =>
+					new Promise(() => {
+						/* never resolves */
+					})
+			);
+			const controller = new AbortController();
 
-			await expect(client.executeTool(createRef(), {})).rejects.toThrow(
+			const promise = createClient(sdk).executeTool(createRef(), {}, { signal: controller.signal });
+			controller.abort();
+
+			await expect(promise).rejects.toThrow(/cancelled/i);
+		});
+
+		it('translates SDK 404 into a tool-or-account-not-found message', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockRejectedValue(sdkError(404, 'not found'));
+
+			await expect(createClient(sdk).executeTool(createRef(), {})).rejects.toThrow(
 				/404.*tool slug or toolkit does not exist/i
 			);
+		});
+
+		it('translates SDK 401 with the friendly API-key message', async () => {
+			const sdk = buildSdkStub();
+			vi.mocked(sdk.tools.execute).mockRejectedValue(sdkError(401, 'unauthorized'));
+
+			await expect(createClient(sdk).executeTool(createRef(), {})).rejects.toThrow(/rejected the API key/i);
 		});
 	});
 });

--- a/packages/plugins/composio/src/__tests__/composio.spec.ts
+++ b/packages/plugins/composio/src/__tests__/composio.spec.ts
@@ -1,24 +1,29 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ComposioPlugin } from '../composio.plugin.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { WorkReference, GenerationRequest, ExistingItems, PluginContext } from '@ever-works/plugin';
 
-type ResponseFactory = () => Response;
+/**
+ * Hoisted SDK mocks. Each is a freshly-created `vi.fn()` that the tests
+ * configure via `mockResolvedValueOnce` / `mockRejectedValueOnce`. The mock
+ * constructor returns an object that exposes these exact spies as
+ * `toolkits.get`, `connectedAccounts.list`, `tools.execute` — matching the
+ * `ComposioSdkLike` shape consumed by `ComposioClient`.
+ */
+const { mockToolkitsGet, mockConnectedAccountsList, mockToolsExecute } = vi.hoisted(() => ({
+	mockToolkitsGet: vi.fn(),
+	mockConnectedAccountsList: vi.fn(),
+	mockToolsExecute: vi.fn()
+}));
 
-function jsonResponse(body: unknown, status = 200): ResponseFactory {
-	return () =>
-		new Response(JSON.stringify(body), {
-			status,
-			headers: { 'content-type': 'application/json' }
-		});
-}
+vi.mock('@composio/core', () => ({
+	Composio: vi.fn().mockImplementation(() => ({
+		toolkits: { get: mockToolkitsGet },
+		connectedAccounts: { list: mockConnectedAccountsList },
+		tools: { execute: mockToolsExecute }
+	}))
+}));
 
-function rawResponse(text: string, status = 200): ResponseFactory {
-	return () =>
-		new Response(text, {
-			status,
-			headers: { 'content-type': 'text/plain' }
-		});
-}
+// Import after vi.mock so the plugin's ComposioClient picks up the mocked SDK.
+const { ComposioPlugin } = await import('../composio.plugin.js');
 
 function createMockContext(settingsOverride?: Record<string, unknown>): PluginContext {
 	const settings = settingsOverride ?? { apiKey: 'test-key' };
@@ -99,39 +104,28 @@ function errorMessage(error: Error | string | undefined): string {
 	return typeof error === 'string' ? error : error.message;
 }
 
-/**
- * Stubs the global fetch with sequential response factories. Each factory
- * is invoked per call so a fresh `Response` (with an unread body stream) is
- * returned — module-scoped `Response` instances would otherwise throw
- * `Body is unusable` on the second test that touches them.
- */
-function stubFetchSequence(factories: ResponseFactory[]): ReturnType<typeof vi.fn> {
-	const spy = vi.fn();
-	for (const factory of factories) {
-		spy.mockImplementationOnce(async () => factory());
-	}
-	// Any further calls return an empty success envelope so tests don't hang.
-	spy.mockImplementation(async () => jsonResponse({ items: [] })());
-	(globalThis as { fetch: typeof fetch }).fetch = spy as unknown as typeof fetch;
-	return spy;
+const ACTIVE_GMAIL_ACCOUNTS = {
+	items: [{ id: 'ca_active', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }]
+};
+
+/** Helper: stage the SDK with an active connection + a successful tool response. */
+function stageHappyPath(toolData: unknown): void {
+	mockConnectedAccountsList.mockResolvedValueOnce(ACTIVE_GMAIL_ACCOUNTS);
+	mockToolsExecute.mockResolvedValueOnce({ successful: true, data: toolData });
 }
 
-const ACTIVE_GMAIL_ACCOUNT: ResponseFactory = jsonResponse({
-	items: [{ id: 'ca_active', status: 'ACTIVE', toolkit: { slug: 'GMAIL' } }]
-});
+function sdkError(status: number, message: string): Error {
+	const err = new Error(message);
+	(err as { status?: number }).status = status;
+	return err;
+}
 
 describe('ComposioPlugin', () => {
-	let plugin: ComposioPlugin;
-	let originalFetch: typeof fetch;
+	let plugin: InstanceType<typeof ComposioPlugin>;
 
 	beforeEach(() => {
 		plugin = new ComposioPlugin();
-		originalFetch = globalThis.fetch;
 		vi.clearAllMocks();
-	});
-
-	afterEach(() => {
-		(globalThis as { fetch: typeof fetch }).fetch = originalFetch;
 	});
 
 	describe('metadata', () => {
@@ -161,7 +155,6 @@ describe('ComposioPlugin', () => {
 
 		it('does not put tool selection in plugin settings (per-run config only)', () => {
 			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
-			// We DO have defaults, but per-tool fields live in the generator form
 			expect(props.toolkit).toBeUndefined();
 			expect(props.tool_slug).toBeUndefined();
 		});
@@ -297,13 +290,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('executes a structured-shape tool and returns items', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({
-					successful: true,
-					data: { items: [{ name: 'A', url: 'https://a' }, { name: 'B' }] }
-				})
-			]);
+			stageHappyPath({ items: [{ name: 'A', url: 'https://a' }, { name: 'B' }] });
 
 			const result = await plugin.execute(createWork(), createRequest(), createExisting());
 
@@ -312,29 +299,24 @@ describe('ComposioPlugin', () => {
 			expect(result.stepsCompleted).toBeGreaterThan(0);
 		});
 
-		it('calls /tools/execute/{slug} with the resolved user_id and arguments', async () => {
-			const spy = stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: true, data: { items: [{ name: 'X' }] } })
-			]);
+		it('calls sdk.tools.execute with the resolved userId and arguments', async () => {
+			stageHappyPath({ items: [{ name: 'X' }] });
 
 			await plugin.execute(createWork(), createRequest(), createExisting());
 
-			const execCall = spy.mock.calls.find(
-				([url]) => typeof url === 'string' && url.includes('/tools/execute/')
-			)!;
-			expect(execCall).toBeDefined();
-			expect(execCall[0]).toContain('/tools/execute/GMAIL_LIST_MESSAGES');
-			const body = JSON.parse((execCall[1] as { body: string }).body);
-			expect(body.user_id).toBe('user-456'); // defaults to ever works user id
-			expect(body.arguments.metadata.workSlug).toBe('test-work');
+			expect(mockToolsExecute).toHaveBeenCalledWith(
+				'GMAIL_LIST_MESSAGES',
+				expect.objectContaining({
+					userId: 'user-456', // defaults to ever works user id
+					arguments: expect.objectContaining({
+						metadata: expect.objectContaining({ workSlug: 'test-work' })
+					})
+				})
+			);
 		});
 
 		it('honors composio_user_id override', async () => {
-			const spy = stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: true, data: { items: [{ name: 'X' }] } })
-			]);
+			stageHappyPath({ items: [{ name: 'X' }] });
 
 			await plugin.execute(
 				createWork(),
@@ -348,15 +330,14 @@ describe('ComposioPlugin', () => {
 				createExisting()
 			);
 
-			const execCall = spy.mock.calls.find(
-				([url]) => typeof url === 'string' && url.includes('/tools/execute/')
-			)!;
-			const body = JSON.parse((execCall[1] as { body: string }).body);
-			expect(body.user_id).toBe('alice@example.com');
+			expect(mockToolsExecute).toHaveBeenCalledWith(
+				'GMAIL_LIST_MESSAGES',
+				expect.objectContaining({ userId: 'alice@example.com' })
+			);
 		});
 
 		it('completes successfully for a side-effect tool with no items', async () => {
-			stubFetchSequence([ACTIVE_GMAIL_ACCOUNT, jsonResponse({ successful: true, data: { ok: true } })]);
+			stageHappyPath({ ok: true });
 
 			const result = await plugin.execute(
 				createWork(),
@@ -376,13 +357,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('deduplicates items against existing names', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({
-					successful: true,
-					data: { items: [{ name: 'Alice' }, { name: 'Bob' }] }
-				})
-			]);
+			stageHappyPath({ items: [{ name: 'Alice' }, { name: 'Bob' }] });
 
 			const result = await plugin.execute(
 				createWork(),
@@ -395,9 +370,9 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('returns failure when no ACTIVE connected account exists', async () => {
-			stubFetchSequence([
-				jsonResponse({ items: [{ id: 'ca_x', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }] })
-			]);
+			mockConnectedAccountsList.mockResolvedValueOnce({
+				items: [{ id: 'ca_x', status: 'EXPIRED', toolkit: { slug: 'GMAIL' } }]
+			});
 
 			const result = await plugin.execute(createWork(), createRequest(), createExisting());
 			expect(result.success).toBe(false);
@@ -416,10 +391,8 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('surfaces Composio successful=false envelope as an error', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: false, error: 'gmail quota exceeded' })
-			]);
+			mockConnectedAccountsList.mockResolvedValueOnce(ACTIVE_GMAIL_ACCOUNTS);
+			mockToolsExecute.mockResolvedValueOnce({ successful: false, error: 'gmail quota exceeded' });
 
 			const result = await plugin.execute(createWork(), createRequest(), createExisting());
 			expect(result.success).toBe(false);
@@ -427,15 +400,9 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('executes a native-shape tool with field mapping', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({
-					successful: true,
-					data: [
-						{ subject: 'Alice', link: 'https://alice', labels: ['important'] },
-						{ subject: 'Bob', link: 'https://bob' }
-					]
-				})
+			stageHappyPath([
+				{ subject: 'Alice', link: 'https://alice', labels: ['important'] },
+				{ subject: 'Bob', link: 'https://bob' }
 			]);
 
 			const result = await plugin.execute(
@@ -460,10 +427,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('exposes pipeline state after execution', async () => {
-			stubFetchSequence([
-				ACTIVE_GMAIL_ACCOUNT,
-				jsonResponse({ successful: true, data: { items: [{ name: 'A' }] } })
-			]);
+			stageHappyPath({ items: [{ name: 'A' }] });
 
 			await plugin.execute(createWork(), createRequest(), createExisting());
 			const state = plugin.getState();
@@ -484,7 +448,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('succeeds when API key is accepted (no default toolkit set)', async () => {
-			stubFetchSequence([jsonResponse({ items: [{ slug: 'GMAIL', name: 'Gmail' }] })]);
+			mockToolkitsGet.mockResolvedValueOnce({ items: [{ slug: 'GMAIL', name: 'Gmail' }] });
 
 			const result = await plugin.validateConnection({ apiKey: 'test-key' });
 			expect(result.success).toBe(true);
@@ -492,10 +456,8 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('reports ACTIVE account for the default toolkit + user', async () => {
-			stubFetchSequence([
-				jsonResponse({ items: [{ slug: 'GMAIL' }] }),
-				jsonResponse({ items: [{ id: 'ca_a', status: 'ACTIVE' }] })
-			]);
+			mockToolkitsGet.mockResolvedValueOnce({ items: [{ slug: 'GMAIL' }] });
+			mockConnectedAccountsList.mockResolvedValueOnce({ items: [{ id: 'ca_a', status: 'ACTIVE' }] });
 
 			const result = await plugin.validateConnection({
 				apiKey: 'test-key',
@@ -508,7 +470,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('flattens wrapped settings values', async () => {
-			stubFetchSequence([jsonResponse({ items: [] })]);
+			mockToolkitsGet.mockResolvedValueOnce({ items: [] });
 
 			const result = await plugin.validateConnection({
 				apiKey: { value: 'wrapped-key' }
@@ -518,7 +480,7 @@ describe('ComposioPlugin', () => {
 		});
 
 		it('reports underlying error when toolkit listing fails', async () => {
-			stubFetchSequence([rawResponse('forbidden', 403)]);
+			mockToolkitsGet.mockRejectedValueOnce(sdkError(403, 'forbidden'));
 
 			const result = await plugin.validateConnection({ apiKey: 'test-key' });
 			expect(result.success).toBe(false);

--- a/packages/plugins/composio/src/composio.plugin.ts
+++ b/packages/plugins/composio/src/composio.plugin.ts
@@ -378,10 +378,13 @@ export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 				`Starting tool "${toolRef.toolSlug}" for user "${toolRef.userId}"...`
 			);
 
+			// Timeout enforcement happens at the pipeline level via the `setTimeout`
+			// above that fires `abortController.abort()` — the SDK doesn't accept
+			// a timeout parameter, so we only forward the signal here.
 			const execResult: ComposioExecutionResult = await client.executeTool(
 				toolRef,
 				payload as unknown as Record<string, unknown>,
-				{ signal, timeoutMs: composioSettings.timeoutMs }
+				{ signal }
 			);
 
 			reportProgress(onProgress, 2, 70, 'Execute Composio Tool', 'Tool completed.');

--- a/packages/plugins/composio/src/utils/composio-client.ts
+++ b/packages/plugins/composio/src/utils/composio-client.ts
@@ -1,10 +1,12 @@
+import { Composio } from '@composio/core';
 import type { ComposioToolRef, ComposioConnectedAccount, ComposioToolkitEntry } from '../types.js';
 
 export interface ComposioExecutionResult {
 	/**
-	 * Raw data returned by the Composio tool. Composio v3 wraps every
-	 * response in `{ successful, data, error }`; we surface `data` here
-	 * and translate `successful=false` into a thrown error in {@link ComposioClient.executeTool}.
+	 * Raw data returned by the Composio tool. The official `@composio/core`
+	 * SDK already unwraps the v3 response envelope (`{ successful, data, error,
+	 * log_id }`) — successful executions resolve to the tool's `data` payload,
+	 * failures throw. We surface that `data` here verbatim.
 	 */
 	data: unknown;
 	composioDuration: number;
@@ -14,8 +16,13 @@ interface ComposioClientOptions {
 	apiKey: string;
 	baseUrl?: string;
 	logger: { log(...args: unknown[]): void; warn(...args: unknown[]): void };
-	/** Test seam — injected by unit tests. Defaults to global `fetch`. */
-	fetchImpl?: typeof fetch;
+	/**
+	 * Test seam — pass a stub `Composio`-shaped object to bypass SDK
+	 * construction. Unit tests inject their mocked SDK here instead of
+	 * `vi.mock`-ing the whole `@composio/core` module, which would also
+	 * trip the version-validation modifier the SDK installs at import time.
+	 */
+	sdkOverride?: ComposioSdkLike;
 }
 
 interface ExecuteToolOptions {
@@ -24,45 +31,79 @@ interface ExecuteToolOptions {
 }
 
 /**
- * Subset of the v3 envelope returned by `POST /tools/execute/{slug}`.
- *
- * Composio always wraps tool responses; even successful calls flag failures
- * via `successful: false` rather than HTTP status codes, so the client must
- * inspect the envelope, not just `response.ok`.
+ * Subset of the official `@composio/core` SDK surface we actually use.
+ * Pinned here so a stray major-version bump doesn't silently re-route us
+ * onto methods we haven't audited. Keep this in sync with the SDK reference
+ * at https://docs.composio.dev/sdk-reference/type-script/core-classes/composio.
  */
-interface ComposioExecuteEnvelope {
-	successful?: boolean;
-	data?: unknown;
-	error?: string;
-	log_id?: string;
+export interface ComposioSdkLike {
+	toolkits: {
+		get(query?: { limit?: number }): Promise<{ items: ComposioToolkitEntry[] }>;
+	};
+	connectedAccounts: {
+		list(query?: {
+			userIds?: string[];
+			toolkitSlugs?: string[];
+			limit?: number;
+		}): Promise<{ items: ComposioConnectedAccount[] }>;
+	};
+	tools: {
+		execute(
+			slug: string,
+			body: { userId: string; arguments?: Record<string, unknown> }
+		): Promise<{ successful?: boolean; data?: unknown; error?: string; logId?: string }>;
+	};
 }
 
 /**
- * Thin wrapper around the Composio v3 REST API.
+ * Thin wrapper around the official `@composio/core` SDK.
  *
- * Avoids the @composio/core SDK to keep dependency footprint small (matches
- * the activepieces / make pattern). Adds abort-signal support and translates
- * Composio's wrapped error envelope into Error instances.
+ * Per Workspace AGENTS.md NN #22 ("Always use the official SDK for
+ * third-party APIs — never hand-roll a REST client"), this replaces the
+ * v1 handwritten REST client that shipped in PR #1079. The SDK gets
+ * pagination, retries, response-envelope unwrapping, query-param list
+ * serialization (e.g. `user_ids` as repeated params), version validation,
+ * and breaking-change handling right — all of which we'd otherwise own.
+ *
+ * What's preserved from v1:
+ *  - The public surface (`validateConnection`, `listToolkits`,
+ *    `listConnectedAccounts`, `executeTool`) so `composio.plugin.ts`
+ *    doesn't change.
+ *  - Abort-signal support layered on top of the SDK via `Promise.race`.
+ *    Note: the SDK call itself can't be cancelled mid-flight; what we
+ *    cancel is our *await* on it. The HTTP request may still complete on
+ *    the wire — that's fine for the plugin's pipeline-timeout use case.
+ *  - Friendly error messages around 401/403, missing connections, etc.
  */
 export class ComposioClient {
-	private readonly apiKey: string;
-	private readonly baseUrl: string;
+	private readonly sdk: ComposioSdkLike;
 	private readonly logger: ComposioClientOptions['logger'];
-	private readonly fetchImpl: typeof fetch;
 
 	constructor(options: ComposioClientOptions) {
 		if (!options.apiKey || options.apiKey.trim() === '') {
 			throw new Error('Composio API key is required.');
 		}
-		this.apiKey = options.apiKey.trim();
-		this.baseUrl = (options.baseUrl ?? 'https://backend.composio.dev/api/v3').replace(/\/+$/, '');
 		this.logger = options.logger;
-		this.fetchImpl = options.fetchImpl ?? fetch;
+		this.sdk = options.sdkOverride ?? this.buildSdk(options.apiKey.trim(), options.baseUrl);
+	}
+
+	private buildSdk(apiKey: string, baseUrl: string | undefined): ComposioSdkLike {
+		const sdkConfig: { apiKey: string; baseURL?: string } = { apiKey };
+		if (baseUrl) {
+			// Composio's SDK config uses `baseURL` (capital L) — the underlying
+			// `@composio/client` follows axios-style naming. Strip trailing
+			// slashes so concatenation in the SDK works the same regardless
+			// of how the user typed it in settings.
+			sdkConfig.baseURL = baseUrl.replace(/\/+$/, '');
+		}
+		// The SDK constructor returns a richer instance than ComposioSdkLike
+		// declares; the structural cast pins us to the subset we actually use.
+		return new Composio(sdkConfig) as unknown as ComposioSdkLike;
 	}
 
 	/**
 	 * Validates that:
-	 *  1. The API key is accepted (200 from `/toolkits`).
+	 *  1. The API key is accepted (the SDK throws on 401/403).
 	 *  2. The toolkit exists.
 	 *  3. The user has at least one ACTIVE connected account for the toolkit.
 	 *
@@ -82,11 +123,12 @@ export class ComposioClient {
 
 	/** Lists toolkits the API key has access to. Used by `isAvailable` and the settings UI. */
 	async listToolkits(limit = 50): Promise<ComposioToolkitEntry[]> {
-		const url = new URL(`${this.baseUrl}/toolkits`);
-		url.searchParams.set('limit', String(Math.max(1, Math.min(limit, 200))));
-		const response = await this.request(url.toString(), { method: 'GET' });
-		const body = (await response.json()) as unknown;
-		return extractList<ComposioToolkitEntry>(body);
+		try {
+			const response = await this.sdk.toolkits.get({ limit: Math.max(1, Math.min(limit, 200)) });
+			return response.items ?? [];
+		} catch (error) {
+			throw this.wrapError(error, 'list toolkits');
+		}
 	}
 
 	/**
@@ -95,26 +137,26 @@ export class ComposioClient {
 	 * if the user has not connected any account yet.
 	 */
 	async listConnectedAccounts(userId: string, toolkit?: string): Promise<ComposioConnectedAccount[]> {
-		const url = new URL(`${this.baseUrl}/connected_accounts`);
-		// Composio v3 connected_accounts filters are list parameters — encode them
-		// as repeated query params (`?user_ids=a&user_ids=b`) which is the format
-		// the Composio Python SDK serializes. `.set()` would replace prior values
-		// AND, on Composio side, can be interpreted as a single value rather than
-		// a one-element list, which has been seen to filter strictly differently.
-		url.searchParams.append('user_ids', userId);
-		if (toolkit) url.searchParams.append('toolkit_slugs', toolkit.toUpperCase());
-		const response = await this.request(url.toString(), { method: 'GET' });
-		const body = (await response.json()) as unknown;
-		return extractList<ComposioConnectedAccount>(body);
+		try {
+			const query: { userIds: string[]; toolkitSlugs?: string[] } = { userIds: [userId] };
+			if (toolkit) query.toolkitSlugs = [toolkit.toUpperCase()];
+			const response = await this.sdk.connectedAccounts.list(query);
+			return response.items ?? [];
+		} catch (error) {
+			throw this.wrapError(error, 'list connected accounts');
+		}
 	}
 
 	/**
-	 * Executes a tool against the resolved user. Composio v3's response
-	 * envelope is always `{ successful, data, error, log_id }` — we extract
-	 * `data` on success and throw on failure with the upstream error text.
+	 * Executes a tool against the resolved user. The SDK unwraps the v3
+	 * envelope (`{ successful, data, error }`) — on success we return its
+	 * `data`; on failure (`successful === false`) we throw with the upstream
+	 * error text including the log id when present.
 	 *
-	 * Races against the abort signal so cancellation during long-running
-	 * tools still resolves cleanly.
+	 * Cancellation: the SDK does not accept an AbortSignal, so we race our
+	 * await against the signal. When the signal fires, this method rejects
+	 * with "Pipeline execution was cancelled"; the SDK's HTTP request may
+	 * still complete on the wire but its result is discarded.
 	 */
 	async executeTool(
 		ref: ComposioToolRef,
@@ -127,27 +169,21 @@ export class ComposioClient {
 		const startTime = Date.now();
 		this.logger.log(`Running Composio tool "${ref.toolSlug}" for user "${ref.userId}"`);
 
-		const url = `${this.baseUrl}/tools/execute/${encodeURIComponent(ref.toolSlug)}`;
-		const body: Record<string, unknown> = {
-			user_id: ref.userId,
-			arguments: args
-		};
-		if (options?.timeoutMs) body.timeout = Math.ceil(options.timeoutMs / 1000);
+		const execPromise = this.sdk.tools
+			.execute(ref.toolSlug, {
+				userId: ref.userId,
+				arguments: args
+			})
+			.catch((error: unknown) => {
+				throw this.wrapError(error, `execute tool ${ref.toolSlug}`);
+			});
 
-		const runPromise = this.request(url, {
-			method: 'POST',
-			headers: { 'content-type': 'application/json' },
-			body: JSON.stringify(body),
-			signal
-		});
-
-		const response = await runPromise;
-		const envelope = (await response.json()) as ComposioExecuteEnvelope;
+		const envelope = signal ? await raceWithAbort(execPromise, signal) : await execPromise;
 
 		if (envelope.successful === false) {
 			throw new Error(
 				`Composio tool "${ref.toolSlug}" execution failed: ${envelope.error ?? 'unknown error'}` +
-					(envelope.log_id ? ` (log_id=${envelope.log_id})` : '')
+					(envelope.logId ? ` (log_id=${envelope.logId})` : '')
 			);
 		}
 
@@ -157,99 +193,71 @@ export class ComposioClient {
 		};
 	}
 
-	private async request(url: string, init: RequestInit & { signal?: AbortSignal }): Promise<Response> {
-		const headers = new Headers(init.headers);
-		headers.set('x-api-key', this.apiKey);
-		headers.set('accept', 'application/json');
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, { ...init, headers });
-		} catch (error) {
-			if (init.signal?.aborted) throw new Error('Pipeline execution was cancelled');
-			throw this.wrapNetworkError(error, url);
-		}
-
-		if (!response.ok) {
-			throw await this.wrapHttpError(response, url);
-		}
-		return response;
-	}
-
-	private wrapNetworkError(error: unknown, url: string): Error {
+	private wrapError(error: unknown, context: string): Error {
 		if (error instanceof Error) {
-			return new Error(`Composio request to ${redactUrl(url)} failed: ${error.message}`);
-		}
-		return new Error(`Composio request to ${redactUrl(url)} failed: ${String(error)}`);
-	}
+			const message = error.message || String(error);
+			const status = readNumberProp(error, 'status') ?? readNumberProp(error, 'statusCode');
 
-	private async wrapHttpError(response: Response, url: string): Promise<Error> {
-		let body = '';
-		try {
-			body = await response.text();
-		} catch {
-			// ignore — best-effort read
+			if (status === 401 || status === 403) {
+				return new Error(
+					`Composio rejected the API key (HTTP ${status}) during ${context}. Verify COMPOSIO_API_KEY in plugin settings.`
+				);
+			}
+			if (status === 404) {
+				return new Error(
+					`Composio returned 404 during ${context}. Likely causes: the tool slug or toolkit does not exist, ` +
+						`or the user has no connected account.`
+				);
+			}
+			if (status === 408 || status === 504) {
+				return new Error(`Composio request timed out during ${context} (HTTP ${status}).`);
+			}
+			if (status === 429) {
+				return new Error('Composio rate limit exceeded (HTTP 429). Wait and retry.');
+			}
+			if (status !== undefined && status >= 500) {
+				return new Error(
+					`Composio is returning HTTP ${status} during ${context}. Check https://status.composio.dev. ` +
+						`(${message})`
+				);
+			}
+			// SDK error subclass we don't have a custom-rewording rule for — keep the original message.
+			return new Error(`Composio error during ${context}: ${message}`);
 		}
-		const preview = body.length > 500 ? `${body.slice(0, 500)}…` : body;
-		const redacted = redactUrl(url);
-
-		if (response.status === 401 || response.status === 403) {
-			return new Error(
-				`Composio rejected the API key (HTTP ${response.status}) when calling ${redacted}. ` +
-					`Verify COMPOSIO_API_KEY in plugin settings.${preview ? ` Response: ${preview}` : ''}`
-			);
-		}
-		if (response.status === 404) {
-			return new Error(
-				`Composio returned 404 for ${redacted}. ` +
-					`Likely causes: the tool slug or toolkit does not exist, or the user has no connected account.` +
-					(preview ? ` Response: ${preview}` : '')
-			);
-		}
-		if (response.status === 408 || response.status === 504) {
-			return new Error(`Composio request to ${redacted} timed out (HTTP ${response.status}).`);
-		}
-		if (response.status === 429) {
-			return new Error('Composio rate limit exceeded (HTTP 429). Wait and retry.');
-		}
-		if (response.status >= 500) {
-			return new Error(
-				`Composio is returning HTTP ${response.status} for ${redacted}. ` +
-					`Check https://status.composio.dev.${preview ? ` Response: ${preview}` : ''}`
-			);
-		}
-		return new Error(
-			`Composio request to ${redacted} failed: HTTP ${response.status}${preview ? ` — ${preview}` : ''}`
-		);
+		return new Error(`Unexpected error during ${context}: ${String(error)}`);
 	}
 }
 
-/**
- * Composio v3 list endpoints wrap results in `{ items: [...] }`. Older
- * preview endpoints sometimes returned `{ data: [...] }` or a bare array,
- * so handle all three.
- */
-function extractList<T>(body: unknown): T[] {
-	if (Array.isArray(body)) return body as T[];
-	if (body && typeof body === 'object') {
-		const record = body as Record<string, unknown>;
-		for (const key of ['items', 'data', 'results', 'records']) {
-			const value = record[key];
-			if (Array.isArray(value)) return value as T[];
-		}
-	}
-	return [];
-}
-
-function normalizeStatus(status: string): string {
+function normalizeStatus(status: string | undefined): string {
 	return (status || '').trim().toUpperCase();
 }
 
+function readNumberProp(target: object, prop: string): number | undefined {
+	const value = (target as Record<string, unknown>)[prop];
+	return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
 /**
- * Strips query strings from a URL before logging — Composio never embeds
- * secrets in query strings today, but `user_id` is PII so we redact it.
+ * Races a promise against an `AbortSignal`. When the signal fires we reject
+ * with the cancellation marker; when the promise settles first we forward
+ * its outcome and unhook the abort listener so we don't leak references.
  */
-function redactUrl(url: string): string {
-	const idx = url.indexOf('?');
-	return idx === -1 ? url : url.slice(0, idx);
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = (): void => {
+			signal.removeEventListener('abort', onAbort);
+			reject(new Error('Pipeline execution was cancelled'));
+		};
+		signal.addEventListener('abort', onAbort, { once: true });
+		promise.then(
+			(value) => {
+				signal.removeEventListener('abort', onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener('abort', onAbort);
+				reject(error as Error);
+			}
+		);
+	});
 }

--- a/packages/plugins/composio/src/utils/composio-client.ts
+++ b/packages/plugins/composio/src/utils/composio-client.ts
@@ -27,7 +27,6 @@ interface ComposioClientOptions {
 
 interface ExecuteToolOptions {
 	signal?: AbortSignal;
-	timeoutMs?: number;
 }
 
 /**
@@ -51,7 +50,20 @@ export interface ComposioSdkLike {
 		execute(
 			slug: string,
 			body: { userId: string; arguments?: Record<string, unknown> }
-		): Promise<{ successful?: boolean; data?: unknown; error?: string; logId?: string }>;
+		): Promise<{
+			successful?: boolean;
+			data?: unknown;
+			error?: string;
+			/**
+			 * The SDK transforms the v3 wire response from snake_case to camelCase
+			 * before resolving the promise — `log_id` → `logId`. Verified against
+			 * `@composio/core@0.10.0` (`dist/index.mjs`: `logId: response.log_id`).
+			 * We also tolerate `log_id` on the envelope as a defensive fallback
+			 * in case a future SDK version skips the transform.
+			 */
+			logId?: string;
+			log_id?: string;
+		}>;
 	};
 }
 
@@ -181,9 +193,13 @@ export class ComposioClient {
 		const envelope = signal ? await raceWithAbort(execPromise, signal) : await execPromise;
 
 		if (envelope.successful === false) {
+			// `logId` is the SDK-camelCased form; fall back to raw `log_id` in case
+			// a future SDK version stops transforming. Operators rely on this id
+			// to look up the upstream-app failure in the Composio dashboard.
+			const logId = envelope.logId ?? envelope.log_id;
 			throw new Error(
 				`Composio tool "${ref.toolSlug}" execution failed: ${envelope.error ?? 'unknown error'}` +
-					(envelope.logId ? ` (log_id=${envelope.logId})` : '')
+					(logId ? ` (log_id=${logId})` : '')
 			);
 		}
 

--- a/packages/plugins/discord-channel/README.md
+++ b/packages/plugins/discord-channel/README.md
@@ -4,8 +4,10 @@ Discord notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-discord`
 - **Shape**: `broadcast` (Discord channels = broadcast surfaces)
-- **Transport**: incoming webhook URL (v1)
+- **Transport**: incoming webhook URL (v1) — a plain HTTPS POST via `fetch`
 - **Bot-token mode**: planned for a future iteration
+
+> **SDK note:** intentionally uses `fetch`, not a vendor SDK. Discord incoming webhooks are a bare URL POST with no official SDK; `discord.js` is a full gateway/bot client (WebSocket connection, intents, caches) — far too heavy for a one-shot notification POST. The SDK rule applies where a _sensible_ vendor SDK exists (cf. slack-channel → `@slack/webhook`, telegram-channel → `grammy`).
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/plugins/github/src/types.ts
+++ b/packages/plugins/github/src/types.ts
@@ -46,5 +46,6 @@ export interface GitHubActionSecret {
 export const ACTIVE_WORKFLOW_NAMES = ['Vercel Deployment', 'Production deployment'] as const;
 export const ACTIVE_WORKFLOW_FILES = [
 	'.github/workflows/deploy_vercel.yaml',
-	'.github/workflows/deploy_prod.yaml'
+	'.github/workflows/deploy_prod.yaml',
+	'.github/workflows/deploy_k8s.yaml'
 ] as const;

--- a/packages/plugins/lm-studio/README.md
+++ b/packages/plugins/lm-studio/README.md
@@ -1,0 +1,83 @@
+# @ever-works/lm-studio-plugin
+
+LM Studio AI provider plugin for Ever Works platform
+
+## Plugin metadata
+
+| Field        | Value           |
+| ------------ | --------------- |
+| ID           | `lm-studio`     |
+| Category     | `ai-provider`   |
+| Capabilities | `ai-provider`   |
+| Author       | Ever Works Team |
+| License      | AGPL-3.0        |
+| Built-in     | yes             |
+| Auto-enable  | no              |
+
+## What is the LM Studio plugin?
+
+This plugin connects Ever Works to an [LM Studio](https://lmstudio.ai) server for AI inference. LM Studio runs open-source models (Llama, Qwen, Mistral, Gemma, and others) locally and exposes them through an OpenAI-compatible API. Because the server runs on your own machine, your data never leaves your infrastructure.
+
+## Why use it?
+
+- **Data privacy** — requests are processed by your LM Studio instance, keeping sensitive content off third-party servers
+- **No API costs** — run unlimited requests against your own hardware
+- **Open-source models** — load any GGUF/MLX model supported by LM Studio
+- **Friendly UI** — manage and download models from the LM Studio desktop app
+
+## How it works in Ever Works
+
+When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your LM Studio server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.
+
+LM Studio exposes the same OpenAI-compatible `/v1` API as the other AI providers, so it reuses the shared `AiOperations` (LangChain) backend with a different base URL.
+
+## Getting started
+
+1. Install LM Studio ([lmstudio.ai](https://lmstudio.ai)) and download at least one model.
+2. Start the **Local Server** in LM Studio (Developer tab) — it listens on `http://localhost:1234` by default.
+3. Enable the LM Studio plugin and set the **Base URL** to your server address (include the `/v1` suffix).
+4. Select your preferred model for each task complexity level.
+
+## Settings
+
+- **LM Studio Server URL** — address of your LM Studio server, e.g. `http://localhost:1234/v1` (per-user, required).
+- **API Key** — usually not needed; only for instances placed behind an auth proxy. Stored encrypted (per-user).
+- **Default Model** — used for all AI tasks unless a tier-specific model is set. No hardcoded default: pick a model after the connection is established and the model list loads.
+- **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
+- **Standard Tasks Model** — handles listings, summaries, and content reformatting.
+- **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Embedding Model** — model used for semantic-search embeddings; only needed if you use KB search.
+- **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
+- **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
+
+## Troubleshooting
+
+| Symptom                               | Likely cause                                                       | Fix                                                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Plugin shows unavailable              | LM Studio local server not started                                 | Open LM Studio → Developer → **Start Server**, then re-test the connection                                   |
+| No models in the dropdown             | No model loaded in LM Studio                                       | Load a model in the LM Studio app; the server serves whatever model is currently loaded                      |
+| `Connection refused` / wrong base URL | Base URL missing the `/v1` suffix or wrong port                    | Verify the URL is `http://localhost:1234/v1` (or your configured host/port)                                  |
+| Empty / truncated AI output           | **Max Tokens** too low, or context window exceeded                 | Raise **Max Tokens**, or split the input into smaller batches                                                |
+| Plugin not selected during generation | Another AI provider plugin is set as the default for `ai-provider` | In **Settings → Plugins**, set `lm-studio` as the default for `ai-provider`, or disable competing AI plugins |
+| Slow responses                        | Model too large for the available hardware                         | Use a smaller / quantized model, or increase available RAM / VRAM                                            |
+
+## Local development
+
+This plugin ships built-in with the Ever Works platform. To work on it locally from the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter @ever-works/lm-studio-plugin build
+pnpm --filter @ever-works/lm-studio-plugin test
+```
+
+## Documentation
+
+- [Ever Works documentation](https://docs.ever.works)
+- [Ever Works repository](https://github.com/ever-works/ever-works)
+- [Plugin system](../../plugin/README.md)
+- [LM Studio homepage](https://lmstudio.ai)
+
+## License
+
+AGPL-3.0

--- a/packages/plugins/lm-studio/package.json
+++ b/packages/plugins/lm-studio/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@ever-works/lm-studio-plugin",
+	"version": "1.0.0",
+	"description": "LM Studio AI provider plugin for Ever Works platform",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@langchain/openai": "^0.6.17",
+		"@langchain/core": "^0.3.80"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^3.2.1"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "lm-studio",
+			"name": "LM Studio",
+			"version": "1.0.0",
+			"category": "ai-provider",
+			"capabilities": [
+				"ai-provider"
+			],
+			"description": "LM Studio AI provider plugin for Ever Works platform",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false
+		}
+	}
+}

--- a/packages/plugins/lm-studio/src/__tests__/lm-studio.plugin.spec.ts
+++ b/packages/plugins/lm-studio/src/__tests__/lm-studio.plugin.spec.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LmStudioPlugin } from '../lm-studio.plugin';
+import type { PluginContext } from '@ever-works/plugin';
+import { AiOperations } from '@ever-works/plugin/ai';
+
+vi.mock('@ever-works/plugin/ai', () => {
+	const MockAiOperations = vi.fn().mockImplementation(() => ({
+		createChatCompletion: vi.fn().mockResolvedValue({ id: 'test', choices: [], model: 'local-model', created: 0 }),
+		createStreamingChatCompletion: vi.fn(),
+		createEmbedding: vi.fn(),
+		askJson: vi.fn().mockResolvedValue({ result: {}, model: 'local-model', usage: undefined }),
+		listModels: vi.fn().mockResolvedValue([]),
+		testConnection: vi.fn().mockResolvedValue({ success: true })
+	}));
+	return { AiOperations: MockAiOperations };
+});
+
+describe('LmStudioPlugin', () => {
+	let plugin: LmStudioPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new LmStudioPlugin();
+	});
+
+	describe('metadata', () => {
+		it('should have correct plugin id and name', () => {
+			expect(plugin.id).toBe('lm-studio');
+			expect(plugin.name).toBe('LM Studio');
+			expect(plugin.version).toBe('1.0.0');
+		});
+
+		it('should have ai-provider category and capability', () => {
+			expect(plugin.category).toBe('ai-provider');
+			expect(plugin.capabilities).toContain('ai-provider');
+		});
+
+		it('should have user-required configuration mode', () => {
+			expect(plugin.configurationMode).toBe('user-required');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('should have required baseUrl and defaultModel fields', () => {
+			expect(plugin.settingsSchema).toBeDefined();
+			expect(plugin.settingsSchema.type).toBe('object');
+			expect(plugin.settingsSchema.required).toEqual(['baseUrl', 'defaultModel']);
+		});
+
+		it('should have apiKey as an encrypted secret with a placeholder default', () => {
+			const apiKeySchema = plugin.settingsSchema.properties?.apiKey as any;
+			expect(apiKeySchema).toBeDefined();
+			expect(apiKeySchema.type).toBe('string');
+			expect(apiKeySchema.default).toBe('lm-studio');
+			expect(apiKeySchema['x-secret']).toBe(true);
+			expect(apiKeySchema['x-scope']).toBe('user');
+		});
+
+		it('should have all model settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('defaultModel');
+			expect(props).toHaveProperty('simpleModel');
+			expect(props).toHaveProperty('mediumModel');
+			expect(props).toHaveProperty('complexModel');
+		});
+
+		it('should NOT hardcode a default model (populated via model-select)', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect((props.defaultModel as any).default).toBeUndefined();
+			expect((props.defaultModel as any)['x-widget']).toBe('model-select');
+		});
+
+		it('should have baseUrl setting with the LM Studio title', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('baseUrl');
+			expect((props.baseUrl as any).type).toBe('string');
+			expect((props.baseUrl as any).title).toBe('LM Studio Server URL');
+		});
+
+		it('should have temperature and maxTokens settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('temperature');
+			expect(props).toHaveProperty('maxTokens');
+			expect((props.temperature as any).type).toBe('number');
+			expect((props.maxTokens as any).type).toBe('number');
+		});
+
+		it('should have description on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).description, `${key} should have a description`).toBeDefined();
+				expect((prop as any).description, `${key} description should not be empty`).not.toBe('');
+			}
+		});
+
+		it('should have title on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).title, `${key} should have a title`).toBeDefined();
+			}
+		});
+	});
+
+	describe('lifecycle hooks', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'lm-studio',
+				logger: {
+					log: vi.fn(),
+					debug: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn()
+				},
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should load successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			expect(mockContext.logger.log).toHaveBeenCalledWith('LM Studio Plugin loaded');
+		});
+
+		it('should unload successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			await plugin.onUnload();
+		});
+	});
+
+	describe('manifest', () => {
+		it('should return correct manifest', () => {
+			const manifest = plugin.getManifest();
+			expect(manifest.id).toBe('lm-studio');
+			expect(manifest.name).toBe('LM Studio');
+			expect(manifest.builtIn).toBe(true);
+			expect(manifest.autoEnable).toBe(false);
+			expect(manifest.visibility).toBe('public');
+			expect(manifest.icon).toBeDefined();
+			expect(manifest.icon?.type).toBe('svg');
+		});
+	});
+
+	describe('healthCheck', () => {
+		it('should return healthy status', async () => {
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+			expect(health.message).toBe('LM Studio plugin is ready');
+			expect(health.checkedAt).toBeDefined();
+		});
+	});
+
+	describe('askJson', () => {
+		const createMockContext2 = (): PluginContext =>
+			({
+				pluginId: 'lm-studio',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should delegate to aiOps.askJson with resolved config', async () => {
+			await plugin.onLoad(createMockContext2());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.askJson('Generate JSON', {
+				settings: { apiKey: 'lm-studio' }
+			});
+
+			expect(aiOpsInstance.askJson).toHaveBeenCalledWith(
+				'Generate JSON',
+				expect.any(Object),
+				expect.objectContaining({ apiKey: 'lm-studio' }),
+				expect.any(Object)
+			);
+		});
+
+		it('should throw when plugin not loaded', async () => {
+			await expect(plugin.askJson('test')).rejects.toThrow('Plugin not loaded');
+		});
+	});
+
+	describe('settings threading', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'lm-studio',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should pass settings as configOverrides to AiOperations.listModels', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.listModels({ baseUrl: 'http://custom:1234/v1' });
+
+			expect(aiOpsInstance.listModels).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:1234/v1' })
+			);
+		});
+
+		it('should pass settings as configOverrides to AiOperations.testConnection', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.isAvailable({ baseUrl: 'http://custom:1234/v1' });
+
+			expect(aiOpsInstance.testConnection).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:1234/v1' })
+			);
+		});
+
+		it('should pass resolved settings (URL, key, embedding model) to AiOperations.createEmbedding', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				settings: {
+					baseUrl: 'http://custom:1234/v1',
+					apiKey: 'proxy-token',
+					embeddingModel: 'nomic-embed-text'
+				}
+			});
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.objectContaining({ input: 'hello' }),
+				expect.objectContaining({
+					baseURL: 'http://custom:1234/v1',
+					apiKey: 'proxy-token',
+					embeddingModel: 'nomic-embed-text'
+				})
+			);
+		});
+	});
+});

--- a/packages/plugins/lm-studio/src/index.ts
+++ b/packages/plugins/lm-studio/src/index.ts
@@ -1,0 +1,1 @@
+export { LmStudioPlugin, LmStudioPlugin as default } from './lm-studio.plugin.js';

--- a/packages/plugins/lm-studio/src/lm-studio.plugin.ts
+++ b/packages/plugins/lm-studio/src/lm-studio.plugin.ts
@@ -1,0 +1,243 @@
+import { BaseAiProvider } from '@ever-works/plugin/abstract';
+import { AiOperations } from '@ever-works/plugin/ai';
+import type {
+	PluginContext,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema,
+	PluginSettings,
+	ChatCompletionOptions,
+	ChatCompletionResponse,
+	ChatCompletionChunk,
+	EmbeddingOptions,
+	EmbeddingResponse,
+	AiModel,
+	AiModelCapabilities
+} from '@ever-works/plugin';
+
+/**
+ * LM Studio AI provider plugin
+ *
+ * Provides AI capabilities through a local (or remote) LM Studio server.
+ * LM Studio exposes an OpenAI-compatible API on `/v1`, so it reuses the same
+ * `AiOperations` (LangChain) backend as the other AI providers.
+ *
+ * Uses 'user-required' configuration mode - users point the plugin at their
+ * LM Studio server URL. LM Studio does not authenticate by default, but the
+ * OpenAI client requires a non-empty key, so `apiKey` defaults to a placeholder.
+ *
+ * Unlike Ollama, LM Studio has no canonical default model: the served model is
+ * whatever the user has loaded in the app. The model fields therefore ship
+ * without a hardcoded default and are populated by the `model-select` widget
+ * once the connection is established and `listModels()` returns.
+ */
+export class LmStudioPlugin extends BaseAiProvider {
+	readonly id = 'lm-studio';
+	readonly name = 'LM Studio';
+	readonly version = '1.0.0';
+	readonly providerType = 'lm-studio';
+	readonly providerName = 'LM Studio';
+
+	readonly configurationMode: 'admin-only' | 'user-required' | 'hybrid' = 'user-required';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			baseUrl: {
+				type: 'string',
+				title: 'LM Studio Server URL',
+				description: 'Address of your LM Studio server (e.g: http://localhost:1234/v1)',
+				'x-scope': 'user'
+			},
+			apiKey: {
+				type: 'string',
+				title: 'API Key',
+				description: 'Usually not needed; only for LM Studio instances placed behind an auth proxy',
+				default: 'lm-studio',
+				'x-secret': true,
+				'x-scope': 'user'
+			},
+			defaultModel: {
+				type: 'string',
+				title: 'Default Model',
+				description: 'Used for all AI tasks unless a tier-specific model is set',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			simpleModel: {
+				type: 'string',
+				title: 'Simple Tasks Model',
+				description: 'Handles tags, short descriptions, and quick classifications',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			mediumModel: {
+				type: 'string',
+				title: 'Standard Tasks Model',
+				description: 'Handles listings, summaries, and content reformatting',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			complexModel: {
+				type: 'string',
+				title: 'Complex Tasks Model',
+				description: 'Handles full page generation and multi-step analysis',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			embeddingModel: {
+				type: 'string',
+				title: 'Embedding Model',
+				description: 'Model used for semantic search embeddings (only needed if you use KB search)',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+
+			temperature: {
+				type: 'number',
+				title: 'Temperature',
+				description: 'Lower values give consistent output, higher values add variety',
+				default: 0.7,
+				minimum: 0,
+				maximum: 2,
+				'x-hidden': true
+			},
+			maxTokens: {
+				type: 'number',
+				title: 'Max Tokens',
+				description: 'Limits the length of each AI-generated response',
+				default: 4096,
+				'x-hidden': true
+			}
+		},
+		required: ['baseUrl', 'defaultModel']
+	};
+
+	async onLoad(context: PluginContext): Promise<void> {
+		await super.onLoad(context);
+		this.aiOps = new AiOperations({
+			apiKey: 'lm-studio',
+			model: this.getDefaultModelId(),
+			baseURL: 'http://localhost:1234/v1',
+			temperature: 0.7,
+			maxTokens: 4096,
+			providerType: 'lm-studio'
+		});
+		context.logger.log('LM Studio Plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.aiOps = null;
+		await super.onUnload();
+	}
+
+	async createChatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		return this.aiOps.createChatCompletion(options, resolvedConfig);
+	}
+
+	async *createStreamingChatCompletion(options: ChatCompletionOptions): AsyncIterable<ChatCompletionChunk> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		yield* this.aiOps.createStreamingChatCompletion(options, resolvedConfig);
+	}
+
+	async createEmbedding(options: EmbeddingOptions): Promise<EmbeddingResponse> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		return this.aiOps.createEmbedding(options, this.resolveConfig(options.settings));
+	}
+
+	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {
+		if (!this.aiOps) {
+			throw new Error('LM Studio plugin not loaded');
+		}
+		return this.aiOps.listModels(this.resolveConfig(settings));
+	}
+
+	async isAvailable(settings?: PluginSettings): Promise<boolean> {
+		if (!this.aiOps) {
+			return false;
+		}
+		const result = await this.aiOps.testConnection(this.resolveConfig(settings));
+		return result.success;
+	}
+
+	getCapabilities(): AiModelCapabilities {
+		return {
+			supportsStructuredOutput: true,
+			supportsStreaming: true,
+			supportsToolCalling: true,
+			supportsVision: true,
+			maxContextLength: 128000
+		};
+	}
+
+	protected getDefaultModelId(): string {
+		return 'local-model';
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'LM Studio plugin is ready',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Connect to an LM Studio server for private, self-hosted AI inference',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public',
+			uiHints: {
+				completionFields: ['defaultModel']
+			},
+			readme: [
+				'## What is the LM Studio plugin?',
+				'',
+				'This plugin connects Ever Works to an [LM Studio](https://lmstudio.ai) server for AI inference. LM Studio runs open-source models (Llama, Qwen, Mistral, Gemma, and others) locally and exposes them through an OpenAI-compatible API. Because the server runs on your own machine, your data never leaves your infrastructure.',
+				'',
+				'## Why use it?',
+				'',
+				'- **Data privacy** — requests are processed by your LM Studio instance, keeping sensitive content off third-party servers',
+				'- **No API costs** — run unlimited requests against your own hardware',
+				'- **Open-source models** — load any GGUF/MLX model supported by LM Studio',
+				'- **Friendly UI** — manage and download models from the LM Studio desktop app',
+				'',
+				'## How it works in Ever Works',
+				'',
+				'When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your LM Studio server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.',
+				'',
+				'## Getting started',
+				'',
+				'1. Install LM Studio ([lmstudio.ai](https://lmstudio.ai)) and download at least one model',
+				'2. Start the **Local Server** in LM Studio (Developer tab) — it listens on `http://localhost:1234` by default',
+				'3. Enable the LM Studio plugin and set the **Base URL** to your server address (include the `/v1` suffix)',
+				'4. Select your preferred model for each task complexity level'
+			].join('\n'),
+			homepage: 'https://lmstudio.ai',
+			icon: {
+				type: 'svg',
+				value: `<svg fill="#000" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>LM Studio</title><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm4.6 4.7v8.6a.6.6 0 0 0 .92.5l6.9-4.3a.6.6 0 0 0 0-1l-6.9-4.3a.6.6 0 0 0-.92.5z"/></svg>`,
+				darkValue: `<svg fill="#fff" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>LM Studio</title><path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm4.6 4.7v8.6a.6.6 0 0 0 .92.5l6.9-4.3a.6.6 0 0 0 0-1l-6.9-4.3a.6.6 0 0 0-.92.5z"/></svg>`
+			}
+		};
+	}
+}
+
+export default LmStudioPlugin;

--- a/packages/plugins/lm-studio/tsconfig.json
+++ b/packages/plugins/lm-studio/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/lm-studio/tsup.config.ts
+++ b/packages/plugins/lm-studio/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/lm-studio/vitest.config.ts
+++ b/packages/plugins/lm-studio/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/slack-channel/README.md
+++ b/packages/plugins/slack-channel/README.md
@@ -4,7 +4,7 @@ Slack notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-slack`
 - **Shape**: `broadcast`
-- **Transport**: Slack incoming webhook (Block Kit supported via the `slack-blocks` rich payload kind)
+- **Transport**: official `@slack/webhook` SDK (`IncomingWebhook`) over a Slack incoming webhook (Block Kit supported via the `slack-blocks` rich payload kind)
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/plugins/slack-channel/package.json
+++ b/packages/plugins/slack-channel/package.json
@@ -32,7 +32,8 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@ever-works/plugin": "workspace:*"
+		"@ever-works/plugin": "workspace:*",
+		"@slack/webhook": "^7.0.5"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/packages/plugins/slack-channel/src/slack-channel-plugin.spec.ts
+++ b/packages/plugins/slack-channel/src/slack-channel-plugin.spec.ts
@@ -1,4 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sendMock = vi.fn();
+const ctorMock = vi.fn();
+
+vi.mock('@slack/webhook', () => ({
+	IncomingWebhook: class {
+		constructor(url: string) {
+			ctorMock(url);
+		}
+		send = sendMock;
+	}
+}));
+
 import { SlackChannelPlugin } from './slack-channel-plugin.js';
 
 describe('SlackChannelPlugin', () => {
@@ -6,6 +19,8 @@ describe('SlackChannelPlugin', () => {
 
 	beforeEach(() => {
 		plugin = new SlackChannelPlugin();
+		sendMock.mockReset();
+		ctorMock.mockReset();
 	});
 
 	it('declares notification-channel + notification-channel-slack', () => {
@@ -34,12 +49,8 @@ describe('SlackChannelPlugin', () => {
 	});
 
 	describe('send', () => {
-		it('POSTs text + blocks to the webhook and returns a synthetic id', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				text: async () => 'ok'
-			} as Response);
+		it('sends text + blocks via the @slack/webhook SDK and returns a synthetic id', async () => {
+			sendMock.mockResolvedValueOnce({ text: 'ok' });
 			const res = await plugin.send(
 				{
 					text: 'build is green',
@@ -51,19 +62,17 @@ describe('SlackChannelPlugin', () => {
 				{}
 			);
 			expect(res.providerMessageId).toBe('slack-ref-1');
-			const [, init] = fetchMock.mock.calls[0];
-			const body = JSON.parse((init as RequestInit).body as string);
-			expect(body.text).toBe('build is green');
-			expect(body.blocks).toEqual([{ type: 'section' }]);
-			fetchMock.mockRestore();
+			expect(ctorMock).toHaveBeenCalledWith('https://hooks.slack.com/services/T/B/x');
+			const message = sendMock.mock.calls[0][0];
+			expect(message.text).toBe('build is green');
+			expect(message.blocks).toEqual([{ type: 'section' }]);
 		});
 
-		it('throws on non-2xx Slack response', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: false,
-				status: 400,
-				text: async () => 'invalid_payload'
-			} as Response);
+		it('throws on a Slack SDK send error (surfacing the HTTP status)', async () => {
+			sendMock.mockRejectedValueOnce({
+				message: 'invalid_payload',
+				original: { response: { status: 400 } }
+			});
 			await expect(
 				plugin.send(
 					{
@@ -74,15 +83,11 @@ describe('SlackChannelPlugin', () => {
 					},
 					{}
 				)
-			).rejects.toThrow(/Slack webhook failed/);
+			).rejects.toThrow(/Slack webhook failed \(400\): invalid_payload/);
 		});
 
 		it('hits the idempotency cache on repeated messageRef', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
-				ok: true,
-				status: 200,
-				text: async () => 'ok'
-			} as Response);
+			sendMock.mockResolvedValue({ text: 'ok' });
 			const input = {
 				text: 'x',
 				messageRef: 'ref-cache',
@@ -91,8 +96,7 @@ describe('SlackChannelPlugin', () => {
 			};
 			await plugin.send(input, {});
 			await plugin.send(input, {});
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-			fetchMock.mockRestore();
+			expect(sendMock).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/plugins/slack-channel/src/slack-channel-plugin.ts
+++ b/packages/plugins/slack-channel/src/slack-channel-plugin.ts
@@ -1,3 +1,4 @@
+import { IncomingWebhook } from '@slack/webhook';
 import type {
 	INotificationChannelPlugin,
 	ChannelSendInput,
@@ -26,9 +27,12 @@ function getWebhookUrl(config: ChannelTargetConfig): string {
  * webhook URL. Block Kit blocks are forwarded when the caller supplies
  * the `slack-blocks` rich payload kind.
  *
- * Slack incoming webhooks return the literal string `ok` on success
- * (no message id), so `providerMessageId` is synthesized from the
- * idempotency `messageRef`.
+ * Built on the official `@slack/webhook` SDK (`IncomingWebhook`) — the
+ * vendor SDK for the incoming-webhook mechanism this channel uses
+ * (`@slack/web-api` is the bot-token `chat.postMessage` path, a
+ * different config contract). Incoming webhooks return the literal
+ * string `ok` on success (no message id), so `providerMessageId` is
+ * synthesized from the idempotency `messageRef`.
  */
 export class SlackChannelPlugin implements INotificationChannelPlugin {
 	readonly id = 'slack-channel';
@@ -88,22 +92,19 @@ export class SlackChannelPlugin implements INotificationChannelPlugin {
 			(typeof options.settings?.defaultIconEmoji === 'string' ? options.settings.defaultIconEmoji : undefined) ??
 			(typeof config.iconEmoji === 'string' ? (config.iconEmoji as string) : undefined);
 
-		const body: Record<string, unknown> = { text: payload.text };
-		if (username) body.username = username;
-		if (iconEmoji) body.icon_emoji = iconEmoji;
+		const message: Record<string, unknown> = { text: payload.text };
+		if (username) message.username = username;
+		if (iconEmoji) message.icon_emoji = iconEmoji;
 		if (payload.rich?.kind === 'slack-blocks') {
-			body.blocks = payload.rich.payload;
+			message.blocks = payload.rich.payload;
 		}
 
-		const response = await fetch(webhookUrl, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body)
-		});
-
-		if (!response.ok) {
-			const text = await response.text().catch(() => '');
-			throw new Error(`Slack webhook failed (${response.status}): ${text}`);
+		try {
+			await new IncomingWebhook(webhookUrl).send(message);
+		} catch (err) {
+			const e = err as { message?: string; original?: { response?: { status?: number } } };
+			const status = e.original?.response?.status ?? 'error';
+			throw new Error(`Slack webhook failed (${status}): ${e.message ?? 'unknown error'}`);
 		}
 		// Success body is the literal "ok"; no id to capture.
 		const result: ChannelSendResult = {

--- a/packages/plugins/telegram-channel/README.md
+++ b/packages/plugins/telegram-channel/README.md
@@ -4,7 +4,7 @@ Telegram notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-telegram`
 - **Shape**: `direct` (one chat per channel)
-- **Transport**: Telegram Bot API `sendMessage` (MarkdownV2 via the `telegram-markdown` rich payload kind)
+- **Transport**: official `grammy` SDK (`Api.sendMessage`, a typed Bot-API client with no polling/bot framework; MarkdownV2 via the `telegram-markdown` rich payload kind)
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/plugins/telegram-channel/package.json
+++ b/packages/plugins/telegram-channel/package.json
@@ -32,7 +32,8 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@ever-works/plugin": "workspace:*"
+		"@ever-works/plugin": "workspace:*",
+		"grammy": "^1.30.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.0.0",

--- a/packages/plugins/telegram-channel/src/telegram-channel-plugin.spec.ts
+++ b/packages/plugins/telegram-channel/src/telegram-channel-plugin.spec.ts
@@ -1,4 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sendMessageMock = vi.fn();
+const getMeMock = vi.fn();
+const ctorMock = vi.fn();
+
+vi.mock('grammy', () => ({
+	Api: class {
+		constructor(token: string) {
+			ctorMock(token);
+		}
+		sendMessage = sendMessageMock;
+		getMe = getMeMock;
+	}
+}));
+
 import { TelegramChannelPlugin } from './telegram-channel-plugin.js';
 
 describe('TelegramChannelPlugin', () => {
@@ -6,6 +21,9 @@ describe('TelegramChannelPlugin', () => {
 
 	beforeEach(() => {
 		plugin = new TelegramChannelPlugin();
+		sendMessageMock.mockReset();
+		getMeMock.mockReset();
+		ctorMock.mockReset();
 	});
 
 	it('declares notification-channel + notification-channel-telegram (direct shape)', () => {
@@ -16,22 +34,15 @@ describe('TelegramChannelPlugin', () => {
 
 	describe('verifyTarget', () => {
 		it('returns valid when getMe succeeds', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { id: 42, username: ' everworks_bot' } })
-			} as Response);
+			getMeMock.mockResolvedValueOnce({ id: 42, username: 'everworks_bot' });
 			const res = await plugin.verifyTarget({ botToken: 'tok', chatId: '123' }, {});
 			expect(res.valid).toBe(true);
-			expect(res.details).toMatchObject({ botId: 42, username: ' everworks_bot' });
+			expect(res.details).toMatchObject({ botId: 42, username: 'everworks_bot' });
+			expect(ctorMock).toHaveBeenCalledWith('tok');
 		});
 
 		it('returns invalid when getMe rejects the token', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: false,
-				status: 401,
-				json: async () => ({ ok: false, description: 'Unauthorized' })
-			} as Response);
+			getMeMock.mockRejectedValueOnce({ error_code: 401, description: 'Unauthorized' });
 			const res = await plugin.verifyTarget({ botToken: 'bad', chatId: '123' }, {});
 			expect(res.valid).toBe(false);
 			expect(res.message).toMatch(/Unauthorized/);
@@ -44,12 +55,8 @@ describe('TelegramChannelPlugin', () => {
 	});
 
 	describe('send', () => {
-		it('POSTs sendMessage + returns the telegram message id', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { message_id: 555 } })
-			} as Response);
+		it('sends via the grammy Api and returns the telegram message id', async () => {
+			sendMessageMock.mockResolvedValueOnce({ message_id: 555 });
 			const res = await plugin.send(
 				{
 					text: 'deploy done',
@@ -60,20 +67,14 @@ describe('TelegramChannelPlugin', () => {
 				{}
 			);
 			expect(res.providerMessageId).toBe('555');
-			const [url, init] = fetchMock.mock.calls[0];
-			expect(url).toContain('/bottok/sendMessage');
-			const body = JSON.parse((init as RequestInit).body as string);
-			expect(body.chat_id).toBe('123');
-			expect(body.text).toBe('deploy done');
-			fetchMock.mockRestore();
+			expect(ctorMock).toHaveBeenCalledWith('tok');
+			const [chatId, text] = sendMessageMock.mock.calls[0];
+			expect(chatId).toBe('123');
+			expect(text).toBe('deploy done');
 		});
 
 		it('forwards MarkdownV2 for the telegram-markdown rich kind', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { message_id: 1 } })
-			} as Response);
+			sendMessageMock.mockResolvedValueOnce({ message_id: 1 });
 			await plugin.send(
 				{
 					text: 'fallback',
@@ -84,18 +85,13 @@ describe('TelegramChannelPlugin', () => {
 				},
 				{}
 			);
-			const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
-			expect(body.parse_mode).toBe('MarkdownV2');
-			expect(body.text).toBe('*bold*');
-			fetchMock.mockRestore();
+			const [, text, other] = sendMessageMock.mock.calls[0];
+			expect(text).toBe('*bold*');
+			expect(other.parse_mode).toBe('MarkdownV2');
 		});
 
-		it('throws when Telegram returns ok:false', async () => {
-			vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-				ok: false,
-				status: 400,
-				json: async () => ({ ok: false, error_code: 400, description: 'chat not found' })
-			} as Response);
+		it('throws when the grammy Api send rejects (surfacing error_code + description)', async () => {
+			sendMessageMock.mockRejectedValueOnce({ error_code: 400, description: 'chat not found' });
 			await expect(
 				plugin.send(
 					{
@@ -106,15 +102,11 @@ describe('TelegramChannelPlugin', () => {
 					},
 					{}
 				)
-			).rejects.toThrow(/Telegram sendMessage failed/);
+			).rejects.toThrow(/Telegram sendMessage failed \(400\): chat not found/);
 		});
 
 		it('hits the idempotency cache on repeated messageRef', async () => {
-			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
-				ok: true,
-				status: 200,
-				json: async () => ({ ok: true, result: { message_id: 9 } })
-			} as Response);
+			sendMessageMock.mockResolvedValue({ message_id: 9 });
 			const input = {
 				text: 'x',
 				messageRef: 'ref-cache',
@@ -123,8 +115,7 @@ describe('TelegramChannelPlugin', () => {
 			};
 			await plugin.send(input, {});
 			await plugin.send(input, {});
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-			fetchMock.mockRestore();
+			expect(sendMessageMock).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/plugins/telegram-channel/src/telegram-channel-plugin.ts
+++ b/packages/plugins/telegram-channel/src/telegram-channel-plugin.ts
@@ -1,3 +1,4 @@
+import { Api } from 'grammy';
 import type {
 	INotificationChannelPlugin,
 	ChannelSendInput,
@@ -10,8 +11,6 @@ import type {
 	JsonSchema
 } from '@ever-works/plugin';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
-
-const TELEGRAM_API_BASE = 'https://api.telegram.org';
 
 interface TelegramTarget {
 	botToken: string;
@@ -30,23 +29,20 @@ function getTarget(config: ChannelTargetConfig): TelegramTarget {
 	return { botToken, chatId };
 }
 
-interface TelegramSendResponse {
-	ok: boolean;
-	result?: { message_id: number };
-	description?: string;
-	error_code?: number;
-}
-
-interface TelegramGetMeResponse {
-	ok: boolean;
-	result?: { id: number; username?: string; first_name?: string };
-	description?: string;
+/** Telegram Bot API errors carry an error_code + description. */
+function describeError(err: unknown): { code: number | string; message: string } {
+	const e = err as { error_code?: number; description?: string; message?: string };
+	return {
+		code: e.error_code ?? 'error',
+		message: e.description ?? e.message ?? 'unknown error'
+	};
 }
 
 /**
- * Telegram notification channel — sends via the Bot API `sendMessage`
- * method. `chatId` is the destination chat; discover it by having the
- * user message the bot then reading `getUpdates` (see README).
+ * Telegram notification channel — sends via the official `grammy`
+ * SDK's lightweight `Api` client (typed Bot API calls, no bot/polling
+ * framework). `chatId` is the destination chat; discover it by having
+ * the user message the bot then reading `getUpdates` (see README).
  *
  * MarkdownV2 is forwarded when the caller supplies the
  * `telegram-markdown` rich payload kind.
@@ -88,22 +84,10 @@ export class TelegramChannelPlugin implements INotificationChannelPlugin {
 			return { valid: false, message: 'chatId is required' };
 		}
 		try {
-			const response = await fetch(`${TELEGRAM_API_BASE}/bot${botToken}/getMe`, {
-				method: 'GET'
-			});
-			const data = (await response.json()) as TelegramGetMeResponse;
-			if (!response.ok || !data.ok) {
-				return {
-					valid: false,
-					message: `Telegram getMe failed: ${data.description ?? response.status}`
-				};
-			}
-			return {
-				valid: true,
-				details: { botId: data.result?.id, username: data.result?.username }
-			};
+			const me = await new Api(botToken).getMe();
+			return { valid: true, details: { botId: me.id, username: me.username } };
 		} catch (err) {
-			return { valid: false, message: err instanceof Error ? err.message : String(err) };
+			return { valid: false, message: `Telegram getMe failed: ${describeError(err).message}` };
 		}
 	}
 
@@ -112,37 +96,26 @@ export class TelegramChannelPlugin implements INotificationChannelPlugin {
 		if (cached) return cached;
 
 		const { botToken, chatId } = getTarget(payload.target ?? {});
-		const disableNotification =
-			typeof options.settings?.disableNotification === 'boolean'
-				? options.settings.disableNotification
-				: undefined;
-
-		const body: Record<string, unknown> = {
-			chat_id: chatId,
-			text: payload.rich?.kind === 'telegram-markdown' ? payload.rich.payload : payload.text
-		};
-		if (payload.rich?.kind === 'telegram-markdown') {
-			body.parse_mode = 'MarkdownV2';
-		}
-		if (disableNotification !== undefined) {
-			body.disable_notification = disableNotification;
+		const isMarkdown = payload.rich?.kind === 'telegram-markdown';
+		const text = isMarkdown ? String(payload.rich.payload) : payload.text;
+		const other: { parse_mode?: 'MarkdownV2'; disable_notification?: boolean } = {};
+		if (isMarkdown) other.parse_mode = 'MarkdownV2';
+		if (typeof options.settings?.disableNotification === 'boolean') {
+			other.disable_notification = options.settings.disableNotification;
 		}
 
-		const response = await fetch(`${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body)
-		});
-		const data = (await response.json()) as TelegramSendResponse;
-		if (!response.ok || !data.ok) {
-			throw new Error(
-				`Telegram sendMessage failed (${response.status} / ${data.error_code ?? '?'}): ${data.description ?? 'unknown error'}`
-			);
+		let messageId: string;
+		try {
+			const message = await new Api(botToken).sendMessage(chatId, text, other);
+			messageId = String(message.message_id);
+		} catch (err) {
+			const { code, message } = describeError(err);
+			throw new Error(`Telegram sendMessage failed (${code}): ${message}`);
 		}
 
 		const result: ChannelSendResult = {
 			provider: this.id,
-			providerMessageId: String(data.result?.message_id ?? `telegram-${payload.messageRef}`),
+			providerMessageId: messageId,
 			deliveredAt: new Date()
 		};
 		this.idempotencyCache.set(payload.messageRef, result);

--- a/packages/plugins/vllm/README.md
+++ b/packages/plugins/vllm/README.md
@@ -1,0 +1,88 @@
+# @ever-works/vllm-plugin
+
+vLLM AI provider plugin for Ever Works platform
+
+## Plugin metadata
+
+| Field        | Value           |
+| ------------ | --------------- |
+| ID           | `vllm`          |
+| Category     | `ai-provider`   |
+| Capabilities | `ai-provider`   |
+| Author       | Ever Works Team |
+| License      | AGPL-3.0        |
+| Built-in     | yes             |
+| Auto-enable  | no              |
+
+## What is the vLLM plugin?
+
+This plugin connects Ever Works to a [vLLM](https://docs.vllm.ai) server for AI inference. vLLM is a high-throughput inference engine for open-source models, usually deployed on a GPU server. It exposes an OpenAI-compatible API, so Ever Works can use it for content generation, conversations, and embeddings — and because you run the server, your data stays within your infrastructure.
+
+## Why use it?
+
+- **Data privacy** — requests are processed by your own vLLM server, keeping sensitive content off third-party servers
+- **No API costs** — run unlimited requests against your own GPU infrastructure
+- **High throughput** — vLLM is optimized for concurrent, batched inference (PagedAttention)
+- **Open-source models** — serve any model supported by vLLM
+
+## How it works in Ever Works
+
+When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your vLLM server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.
+
+vLLM exposes the same OpenAI-compatible `/v1` API as the other AI providers, so it reuses the shared `AiOperations` (LangChain) backend with a different base URL.
+
+## Getting started
+
+1. Start a vLLM OpenAI-compatible server: `vllm serve <model>` (listens on `http://localhost:8000` by default).
+2. If you secured it with `--api-key <token>`, have that token ready.
+3. Enable the vLLM plugin and set the **Base URL** to your server address (include the `/v1` suffix).
+4. Enter the **API Key** if your server requires one (otherwise leave it as `EMPTY`).
+5. Select your preferred model for each task complexity level.
+
+## Settings
+
+- **vLLM Server URL** — address of your vLLM server, e.g. `http://localhost:8000/v1` (per-user, required).
+- **API Key** — only required if the server was started with `--api-key`; defaults to `EMPTY` for unsecured servers. Stored encrypted (per-user).
+- **Default Model** — used for all AI tasks unless a tier-specific model is set. No hardcoded default: pick the model your server was launched with (`--model`) after the connection is established.
+- **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
+- **Standard Tasks Model** — handles listings, summaries, and content reformatting.
+- **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Embedding Model** — model used for semantic-search embeddings; only needed if you use KB search.
+- **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
+- **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
+
+## Networking note (managed cloud vs self-hosted)
+
+vLLM is typically deployed on a GPU server rather than a laptop. For the managed Ever Works cloud to reach it, the **Base URL must be resolvable from where work generation runs** — either a self-hosted Ever Works deployment on the same network, or a vLLM server exposed at a reachable (public or VPN) URL secured with `--api-key`. A `localhost` URL only works when Ever Works itself runs on the same machine/LAN as the vLLM server.
+
+## Troubleshooting
+
+| Symptom                                 | Likely cause                                                       | Fix                                                                                                       |
+| --------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Plugin shows unavailable                | vLLM server not running or not reachable from Ever Works           | Confirm `vllm serve` is up and the Base URL is reachable from where generation runs (see networking note) |
+| `401` / `Invalid API key`               | Server started with `--api-key` but no/incorrect token entered     | Enter the exact `--api-key` token in the **API Key** field                                                |
+| `Model not found` / `400 invalid model` | Selected model differs from the one vLLM was launched with         | Set the model fields to the value passed to `vllm serve --model ...` (use the model-select dropdown)      |
+| No models in the dropdown               | Connection failed before `listModels()` could run                  | Fix the Base URL / API key first, then re-open the model picker                                           |
+| Empty / truncated AI output             | **Max Tokens** too low, or context window exceeded                 | Raise **Max Tokens**, or reduce input size                                                                |
+| Plugin not selected during generation   | Another AI provider plugin is set as the default for `ai-provider` | In **Settings → Plugins**, set `vllm` as the default for `ai-provider`, or disable competing AI plugins   |
+
+## Local development
+
+This plugin ships built-in with the Ever Works platform. To work on it locally from the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter @ever-works/vllm-plugin build
+pnpm --filter @ever-works/vllm-plugin test
+```
+
+## Documentation
+
+- [Ever Works documentation](https://docs.ever.works)
+- [Ever Works repository](https://github.com/ever-works/ever-works)
+- [Plugin system](../../plugin/README.md)
+- [vLLM documentation](https://docs.vllm.ai)
+
+## License
+
+AGPL-3.0

--- a/packages/plugins/vllm/package.json
+++ b/packages/plugins/vllm/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@ever-works/vllm-plugin",
+	"version": "1.0.0",
+	"description": "vLLM AI provider plugin for Ever Works platform",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@langchain/openai": "^0.6.17",
+		"@langchain/core": "^0.3.80"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^3.2.1"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "vllm",
+			"name": "vLLM",
+			"version": "1.0.0",
+			"category": "ai-provider",
+			"capabilities": [
+				"ai-provider"
+			],
+			"description": "vLLM AI provider plugin for Ever Works platform",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false
+		}
+	}
+}

--- a/packages/plugins/vllm/src/__tests__/vllm.plugin.spec.ts
+++ b/packages/plugins/vllm/src/__tests__/vllm.plugin.spec.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VllmPlugin } from '../vllm.plugin';
+import type { PluginContext } from '@ever-works/plugin';
+import { AiOperations } from '@ever-works/plugin/ai';
+
+vi.mock('@ever-works/plugin/ai', () => {
+	const MockAiOperations = vi.fn().mockImplementation(() => ({
+		createChatCompletion: vi.fn().mockResolvedValue({ id: 'test', choices: [], model: 'local-model', created: 0 }),
+		createStreamingChatCompletion: vi.fn(),
+		createEmbedding: vi.fn(),
+		askJson: vi.fn().mockResolvedValue({ result: {}, model: 'local-model', usage: undefined }),
+		listModels: vi.fn().mockResolvedValue([]),
+		testConnection: vi.fn().mockResolvedValue({ success: true })
+	}));
+	return { AiOperations: MockAiOperations };
+});
+
+describe('VllmPlugin', () => {
+	let plugin: VllmPlugin;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = new VllmPlugin();
+	});
+
+	describe('metadata', () => {
+		it('should have correct plugin id and name', () => {
+			expect(plugin.id).toBe('vllm');
+			expect(plugin.name).toBe('vLLM');
+			expect(plugin.version).toBe('1.0.0');
+		});
+
+		it('should have ai-provider category and capability', () => {
+			expect(plugin.category).toBe('ai-provider');
+			expect(plugin.capabilities).toContain('ai-provider');
+		});
+
+		it('should have user-required configuration mode', () => {
+			expect(plugin.configurationMode).toBe('user-required');
+		});
+	});
+
+	describe('settingsSchema', () => {
+		it('should have required baseUrl and defaultModel fields', () => {
+			expect(plugin.settingsSchema).toBeDefined();
+			expect(plugin.settingsSchema.type).toBe('object');
+			expect(plugin.settingsSchema.required).toEqual(['baseUrl', 'defaultModel']);
+		});
+
+		it('should have apiKey as an encrypted secret with EMPTY default', () => {
+			const apiKeySchema = plugin.settingsSchema.properties?.apiKey as any;
+			expect(apiKeySchema).toBeDefined();
+			expect(apiKeySchema.type).toBe('string');
+			expect(apiKeySchema.default).toBe('EMPTY');
+			expect(apiKeySchema['x-secret']).toBe(true);
+			expect(apiKeySchema['x-scope']).toBe('user');
+		});
+
+		it('should have all model settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('defaultModel');
+			expect(props).toHaveProperty('simpleModel');
+			expect(props).toHaveProperty('mediumModel');
+			expect(props).toHaveProperty('complexModel');
+		});
+
+		it('should NOT hardcode a default model (populated via model-select)', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect((props.defaultModel as any).default).toBeUndefined();
+			expect((props.defaultModel as any)['x-widget']).toBe('model-select');
+		});
+
+		it('should have baseUrl setting with the vLLM title', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('baseUrl');
+			expect((props.baseUrl as any).type).toBe('string');
+			expect((props.baseUrl as any).title).toBe('vLLM Server URL');
+		});
+
+		it('should have temperature and maxTokens settings', () => {
+			const props = plugin.settingsSchema.properties!;
+			expect(props).toHaveProperty('temperature');
+			expect(props).toHaveProperty('maxTokens');
+			expect((props.temperature as any).type).toBe('number');
+			expect((props.maxTokens as any).type).toBe('number');
+		});
+
+		it('should have description on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).description, `${key} should have a description`).toBeDefined();
+				expect((prop as any).description, `${key} description should not be empty`).not.toBe('');
+			}
+		});
+
+		it('should have title on all settings fields', () => {
+			const props = plugin.settingsSchema.properties!;
+			for (const [key, prop] of Object.entries(props)) {
+				expect((prop as any).title, `${key} should have a title`).toBeDefined();
+			}
+		});
+	});
+
+	describe('lifecycle hooks', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'vllm',
+				logger: {
+					log: vi.fn(),
+					debug: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn()
+				},
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should load successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			expect(mockContext.logger.log).toHaveBeenCalledWith('vLLM Plugin loaded');
+		});
+
+		it('should unload successfully', async () => {
+			const mockContext = createMockContext();
+			await plugin.onLoad(mockContext);
+			await plugin.onUnload();
+		});
+	});
+
+	describe('manifest', () => {
+		it('should return correct manifest', () => {
+			const manifest = plugin.getManifest();
+			expect(manifest.id).toBe('vllm');
+			expect(manifest.name).toBe('vLLM');
+			expect(manifest.builtIn).toBe(true);
+			expect(manifest.autoEnable).toBe(false);
+			expect(manifest.visibility).toBe('public');
+			expect(manifest.icon).toBeDefined();
+			expect(manifest.icon?.type).toBe('svg');
+		});
+	});
+
+	describe('healthCheck', () => {
+		it('should return healthy status', async () => {
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+			expect(health.message).toBe('vLLM plugin is ready');
+			expect(health.checkedAt).toBeDefined();
+		});
+	});
+
+	describe('askJson', () => {
+		const createMockContext2 = (): PluginContext =>
+			({
+				pluginId: 'vllm',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should delegate to aiOps.askJson with resolved config', async () => {
+			await plugin.onLoad(createMockContext2());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.askJson('Generate JSON', {
+				settings: { apiKey: 'EMPTY' }
+			});
+
+			expect(aiOpsInstance.askJson).toHaveBeenCalledWith(
+				'Generate JSON',
+				expect.any(Object),
+				expect.objectContaining({ apiKey: 'EMPTY' }),
+				expect.any(Object)
+			);
+		});
+
+		it('should throw when plugin not loaded', async () => {
+			await expect(plugin.askJson('test')).rejects.toThrow('Plugin not loaded');
+		});
+	});
+
+	describe('settings threading', () => {
+		const createMockContext = (): PluginContext =>
+			({
+				pluginId: 'vllm',
+				logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+				getSettings: vi.fn().mockResolvedValue({})
+			}) as unknown as PluginContext;
+
+		it('should pass settings as configOverrides to AiOperations.listModels', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.listModels({ baseUrl: 'http://custom:8000/v1' });
+
+			expect(aiOpsInstance.listModels).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:8000/v1' })
+			);
+		});
+
+		it('should pass settings as configOverrides to AiOperations.testConnection', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.isAvailable({ baseUrl: 'http://custom:8000/v1' });
+
+			expect(aiOpsInstance.testConnection).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: 'http://custom:8000/v1' })
+			);
+		});
+
+		it('should pass resolved settings (URL, key, embedding model) to AiOperations.createEmbedding', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				settings: {
+					baseUrl: 'http://custom:8000/v1',
+					apiKey: 'sk-vllm-token',
+					embeddingModel: 'intfloat/e5-mistral-7b-instruct'
+				}
+			});
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.objectContaining({ input: 'hello' }),
+				expect.objectContaining({
+					baseURL: 'http://custom:8000/v1',
+					apiKey: 'sk-vllm-token',
+					embeddingModel: 'intfloat/e5-mistral-7b-instruct'
+				})
+			);
+		});
+	});
+});

--- a/packages/plugins/vllm/src/index.ts
+++ b/packages/plugins/vllm/src/index.ts
@@ -1,0 +1,1 @@
+export { VllmPlugin, VllmPlugin as default } from './vllm.plugin.js';

--- a/packages/plugins/vllm/src/vllm.plugin.ts
+++ b/packages/plugins/vllm/src/vllm.plugin.ts
@@ -1,0 +1,246 @@
+import { BaseAiProvider } from '@ever-works/plugin/abstract';
+import { AiOperations } from '@ever-works/plugin/ai';
+import type {
+	PluginContext,
+	PluginManifest,
+	PluginHealthCheck,
+	JsonSchema,
+	PluginSettings,
+	ChatCompletionOptions,
+	ChatCompletionResponse,
+	ChatCompletionChunk,
+	EmbeddingOptions,
+	EmbeddingResponse,
+	AiModel,
+	AiModelCapabilities
+} from '@ever-works/plugin';
+
+/**
+ * vLLM AI provider plugin
+ *
+ * Provides AI capabilities through a self-hosted vLLM server. vLLM serves an
+ * OpenAI-compatible API on `/v1`, so it reuses the same `AiOperations`
+ * (LangChain) backend as the other AI providers.
+ *
+ * Uses 'user-required' configuration mode - users point the plugin at their
+ * vLLM server URL. An unsecured vLLM server accepts any key, so `apiKey`
+ * defaults to vLLM's documented `EMPTY` placeholder; when the server is
+ * started with `--api-key`, users enter that token (stored encrypted via
+ * `x-secret`).
+ *
+ * vLLM serves whatever model it was launched with (`--model ...`), so there is
+ * no canonical default model. The model fields ship without a hardcoded
+ * default and are populated by the `model-select` widget once the connection
+ * is established and `listModels()` returns.
+ */
+export class VllmPlugin extends BaseAiProvider {
+	readonly id = 'vllm';
+	readonly name = 'vLLM';
+	readonly version = '1.0.0';
+	readonly providerType = 'vllm';
+	readonly providerName = 'vLLM';
+
+	readonly configurationMode: 'admin-only' | 'user-required' | 'hybrid' = 'user-required';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			baseUrl: {
+				type: 'string',
+				title: 'vLLM Server URL',
+				description: 'Address of your vLLM OpenAI-compatible server (e.g: http://localhost:8000/v1)',
+				'x-scope': 'user'
+			},
+			apiKey: {
+				type: 'string',
+				title: 'API Key',
+				description: 'Only required if your vLLM server was started with --api-key; leave as EMPTY otherwise',
+				default: 'EMPTY',
+				'x-secret': true,
+				'x-scope': 'user'
+			},
+			defaultModel: {
+				type: 'string',
+				title: 'Default Model',
+				description: 'Used for all AI tasks unless a tier-specific model is set',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			simpleModel: {
+				type: 'string',
+				title: 'Simple Tasks Model',
+				description: 'Handles tags, short descriptions, and quick classifications',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			mediumModel: {
+				type: 'string',
+				title: 'Standard Tasks Model',
+				description: 'Handles listings, summaries, and content reformatting',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			complexModel: {
+				type: 'string',
+				title: 'Complex Tasks Model',
+				description: 'Handles full page generation and multi-step analysis',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+			embeddingModel: {
+				type: 'string',
+				title: 'Embedding Model',
+				description: 'Model used for semantic search embeddings (only needed if you use KB search)',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
+
+			temperature: {
+				type: 'number',
+				title: 'Temperature',
+				description: 'Lower values give consistent output, higher values add variety',
+				default: 0.7,
+				minimum: 0,
+				maximum: 2,
+				'x-hidden': true
+			},
+			maxTokens: {
+				type: 'number',
+				title: 'Max Tokens',
+				description: 'Limits the length of each AI-generated response',
+				default: 4096,
+				'x-hidden': true
+			}
+		},
+		required: ['baseUrl', 'defaultModel']
+	};
+
+	async onLoad(context: PluginContext): Promise<void> {
+		await super.onLoad(context);
+		this.aiOps = new AiOperations({
+			apiKey: 'EMPTY',
+			model: this.getDefaultModelId(),
+			baseURL: 'http://localhost:8000/v1',
+			temperature: 0.7,
+			maxTokens: 4096,
+			providerType: 'vllm'
+		});
+		context.logger.log('vLLM Plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.aiOps = null;
+		await super.onUnload();
+	}
+
+	async createChatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		return this.aiOps.createChatCompletion(options, resolvedConfig);
+	}
+
+	async *createStreamingChatCompletion(options: ChatCompletionOptions): AsyncIterable<ChatCompletionChunk> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		yield* this.aiOps.createStreamingChatCompletion(options, resolvedConfig);
+	}
+
+	async createEmbedding(options: EmbeddingOptions): Promise<EmbeddingResponse> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		return this.aiOps.createEmbedding(options, this.resolveConfig(options.settings));
+	}
+
+	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {
+		if (!this.aiOps) {
+			throw new Error('vLLM plugin not loaded');
+		}
+		return this.aiOps.listModels(this.resolveConfig(settings));
+	}
+
+	async isAvailable(settings?: PluginSettings): Promise<boolean> {
+		if (!this.aiOps) {
+			return false;
+		}
+		const result = await this.aiOps.testConnection(this.resolveConfig(settings));
+		return result.success;
+	}
+
+	getCapabilities(): AiModelCapabilities {
+		return {
+			supportsStructuredOutput: true,
+			supportsStreaming: true,
+			supportsToolCalling: true,
+			supportsVision: true,
+			maxContextLength: 128000
+		};
+	}
+
+	protected getDefaultModelId(): string {
+		return 'local-model';
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'vLLM plugin is ready',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description: 'Connect to a self-hosted vLLM server for high-throughput, private AI inference',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public',
+			uiHints: {
+				completionFields: ['defaultModel']
+			},
+			readme: [
+				'## What is the vLLM plugin?',
+				'',
+				'This plugin connects Ever Works to a [vLLM](https://docs.vllm.ai) server for AI inference. vLLM is a high-throughput inference engine for open-source models, usually deployed on a GPU server. It exposes an OpenAI-compatible API, so Ever Works can use it for content generation, conversations, and embeddings.',
+				'',
+				'## Why use it?',
+				'',
+				'- **Data privacy** — requests are processed by your own vLLM server, keeping sensitive content off third-party servers',
+				'- **No API costs** — run unlimited requests against your own GPU infrastructure',
+				'- **High throughput** — vLLM is optimized for concurrent, batched inference (PagedAttention)',
+				'- **Open-source models** — serve any model supported by vLLM',
+				'',
+				'## How it works in Ever Works',
+				'',
+				'When selected as the AI provider, Ever Works routes content generation, conversational AI, and embedding requests to your vLLM server. The plugin is used during work generation to produce item descriptions, summaries, and categorizations. You can assign different models to simple, standard, and complex task tiers to balance speed and quality.',
+				'',
+				'## Getting started',
+				'',
+				'1. Start a vLLM OpenAI-compatible server: `vllm serve <model>` (listens on `http://localhost:8000` by default)',
+				'2. If you secured it with `--api-key <token>`, have that token ready',
+				'3. Enable the vLLM plugin and set the **Base URL** to your server address (include the `/v1` suffix)',
+				'4. Enter the **API Key** if your server requires one (otherwise leave it as `EMPTY`)',
+				'5. Select your preferred model for each task complexity level'
+			].join('\n'),
+			homepage: 'https://docs.vllm.ai',
+			icon: {
+				type: 'svg',
+				value: `<svg fill="#000" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>vLLM</title><path d="M13.1 1.2 4.2 13.3a.7.7 0 0 0 .56 1.11h5.05l-1.02 8.3a.5.5 0 0 0 .9.36l8.9-12.1a.7.7 0 0 0-.56-1.11h-5.05l1.02-8.3a.5.5 0 0 0-.9-.36z"/></svg>`,
+				darkValue: `<svg fill="#fff" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>vLLM</title><path d="M13.1 1.2 4.2 13.3a.7.7 0 0 0 .56 1.11h5.05l-1.02 8.3a.5.5 0 0 0 .9.36l8.9-12.1a.7.7 0 0 0-.56-1.11h-5.05l1.02-8.3a.5.5 0 0 0-.9-.36z"/></svg>`
+			}
+		};
+	}
+}
+
+export default VllmPlugin;

--- a/packages/plugins/vllm/tsconfig.json
+++ b/packages/plugins/vllm/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/vllm/tsup.config.ts
+++ b/packages/plugins/vllm/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/vllm/vitest.config.ts
+++ b/packages/plugins/vllm/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/whatsapp-channel/README.md
+++ b/packages/plugins/whatsapp-channel/README.md
@@ -4,7 +4,9 @@ WhatsApp notification channel for the Ever Works platform.
 
 - **Capabilities**: `notification-channel`, `notification-channel-whatsapp`
 - **Shape**: `direct` (one recipient per channel)
-- **Transport**: WhatsApp Business Cloud API (`/{phoneNumberId}/messages`)
+- **Transport**: WhatsApp Business Cloud API (`/{phoneNumberId}/messages`) via `fetch`
+
+> **SDK note:** intentionally uses `fetch`, not a vendor SDK. Meta ships no official Node SDK for the WhatsApp Business Cloud API; the community packages are thin/unmaintained Graph-API wrappers that add no real value over a typed `fetch` call. The SDK rule applies where a _sensible_ vendor SDK exists (cf. slack-channel → `@slack/webhook`, telegram-channel → `grammy`).
 
 ## Settings (channel-level `targetConfig`)
 

--- a/packages/tasks/src/tasks/trigger/notification-channel-delivery.task.ts
+++ b/packages/tasks/src/tasks/trigger/notification-channel-delivery.task.ts
@@ -1,0 +1,72 @@
+import { task } from '@trigger.dev/sdk';
+import { NestFactory } from '@nestjs/core';
+import {
+    NotificationChannelFacadeService,
+    type NotificationChannelDeliveryPayload,
+} from '@ever-works/agent/facades';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
+
+/**
+ * Notifications v2 (EW-663) — per-channel notification delivery worker.
+ *
+ * One run per (channel, event) pair. The producer-side dispatcher
+ * (`NotificationChannelFacadeService.send` → the bound
+ * `NotificationChannelDeliveryDispatcher` adapter →
+ * `TriggerService.dispatchNotificationChannelDelivery`) enqueues this
+ * task; quiet-hours-deferred sends are enqueued with a `delay` so the
+ * run fires at end-of-window (item D).
+ *
+ * The run boots the lightweight {@link TriggerInternalModule} and calls
+ * the RPC-proxied {@link NotificationChannelFacadeService.deliverToChannelOrThrow}
+ * on the live API (where the channel plugins are already loaded). That
+ * method THROWS on a failed attempt, which surfaces here so the
+ * Trigger.dev retry policy below re-runs it. When attempts exhaust, the
+ * `notification_channel_delivery_log` row left by the facade is the
+ * dead-letter.
+ *
+ * Backoff: 30s → 2m → 8m → 32m → 2h (maxAttempts 5, factor 4) — shorter
+ * tail than webhook delivery; a chat/email notification has little value
+ * a full day late.
+ */
+export const notificationChannelDeliveryTask = task<
+    'notification-channel-delivery',
+    NotificationChannelDeliveryPayload
+>({
+    id: 'notification-channel-delivery',
+    maxDuration: 5 * 60,
+    retry: {
+        maxAttempts: 5,
+        minTimeoutInMs: 30_000, // 30s
+        maxTimeoutInMs: 6 * 60 * 60 * 1000, // 6h cap
+        factor: 4,
+        randomize: true,
+    },
+    run: async (payload: NotificationChannelDeliveryPayload) => {
+        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+        appContext.useLogger(createTriggerLogger('NotificationChannelDelivery'));
+
+        try {
+            const facade = appContext.get(NotificationChannelFacadeService);
+            const result = await facade.deliverToChannelOrThrow(
+                payload.channelId,
+                {
+                    text: payload.text,
+                    rich: payload.rich,
+                    messageRef: payload.messageRef,
+                    eventType: payload.eventType,
+                },
+                payload.options,
+                payload.eventType,
+            );
+            return {
+                channelId: payload.channelId,
+                status: result.status,
+                pluginId: result.pluginId,
+                providerMessageId: result.providerMessageId ?? null,
+            };
+        } finally {
+            await appContext.close();
+        }
+    },
+});

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -10,6 +10,11 @@ import {
     KB_EMBED_DOCUMENT_DISPATCHER,
     KB_ORG_OVERLAY_FANOUT_DISPATCHER,
 } from '@ever-works/agent/tasks';
+import {
+    NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
+    type NotificationChannelDeliveryDispatcher,
+    type NotificationChannelDeliveryPayload,
+} from '@ever-works/agent/facades';
 
 @Global()
 @Module({
@@ -47,6 +52,20 @@ import {
             provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER,
             useExisting: TriggerService,
         },
+        // Notifications v2 (EW-663) — the facade's delivery dispatcher
+        // contract is `enqueue(payload) → { runId }`, so a thin adapter
+        // bridges to TriggerService.dispatchNotificationChannelDelivery
+        // (which returns the run id, or null when Trigger is disabled →
+        // the facade falls back to in-process delivery).
+        {
+            provide: NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
+            useFactory: (trigger: TriggerService): NotificationChannelDeliveryDispatcher => ({
+                async enqueue(payload: NotificationChannelDeliveryPayload) {
+                    return { runId: await trigger.dispatchNotificationChannelDelivery(payload) };
+                },
+            }),
+            inject: [TriggerService],
+        },
     ],
     exports: [
         TriggerService,
@@ -58,6 +77,7 @@ import {
         KB_BACKFILL_SKELETON_DISPATCHER,
         KB_EMBED_DOCUMENT_DISPATCHER,
         KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+        NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
     ],
 })
 export class TriggerModule {}

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -27,6 +27,8 @@ import { kbMirrorDocumentTask } from '../tasks/trigger/kb-mirror-document.task';
 import { kbBackfillSkeletonTask } from '../tasks/trigger/kb-backfill-skeleton.task';
 import { kbEmbedDocumentTask } from '../tasks/trigger/kb-embed-document.task';
 import { kbOrgOverlayFanoutTask } from '../tasks/trigger/kb-org-overlay-fanout.task';
+import { notificationChannelDeliveryTask } from '../tasks/trigger/notification-channel-delivery.task';
+import type { NotificationChannelDeliveryPayload } from '@ever-works/agent/facades';
 
 @Injectable()
 export class TriggerService
@@ -178,6 +180,43 @@ export class TriggerService
             return handle.id;
         } catch (error) {
             this.logger.error('Failed to dispatch webhook-delivery task', error as Error);
+            return null;
+        }
+    }
+
+    /**
+     * Notifications v2 (EW-663) — enqueue one channel delivery to
+     * Trigger.dev. Returns the run id, or `null` when Trigger.dev is
+     * disabled (`shouldUseTrigger()` false) or the dispatch threw — the
+     * facade's in-process fallback handles both. When `payload.deferUntil`
+     * is set (quiet-hours), the run is scheduled with a `delay` so it
+     * fires at end-of-window.
+     */
+    async dispatchNotificationChannelDelivery(
+        payload: NotificationChannelDeliveryPayload,
+    ): Promise<string | null> {
+        if (!this.ensureConfigured()) {
+            return null;
+        }
+
+        try {
+            const delay = payload.deferUntil ? new Date(payload.deferUntil) : undefined;
+            const handle = await notificationChannelDeliveryTask.trigger(payload, {
+                tags: [
+                    'notification-channel-delivery',
+                    `channel:${payload.channelId}`,
+                    ...(payload.eventType ? [`event:${payload.eventType}`] : []),
+                ],
+                machine: this.machine() as any,
+                ...(delay ? { delay } : {}),
+            });
+
+            return handle.id;
+        } catch (error) {
+            this.logger.error(
+                'Failed to dispatch notification-channel-delivery task',
+                error as Error,
+            );
             return null;
         }
     }

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -8,6 +8,7 @@ import { MissionTickService } from '@ever-works/agent/missions';
 import { AgentScheduleDispatcherService } from '@ever-works/agent/agents';
 import { TaskRecurrenceDispatcherService } from '@ever-works/agent/tasks-domain';
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
+import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
 
@@ -88,6 +89,15 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'TaskRecurrenceDispatcherService'),
             inject: [TriggerInternalApiClient],
         },
+        // Notifications v2 (EW-663) — the notification-channel-delivery
+        // task calls `deliverToChannelOrThrow` on this proxy, which RPCs
+        // to the live API where the channel plugins are loaded.
+        {
+            provide: NotificationChannelFacadeService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'NotificationChannelFacadeService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
@@ -100,6 +110,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         AgentRepository,
         AgentRunRepository,
         TaskRecurrenceDispatcherService,
+        NotificationChannelFacadeService,
     ],
 })
 export class TriggerInternalModule {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -223,16 +223,16 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -469,10 +469,10 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -898,13 +898,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -1069,7 +1069,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1824,10 +1824,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2566,10 +2566,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -19940,17 +19940,6 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
-  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      jsonc-parser: 3.3.1
-      picomatch: 4.0.4
-      rxjs: 7.8.1
-      source-map: 0.7.4
-    optionalDependencies:
-      chokidar: 3.6.0
-
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -19972,16 +19961,6 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -24468,7 +24447,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -24485,7 +24464,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.0
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@3.6.0)
+      nunjucks: 3.2.4(chokidar@4.0.3)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -24512,7 +24491,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -24531,35 +24510,6 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
-      webpack-node-externals: 3.0.0
-    optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
-      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
-      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      cli-table3: 0.6.5
-      commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21)))
-      glob: 13.0.6
-      node-emoji: 1.11.0
-      ora: 5.4.1
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-      typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
@@ -24591,7 +24541,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24620,7 +24570,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24722,17 +24672,6 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
-
-  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -27450,25 +27389,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)':
-    dependencies:
-      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.2.2
-      commander: 8.3.0
-      minimatch: 10.2.5
-      piscina: 4.9.2
-      semver: 7.7.4
-      slash: 3.0.0
-      source-map: 0.7.6
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      chokidar: 3.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -36157,13 +36077,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@3.6.0):
+  nunjucks@3.2.4(chokidar@4.0.3):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
     optional: true
 
   nypm@0.6.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2344,6 +2344,9 @@ importers:
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
+      '@slack/webhook':
+        specifier: ^7.0.5
+        version: 7.0.9
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -8475,6 +8478,14 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/webhook@7.0.9':
+    resolution: {integrity: sha512-hMfkQ5Y3Y7FtL+ZYhcxFblidx4Z2LPRFrhY1KJb6NqQdnK6kzTzTS1mjH5taVQIB496eqwpg9FE9mq9BFx0DWw==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@slorber/react-helmet-async@1.3.0':
     resolution: {integrity: sha512-e9/OK8VhwUSc67diWI8Rb3I0YgI9/SBQtnhe9aEuK6MhZm7ntZZimXgwXnd8W96YTmSOb9M4d8LwhRZyhWr/1A==}
@@ -26848,6 +26859,16 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@slack/types@2.21.1': {}
+
+  '@slack/webhook@7.0.9':
+    dependencies:
+      '@slack/types': 2.21.1
+      '@types/node': 22.19.11
+      axios: 1.16.0
+    transitivePeerDependencies:
+      - debug
 
   '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,6 +1813,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
+  packages/plugins/lm-studio:
+    dependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@langchain/core':
+        specifier: ^0.3.80
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/openai':
+        specifier: ^0.6.17
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
   packages/plugins/local-content-extractor:
     dependencies:
       '@mozilla/readability':
@@ -2500,6 +2525,31 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/plugins/vercel-ai-gateway:
+    dependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@langchain/core':
+        specifier: ^0.3.80
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/openai':
+        specifier: ^0.6.17
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
+
+  packages/plugins/vllm:
     dependencies:
       '@ever-works/plugin':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2419,6 +2419,9 @@ importers:
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
+      grammy:
+        specifier: ^1.30.0
+        version: 1.43.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -5133,6 +5136,9 @@ packages:
   '@google-cloud/precise-date@4.0.0':
     resolution: {integrity: sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==}
     engines: {node: '>=14.0.0'}
+
+  '@grammyjs/types@3.27.3':
+    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -13194,6 +13200,10 @@ packages:
 
   graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
+
+  grammy@1.43.0:
+    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
+    engines: {node: ^12.20.0 || >=14.13.1}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -23006,6 +23016,8 @@ snapshots:
 
   '@google-cloud/precise-date@4.0.0': {}
 
+  '@grammyjs/types@3.27.3': {}
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -32474,6 +32486,16 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graceful-readlink@1.0.1: {}
+
+  grammy@1.43.0:
+    dependencies:
+      '@grammyjs/types': 3.27.3
+      abort-controller: 3.0.0
+      debug: 4.4.3
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   graphemer@1.4.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,9 @@ importers:
       path-to-regexp:
         specifier: ^8.4.2
         version: 8.4.2
+      posthog-js:
+        specifier: ^1.376.3
+        version: 1.376.3
       posthog-node:
         specifier: ^5.18.0
         version: 5.24.15
@@ -6722,6 +6725,10 @@ packages:
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.211.0':
     resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
     engines: {node: '>=8.0.0'}
@@ -6748,6 +6755,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@2.5.0':
     resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -6762,6 +6775,12 @@ packages:
 
   '@opentelemetry/exporter-logs-otlp-http@0.203.0':
     resolution: {integrity: sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -6946,8 +6965,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-transformer@0.203.0':
     resolution: {integrity: sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -6958,6 +6989,12 @@ packages:
 
   '@opentelemetry/resources@2.0.1':
     resolution: {integrity: sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -6974,14 +7011,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
   '@opentelemetry/sdk-metrics@2.0.1':
     resolution: {integrity: sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.0.1':
     resolution: {integrity: sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -7188,6 +7243,12 @@ packages:
 
   '@posthog/core@1.22.0':
     resolution: {integrity: sha512-WkmOnq95aAOu6yk6r5LWr5cfXsQdpVbWDCwOxQwxSne8YV6GuZET1ziO5toSQXgrgbdcjrSz2/GopAfiL6iiAA==}
+
+  '@posthog/core@1.29.12':
+    resolution: {integrity: sha512-r/2RUa4zbN0XdBp6d+Yk8Jw1rPWXHxyXIgSm/wJf9yDLIouZbH0Pdkgbc1RIuhwL6BIHCFrOqK5jy8TFKTI6iw==}
+
+  '@posthog/types@1.376.3':
+    resolution: {integrity: sha512-w21lBoz3/ZGw7BZT7t2lJq1mpJwMvWpZijW7vEwBFNAQlq0KfKf2mj5KKUYZMXM1GdIQ0jHnn931uXPB1Ae60w==}
 
   '@prisma/config@6.19.2':
     resolution: {integrity: sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==}
@@ -12769,6 +12830,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -16672,6 +16736,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.376.3:
+    resolution: {integrity: sha512-Wmj4N6E352b8aWt/AjRYIOfagQgOlkb8LCD/r7i1eGj8WPBhrYLEXojQeZ+jndbiPbRo21l24bFJso7fyNafWQ==}
+
   posthog-node@5.24.15:
     resolution: {integrity: sha512-0QnWVOZAPwEAlp+r3r0jIGfk2IaNYM/2YnEJJhBMJZXs4LpHcTu7mX42l+e95o9xX87YpVuZU0kOkmtQUxgnOA==}
     engines: {node: ^20.20.0 || >=22.22.0}
@@ -16694,6 +16761,9 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -16999,6 +17069,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -19176,6 +19249,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -24835,6 +24911,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.211.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -24854,6 +24934,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.41.1
 
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -24862,7 +24947,7 @@ snapshots:
   '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/exporter-logs-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -24872,6 +24957,15 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-metrics-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -25052,7 +25146,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25128,6 +25222,12 @@ snapshots:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/otlp-transformer@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -25139,12 +25239,29 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
       protobufjs: 8.0.3
 
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
+      protobufjs: 8.0.3
+
   '@opentelemetry/redis-common@0.38.2': {}
 
   '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0)':
@@ -25160,17 +25277,37 @@ snapshots:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0)':
@@ -25396,6 +25533,12 @@ snapshots:
   '@posthog/core@1.22.0':
     dependencies:
       cross-spawn: 7.0.6
+
+  '@posthog/core@1.29.12':
+    dependencies:
+      '@posthog/types': 1.376.3
+
+  '@posthog/types@1.376.3': {}
 
   '@prisma/config@6.19.2':
     dependencies:
@@ -26750,7 +26893,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/node-core@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
+  '@sentry/node-core@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
       '@apm-js-collab/tracing-hooks': 0.3.1
       '@opentelemetry/api': 1.9.0
@@ -26759,9 +26902,9 @@ snapshots:
       '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.38.0
-      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
       import-in-the-middle: 2.0.6
     transitivePeerDependencies:
       - supports-color
@@ -26796,23 +26939,23 @@ snapshots:
       '@opentelemetry/instrumentation-undici': 0.21.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@prisma/instrumentation': 7.2.0(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.38.0
-      '@sentry/node-core': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
-      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      '@sentry/node-core': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)
       import-in-the-middle: 2.0.6
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
+  '@sentry/opentelemetry@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.38.0
 
   '@sentry/profiling-node@10.38.0':
@@ -31952,6 +32095,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.4.8: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -37002,6 +37147,22 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.376.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@posthog/core': 1.29.12
+      '@posthog/types': 1.376.3
+      core-js: 3.48.0
+      dompurify: 3.4.2
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
   posthog-node@5.24.15:
     dependencies:
       '@posthog/core': 1.22.0
@@ -37029,6 +37190,8 @@ snapshots:
       - debug
 
   powershell-utils@0.1.0: {}
+
+  preact@10.29.2: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -37411,6 +37574,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -40465,6 +40630,8 @@ snapshots:
     optional: true
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.2.0: {}
 
   web-worker@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
+        version: 2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -223,16 +223,16 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -469,10 +469,10 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -771,7 +771,7 @@ importers:
         version: link:../plugin
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
@@ -895,13 +895,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.24(@swc/helpers@0.5.21)
@@ -1066,7 +1066,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21)))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1133,10 +1133,10 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -1187,7 +1187,7 @@ importers:
         version: 2.0.41(zod@3.25.76)
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       ai:
         specifier: ^6.0.154
         version: 6.0.154(zod@3.25.76)
@@ -1254,10 +1254,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1445,6 +1445,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.3)
 
   packages/plugins/composio:
+    dependencies:
+      '@composio/core':
+        specifier: ^0.10.0
+        version: 0.10.0(ws@8.19.0)(zod@4.4.3)
     devDependencies:
       '@ever-works/plugin':
         specifier: workspace:*
@@ -1638,10 +1642,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1663,10 +1667,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1688,10 +1692,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1980,10 +1984,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2049,10 +2053,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2074,10 +2078,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2124,10 +2128,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2362,7 +2366,7 @@ importers:
     dependencies:
       '@langchain/textsplitters':
         specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+        version: 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       stopword:
         specifier: ^3.1.5
         version: 3.1.5
@@ -2503,10 +2507,10 @@ importers:
         version: link:../../plugin
       '@langchain/core':
         specifier: ^0.3.80
-        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+        version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
       '@langchain/openai':
         specifier: ^0.6.17
-        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+        version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -3796,6 +3800,19 @@ packages:
   '@commitlint/types@19.8.1':
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
+
+  '@composio/client@0.1.0-alpha.72':
+    resolution: {integrity: sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ==}
+
+  '@composio/core@0.10.0':
+    resolution: {integrity: sha512-dG2BKF4NRiE8HHDzWLLgjMMo3FU4NJ6SxR961EpdLWWEKhkl+yP/mZlIN7p/4WnCR/fuDBKH1Qh+7kBdcHmEHA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  '@composio/json-schema-to-zod@0.1.20':
+    resolution: {integrity: sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q==}
+    peerDependencies:
+      zod: '>=3.25.76 <5'
 
   '@corvu/utils@0.4.2':
     resolution: {integrity: sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==}
@@ -15639,6 +15656,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.39.0:
+    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -16980,6 +17009,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pusher-js@8.5.0:
+    resolution: {integrity: sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -18571,6 +18603,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -19758,6 +19793,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -19779,6 +19825,16 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -21162,6 +21218,26 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
+
+  '@composio/client@0.1.0-alpha.72': {}
+
+  '@composio/core@0.10.0(ws@8.19.0)(zod@4.4.3)':
+    dependencies:
+      '@composio/client': 0.1.0-alpha.72
+      '@composio/json-schema-to-zod': 0.1.20(zod@4.4.3)
+      '@types/json-schema': 7.0.15
+      chalk: 4.1.2
+      openai: 6.39.0(ws@8.19.0)(zod@4.4.3)
+      pusher-js: 8.5.0
+      semver: 7.8.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+    transitivePeerDependencies:
+      - ws
+
+  '@composio/json-schema-to-zod@0.1.20(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@corvu/utils@0.4.2(solid-js@1.9.13)':
     dependencies:
@@ -23754,14 +23830,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -23775,18 +23851,48 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
       openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0))(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0)
+      js-tiktoken: 1.0.21
+      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
 
   '@langfuse/client@4.6.1(@opentelemetry/api@1.9.0)':
@@ -24213,7 +24319,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@4.0.3)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
+  '@nestjs-modules/mailer@2.3.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18))(chokidar@3.6.0)(nodemailer@8.0.5)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -24230,7 +24336,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.0
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -24257,7 +24363,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.27.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -24276,6 +24382,35 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21)))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
@@ -24307,7 +24442,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24336,7 +24471,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24438,6 +24573,17 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
+
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -27079,6 +27225,25 @@ snapshots:
       - supports-color
       - typescript
 
+  '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.24(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.2
+      semver: 7.7.4
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
   '@swc/cli@0.8.1(@swc/core@1.15.24(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
       '@swc/core': 1.15.24(@swc/helpers@0.5.21)
@@ -28289,7 +28454,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.53.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -32123,7 +32288,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.0
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.25.12)
@@ -32140,7 +32305,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.0
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))(esbuild@0.27.3)
@@ -32157,7 +32322,7 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.0
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.24(@swc/helpers@0.5.21))
@@ -33893,13 +34058,22 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
+  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      openai: 6.39.0(ws@8.19.0)(zod@3.25.76)
+      ws: 8.19.0
+
+  langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.19.0)(zod@4.4.3))(ws@8.19.0):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      openai: 6.39.0(ws@8.19.0)(zod@4.4.3)
       ws: 8.19.0
 
   language-subtag-registry@0.3.23: {}
@@ -35745,13 +35919,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:
@@ -35904,6 +36078,17 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 3.25.76
+
+  openai@6.39.0(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
+    optional: true
+
+  openai@6.39.0(ws@8.19.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.4.3
 
   openapi-types@12.1.3: {}
 
@@ -37390,6 +37575,10 @@ snapshots:
       escape-goat: 4.0.0
 
   pure-rand@6.1.0: {}
+
+  pusher-js@8.5.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   pvtsutils@1.3.6:
     dependencies:
@@ -39543,6 +39732,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@1.0.3: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -40940,6 +41131,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@1.5.0(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

Routine `develop → stage` promotion. Carries everything on develop not yet on stage:

- **#1104** feat(notifications-v2): Trigger.dev delivery, quiet-hours deferral, agent email templates, channel SDKs
- **#1094** feat(composio): migrate to @composio/core SDK (EW-684 PR-A)
- **#1088** feat(deploy): ever-works provider alias + k8s workflow support
- **#1100** feat(monitoring): activate Sentry + PostHog in deployed envs
- **#1096** feat(web): posthog-js client (autocapture + session replay)
- **#1097** feat: LM Studio + vLLM local AI provider plugins
- **#1098** docs: dual-mode plugin distribution spec

## Test plan

- [ ] CI green on stage (lint-and-test, api, web, e2e, e2e-prod-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)