### PR TITLE
fix(agent): register ComposioTriggerSubscription in entity-names inventory

### DIFF
--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -58,6 +58,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'AuthSession',
     'AuthVerification',
     'CacheEntry',
+    'ComposioTriggerSubscription',
     'Conversation',
     'ConversationMessage',
     'EmailConversation',


### PR DESCRIPTION
## Summary

- 1-line drift fix: add `'ComposioTriggerSubscription'` to `packages/agent/src/database/_entity-names.ts`
- Unblocks CI on **stage** (run 26597573172) and **main** (run 26597590158) where `database.module.spec.ts:244` drift spec failed after PR #1103's squash-merge.

## Why

PR #1103 (composio-triggers) added `ComposioTriggerSubscription` entity + barrel export but the inventory bookkeeping in `_entity-names.ts` slipped through the squash. The drift spec catches exactly this divergence — barrel must match inventory.

## Test plan

- [x] Inventory now matches `entities/index.ts` (`grep ComposioTriggerSubscription` finds both)
- [ ] CI `lint-and-test` job goes green on develop
- [ ] Cascade develop → stage → main re-runs CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trigger subscriptions in the agent system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->