### PR TITLE
fix(web): restore spinning favicon + always-on org popover in sidebar

### DIFF
--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -153,22 +153,19 @@ export function DashboardSidebar({
                 >
                     <div className="w-full relative">
                         {/*
-                            EW-660 (Tenants & Organizations Phase 8) —
-                            the expanded sidebar swaps `<LogoEverWork>`
-                            for `<WorkspaceSwitcher>`, which itself
-                            renders the unmodified logo when the user
-                            has zero Organizations (NN #20 — extension,
-                            not replacement). The collapsed sidebar
-                            keeps the bare favicon: there's no room for
-                            a chip+chevron at 16px column width, and
-                            users in that mode already expand the
-                            sidebar before reaching for the switcher.
+                            Expanded sidebar renders `<WorkspaceSwitcher>`,
+                            which always shows `[spinning favicon] [active
+                            org name OR Ever Works wordmark] [chevron]` and
+                            opens a popover with the org list + "+ Create
+                            Organization". The collapsed sidebar keeps the
+                            bare favicon — there's no room for a chip at
+                            16px column width.
                         */}
-                        <div className={cn('flex items-center -ml-2')}>
+                        <div className="flex items-center pr-6">
                             {isCollapsed ? (
                                 <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
                             ) : (
-                                <WorkspaceSwitcher config={config} logoClassName="" />
+                                <WorkspaceSwitcher config={config} />
                             )}
                         </div>
                         <div

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -117,7 +117,10 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
                     aria-label={t('heading')}
                 >
                     <div className="flex items-center gap-1.5 w-full min-w-0">
-                        <FaviconEverWorkImage config={config} className="w-9 h-9 shrink-0" />
+                        <FaviconEverWorkImage
+                            config={config}
+                            className="w-9 h-9 max-h-none shrink-0"
+                        />
                         {triggerOrg ? (
                             <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
                                 {pickLabel(triggerOrg)}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -15,15 +15,15 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { useActiveScope } from '@/lib/hooks/use-active-scope';
-import { LogoEverWork } from '../logos';
+import { FaviconEverWorkImage, LogoEverWorkImage } from '../logos';
 import { CreateOrganizationModal } from '../organizations/CreateOrganizationModal';
 import type { WorkConfig } from '@/lib/api';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
 interface WorkspaceSwitcherProps {
-    /** Site config passed through to the empty-state `<LogoEverWork>`. */
+    /** Site config passed through to the inline logo / favicon. */
     config?: WorkConfig | null;
-    /** Tailwind class for the empty-state logo. Lets the sidebar size it. */
+    /** Tailwind class for the inline wordmark image. */
     logoClassName?: string;
 }
 
@@ -61,67 +61,40 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
 
 /**
  * EW-660 (Tenants & Organizations Phase 8) — top-of-sidebar component
- * showing the active Organization (or the bare Ever Works logo when
- * the user has zero Orgs) with a popover to switch between Orgs.
+ * showing the spinning favicon + the active Organization (or the
+ * Ever Works wordmark when the user has zero Orgs) with a popover to
+ * switch between Orgs or create a new one.
  *
- * Behavior matrix:
+ * The whole row is a single dropdown trigger:
  *
- * | Org count | Trigger UI                       | Popover                   |
- * |-----------|----------------------------------|---------------------------|
- * | 0         | `<LogoEverWork />` unmodified    | none (no chevron)         |
- * | 1+        | Chip: [avatar] [name] [chevron]  | List of orgs + create row |
+ *   [spinning favicon] [label] [chevron]
  *
- * The empty-state branch renders `<LogoEverWork />` AS-IS so the
- * sidebar visuals for the no-org majority of users stay pixel-identical
- * (NN #20 — extension, not replacement).
+ * The trigger renders in every state (including zero-org), so the user
+ * can always reach "+ Create Organization" — pre-fix, the zero-org
+ * branch fell back to a bare logo with no popover and clicking it did
+ * nothing useful.
  *
- * Clicking an Org row navigates to `/{org.slug}/dashboard`. Clicking
- * "+ Create Organization" is a stub for Phase 9 — it `console.log`s
- * and the modal lands in EW-661.
+ * Trigger label by state:
+ *
+ * | Org count | Label                | Popover                         |
+ * |-----------|----------------------|---------------------------------|
+ * | 0         | Wordmark image       | "+ Create Organization" only    |
+ * | 1+        | Active org name      | Org list + "+ Create"           |
  */
 export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
     const { activeOrganization } = useActiveScope();
-    // Phase 9 — EW-661 — lifts the create-Org modal state into the
-    // switcher. `+ Create Organization` opens it; on success the modal
-    // routes to `/{slug}/dashboard` and (if first Org) chains into the
-    // upgrade-or-empty dialog.
     const [isCreateOpen, setIsCreateOpen] = useState(false);
 
-    // Empty state: no orgs yet → render the existing logo unmodified.
-    // We intentionally treat `isLoading` as empty for the initial
-    // render so we don't flash a "Loading…" chip in the most common
-    // case (zero orgs). Once the fetch resolves and orgs > 0, the
-    // chip appears.
-    if (!isLoading && organizations.length === 0) {
-        return <LogoEverWork config={config} className={logoClassName} />;
-    }
-
-    // Loading state, but only on the very first fetch when we don't
-    // yet know whether the user has orgs. Render a minimal skeleton
-    // (same width as the chip) so layout doesn't jump.
-    if (isLoading && organizations.length === 0) {
-        return (
-            <div
-                className={cn(
-                    'flex items-center gap-2 px-2 py-1.5 rounded-md',
-                    'text-text-muted dark:text-text-muted-dark',
-                    'text-sm',
-                )}
-                aria-busy="true"
-            >
-                <span className="w-7 h-7 rounded-md bg-surface-tertiary/60 dark:bg-surface-tertiary-dark/60 animate-pulse" />
-                <span className="truncate">{t('loading')}</span>
-            </div>
-        );
-    }
-
-    // Active state: 1+ orgs. Pick the trigger label — if we know the
-    // active Org from the URL slug, use it; otherwise fall back to the
-    // first org in the list so the chip never shows up empty.
-    const triggerOrg = activeOrganization ?? organizations[0];
+    const hasOrgs = organizations.length > 0;
+    // Pick the trigger label org — use the active one (from URL slug) if
+    // resolved, otherwise fall back to the first org so the chip never
+    // shows up empty when orgs exist.
+    const triggerOrg: OrganizationResponse | null = hasOrgs
+        ? (activeOrganization ?? organizations[0])
+        : null;
 
     const handleSelectOrg = (org: OrganizationResponse) => {
         router.push(`/${org.slug}/dashboard`);
@@ -139,14 +112,22 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
                         'w-full rounded-md transition-colors cursor-pointer',
                         'focus:outline-none focus-visible:outline-none',
                         'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                        'px-2 py-1.5',
+                        'px-1.5 py-1',
                     )}
+                    aria-label={t('heading')}
                 >
-                    <div className="flex items-center gap-2 w-full">
-                        <OrgAvatar org={triggerOrg} />
-                        <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                            {pickLabel(triggerOrg)}
-                        </span>
+                    <div className="flex items-center gap-1.5 w-full min-w-0">
+                        <FaviconEverWorkImage config={config} className="w-9 h-9 shrink-0" />
+                        {triggerOrg ? (
+                            <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                                {pickLabel(triggerOrg)}
+                            </span>
+                        ) : (
+                            <LogoEverWorkImage
+                                config={config}
+                                className={cn('flex-1 min-w-0', logoClassName)}
+                            />
+                        )}
                         <ChevronsUpDown
                             className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
                             strokeWidth={1.5}
@@ -155,32 +136,40 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
                     </div>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="start" className="w-60">
-                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
-                    {organizations.map((org) => {
-                        const isActive = activeOrganization?.id === org.id;
-                        return (
-                            <DropdownMenuItem
-                                key={org.id}
-                                onClick={() => handleSelectOrg(org)}
-                                className="cursor-pointer"
-                            >
-                                <div className="flex items-center gap-2 w-full">
-                                    <OrgAvatar org={org} size="xs" />
-                                    <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
-                                        {pickLabel(org)}
-                                    </span>
-                                    {isActive && (
-                                        <Check
-                                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                                            strokeWidth={1.5}
-                                            aria-label="Active organization"
-                                        />
-                                    )}
-                                </div>
-                            </DropdownMenuItem>
-                        );
-                    })}
-                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>
+                        {hasOrgs ? t('heading') : t('bareTenant')}
+                    </DropdownMenuLabel>
+                    {hasOrgs &&
+                        organizations.map((org) => {
+                            const isActive = activeOrganization?.id === org.id;
+                            return (
+                                <DropdownMenuItem
+                                    key={org.id}
+                                    onClick={() => handleSelectOrg(org)}
+                                    className="cursor-pointer"
+                                >
+                                    <div className="flex items-center gap-2 w-full">
+                                        <OrgAvatar org={org} size="xs" />
+                                        <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                            {pickLabel(org)}
+                                        </span>
+                                        {isActive && (
+                                            <Check
+                                                className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                                strokeWidth={1.5}
+                                                aria-label="Active organization"
+                                            />
+                                        )}
+                                    </div>
+                                </DropdownMenuItem>
+                            );
+                        })}
+                    {hasOrgs && <DropdownMenuSeparator />}
+                    {isLoading && !hasOrgs && (
+                        <DropdownMenuItem disabled className="text-text-muted">
+                            {t('loading')}
+                        </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
                         <div className="flex items-center gap-2 w-full">
                             <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -26,11 +26,18 @@ vi.mock('@/i18n/navigation', () => ({
     useRouter: () => ({ push: routerPushMock }),
 }));
 
-// Mock the LogoEverWork to a simple sentinel — we don't want to render
-// the real Next.js Image (jsdom) and we want a stable test selector
-// for the empty-state assertion.
+// Mock the image-only logo variants to simple sentinels — we don't want
+// to render real Next.js Image components in jsdom, and we want stable
+// test selectors for the empty-state assertion.
 vi.mock('../logos', () => ({
-    LogoEverWork: () => <div data-testid="logo-everwork">LogoEverWork</div>,
+    LogoEverWorkImage: () => <span data-testid="logo-everwork-image">LogoEverWork</span>,
+    FaviconEverWorkImage: () => <span data-testid="favicon-everwork-image">FaviconEverWork</span>,
+}));
+
+// `CreateOrganizationModal` pulls in next/image and the full org create
+// flow — stub it to a noop so the trigger renders without exploding.
+vi.mock('../organizations/CreateOrganizationModal', () => ({
+    CreateOrganizationModal: () => null,
 }));
 
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
@@ -68,28 +75,41 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     });
 
     /**
-     * Empty state: `organizations.length === 0` → falls back to the
-     * unmodified `<LogoEverWork>` (NN #20 — extension, not replacement).
-     * No popover trigger should be present.
+     * Empty state: even with zero orgs the switcher renders the
+     * spinning favicon + wordmark + chevron trigger so the user can
+     * still reach "+ Create Organization". The previous behaviour
+     * (bare logo, no trigger) silently broke the create flow.
      */
-    it('renders the LogoEverWork (no popover trigger) when the user has zero organizations', () => {
+    it('renders favicon + wordmark + trigger when the user has zero organizations', () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
 
-        const { container } = render(<WorkspaceSwitcher />);
+        render(<WorkspaceSwitcher />);
 
-        expect(screen.getByTestId('logo-everwork')).toBeInTheDocument();
-        // No popover-trigger button — the empty state is the bare logo.
-        expect(container.querySelector('[role="button"]')).toBeNull();
-        // And the chevron icon — used as the trigger affordance — is
-        // absent.
-        expect(container.querySelectorAll('svg').length).toBe(0);
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        expect(screen.getByTestId('logo-everwork-image')).toBeInTheDocument();
+        // Trigger button is always present.
+        expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(1);
     });
 
     /**
-     * Active state with 1 org: the chip renders with the org's display
-     * name AND a trigger affordance (chevron icon).
+     * Empty state popover: opening the trigger surfaces the
+     * "+ Create Organization" row even when no orgs exist.
      */
-    it('renders the chip with the org name and a popover trigger when the user has 1 organization', () => {
+    it('shows "+ Create Organization" in the popover when zero orgs', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        render(<WorkspaceSwitcher />);
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Active state with 1 org: the trigger shows the spinning favicon
+     * + the org's display name (no wordmark) + chevron.
+     */
+    it('renders favicon + org name + trigger when the user has 1 organization', () => {
         const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
         __seedOrganizationsStoreForTests({
             data: [org],
@@ -99,18 +119,15 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
         render(<WorkspaceSwitcher />);
 
-        // Chip text shows the display name.
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
-        // The logo from the empty-state branch should NOT render.
-        expect(screen.queryByTestId('logo-everwork')).toBeNull();
+        // Wordmark is replaced by the active-org label.
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
     });
 
     /**
      * 3 orgs — when the popover opens, all three list rows are
-     * present. We assert against the DOM (text content) rather than
-     * driving headlessui's actual open animation, since the items are
-     * rendered into the menu's items container regardless of open
-     * state at the JSX level.
+     * present plus the "+ Create Organization" footer row.
      */
     it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
         const orgs = [
@@ -124,21 +141,14 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
             error: null,
         });
 
-        // Force the popover to open by clicking the trigger. Headless UI's
-        // MenuButton handles the click; the items mount on open.
         render(<WorkspaceSwitcher />);
         const trigger = screen.getAllByRole('button')[0];
         fireEvent.click(trigger);
 
-        // All three display names appear in the rendered tree (some
-        // also in the trigger chip — assert >= 1 for each).
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Globex LLC').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Initech').length).toBeGreaterThanOrEqual(1);
 
-        // The "+ Create Organization" row uses the i18n key
-        // `organizations.switcher.createNew` (our mock returns the key
-        // verbatim).
         expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 
@@ -146,7 +156,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
      * Falls back to the org's slug when `displayName` is null — slug is
      * NOT NULL on the DB row, so this is the right fallback shape.
      */
-    it('uses the org slug as the chip label when displayName is null', () => {
+    it('uses the org slug as the trigger label when displayName is null', () => {
         const org = makeOrg({ displayName: null, slug: 'fallback-org' });
         __seedOrganizationsStoreForTests({
             data: [org],

--- a/apps/web/src/components/logos/index.tsx
+++ b/apps/web/src/components/logos/index.tsx
@@ -17,7 +17,13 @@ interface LogoEverWorkProps {
     config?: WorkConfig | null;
 }
 
-export function LogoEverWork({
+/**
+ * Wordmark image only — no `<Link>` wrapper. Use this when the logo
+ * needs to live inside another interactive element (e.g. the
+ * `<WorkspaceSwitcher>` dropdown trigger) where nesting a `<Link>`
+ * inside a `<button>` would be invalid HTML.
+ */
+export function LogoEverWorkImage({
     className,
     width = 120,
     height = 40,
@@ -25,10 +31,8 @@ export function LogoEverWork({
     config: configProps,
 }: LogoEverWorkProps) {
     const siteConfig = getSiteConfig(configProps);
-    const logoHref = siteConfig.website || '/';
-
     return (
-        <Link href={logoHref} className={cn('relative flex items-center', className)}>
+        <span className={cn('relative flex items-center', className)}>
             <Image
                 src={siteConfig.logo.light}
                 alt={siteConfig.name}
@@ -45,7 +49,64 @@ export function LogoEverWork({
                 priority={false}
                 className="hidden dark:block h-auto w-auto max-h-12 object-contain"
             />
+        </span>
+    );
+}
+
+export function LogoEverWork({
+    className,
+    width = 120,
+    height = 40,
+    priority = true,
+    config: configProps,
+}: LogoEverWorkProps) {
+    const siteConfig = getSiteConfig(configProps);
+    const logoHref = siteConfig.website || '/';
+
+    return (
+        <Link href={logoHref} className={cn('relative flex items-center', className)}>
+            <LogoEverWorkImage
+                width={width}
+                height={height}
+                priority={priority}
+                config={configProps}
+            />
         </Link>
+    );
+}
+
+/**
+ * Spinning favicon image only — no `<Link>` wrapper. Same rationale as
+ * `LogoEverWorkImage`: lets the favicon be embedded inside other
+ * interactive elements (or composed alongside other content) without
+ * nesting links.
+ */
+export function FaviconEverWorkImage({
+    className,
+    config: configProps,
+    size = 32,
+}: {
+    className?: string;
+    config?: WorkConfig | null;
+    size?: number;
+}) {
+    const siteConfig = getSiteConfig(configProps);
+    const { isDark, mounted } = useTheme();
+    const faviconSrc = mounted && isDark ? siteConfig.favicon.dark : siteConfig.favicon.light;
+
+    return (
+        <Image
+            key={faviconSrc}
+            src={faviconSrc}
+            alt={siteConfig.name}
+            width={size}
+            height={size}
+            style={{ animationDuration: '10s' }}
+            className={cn(
+                'object-contain max-h-8 animate-spin motion-reduce:animate-none',
+                className,
+            )}
+        />
     );
 }
 
@@ -57,23 +118,13 @@ export function FaviconEverWork({
     config?: WorkConfig | null;
 }) {
     const siteConfig = getSiteConfig(configProps);
-    const { isDark, mounted } = useTheme();
-    const faviconSrc = mounted && isDark ? siteConfig.favicon.dark : siteConfig.favicon.light;
 
     return (
         <Link
             href={siteConfig.website || '/'}
             className={cn('relative flex items-center', className)}
         >
-            <Image
-                key={faviconSrc}
-                src={faviconSrc}
-                alt={siteConfig.name}
-                width={32}
-                height={32}
-                style={{ animationDuration: '10s' }}
-                className="object-contain max-h-8 ml-[10.5px] animate-spin motion-reduce:animate-none"
-            />
+            <FaviconEverWorkImage config={configProps} className="ml-[10.5px]" />
         </Link>
     );
 }

--- a/apps/web/src/components/logos/index.tsx
+++ b/apps/web/src/components/logos/index.tsx
@@ -60,8 +60,8 @@ export function LogoEverWork({
     priority = true,
     config: configProps,
 }: LogoEverWorkProps) {
-    const siteConfig = getSiteConfig(configProps);
-    const logoHref = siteConfig.website || '/';
+    // Derive only what this wrapper needs; LogoEverWorkImage derives its own.
+    const logoHref = getSiteConfig(configProps).website || '/';
 
     return (
         <Link href={logoHref} className={cn('relative flex items-center', className)}>


### PR DESCRIPTION
## Summary

EW-660 Phase 8 (#1062) regressed the top-left sidebar:

- The **spinning Ever Works favicon disappeared** (pre-EW-660 it sat to the left of the wordmark; the new switcher only rendered the bare wordmark in the zero-org case).
- The **logo block was misaligned** — the `-ml-2` from the dual `[favicon][logo]` layout was carried over but no longer matched the single-element layout.
- The **organization popover was unreachable** when the user had zero Organizations — clicking the area did nothing, so users couldn't even reach "+ Create Organization" without first going elsewhere.

This PR restores the spinning favicon and makes the popover always reachable.

### Behaviour

| State | Trigger renders | Popover |
| --- | --- | --- |
| 0 orgs | spinning favicon + Ever Works wordmark + chevron | "+ Create Organization" |
| 1+ orgs | spinning favicon + active-org name + chevron | org list (with Check on active) + "+ Create Organization" |

The first-org create flow still chains into the existing `UpgradeOrCreateDialog` for the convert-account-to-Organization branch.

### Changes

- `components/logos/index.tsx` — extract `LogoEverWorkImage` and `FaviconEverWorkImage` (image-only, no `<Link>` wrapper) so they can be nested inside a `<button>` (the dropdown trigger) without invalid `<a>`-in-`<button>` HTML. The existing Link-wrapped exports keep working unchanged for callers outside the trigger.
- `components/layout/WorkspaceSwitcher.tsx` — single dropdown trigger that always shows `[favicon][label][chevron]`. Label is the active org name (when any orgs exist) or the wordmark (when zero). Popover always offers "+ Create Organization"; lists orgs above it when any exist.
- `components/dashboard/DashboardSidebar.tsx` — drop the `-ml-2` wrapper that was making the new single-element layout look misaligned.
- `components/layout/WorkspaceSwitcher.unit.spec.tsx` — update assertions for the new always-on trigger; add a test that "+ Create Organization" is reachable from the zero-org state.

## Test plan

- [x] `pnpm -F ever-works-web type-check` clean
- [x] `pnpm -F ever-works-web exec vitest run src/components/layout/WorkspaceSwitcher.unit.spec.tsx` — 5/5 passing
- [x] Prettier clean on changed files
- [ ] Manual: open expanded sidebar in zero-org state → favicon spins, click row → popover opens with "+ Create Organization"
- [ ] Manual: open expanded sidebar with 1+ orgs → favicon spins, active org name shown, popover lists orgs + "+ Create Organization"
- [ ] Manual: collapsed sidebar still renders only the favicon (unchanged)

Refs: EW-660 · regression introduced in #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace switcher now displays properly even when no organizations are available, showing logo and creation option.

* **Bug Fixes**
  * Improved workspace switcher behavior and layout consistency across different states.

* **Style**
  * Updated sidebar branding area layout and logo display styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->