### PR TITLE
docs: document the autonomous-workforce platform (Agents, Email, KB, Store/Company, Desktop, Founder Journey)

### DIFF
--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -48,8 +48,16 @@ const sidebars: SidebarsConfig = {
 				'features/creating-a-work',
 				'features/missions',
 				'features/ideas',
+				'features/agents',
+				'features/agent-email',
 				'features/mission-templates',
 				'features/budgets-and-usage',
+				'features/knowledge-base',
+				'features/autonomous-operation',
+				'features/workers',
+				'features/store-builder',
+				'features/company-builder',
+				'features/desktop-app',
 				'features/community-pr-processing',
 				'features/work-changelog',
 				'features/collections',
@@ -65,10 +73,16 @@ const sidebars: SidebarsConfig = {
 				'features/taxonomy-system',
 				'features/api-keys',
 				'features/custom-domains',
+				'features/website-templates',
 				'features/k8s-deployment',
 				'features/mcp-server',
 				'features/data-management'
 			]
+		},
+		{
+			type: 'category',
+			label: 'Guides',
+			items: ['guides/founder-journey']
 		},
 		{
 			type: 'category',

--- a/docs/features/agent-email.md
+++ b/docs/features/agent-email.md
@@ -1,0 +1,80 @@
+---
+id: agent-email
+title: Agent Email & Inboxes
+sidebar_label: Agent Email & Inboxes
+---
+
+# Agent Email & Inboxes
+
+Real employees have email addresses. So do Ever Works [Agents](./agents.md). Any Agent — and any [Mission](./missions.md), [Idea](./ideas.md), or [Work](./creating-a-work.md) — can be given one or more **inbound and outbound mailboxes**, so your AI workforce can send updates, receive replies, and turn incoming mail into work, without a human in the loop.
+
+This turns email from a thing the platform occasionally *sends* (password resets, alerts) into a first-class, two-way channel your Agents live on.
+
+## What you can do
+
+- **Give an Agent a real "from" address** so its standups, summaries, and outreach land in inboxes looking like they came from a person, not a no-reply.
+- **Receive email** on an address and route it straight into a Task (or an ongoing conversation) that the right Agent picks up.
+- **Connect mailboxes to a Mission, Idea, or Work** — e.g. `support@` feeds a support-triage Agent on your store Work; `press@` feeds your company Mission.
+- **Let Agents email each other** as a parallel channel to tasks — a clean "send a message to a peer Agent" verb.
+- **Match commit identity** — when an Agent commits to a Work's repo, the commit author email matches its assigned address.
+
+## Tenant email addresses
+
+Register addresses once under **Settings → Integrations → Email Addresses**:
+
+- **Outbound addresses** — each has an address, a provider, an optional from-name, a verified flag, and a per-address spend rollup.
+- **Inbound addresses** — same, plus a routing rule (a pattern over subject/from that decides which Mission/Idea/Work/Task the mail lands in).
+- **Add-address wizard** — pick direction (Outbound / Inbound / Both), pick a provider, enter the address and provider settings, then verify (a confirmation email outbound; a test email inbound).
+
+Addresses are backed by **Email Provider plugins**, enabled and configured per tenant exactly like AI providers:
+
+| Provider | Direction |
+|---|---|
+| Mailchimp Transactional (Mandrill) | Outbound + Inbound |
+| Mailgun | Outbound + Inbound |
+| Postmark | Outbound + Inbound |
+| Sendgrid | Outbound + Inbound |
+| Resend | Outbound |
+| `local-smtp` (dev / self-host) | Outbound |
+
+Because providers are pluggable, you get **failover**: drain traffic from one provider to another on the same address without touching any Agent's configuration.
+
+## Assigning mailboxes to an Agent
+
+On an Agent's detail page, the **Identity** section has an **Email addresses** panel:
+
+- **Outbound** — one default (what `from:` resolves to) plus any number of additional addresses.
+- **Inbound** — zero or more addresses whose incoming mail dispatches work to this Agent.
+
+Both are searchable pickers over your registered tenant addresses.
+
+## How inbound mail becomes work
+
+When mail arrives on an Agent's inbound address, the platform verifies the provider's webhook signature, decodes it into a canonical message, stores it, and dispatches it. Each inbound assignment runs in one of two modes:
+
+```mermaid
+flowchart LR
+    Email[Inbound email] --> D{Assignment mode}
+    D -->|task-spawn| T[Create or join a Task<br/>Agent processes it]
+    D -->|conversation| C[Append to an email thread<br/>Agent replies in dialogue]
+```
+
+- **`task-spawn`** (default) — each message creates or joins a [Task](../api/tasks.md). The subject can carry a Task slug like `[ACME-123]` to thread into an existing one; otherwise a fresh Task is created with the email as its body. The assigned Agent then works the Task like any other.
+- **`conversation`** — messages append to an ongoing thread and the Agent replies in dialogue, with no new Task created. Use this for back-and-forth that isn't a discrete unit of work ("FYI, the deploy finished").
+
+## Agents sending email
+
+An Agent gets a `sendEmail` tool when it has an outbound address assigned **and** `canCallExternalTools` is on. A higher-level `messageAgent` tool lets one Agent message another by name — the platform resolves the peer's inbound address and routes the message into conversation mode. Every send records usage against the Agent (and the Task, if any) so spend rollups work automatically, and writes an `EMAIL_SENT` entry to the activity log.
+
+Outbound bodies can be authored as plain text/HTML or rendered from **React-Email templates** (server-side), and an in-app **composer** offers a rich editor with a live preview and a template picker.
+
+## Why email, not just tasks?
+
+Tasks are units of *work* with a lifecycle. Email is the universal addressing scheme: an Agent reachable by email is reachable by humans, by external systems, by webhooks, and by other AI agents — without bespoke integration. Both coexist; you pick the right one per interaction.
+
+## See also
+
+- [Agents (Your AI Employees)](./agents.md)
+- [Missions](./missions.md) · [Creating a Work](./creating-a-work.md)
+- [Autonomous Operation](./autonomous-operation.md)
+- API reference: [Mail](../api/mail.md), [Email Templates](../api/email-templates.md), [Tasks](../api/tasks.md)

--- a/docs/features/agent-email.md
+++ b/docs/features/agent-email.md
@@ -8,7 +8,7 @@ sidebar_label: Agent Email & Inboxes
 
 Real employees have email addresses. So do Ever Works [Agents](./agents.md). Any Agent — and any [Mission](./missions.md), [Idea](./ideas.md), or [Work](./creating-a-work.md) — can be given one or more **inbound and outbound mailboxes**, so your AI workforce can send updates, receive replies, and turn incoming mail into work, without a human in the loop.
 
-This turns email from a thing the platform occasionally *sends* (password resets, alerts) into a first-class, two-way channel your Agents live on.
+This turns email from a thing the platform occasionally _sends_ (password resets, alerts) into a first-class, two-way channel your Agents live on.
 
 ## What you can do
 
@@ -28,14 +28,14 @@ Register addresses once under **Settings → Integrations → Email Addresses**:
 
 Addresses are backed by **Email Provider plugins**, enabled and configured per tenant exactly like AI providers:
 
-| Provider | Direction |
-|---|---|
+| Provider                           | Direction          |
+| ---------------------------------- | ------------------ |
 | Mailchimp Transactional (Mandrill) | Outbound + Inbound |
-| Mailgun | Outbound + Inbound |
-| Postmark | Outbound + Inbound |
-| Sendgrid | Outbound + Inbound |
-| Resend | Outbound |
-| `local-smtp` (dev / self-host) | Outbound |
+| Mailgun                            | Outbound + Inbound |
+| Postmark                           | Outbound + Inbound |
+| Sendgrid                           | Outbound + Inbound |
+| Resend                             | Outbound           |
+| `local-smtp` (dev / self-host)     | Outbound           |
 
 Because providers are pluggable, you get **failover**: drain traffic from one provider to another on the same address without touching any Agent's configuration.
 
@@ -70,7 +70,7 @@ Outbound bodies can be authored as plain text/HTML or rendered from **React-Emai
 
 ## Why email, not just tasks?
 
-Tasks are units of *work* with a lifecycle. Email is the universal addressing scheme: an Agent reachable by email is reachable by humans, by external systems, by webhooks, and by other AI agents — without bespoke integration. Both coexist; you pick the right one per interaction.
+Tasks are units of _work_ with a lifecycle. Email is the universal addressing scheme: an Agent reachable by email is reachable by humans, by external systems, by webhooks, and by other AI agents — without bespoke integration. Both coexist; you pick the right one per interaction.
 
 ## See also
 

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -14,12 +14,12 @@ If a [Work](./creating-a-work.md) is the thing being built and a [Mission](./mis
 
 Ever Works ships with two complementary layers:
 
-| Layer | What it is | When it runs |
-|---|---|---|
-| **Work Agent** (built-in) | The platform-managed engine that turns a Goal into [Ideas](./ideas.md) and Ideas into Works. Zero setup. | Always available — the default zero-friction path. |
-| **Agents** (you define) | Named specialists you create, scope, and give a personality, a budget, and a schedule. | Optional, advanced — for users who want a standing team. |
+| Layer                     | What it is                                                                                               | When it runs                                             |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Work Agent** (built-in) | The platform-managed engine that turns a Goal into [Ideas](./ideas.md) and Ideas into Works. Zero setup. | Always available — the default zero-friction path.       |
+| **Agents** (you define)   | Named specialists you create, scope, and give a personality, a budget, and a schedule.                   | Optional, advanced — for users who want a standing team. |
 
-The Work Agent stays the easy on-ramp. User-defined Agents are the layer you reach for when you want a *standing organization* — a CEO that keeps every Mission on-roadmap, a Researcher that files findings every morning, a Reviewer that triages incoming community PRs.
+The Work Agent stays the easy on-ramp. User-defined Agents are the layer you reach for when you want a _standing organization_ — a CEO that keeps every Mission on-roadmap, a Researcher that files findings every morning, a Reviewer that triages incoming community PRs.
 
 ## What an Agent has
 
@@ -56,26 +56,26 @@ Ready-made Agent definitions (CEO, CTO, and more) ship as templates from the [`e
 
 An Agent's brain is five files, stored in the **scope's Git repo** (the Mission repo for Mission-scoped Agents, the Work's data repo for Work-scoped Agents) so you own and version everything:
 
-| File | Purpose |
-|---|---|
-| `SOUL.md` | Who the Agent is — personality, principles, voice. |
-| `AGENTS.md` | Operating instructions and house rules. |
-| `HEARTBEAT.md` | What to do on a scheduled tick. |
-| `TOOLS.md` | Which tools the Agent leans on. |
-| `agent.yml` | Metadata (provider, idle behavior, avatar, …). |
+| File           | Purpose                                            |
+| -------------- | -------------------------------------------------- |
+| `SOUL.md`      | Who the Agent is — personality, principles, voice. |
+| `AGENTS.md`    | Operating instructions and house rules.            |
+| `HEARTBEAT.md` | What to do on a scheduled tick.                    |
+| `TOOLS.md`     | Which tools the Agent leans on.                    |
+| `agent.yml`    | Metadata (provider, idle behavior, avatar, …).     |
 
 Tenant-scoped Agents with no control repo keep these inline in the database and serve them through the same API. You edit them in the Agent's **Instructions** tab (a five-tab markdown editor with autosave). The platform never auto-rewrites them — an Agent can only edit its own files, and only when `canEditAgentFiles` is on.
 
 ## Heartbeats — what an Agent does on an idle tick
 
-Set a `heartbeatCadence` (a cron expression, or `manual`) and the Agent wakes on schedule. Even with nothing assigned, a heartbeat is **not** a no-op — the Agent is asked *"What's the next action you should take? Choose ONE."* and may:
+Set a `heartbeatCadence` (a cron expression, or `manual`) and the Agent wakes on schedule. Even with nothing assigned, a heartbeat is **not** a no-op — the Agent is asked _"What's the next action you should take? Choose ONE."_ and may:
 
 - **Create a task** (self-assigned or assigned to another Agent in scope),
 - **Comment on an open task** it's part of,
 - **Edit one of its own definition files** to capture a learning, or
 - **Observe** the current state and do nothing this tick.
 
-This is the loop that makes Ever Works *keep going*. Tune it per Agent with `agent.yml`'s `idleBehavior: propose | observe | noop`.
+This is the loop that makes Ever Works _keep going_. Tune it per Agent with `agent.yml`'s `idleBehavior: propose | observe | noop`.
 
 ## Memory
 
@@ -113,7 +113,7 @@ A **dry-run** mode (`POST /agents/:id/dry-run`) builds the prompt and estimates 
 4. Choose a scope — Tenant for a company-wide role, or a specific Mission/Idea/Work.
 5. Create it (starts in `draft`), then open the **Dashboard** tab and click **Start**, optionally setting a heartbeat cadence and budget.
 
-You can also drive everything from the in-app AI Chat or any MCP client — *"Create a CEO agent for my company mission and run it daily."*
+You can also drive everything from the in-app AI Chat or any MCP client — _"Create a CEO agent for my company mission and run it daily."_
 
 ## See also
 

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -1,0 +1,125 @@
+---
+id: agents
+title: Agents (Your AI Employees)
+sidebar_label: Agents
+---
+
+# Agents (Your AI Employees)
+
+An **Agent** is a named, persistent AI worker you create inside Ever Works — a "CEO", a "VP of Engineering", a "Researcher", a "PR Reviewer". Agents are how Ever Works stops being a one-shot builder and starts behaving like a team that keeps working: they run on a schedule, react to tasks, write content, improve code, and hand work to each other — 24/7, on the Missions, Ideas, and Works you give them.
+
+If a [Work](./creating-a-work.md) is the thing being built and a [Mission](./missions.md) is the goal, an **Agent is the worker** that pushes both forward when you're not watching.
+
+## The Work Agent vs. your own Agents
+
+Ever Works ships with two complementary layers:
+
+| Layer | What it is | When it runs |
+|---|---|---|
+| **Work Agent** (built-in) | The platform-managed engine that turns a Goal into [Ideas](./ideas.md) and Ideas into Works. Zero setup. | Always available — the default zero-friction path. |
+| **Agents** (you define) | Named specialists you create, scope, and give a personality, a budget, and a schedule. | Optional, advanced — for users who want a standing team. |
+
+The Work Agent stays the easy on-ramp. User-defined Agents are the layer you reach for when you want a *standing organization* — a CEO that keeps every Mission on-roadmap, a Researcher that files findings every morning, a Reviewer that triages incoming community PRs.
+
+## What an Agent has
+
+Every Agent carries:
+
+- **An identity** — a `name`, an optional `title`, and a `capabilities` description that says what it's for.
+- **A scope** — exactly one of **Tenant**, **Mission**, **Idea**, or **Work**. Scope decides where the Agent shows up and what it's allowed to act on.
+- **A provider + model** — defaults to your account default; override per Agent.
+- **A heartbeat** — an optional cron cadence so the Agent wakes up and decides what to do next, even with nothing assigned.
+- **A budget** — a per-Agent spend cap (hourly / daily / weekly / monthly / unlimited) enforced before every AI call.
+- **A permission set** — granular flags (`canAssignTasks`, `canEditAgentFiles`, `canCommitToRepo`, `canCreateAgents`, `canCallExternalTools`, …) that gate what tools the Agent may call. Every flag defaults to `false`.
+- **An avatar** — initials, a curated icon, or an uploaded image.
+
+### Agent scope
+
+```mermaid
+flowchart TD
+    T[Tenant-scoped Agent<br/>e.g. CEO — available everywhere]
+    M[Mission-scoped Agent<br/>e.g. Catnip Researcher — one Mission]
+    I[Idea-scoped Agent<br/>scoped to a single Idea]
+    W[Work-scoped Agent<br/>e.g. Blog Editor — one Work]
+    T --> M --> I --> W
+```
+
+A **Tenant-scoped** Agent (like a CEO) is available across everything you own. A **Mission-scoped** Agent only appears inside that Mission. A **Work-scoped** Agent only acts on its one Work. An Agent can only create or assign work to scopes equal to or narrower than its own.
+
+## Agents as an organization
+
+Because Agents can create tasks for other Agents, you can model an actual company. A tenant-scoped **CEO** keeps the roadmap coherent; a **CTO** owns the technical Works; a **Lead Engineer** ships code; a **Researcher** feeds Ideas. They collaborate the way a real team does — through tasks and shared context, not magic.
+
+Ready-made Agent definitions (CEO, CTO, and more) ship as templates from the [`ever-works/agents`](https://github.com/ever-works/agents) repository, and [Mission Templates](./mission-templates.md) can pre-declare the Agents a Mission needs so a brand-new Mission arrives already staffed.
+
+## Agent definition files
+
+An Agent's brain is five files, stored in the **scope's Git repo** (the Mission repo for Mission-scoped Agents, the Work's data repo for Work-scoped Agents) so you own and version everything:
+
+| File | Purpose |
+|---|---|
+| `SOUL.md` | Who the Agent is — personality, principles, voice. |
+| `AGENTS.md` | Operating instructions and house rules. |
+| `HEARTBEAT.md` | What to do on a scheduled tick. |
+| `TOOLS.md` | Which tools the Agent leans on. |
+| `agent.yml` | Metadata (provider, idle behavior, avatar, …). |
+
+Tenant-scoped Agents with no control repo keep these inline in the database and serve them through the same API. You edit them in the Agent's **Instructions** tab (a five-tab markdown editor with autosave). The platform never auto-rewrites them — an Agent can only edit its own files, and only when `canEditAgentFiles` is on.
+
+## Heartbeats — what an Agent does on an idle tick
+
+Set a `heartbeatCadence` (a cron expression, or `manual`) and the Agent wakes on schedule. Even with nothing assigned, a heartbeat is **not** a no-op — the Agent is asked *"What's the next action you should take? Choose ONE."* and may:
+
+- **Create a task** (self-assigned or assigned to another Agent in scope),
+- **Comment on an open task** it's part of,
+- **Edit one of its own definition files** to capture a learning, or
+- **Observe** the current state and do nothing this tick.
+
+This is the loop that makes Ever Works *keep going*. Tune it per Agent with `agent.yml`'s `idleBehavior: propose | observe | noop`.
+
+## Memory
+
+- **Short-term** — the messages within a single run; not persisted.
+- **Long-term** — the five definition files, the durable, intentional store the Agent edits deliberately.
+- **Passive history** — recent activity, read on demand (not injected every tick, to save cost).
+- **Institutional context** — the per-Work [Knowledge Base](./knowledge-base.md): brand voice, legal copy, personas, research, glossary. Agents read from it on every run.
+
+Agents cannot read each other's definition files. Shared knowledge flows through **tasks**, **KB documents**, and the **activity log**.
+
+## Tasks, skills, and email
+
+- **Tasks** — Agents create, transition, comment on, and get assigned tasks. Mention an Agent in a task chat (`@ceo can you review this?`) and it replies within seconds. Tasks are the only channel for Agent-to-Agent collaboration, which gives every interaction an audit trail and attributes cost to the Agent that did the work.
+- **Skills** — reusable capabilities bound to an Agent or inherited from its scope, surfaced via the Skills tab.
+- **Email** — Agents can have their own inbound and outbound mailboxes. See **[Agent Email & Inboxes](./agent-email.md)**.
+
+## Budgets & guardrails
+
+Every Agent can have one budget row. Before any AI call, the platform checks the Agent's remaining headroom for the current interval and short-circuits the run if the cap is hit (logging `AGENT_BUDGET_EXCEEDED`). Repeated failures auto-pause an Agent so a misbehaving worker can't run away with your spend. See [Budgets & Usage](./budgets-and-usage.md).
+
+## The Agents workbench
+
+- **Sidebar → Agents** lists every Agent you own, with Cards/Table views and filters for status (`All / Active / Paused / Error`) and scope (`Tenant / Mission / Idea / Work`).
+- Each **Agent detail page** has six tabs: **Dashboard** (live status, run history, tasks, cost snapshot), **Activity**, **Instructions**, **Skills**, **Budgets**, and **Settings**.
+- Header actions: **Run heartbeat now**, **Assign Task**, **Pause / Resume**, **Archive**, **Delete**.
+- Work, Mission, and Idea detail pages each gain an **Agents** tab listing the Agents that can act on them.
+
+A **dry-run** mode (`POST /agents/:id/dry-run`) builds the prompt and estimates cost without calling the provider — handy while iterating on an Agent's instructions. You can also **export and import** an Agent as a JSON envelope to back it up, share it, or move it between scopes.
+
+## Creating an Agent
+
+1. Sidebar → **Agents** → **+ New Agent**.
+2. Give it a `name` and `title`, and describe its `capabilities`.
+3. Pick a provider/model (or keep your account default).
+4. Choose a scope — Tenant for a company-wide role, or a specific Mission/Idea/Work.
+5. Create it (starts in `draft`), then open the **Dashboard** tab and click **Start**, optionally setting a heartbeat cadence and budget.
+
+You can also drive everything from the in-app AI Chat or any MCP client — *"Create a CEO agent for my company mission and run it daily."*
+
+## See also
+
+- [Missions](./missions.md) · [Ideas](./ideas.md) · [Creating a Work](./creating-a-work.md)
+- [Agent Email & Inboxes](./agent-email.md)
+- [Knowledge Base](./knowledge-base.md)
+- [Autonomous Operation](./autonomous-operation.md)
+- [Budgets & Usage](./budgets-and-usage.md)
+- API reference: [Agents](../api/agents.md), [Tasks](../api/tasks.md), [Skills](../api/skills.md)

--- a/docs/features/autonomous-operation.md
+++ b/docs/features/autonomous-operation.md
@@ -1,0 +1,64 @@
+---
+id: autonomous-operation
+title: Autonomous Operation (24/7)
+sidebar_label: Autonomous Operation
+---
+
+# Autonomous Operation (24/7)
+
+Most AI builders generate a site once and stop. You get code, and then you're on your own — to write the content, keep it fresh, fix what breaks, market it, and grow it. **Ever Works keeps going.** Once you've pointed it at a [Mission](./missions.md) or shipped a [Work](./creating-a-work.md), the platform's [Agents](./agents.md) and background workers keep researching, writing, building, deploying, and improving — on a schedule, not just when you prompt.
+
+This is the difference between *"here's your code, figure out the rest"* and *"here's your working business that keeps getting better."* It's also the half of the product that the one-shot builders don't have.
+
+## What "keeps going" actually means
+
+| It keeps… | …by |
+|---|---|
+| **Adding content** | Scheduled generation writes new blog posts, finds and adds new directory items, refreshes stale entries. |
+| **Generating ideas** | A running Mission keeps proposing new [Ideas](./ideas.md) that ladder up to your goal. |
+| **Improving the build** | Agents open work on the code and content of a Work — fixes, new pages, new sections. |
+| **Researching** | Agents gather findings into the [Knowledge Base](./knowledge-base.md) so future runs are smarter. |
+| **Maintaining quality** | Scheduled updates re-run the pipeline; community PRs and item-source validation keep data accurate. |
+| **Deploying** | Every change is committed to Git and redeployed to your target automatically. |
+
+## The mechanisms
+
+Autonomy isn't one feature — it's several, working together:
+
+- **[Scheduled Updates](./scheduled-updates.md)** — re-run a Work's generation pipeline on a cadence (daily, weekly, your choice) to keep content current.
+- **Agent heartbeats** — each [Agent](./agents.md) wakes on its own cron, decides the single most useful next action, and takes it: create a task, advance one, write to the KB, or observe.
+- **Scheduled Missions** — a [Mission](./missions.md) can tick on a cadence, generating fresh Ideas each time as the world changes.
+- **Auto-build** — turn it on and accepted Ideas become Works without you clicking anything.
+- **Background workers** — the [Workers](./workers.md) layer runs all of this reliably in the background, in parallel, with retries.
+- **Community PR processing** — incoming contributions are triaged and merged into your data automatically.
+
+```mermaid
+flowchart LR
+    M[Mission ticks] --> I[New Ideas]
+    I -->|auto-build on| W[Works]
+    W --> S[Scheduled updates<br/>refresh content]
+    A[Agent heartbeats] --> W
+    A --> KB[Knowledge Base grows]
+    S --> D[Commit + redeploy]
+    A --> D
+```
+
+## You stay in control
+
+Autonomy is opt-in and bounded:
+
+- **Budgets at every level** — per-Work, per-Idea, per-Mission, per-Agent, and account-wide caps, soft (alert) or hard (block). See [Budgets & Usage](./budgets-and-usage.md).
+- **Guardrails** — max items per run, approval rules, outstanding-Ideas caps on Missions.
+- **Pause / Resume** — stop any Agent, Mission, or schedule instantly.
+- **Auto-pause on failure** — a worker that keeps erroring pauses itself rather than burning spend.
+- **Full audit trail** — every autonomous action emits activity-log entries and Git commits you can review and revert.
+
+## You own everything
+
+Because code and content both live in **your Git repositories**, autonomous operation never locks you in. Every blog post written overnight, every product added to a directory, every code change an Agent ships is a commit in a repo you own. Turn the platform off and your working business is still yours.
+
+## See also
+
+- [Missions](./missions.md) · [Ideas](./ideas.md) · [Agents](./agents.md)
+- [Scheduled Updates](./scheduled-updates.md) · [Workers](./workers.md)
+- [Knowledge Base & Memory](./knowledge-base.md) · [Budgets & Usage](./budgets-and-usage.md)

--- a/docs/features/autonomous-operation.md
+++ b/docs/features/autonomous-operation.md
@@ -8,18 +8,18 @@ sidebar_label: Autonomous Operation
 
 Most AI builders generate a site once and stop. You get code, and then you're on your own — to write the content, keep it fresh, fix what breaks, market it, and grow it. **Ever Works keeps going.** Once you've pointed it at a [Mission](./missions.md) or shipped a [Work](./creating-a-work.md), the platform's [Agents](./agents.md) and background workers keep researching, writing, building, deploying, and improving — on a schedule, not just when you prompt.
 
-This is the difference between *"here's your code, figure out the rest"* and *"here's your working business that keeps getting better."* It's also the half of the product that the one-shot builders don't have.
+This is the difference between _"here's your code, figure out the rest"_ and _"here's your working business that keeps getting better."_ It's also the half of the product that the one-shot builders don't have.
 
 ## What "keeps going" actually means
 
-| It keeps… | …by |
-|---|---|
-| **Adding content** | Scheduled generation writes new blog posts, finds and adds new directory items, refreshes stale entries. |
-| **Generating ideas** | A running Mission keeps proposing new [Ideas](./ideas.md) that ladder up to your goal. |
-| **Improving the build** | Agents open work on the code and content of a Work — fixes, new pages, new sections. |
-| **Researching** | Agents gather findings into the [Knowledge Base](./knowledge-base.md) so future runs are smarter. |
-| **Maintaining quality** | Scheduled updates re-run the pipeline; community PRs and item-source validation keep data accurate. |
-| **Deploying** | Every change is committed to Git and redeployed to your target automatically. |
+| It keeps…               | …by                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Adding content**      | Scheduled generation writes new blog posts, finds and adds new directory items, refreshes stale entries. |
+| **Generating ideas**    | A running Mission keeps proposing new [Ideas](./ideas.md) that ladder up to your goal.                   |
+| **Improving the build** | Agents open work on the code and content of a Work — fixes, new pages, new sections.                     |
+| **Researching**         | Agents gather findings into the [Knowledge Base](./knowledge-base.md) so future runs are smarter.        |
+| **Maintaining quality** | Scheduled updates re-run the pipeline; community PRs and item-source validation keep data accurate.      |
+| **Deploying**           | Every change is committed to Git and redeployed to your target automatically.                            |
 
 ## The mechanisms
 

--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -8,7 +8,7 @@ sidebar_label: Company Builder
 
 > **Status: coming soon.** Company is a planned scope, telegraphed today by the **Company** chip on the create surface. Its foundations — [Missions](./missions.md), [Agents](./agents.md) with Tenant scope, [Tenants & Organizations](../advanced/multi-tenancy.md) — are live. The company-registration integrations and the "company-as-a-business" surface are on the roadmap. This page describes the destination.
 
-The **Company Builder** is Ever Works' most ambitious shape: not a website, but the *organization that runs websites, stores, and everything else* — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
+The **Company Builder** is Ever Works' most ambitious shape: not a website, but the _organization that runs websites, stores, and everything else_ — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
 
 ## From idea to operating company
 
@@ -33,7 +33,7 @@ flowchart TD
 
 ## How it relates to Tenants & Organizations
 
-The Company Builder is the product-facing expression of the platform's [multi-tenancy](../advanced/multi-tenancy.md) foundation. An Organization is the container; a Company is what you *do* with it — register it, staff it with Agents, give it Works, and let it run.
+The Company Builder is the product-facing expression of the platform's [multi-tenancy](../advanced/multi-tenancy.md) foundation. An Organization is the container; a Company is what you _do_ with it — register it, staff it with Agents, give it Works, and let it run.
 
 ## You own the company's output
 

--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -1,0 +1,47 @@
+---
+id: company-builder
+title: Company Builder
+sidebar_label: Company Builder
+---
+
+# Company Builder
+
+> **Status: coming soon.** Company is a planned scope, telegraphed today by the **Company** chip on the create surface. Its foundations — [Missions](./missions.md), [Agents](./agents.md) with Tenant scope, [Tenants & Organizations](../advanced/multi-tenancy.md) — are live. The company-registration integrations and the "company-as-a-business" surface are on the roadmap. This page describes the destination.
+
+The **Company Builder** is Ever Works' most ambitious shape: not a website, but the *organization that runs websites, stores, and everything else* — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
+
+## From idea to operating company
+
+```mermaid
+flowchart TD
+    Goal[Your Mission<br/>'launch and run an AI-tools business'] --> Co[Company]
+    Co --> Reg[Register the legal entity]
+    Co --> Org[Staff it with Agents:<br/>CEO, CTO, Lead Engineer, Researcher]
+    Co --> Works[Spin up Works:<br/>marketing site, blog, directory, store]
+    Org --> Run[Everyone works 24/7]
+    Works --> Run
+    Run --> Grow[Content ships, ideas surface,<br/>the business keeps improving]
+```
+
+## What the Company Builder is planned to do
+
+- **Help you register the company** — guided incorporation through provider integrations (planned: Stripe Atlas and other formation/banking providers), so going from idea to a real legal entity is part of the flow, not a separate scramble.
+- **Staff it with an AI organization** — Tenant-scoped [Agents](./agents.md) for company-wide roles (CEO, CTO, Lead Engineer, Researcher, …), drawn from ready-made [templates](./mission-templates.md), each with its own mailbox, budget, and heartbeat.
+- **Spin up the Works the company needs** — a marketing site, a blog, a directory, a landing page, a [store](./store-builder.md) — each its own self-maintaining Work.
+- **Give the company a shared brain** — the [Knowledge Base](./knowledge-base.md) holds the company's brand, strategy, research, and decisions; org-level `legal`/`style`/`seo` policy is inherited by every Work.
+- **Run continuously** — the whole organization operates [autonomously](./autonomous-operation.md), under budgets and guardrails you set, with a full audit trail.
+
+## How it relates to Tenants & Organizations
+
+The Company Builder is the product-facing expression of the platform's [multi-tenancy](../advanced/multi-tenancy.md) foundation. An Organization is the container; a Company is what you *do* with it — register it, staff it with Agents, give it Works, and let it run.
+
+## You own the company's output
+
+Every site, every document, every line of code the company's Agents produce lives in **your Git repositories** and deploys to **your infrastructure**. The AI organization works for you; the assets are yours.
+
+## See also
+
+- [Missions](./missions.md) · [Agents](./agents.md) · [Mission Templates](./mission-templates.md)
+- [Store Builder](./store-builder.md) · [Knowledge Base](./knowledge-base.md)
+- [Tenants & Organizations](../advanced/multi-tenancy.md) · [Autonomous Operation](./autonomous-operation.md)
+- Guide: [The Founder Journey](../guides/founder-journey.md)

--- a/docs/features/desktop-app.md
+++ b/docs/features/desktop-app.md
@@ -1,0 +1,38 @@
+---
+id: desktop-app
+title: Desktop App
+sidebar_label: Desktop App
+---
+
+# Desktop App
+
+> **Status: coming soon.** The Desktop App is on the roadmap. Today you can run Ever Works in the cloud or self-host the full stack with Docker. This page describes where the local experience is headed.
+
+The **Desktop App** will let you run all of Ever Works **locally as a single application** — the API, the web dashboard, the [Workers](./workers.md), and the database, all bundled together. Install it, open it, and you have the entire platform on your own machine: build [Works](./creating-a-work.md), run [Agents](./agents.md), and operate [Missions](./missions.md) without depending on anyone else's servers.
+
+## What "all local" means
+
+- **Full stack in one app** — the API, frontend, background-jobs runtime, and database ship together. No separate services to wire up.
+- **Your data on your machine** — repositories, Knowledge Base, and configuration stay local by default.
+- **Works offline-first** — the platform keeps working without a constant connection to a cloud backend.
+
+## Local, but not isolated
+
+The Desktop App is designed to **connect outward** when you want it to:
+
+- Point it at an **external database** (managed Postgres, or your own server).
+- Use an **external background-jobs backend** (a hosted or self-hosted jobs service) instead of the bundled one.
+- Connect any **AI, search, deployment, storage, or email provider** through the same [plugin system](../plugin-system/index.md) the cloud uses.
+- Push your Works' code and content to **your Git provider** and deploy to **your targets**, exactly as in the cloud.
+
+So you can start fully local and selectively move pieces to the cloud as you grow — without changing how you work.
+
+## Why it matters
+
+The Desktop App is the strongest expression of the platform's ownership promise: **open source (AGPLv3), your machine, your data, your repositories.** It's Ever Works as a workshop that lives on your desk, not just in a browser tab.
+
+## See also
+
+- [Workers](./workers.md) · [Plugin System](../plugin-system/index.md)
+- [Installation](../installation.md) · [DevOps & Deployment](../devops/docker.md)
+- [Roadmap](../roadmap.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,27 +7,60 @@ sidebar_position: 1
 
 # Platform Features
 
-This section covers individual capabilities built into the Ever Works Platform beyond the core work CRUD and AI generation pipeline.
+Ever Works combines two things most tools keep separate: the **builder** that turns an idea into a shipped website, store, blog, or directory — and the **autonomous workforce** that keeps that thing researching, writing, improving, and growing 24/7. You set a goal; an AI organization runs it, with all code and content owned in your own Git.
 
-| Feature                                              | Description                                                                                               |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [Missions](./missions)                               | Long-running goals that spawn Ideas and optionally auto-build Works on a schedule                         |
-| [Ideas](./ideas)                                     | Proposed Works in the queue between "topic" and "finished website" — build, retry, dismiss, accept        |
-| [Mission Templates](./mission-templates)             | Pre-built Mission setups (cadence, guardrails, KB seed) you can fork via "Use this Template"              |
-| [Budgets & Usage](./budgets-and-usage)               | Per-Mission / per-Idea / per-Work / account-wide caps that gate AI spend before the bill arrives          |
-| [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI                       |
-| [Work Changelog](./work-changelog)                   | Track item, comparison, taxonomy, and community PR changes in a paginated work history timeline           |
-| [Collections](./collections)                         | Curate items into named groups like "Editor's Picks" or "Best for Beginners"                              |
-| [Item Source Validation](./item-source-validation)   | Validate whether item source URLs are both reachable and actually good sources for the item               |
-| [Scheduled Updates](./scheduled-updates)             | Re-run the AI generation pipeline on a recurring cadence to keep content fresh                            |
-| [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API                   |
-| [.works/works.yml Config](./works-config)            | Source-controlled work configuration in the data repo — used for onboarding existing repos and sync       |
-| [Work Import](./work-import)                         | Bootstrap a work from an existing data repo or Awesome List README                                        |
-| [Work Members](./work-members)                       | Invite collaborators with role-based access (Manager, Editor, Viewer)                                     |
-| [Comparisons](./comparisons)                         | Automatically generate A vs B comparison pages between work items with AI-powered research and scoring    |
-| [Advanced Prompts](./advanced-prompts)               | Customize AI behavior per-work with prompt overrides for each pipeline step                               |
-| [API Keys](./api-keys)                               | Generate long-lived API keys for programmatic access to the Ever Works API                                |
-| [Custom Domains](./custom-domains)                   | Assign your own domain name to a work's deployed website                                                  |
-| [Website Templates](./website-templates)             | Catalogue of base templates a Work's website can be generated from (Next.js / Astro, directory / general) |
-| [MCP Server](./mcp-server)                           | Expose the Ever Works API as tools for AI assistants like Claude                                          |
-| [Data Management](./data-management)                 | Export, import, and sync account data (works, items, plugins, secrets) with GitHub backup                 |
+This section covers the individual capabilities that make that possible, beyond the core work CRUD and AI generation pipeline.
+
+> New here? Read the [Platform Overview](../overview.md) for the big picture, or the [Founder Journey guide](../guides/founder-journey.md) for the Start → Build → Sell → Scale playbook that ties these features together.
+
+## The core loop
+
+| Feature | Description |
+| --- | --- |
+| [Missions](./missions) | Long-running goals that spawn Ideas and optionally auto-build Works on a schedule |
+| [Ideas](./ideas) | Proposed Works in the queue between "topic" and "finished website" — build, retry, dismiss, accept |
+| [Creating a Work](./creating-a-work) | The buildable unit — websites, blogs, directories, landing pages — created with AI, manually, or by import |
+| [Agents (AI Employees)](./agents) | Named, persistent AI workers you create, scope, schedule, and budget — your standing team |
+| [Agent Email & Inboxes](./agent-email) | Inbound + outbound mailboxes per Agent / Mission / Idea / Work — your AI team's email |
+| [Knowledge Base & Memory](./knowledge-base) | Per-Work, typed, Git-backed institutional context and long-term memory every run reads from |
+| [Autonomous Operation](./autonomous-operation) | How the platform keeps working 24/7 — the half one-shot builders don't have |
+| [Workers](./workers) | The background-execution engine that runs Agents, pipelines, and schedules in parallel |
+
+## Work types & templates
+
+| Feature | Description |
+| --- | --- |
+| [Website Templates](./website-templates) | Catalogue of base templates a Work's website is generated from (Next.js / Astro, directory / general) |
+| [Mission Templates](./mission-templates) | Pre-built Mission playbooks (cadence, guardrails, KB seed, pre-declared Agents) you fork via "Use this Template" |
+| [Store Builder](./store-builder) | _(Coming soon)_ eCommerce storefronts an AI team researches, stocks, writes, and optimizes |
+| [Company Builder](./company-builder) | _(Coming soon)_ Register and run a whole company, staffed by AI Agents, on top of the platform |
+| [Desktop App](./desktop-app) | _(Coming soon)_ Run the full stack locally as a single application |
+
+## Operating a Work
+
+| Feature | Description |
+| --- | --- |
+| [Budgets & Usage](./budgets-and-usage) | Per-Mission / per-Idea / per-Work / per-Agent / account-wide caps that gate AI spend before the bill arrives |
+| [Scheduled Updates](./scheduled-updates) | Re-run the AI generation pipeline on a recurring cadence to keep content fresh |
+| [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API |
+| [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI |
+| [Work Changelog](./work-changelog) | Track item, comparison, taxonomy, and community PR changes in a paginated work history timeline |
+| [Collections](./collections) | Curate items into named groups like "Editor's Picks" or "Best for Beginners" |
+| [Item Source Validation](./item-source-validation) | Validate whether item source URLs are both reachable and actually good sources for the item |
+| [Comparisons](./comparisons) | Automatically generate A vs B comparison pages between work items with AI-powered research and scoring |
+| [Advanced Prompts](./advanced-prompts) | Customize AI behavior per-work with prompt overrides for each pipeline step |
+| [Work Members](./work-members) | Invite collaborators with role-based access (Manager, Editor, Viewer) |
+
+## Configuration, data & access
+
+| Feature | Description |
+| --- | --- |
+| [.works/works.yml Config](./works-config) | Source-controlled work configuration in the data repo — used for onboarding existing repos and sync |
+| [Work Import](./work-import) | Bootstrap a work from an existing data repo or Awesome List README |
+| [Taxonomy System](./taxonomy-system) | Categories, tags, and structured classification across a Work's items |
+| [Git Operations](./git-operations) | How the platform reads and writes your Work's Git repositories |
+| [API Keys](./api-keys) | Generate long-lived API keys for programmatic access to the Ever Works API |
+| [Custom Domains](./custom-domains) | Assign your own domain name to a work's deployed website |
+| [K8s Deployment](./k8s-deployment) | Deploy a Work to a Kubernetes cluster |
+| [MCP Server](./mcp-server) | Expose the Ever Works API as tools for AI assistants like Claude |
+| [Data Management](./data-management) | Export, import, and sync account data (works, items, plugins, secrets) with GitHub backup |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,52 +15,52 @@ This section covers the individual capabilities that make that possible, beyond 
 
 ## The core loop
 
-| Feature | Description |
-| --- | --- |
-| [Missions](./missions) | Long-running goals that spawn Ideas and optionally auto-build Works on a schedule |
-| [Ideas](./ideas) | Proposed Works in the queue between "topic" and "finished website" — build, retry, dismiss, accept |
-| [Creating a Work](./creating-a-work) | The buildable unit — websites, blogs, directories, landing pages — created with AI, manually, or by import |
-| [Agents (AI Employees)](./agents) | Named, persistent AI workers you create, scope, schedule, and budget — your standing team |
-| [Agent Email & Inboxes](./agent-email) | Inbound + outbound mailboxes per Agent / Mission / Idea / Work — your AI team's email |
-| [Knowledge Base & Memory](./knowledge-base) | Per-Work, typed, Git-backed institutional context and long-term memory every run reads from |
-| [Autonomous Operation](./autonomous-operation) | How the platform keeps working 24/7 — the half one-shot builders don't have |
-| [Workers](./workers) | The background-execution engine that runs Agents, pipelines, and schedules in parallel |
+| Feature                                        | Description                                                                                                |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [Missions](./missions)                         | Long-running goals that spawn Ideas and optionally auto-build Works on a schedule                          |
+| [Ideas](./ideas)                               | Proposed Works in the queue between "topic" and "finished website" — build, retry, dismiss, accept         |
+| [Creating a Work](./creating-a-work)           | The buildable unit — websites, blogs, directories, landing pages — created with AI, manually, or by import |
+| [Agents (AI Employees)](./agents)              | Named, persistent AI workers you create, scope, schedule, and budget — your standing team                  |
+| [Agent Email & Inboxes](./agent-email)         | Inbound + outbound mailboxes per Agent / Mission / Idea / Work — your AI team's email                      |
+| [Knowledge Base & Memory](./knowledge-base)    | Per-Work, typed, Git-backed institutional context and long-term memory every run reads from                |
+| [Autonomous Operation](./autonomous-operation) | How the platform keeps working 24/7 — the half one-shot builders don't have                                |
+| [Workers](./workers)                           | The background-execution engine that runs Agents, pipelines, and schedules in parallel                     |
 
 ## Work types & templates
 
-| Feature | Description |
-| --- | --- |
-| [Website Templates](./website-templates) | Catalogue of base templates a Work's website is generated from (Next.js / Astro, directory / general) |
+| Feature                                  | Description                                                                                                      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [Website Templates](./website-templates) | Catalogue of base templates a Work's website is generated from (Next.js / Astro, directory / general)            |
 | [Mission Templates](./mission-templates) | Pre-built Mission playbooks (cadence, guardrails, KB seed, pre-declared Agents) you fork via "Use this Template" |
-| [Store Builder](./store-builder) | _(Coming soon)_ eCommerce storefronts an AI team researches, stocks, writes, and optimizes |
-| [Company Builder](./company-builder) | _(Coming soon)_ Register and run a whole company, staffed by AI Agents, on top of the platform |
-| [Desktop App](./desktop-app) | _(Coming soon)_ Run the full stack locally as a single application |
+| [Store Builder](./store-builder)         | _(Coming soon)_ eCommerce storefronts an AI team researches, stocks, writes, and optimizes                       |
+| [Company Builder](./company-builder)     | _(Coming soon)_ Register and run a whole company, staffed by AI Agents, on top of the platform                   |
+| [Desktop App](./desktop-app)             | _(Coming soon)_ Run the full stack locally as a single application                                               |
 
 ## Operating a Work
 
-| Feature | Description |
-| --- | --- |
-| [Budgets & Usage](./budgets-and-usage) | Per-Mission / per-Idea / per-Work / per-Agent / account-wide caps that gate AI spend before the bill arrives |
-| [Scheduled Updates](./scheduled-updates) | Re-run the AI generation pipeline on a recurring cadence to keep content fresh |
-| [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API |
-| [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI |
-| [Work Changelog](./work-changelog) | Track item, comparison, taxonomy, and community PR changes in a paginated work history timeline |
-| [Collections](./collections) | Curate items into named groups like "Editor's Picks" or "Best for Beginners" |
-| [Item Source Validation](./item-source-validation) | Validate whether item source URLs are both reachable and actually good sources for the item |
-| [Comparisons](./comparisons) | Automatically generate A vs B comparison pages between work items with AI-powered research and scoring |
-| [Advanced Prompts](./advanced-prompts) | Customize AI behavior per-work with prompt overrides for each pipeline step |
-| [Work Members](./work-members) | Invite collaborators with role-based access (Manager, Editor, Viewer) |
+| Feature                                              | Description                                                                                                  |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [Budgets & Usage](./budgets-and-usage)               | Per-Mission / per-Idea / per-Work / per-Agent / account-wide caps that gate AI spend before the bill arrives |
+| [Scheduled Updates](./scheduled-updates)             | Re-run the AI generation pipeline on a recurring cadence to keep content fresh                               |
+| [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API                      |
+| [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI                          |
+| [Work Changelog](./work-changelog)                   | Track item, comparison, taxonomy, and community PR changes in a paginated work history timeline              |
+| [Collections](./collections)                         | Curate items into named groups like "Editor's Picks" or "Best for Beginners"                                 |
+| [Item Source Validation](./item-source-validation)   | Validate whether item source URLs are both reachable and actually good sources for the item                  |
+| [Comparisons](./comparisons)                         | Automatically generate A vs B comparison pages between work items with AI-powered research and scoring       |
+| [Advanced Prompts](./advanced-prompts)               | Customize AI behavior per-work with prompt overrides for each pipeline step                                  |
+| [Work Members](./work-members)                       | Invite collaborators with role-based access (Manager, Editor, Viewer)                                        |
 
 ## Configuration, data & access
 
-| Feature | Description |
-| --- | --- |
+| Feature                                   | Description                                                                                         |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | [.works/works.yml Config](./works-config) | Source-controlled work configuration in the data repo — used for onboarding existing repos and sync |
-| [Work Import](./work-import) | Bootstrap a work from an existing data repo or Awesome List README |
-| [Taxonomy System](./taxonomy-system) | Categories, tags, and structured classification across a Work's items |
-| [Git Operations](./git-operations) | How the platform reads and writes your Work's Git repositories |
-| [API Keys](./api-keys) | Generate long-lived API keys for programmatic access to the Ever Works API |
-| [Custom Domains](./custom-domains) | Assign your own domain name to a work's deployed website |
-| [K8s Deployment](./k8s-deployment) | Deploy a Work to a Kubernetes cluster |
-| [MCP Server](./mcp-server) | Expose the Ever Works API as tools for AI assistants like Claude |
-| [Data Management](./data-management) | Export, import, and sync account data (works, items, plugins, secrets) with GitHub backup |
+| [Work Import](./work-import)              | Bootstrap a work from an existing data repo or Awesome List README                                  |
+| [Taxonomy System](./taxonomy-system)      | Categories, tags, and structured classification across a Work's items                               |
+| [Git Operations](./git-operations)        | How the platform reads and writes your Work's Git repositories                                      |
+| [API Keys](./api-keys)                    | Generate long-lived API keys for programmatic access to the Ever Works API                          |
+| [Custom Domains](./custom-domains)        | Assign your own domain name to a work's deployed website                                            |
+| [K8s Deployment](./k8s-deployment)        | Deploy a Work to a Kubernetes cluster                                                               |
+| [MCP Server](./mcp-server)                | Expose the Ever Works API as tools for AI assistants like Claude                                    |
+| [Data Management](./data-management)      | Export, import, and sync account data (works, items, plugins, secrets) with GitHub backup           |

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -6,7 +6,7 @@ sidebar_label: Knowledge Base & Memory
 
 # Knowledge Base & Memory
 
-Every [Work](./creating-a-work.md) in Ever Works has its own **Knowledge Base (KB)** — a structured, typed, Git-backed store of institutional context: brand voice, legal copy, SEO conventions, glossary, competitor lists, audience personas, prior research, and the artifacts your [Agents](./agents.md) produce. It's the memory that makes the "maintain" half of *research → generate → deploy → maintain* mean something. Without it, every scheduled run starts from a blank prompt; with it, the runtime accumulates a durable, owned understanding of what your business actually is.
+Every [Work](./creating-a-work.md) in Ever Works has its own **Knowledge Base (KB)** — a structured, typed, Git-backed store of institutional context: brand voice, legal copy, SEO conventions, glossary, competitor lists, audience personas, prior research, and the artifacts your [Agents](./agents.md) produce. It's the memory that makes the "maintain" half of _research → generate → deploy → maintain_ mean something. Without it, every scheduled run starts from a blank prompt; with it, the runtime accumulates a durable, owned understanding of what your business actually is.
 
 This is the built-in equivalent of an internal wiki and a long-term memory layer — owned by you, versioned in Git, and read by every pipeline automatically.
 
@@ -14,18 +14,18 @@ This is the built-in equivalent of an internal wiki and a long-term memory layer
 
 A **KB document** is one piece of institutional context. Each has a markdown body, a metadata sidecar, a hierarchical path, a class, tags, and a status. Documents are **typed** by class, and the class drives how Agents use the document:
 
-| Class | How Agents treat it |
-|---|---|
-| `brand` | Soft guidance — "follow these brand guidelines". |
-| `legal` | Verbatim-or-omitted — copied exactly, never paraphrased. |
-| `seo` | Constraints — target keywords and structured-data patterns per page type. |
-| `glossary` | Term substitution — always use these terms, never invent synonyms. |
-| `competitors` | Inclusion / exclusion — drives comparisons and the do-not-mention rule. |
-| `personas` | Audience definitions — write for these readers. |
-| `style` | Editorial style guide — grammar, banned words, voice, tense. |
-| `research` | Reference material — retrieved opportunistically and cited. |
-| `output` | Agent-authored artifacts — reports, summaries, decks. |
-| `freeform` | Catch-all notes — retrieved by similarity or explicit mention. |
+| Class         | How Agents treat it                                                       |
+| ------------- | ------------------------------------------------------------------------- |
+| `brand`       | Soft guidance — "follow these brand guidelines".                          |
+| `legal`       | Verbatim-or-omitted — copied exactly, never paraphrased.                  |
+| `seo`         | Constraints — target keywords and structured-data patterns per page type. |
+| `glossary`    | Term substitution — always use these terms, never invent synonyms.        |
+| `competitors` | Inclusion / exclusion — drives comparisons and the do-not-mention rule.   |
+| `personas`    | Audience definitions — write for these readers.                           |
+| `style`       | Editorial style guide — grammar, banned words, voice, tense.              |
+| `research`    | Reference material — retrieved opportunistically and cited.               |
+| `output`      | Agent-authored artifacts — reports, summaries, decks.                     |
+| `freeform`    | Catch-all notes — retrieved by similarity or explicit mention.            |
 
 ## Git-backed, two-layer storage
 
@@ -72,7 +72,7 @@ Agents never read the binary original — they read the clean extract.
 
 The KB is exposed over REST, the [MCP server](./mcp-server.md) (`kb.list`, `kb.read`, `kb.search`, `kb.create`, `kb.update`, `kb.upload`), and the CLI (`ever works kb …`), so external Claude / GPT / Gemini sessions and scripts can read and write it with the same access controls.
 
-> **Built-in, with room to extend.** Memory, wiki, and knowledge management ship *inside* Ever Works as first-class features rather than something you bolt on. Where you want to connect an external knowledge or memory system (for example, an OpenHuman-style memory/wiki layer), that arrives as a plugin alongside these built-ins — additive, never a replacement.
+> **Built-in, with room to extend.** Memory, wiki, and knowledge management ship _inside_ Ever Works as first-class features rather than something you bolt on. Where you want to connect an external knowledge or memory system (for example, an OpenHuman-style memory/wiki layer), that arrives as a plugin alongside these built-ins — additive, never a replacement.
 
 ## See also
 

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -72,7 +72,7 @@ Agents never read the binary original — they read the clean extract.
 
 The KB is exposed over REST, the [MCP server](./mcp-server.md) (`kb.list`, `kb.read`, `kb.search`, `kb.create`, `kb.update`, `kb.upload`), and the CLI (`ever works kb …`), so external Claude / GPT / Gemini sessions and scripts can read and write it with the same access controls.
 
-> **Built-in, with room to extend.** Memory, wiki, and knowledge management ship _inside_ Ever Works as first-class features rather than something you bolt on. Where you want to connect an external knowledge or memory system (for example, an OpenHuman-style memory/wiki layer), that arrives as a plugin alongside these built-ins — additive, never a replacement.
+> **Built-in, with room to extend.** Memory, wiki, and knowledge management ship _inside_ Ever Works as first-class features rather than something you bolt on. Where you want to connect an external knowledge or memory system, that arrives as a plugin alongside these built-ins — additive, never a replacement.
 
 ## See also
 

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -1,0 +1,81 @@
+---
+id: knowledge-base
+title: Knowledge Base & Memory
+sidebar_label: Knowledge Base & Memory
+---
+
+# Knowledge Base & Memory
+
+Every [Work](./creating-a-work.md) in Ever Works has its own **Knowledge Base (KB)** — a structured, typed, Git-backed store of institutional context: brand voice, legal copy, SEO conventions, glossary, competitor lists, audience personas, prior research, and the artifacts your [Agents](./agents.md) produce. It's the memory that makes the "maintain" half of *research → generate → deploy → maintain* mean something. Without it, every scheduled run starts from a blank prompt; with it, the runtime accumulates a durable, owned understanding of what your business actually is.
+
+This is the built-in equivalent of an internal wiki and a long-term memory layer — owned by you, versioned in Git, and read by every pipeline automatically.
+
+## What lives in the KB
+
+A **KB document** is one piece of institutional context. Each has a markdown body, a metadata sidecar, a hierarchical path, a class, tags, and a status. Documents are **typed** by class, and the class drives how Agents use the document:
+
+| Class | How Agents treat it |
+|---|---|
+| `brand` | Soft guidance — "follow these brand guidelines". |
+| `legal` | Verbatim-or-omitted — copied exactly, never paraphrased. |
+| `seo` | Constraints — target keywords and structured-data patterns per page type. |
+| `glossary` | Term substitution — always use these terms, never invent synonyms. |
+| `competitors` | Inclusion / exclusion — drives comparisons and the do-not-mention rule. |
+| `personas` | Audience definitions — write for these readers. |
+| `style` | Editorial style guide — grammar, banned words, voice, tense. |
+| `research` | Reference material — retrieved opportunistically and cited. |
+| `output` | Agent-authored artifacts — reports, summaries, decks. |
+| `freeform` | Catch-all notes — retrieved by similarity or explicit mention. |
+
+## Git-backed, two-layer storage
+
+The KB lives in two synchronized places:
+
+- **The Work's Git data repository** under `.content/kb/` — one folder per class, each document a `<slug>.md` + `<slug>.yml` pair, plus an auto-maintained `.index.yml`. This is the durable, portable, diff-able source of truth that every downstream pipeline already reads.
+- **The database** — fast queries, search, locks, and audit metadata.
+
+Because the agent-readable layer is always in Git, you own it, you can inspect it, and nothing is locked in.
+
+## The workbench
+
+A dedicated page at **`/works/:id/kb`** gives you:
+
+- A two-pane tree — the **KB** (agent-readable extracts) and the **Originals** (your uploaded source files).
+- A center editor — a WYSIWYG markdown editor for `.md` documents, and inline viewers for PDFs, spreadsheets, video, and other originals.
+- An **AI side panel** scoped to the KB — `@mention` any document (`@kb:brand/voice`) to pin it into context; answers come back with citations.
+- A top bar with search and filters by class, tag, status, and lock state.
+
+## Ingest: drop a file, get usable knowledge
+
+Drop a PDF, Word doc, spreadsheet, image, video, or URL into the workbench and the platform:
+
+1. Stores the **original** verbatim in the Work's configured storage plugin (GitHub, S3, MinIO, local FS).
+2. Normalizes media (video → MP4, audio → MP3 + transcript) where needed.
+3. Runs the configured **content extractor** plugin to produce an agent-readable markdown extract.
+4. Classifies and tags it (you choose, or let the AI suggest), writes it into Git, and indexes it for retrieval.
+
+Agents never read the binary original — they read the clean extract.
+
+## How Agents use it
+
+- **Deterministic injection** — `brand`, `legal`, `glossary`, `style`, `personas`, and page-matched `seo` documents are injected into every relevant run, capped by a token budget with class-precedence truncation.
+- **Query-driven retrieval** — `research`, `freeform`, and `output` documents are retrieved by semantic similarity for the task at hand, and every use is recorded as a **citation** so you can audit exactly what context produced a given output.
+- **Agents write back** — research notes and generated artifacts land in the KB as `output`-class documents, under the same governance (locks, audit trail, Git history) as your own documents.
+
+## Locks, inheritance, and audit
+
+- **Per-document locks** (`full` or `additions-only`) protect a document from being changed by scheduled regeneration or Agent runs.
+- **Org-level inheritance** — `legal`, `style`, and `seo` documents can be published once at the organization level and inherited by every Work, with per-Work override. (See [Tenants & Organizations](../advanced/multi-tenancy.md).)
+- **Full audit** — every KB mutation flows through the activity log and Git history.
+
+## Reaching the KB from anywhere
+
+The KB is exposed over REST, the [MCP server](./mcp-server.md) (`kb.list`, `kb.read`, `kb.search`, `kb.create`, `kb.update`, `kb.upload`), and the CLI (`ever works kb …`), so external Claude / GPT / Gemini sessions and scripts can read and write it with the same access controls.
+
+> **Built-in, with room to extend.** Memory, wiki, and knowledge management ship *inside* Ever Works as first-class features rather than something you bolt on. Where you want to connect an external knowledge or memory system (for example, an OpenHuman-style memory/wiki layer), that arrives as a plugin alongside these built-ins — additive, never a replacement.
+
+## See also
+
+- [Agents (Your AI Employees)](./agents.md) · [Advanced Prompts](./advanced-prompts.md)
+- [Creating a Work](./creating-a-work.md) · [Autonomous Operation](./autonomous-operation.md)
+- [Data Management](./data-management.md) · [MCP Server](./mcp-server.md)

--- a/docs/features/store-builder.md
+++ b/docs/features/store-builder.md
@@ -1,0 +1,48 @@
+---
+id: store-builder
+title: Store Builder (eCommerce)
+sidebar_label: Store Builder
+---
+
+# Store Builder (eCommerce)
+
+> **Status: coming soon.** Stores are a planned [Work](./creating-a-work.md) type, telegraphed today by the **Store** chip on the create surface. The Mission → Idea → Work → Agents model below is live; the storefront generator and commerce integrations are on the roadmap. This page describes where it's going.
+
+A **Store** is a Work whose output is a working storefront — products, copy, categories, checkout — built from a commerce [template](./website-templates.md) and then *kept running* by your [Agents](./agents.md). The point isn't to hand you an empty shop. It's to research the catalog, write the product copy, populate the storefront, and keep optimizing it on a schedule. An AI workforce that's built to **act on your business, not just advise it**.
+
+## How a Store fits the model
+
+A Store is the same lifecycle as any other Work, pointed at commerce:
+
+```mermaid
+flowchart LR
+    M[Mission<br/>'run the best cat-toys store'] --> I[Idea<br/>'storefront for premium cat toys']
+    I --> W[Store Work<br/>built from a commerce template]
+    W --> R[Agents research products,<br/>write copy, set categories]
+    R --> O[Storefront deploys + keeps refreshing]
+```
+
+You can start a Store directly when you know exactly what you want, or let a [Mission](./missions.md) propose it as one of several Works needed for a bigger commerce goal.
+
+## What the Store builder is planned to do
+
+- **Research the catalog** — find products, suppliers, and pricing signals relevant to the store's niche, with sources recorded in the [Knowledge Base](./knowledge-base.md).
+- **Write the storefront** — product titles, descriptions, category pages, collection copy, and SEO metadata, on-brand via your KB.
+- **Populate and maintain inventory** — add new products as they're found, refresh descriptions, retire dead listings, keep stock data current.
+- **Run experiments** — propose and track A/B tests on copy, layout, and merchandising in an experiment notebook, so the storefront keeps improving on evidence, not guesses.
+- **Connect commerce + payments** — integrate storefront and checkout through provider plugins (planned: Stripe and other payment/commerce providers).
+- **Operate 24/7** — once live, the Store keeps refreshing content and acting on its own under your [budgets and guardrails](./budgets-and-usage.md). See [Autonomous Operation](./autonomous-operation.md).
+
+## Agents for a Store
+
+A Store can be staffed like a small commerce team: a **Merchandiser** Agent that curates the catalog, a **Copywriter** Agent that keeps product pages sharp, an **Analyst** Agent that reads experiment results and proposes the next test. They coordinate through tasks, all scoped to the Store Work. See [Agents](./agents.md).
+
+## You own the store
+
+As with every Work, the storefront's code and content live in **your Git repository** and deploy to **your target**. Nothing about your catalog, copy, or configuration is locked into the platform.
+
+## See also
+
+- [Creating a Work](./creating-a-work.md) · [Website Templates](./website-templates.md)
+- [Company Builder](./company-builder.md) · [Autonomous Operation](./autonomous-operation.md)
+- [Agents](./agents.md) · [Budgets & Usage](./budgets-and-usage.md)

--- a/docs/features/store-builder.md
+++ b/docs/features/store-builder.md
@@ -8,7 +8,7 @@ sidebar_label: Store Builder
 
 > **Status: coming soon.** Stores are a planned [Work](./creating-a-work.md) type, telegraphed today by the **Store** chip on the create surface. The Mission → Idea → Work → Agents model below is live; the storefront generator and commerce integrations are on the roadmap. This page describes where it's going.
 
-A **Store** is a Work whose output is a working storefront — products, copy, categories, checkout — built from a commerce [template](./website-templates.md) and then *kept running* by your [Agents](./agents.md). The point isn't to hand you an empty shop. It's to research the catalog, write the product copy, populate the storefront, and keep optimizing it on a schedule. An AI workforce that's built to **act on your business, not just advise it**.
+A **Store** is a Work whose output is a working storefront — products, copy, categories, checkout — built from a commerce [template](./website-templates.md) and then _kept running_ by your [Agents](./agents.md). The point isn't to hand you an empty shop. It's to research the catalog, write the product copy, populate the storefront, and keep optimizing it on a schedule. An AI workforce that's built to **act on your business, not just advise it**.
 
 ## How a Store fits the model
 

--- a/docs/features/workers.md
+++ b/docs/features/workers.md
@@ -8,20 +8,20 @@ sidebar_label: Workers
 
 **Workers** are the engine room behind everything that happens when you're not looking. They're the background-execution layer that runs your [Agents](./agents.md), generation pipelines, [scheduled updates](./scheduled-updates.md), and [Mission](./missions.md) ticks reliably, in parallel, with retries — so the platform's [autonomous operation](./autonomous-operation.md) keeps humming whether you have one Work or a hundred.
 
-You rarely manage Workers directly. They're the "who's actually doing the job" answer underneath the Agents and schedules you *do* manage.
+You rarely manage Workers directly. They're the "who's actually doing the job" answer underneath the Agents and schedules you _do_ manage.
 
 ## What Workers run
 
-| Job kind | What it does |
-|---|---|
-| **Agent heartbeats** | Wake each active Agent on its cadence, run its decision loop, record the run. |
-| **Agent tasks & chat replies** | Execute work assigned to an Agent; reply when an Agent is mentioned. |
-| **Generation pipelines** | Build and refresh a Work's content and code. |
-| **Scheduled updates** | Re-run a Work's pipeline on its cadence. |
-| **Mission ticks** | Generate fresh Ideas for scheduled Missions. |
-| **Inbound email** | Turn incoming mail into Tasks or conversations. |
-| **Ingest & extraction** | Normalize and extract uploaded Knowledge Base sources. |
-| **Community PR processing** | Triage and merge community contributions. |
+| Job kind                       | What it does                                                                  |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| **Agent heartbeats**           | Wake each active Agent on its cadence, run its decision loop, record the run. |
+| **Agent tasks & chat replies** | Execute work assigned to an Agent; reply when an Agent is mentioned.          |
+| **Generation pipelines**       | Build and refresh a Work's content and code.                                  |
+| **Scheduled updates**          | Re-run a Work's pipeline on its cadence.                                      |
+| **Mission ticks**              | Generate fresh Ideas for scheduled Missions.                                  |
+| **Inbound email**              | Turn incoming mail into Tasks or conversations.                               |
+| **Ingest & extraction**        | Normalize and extract uploaded Knowledge Base sources.                        |
+| **Community PR processing**    | Triage and merge community contributions.                                     |
 
 ## How Workers behave
 

--- a/docs/features/workers.md
+++ b/docs/features/workers.md
@@ -1,0 +1,42 @@
+---
+id: workers
+title: Workers (Background Execution)
+sidebar_label: Workers
+---
+
+# Workers (Background Execution)
+
+**Workers** are the engine room behind everything that happens when you're not looking. They're the background-execution layer that runs your [Agents](./agents.md), generation pipelines, [scheduled updates](./scheduled-updates.md), and [Mission](./missions.md) ticks reliably, in parallel, with retries — so the platform's [autonomous operation](./autonomous-operation.md) keeps humming whether you have one Work or a hundred.
+
+You rarely manage Workers directly. They're the "who's actually doing the job" answer underneath the Agents and schedules you *do* manage.
+
+## What Workers run
+
+| Job kind | What it does |
+|---|---|
+| **Agent heartbeats** | Wake each active Agent on its cadence, run its decision loop, record the run. |
+| **Agent tasks & chat replies** | Execute work assigned to an Agent; reply when an Agent is mentioned. |
+| **Generation pipelines** | Build and refresh a Work's content and code. |
+| **Scheduled updates** | Re-run a Work's pipeline on its cadence. |
+| **Mission ticks** | Generate fresh Ideas for scheduled Missions. |
+| **Inbound email** | Turn incoming mail into Tasks or conversations. |
+| **Ingest & extraction** | Normalize and extract uploaded Knowledge Base sources. |
+| **Community PR processing** | Triage and merge community contributions. |
+
+## How Workers behave
+
+- **Parallel** — many jobs run at once; a dispatcher claims due work in batches so thousands of Agents and schedules scale without stepping on each other.
+- **Safe under contention** — a single Agent's heartbeat can only be claimed by one Worker at a time (compare-and-set), so nothing runs twice.
+- **Retried** — transient failures (network blips, provider rate limits, upstream 5xx) are retried with backoff before a job is marked failed.
+- **Bounded** — runs have timeouts; an Agent that keeps failing auto-pauses rather than burning budget.
+- **Observable** — every run emits activity-log entries and surfaces on the relevant Dashboard, with cost attributed to the right Agent, Task, or Work.
+
+## Where they run
+
+Workers are powered by the platform's background-jobs infrastructure (Trigger.dev plus internal queues). In the cloud, this is fully managed for you. When you self-host — or run the upcoming [Desktop App](./desktop-app.md) — Workers run alongside the rest of the stack, and you can also point them at an external or self-hosted jobs backend.
+
+## See also
+
+- [Agents](./agents.md) · [Autonomous Operation](./autonomous-operation.md)
+- [Scheduled Updates](./scheduled-updates.md) · [Missions](./missions.md)
+- [Desktop App](./desktop-app.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -39,6 +39,60 @@ The overall classification system for a work, encompassing categories, tags, and
 
 A URL-friendly, human-readable identifier derived from an entity's name. Slugs are used in URLs instead of numeric IDs. For example, an item named "Visual Studio Code" might have the slug `visual-studio-code`. Slugs are unique within their scope (e.g., item slugs are unique per work).
 
+## Missions, Ideas, Agents & Autonomy
+
+### Mission
+
+An ambitious, ongoing goal that the platform keeps pursuing for you — bigger than any single website (e.g. "run the best cats business worldwide"). A Mission generates [Ideas](/features/ideas) and, optionally, auto-builds them into Works on a schedule. See [Missions](/features/missions).
+
+### Idea
+
+A one-shot proposal for a single Work — one Idea becomes one Work, then is marked done. Ideas can be suggested by the platform, added by you, or spawned by a Mission. Useful as a lightweight "plan" you can research before committing to a build. See [Ideas](/features/ideas).
+
+### Agent (AI Employee)
+
+A named, persistent, user-defined AI worker scoped to a Tenant, Mission, Idea, or Work — for example a "CEO", "CTO", or "Researcher". Distinct from the pipeline **Agent** below: this is a standing team member with its own identity files, provider, heartbeat schedule, budget, permissions, skills, tasks, and optional mailboxes. See [Agents](/features/agents).
+
+### Work Agent
+
+The built-in, platform-managed engine that turns a Goal into Ideas and Ideas into Works with zero setup. It is the default zero-friction path and stands alongside user-defined Agents.
+
+### Heartbeat
+
+An Agent's scheduled "what should I do next?" tick. On each heartbeat the Agent chooses one action — create a task, advance one, update its own instructions, or observe. The mechanism behind 24/7 [autonomous operation](/features/autonomous-operation).
+
+### Skill
+
+A reusable capability that can be bound to an Agent (or inherited from its scope), delivered through a skills-provider plugin. Skills extend what an Agent can do without changing core code.
+
+### Task
+
+A unit of work assigned to an Agent (or human), with a lifecycle and chat. Tasks are the canonical channel for Agent-to-Agent collaboration, giving every interaction an audit trail and correct cost attribution.
+
+### Knowledge Base (KB)
+
+A per-Work, typed, Git-backed store of institutional context — brand voice, legal copy, SEO conventions, glossary, competitors, personas, research, and agent outputs — that every generation run reads from. The platform's built-in memory and wiki layer. See [Knowledge Base](/features/knowledge-base).
+
+### Email Address / Inbox
+
+A tenant-registered email address (outbound, inbound, or both) backed by an email-provider plugin, assignable to an Agent / Mission / Idea / Work. Inbound mail becomes Tasks or conversations; outbound mail is sent by Agents. See [Agent Email & Inboxes](/features/agent-email).
+
+### Work Template / Mission Template
+
+A **Work Template** is the codebase a Work's website is generated from (the [website templates](/features/website-templates) catalog). A **Mission Template** is a curated playbook (docs, prompts, cadence, pre-declared Agents) for an ambitious goal. See [Mission Templates](/features/mission-templates).
+
+### Store / Company
+
+Planned [Work](/features/creating-a-work) shapes. A **Store** is a self-maintaining eCommerce storefront; a **Company** is a whole AI-staffed organization that runs Works toward a Mission. See [Store Builder](/features/store-builder) and [Company Builder](/features/company-builder).
+
+### Worker
+
+The background-execution layer (Trigger.dev plus internal queues) that runs Agent heartbeats, generation pipelines, scheduled updates, and Mission ticks in parallel, with retries. See [Workers](/features/workers).
+
+### Tenant / Organization
+
+The multi-tenancy containers that own addresses, Agents, Works, and inheritable KB policy. The foundation under the [Company Builder](/features/company-builder). See [Multi-Tenancy](/advanced/multi-tenancy).
+
 ## AI and Automation
 
 ### Pipeline

--- a/docs/guides/founder-journey.md
+++ b/docs/guides/founder-journey.md
@@ -1,0 +1,91 @@
+---
+id: founder-journey
+title: The Founder Journey — Start, Build, Sell, Scale
+sidebar_label: The Founder Journey
+---
+
+# The Founder Journey — Start, Build, Sell, Scale
+
+Most guides for founders are *just content* — articles that tell you what to do and leave you to do it. This one is different: every step maps to something Ever Works can actually **do for you**. Read it top to bottom as one playbook, or jump to the phase you're in. The four phases — **Start → Build → Sell → Scale** — line up with the platform's core building blocks: [Missions](../features/missions.md), [Ideas](../features/ideas.md), [Works](../features/creating-a-work.md), and [Agents](../features/agents.md).
+
+The mental model in one line: **you set the goal; an AI organization researches, builds, and runs the business toward it — 24/7, in your own Git.**
+
+```mermaid
+flowchart LR
+    Start --> Build --> Sell --> Scale
+    Start -.-> M[Mission + Ideas]
+    Build -.-> W[Works + Templates]
+    Sell -.-> Co[Store + Company + Agents]
+    Scale -.-> Auto[Autonomous Operation]
+```
+
+---
+
+## 1. Start — turn a goal into a plan
+
+You don't need a finished plan to begin. You need a **goal**.
+
+- **Define a [Mission](../features/missions.md).** A Mission is an ambitious, ongoing goal — *"run the best cats business worldwide,"* *"launch an AI-tools media company."* It's bigger than any one website, and Ever Works keeps pursuing it for you.
+- **Let Ideas come to you.** From a Mission, the platform generates [Ideas](../features/ideas.md): atomic, one-shot proposals (*"a directory of indie cat-toy brands," "a weekly cat-care blog"*). Add your own, accept the good ones, dismiss the rest.
+- **Plan vs. commit.** Not sure yet? Capture it as an **Idea** and let the system research it before you commit — think of an Idea as a lightweight plan you can drop cheaply. Already know exactly what you want? Skip straight to a **Work**.
+- **Think about the entity early.** If this is a real business, you'll eventually want a company behind it. The planned [Company Builder](../features/company-builder.md) is designed to guide incorporation through provider integrations (e.g. Stripe Atlas) — so registering the company is part of the journey, not a side quest.
+
+**Platform pieces:** [Missions](../features/missions.md) · [Ideas](../features/ideas.md) · [Mission Templates](../features/mission-templates.md)
+
+---
+
+## 2. Build — ship the things the goal needs
+
+A goal succeeds when real things exist online. In Ever Works, each of those is a **[Work](../features/creating-a-work.md)**.
+
+- **Works are built from [Templates](../features/website-templates.md).** Websites, blogs, directories, landing pages — and soon [stores](../features/store-builder.md) — start from a base template in the catalog, so you're never staring at a blank page.
+- **One Idea → one Work.** Accept an Idea and the platform builds it: researches the topic, writes the content, generates the code, and deploys it to your target.
+- **Everything lives in your Git.** Code and content are committed to repositories you own. Nothing is locked in.
+- **Give Works a brain.** Each Work has a [Knowledge Base](../features/knowledge-base.md) — brand voice, SEO rules, personas, research — that every build reads from, so output stays on-brand and gets smarter over time.
+
+**Platform pieces:** [Creating a Work](../features/creating-a-work.md) · [Website Templates](../features/website-templates.md) · [Knowledge Base](../features/knowledge-base.md) · [Custom Domains](../features/custom-domains.md)
+
+---
+
+## 3. Sell — staff a team and open for business
+
+This is where Ever Works diverges hardest from one-shot builders. A site that exists isn't a business. You need people doing the work — and here, those people are [Agents](../features/agents.md).
+
+- **Hire an AI organization.** Create Tenant-scoped Agents for company-wide roles — a **CEO** to keep the roadmap coherent, a **CTO** to own the build, a **Researcher** to feed Ideas, a **Copywriter** to keep pages sharp. Ready-made roles ship as templates.
+- **Split global vs. focused.** Some Agents work across the whole company; others are scoped to a single Work (a "Blog Editor" for one blog). You decide the org chart.
+- **Give them mailboxes.** With [Agent Email & Inboxes](../features/agent-email.md), Agents send updates and outreach from real addresses and turn incoming mail into work — so sales and support conversations actually happen.
+- **Open a storefront.** The planned [Store Builder](../features/store-builder.md) turns a commerce goal into a working storefront that an AI team researches, stocks, writes, and optimizes — built to *act on* your business, not just advise.
+
+**Platform pieces:** [Agents](../features/agents.md) · [Agent Email & Inboxes](../features/agent-email.md) · [Store Builder](../features/store-builder.md) · [Company Builder](../features/company-builder.md)
+
+---
+
+## 4. Scale — let it run, then grow it
+
+The point of all this is leverage: the business should keep moving without you in the loop for every step.
+
+- **Run 24/7.** With [Autonomous Operation](../features/autonomous-operation.md), Agents and [Workers](../features/workers.md) keep writing content, finding products, improving code, generating new Ideas, and redeploying — on a schedule.
+- **Stay in control of spend.** Set [budgets](../features/budgets-and-usage.md) per Work, Idea, Mission, and Agent, soft or hard, with alerts and auto-pause.
+- **Add Missions and Works as you grow.** A successful company runs many Works toward several Missions; the model scales sideways without adding process.
+- **Own it, forever.** Because everything is open source (AGPLv3) and lives in your Git, you can self-host, take it offline with the upcoming [Desktop App](../features/desktop-app.md), or move providers at any time. Growth never becomes a lock-in trap.
+
+**Platform pieces:** [Autonomous Operation](../features/autonomous-operation.md) · [Workers](../features/workers.md) · [Budgets & Usage](../features/budgets-and-usage.md) · [Desktop App](../features/desktop-app.md)
+
+---
+
+## The whole journey, in one picture
+
+| Phase | You do | Ever Works does | Core pieces |
+|---|---|---|---|
+| **Start** | Set a goal | Generates Ideas, plans, suggests the entity | Missions, Ideas |
+| **Build** | Pick what to ship | Researches, writes, codes, deploys from Templates | Works, Templates, KB |
+| **Sell** | Define the team & offer | Staffs Agents, gives them mailboxes, opens the store | Agents, Email, Store, Company |
+| **Scale** | Set budgets & let go | Runs everything 24/7, keeps improving | Autonomous Operation, Workers |
+
+You can be the solo founder who is *all of these roles at once* — on top of a platform that does the work. Start with a single Idea, or set a Mission and watch a company take shape.
+
+## See also
+
+- [Platform Overview](../overview.md)
+- [Missions](../features/missions.md) · [Ideas](../features/ideas.md) · [Creating a Work](../features/creating-a-work.md) · [Agents](../features/agents.md)
+- [Company Builder](../features/company-builder.md) · [Autonomous Operation](../features/autonomous-operation.md)

--- a/docs/guides/founder-journey.md
+++ b/docs/guides/founder-journey.md
@@ -6,7 +6,7 @@ sidebar_label: The Founder Journey
 
 # The Founder Journey — Start, Build, Sell, Scale
 
-Most guides for founders are *just content* — articles that tell you what to do and leave you to do it. This one is different: every step maps to something Ever Works can actually **do for you**. Read it top to bottom as one playbook, or jump to the phase you're in. The four phases — **Start → Build → Sell → Scale** — line up with the platform's core building blocks: [Missions](../features/missions.md), [Ideas](../features/ideas.md), [Works](../features/creating-a-work.md), and [Agents](../features/agents.md).
+Most guides for founders are _just content_ — articles that tell you what to do and leave you to do it. This one is different: every step maps to something Ever Works can actually **do for you**. Read it top to bottom as one playbook, or jump to the phase you're in. The four phases — **Start → Build → Sell → Scale** — line up with the platform's core building blocks: [Missions](../features/missions.md), [Ideas](../features/ideas.md), [Works](../features/creating-a-work.md), and [Agents](../features/agents.md).
 
 The mental model in one line: **you set the goal; an AI organization researches, builds, and runs the business toward it — 24/7, in your own Git.**
 
@@ -25,8 +25,8 @@ flowchart LR
 
 You don't need a finished plan to begin. You need a **goal**.
 
-- **Define a [Mission](../features/missions.md).** A Mission is an ambitious, ongoing goal — *"run the best cats business worldwide,"* *"launch an AI-tools media company."* It's bigger than any one website, and Ever Works keeps pursuing it for you.
-- **Let Ideas come to you.** From a Mission, the platform generates [Ideas](../features/ideas.md): atomic, one-shot proposals (*"a directory of indie cat-toy brands," "a weekly cat-care blog"*). Add your own, accept the good ones, dismiss the rest.
+- **Define a [Mission](../features/missions.md).** A Mission is an ambitious, ongoing goal — _"run the best cats business worldwide,"_ _"launch an AI-tools media company."_ It's bigger than any one website, and Ever Works keeps pursuing it for you.
+- **Let Ideas come to you.** From a Mission, the platform generates [Ideas](../features/ideas.md): atomic, one-shot proposals (_"a directory of indie cat-toy brands," "a weekly cat-care blog"_). Add your own, accept the good ones, dismiss the rest.
 - **Plan vs. commit.** Not sure yet? Capture it as an **Idea** and let the system research it before you commit — think of an Idea as a lightweight plan you can drop cheaply. Already know exactly what you want? Skip straight to a **Work**.
 - **Think about the entity early.** If this is a real business, you'll eventually want a company behind it. The planned [Company Builder](../features/company-builder.md) is designed to guide incorporation through provider integrations (e.g. Stripe Atlas) — so registering the company is part of the journey, not a side quest.
 
@@ -54,7 +54,7 @@ This is where Ever Works diverges hardest from one-shot builders. A site that ex
 - **Hire an AI organization.** Create Tenant-scoped Agents for company-wide roles — a **CEO** to keep the roadmap coherent, a **CTO** to own the build, a **Researcher** to feed Ideas, a **Copywriter** to keep pages sharp. Ready-made roles ship as templates.
 - **Split global vs. focused.** Some Agents work across the whole company; others are scoped to a single Work (a "Blog Editor" for one blog). You decide the org chart.
 - **Give them mailboxes.** With [Agent Email & Inboxes](../features/agent-email.md), Agents send updates and outreach from real addresses and turn incoming mail into work — so sales and support conversations actually happen.
-- **Open a storefront.** The planned [Store Builder](../features/store-builder.md) turns a commerce goal into a working storefront that an AI team researches, stocks, writes, and optimizes — built to *act on* your business, not just advise.
+- **Open a storefront.** The planned [Store Builder](../features/store-builder.md) turns a commerce goal into a working storefront that an AI team researches, stocks, writes, and optimizes — built to _act on_ your business, not just advise.
 
 **Platform pieces:** [Agents](../features/agents.md) · [Agent Email & Inboxes](../features/agent-email.md) · [Store Builder](../features/store-builder.md) · [Company Builder](../features/company-builder.md)
 
@@ -75,14 +75,14 @@ The point of all this is leverage: the business should keep moving without you i
 
 ## The whole journey, in one picture
 
-| Phase | You do | Ever Works does | Core pieces |
-|---|---|---|---|
-| **Start** | Set a goal | Generates Ideas, plans, suggests the entity | Missions, Ideas |
-| **Build** | Pick what to ship | Researches, writes, codes, deploys from Templates | Works, Templates, KB |
-| **Sell** | Define the team & offer | Staffs Agents, gives them mailboxes, opens the store | Agents, Email, Store, Company |
-| **Scale** | Set budgets & let go | Runs everything 24/7, keeps improving | Autonomous Operation, Workers |
+| Phase     | You do                  | Ever Works does                                      | Core pieces                   |
+| --------- | ----------------------- | ---------------------------------------------------- | ----------------------------- |
+| **Start** | Set a goal              | Generates Ideas, plans, suggests the entity          | Missions, Ideas               |
+| **Build** | Pick what to ship       | Researches, writes, codes, deploys from Templates    | Works, Templates, KB          |
+| **Sell**  | Define the team & offer | Staffs Agents, gives them mailboxes, opens the store | Agents, Email, Store, Company |
+| **Scale** | Set budgets & let go    | Runs everything 24/7, keeps improving                | Autonomous Operation, Workers |
 
-You can be the solo founder who is *all of these roles at once* — on top of a platform that does the work. Start with a single Idea, or set a Mission and watch a company take shape.
+You can be the solo founder who is _all of these roles at once_ — on top of a platform that does the work. Start with a single Idea, or set a Mission and watch a company take shape.
 
 ## See also
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,6 +9,32 @@ sidebar_position: 2
 
 The Ever Works Platform provides the backend infrastructure for building, generating, and deploying AI-powered work websites.
 
+## What Ever Works is
+
+Ever Works is an **open-source, agentic runtime** that researches, ships, and maintains content-rich websites and Git repositories. It brings together two things most tools keep apart:
+
+- **The builder experience** — describe what you want and get a shipped website, blog, directory, landing page (and, soon, [stores](/features/store-builder)) generated from a [template](/features/website-templates).
+- **The autonomous workforce** — an army of AI [Agents](/features/agents) acting as real employees that keep the work going long after the first build: writing content, finding and adding items, improving code, researching, and proposing what to do next — [24/7, on a schedule](/features/autonomous-operation).
+
+One-shot AI builders generate code and stop. Ever Works keeps building, maintaining, and growing — and because **code and content both live in your own Git**, you own everything and nothing is locked in. The platform is open source under **AGPLv3**.
+
+### The mental model
+
+```mermaid
+flowchart LR
+    M[Mission<br/>an ongoing goal] --> I[Ideas<br/>atomic proposals]
+    I --> W[Works<br/>live, self-updating sites]
+    A[Agents<br/>your AI employees] --> W
+    A --> I
+```
+
+- A **[Mission](/features/missions)** is an ambitious, ongoing goal the system keeps pursuing.
+- An **[Idea](/features/ideas)** is a one-shot proposal — one Idea becomes one Work. (Unsure what to build? Capture an Idea and let it be researched first, like a lightweight plan.)
+- A **[Work](/features/creating-a-work)** is the buildable, self-maintaining unit — a website, blog, directory, landing page, store, and more.
+- **[Agents](/features/agents)** are named AI workers (CEO, CTO, Researcher, …) that run the Missions, Ideas, and Works for you.
+
+For the full step-by-step, see the [Founder Journey guide](/guides/founder-journey).
+
 ## How It Works
 
 1. **Create a Work** — A user creates a work project through the web dashboard or API, providing a topic and description.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,10 +11,13 @@ This page outlines the current direction of Ever Works, areas of active developm
 
 ## Product Vision
 
-Ever Works aims to be the most comprehensive open-source solution for building professional work websites. The long-term vision encompasses:
+Ever Works aims to be the open-source, agentic runtime that **researches, ships, and maintains** content-rich websites and the businesses around them — merging the builder experience of one-shot AI site builders with an autonomous workforce that keeps working 24/7. The long-term vision encompasses:
 
 - **AI-first content generation** that makes it possible to build and maintain large works with minimal manual effort
-- **A thriving plugin ecosystem** that allows developers to extend the Platform with custom AI providers, data sources, and integrations
+- **An autonomous AI workforce** — user-defined [Agents](/features/agents) (CEO, CTO, Researcher, …) that run [Missions](/features/missions), [Ideas](/features/ideas), and [Works](/features/creating-a-work) on a schedule, not just on prompt — see [Autonomous Operation](/features/autonomous-operation)
+- **From idea to business** — beyond websites, planned [Store](/features/store-builder) and [Company](/features/company-builder) builders so a goal can become a registered, AI-run operation
+- **Own everything** — code and content live in your own Git under AGPLv3; a planned [Desktop App](/features/desktop-app) runs the whole stack locally
+- **A thriving plugin ecosystem** that allows developers to extend the Platform with custom AI providers, data sources, email providers, and integrations
 - **Production-grade website templates** that are beautiful, performant, and fully customizable
 - **Multi-work management** that scales from a single work to hundreds, all managed from a unified backend
 
@@ -23,6 +26,16 @@ Ever Works aims to be the most comprehensive open-source solution for building p
 ### Platform
 
 The following areas are actively being worked on in the Platform repository:
+
+#### Autonomous Workforce (Agents, Missions, Ideas)
+
+- [Missions](/features/missions) and [Ideas](/features/ideas) — the goal → proposal → Work hierarchy that lets the platform keep generating what to build next
+- User-defined [Agents](/features/agents) — named AI employees with scopes, heartbeats, budgets, permissions, skills, and tasks
+- [Agent Email & Inboxes](/features/agent-email) — inbound/outbound mailboxes per Agent and per Mission/Idea/Work, backed by pluggable email providers
+- [Knowledge Base & Memory](/features/knowledge-base) — per-Work, Git-backed institutional context and long-term memory
+- [Store](/features/store-builder) and [Company](/features/company-builder) builders — new Work shapes that turn a goal into a self-maintaining storefront or AI-run company
+- [Desktop App](/features/desktop-app) — the full stack running locally as a single application
+- Dynamic plugin distribution — install plugins on demand at runtime rather than bundling everything
 
 #### Plugin System Expansion
 


### PR DESCRIPTION
## Summary

Adds comprehensive **user-facing documentation** for the features that make Ever Works a *builder + 24/7 autonomous workforce* — not a one-shot site builder. Fills the biggest gaps in `docs/features/` and refreshes the top-level framing. **Additive only** — nothing removed or renamed.

## New docs (`docs/features/` + `docs/guides/`)

- **agents.md** — user-defined AI employees: scopes (Tenant/Mission/Idea/Work), heartbeats, budgets, permissions, skills, tasks, definition files, the org-of-agents (CEO/CTO/…)
- **agent-email.md** — per-Agent and per-Mission/Idea/Work inbound + outbound mailboxes, providers, inbound→Task/conversation routing
- **knowledge-base.md** — per-Work, Git-backed institutional context + long-term memory (built-in wiki/memory)
- **autonomous-operation.md** — the 24/7 "keeps going" differentiator
- **store-builder.md**, **company-builder.md**, **desktop-app.md** — roadmap shapes (clearly flagged coming-soon)
- **workers.md** — the background-execution engine
- **guides/founder-journey.md** — Start → Build → Sell → Scale, each step wired to real functionality

## Updates

- `apps/docs/sidebarsPlatform.ts` — register all new docs + new **Guides** category; also register the previously-orphaned `features/website-templates`
- `docs/features/index.md` — regrouped + new rows
- `docs/overview.md` — adds the Mission → Idea → Work → Agent model + builder/autonomy framing
- `docs/glossary.md` — new terms (Mission, Idea, Agent/Work Agent, Heartbeat, Skill, Task, KB, Email, Templates, Store/Company, Worker, Tenant/Org)
- `docs/roadmap.md` — autonomous-workforce direction

Docs are grounded in the existing internal specs (`docs/specs/features/agents`, `email-providers`, `knowledge-base`, …). Markdown formatted with the repo's pinned Prettier. No competitor/third-party product names in the official docs (named comparisons stay in `/compare`).

## Test plan

- [x] New pages appear under **Features** and **Guides** in the sidebar (sidebar ids resolve — confirmed by the Greptile review)
- [x] Cross-links between new docs and to API/advanced docs resolve (confirmed by the Greptile review)
- [x] `lint-and-test` green (Prettier "Check formatting" passing)
- [x] Full Docusaurus production build (`pnpm --filter ever-works-docs build`) — **passes locally, exit 0**; all 8 new feature pages + `guides/founder-journey` generated; no broken links from the new content (`onBrokenLinks: throw` did not trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)