### PR TITLE
fix(migrations): resolve attachment migration class timestamp collision

### DIFF
--- a/apps/api/src/migrations/1779991006500-CreateMissionIdeaAgentAttachmentTables.ts
+++ b/apps/api/src/migrations/1779991006500-CreateMissionIdeaAgentAttachmentTables.ts
@@ -24,8 +24,18 @@ import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } f
  *
  * Idempotent: each `CREATE TABLE` is guarded by `hasTable`, each index
  * by name lookup. Re-runs are no-ops.
+ *
+ * Timestamp note: PR #1050 renamed this file to `1779991006000-…` to clear
+ * a *filename* collision but left the class timestamp at `1779991000000`,
+ * which still collided with `AddUniqueIndexToUsername1779991000000` at the
+ * level TypeORM actually orders on (the trailing digits of the class name).
+ * Both file and class are now `1779991006500`: unique, ordered right after
+ * `AddTenantIdAndOrganizationIdToTierA1779991006000` and before
+ * `UpgradeWorkOrganizationIdToFk1779991007000`. Because every statement is
+ * idempotent, environments that already applied the old class name simply
+ * re-run this as a no-op.
  */
-export class CreateMissionIdeaAgentAttachmentTables1779991000000 implements MigrationInterface {
+export class CreateMissionIdeaAgentAttachmentTables1779991006500 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await this.createAttachmentTable(queryRunner, {
             tableName: 'mission_attachments',


### PR DESCRIPTION
## Summary

Implements review finding #3.

`CreateMissionIdeaAgentAttachmentTables` had its **class** timestamp at `1779991000000`, colliding with `AddUniqueIndexToUsername1779991000000`. TypeORM orders migrations by the trailing digits of the **class name**, not the filename — so PR #1050's earlier file-only rename (to `1779991006000-`) never actually cleared the collision it targeted.

- Renames both file and class to `1779991006500` — unique, ordered right after `AddTenantIdAndOrganizationIdToTierA1779991006000` and before `UpgradeWorkOrganizationIdToFk1779991007000`.
- The migration is fully idempotent (every `CREATE TABLE`/index is guarded), so any environment that already applied the old class name re-runs it as a harmless no-op; fresh DBs (CI) run it once in the correct order.

Out of scope (noted, not changed): the `1779800000000` *filename* pair (`AddMagicLinkToken` / `AddWorkProposalGeneratedPrompt`) — their class timestamps already differ so ordering is deterministic; renaming them would risk re-run failures (not guaranteed idempotent) for no functional benefit.

## Test plan

- [x] No remaining class-name timestamp collisions (`grep` uniq check is empty).
- [x] No code/test references to the old class name or timestamp.
- [ ] CI green on develop (fresh-DB migration run in order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->