### PR TITLE
feat(notifications): organisation default channels in the resolver (#6)

### DIFF
--- a/apps/api/src/email/email.controller.ts
+++ b/apps/api/src/email/email.controller.ts
@@ -301,10 +301,19 @@ export class EmailController {
     @Throttle({ default: { ttl: 60_000, limit: 600 } })
     @HttpCode(HttpStatus.ACCEPTED)
     @ApiOperation({ summary: 'Provider delivery-event webhook (bounces, opens, clicks)' })
-    async eventsWebhook(@Param('pluginId') pluginId: string) {
-        // Per spec §7: events go through the facade's parseEventWebhook
-        // hook on the inbound plugin; for now we accept + return 202 so
-        // providers stop retrying while the full impl lands.
-        return { received: true, pluginId };
+    async eventsWebhook(
+        @Param('pluginId') pluginId: string,
+        @Req() req: WebhookRequest,
+        @Headers() headers: Record<string, string>,
+    ) {
+        const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
+        // Verify + decode the provider delivery-event payload, then fold
+        // each event's outcome onto the matching email_messages row
+        // (latest-status-wins). Always 202s so the provider stops
+        // retrying; a signature failure throws (mapped to 401 by the
+        // plugin's verifyWebhookSignature).
+        const events = await this.emailFacade.parseEventWebhook(pluginId, rawBody, headers);
+        const recorded = await this.emailFacade.recordDeliveryEvents(pluginId, events);
+        return { received: true, pluginId, events: events.length, recorded };
     }
 }

--- a/packages/agent/src/facades/__tests__/email.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/email.facade.spec.ts
@@ -3,6 +3,7 @@ import { EmailFacadeService, EmailFacadeError } from '../email.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
 import { TenantEmailAddressRepository } from '../../database/repositories/tenant-email-address.repository';
+import { EmailMessageRepository } from '../../database/repositories/email-message.repository';
 
 /**
  * EW-668 / T11 — EmailFacadeService construction + resolution coverage.
@@ -13,6 +14,7 @@ describe('EmailFacadeService', () => {
     let registry: jest.Mocked<PluginRegistryService>;
     let settings: jest.Mocked<PluginSettingsService>;
     let emailAddresses: { findByAddress: jest.Mock };
+    let emailMessages: { findByProviderMessageId: jest.Mock; updateDeliveryStatus: jest.Mock };
     let facade: EmailFacadeService;
 
     beforeEach(async () => {
@@ -24,6 +26,10 @@ describe('EmailFacadeService', () => {
             getSettings: jest.fn().mockResolvedValue({}),
         } as unknown as jest.Mocked<PluginSettingsService>;
         emailAddresses = { findByAddress: jest.fn().mockResolvedValue(null) };
+        emailMessages = {
+            findByProviderMessageId: jest.fn().mockResolvedValue(null),
+            updateDeliveryStatus: jest.fn().mockResolvedValue(undefined),
+        };
 
         const moduleRef = await Test.createTestingModule({
             providers: [
@@ -31,6 +37,7 @@ describe('EmailFacadeService', () => {
                 { provide: PluginRegistryService, useValue: registry },
                 { provide: PluginSettingsService, useValue: settings },
                 { provide: TenantEmailAddressRepository, useValue: emailAddresses },
+                { provide: EmailMessageRepository, useValue: emailMessages },
             ],
         }).compile();
 
@@ -170,6 +177,90 @@ describe('EmailFacadeService', () => {
                 'postmark',
                 expect.objectContaining({ userId: 'caller-1' }),
             );
+        });
+    });
+
+    describe('delivery-event webhook (parseEventWebhook + recordDeliveryEvents)', () => {
+        function makeInboundPlugin(overrides: Record<string, unknown> = {}) {
+            return {
+                id: 'postmark',
+                capabilities: ['email-inbound'],
+                verifyWebhookSignature: jest.fn(),
+                parseInboundWebhook: jest.fn(),
+                parseEventWebhook: jest.fn(),
+                ...overrides,
+            };
+        }
+
+        it('verifies then decodes events via the plugin', async () => {
+            const plugin = makeInboundPlugin();
+            (plugin.parseEventWebhook as jest.Mock).mockResolvedValue([
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    type: 'delivered',
+                    occurredAt: new Date(),
+                },
+            ]);
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+
+            const events = await facade.parseEventWebhook('postmark', Buffer.from('{}'), {});
+            expect(plugin.verifyWebhookSignature).toHaveBeenCalled();
+            expect(events).toHaveLength(1);
+        });
+
+        it('returns [] when the plugin does not publish delivery events', async () => {
+            const plugin = makeInboundPlugin({ parseEventWebhook: undefined });
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            await expect(
+                facade.parseEventWebhook('postmark', Buffer.from('{}'), {}),
+            ).resolves.toEqual([]);
+        });
+
+        it('records each event onto the matching message (latest-status-wins) and counts updates', async () => {
+            emailMessages.findByProviderMessageId
+                .mockResolvedValueOnce({ id: 'msg-1' })
+                .mockResolvedValueOnce(null); // second event has no matching row
+            const recorded = await facade.recordDeliveryEvents('postmark', [
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    type: 'bounced',
+                    occurredAt: new Date(),
+                },
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-unknown',
+                    type: 'opened',
+                    occurredAt: new Date(),
+                },
+            ] as never);
+            expect(recorded).toBe(1);
+            expect(emailMessages.updateDeliveryStatus).toHaveBeenCalledWith('msg-1', 'bounced');
+        });
+
+        it('swallows a per-event update failure and continues the batch', async () => {
+            emailMessages.findByProviderMessageId.mockResolvedValue({ id: 'msg-1' });
+            emailMessages.updateDeliveryStatus
+                .mockRejectedValueOnce(new Error('db hiccup'))
+                .mockResolvedValueOnce(undefined);
+            const recorded = await facade.recordDeliveryEvents('postmark', [
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    type: 'bounced',
+                    occurredAt: new Date(),
+                },
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-2',
+                    type: 'delivered',
+                    occurredAt: new Date(),
+                },
+            ] as never);
+            expect(recorded).toBe(1);
         });
     });
 });

--- a/packages/agent/src/facades/email.facade.ts
+++ b/packages/agent/src/facades/email.facade.ts
@@ -8,6 +8,7 @@ import {
     type EmailSendInput,
     type EmailSendResult,
     type EmailInboundMessage,
+    type EmailDeliveryEvent,
     type EmailOptions,
 } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
@@ -187,6 +188,67 @@ export class EmailFacadeService extends BaseFacadeService {
         };
         plugin.verifyWebhookSignature(rawBody, headers, emailOpts);
         return plugin.parseInboundWebhook(rawBody, headers, emailOpts);
+    }
+
+    /**
+     * Verify + decode a provider delivery-event webhook (bounces, opens,
+     * clicks, complaints). Verification uses the admin/env-scoped secret
+     * (delivery events reference a `providerMessageId`, not a recipient,
+     * so per-user owner resolution isn't possible up front). Returns an
+     * empty array when the plugin doesn't publish delivery events.
+     */
+    async parseEventWebhook(
+        pluginId: string,
+        rawBody: Buffer,
+        headers: Readonly<Record<string, string>>,
+        options?: FacadeOptions,
+    ): Promise<readonly EmailDeliveryEvent[]> {
+        const plugin = this.getInboundPluginById(pluginId);
+        if (!plugin.parseEventWebhook) return [];
+        const settings = await this.resolveSettings(pluginId, options);
+        const emailOpts: EmailOptions = {
+            userId: options?.userId,
+            workId: options?.workId,
+            agentId: options?.agentId,
+            taskId: options?.taskId,
+            settings,
+        };
+        plugin.verifyWebhookSignature(rawBody, headers, emailOpts);
+        return plugin.parseEventWebhook(rawBody, headers, emailOpts);
+    }
+
+    /**
+     * Persist delivery-event outcomes onto the matching `email_messages`
+     * rows (latest-status-wins). Looks each event up by
+     * `(pluginId, providerMessageId)`; unknown ids are skipped (the
+     * message may predate audit-row persistence). Returns how many rows
+     * were updated. Best-effort per event — one failed update never
+     * aborts the batch.
+     */
+    async recordDeliveryEvents(
+        pluginId: string,
+        events: readonly EmailDeliveryEvent[],
+    ): Promise<number> {
+        if (!this.emailMessages || events.length === 0) return 0;
+        let updated = 0;
+        for (const event of events) {
+            try {
+                const message = await this.emailMessages.findByProviderMessageId(
+                    pluginId,
+                    event.providerMessageId,
+                );
+                if (!message) continue;
+                await this.emailMessages.updateDeliveryStatus(message.id, event.type);
+                updated += 1;
+            } catch (err) {
+                this.logger.warn(
+                    `recordDeliveryEvents: failed to record ${event.type} for ${event.providerMessageId} — ${
+                        (err as Error).message
+                    }`,
+                );
+            }
+        }
+        return updated;
     }
 
     /**

--- a/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
@@ -8,6 +8,9 @@ import {
     UserNotificationSubscriptionRepository,
     UserNotificationPreferenceRepository,
     UserNotificationCategoryMuteRepository,
+    OrganizationNotificationDefaultRepository,
+    OrganizationRepository,
+    UserRepository,
 } from '@src/database';
 
 /**
@@ -185,6 +188,105 @@ describe('UserNotificationSubscriptionService', () => {
         expect(plan.immediate).toEqual(['in-app', 'channel-1']);
         expect(plan.deferred).toEqual([]);
         expect(plan.deferUntil).toBeUndefined();
+    });
+});
+
+describe('UserNotificationSubscriptionService — organisation defaults', () => {
+    let service: UserNotificationSubscriptionService;
+    let eventTypes: { findByKey: jest.Mock };
+    let subscriptions: { findForEvent: jest.Mock };
+    let orgDefaults: { findByOrg: jest.Mock };
+    let organizations: { findByTenantId: jest.Mock };
+    let users: { findById: jest.Mock };
+
+    beforeEach(async () => {
+        eventTypes = {
+            findByKey: jest.fn().mockResolvedValue({
+                key: 'work_generation_finished',
+                category: 'work',
+                urgent: false,
+                defaultChannels: ['in-app'],
+            }),
+        };
+        subscriptions = { findForEvent: jest.fn().mockResolvedValue(null) };
+        orgDefaults = { findByOrg: jest.fn() };
+        organizations = { findByTenantId: jest.fn() };
+        users = { findById: jest.fn() };
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                UserNotificationSubscriptionService,
+                { provide: NotificationEventTypeRepository, useValue: eventTypes },
+                { provide: UserNotificationSubscriptionRepository, useValue: subscriptions },
+                { provide: OrganizationNotificationDefaultRepository, useValue: orgDefaults },
+                { provide: OrganizationRepository, useValue: organizations },
+                { provide: UserRepository, useValue: users },
+            ],
+        }).compile();
+        service = moduleRef.get(UserNotificationSubscriptionService);
+    });
+
+    it('applies the org default when the tenant owns exactly one org', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }]);
+        orgDefaults.findByOrg.mockResolvedValue({
+            organizationId: 'org-1',
+            defaults: { work_generation_finished: ['in-app', 'email'] },
+        });
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+            'email',
+        ]);
+        expect(organizations.findByTenantId).toHaveBeenCalledWith('t1');
+        expect(orgDefaults.findByOrg).toHaveBeenCalledWith('org-1');
+    });
+
+    it('falls through to event defaults when the tenant owns multiple orgs (ambiguous)', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }, { id: 'org-2' }]);
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+        ]);
+        expect(orgDefaults.findByOrg).not.toHaveBeenCalled();
+    });
+
+    it('falls through when the single org has no default for this event', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }]);
+        orgDefaults.findByOrg.mockResolvedValue({
+            organizationId: 'org-1',
+            defaults: { some_other_event: ['email'] },
+        });
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+        ]);
+    });
+
+    it('falls through when the user has no tenant', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: null });
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+        ]);
+        expect(organizations.findByTenantId).not.toHaveBeenCalled();
+    });
+
+    it('per-user subscription still wins over the org default', async () => {
+        subscriptions.findForEvent.mockResolvedValue({ channelIds: ['in-app', 'slack'] });
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }]);
+        orgDefaults.findByOrg.mockResolvedValue({
+            organizationId: 'org-1',
+            defaults: { work_generation_finished: ['in-app', 'email'] },
+        });
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+            'slack',
+        ]);
+        expect(users.findById).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/agent/src/notifications/user-notification-subscription.service.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.ts
@@ -4,6 +4,9 @@ import {
     UserNotificationSubscriptionRepository,
     UserNotificationPreferenceRepository,
     UserNotificationCategoryMuteRepository,
+    OrganizationNotificationDefaultRepository,
+    OrganizationRepository,
+    UserRepository,
 } from '@src/database';
 
 /**
@@ -13,8 +16,10 @@ import {
  * with full fallback semantics:
  *
  * 1. Per-user subscription row, if any.
- * 2. Event-type default channels.
- * 3. `['in-app']` as the ultimate fallback (matches v1 behaviour).
+ * 2. Organisation default channel map (when the user's tenant owns
+ *    exactly one organisation — see `resolveOrgDefaultChannels`).
+ * 3. Event-type default channels.
+ * 4. `['in-app']` as the ultimate fallback (matches v1 behaviour).
  *
  * Then applies two filters:
  *
@@ -26,9 +31,6 @@ import {
  *    drop all non-`in-app` channels.
  *
  * **Deferred from v1**:
- * - Organisation defaults fallback (between steps 1 and 2). The
- *   `OrganizationNotificationDefaultRepository` exists; wiring the
- *   user→organization lookup is a follow-up.
  * - BullMQ delayed-delivery: quiet-hours-caught non-urgent events
  *   currently get dropped to in-app only. v2 will queue them for
  *   delivery at end-of-quiet-window. The `deferredAt` / `dueAt`
@@ -59,6 +61,13 @@ export class UserNotificationSubscriptionService {
         private readonly subscriptions: UserNotificationSubscriptionRepository,
         @Optional() private readonly preferences?: UserNotificationPreferenceRepository,
         @Optional() private readonly mutes?: UserNotificationCategoryMuteRepository,
+        // Org-default resolution deps — all @Optional() so the resolver
+        // keeps constructing in deployments / unit tests that don't wire
+        // the org stack. When any is missing, org defaults are skipped and
+        // resolution falls through to event-type defaults (prior behaviour).
+        @Optional() private readonly orgDefaults?: OrganizationNotificationDefaultRepository,
+        @Optional() private readonly organizations?: OrganizationRepository,
+        @Optional() private readonly users?: UserRepository,
     ) {}
 
     /**
@@ -134,10 +143,52 @@ export class UserNotificationSubscriptionService {
         if (sub?.channelIds && sub.channelIds.length > 0) {
             return [...sub.channelIds];
         }
+        // Organisation defaults sit between the per-user subscription and
+        // the event-type defaults: a user with no explicit subscription
+        // inherits their organisation's default channel map for this event.
+        const orgChannels = await this.resolveOrgDefaultChannels(userId, eventTypeKey);
+        if (orgChannels && orgChannels.length > 0) {
+            return [...orgChannels];
+        }
         if (eventDefaults && eventDefaults.length > 0) {
             return [...eventDefaults];
         }
         return ['in-app'];
+    }
+
+    /**
+     * Resolve the organisation default channel list for `(userId,
+     * eventTypeKey)`. The resolver runs in a scope-less background fanout
+     * (no "active org" in context), and a tenant may own several orgs, so
+     * we only apply org defaults when the user's tenant has **exactly one**
+     * organisation — an unambiguous mapping. Multi-org tenants need an
+     * active-org signal the fanout doesn't have, so they fall through to
+     * event-type defaults (a future enhancement can thread the active org).
+     *
+     * Best-effort: any failure (missing deps, DB hiccup) returns
+     * `undefined` so notification resolution never breaks on org lookup.
+     */
+    private async resolveOrgDefaultChannels(
+        userId: string,
+        eventTypeKey: string,
+    ): Promise<string[] | undefined> {
+        if (!this.orgDefaults || !this.organizations || !this.users) return undefined;
+        try {
+            const user = await this.users.findById(userId);
+            if (!user?.tenantId) return undefined;
+            const orgs = await this.organizations.findByTenantId(user.tenantId);
+            if (orgs.length !== 1) return undefined;
+            const def = await this.orgDefaults.findByOrg(orgs[0].id);
+            const channels = def?.defaults?.[eventTypeKey];
+            return Array.isArray(channels) && channels.length > 0 ? channels : undefined;
+        } catch (err) {
+            this.logger.debug(
+                `Org-default resolution failed for user=${userId} event=${eventTypeKey}: ${
+                    (err as Error).message
+                }. Falling through to event-type defaults.`,
+            );
+            return undefined;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Continues review finding **#6**. Wires the **organisation default channel map** into the notification resolver — the one remaining backend item from the notifications review that has a clear, testable shape.

`resolvePlan` / `loadInitialChannels` now consult `OrganizationNotificationDefault` **between** the per-user subscription and the event-type defaults. A user with no explicit subscription inherits their org's default channel map for the event.

**Policy (documented in code):** the resolver runs in a scope-less background fanout, and a tenant can own several orgs, so org defaults apply only when the user's tenant owns **exactly one** organisation (unambiguous). Multi-org tenants fall through to event-type defaults until an active-org signal is threaded through the fanout (future enhancement). All new deps are `@Optional()` + best-effort, so resolution never breaks on the org lookup and deployments without the org stack are unaffected.

## Test plan
- [x] Resolver jest — +5 cases (single-org applies; multi-org falls through; single-org-no-default falls through; no-tenant falls through; per-user subscription still wins). 20/20 pass.
- [ ] CI green on develop.

## Still open under #6 (not in this PR)
- **Delivery-event webhook persistence** (email `events/:pluginId` + channel events are 202 stubs) — backend, can follow next.
- **Settings UI** (add-channel wizard + Test-button handler) — needs real browser verification per the repo's frontend guidance; best as a dedicated verified PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization administrators can now set default notification channels at the organization level. These defaults apply to users when no personal preference is configured, while individual user settings continue to take priority.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->