### PR TITLE
feat(agent-memory): make pipeline memory-session pipe live + polish

### DIFF
--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
@@ -152,9 +152,26 @@ describe('AgentMemoryController', () => {
         });
 
         it('closeSession rejects an empty sessionId', async () => {
-            await expect(controller.closeSession(auth, '')).rejects.toBeInstanceOf(
+            await expect(controller.closeSession(auth, '', {})).rejects.toBeInstanceOf(
                 BadRequestException,
             );
+        });
+
+        it('closeSession enforces ownership + scopes by workId when one is supplied', async () => {
+            await controller.closeSession(auth, 'sess-1', { workId: 'work-1' });
+            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(agentMemory.closeSession).toHaveBeenCalledWith(
+                'sess-1',
+                expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
+            );
+        });
+
+        it('closeSession propagates an ownership rejection (cannot close another user Work session)', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            await expect(
+                controller.closeSession(auth, 'sess-1', { workId: 'work-x' }),
+            ).rejects.toThrow('not your work');
+            expect(agentMemory.closeSession).not.toHaveBeenCalled();
         });
 
         it('listSessions forwards limit + projectId', async () => {
@@ -168,17 +185,34 @@ describe('AgentMemoryController', () => {
 
     describe('deleteEntry', () => {
         it('rejects an empty entryId', async () => {
-            await expect(controller.deleteEntry(auth, '')).rejects.toBeInstanceOf(
+            await expect(controller.deleteEntry(auth, '', {})).rejects.toBeInstanceOf(
                 BadRequestException,
             );
         });
 
         it('passes the id to the facade', async () => {
-            await controller.deleteEntry(auth, 'mem-42');
+            await controller.deleteEntry(auth, 'mem-42', {});
             expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
                 'mem-42',
                 expect.objectContaining({ userId: 'user-1' }),
             );
+        });
+
+        it('enforces ownership + scopes by workId when one is supplied', async () => {
+            await controller.deleteEntry(auth, 'mem-42', { workId: 'work-1' });
+            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
+                'mem-42',
+                expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
+            );
+        });
+
+        it('propagates an ownership rejection (cannot forget another user Work entry)', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            await expect(
+                controller.deleteEntry(auth, 'mem-42', { workId: 'work-x' }),
+            ).rejects.toThrow('not your work');
+            expect(agentMemory.deleteEntry).not.toHaveBeenCalled();
         });
     });
 
@@ -203,7 +237,7 @@ describe('AgentMemoryController', () => {
             agentMemory.deleteEntry.mockRejectedValueOnce(
                 new Error('Agent-memory provider "x" does not support deleteEntry'),
             );
-            await expect(controller.deleteEntry(auth, 'mem-1')).rejects.toBeInstanceOf(
+            await expect(controller.deleteEntry(auth, 'mem-1', {})).rejects.toBeInstanceOf(
                 NotFoundException,
             );
         });

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
@@ -19,6 +19,7 @@ import { AuthenticatedUser } from '../../auth/types/auth.types';
 import {
     BuildContextDto,
     ListSessionsQueryDto,
+    MemoryScopeQueryDto,
     OpenSessionDto,
     SaveMemoryDto,
     SearchMemoryDto,
@@ -104,10 +105,12 @@ export class AgentMemoryController {
     async closeSession(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('sessionId') sessionId: string,
+        @Query() query: MemoryScopeQueryDto,
     ) {
         if (!sessionId) throw new BadRequestException('sessionId is required');
+        await this.assertWorkAccess(auth, query.workId);
         try {
-            await this.agentMemory.closeSession(sessionId, this.facadeOptions(auth));
+            await this.agentMemory.closeSession(sessionId, this.facadeOptions(auth, query.workId));
             return { status: 'success' };
         } catch (error) {
             throw this.toHttpError(error, 'closeSession');
@@ -202,10 +205,15 @@ export class AgentMemoryController {
     @Delete('/entries/:entryId')
     @ApiOperation({ summary: 'Forget a single memory record' })
     @ApiResponse({ status: 200, description: 'Deleted' })
-    async deleteEntry(@CurrentUser() auth: AuthenticatedUser, @Param('entryId') entryId: string) {
+    async deleteEntry(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('entryId') entryId: string,
+        @Query() query: MemoryScopeQueryDto,
+    ) {
         if (!entryId) throw new BadRequestException('entryId is required');
+        await this.assertWorkAccess(auth, query.workId);
         try {
-            await this.agentMemory.deleteEntry(entryId, this.facadeOptions(auth));
+            await this.agentMemory.deleteEntry(entryId, this.facadeOptions(auth, query.workId));
             return { status: 'success' };
         } catch (error) {
             throw this.toHttpError(error, 'deleteEntry');

--- a/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
@@ -146,6 +146,15 @@ export class OpenSessionDto extends WorkScopedDto {
     metadata?: Record<string, unknown>;
 }
 
+/**
+ * Query scope for the id-addressed mutations (`DELETE /entries/:id`,
+ * `POST /sessions/:id/close`). Supplying `workId` runs the same
+ * `WorkOwnershipService.ensureCanView` check the other mutations use and
+ * scopes provider/project resolution to that Work, so a user can't
+ * close/forget another user's Work-scoped memory by guessing an id.
+ */
+export class MemoryScopeQueryDto extends WorkScopedDto {}
+
 export class ListSessionsQueryDto extends WorkScopedDto {
     @ApiPropertyOptional({ description: 'Max sessions to return.', minimum: 1, maximum: 100 })
     @IsOptional()

--- a/docs/specs/features/agent-memory/spec.md
+++ b/docs/specs/features/agent-memory/spec.md
@@ -41,12 +41,12 @@ exists for "memory entries" because there is no memory table.
 
 ## 2. Personas + use cases
 
-| Persona  | Use case                                                                                                  |
-| -------- | --------------------------------------------------------------------------------------------------------- |
-| Operator | Enables an agent-memory provider so Works accumulate context across scheduled regenerations.               |
-| User     | Turns on "Agent Memory Hooks" for a Work; each run fetches prior context and saves a digest.               |
-| User     | Reviews / forgets individual memory observations from the admin UI.                                        |
-| Agent    | An agent run opens one memory session and shares it across everything it does in that run.                 |
+| Persona  | Use case                                                                                     |
+| -------- | -------------------------------------------------------------------------------------------- |
+| Operator | Enables an agent-memory provider so Works accumulate context across scheduled regenerations. |
+| User     | Turns on "Agent Memory Hooks" for a Work; each run fetches prior context and saves a digest. |
+| User     | Reviews / forgets individual memory observations from the admin UI.                          |
+| Agent    | An agent run opens one memory session and shares it across everything it does in that run.   |
 
 ---
 
@@ -126,13 +126,13 @@ no metrics, no executor branching) on Works that don't use memory. A defensive
 
 Mounted at `/api/agent-memory`, JWT-protected (`AuthSessionGuard`):
 
-| Method + path                         | Notes                                                                 |
-| ------------------------------------- | --------------------------------------------------------------------- |
-| `GET /check-availability`             | Whether a provider is registered + loaded.                            |
-| `POST /sessions`                      | Open a session. Ownership-checked when `workId` supplied.             |
-| `POST /sessions/:sessionId/close`     | Close a session. Ownership-checked + work-scoped when `workId` given. |
-| `GET /sessions`                       | List sessions (404 if provider lacks `listSessions`).                 |
-| `POST /save` / `/search` / `/context` | Save / search / build-context. Ownership-checked when `workId` given. |
+| Method + path                         | Notes                                                                   |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| `GET /check-availability`             | Whether a provider is registered + loaded.                              |
+| `POST /sessions`                      | Open a session. Ownership-checked when `workId` supplied.               |
+| `POST /sessions/:sessionId/close`     | Close a session. Ownership-checked + work-scoped when `workId` given.   |
+| `GET /sessions`                       | List sessions (404 if provider lacks `listSessions`).                   |
+| `POST /save` / `/search` / `/context` | Save / search / build-context. Ownership-checked when `workId` given.   |
 | `DELETE /entries/:entryId`            | Forget one record. Ownership-checked + work-scoped when `workId` given. |
 
 **Ownership / isolation.** When a request carries a `workId`, the controller

--- a/docs/specs/features/agent-memory/spec.md
+++ b/docs/specs/features/agent-memory/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Agent Memory
+
+**Feature ID**: `agent-memory`
+**Status**: `Shipped` (documented as-built)
+**Jira Epic**: [EW-672](https://evertech.atlassian.net/browse/EW-672)
+**Created**: 2026-05-28
+**Last updated**: 2026-05-28
+**Owner**: Product (Ruslan)
+**Shipped via PRs**: #1073 (plugin), #1081 (pipeline-step), #1082 (rollback), #1084 (sessions), #1086 (API controllers), #1090 (canSkipAtBuildTime + session pipe), #1095 (session pipe finish)
+
+**Related code today**:
+
+- Capability contract: `packages/plugin/src/contracts/capabilities/agent-memory.interface.ts`
+- Step facade: `packages/plugin/src/facades/agent-memory-facade.interface.ts`
+- First-party provider: `packages/plugins/agentmemory/` (external REST backend)
+- Pipeline modifier: `packages/plugins/memory-pipeline-modifier/`
+- Bound facade: `packages/agent/src/facades/agent-memory.facade.ts`
+- Pipeline wiring: `packages/agent/src/pipeline/pipeline-facade.service.ts`, `step-pipeline-executor.service.ts`, `full-pipeline-executor.service.ts`
+- REST surface: `apps/api/src/plugins-capabilities/agent-memory/`
+- Run-level session lifecycle: `packages/agent/src/services/agent-run.service.ts`
+
+---
+
+## 1. What it is
+
+Agent Memory gives Works and agent runs **persistent, retrievable memory** across
+generations: a run can fetch a digest of what prior runs learned and save a short
+observation at the end, so the next run starts informed rather than cold.
+
+Memory is **not stored in Postgres.** It lives entirely in an external
+agent-memory REST backend (default `@ever-works/agentmemory-plugin`, base URL
+`http://localhost:3111`), partitioned by a `project` namespace (derived from the
+Work slug/id). The **only** Postgres surface is a single nullable column,
+`agent_runs.memorySessionId` (migration
+`1779991011000-AddMemorySessionIdToAgentRuns.ts`), which records the opaque
+session id an agent run opened so the run row can be correlated with its memory
+session. Memory being external is a deliberate design choice — no migration
+exists for "memory entries" because there is no memory table.
+
+---
+
+## 2. Personas + use cases
+
+| Persona  | Use case                                                                                                  |
+| -------- | --------------------------------------------------------------------------------------------------------- |
+| Operator | Enables an agent-memory provider so Works accumulate context across scheduled regenerations.               |
+| User     | Turns on "Agent Memory Hooks" for a Work; each run fetches prior context and saves a digest.               |
+| User     | Reviews / forgets individual memory observations from the admin UI.                                        |
+| Agent    | An agent run opens one memory session and shares it across everything it does in that run.                 |
+
+---
+
+## 3. Capability contract
+
+`IAgentMemoryPlugin` (full) / `IAgentMemoryStepFacade` (bound, exposed to pipeline
+steps) expose: `openSession`, `closeSession`, `saveMemory`, `searchMemory`,
+`buildContext`, `deleteEntry`, `listSessions`. `listSessions` is optional on the
+plugin — the default `agentmemory` provider does not implement it yet, so
+`GET /api/agent-memory/sessions` returns 404 against that backend. All calls are
+**best-effort** at the consumption sites: a memory failure must never crash a
+host pipeline or agent run.
+
+---
+
+## 4. Sessions and the session pipe
+
+A **session** groups the reads/writes of one logical unit of work so the backend
+can relate them (recall, recency, slot tracking). Two producers open sessions:
+
+1. **Agent runs** (`AgentRunService`) — open a session per run via
+   `tryOpenMemorySession`, persist its id to `agent_runs.memorySessionId`, and
+   close it when the run ends. Fully wired and best-effort (a no-provider or
+   DB hiccup never fails the run).
+
+2. **Work-generation pipelines** (via the `memory-pipeline-modifier`). The
+   modifier injects two steps — `memory-fetch-context` (position `first`) and
+   `memory-save` (position `last`) — into step-orchestratable pipelines
+   (`standard-pipeline`, `agent-pipeline`).
+
+**Session sharing (the "session pipe").** `StepExecutionContext.memorySessionId`
+carries an orchestrator-supplied session id down to every step.
+`PipelineExecutionOptions.memorySessionId` lets a caller that already opened a
+session (e.g. an agent run that triggers a pipeline) hand it in; both pipeline
+executors forward it to `PipelineFacadeService.createStepExecutionContext`, which
+places it on the step context. When this id is present, the memory modifier
+associates its fetch / save / rollback with that shared session instead of
+opening its own.
+
+When **no** orchestrator session is supplied (the common case for plain
+Work-generation runs), the `memory-fetch-context` step **opens one per-run
+session of its own**, stashes it on the pipeline context, and the `memory-save`
+step and the failure `rollback` reuse it — so the context read, the success
+digest, and any failure digest all land on the **same** session row. The modifier
+closes a session it opened itself at the terminal step (save, save-disabled exit,
+or rollback); it never closes an orchestrator-supplied session (the caller owns
+that lifecycle). All of this is best-effort: a failure to open/close a session
+is swallowed and the run continues session-less.
+
+---
+
+## 5. Rollback semantics
+
+`memory-save` only runs on **success** (it's the `last` step; the executor breaks
+out of the step loop before reaching it on failure/cancellation). To persist a
+digest for failed or cancelled runs, the modifier implements
+`IPipelineModifierPlugin.rollback(context, error)`, which the step executor
+invokes for every plugin modifier that contributed steps. Rollback tags the
+observation `failed` vs `cancelled` (AbortError / cancellation detection) and is
+wrapped in its own try/catch so a faulty rollback can never mask the original
+pipeline error.
+
+---
+
+## 6. `canSkipAtBuildTime`
+
+The modifier is **opt-in** (`enabled` setting, default off, work-scoped).
+`canSkipAtBuildTime` lets the pipeline builder skip injecting the two steps
+entirely when the modifier is disabled — zero overhead (no STEP_STARTED events,
+no metrics, no executor branching) on Works that don't use memory. A defensive
+`enabled` guard remains inside `execute()` for hosts that don't honour
+`canSkipAtBuildTime`.
+
+---
+
+## 7. REST surface
+
+Mounted at `/api/agent-memory`, JWT-protected (`AuthSessionGuard`):
+
+| Method + path                         | Notes                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| `GET /check-availability`             | Whether a provider is registered + loaded.                            |
+| `POST /sessions`                      | Open a session. Ownership-checked when `workId` supplied.             |
+| `POST /sessions/:sessionId/close`     | Close a session. Ownership-checked + work-scoped when `workId` given. |
+| `GET /sessions`                       | List sessions (404 if provider lacks `listSessions`).                 |
+| `POST /save` / `/search` / `/context` | Save / search / build-context. Ownership-checked when `workId` given. |
+| `DELETE /entries/:entryId`            | Forget one record. Ownership-checked + work-scoped when `workId` given. |
+
+**Ownership / isolation.** When a request carries a `workId`, the controller
+runs `WorkOwnershipService.ensureCanView(workId, userId)` and scopes provider
+resolution to that Work. The id-addressed mutations (`close`, `deleteEntry`)
+accept an optional `workId` query param so they get the same check — without it
+they operate against the caller's default project. Cross-user isolation
+therefore depends on per-user / per-work `project` separation being configured in
+the backend.
+
+---
+
+## 8. Hard rules (additive)
+
+- Memory is **always best-effort** — never throw into a host pipeline or run.
+- The feature is **opt-in** per Work; default off.
+- Storage is **external**, not Postgres; the only DB column is
+  `agent_runs.memorySessionId`.
+- An orchestrator-supplied session id always wins over a self-opened one, and the
+  modifier never closes a session it did not open.

--- a/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
@@ -708,6 +708,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId (no orchestrator session)
             );
         });
 
@@ -722,6 +723,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 
@@ -741,6 +743,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 
@@ -774,6 +777,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 bundle,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 
@@ -796,6 +800,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
@@ -96,6 +96,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined, // no signal in options
                 undefined, // no kbContext (no KB service wired)
                 undefined, // no kbTools (no adapter wired)
+                undefined, // no memorySessionId (no orchestrator session)
             );
 
             // plugin.execute received {...options, execContext, onLogEntry}.
@@ -144,6 +145,7 @@ describe('FullPipelineExecutorService', () => {
                 signal,
                 undefined,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
 
@@ -218,6 +220,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined,
                 bundle,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
 
@@ -246,6 +249,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
 
@@ -281,6 +285,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
     });

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.ts
@@ -139,6 +139,7 @@ export class FullPipelineExecutorService {
                 options?.signal,
                 kbContext,
                 kbTools,
+                options?.memorySessionId,
             );
 
             // Delegate to the plugin's execute method with execContext

--- a/packages/agent/src/pipeline/step-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/step-pipeline-executor.service.ts
@@ -613,6 +613,7 @@ export class StepPipelineExecutorService {
             options?.signal,
             kbContext,
             kbTools,
+            options?.memorySessionId,
         );
 
         if (executor.type === 'builtin') {

--- a/packages/plugin/src/contracts/capabilities/pipeline-plugin.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/pipeline-plugin.interface.ts
@@ -38,6 +38,17 @@ export interface PipelineExecutionOptions {
 	readonly execContext?: StepExecutionContext;
 	/** Callback for structured log entries (used by log collector) */
 	readonly onLogEntry?: (log: GenerationStepLog) => void;
+	/**
+	 * Agent-memory session id supplied by an orchestrator that already
+	 * opened a session for this run (e.g. an agent run that triggers a
+	 * pipeline). When set, the executor forwards it to every step via
+	 * `StepExecutionContext.memorySessionId` so memory-touching steps
+	 * associate their reads/writes with the shared session instead of
+	 * opening their own. Left `undefined` for plain Work-generation
+	 * runs, where the `memory-pipeline-modifier` opens a per-run session
+	 * of its own.
+	 */
+	readonly memorySessionId?: string;
 }
 
 /**

--- a/packages/plugins/memory-pipeline-modifier/package.json
+++ b/packages/plugins/memory-pipeline-modifier/package.json
@@ -61,7 +61,8 @@
 			"autoEnable": false,
 			"visibility": "public",
 			"targetPipelines": [
-				"*"
+				"standard-pipeline",
+				"agent-pipeline"
 			]
 		}
 	}

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -529,6 +529,25 @@ describe('MemoryPipelineModifierPlugin', () => {
 			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-4', expect.anything());
 		});
 
+		it('closes the self-opened session on rollback even when saveSummary is disabled', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-5',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			const context = makeContext({
+				stepSettings: { 'memory-pipeline-modifier': { enabled: true, saveSummary: false } }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.rollback(context, new Error('boom'));
+			// saveSummary off → no failure digest persisted, but the session
+			// we opened in fetch-context must still be closed.
+			expect(memoryFacade.saveMemory).not.toHaveBeenCalled();
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-5', expect.anything());
+		});
+
 		it('does NOT open or close a session when the orchestrator supplies one', async () => {
 			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
 			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-o' });

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -449,5 +449,116 @@ describe('MemoryPipelineModifierPlugin', () => {
 				expect.anything()
 			);
 		});
+
+		it('opens a per-run session on fetch when none supplied and threads it into buildContext', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-1',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: 'x' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.openSession).toHaveBeenCalledTimes(1);
+			expect(memoryFacade.buildContext).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-self-1' }),
+				expect.anything()
+			);
+			expect((context as Record<string, unknown>).__memoryModifierSessionId).toBe('sess-self-1');
+		});
+
+		it('reuses the self-opened session on save (no second open) and closes it once', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-2',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-2' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.openSession).toHaveBeenCalledTimes(1);
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-self-2' }),
+				expect.anything()
+			);
+			expect(memoryFacade.closeSession).toHaveBeenCalledTimes(1);
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-2', expect.anything());
+		});
+
+		it('closes the self-opened session even when saveSummary is disabled', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-3',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			const context = makeContext({
+				stepSettings: { 'memory-pipeline-modifier': { enabled: true, saveSummary: false } }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.saveMemory).not.toHaveBeenCalled();
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-3', expect.anything());
+		});
+
+		it('closes the self-opened session via rollback on failure', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-4',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-rb' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.rollback(context, new Error('boom'));
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-self-4' }),
+				expect.anything()
+			);
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-4', expect.anything());
+		});
+
+		it('does NOT open or close a session when the orchestrator supplies one', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-o' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContextWithSession('sess-orch') }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContextWithSession('sess-orch') }
+			});
+			expect(memoryFacade.openSession).not.toHaveBeenCalled();
+			expect(memoryFacade.closeSession).not.toHaveBeenCalled();
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-orch' }),
+				expect.anything()
+			);
+		});
+
+		it('swallows a session-open failure and continues session-less', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('session server down'));
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: 'x' });
+			const context = makeContext();
+			await expect(
+				plugin.execute(context, {
+					settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+				})
+			).resolves.toBeDefined();
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/failed to open session/));
+			const buildArg = (memoryFacade.buildContext as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(buildArg).not.toHaveProperty('sessionId');
+		});
 	});
 });

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -315,7 +315,7 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 			const summary = this.buildFailureSummary(work, items, error, isCancellation);
 			const tags = this.buildFailureTags(work, isCancellation);
-			const sessionId = execContext?.memorySessionId;
+			const sessionId = this.resolveSessionId(context as ContextBag);
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
@@ -344,6 +344,96 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			// Do not rethrow — the host executor catches and demotes
 			// rollback errors, but defending here too keeps the
 			// invariant local.
+		} finally {
+			// Close the per-run session we opened (no-op when the session
+			// was supplied by an orchestrator, which owns its lifecycle).
+			await this.closeSelfOpenedSession(context as ContextBag, memoryFacade, logger);
+		}
+	}
+
+	// ── session lifecycle ──────────────────────────────────────────────
+
+	/**
+	 * Resolve the agent-memory session id to associate this run's
+	 * reads/writes with, WITHOUT opening a new one:
+	 *
+	 *   1. An orchestrator-supplied session (`execContext.memorySessionId`,
+	 *      forwarded by the pipeline executor from
+	 *      `PipelineExecutionOptions.memorySessionId`) always wins — the
+	 *      caller owns that session's lifecycle, so we never close it.
+	 *   2. Otherwise a session this modifier opened earlier in the same
+	 *      run (stashed on the context bag by `ensureSessionId`).
+	 *
+	 * Returns `undefined` when neither exists yet.
+	 */
+	private resolveSessionId(context: ContextBag): string | undefined {
+		const execContext = context.__memoryModifierExecContext as StepExecutionContext | undefined;
+		if (execContext?.memorySessionId) return execContext.memorySessionId;
+		return context.__memoryModifierSessionId as string | undefined;
+	}
+
+	/**
+	 * Resolve an existing session id or, when none is supplied by an
+	 * orchestrator, open a per-run session of our own so that the
+	 * fetch-context read, the save digest, and any failure rollback all
+	 * land on the SAME `agent_memory_sessions` row. Called from the
+	 * first-position fetch step so the session exists for the whole run.
+	 *
+	 * Best-effort: a failure to open is swallowed (memory must never crash
+	 * the host pipeline) and the run continues session-less.
+	 */
+	private async ensureSessionId(
+		context: ContextBag,
+		memoryFacade: IAgentMemoryStepFacade,
+		logger: { log(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void }
+	): Promise<string | undefined> {
+		const existing = this.resolveSessionId(context);
+		if (existing) return existing;
+
+		try {
+			const work = (context as { work?: { id?: string; slug?: string } }).work;
+			const session = await memoryFacade.openSession(
+				{ source: this.id, workId: work?.id, workSlug: work?.slug },
+				// Bound facade ignores its facadeOptions — pass placeholder.
+				{ userId: 'bound', workId: 'bound' }
+			);
+			if (session?.id) {
+				context.__memoryModifierSessionId = session.id;
+				context.__memoryModifierSessionSelfOpened = true;
+				logger.log(`memory-session: opened session ${session.id} for Work "${work?.slug ?? work?.id ?? '?'}"`);
+				return session.id;
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`memory-session: failed to open session — ${message}`);
+		}
+		return undefined;
+	}
+
+	/**
+	 * Close the session this modifier opened, exactly once, at the end of
+	 * the run (success digest, save-disabled exit, or failure rollback).
+	 * No-ops when the session was supplied by an orchestrator (it owns the
+	 * lifecycle) or when we never opened one. Best-effort.
+	 */
+	private async closeSelfOpenedSession(
+		context: ContextBag,
+		memoryFacade: IAgentMemoryStepFacade,
+		logger: { log(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void }
+	): Promise<void> {
+		if (context.__memoryModifierSessionSelfOpened !== true) return;
+		const sessionId = context.__memoryModifierSessionId as string | undefined;
+		// Flip the flag first so a concurrent/repeated terminal step can't
+		// double-close.
+		context.__memoryModifierSessionSelfOpened = false;
+		if (!sessionId) return;
+
+		try {
+			await memoryFacade.closeSession(sessionId, { userId: 'bound', workId: 'bound' });
+			logger.log(`memory-session: closed session ${sessionId}`);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`memory-session: failed to close session ${sessionId} — ${message}`);
 		}
 	}
 
@@ -359,14 +449,13 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			const work = (context as { work?: { id?: string; name?: string; slug?: string } }).work;
 			const request = (context as { request?: { prompt?: string } }).request;
 
-			// Honour a session id supplied by the orchestrator (e.g.
-			// AgentRunService opens a session per agent run and propagates
-			// it via StepExecutionContext.memorySessionId). When absent —
-			// the usual case for plain Work-generation pipelines — the
-			// backend associates the record with no specific session.
-			const sessionId = (context as ContextBag).__memoryModifierExecContext
-				? ((context as ContextBag).__memoryModifierExecContext as StepExecutionContext).memorySessionId
-				: undefined;
+			// Associate this read with the run's session. Honour an
+			// orchestrator-supplied session id (e.g. an agent run that
+			// triggers a pipeline, forwarded via
+			// StepExecutionContext.memorySessionId); otherwise open a
+			// per-run session of our own so the fetch read, the save
+			// digest, and any failure rollback all share one session row.
+			const sessionId = await this.ensureSessionId(context, memoryFacade, logger);
 
 			const ctx: AgentMemoryContext = await memoryFacade.buildContext(
 				{
@@ -407,6 +496,7 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 	): Promise<IPipelineContext> {
 		if (settings.saveSummary === false) {
 			logger.log('memory-save: saveSummary disabled — skipping');
+			await this.closeSelfOpenedSession(context, memoryFacade, logger);
 			return context;
 		}
 
@@ -420,9 +510,7 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			// unreachable at this step's call site.
 			const summary = this.buildSummary(work, items);
 			const tags = this.buildTags(work);
-			const sessionId = (context as ContextBag).__memoryModifierExecContext
-				? ((context as ContextBag).__memoryModifierExecContext as StepExecutionContext).memorySessionId
-				: undefined;
+			const sessionId = this.resolveSessionId(context);
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
@@ -441,10 +529,12 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			);
 
 			logger.log(`memory-save: saved observation ${record.id} for Work "${work?.slug ?? work?.id ?? '?'}"`);
+			await this.closeSelfOpenedSession(context, memoryFacade, logger);
 			return context;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			logger.warn(`memory-save: failed to save observation — ${message}`);
+			await this.closeSelfOpenedSession(context, memoryFacade, logger);
 			return context;
 		}
 	}

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -296,7 +296,6 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 	async rollback(context: IPipelineContext, error: Error): Promise<void> {
 		const settings = this.resolveSettings(context);
 		if (settings.enabled !== true) return;
-		if (settings.saveSummary === false) return;
 
 		const execContext = (context as ContextBag).__memoryModifierExecContext as StepExecutionContext | undefined;
 		const memoryFacade = execContext?.agentMemoryFacade;
@@ -304,7 +303,17 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 		if (!memoryFacade) {
 			// fetch-context didn't run, or the modifier was disabled when
-			// it did. Either way there's no facade to call.
+			// it did. Either way there's no facade to call (and so nothing
+			// was opened that needs closing).
+			return;
+		}
+
+		// When the failure digest is disabled we still MUST close any
+		// session this modifier opened during fetch-context — otherwise a
+		// failed/cancelled run with `saveSummary: false` leaks the session
+		// (Codex P2 on PR #1113).
+		if (settings.saveSummary === false) {
+			await this.closeSelfOpenedSession(context as ContextBag, memoryFacade, logger);
 			return;
 		}
 
@@ -393,7 +402,10 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 		try {
 			const work = (context as { work?: { id?: string; slug?: string } }).work;
 			const session = await memoryFacade.openSession(
-				{ source: this.id, workId: work?.id, workSlug: work?.slug },
+				// Open in the SAME project namespace the fetch/save/rollback
+				// calls use (`work.slug ?? work.id`) so the session row and
+				// its memory entries live together (Codex P2 on PR #1113).
+				{ projectId: work?.slug ?? work?.id, source: this.id, workId: work?.id, workSlug: work?.slug },
 				// Bound facade ignores its facadeOptions — pass placeholder.
 				{ userId: 'bound', workId: 'bound' }
 			);


### PR DESCRIPTION
## Summary

Implements review findings #1 and #5 from the emails/plugins/agent-memory deep review.

**#1 — the memory "session pipe" is now live.** The carrier (`StepExecutionContext.memorySessionId`) was plumbed but never populated, so pipeline-step memory writes were always session-less.

- Both pipeline executors now forward `PipelineExecutionOptions.memorySessionId` as the 7th positional arg to `createStepExecutionContext`, so an orchestrator that already opened a session (e.g. an agent run that triggers a pipeline) can share it with every step.
- When no orchestrator session is supplied (plain Work-generation), `memory-pipeline-modifier` opens **one per-run session of its own** on `memory-fetch-context`, reuses it on `memory-save` and on failure `rollback`, and closes it at the terminal step — so a run's context read, success digest, and failure digest all land on the same session row. It never closes an orchestrator-supplied session. All best-effort (a memory failure never crashes the host pipeline).

**#5 — agent-memory polish:**
- `closeSession` / `deleteEntry` REST endpoints accept an optional `workId` and enforce `WorkOwnershipService.ensureCanView` + work-scoping, closing the cross-user id-guessing gap on the two id-addressed mutations.
- Fixed `memory-pipeline-modifier` manifest `targetPipelines` drift (`["*"]` → `["standard-pipeline","agent-pipeline"]`) so the manifest matches the class (which already narrowed it).
- Added `docs/specs/features/agent-memory/spec.md` documenting the as-built feature (external storage, sessions, the session pipe, rollback, `canSkipAtBuildTime`, REST surface, ownership).

## Test plan

- [x] `memory-pipeline-modifier` vitest — +6 session-lifecycle cases (open-on-fetch, reuse-on-save, close-on-terminal, close-via-rollback, honour-orchestrator-session, swallow-open-failure); 38 pass.
- [x] agent pipeline jest (step + full executor) — 421 pass; executor specs updated for the new positional arg.
- [x] `agent-memory.controller` jest — +4 ownership cases (close/delete enforce + propagate rejection).
- [ ] CI green on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work-scoped agent-memory operations now enforce ownership checks.
  * Pipeline execution supports an optional shared memory session ID and automatic per-run session management when none is provided.

* **Documentation**
  * Added comprehensive Agent Memory spec covering session lifecycle, API surface, and access/isolation rules.

* **Tests**
  * Expanded tests for ownership enforcement, memory session propagation, and lifecycle (open/close/rollback) scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->