### PR TITLE
fix(email+notifications): inbound webhook owner-scoping + subscription validation

### DIFF
--- a/apps/api/src/notifications/notification-preferences.service.spec.ts
+++ b/apps/api/src/notifications/notification-preferences.service.spec.ts
@@ -1,0 +1,82 @@
+import { BadRequestException } from '@nestjs/common';
+
+// Stub the agent database barrel so importing the service under test
+// doesn't pull in `@ever-works/agent/database`'s source `database.module`
+// (which uses the agent-internal `@src/config` alias the api jest config
+// can't resolve). We construct the service directly with mocks below, so
+// the real repository classes are only needed as DI metadata tokens.
+jest.mock('@ever-works/agent/database', () => ({
+    NotificationEventTypeRepository: class {},
+    UserNotificationSubscriptionRepository: class {},
+    UserNotificationPreferenceRepository: class {},
+    UserNotificationCategoryMuteRepository: class {},
+    NotificationChannelRepository: class {},
+}));
+
+import { NotificationPreferencesService } from './notification-preferences.service';
+
+/**
+ * Covers the channel-ownership + event-type validation added to
+ * `setEventSubscription` (review finding #6) — a caller must not be able
+ * to persist unknown event keys or channel ids they don't own.
+ */
+describe('NotificationPreferencesService.setEventSubscription validation', () => {
+    let eventTypes: { findByKey: jest.Mock };
+    let subscriptions: { upsert: jest.Mock; findForEvent: jest.Mock };
+    let channels: { findByIdForUser: jest.Mock };
+    let service: NotificationPreferencesService;
+
+    beforeEach(() => {
+        eventTypes = { findByKey: jest.fn().mockResolvedValue({ key: 'ai.credits.depleted' }) };
+        subscriptions = {
+            upsert: jest.fn().mockResolvedValue(undefined),
+            findForEvent: jest.fn().mockResolvedValue({ id: 'sub-1' }),
+        };
+        channels = { findByIdForUser: jest.fn().mockResolvedValue({ id: 'ch-1' }) };
+        service = new NotificationPreferencesService(
+            eventTypes as never,
+            subscriptions as never,
+            {} as never,
+            {} as never,
+            channels as never,
+        );
+    });
+
+    it('rejects an unknown event type', async () => {
+        eventTypes.findByKey.mockResolvedValue(null);
+        await expect(
+            service.setEventSubscription('user-1', 'bogus.key', ['in-app']),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(subscriptions.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a channel id the user does not own', async () => {
+        channels.findByIdForUser.mockResolvedValue(null);
+        await expect(
+            service.setEventSubscription('user-1', 'ai.credits.depleted', ['ch-foreign']),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(channels.findByIdForUser).toHaveBeenCalledWith('ch-foreign', 'user-1');
+        expect(subscriptions.upsert).not.toHaveBeenCalled();
+    });
+
+    it('accepts the built-in in-app channel without an ownership lookup', async () => {
+        await service.setEventSubscription('user-1', 'ai.credits.depleted', ['in-app']);
+        expect(channels.findByIdForUser).not.toHaveBeenCalled();
+        expect(subscriptions.upsert).toHaveBeenCalledWith('user-1', 'ai.credits.depleted', [
+            'in-app',
+        ]);
+    });
+
+    it('accepts an owned channel id and dedupes the list', async () => {
+        await service.setEventSubscription('user-1', 'ai.credits.depleted', [
+            'in-app',
+            'ch-1',
+            'ch-1',
+        ]);
+        expect(channels.findByIdForUser).toHaveBeenCalledTimes(1);
+        expect(subscriptions.upsert).toHaveBeenCalledWith('user-1', 'ai.credits.depleted', [
+            'in-app',
+            'ch-1',
+        ]);
+    });
+});

--- a/apps/api/src/notifications/notification-preferences.service.ts
+++ b/apps/api/src/notifications/notification-preferences.service.ts
@@ -1,10 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import {
     NotificationEventTypeRepository,
     UserNotificationSubscriptionRepository,
     UserNotificationPreferenceRepository,
     UserNotificationCategoryMuteRepository,
+    NotificationChannelRepository,
 } from '@ever-works/agent/database';
+
+/**
+ * Channel ids that are not rows in `notification_channels` — always
+ * available to every user and therefore exempt from the ownership check.
+ */
+const BUILT_IN_CHANNEL_IDS = new Set<string>(['in-app']);
 import type {
     NotificationEventType,
     UserNotificationSubscription,
@@ -32,6 +39,7 @@ export class NotificationPreferencesService {
         private readonly subscriptions: UserNotificationSubscriptionRepository,
         private readonly preferences: UserNotificationPreferenceRepository,
         private readonly mutes: UserNotificationCategoryMuteRepository,
+        private readonly channels: NotificationChannelRepository,
     ) {}
 
     async listEventTypes(): Promise<NotificationEventType[]> {
@@ -62,7 +70,31 @@ export class NotificationPreferencesService {
         eventTypeKey: string,
         channelIds: string[],
     ): Promise<UserNotificationSubscription> {
-        await this.subscriptions.upsert(userId, eventTypeKey, channelIds);
+        // Reject unknown event types so a typo can't persist a dead
+        // subscription row that silently never resolves.
+        const eventType = await this.eventTypes.findByKey(eventTypeKey);
+        if (!eventType) {
+            throw new BadRequestException(`Unknown notification event type: ${eventTypeKey}`);
+        }
+
+        // Validate channel ownership: every non-built-in channel id must
+        // be a notification_channels row owned by this user. Without this
+        // a caller could persist arbitrary (or another user's) channel
+        // UUIDs into their subscription row. Send-time scoping already
+        // blocks cross-tenant *delivery*, but storing foreign ids is a
+        // storage-integrity / info-leak gap. Dedupe first.
+        const unique = [...new Set(channelIds)];
+        for (const id of unique) {
+            if (BUILT_IN_CHANNEL_IDS.has(id)) continue;
+            const owned = await this.channels.findByIdForUser(id, userId);
+            if (!owned) {
+                throw new BadRequestException(
+                    `Unknown or unauthorized notification channel: ${id}`,
+                );
+            }
+        }
+
+        await this.subscriptions.upsert(userId, eventTypeKey, unique);
         return (await this.subscriptions.findForEvent(
             userId,
             eventTypeKey,

--- a/packages/agent/src/facades/__tests__/email.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/email.facade.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { EmailFacadeService, EmailFacadeError } from '../email.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { TenantEmailAddressRepository } from '../../database/repositories/tenant-email-address.repository';
 
 /**
  * EW-668 / T11 — EmailFacadeService construction + resolution coverage.
@@ -11,6 +12,7 @@ import { PluginSettingsService } from '../../plugins/services/plugin-settings.se
 describe('EmailFacadeService', () => {
     let registry: jest.Mocked<PluginRegistryService>;
     let settings: jest.Mocked<PluginSettingsService>;
+    let emailAddresses: { findByAddress: jest.Mock };
     let facade: EmailFacadeService;
 
     beforeEach(async () => {
@@ -19,13 +21,16 @@ describe('EmailFacadeService', () => {
         } as unknown as jest.Mocked<PluginRegistryService>;
         settings = {
             getResolvedSettings: jest.fn().mockResolvedValue({}),
+            getSettings: jest.fn().mockResolvedValue({}),
         } as unknown as jest.Mocked<PluginSettingsService>;
+        emailAddresses = { findByAddress: jest.fn().mockResolvedValue(null) };
 
         const moduleRef = await Test.createTestingModule({
             providers: [
                 EmailFacadeService,
                 { provide: PluginRegistryService, useValue: registry },
                 { provide: PluginSettingsService, useValue: settings },
+                { provide: TenantEmailAddressRepository, useValue: emailAddresses },
             ],
         }).compile();
 
@@ -60,5 +65,90 @@ describe('EmailFacadeService', () => {
         await expect(
             facade.parseInbound('postmark', Buffer.from(''), {}, { userId: 'user-1' }),
         ).rejects.toBeInstanceOf(EmailFacadeError);
+    });
+
+    describe('parseInbound recipient-owner scoping (EW-670 follow-up)', () => {
+        function makeInboundPlugin() {
+            return {
+                id: 'postmark',
+                name: 'Postmark',
+                version: '1.0.0',
+                category: 'email',
+                capabilities: ['email-inbound'],
+                extractInboundRecipients: jest.fn().mockReturnValue(['inbox@ever.works']),
+                verifyWebhookSignature: jest.fn(),
+                parseInboundWebhook: jest.fn().mockResolvedValue({
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    from: 'sender@example.com',
+                    to: ['inbox@ever.works'],
+                    subject: 's',
+                    bodyText: 't',
+                    attachments: [],
+                    receivedAt: new Date(),
+                }),
+            };
+        }
+
+        it('resolves the recipient owner and verifies with the owner-scoped secret', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            (settings.getSettings as jest.Mock).mockResolvedValue({
+                inboundWebhookSecret: 'owner-secret',
+            });
+            emailAddresses.findByAddress.mockResolvedValue({ userId: 'owner-9' });
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {});
+
+            expect(plugin.extractInboundRecipients).toHaveBeenCalled();
+            expect(emailAddresses.findByAddress).toHaveBeenCalledWith('inbox@ever.works');
+            // settings (and thus the secret) resolved at the OWNER's scope
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: 'owner-9', includeSecrets: true }),
+            );
+            // verification ran with those owner-scoped settings
+            expect(plugin.verifyWebhookSignature).toHaveBeenCalledWith(
+                expect.any(Buffer),
+                expect.anything(),
+                expect.objectContaining({
+                    userId: 'owner-9',
+                    settings: { inboundWebhookSecret: 'owner-secret' },
+                }),
+            );
+        });
+
+        it('falls back to default scope when no owner matches the recipient', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            emailAddresses.findByAddress.mockResolvedValue(null);
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {});
+
+            expect(emailAddresses.findByAddress).toHaveBeenCalledWith('inbox@ever.works');
+            // No owner → settings resolved without a userId (admin/env scope)
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: undefined }),
+            );
+            expect(plugin.verifyWebhookSignature).toHaveBeenCalled();
+        });
+
+        it('skips recipient resolution when the caller already supplies a userId', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {}, { userId: 'caller-1' });
+
+            expect(plugin.extractInboundRecipients).not.toHaveBeenCalled();
+            expect(emailAddresses.findByAddress).not.toHaveBeenCalled();
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: 'caller-1' }),
+            );
+        });
     });
 });

--- a/packages/agent/src/facades/__tests__/email.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/email.facade.spec.ts
@@ -97,7 +97,10 @@ describe('EmailFacadeService', () => {
             (settings.getSettings as jest.Mock).mockResolvedValue({
                 inboundWebhookSecret: 'owner-secret',
             });
-            emailAddresses.findByAddress.mockResolvedValue({ userId: 'owner-9' });
+            emailAddresses.findByAddress.mockResolvedValue({
+                userId: 'owner-9',
+                pluginId: 'postmark',
+            });
 
             await facade.parseInbound('postmark', Buffer.from('{}'), {});
 
@@ -134,6 +137,24 @@ describe('EmailFacadeService', () => {
                 expect.objectContaining({ userId: undefined }),
             );
             expect(plugin.verifyWebhookSignature).toHaveBeenCalled();
+        });
+
+        it('falls back to default scope when the matched address belongs to a different plugin', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            // Address is registered to mailgun, not the postmark webhook in flight.
+            emailAddresses.findByAddress.mockResolvedValue({
+                userId: 'owner-9',
+                pluginId: 'mailgun',
+            });
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {});
+
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: undefined }),
+            );
         });
 
         it('skips recipient resolution when the caller already supplies a userId', async () => {

--- a/packages/agent/src/facades/email.facade.ts
+++ b/packages/agent/src/facades/email.facade.ts
@@ -210,7 +210,19 @@ export class EmailFacadeService extends BaseFacadeService {
             for (const recipient of recipients) {
                 if (!recipient) continue;
                 const owner = await this.emailAddresses.findByAddress(recipient);
-                if (owner?.userId) {
+                // Only adopt the resolved owner when the matched address is
+                // registered to THIS plugin — a mailbox can be registered by
+                // multiple tenants/providers, so an address-only match could
+                // otherwise attribute the verification scope to the wrong
+                // owner (Codex/Greptile on PR #1115). When it doesn't match we
+                // fall back to the base (admin/env) scope below.
+                //
+                // Note: widening the scope to the owner's userId never
+                // *weakens* verification — `getSettings({ userId })` resolves
+                // the admin→user hierarchy, so an admin-level
+                // `inboundWebhookSecret` is still present (and enforced) at
+                // owner scope; the user's own secret only layers on top.
+                if (owner?.userId && owner.pluginId === plugin.id) {
                     return { ...base, userId: owner.userId };
                 }
             }

--- a/packages/agent/src/facades/email.facade.ts
+++ b/packages/agent/src/facades/email.facade.ts
@@ -162,16 +162,66 @@ export class EmailFacadeService extends BaseFacadeService {
         options?: FacadeOptions,
     ): Promise<EmailInboundMessage> {
         const plugin = this.getInboundPluginById(pluginId);
-        const settings = await this.resolveSettings(pluginId, options);
+
+        // EW-670 follow-up — resolve the recipient address's OWNER before
+        // verifying the signature. The inbound webhook controller can't
+        // know the owning user up front (the recipient lives in the
+        // payload), so without this the secret resolves at admin/env
+        // scope only and a per-user `inboundWebhookSecret` is never
+        // loaded — meaning a Postmark/Mailgun `if (!expected) return`
+        // accept-all path silently skips verification for user-scoped
+        // secrets. Map recipient → owning tenant address → userId, then
+        // resolve settings (and therefore the secret) at that scope.
+        // Best-effort and additive: when the caller already supplies a
+        // userId, the plugin omits `extractInboundRecipients`, or no
+        // owner matches, this falls back to the previous behaviour.
+        const scope = await this.resolveInboundScope(plugin, rawBody, headers, options);
+
+        const settings = await this.resolveSettings(pluginId, scope);
         const emailOpts: EmailOptions = {
-            userId: options?.userId,
-            workId: options?.workId,
-            agentId: options?.agentId,
-            taskId: options?.taskId,
+            userId: scope.userId,
+            workId: scope.workId,
+            agentId: scope.agentId,
+            taskId: scope.taskId,
             settings,
         };
         plugin.verifyWebhookSignature(rawBody, headers, emailOpts);
         return plugin.parseInboundWebhook(rawBody, headers, emailOpts);
+    }
+
+    /**
+     * Best-effort: widen the inbound FacadeOptions with the owning user
+     * resolved from the payload's recipient address, so signature
+     * verification reads the owner's per-user secret. Never throws —
+     * returns the original options on any failure.
+     */
+    private async resolveInboundScope(
+        plugin: IEmailInboundPlugin,
+        rawBody: Buffer,
+        headers: Readonly<Record<string, string>>,
+        options?: FacadeOptions,
+    ): Promise<FacadeOptions> {
+        const base: FacadeOptions = { ...options };
+        if (base.userId || !plugin.extractInboundRecipients || !this.emailAddresses) {
+            return base;
+        }
+        try {
+            const recipients = plugin.extractInboundRecipients(rawBody, headers);
+            for (const recipient of recipients) {
+                if (!recipient) continue;
+                const owner = await this.emailAddresses.findByAddress(recipient);
+                if (owner?.userId) {
+                    return { ...base, userId: owner.userId };
+                }
+            }
+        } catch (err) {
+            this.logger.warn(
+                `parseInbound: recipient-owner resolution failed, falling back to default scope — ${
+                    (err as Error).message
+                }`,
+            );
+        }
+        return base;
     }
 
     /**

--- a/packages/plugin/src/contracts/capabilities/email-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/email-provider.interface.ts
@@ -210,6 +210,18 @@ export interface IEmailInboundPlugin extends IPlugin {
 	verifyWebhookSignature(rawBody: Buffer, headers: Readonly<Record<string, string>>, options: EmailOptions): void;
 
 	/**
+	 * Optional: best-effort extraction of the recipient mailbox
+	 * address(es) from the raw webhook payload, WITHOUT verifying the
+	 * signature. The facade uses this to map an inbound webhook to its
+	 * owning tenant address *before* signature verification, so a
+	 * per-user `inboundWebhookSecret` is resolved at the right scope
+	 * rather than only at admin/env scope. MUST NOT throw — return an
+	 * empty array when the recipient can't be determined. Plugins that
+	 * omit this fall back to admin/env-scoped secret resolution.
+	 */
+	extractInboundRecipients?(rawBody: Buffer, headers: Readonly<Record<string, string>>): readonly string[];
+
+	/**
 	 * Optional: decode a provider's delivery-event webhook (separate
 	 * shape from inbound on most providers). Plugins that don't
 	 * publish delivery events may omit this — the controller skips

--- a/packages/plugins/mailgun/src/mailgun-plugin.ts
+++ b/packages/plugins/mailgun/src/mailgun-plugin.ts
@@ -193,6 +193,27 @@ export class MailgunPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin 
 		}
 	}
 
+	extractInboundRecipients(rawBody: Buffer, _headers: Readonly<Record<string, string>>): readonly string[] {
+		// Best-effort recipient extraction WITHOUT verifying the
+		// signature — used by the facade to resolve the owning user's
+		// scope before verification. Must never throw.
+		try {
+			const body = decodeBody(rawBody);
+			const raw =
+				(typeof body['recipient'] === 'string' ? (body['recipient'] as string) : undefined) ??
+				(typeof body['To'] === 'string' ? (body['To'] as string) : undefined) ??
+				'';
+			return raw
+				? raw
+						.split(',')
+						.map((s) => s.trim())
+						.filter((s) => s.length > 0)
+				: [];
+		} catch {
+			return [];
+		}
+	}
+
 	async parseInboundWebhook(
 		rawBody: Buffer,
 		_headers: Readonly<Record<string, string>>,

--- a/packages/plugins/mailgun/src/mailgun-plugin.ts
+++ b/packages/plugins/mailgun/src/mailgun-plugin.ts
@@ -203,10 +203,17 @@ export class MailgunPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin 
 				(typeof body['recipient'] === 'string' ? (body['recipient'] as string) : undefined) ??
 				(typeof body['To'] === 'string' ? (body['To'] as string) : undefined) ??
 				'';
+			// `recipient` is a bare address, but the `To` fallback is the raw
+			// RFC 2822 header (may be `"Name" <a@b>`), so strip the display
+			// name / angle brackets before matching.
 			return raw
 				? raw
 						.split(',')
-						.map((s) => s.trim())
+						.map((s) => {
+							const trimmed = s.trim();
+							const match = trimmed.match(/<([^>]+)>/);
+							return (match ? match[1] : trimmed).trim();
+						})
 						.filter((s) => s.length > 0)
 				: [];
 		} catch {

--- a/packages/plugins/postmark/src/postmark-plugin.spec.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.spec.ts
@@ -104,6 +104,27 @@ describe('PostmarkPlugin', () => {
 		});
 	});
 
+	describe('extractInboundRecipients', () => {
+		it('returns ToFull emails as bare addresses', () => {
+			const payload = { ToFull: [{ Email: 'inbox@acme.com' }, { Email: 'team@acme.com' }] };
+			expect(plugin.extractInboundRecipients(Buffer.from(JSON.stringify(payload)), {})).toEqual([
+				'inbox@acme.com',
+				'team@acme.com'
+			]);
+		});
+
+		it('strips the display name from the raw To header fallback', () => {
+			const payload = { To: '"Acme Inbox" <inbox@acme.com>' };
+			expect(plugin.extractInboundRecipients(Buffer.from(JSON.stringify(payload)), {})).toEqual([
+				'inbox@acme.com'
+			]);
+		});
+
+		it('returns [] on malformed JSON (never throws)', () => {
+			expect(plugin.extractInboundRecipients(Buffer.from('not json'), {})).toEqual([]);
+		});
+	});
+
 	describe('verifyWebhookSignature', () => {
 		it('throws on Authorization header mismatch when secret is set', () => {
 			expect(() =>

--- a/packages/plugins/postmark/src/postmark-plugin.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.ts
@@ -35,6 +35,16 @@ function resolveInboundSecret(options: EmailOptions): string | undefined {
 	return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
 }
 
+/**
+ * Extract the bare mailbox from a possibly display-name-wrapped RFC 2822
+ * address (`"Name" <a@b>` → `a@b`). Returns the trimmed input when no
+ * angle-bracket form is present.
+ */
+function parseEmailAddress(raw: string): string {
+	const match = raw.match(/<([^>]+)>/);
+	return (match ? match[1] : raw).trim();
+}
+
 interface PostmarkInboundPayload {
 	readonly MessageID: string;
 	readonly From: string;
@@ -169,7 +179,10 @@ export class PostmarkPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin
 		// scope before verification. Must never throw.
 		try {
 			const payload = JSON.parse(rawBody.toString('utf8')) as PostmarkInboundPayload;
-			const to = payload.ToFull?.map((t) => t.Email) ?? (payload.To ? [payload.To] : []);
+			// `ToFull[].Email` is already a bare address. The `To` fallback
+			// is the raw RFC 2822 header (may be `"Name" <a@b>`), so strip
+			// the display name / angle brackets before matching.
+			const to = payload.ToFull?.map((t) => t.Email) ?? (payload.To ? [parseEmailAddress(payload.To)] : []);
 			return to.filter((address): address is string => typeof address === 'string' && address.length > 0);
 		} catch {
 			return [];

--- a/packages/plugins/postmark/src/postmark-plugin.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.ts
@@ -163,6 +163,19 @@ export class PostmarkPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin
 		}
 	}
 
+	extractInboundRecipients(rawBody: Buffer, _headers: Readonly<Record<string, string>>): readonly string[] {
+		// Best-effort recipient extraction WITHOUT verifying the
+		// signature — used by the facade to resolve the owning user's
+		// scope before verification. Must never throw.
+		try {
+			const payload = JSON.parse(rawBody.toString('utf8')) as PostmarkInboundPayload;
+			const to = payload.ToFull?.map((t) => t.Email) ?? (payload.To ? [payload.To] : []);
+			return to.filter((address): address is string => typeof address === 'string' && address.length > 0);
+		} catch {
+			return [];
+		}
+	}
+
 	async parseInboundWebhook(
 		rawBody: Buffer,
 		_headers: Readonly<Record<string, string>>,


### PR DESCRIPTION
## Summary

Implements review finding #2 and the safe backend part of #6.

### #2 — inbound email webhook signature scoping
The inbound webhook controller calls `EmailFacadeService.parseInbound` with no user context, so the `inboundWebhookSecret` resolved at admin/env scope only. A user-configured per-user secret was never loaded → Postmark/Mailgun's `if (!expected) return` accept-all path silently skipped verification for user-scoped secrets (spoofable inbound mail).

- New optional `IEmailInboundPlugin.extractInboundRecipients(rawBody, headers)` — best-effort recipient extraction **without** verifying the signature (implemented on postmark + mailgun).
- `parseInbound` now maps the payload recipient → owning tenant address → `userId`, resolves settings (and the secret) at that scope **before** verifying. Best-effort + additive: falls back to the prior admin/env behaviour when the caller supplies a userId, the plugin omits the hook, or no owner matches.

### #6 (part) — subscription validation
`setEventSubscription` stored arbitrary `channelIds` with no validation.
- Reject unknown event types.
- Validate every non-built-in channel id is a `notification_channels` row owned by the caller (`in-app` is built-in/exempt); dedupe before persisting.

### #6 — deliberately deferred (need a decision / browser verification, not a blind code change)
- **Org-defaults fallback in `resolvePlan`** — needs a product decision on *which* org's defaults apply to a user in a background fanout (no request scope; users can belong to multiple orgs).
- **Events-webhook full persistence** + **add-channel UI wizard / Test button** — larger surfaces; the UI needs real browser verification.

## Test plan

- [x] `email.facade` jest — +3 owner-scoping cases (resolve owner, fallback, caller-supplied userId); 7 pass.
- [x] postmark + mailgun vitest — 7 + 7 pass (extract hook added, existing green).
- [x] `notification-preferences.service` jest — +4 validation cases.
- [x] Full apps/api notifications + email suites — 161 suites / 2559 tests green locally.
- [ ] CI green on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in notification channels that work without additional configuration.

* **Bug Fixes & Improvements**
  * Enhanced validation for notification subscriptions to reject invalid event types and unauthorized channels.
  * Improved email webhook handling with proper per-recipient scoping for multi-tenant environments.
  * Added recipient address extraction for email provider webhooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->