### PR TITLE
feat(composio): enable triggers upstream via SDK + verify webhooks with project secret

### DIFF
--- a/apps/api/src/plugins/composio-triggers/composio-triggers.controller.spec.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.controller.spec.ts
@@ -1,0 +1,153 @@
+import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+// The controller is constructed directly with mocks below; stub the
+// heavy import-graph modules so loading the controller doesn't pull the
+// real auth → agent/database chain (which uses the agent-internal
+// `@src/config` alias the api jest config can't resolve) or the Composio
+// SDK. Mirrors the mocking strategy in composio.service.spec.ts.
+jest.mock('../composio/composio.service', () => ({ ComposioService: class {} }));
+jest.mock('../../auth', () => ({
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+jest.mock('@src/auth/decorators/public.decorator', () => ({ Public: () => () => undefined }));
+
+import { ComposioTriggersController } from './composio-triggers.controller';
+import type { ComposioTriggersService } from './composio-triggers.service';
+import type { ComposioService } from '../composio/composio.service';
+import type { AuthenticatedUser } from '@src/auth/types/auth.types';
+
+const auth = { userId: 'user-1' } as AuthenticatedUser;
+
+describe('ComposioTriggersController', () => {
+    let triggers: jest.Mocked<
+        Pick<
+            ComposioTriggersService,
+            'create' | 'remove' | 'findByComposioTriggerId' | 'recordDelivery'
+        >
+    >;
+    let composio: jest.Mocked<
+        Pick<ComposioService, 'createTrigger' | 'deleteTrigger' | 'verifyWebhook'>
+    >;
+    let controller: ComposioTriggersController;
+
+    beforeEach(() => {
+        triggers = {
+            create: jest.fn(),
+            remove: jest.fn(),
+            findByComposioTriggerId: jest.fn(),
+            recordDelivery: jest.fn().mockResolvedValue(undefined),
+        } as never;
+        composio = {
+            createTrigger: jest.fn(),
+            deleteTrigger: jest.fn().mockResolvedValue(true),
+            verifyWebhook: jest.fn(),
+        } as never;
+        controller = new ComposioTriggersController(
+            triggers as unknown as ComposioTriggersService,
+            composio as unknown as ComposioService,
+        );
+    });
+
+    describe('create', () => {
+        it('enables the trigger upstream then persists the row keyed by the real tg_* id', async () => {
+            composio.createTrigger.mockResolvedValue({ triggerId: 'tg_real_1' });
+            triggers.create.mockResolvedValue({
+                id: 'sub-1',
+                toolkitSlug: 'GMAIL',
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                composioTriggerId: 'tg_real_1',
+                composioConnectedAccountId: 'ca_1',
+                enabled: true,
+                deliveriesReceived: 0,
+                deliveriesRejected: 0,
+                lastFiredAt: null,
+                createdAt: new Date('2026-05-29T00:00:00Z'),
+            } as never);
+
+            const dto = await controller.create(auth, {
+                toolkitSlug: 'GMAIL',
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                composioConnectedAccountId: 'ca_1',
+            } as never);
+
+            expect(composio.createTrigger).toHaveBeenCalledWith('user-1', {
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                connectedAccountId: 'ca_1',
+                config: undefined,
+            });
+            expect(triggers.create).toHaveBeenCalledWith('user-1', 'tg_real_1', expect.any(Object));
+            expect(dto.composioTriggerId).toBe('tg_real_1');
+            // The vestigial per-subscription secret is never surfaced.
+            expect((dto as unknown as Record<string, unknown>).webhookSecret).toBeUndefined();
+        });
+    });
+
+    describe('remove', () => {
+        it('removes locally then tears the trigger down upstream', async () => {
+            triggers.remove.mockResolvedValue('tg_real_1');
+            await controller.remove(auth, 'sub-1');
+            expect(triggers.remove).toHaveBeenCalledWith('user-1', 'sub-1');
+            expect(composio.deleteTrigger).toHaveBeenCalledWith('user-1', 'tg_real_1');
+        });
+    });
+
+    describe('webhook', () => {
+        const v3Body = { type: 'gmail.new_email', metadata: { trigger_id: 'tg_real_1' } };
+        const headers = {
+            'webhook-id': 'wh_1',
+            'webhook-signature': 'v1,sig',
+            'webhook-timestamp': '1700000000',
+        };
+
+        it('400s when the trigger id is missing from the payload', async () => {
+            await expect(
+                controller.webhook({ rawBody: '{}' }, {} as never, headers),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('404s for an unknown trigger', async () => {
+            triggers.findByComposioTriggerId.mockResolvedValue(null);
+            await expect(
+                controller.webhook({ rawBody: JSON.stringify(v3Body) }, v3Body as never, headers),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('verifies via the owning user, records accepted, and returns ok', async () => {
+            triggers.findByComposioTriggerId.mockResolvedValue({
+                id: 'sub-1',
+                userId: 'owner-7',
+            } as never);
+            composio.verifyWebhook.mockResolvedValue({ version: 'V3', payload: {} });
+
+            const result = await controller.webhook(
+                { rawBody: JSON.stringify(v3Body) },
+                v3Body as never,
+                headers,
+            );
+
+            expect(triggers.findByComposioTriggerId).toHaveBeenCalledWith('tg_real_1');
+            expect(composio.verifyWebhook).toHaveBeenCalledWith('owner-7', {
+                id: 'wh_1',
+                rawBody: JSON.stringify(v3Body),
+                signature: 'v1,sig',
+                timestamp: '1700000000',
+            });
+            expect(triggers.recordDelivery).toHaveBeenCalledWith('sub-1', 'accepted');
+            expect(result).toEqual({ ok: true });
+        });
+
+        it('records rejected and rethrows when verification fails', async () => {
+            triggers.findByComposioTriggerId.mockResolvedValue({
+                id: 'sub-1',
+                userId: 'owner-7',
+            } as never);
+            composio.verifyWebhook.mockRejectedValue(new UnauthorizedException('bad sig'));
+
+            await expect(
+                controller.webhook({ rawBody: JSON.stringify(v3Body) }, v3Body as never, headers),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+            expect(triggers.recordDelivery).toHaveBeenCalledWith('sub-1', 'rejected');
+        });
+    });
+});

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.controller.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.controller.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import {
     BadRequestException,
     Body,
@@ -20,6 +19,7 @@ import { AuthSessionGuard, CurrentUser } from '../../auth';
 import { Public } from '@src/auth/decorators/public.decorator';
 import type { AuthenticatedUser } from '@src/auth/types/auth.types';
 import { ComposioTriggersService } from './composio-triggers.service';
+import { ComposioService } from '../composio/composio.service';
 import {
     ComposioTriggerDto,
     ComposioTriggerListDto,
@@ -30,7 +30,10 @@ import type { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 @ApiTags('Composio Triggers')
 @Controller('api/plugins/composio')
 export class ComposioTriggersController {
-    constructor(private readonly triggers: ComposioTriggersService) {}
+    constructor(
+        private readonly triggers: ComposioTriggersService,
+        private readonly composio: ComposioService,
+    ) {}
 
     @Get('triggers')
     @ApiBearerAuth('JWT-auth')
@@ -49,20 +52,23 @@ export class ComposioTriggersController {
     @ApiOperation({
         summary: 'Create a Composio trigger subscription',
         description:
-            "Allocates a server-generated HMAC secret and stores the subscription. The created `webhookSecret` is returned in the response **once** — store it client-side if you need to register the same trigger on a different platform. Subsequent GETs never include it. (Follow-up PR will also call Composio's `POST /triggers` to enable the trigger upstream and persist the returned `tg_*` id.)",
+            'Enables the trigger upstream on Composio (`triggers.create` via the official SDK) and stores the subscription keyed by the returned `tg_*` id. Composio signs inbound deliveries with the project webhook secret (configured under Settings → Plugins → Composio), which the `/webhook` endpoint verifies via the SDK.',
     })
     @ApiResponse({ status: 201, type: ComposioTriggerDto })
     async create(
         @CurrentUser() auth: AuthenticatedUser,
         @Body() body: CreateComposioTriggerDto,
     ): Promise<ComposioTriggerDto> {
-        // Until the upstream Composio enable-trigger call is wired,
-        // we mint a placeholder composioTriggerId so the row is uniquely
-        // queryable. Once enabled, this is replaced with the real
-        // `tg_*` returned by Composio in the same transaction.
-        const placeholderTriggerId = `local_${randomUUID()}`;
-        const row = await this.triggers.create(auth.userId, placeholderTriggerId, body);
-        return { ...toDto(row), webhookSecret: row.webhookSecret };
+        // Enable the trigger upstream on Composio first, then persist the
+        // row keyed by the real `tg_*` id so webhook deliveries (which
+        // carry that id) resolve back to this subscription.
+        const { triggerId } = await this.composio.createTrigger(auth.userId, {
+            triggerSlug: body.triggerSlug,
+            connectedAccountId: body.composioConnectedAccountId,
+            config: body.config ?? undefined,
+        });
+        const row = await this.triggers.create(auth.userId, triggerId, body);
+        return toDto(row);
     }
 
     @Delete('triggers/:id')
@@ -74,7 +80,13 @@ export class ComposioTriggersController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', new ParseUUIDPipe()) id: string,
     ): Promise<void> {
-        await this.triggers.remove(auth.userId, id);
+        const composioTriggerId = await this.triggers.remove(auth.userId, id);
+        // Best-effort upstream teardown — the local row is already gone; a
+        // failed upstream delete (e.g. trigger already removed) is logged
+        // and swallowed inside the service.
+        if (composioTriggerId) {
+            await this.composio.deleteTrigger(auth.userId, composioTriggerId);
+        }
     }
 
     @Public()
@@ -83,16 +95,16 @@ export class ComposioTriggersController {
     @ApiOperation({
         summary: 'Composio webhook receiver',
         description:
-            'Inbound Composio webhook deliveries land here. Composio signs the JSON body with HMAC-SHA256 of the per-subscription secret; the digest arrives as `x-composio-signature`. The handler resolves the subscription by the `tg_*` trigger id in the payload, verifies the signature in constant time, and records the outcome. Returns 200 even on no-op outcomes so Composio does not retry; 401 only when signature verification fails.',
+            'Inbound Composio webhook deliveries land here. The handler resolves the subscription by the `tg_*` trigger id in the payload, then verifies the delivery via the official Composio SDK (`triggers.verifyWebhook`) using the project webhook secret + the `webhook-id` / `webhook-signature` / `webhook-timestamp` headers. Returns 200 on accept so Composio does not retry; 401 when verification fails, 404 for an unknown trigger.',
     })
     async webhook(
         @Req() req: { rawBody?: string },
         @Body() body: ComposioWebhookPayload,
-        @Headers('x-composio-signature') signature: string | undefined,
+        @Headers() headers: Record<string, string>,
     ): Promise<{ ok: true }> {
-        const triggerId = body?.trigger_id ?? body?.triggerId;
-        if (!triggerId || typeof triggerId !== 'string') {
-            throw new BadRequestException('Missing trigger_id in webhook payload');
+        const triggerId = extractComposioTriggerId(body);
+        if (!triggerId) {
+            throw new BadRequestException('Missing trigger id in webhook payload');
         }
         if (!req.rawBody) {
             throw new BadRequestException('Missing raw webhook payload');
@@ -106,7 +118,15 @@ export class ComposioTriggersController {
         }
 
         try {
-            this.triggers.verifyDelivery(subscription, req.rawBody, signature);
+            // Verify against the OWNING user's project webhook secret — the
+            // webhook is @Public(), so the user is resolved from the trigger
+            // id, not an auth token. Fails closed when no secret is set.
+            await this.composio.verifyWebhook(subscription.userId, {
+                id: headers['webhook-id'] ?? '',
+                rawBody: req.rawBody,
+                signature: headers['webhook-signature'] ?? '',
+                timestamp: headers['webhook-timestamp'] ?? '',
+            });
         } catch (error) {
             await this.triggers.recordDelivery(subscription.id, 'rejected');
             throw error;
@@ -123,7 +143,18 @@ export class ComposioTriggersController {
 interface ComposioWebhookPayload {
     trigger_id?: string;
     triggerId?: string;
+    metadata?: { trigger_id?: string };
     [key: string]: unknown;
+}
+
+/**
+ * Extract the `tg_*` trigger id from a Composio webhook payload. V3
+ * nests it under `metadata.trigger_id`; legacy V1/V2 carry it top-level
+ * as `trigger_id` / `triggerId`.
+ */
+function extractComposioTriggerId(body: ComposioWebhookPayload | undefined): string | undefined {
+    const candidate = body?.metadata?.trigger_id ?? body?.trigger_id ?? body?.triggerId;
+    return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined;
 }
 
 function toDto(row: ComposioTriggerSubscription): ComposioTriggerDto {

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -7,7 +7,11 @@ import { ComposioTriggersService } from './composio-triggers.service';
 import { ComposioApiModule } from '../composio/composio.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioApiModule],
+    imports: [
+        TypeOrmModule.forFeature([ComposioTriggerSubscription]),
+        AuthModule,
+        ComposioApiModule,
+    ],
     controllers: [ComposioTriggersController],
     providers: [ComposioTriggersService],
     exports: [ComposioTriggersService],

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -4,9 +4,10 @@ import { AuthModule } from '../../auth/auth.module';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import { ComposioTriggersController } from './composio-triggers.controller';
 import { ComposioTriggersService } from './composio-triggers.service';
+import { ComposioModule } from '../composio/composio.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule],
+    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioModule],
     controllers: [ComposioTriggersController],
     providers: [ComposioTriggersService],
     exports: [ComposioTriggersService],

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -4,10 +4,10 @@ import { AuthModule } from '../../auth/auth.module';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import { ComposioTriggersController } from './composio-triggers.controller';
 import { ComposioTriggersService } from './composio-triggers.service';
-import { ComposioModule } from '../composio/composio.module';
+import { ComposioApiModule } from '../composio/composio.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioModule],
+    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioApiModule],
     controllers: [ComposioTriggersController],
     providers: [ComposioTriggersService],
     exports: [ComposioTriggersService],

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
@@ -1,6 +1,5 @@
-import { createHmac } from 'node:crypto';
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import { ComposioTriggersService } from './composio-triggers.service';
@@ -58,46 +57,15 @@ describe('ComposioTriggersService', () => {
             );
         });
 
-        it('deletes when found', async () => {
-            repo.findOne.mockResolvedValue({ id: 'sub-1', userId: 'user-1' });
-            await service.remove('user-1', 'sub-1');
+        it('deletes when found and returns the composio trigger id for upstream teardown', async () => {
+            repo.findOne.mockResolvedValue({
+                id: 'sub-1',
+                userId: 'user-1',
+                composioTriggerId: 'tg_abc',
+            });
+            const result = await service.remove('user-1', 'sub-1');
             expect(repo.delete).toHaveBeenCalledWith({ id: 'sub-1' });
-        });
-    });
-
-    describe('verifyDelivery', () => {
-        const secret = 'a'.repeat(64);
-        const rawBody = '{"trigger_id":"tg_1","data":{"foo":"bar"}}';
-        const validSig = createHmac('sha256', secret).update(rawBody).digest('hex');
-
-        it('accepts a valid signature', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, validSig),
-            ).not.toThrow();
-        });
-
-        it('accepts a valid signature with the `sha256=` prefix', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, `sha256=${validSig}`),
-            ).not.toThrow();
-        });
-
-        it('rejects a tampered body', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody + 'tampered', validSig),
-            ).toThrow(UnauthorizedException);
-        });
-
-        it('rejects when the signature is missing', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, undefined),
-            ).toThrow(UnauthorizedException);
-        });
-
-        it('rejects when the signature length is wrong (defeats truncation oracle)', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, validSig.slice(0, 32)),
-            ).toThrow(UnauthorizedException);
+            expect(result).toBe('tg_abc');
         });
     });
 

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
@@ -1,28 +1,23 @@
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import type { CreateComposioTriggerDto } from './dto/composio-trigger.dto';
 
 /**
- * CRUD + webhook-verification service for `composio_trigger_subscriptions`.
+ * CRUD + delivery-bookkeeping service for `composio_trigger_subscriptions`.
  *
- * Triggers are created via `POST /api/plugins/composio/triggers`. The
- * service generates a per-subscription HMAC secret server-side and
- * returns it ONCE in the create response. Subsequent reads never
- * include the secret.
- *
- * Webhook deliveries arrive at `POST /api/plugins/composio/webhook`
- * with the Composio trigger id in the JSON body (`tg_*`) plus an
- * `x-composio-signature` header — the controller resolves the
- * subscription by trigger id, then `verifyDelivery` HMAC-checks the
- * raw request body against the stored secret in constant time.
+ * Triggers are enabled upstream on Composio (via the SDK in
+ * `ComposioService`) and stored here keyed by the returned `tg_*` id.
+ * Webhook deliveries arrive at `POST /api/plugins/composio/webhook`; the
+ * controller resolves the subscription by trigger id and verifies the
+ * delivery via the official Composio SDK against the project webhook
+ * secret (see `ComposioService.verifyWebhook`). This service then records
+ * the accepted/rejected outcome.
  */
 @Injectable()
 export class ComposioTriggersService {
-    private readonly logger = new Logger(ComposioTriggersService.name);
-
     constructor(
         @InjectRepository(ComposioTriggerSubscription)
         private readonly repo: Repository<ComposioTriggerSubscription>,
@@ -36,10 +31,15 @@ export class ComposioTriggersService {
     }
 
     /**
-     * Creates a trigger subscription row. In a follow-up PR this will
-     * also call Composio's `POST /triggers` to enable the trigger
-     * upstream — for now the controller layer wires the upstream call
-     * and passes us the resulting `composioTriggerId`.
+     * Persist a trigger subscription row keyed by the real Composio
+     * `tg_*` id (the controller enables the trigger upstream via the SDK
+     * first and passes the returned id here).
+     *
+     * `webhookSecret` is retained as an internal random value only to
+     * satisfy the column's NOT NULL constraint — it is **no longer** the
+     * verification secret. Composio signs deliveries with the project
+     * webhook secret (resolved from plugin settings at verify time), so
+     * the per-subscription value is vestigial and never surfaced.
      */
     async create(
         userId: string,
@@ -62,57 +62,21 @@ export class ComposioTriggersService {
         return this.repo.save(entity);
     }
 
-    async remove(userId: string, id: string): Promise<void> {
+    /**
+     * Remove the local subscription row and return its Composio `tg_*` id
+     * so the caller can tear the trigger down upstream (best-effort).
+     */
+    async remove(userId: string, id: string): Promise<string> {
         const subscription = await this.repo.findOne({ where: { id, userId } });
         if (!subscription) throw new NotFoundException('Trigger subscription not found');
         await this.repo.delete({ id });
+        return subscription.composioTriggerId;
     }
 
     async findByComposioTriggerId(
         composioTriggerId: string,
     ): Promise<ComposioTriggerSubscription | null> {
         return this.repo.findOne({ where: { composioTriggerId } });
-    }
-
-    /**
-     * Verifies an inbound Composio webhook delivery against the stored
-     * per-subscription HMAC secret. Composio signs deliveries with
-     * HMAC-SHA256 of the raw JSON body; the signature is sent as the
-     * hex digest in the `x-composio-signature` header.
-     *
-     * Uses `crypto.timingSafeEqual` to defeat timing attacks. Throws
-     * `UnauthorizedException` on mismatch.
-     */
-    verifyDelivery(
-        subscription: Pick<ComposioTriggerSubscription, 'webhookSecret'>,
-        rawBody: string,
-        signature: string | undefined,
-    ): void {
-        if (!signature || typeof signature !== 'string') {
-            throw new UnauthorizedException('Missing x-composio-signature header');
-        }
-
-        const computed = createHmac('sha256', subscription.webhookSecret)
-            .update(rawBody)
-            .digest('hex');
-
-        const provided = signature
-            .trim()
-            .toLowerCase()
-            .replace(/^sha256=/, '');
-        if (provided.length !== computed.length) {
-            throw new UnauthorizedException('Invalid Composio webhook signature');
-        }
-
-        let equal = false;
-        try {
-            equal = timingSafeEqual(Buffer.from(provided, 'hex'), Buffer.from(computed, 'hex'));
-        } catch {
-            equal = false;
-        }
-        if (!equal) {
-            throw new UnauthorizedException('Invalid Composio webhook signature');
-        }
     }
 
     async recordDelivery(subscriptionId: string, outcome: 'accepted' | 'rejected'): Promise<void> {

--- a/apps/api/src/plugins/composio-triggers/dto/composio-trigger.dto.ts
+++ b/apps/api/src/plugins/composio-triggers/dto/composio-trigger.dto.ts
@@ -36,9 +36,6 @@ export class ComposioTriggerDto {
     @ApiProperty() deliveriesRejected!: number;
     @ApiPropertyOptional({ type: String }) lastFiredAt?: string | null;
     @ApiProperty() createdAt!: string;
-
-    /** Only returned on initial creation. Never re-fetched. */
-    @ApiPropertyOptional() webhookSecret?: string;
 }
 
 export class ComposioTriggerListDto {

--- a/apps/api/src/plugins/composio/composio.service.spec.ts
+++ b/apps/api/src/plugins/composio/composio.service.spec.ts
@@ -17,6 +17,7 @@ jest.mock('@composio/core', () => ({
     Composio: jest.fn().mockImplementation(() => ({
         toolkits: { get: jest.fn() },
         connectedAccounts: { list: jest.fn(), initiate: jest.fn() },
+        triggers: { create: jest.fn(), delete: jest.fn(), verifyWebhook: jest.fn() },
     })),
 }));
 
@@ -27,6 +28,7 @@ function buildSdkStub(): ComposioSdkLike {
     return {
         toolkits: { get: jest.fn() },
         connectedAccounts: { list: jest.fn(), initiate: jest.fn() },
+        triggers: { create: jest.fn(), delete: jest.fn(), verifyWebhook: jest.fn() },
     } as unknown as ComposioSdkLike;
 }
 
@@ -268,6 +270,110 @@ describe('ComposioService', () => {
                     authConfigId: 'ac_xyz',
                 }),
             ).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+
+    describe('triggers — upstream enable + webhook verification', () => {
+        it('createTrigger calls the SDK and returns the tg_* id', async () => {
+            const sdk = buildSdkStub();
+            (sdk.triggers.create as jest.Mock).mockResolvedValue({ triggerId: 'tg_real_1' });
+            injectSdk(service, sdk);
+
+            const result = await service.createTrigger('user-1', {
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                connectedAccountId: 'ca_1',
+                config: { labelIds: ['INBOX'] },
+            });
+
+            expect(result).toEqual({ triggerId: 'tg_real_1' });
+            expect(sdk.triggers.create).toHaveBeenCalledWith('user-1', 'GMAIL_NEW_EMAIL', {
+                triggerConfig: { labelIds: ['INBOX'] },
+                connectedAccountId: 'ca_1',
+            });
+        });
+
+        it('createTrigger throws when the SDK returns no trigger id', async () => {
+            const sdk = buildSdkStub();
+            (sdk.triggers.create as jest.Mock).mockResolvedValue({});
+            injectSdk(service, sdk);
+            await expect(
+                service.createTrigger('user-1', { triggerSlug: 'X' }),
+            ).rejects.toBeInstanceOf(Error);
+        });
+
+        it('deleteTrigger returns true on success, false (swallowed) on failure', async () => {
+            const sdk = buildSdkStub();
+            (sdk.triggers.delete as jest.Mock).mockResolvedValue({ triggerId: 'tg_1' });
+            injectSdk(service, sdk);
+            await expect(service.deleteTrigger('user-1', 'tg_1')).resolves.toBe(true);
+
+            (sdk.triggers.delete as jest.Mock).mockRejectedValue(new Error('already gone'));
+            await expect(service.deleteTrigger('user-1', 'tg_1')).resolves.toBe(false);
+        });
+
+        it('verifyWebhook fails closed when no webhook secret is configured', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(buildResolvedSettings());
+            const prevEnv = process.env.COMPOSIO_WEBHOOK_SECRET;
+            delete process.env.COMPOSIO_WEBHOOK_SECRET;
+            try {
+                await expect(
+                    service.verifyWebhook('user-1', {
+                        id: 'wh_1',
+                        rawBody: '{}',
+                        signature: 'v1,sig',
+                        timestamp: '123',
+                    }),
+                ).rejects.toBeInstanceOf(UnauthorizedException);
+            } finally {
+                if (prevEnv !== undefined) process.env.COMPOSIO_WEBHOOK_SECRET = prevEnv;
+            }
+        });
+
+        it('verifyWebhook delegates to the SDK with the resolved project secret', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(
+                buildResolvedSettings({ webhookSecret: 'whsec_project' }),
+            );
+            const sdk = buildSdkStub();
+            (sdk.triggers.verifyWebhook as jest.Mock).mockResolvedValue({
+                version: 'V3',
+                payload: { ok: true },
+                rawPayload: '{}',
+            });
+            injectSdk(service, sdk);
+
+            const result = await service.verifyWebhook('user-1', {
+                id: 'wh_1',
+                rawBody: '{"a":1}',
+                signature: 'v1,sig',
+                timestamp: '1700000000',
+            });
+
+            expect(result).toEqual({ version: 'V3', payload: { ok: true } });
+            expect(sdk.triggers.verifyWebhook).toHaveBeenCalledWith({
+                id: 'wh_1',
+                payload: '{"a":1}',
+                signature: 'v1,sig',
+                timestamp: '1700000000',
+                secret: 'whsec_project',
+            });
+        });
+
+        it('verifyWebhook maps SDK verification failure to UnauthorizedException', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(
+                buildResolvedSettings({ webhookSecret: 'whsec_project' }),
+            );
+            const sdk = buildSdkStub();
+            (sdk.triggers.verifyWebhook as jest.Mock).mockRejectedValue(new Error('bad signature'));
+            injectSdk(service, sdk);
+
+            await expect(
+                service.verifyWebhook('user-1', {
+                    id: 'wh_1',
+                    rawBody: '{}',
+                    signature: 'v1,bad',
+                    timestamp: '1700000000',
+                }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
         });
     });
 });

--- a/apps/api/src/plugins/composio/composio.service.ts
+++ b/apps/api/src/plugins/composio/composio.service.ts
@@ -46,6 +46,21 @@ export interface ComposioSdkLike {
             redirectUrl?: string;
         }>;
     };
+    triggers: {
+        create(
+            userId: string,
+            slug: string,
+            body?: { triggerConfig?: Record<string, unknown>; connectedAccountId?: string },
+        ): Promise<{ triggerId: string }>;
+        delete(triggerId: string): Promise<{ triggerId: string }>;
+        verifyWebhook(params: {
+            id: string;
+            payload: string;
+            signature: string;
+            timestamp: string;
+            secret: string;
+        }): Promise<{ version: string; payload: unknown; rawPayload: string }>;
+    };
 }
 
 /**
@@ -176,6 +191,111 @@ export class ComposioService {
             };
         } catch (error) {
             throw this.wrapComposioError(error, `initiate connection to ${body.toolkitSlug}`);
+        }
+    }
+
+    /**
+     * Enable a trigger upstream on Composio for the caller and return the
+     * Composio-assigned `tg_*` id. When `connectedAccountId` is omitted,
+     * Composio uses the user's first connected account for the toolkit.
+     */
+    async createTrigger(
+        userId: string,
+        params: {
+            triggerSlug: string;
+            connectedAccountId?: string;
+            config?: Record<string, unknown>;
+        },
+    ): Promise<{ triggerId: string }> {
+        const sdk = await this.getSdk(userId);
+        try {
+            const body: { triggerConfig?: Record<string, unknown>; connectedAccountId?: string } =
+                {};
+            if (params.config) body.triggerConfig = params.config;
+            if (params.connectedAccountId) body.connectedAccountId = params.connectedAccountId;
+            const result = await sdk.triggers.create(userId, params.triggerSlug, body);
+            if (!result?.triggerId) {
+                throw new Error('Composio did not return a trigger id for the new trigger.');
+            }
+            return { triggerId: result.triggerId };
+        } catch (error) {
+            throw this.wrapComposioError(error, `enable trigger ${params.triggerSlug}`);
+        }
+    }
+
+    /**
+     * Disable/remove a trigger upstream on Composio. Best-effort — callers
+     * still remove the local row even when the upstream delete fails (the
+     * trigger may already be gone). Returns whether the upstream call
+     * succeeded so the caller can log.
+     */
+    async deleteTrigger(userId: string, composioTriggerId: string): Promise<boolean> {
+        try {
+            const sdk = await this.getSdk(userId);
+            await sdk.triggers.delete(composioTriggerId);
+            return true;
+        } catch (error) {
+            this.logger.warn(
+                `Composio upstream trigger delete failed for ${composioTriggerId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Resolve the caller's project-level Composio webhook secret
+     * (`COMPOSIO_WEBHOOK_SECRET`, set under Composio dashboard → Project
+     * Settings → Webhook, mirrored into the plugin's `webhookSecret`
+     * setting). Returns undefined when not configured.
+     */
+    async getWebhookSecret(userId: string): Promise<string | undefined> {
+        const resolved = await this.settingsService
+            .getResolvedSettings(COMPOSIO_PLUGIN_ID, { userId, includeSecrets: true })
+            .catch(() => null);
+        const settings = (resolved?.settings ?? null) as Record<string, unknown> | null;
+        const fromSettings = readString(settings, 'webhookSecret');
+        if (fromSettings) return fromSettings;
+        const fromEnv = process.env.COMPOSIO_WEBHOOK_SECRET;
+        return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+    }
+
+    /**
+     * Verify a Composio webhook delivery for `userId` using the official
+     * SDK verifier (HMAC-SHA256 of `{webhook-id}.{webhook-timestamp}.{body}`
+     * against the project webhook secret, base64 `v1,<sig>` form). Throws
+     * `UnauthorizedException` when the secret isn't configured or the
+     * signature/timestamp is invalid. Returns the parsed payload + version.
+     */
+    async verifyWebhook(
+        userId: string,
+        delivery: { id: string; rawBody: string; signature: string; timestamp: string },
+    ): Promise<{ version: string; payload: unknown }> {
+        const secret = await this.getWebhookSecret(userId);
+        if (!secret) {
+            // Fail CLOSED: a delivery for a known trigger with no secret
+            // configured cannot be trusted — never accept-all.
+            throw new UnauthorizedException(
+                'Composio webhook secret is not configured. Set it under Settings → Plugins → Composio (from Composio dashboard → Project Settings → Webhook).',
+            );
+        }
+        const sdk = await this.getSdk(userId);
+        try {
+            const result = await sdk.triggers.verifyWebhook({
+                id: delivery.id,
+                payload: delivery.rawBody,
+                signature: delivery.signature,
+                timestamp: delivery.timestamp,
+                secret,
+            });
+            return { version: result.version, payload: result.payload };
+        } catch (error) {
+            throw new UnauthorizedException(
+                `Composio webhook signature verification failed: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
         }
     }
 

--- a/apps/web/src/lib/api/plugins-capabilities/composio-triggers.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/composio-triggers.ts
@@ -12,8 +12,6 @@ export interface ComposioTrigger {
     deliveriesRejected: number;
     lastFiredAt?: string | null;
     createdAt: string;
-    /** Returned only on create — never on subsequent reads. */
-    webhookSecret?: string;
 }
 
 export interface CreateComposioTriggerInput {

--- a/packages/plugins/composio/src/composio.plugin.ts
+++ b/packages/plugins/composio/src/composio.plugin.ts
@@ -99,6 +99,15 @@ export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 				'x-envVar': 'COMPOSIO_API_KEY',
 				'x-scope': 'user'
 			},
+			webhookSecret: {
+				type: 'string',
+				title: 'Composio Webhook Secret',
+				description:
+					'Your Composio project webhook secret, from Composio dashboard → Project Settings → Webhook. Required to verify inbound trigger webhook deliveries (HMAC-SHA256 of the signed payload). Without it, trigger deliveries are rejected.',
+				'x-secret': true,
+				'x-envVar': 'COMPOSIO_WEBHOOK_SECRET',
+				'x-scope': 'user'
+			},
 			baseUrl: {
 				type: 'string',
 				title: 'Composio API Base URL',


### PR DESCRIPTION
## Summary

Completes review finding **#4** — the Composio trigger flow now enables triggers upstream and verifies real deliveries, using the official `@composio/core` SDK (NN #22). Replaces the `local_<uuid>` placeholder id and the self-generated per-subscription HMAC secret (which could never match real Composio signatures).

Researched against [Composio webhook-verification docs](https://docs.composio.dev/docs/webhook-verification): Composio signs `{webhook-id}.{webhook-timestamp}.{body}` with HMAC-SHA256 against the **project** webhook secret (`COMPOSIO_WEBHOOK_SECRET`), header `webhook-signature: v1,<base64>`, and ships `triggers.verifyWebhook()`.

### Changes
- **ComposioService**: `createTrigger` (`sdk.triggers.create` → real `tg_*`), `deleteTrigger` (best-effort `sdk.triggers.delete`), `getWebhookSecret` (project secret from settings/env), `verifyWebhook` (official `sdk.triggers.verifyWebhook`).
- **Controller**: `create()` enables upstream then persists by the real id; `remove()` tears down upstream; `webhook()` is **V3-aware** (`metadata.trigger_id`), reads the `webhook-id/-signature/-timestamp` headers, verifies via the **owning user's** project secret (endpoint is `@Public()`; user resolved from the trigger id), and **fails closed** when no secret is configured (no more accept-all).
- Add `webhookSecret` (x-secret) to the Composio plugin settings.
- Retire the per-subscription secret: drop `verifyDelivery`, stop surfacing `webhookSecret` in the DTO/web client. The column stays as a vestigial NOT NULL internal value — **no schema change / migration**.

## Test plan
- [x] `ComposioService` jest — createTrigger, deleteTrigger, getWebhookSecret, verifyWebhook (fail-closed + SDK delegation + error mapping).
- [x] `ComposioTriggersController` jest (new) — create→upstream→persist, remove→upstream teardown, webhook V3 extraction + verify + record accepted/rejected + 400/404.
- [x] `ComposioTriggersService` jest — remove returns tg_* id; verifyDelivery tests removed.
- [x] Composio plugin vitest — 107 pass.
- [ ] CI green on develop.

> Operator note: set the **Composio Webhook Secret** under Settings → Plugins → Composio (from Composio dashboard → Project Settings → Webhook) for inbound trigger deliveries to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upstream trigger lifecycle support and optional webhook secret configuration for Composio integrations.

* **Security Improvements**
  * Webhook verification delegated to the composio integration layer.
  * Webhook secret removed from API responses.

* **Tests**
  * Added comprehensive unit tests covering trigger creation, deletion, webhook verification, and delivery recording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->