### PR TITLE
fix: Ollama plugin createEmbedding ignores user-configured URL/key/model

### DIFF
--- a/packages/plugins/ollama/README.md
+++ b/packages/plugins/ollama/README.md
@@ -44,6 +44,7 @@ When selected as the AI provider, Ever Works routes content generation, conversa
 - **Simple Tasks Model** — handles tags, short descriptions, and quick classifications.
 - **Standard Tasks Model** — handles listings, summaries, and content reformatting.
 - **Complex Tasks Model** — handles full page generation and multi-step analysis.
+- **Embedding Model** — model used for semantic-search embeddings (e.g. `nomic-embed-text`); only needed if you use KB search.
 - **Temperature** — controls output variety; lower is more consistent (hidden, advanced).
 - **Max Tokens** — limits the length of each AI-generated response (hidden, advanced).
 

--- a/packages/plugins/ollama/src/__tests__/ollama.plugin.spec.ts
+++ b/packages/plugins/ollama/src/__tests__/ollama.plugin.spec.ts
@@ -200,5 +200,28 @@ describe('OllamaPlugin', () => {
 				expect.objectContaining({ baseURL: 'http://custom:11434/v1' })
 			);
 		});
+
+		it('should pass resolved settings (URL, key, embedding model) to AiOperations.createEmbedding', async () => {
+			await plugin.onLoad(createMockContext());
+			const aiOpsInstance = (AiOperations as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+
+			await plugin.createEmbedding({
+				input: 'hello',
+				settings: {
+					baseUrl: 'http://custom:11434/v1',
+					apiKey: 'ollama',
+					embeddingModel: 'nomic-embed-text'
+				}
+			});
+
+			expect(aiOpsInstance.createEmbedding).toHaveBeenCalledWith(
+				expect.objectContaining({ input: 'hello' }),
+				expect.objectContaining({
+					baseURL: 'http://custom:11434/v1',
+					apiKey: 'ollama',
+					embeddingModel: 'nomic-embed-text'
+				})
+			);
+		});
 	});
 });

--- a/packages/plugins/ollama/src/ollama.plugin.ts
+++ b/packages/plugins/ollama/src/ollama.plugin.ts
@@ -79,6 +79,14 @@ export class OllamaPlugin extends BaseAiProvider {
 				'x-widget': 'model-select',
 				'x-scope': 'global'
 			},
+			embeddingModel: {
+				type: 'string',
+				title: 'Embedding Model',
+				description:
+					'Model used for semantic-search embeddings (e.g. nomic-embed-text); only needed if you use KB search',
+				'x-widget': 'model-select',
+				'x-scope': 'global'
+			},
 
 			temperature: {
 				type: 'number',
@@ -138,7 +146,7 @@ export class OllamaPlugin extends BaseAiProvider {
 		if (!this.aiOps) {
 			throw new Error('Ollama plugin not loaded');
 		}
-		return this.aiOps.createEmbedding(options);
+		return this.aiOps.createEmbedding(options, this.resolveConfig(options.settings));
 	}
 
 	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {


### PR DESCRIPTION
## Summary

The Ollama AI provider plugin's `createEmbedding` called `this.aiOps.createEmbedding(options)` **without** the resolved config, unlike `createChatCompletion` / `listModels` / `isAvailable`. As a result embedding requests always hit the hardcoded `http://localhost:11434/v1` from `onLoad` and ignored the user's configured `baseUrl` / `apiKey` / embedding model — so KB semantic search silently failed or routed to the wrong endpoint for anyone on a remote or non-default-port Ollama.

This is the same class of bug Greptile/Codex flagged on the new LM Studio and vLLM plugins, fixed in [#1097](https://github.com/ever-works/ever-works/pull/1097); this applies the same fix to the pre-existing Ollama plugin.

## Changes
- `createEmbedding` now threads `this.resolveConfig(options.settings)` into `AiOperations.createEmbedding`.
- Added a configurable `embeddingModel` setting (`model-select`, global scope) so KB embeddings can resolve a model (e.g. `nomic-embed-text`) — Ollama previously had no embedding-model field.
- Added a `createEmbedding` config-threading unit test and a README settings entry.

## Test plan
- [x] `pnpm --filter @ever-works/ollama-plugin test` (19/19)
- [x] `turbo build --filter=@ever-works/ollama-plugin` (ESM + CJS + DTS)
- [x] Prettier clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Embedding Model configuration option for Ollama plugin, allowing users to specify the model for semantic-search embeddings in knowledge base functionality.

* **Documentation**
  * Updated documentation describing the new Embedding Model configuration option and its use in knowledge base search scenarios.

* **Tests**
  * Added unit test verifying proper embedding configuration handling and settings forwarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->