### PR TITLE
chore(release): cascade stage → main (review findings #1–6 backend + Composio triggers)

### DIFF
--- a/apps/api/src/email/email.controller.ts
+++ b/apps/api/src/email/email.controller.ts
@@ -301,10 +301,19 @@ export class EmailController {
     @Throttle({ default: { ttl: 60_000, limit: 600 } })
     @HttpCode(HttpStatus.ACCEPTED)
     @ApiOperation({ summary: 'Provider delivery-event webhook (bounces, opens, clicks)' })
-    async eventsWebhook(@Param('pluginId') pluginId: string) {
-        // Per spec §7: events go through the facade's parseEventWebhook
-        // hook on the inbound plugin; for now we accept + return 202 so
-        // providers stop retrying while the full impl lands.
-        return { received: true, pluginId };
+    async eventsWebhook(
+        @Param('pluginId') pluginId: string,
+        @Req() req: WebhookRequest,
+        @Headers() headers: Record<string, string>,
+    ) {
+        const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
+        // Verify + decode the provider delivery-event payload, then fold
+        // each event's outcome onto the matching email_messages row
+        // (latest-status-wins). Always 202s so the provider stops
+        // retrying; a signature failure throws (mapped to 401 by the
+        // plugin's verifyWebhookSignature).
+        const events = await this.emailFacade.parseEventWebhook(pluginId, rawBody, headers);
+        const recorded = await this.emailFacade.recordDeliveryEvents(pluginId, events);
+        return { received: true, pluginId, events: events.length, recorded };
     }
 }

--- a/apps/api/src/migrations/1779991006500-CreateMissionIdeaAgentAttachmentTables.ts
+++ b/apps/api/src/migrations/1779991006500-CreateMissionIdeaAgentAttachmentTables.ts
@@ -24,8 +24,18 @@ import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } f
  *
  * Idempotent: each `CREATE TABLE` is guarded by `hasTable`, each index
  * by name lookup. Re-runs are no-ops.
+ *
+ * Timestamp note: PR #1050 renamed this file to `1779991006000-…` to clear
+ * a *filename* collision but left the class timestamp at `1779991000000`,
+ * which still collided with `AddUniqueIndexToUsername1779991000000` at the
+ * level TypeORM actually orders on (the trailing digits of the class name).
+ * Both file and class are now `1779991006500`: unique, ordered right after
+ * `AddTenantIdAndOrganizationIdToTierA1779991006000` and before
+ * `UpgradeWorkOrganizationIdToFk1779991007000`. Because every statement is
+ * idempotent, environments that already applied the old class name simply
+ * re-run this as a no-op.
  */
-export class CreateMissionIdeaAgentAttachmentTables1779991000000 implements MigrationInterface {
+export class CreateMissionIdeaAgentAttachmentTables1779991006500 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await this.createAttachmentTable(queryRunner, {
             tableName: 'mission_attachments',

--- a/apps/api/src/notifications/notification-preferences.service.spec.ts
+++ b/apps/api/src/notifications/notification-preferences.service.spec.ts
@@ -1,0 +1,82 @@
+import { BadRequestException } from '@nestjs/common';
+
+// Stub the agent database barrel so importing the service under test
+// doesn't pull in `@ever-works/agent/database`'s source `database.module`
+// (which uses the agent-internal `@src/config` alias the api jest config
+// can't resolve). We construct the service directly with mocks below, so
+// the real repository classes are only needed as DI metadata tokens.
+jest.mock('@ever-works/agent/database', () => ({
+    NotificationEventTypeRepository: class {},
+    UserNotificationSubscriptionRepository: class {},
+    UserNotificationPreferenceRepository: class {},
+    UserNotificationCategoryMuteRepository: class {},
+    NotificationChannelRepository: class {},
+}));
+
+import { NotificationPreferencesService } from './notification-preferences.service';
+
+/**
+ * Covers the channel-ownership + event-type validation added to
+ * `setEventSubscription` (review finding #6) — a caller must not be able
+ * to persist unknown event keys or channel ids they don't own.
+ */
+describe('NotificationPreferencesService.setEventSubscription validation', () => {
+    let eventTypes: { findByKey: jest.Mock };
+    let subscriptions: { upsert: jest.Mock; findForEvent: jest.Mock };
+    let channels: { findByIdForUser: jest.Mock };
+    let service: NotificationPreferencesService;
+
+    beforeEach(() => {
+        eventTypes = { findByKey: jest.fn().mockResolvedValue({ key: 'ai.credits.depleted' }) };
+        subscriptions = {
+            upsert: jest.fn().mockResolvedValue(undefined),
+            findForEvent: jest.fn().mockResolvedValue({ id: 'sub-1' }),
+        };
+        channels = { findByIdForUser: jest.fn().mockResolvedValue({ id: 'ch-1' }) };
+        service = new NotificationPreferencesService(
+            eventTypes as never,
+            subscriptions as never,
+            {} as never,
+            {} as never,
+            channels as never,
+        );
+    });
+
+    it('rejects an unknown event type', async () => {
+        eventTypes.findByKey.mockResolvedValue(null);
+        await expect(
+            service.setEventSubscription('user-1', 'bogus.key', ['in-app']),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(subscriptions.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a channel id the user does not own', async () => {
+        channels.findByIdForUser.mockResolvedValue(null);
+        await expect(
+            service.setEventSubscription('user-1', 'ai.credits.depleted', ['ch-foreign']),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(channels.findByIdForUser).toHaveBeenCalledWith('ch-foreign', 'user-1');
+        expect(subscriptions.upsert).not.toHaveBeenCalled();
+    });
+
+    it('accepts the built-in in-app channel without an ownership lookup', async () => {
+        await service.setEventSubscription('user-1', 'ai.credits.depleted', ['in-app']);
+        expect(channels.findByIdForUser).not.toHaveBeenCalled();
+        expect(subscriptions.upsert).toHaveBeenCalledWith('user-1', 'ai.credits.depleted', [
+            'in-app',
+        ]);
+    });
+
+    it('accepts an owned channel id and dedupes the list', async () => {
+        await service.setEventSubscription('user-1', 'ai.credits.depleted', [
+            'in-app',
+            'ch-1',
+            'ch-1',
+        ]);
+        expect(channels.findByIdForUser).toHaveBeenCalledTimes(1);
+        expect(subscriptions.upsert).toHaveBeenCalledWith('user-1', 'ai.credits.depleted', [
+            'in-app',
+            'ch-1',
+        ]);
+    });
+});

--- a/apps/api/src/notifications/notification-preferences.service.ts
+++ b/apps/api/src/notifications/notification-preferences.service.ts
@@ -1,10 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import {
     NotificationEventTypeRepository,
     UserNotificationSubscriptionRepository,
     UserNotificationPreferenceRepository,
     UserNotificationCategoryMuteRepository,
+    NotificationChannelRepository,
 } from '@ever-works/agent/database';
+
+/**
+ * Channel ids that are not rows in `notification_channels` — always
+ * available to every user and therefore exempt from the ownership check.
+ */
+const BUILT_IN_CHANNEL_IDS = new Set<string>(['in-app']);
 import type {
     NotificationEventType,
     UserNotificationSubscription,
@@ -32,6 +39,7 @@ export class NotificationPreferencesService {
         private readonly subscriptions: UserNotificationSubscriptionRepository,
         private readonly preferences: UserNotificationPreferenceRepository,
         private readonly mutes: UserNotificationCategoryMuteRepository,
+        private readonly channels: NotificationChannelRepository,
     ) {}
 
     async listEventTypes(): Promise<NotificationEventType[]> {
@@ -62,7 +70,31 @@ export class NotificationPreferencesService {
         eventTypeKey: string,
         channelIds: string[],
     ): Promise<UserNotificationSubscription> {
-        await this.subscriptions.upsert(userId, eventTypeKey, channelIds);
+        // Reject unknown event types so a typo can't persist a dead
+        // subscription row that silently never resolves.
+        const eventType = await this.eventTypes.findByKey(eventTypeKey);
+        if (!eventType) {
+            throw new BadRequestException(`Unknown notification event type: ${eventTypeKey}`);
+        }
+
+        // Validate channel ownership: every non-built-in channel id must
+        // be a notification_channels row owned by this user. Without this
+        // a caller could persist arbitrary (or another user's) channel
+        // UUIDs into their subscription row. Send-time scoping already
+        // blocks cross-tenant *delivery*, but storing foreign ids is a
+        // storage-integrity / info-leak gap. Dedupe first.
+        const unique = [...new Set(channelIds)];
+        for (const id of unique) {
+            if (BUILT_IN_CHANNEL_IDS.has(id)) continue;
+            const owned = await this.channels.findByIdForUser(id, userId);
+            if (!owned) {
+                throw new BadRequestException(
+                    `Unknown or unauthorized notification channel: ${id}`,
+                );
+            }
+        }
+
+        await this.subscriptions.upsert(userId, eventTypeKey, unique);
         return (await this.subscriptions.findForEvent(
             userId,
             eventTypeKey,

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
@@ -152,9 +152,26 @@ describe('AgentMemoryController', () => {
         });
 
         it('closeSession rejects an empty sessionId', async () => {
-            await expect(controller.closeSession(auth, '')).rejects.toBeInstanceOf(
+            await expect(controller.closeSession(auth, '', {})).rejects.toBeInstanceOf(
                 BadRequestException,
             );
+        });
+
+        it('closeSession enforces ownership + scopes by workId when one is supplied', async () => {
+            await controller.closeSession(auth, 'sess-1', { workId: 'work-1' });
+            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(agentMemory.closeSession).toHaveBeenCalledWith(
+                'sess-1',
+                expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
+            );
+        });
+
+        it('closeSession propagates an ownership rejection (cannot close another user Work session)', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            await expect(
+                controller.closeSession(auth, 'sess-1', { workId: 'work-x' }),
+            ).rejects.toThrow('not your work');
+            expect(agentMemory.closeSession).not.toHaveBeenCalled();
         });
 
         it('listSessions forwards limit + projectId', async () => {
@@ -168,17 +185,34 @@ describe('AgentMemoryController', () => {
 
     describe('deleteEntry', () => {
         it('rejects an empty entryId', async () => {
-            await expect(controller.deleteEntry(auth, '')).rejects.toBeInstanceOf(
+            await expect(controller.deleteEntry(auth, '', {})).rejects.toBeInstanceOf(
                 BadRequestException,
             );
         });
 
         it('passes the id to the facade', async () => {
-            await controller.deleteEntry(auth, 'mem-42');
+            await controller.deleteEntry(auth, 'mem-42', {});
             expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
                 'mem-42',
                 expect.objectContaining({ userId: 'user-1' }),
             );
+        });
+
+        it('enforces ownership + scopes by workId when one is supplied', async () => {
+            await controller.deleteEntry(auth, 'mem-42', { workId: 'work-1' });
+            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
+                'mem-42',
+                expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
+            );
+        });
+
+        it('propagates an ownership rejection (cannot forget another user Work entry)', async () => {
+            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            await expect(
+                controller.deleteEntry(auth, 'mem-42', { workId: 'work-x' }),
+            ).rejects.toThrow('not your work');
+            expect(agentMemory.deleteEntry).not.toHaveBeenCalled();
         });
     });
 
@@ -203,7 +237,7 @@ describe('AgentMemoryController', () => {
             agentMemory.deleteEntry.mockRejectedValueOnce(
                 new Error('Agent-memory provider "x" does not support deleteEntry'),
             );
-            await expect(controller.deleteEntry(auth, 'mem-1')).rejects.toBeInstanceOf(
+            await expect(controller.deleteEntry(auth, 'mem-1', {})).rejects.toBeInstanceOf(
                 NotFoundException,
             );
         });

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
@@ -19,6 +19,7 @@ import { AuthenticatedUser } from '../../auth/types/auth.types';
 import {
     BuildContextDto,
     ListSessionsQueryDto,
+    MemoryScopeQueryDto,
     OpenSessionDto,
     SaveMemoryDto,
     SearchMemoryDto,
@@ -104,10 +105,12 @@ export class AgentMemoryController {
     async closeSession(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('sessionId') sessionId: string,
+        @Query() query: MemoryScopeQueryDto,
     ) {
         if (!sessionId) throw new BadRequestException('sessionId is required');
+        await this.assertWorkAccess(auth, query.workId);
         try {
-            await this.agentMemory.closeSession(sessionId, this.facadeOptions(auth));
+            await this.agentMemory.closeSession(sessionId, this.facadeOptions(auth, query.workId));
             return { status: 'success' };
         } catch (error) {
             throw this.toHttpError(error, 'closeSession');
@@ -202,10 +205,15 @@ export class AgentMemoryController {
     @Delete('/entries/:entryId')
     @ApiOperation({ summary: 'Forget a single memory record' })
     @ApiResponse({ status: 200, description: 'Deleted' })
-    async deleteEntry(@CurrentUser() auth: AuthenticatedUser, @Param('entryId') entryId: string) {
+    async deleteEntry(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('entryId') entryId: string,
+        @Query() query: MemoryScopeQueryDto,
+    ) {
         if (!entryId) throw new BadRequestException('entryId is required');
+        await this.assertWorkAccess(auth, query.workId);
         try {
-            await this.agentMemory.deleteEntry(entryId, this.facadeOptions(auth));
+            await this.agentMemory.deleteEntry(entryId, this.facadeOptions(auth, query.workId));
             return { status: 'success' };
         } catch (error) {
             throw this.toHttpError(error, 'deleteEntry');

--- a/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/dto/agent-memory.dto.ts
@@ -146,6 +146,15 @@ export class OpenSessionDto extends WorkScopedDto {
     metadata?: Record<string, unknown>;
 }
 
+/**
+ * Query scope for the id-addressed mutations (`DELETE /entries/:id`,
+ * `POST /sessions/:id/close`). Supplying `workId` runs the same
+ * `WorkOwnershipService.ensureCanView` check the other mutations use and
+ * scopes provider/project resolution to that Work, so a user can't
+ * close/forget another user's Work-scoped memory by guessing an id.
+ */
+export class MemoryScopeQueryDto extends WorkScopedDto {}
+
 export class ListSessionsQueryDto extends WorkScopedDto {
     @ApiPropertyOptional({ description: 'Max sessions to return.', minimum: 1, maximum: 100 })
     @IsOptional()

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.controller.spec.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.controller.spec.ts
@@ -1,0 +1,153 @@
+import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+// The controller is constructed directly with mocks below; stub the
+// heavy import-graph modules so loading the controller doesn't pull the
+// real auth → agent/database chain (which uses the agent-internal
+// `@src/config` alias the api jest config can't resolve) or the Composio
+// SDK. Mirrors the mocking strategy in composio.service.spec.ts.
+jest.mock('../composio/composio.service', () => ({ ComposioService: class {} }));
+jest.mock('../../auth', () => ({
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+jest.mock('@src/auth/decorators/public.decorator', () => ({ Public: () => () => undefined }));
+
+import { ComposioTriggersController } from './composio-triggers.controller';
+import type { ComposioTriggersService } from './composio-triggers.service';
+import type { ComposioService } from '../composio/composio.service';
+import type { AuthenticatedUser } from '@src/auth/types/auth.types';
+
+const auth = { userId: 'user-1' } as AuthenticatedUser;
+
+describe('ComposioTriggersController', () => {
+    let triggers: jest.Mocked<
+        Pick<
+            ComposioTriggersService,
+            'create' | 'remove' | 'findByComposioTriggerId' | 'recordDelivery'
+        >
+    >;
+    let composio: jest.Mocked<
+        Pick<ComposioService, 'createTrigger' | 'deleteTrigger' | 'verifyWebhook'>
+    >;
+    let controller: ComposioTriggersController;
+
+    beforeEach(() => {
+        triggers = {
+            create: jest.fn(),
+            remove: jest.fn(),
+            findByComposioTriggerId: jest.fn(),
+            recordDelivery: jest.fn().mockResolvedValue(undefined),
+        } as never;
+        composio = {
+            createTrigger: jest.fn(),
+            deleteTrigger: jest.fn().mockResolvedValue(true),
+            verifyWebhook: jest.fn(),
+        } as never;
+        controller = new ComposioTriggersController(
+            triggers as unknown as ComposioTriggersService,
+            composio as unknown as ComposioService,
+        );
+    });
+
+    describe('create', () => {
+        it('enables the trigger upstream then persists the row keyed by the real tg_* id', async () => {
+            composio.createTrigger.mockResolvedValue({ triggerId: 'tg_real_1' });
+            triggers.create.mockResolvedValue({
+                id: 'sub-1',
+                toolkitSlug: 'GMAIL',
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                composioTriggerId: 'tg_real_1',
+                composioConnectedAccountId: 'ca_1',
+                enabled: true,
+                deliveriesReceived: 0,
+                deliveriesRejected: 0,
+                lastFiredAt: null,
+                createdAt: new Date('2026-05-29T00:00:00Z'),
+            } as never);
+
+            const dto = await controller.create(auth, {
+                toolkitSlug: 'GMAIL',
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                composioConnectedAccountId: 'ca_1',
+            } as never);
+
+            expect(composio.createTrigger).toHaveBeenCalledWith('user-1', {
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                connectedAccountId: 'ca_1',
+                config: undefined,
+            });
+            expect(triggers.create).toHaveBeenCalledWith('user-1', 'tg_real_1', expect.any(Object));
+            expect(dto.composioTriggerId).toBe('tg_real_1');
+            // The vestigial per-subscription secret is never surfaced.
+            expect((dto as unknown as Record<string, unknown>).webhookSecret).toBeUndefined();
+        });
+    });
+
+    describe('remove', () => {
+        it('removes locally then tears the trigger down upstream', async () => {
+            triggers.remove.mockResolvedValue('tg_real_1');
+            await controller.remove(auth, 'sub-1');
+            expect(triggers.remove).toHaveBeenCalledWith('user-1', 'sub-1');
+            expect(composio.deleteTrigger).toHaveBeenCalledWith('user-1', 'tg_real_1');
+        });
+    });
+
+    describe('webhook', () => {
+        const v3Body = { type: 'gmail.new_email', metadata: { trigger_id: 'tg_real_1' } };
+        const headers = {
+            'webhook-id': 'wh_1',
+            'webhook-signature': 'v1,sig',
+            'webhook-timestamp': '1700000000',
+        };
+
+        it('400s when the trigger id is missing from the payload', async () => {
+            await expect(
+                controller.webhook({ rawBody: '{}' }, {} as never, headers),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('404s for an unknown trigger', async () => {
+            triggers.findByComposioTriggerId.mockResolvedValue(null);
+            await expect(
+                controller.webhook({ rawBody: JSON.stringify(v3Body) }, v3Body as never, headers),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('verifies via the owning user, records accepted, and returns ok', async () => {
+            triggers.findByComposioTriggerId.mockResolvedValue({
+                id: 'sub-1',
+                userId: 'owner-7',
+            } as never);
+            composio.verifyWebhook.mockResolvedValue({ version: 'V3', payload: {} });
+
+            const result = await controller.webhook(
+                { rawBody: JSON.stringify(v3Body) },
+                v3Body as never,
+                headers,
+            );
+
+            expect(triggers.findByComposioTriggerId).toHaveBeenCalledWith('tg_real_1');
+            expect(composio.verifyWebhook).toHaveBeenCalledWith('owner-7', {
+                id: 'wh_1',
+                rawBody: JSON.stringify(v3Body),
+                signature: 'v1,sig',
+                timestamp: '1700000000',
+            });
+            expect(triggers.recordDelivery).toHaveBeenCalledWith('sub-1', 'accepted');
+            expect(result).toEqual({ ok: true });
+        });
+
+        it('records rejected and rethrows when verification fails', async () => {
+            triggers.findByComposioTriggerId.mockResolvedValue({
+                id: 'sub-1',
+                userId: 'owner-7',
+            } as never);
+            composio.verifyWebhook.mockRejectedValue(new UnauthorizedException('bad sig'));
+
+            await expect(
+                controller.webhook({ rawBody: JSON.stringify(v3Body) }, v3Body as never, headers),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+            expect(triggers.recordDelivery).toHaveBeenCalledWith('sub-1', 'rejected');
+        });
+    });
+});

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.controller.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.controller.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import {
     BadRequestException,
     Body,
@@ -20,6 +19,7 @@ import { AuthSessionGuard, CurrentUser } from '../../auth';
 import { Public } from '@src/auth/decorators/public.decorator';
 import type { AuthenticatedUser } from '@src/auth/types/auth.types';
 import { ComposioTriggersService } from './composio-triggers.service';
+import { ComposioService } from '../composio/composio.service';
 import {
     ComposioTriggerDto,
     ComposioTriggerListDto,
@@ -30,7 +30,10 @@ import type { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 @ApiTags('Composio Triggers')
 @Controller('api/plugins/composio')
 export class ComposioTriggersController {
-    constructor(private readonly triggers: ComposioTriggersService) {}
+    constructor(
+        private readonly triggers: ComposioTriggersService,
+        private readonly composio: ComposioService,
+    ) {}
 
     @Get('triggers')
     @ApiBearerAuth('JWT-auth')
@@ -49,20 +52,23 @@ export class ComposioTriggersController {
     @ApiOperation({
         summary: 'Create a Composio trigger subscription',
         description:
-            "Allocates a server-generated HMAC secret and stores the subscription. The created `webhookSecret` is returned in the response **once** — store it client-side if you need to register the same trigger on a different platform. Subsequent GETs never include it. (Follow-up PR will also call Composio's `POST /triggers` to enable the trigger upstream and persist the returned `tg_*` id.)",
+            'Enables the trigger upstream on Composio (`triggers.create` via the official SDK) and stores the subscription keyed by the returned `tg_*` id. Composio signs inbound deliveries with the project webhook secret (configured under Settings → Plugins → Composio), which the `/webhook` endpoint verifies via the SDK.',
     })
     @ApiResponse({ status: 201, type: ComposioTriggerDto })
     async create(
         @CurrentUser() auth: AuthenticatedUser,
         @Body() body: CreateComposioTriggerDto,
     ): Promise<ComposioTriggerDto> {
-        // Until the upstream Composio enable-trigger call is wired,
-        // we mint a placeholder composioTriggerId so the row is uniquely
-        // queryable. Once enabled, this is replaced with the real
-        // `tg_*` returned by Composio in the same transaction.
-        const placeholderTriggerId = `local_${randomUUID()}`;
-        const row = await this.triggers.create(auth.userId, placeholderTriggerId, body);
-        return { ...toDto(row), webhookSecret: row.webhookSecret };
+        // Enable the trigger upstream on Composio first, then persist the
+        // row keyed by the real `tg_*` id so webhook deliveries (which
+        // carry that id) resolve back to this subscription.
+        const { triggerId } = await this.composio.createTrigger(auth.userId, {
+            triggerSlug: body.triggerSlug,
+            connectedAccountId: body.composioConnectedAccountId,
+            config: body.config ?? undefined,
+        });
+        const row = await this.triggers.create(auth.userId, triggerId, body);
+        return toDto(row);
     }
 
     @Delete('triggers/:id')
@@ -74,7 +80,13 @@ export class ComposioTriggersController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', new ParseUUIDPipe()) id: string,
     ): Promise<void> {
-        await this.triggers.remove(auth.userId, id);
+        const composioTriggerId = await this.triggers.remove(auth.userId, id);
+        // Best-effort upstream teardown — the local row is already gone; a
+        // failed upstream delete (e.g. trigger already removed) is logged
+        // and swallowed inside the service.
+        if (composioTriggerId) {
+            await this.composio.deleteTrigger(auth.userId, composioTriggerId);
+        }
     }
 
     @Public()
@@ -83,16 +95,16 @@ export class ComposioTriggersController {
     @ApiOperation({
         summary: 'Composio webhook receiver',
         description:
-            'Inbound Composio webhook deliveries land here. Composio signs the JSON body with HMAC-SHA256 of the per-subscription secret; the digest arrives as `x-composio-signature`. The handler resolves the subscription by the `tg_*` trigger id in the payload, verifies the signature in constant time, and records the outcome. Returns 200 even on no-op outcomes so Composio does not retry; 401 only when signature verification fails.',
+            'Inbound Composio webhook deliveries land here. The handler resolves the subscription by the `tg_*` trigger id in the payload, then verifies the delivery via the official Composio SDK (`triggers.verifyWebhook`) using the project webhook secret + the `webhook-id` / `webhook-signature` / `webhook-timestamp` headers. Returns 200 on accept so Composio does not retry; 401 when verification fails, 404 for an unknown trigger.',
     })
     async webhook(
         @Req() req: { rawBody?: string },
         @Body() body: ComposioWebhookPayload,
-        @Headers('x-composio-signature') signature: string | undefined,
+        @Headers() headers: Record<string, string>,
     ): Promise<{ ok: true }> {
-        const triggerId = body?.trigger_id ?? body?.triggerId;
-        if (!triggerId || typeof triggerId !== 'string') {
-            throw new BadRequestException('Missing trigger_id in webhook payload');
+        const triggerId = extractComposioTriggerId(body);
+        if (!triggerId) {
+            throw new BadRequestException('Missing trigger id in webhook payload');
         }
         if (!req.rawBody) {
             throw new BadRequestException('Missing raw webhook payload');
@@ -106,7 +118,15 @@ export class ComposioTriggersController {
         }
 
         try {
-            this.triggers.verifyDelivery(subscription, req.rawBody, signature);
+            // Verify against the OWNING user's project webhook secret — the
+            // webhook is @Public(), so the user is resolved from the trigger
+            // id, not an auth token. Fails closed when no secret is set.
+            await this.composio.verifyWebhook(subscription.userId, {
+                id: headers['webhook-id'] ?? '',
+                rawBody: req.rawBody,
+                signature: headers['webhook-signature'] ?? '',
+                timestamp: headers['webhook-timestamp'] ?? '',
+            });
         } catch (error) {
             await this.triggers.recordDelivery(subscription.id, 'rejected');
             throw error;
@@ -123,7 +143,18 @@ export class ComposioTriggersController {
 interface ComposioWebhookPayload {
     trigger_id?: string;
     triggerId?: string;
+    metadata?: { trigger_id?: string };
     [key: string]: unknown;
+}
+
+/**
+ * Extract the `tg_*` trigger id from a Composio webhook payload. V3
+ * nests it under `metadata.trigger_id`; legacy V1/V2 carry it top-level
+ * as `trigger_id` / `triggerId`.
+ */
+function extractComposioTriggerId(body: ComposioWebhookPayload | undefined): string | undefined {
+    const candidate = body?.metadata?.trigger_id ?? body?.trigger_id ?? body?.triggerId;
+    return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined;
 }
 
 function toDto(row: ComposioTriggerSubscription): ComposioTriggerDto {

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -7,7 +7,11 @@ import { ComposioTriggersService } from './composio-triggers.service';
 import { ComposioApiModule } from '../composio/composio.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioApiModule],
+    imports: [
+        TypeOrmModule.forFeature([ComposioTriggerSubscription]),
+        AuthModule,
+        ComposioApiModule,
+    ],
     controllers: [ComposioTriggersController],
     providers: [ComposioTriggersService],
     exports: [ComposioTriggersService],

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -4,9 +4,10 @@ import { AuthModule } from '../../auth/auth.module';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import { ComposioTriggersController } from './composio-triggers.controller';
 import { ComposioTriggersService } from './composio-triggers.service';
+import { ComposioModule } from '../composio/composio.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule],
+    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioModule],
     controllers: [ComposioTriggersController],
     providers: [ComposioTriggersService],
     exports: [ComposioTriggersService],

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.module.ts
@@ -4,10 +4,10 @@ import { AuthModule } from '../../auth/auth.module';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import { ComposioTriggersController } from './composio-triggers.controller';
 import { ComposioTriggersService } from './composio-triggers.service';
-import { ComposioModule } from '../composio/composio.module';
+import { ComposioApiModule } from '../composio/composio.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioModule],
+    imports: [TypeOrmModule.forFeature([ComposioTriggerSubscription]), AuthModule, ComposioApiModule],
     controllers: [ComposioTriggersController],
     providers: [ComposioTriggersService],
     exports: [ComposioTriggersService],

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.spec.ts
@@ -1,6 +1,5 @@
-import { createHmac } from 'node:crypto';
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import { ComposioTriggersService } from './composio-triggers.service';
@@ -58,46 +57,15 @@ describe('ComposioTriggersService', () => {
             );
         });
 
-        it('deletes when found', async () => {
-            repo.findOne.mockResolvedValue({ id: 'sub-1', userId: 'user-1' });
-            await service.remove('user-1', 'sub-1');
+        it('deletes when found and returns the composio trigger id for upstream teardown', async () => {
+            repo.findOne.mockResolvedValue({
+                id: 'sub-1',
+                userId: 'user-1',
+                composioTriggerId: 'tg_abc',
+            });
+            const result = await service.remove('user-1', 'sub-1');
             expect(repo.delete).toHaveBeenCalledWith({ id: 'sub-1' });
-        });
-    });
-
-    describe('verifyDelivery', () => {
-        const secret = 'a'.repeat(64);
-        const rawBody = '{"trigger_id":"tg_1","data":{"foo":"bar"}}';
-        const validSig = createHmac('sha256', secret).update(rawBody).digest('hex');
-
-        it('accepts a valid signature', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, validSig),
-            ).not.toThrow();
-        });
-
-        it('accepts a valid signature with the `sha256=` prefix', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, `sha256=${validSig}`),
-            ).not.toThrow();
-        });
-
-        it('rejects a tampered body', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody + 'tampered', validSig),
-            ).toThrow(UnauthorizedException);
-        });
-
-        it('rejects when the signature is missing', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, undefined),
-            ).toThrow(UnauthorizedException);
-        });
-
-        it('rejects when the signature length is wrong (defeats truncation oracle)', () => {
-            expect(() =>
-                service.verifyDelivery({ webhookSecret: secret }, rawBody, validSig.slice(0, 32)),
-            ).toThrow(UnauthorizedException);
+            expect(result).toBe('tg_abc');
         });
     });
 

--- a/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
+++ b/apps/api/src/plugins/composio-triggers/composio-triggers.service.ts
@@ -1,28 +1,23 @@
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ComposioTriggerSubscription } from '@ever-works/agent/entities';
 import type { CreateComposioTriggerDto } from './dto/composio-trigger.dto';
 
 /**
- * CRUD + webhook-verification service for `composio_trigger_subscriptions`.
+ * CRUD + delivery-bookkeeping service for `composio_trigger_subscriptions`.
  *
- * Triggers are created via `POST /api/plugins/composio/triggers`. The
- * service generates a per-subscription HMAC secret server-side and
- * returns it ONCE in the create response. Subsequent reads never
- * include the secret.
- *
- * Webhook deliveries arrive at `POST /api/plugins/composio/webhook`
- * with the Composio trigger id in the JSON body (`tg_*`) plus an
- * `x-composio-signature` header — the controller resolves the
- * subscription by trigger id, then `verifyDelivery` HMAC-checks the
- * raw request body against the stored secret in constant time.
+ * Triggers are enabled upstream on Composio (via the SDK in
+ * `ComposioService`) and stored here keyed by the returned `tg_*` id.
+ * Webhook deliveries arrive at `POST /api/plugins/composio/webhook`; the
+ * controller resolves the subscription by trigger id and verifies the
+ * delivery via the official Composio SDK against the project webhook
+ * secret (see `ComposioService.verifyWebhook`). This service then records
+ * the accepted/rejected outcome.
  */
 @Injectable()
 export class ComposioTriggersService {
-    private readonly logger = new Logger(ComposioTriggersService.name);
-
     constructor(
         @InjectRepository(ComposioTriggerSubscription)
         private readonly repo: Repository<ComposioTriggerSubscription>,
@@ -36,10 +31,15 @@ export class ComposioTriggersService {
     }
 
     /**
-     * Creates a trigger subscription row. In a follow-up PR this will
-     * also call Composio's `POST /triggers` to enable the trigger
-     * upstream — for now the controller layer wires the upstream call
-     * and passes us the resulting `composioTriggerId`.
+     * Persist a trigger subscription row keyed by the real Composio
+     * `tg_*` id (the controller enables the trigger upstream via the SDK
+     * first and passes the returned id here).
+     *
+     * `webhookSecret` is retained as an internal random value only to
+     * satisfy the column's NOT NULL constraint — it is **no longer** the
+     * verification secret. Composio signs deliveries with the project
+     * webhook secret (resolved from plugin settings at verify time), so
+     * the per-subscription value is vestigial and never surfaced.
      */
     async create(
         userId: string,
@@ -62,57 +62,21 @@ export class ComposioTriggersService {
         return this.repo.save(entity);
     }
 
-    async remove(userId: string, id: string): Promise<void> {
+    /**
+     * Remove the local subscription row and return its Composio `tg_*` id
+     * so the caller can tear the trigger down upstream (best-effort).
+     */
+    async remove(userId: string, id: string): Promise<string> {
         const subscription = await this.repo.findOne({ where: { id, userId } });
         if (!subscription) throw new NotFoundException('Trigger subscription not found');
         await this.repo.delete({ id });
+        return subscription.composioTriggerId;
     }
 
     async findByComposioTriggerId(
         composioTriggerId: string,
     ): Promise<ComposioTriggerSubscription | null> {
         return this.repo.findOne({ where: { composioTriggerId } });
-    }
-
-    /**
-     * Verifies an inbound Composio webhook delivery against the stored
-     * per-subscription HMAC secret. Composio signs deliveries with
-     * HMAC-SHA256 of the raw JSON body; the signature is sent as the
-     * hex digest in the `x-composio-signature` header.
-     *
-     * Uses `crypto.timingSafeEqual` to defeat timing attacks. Throws
-     * `UnauthorizedException` on mismatch.
-     */
-    verifyDelivery(
-        subscription: Pick<ComposioTriggerSubscription, 'webhookSecret'>,
-        rawBody: string,
-        signature: string | undefined,
-    ): void {
-        if (!signature || typeof signature !== 'string') {
-            throw new UnauthorizedException('Missing x-composio-signature header');
-        }
-
-        const computed = createHmac('sha256', subscription.webhookSecret)
-            .update(rawBody)
-            .digest('hex');
-
-        const provided = signature
-            .trim()
-            .toLowerCase()
-            .replace(/^sha256=/, '');
-        if (provided.length !== computed.length) {
-            throw new UnauthorizedException('Invalid Composio webhook signature');
-        }
-
-        let equal = false;
-        try {
-            equal = timingSafeEqual(Buffer.from(provided, 'hex'), Buffer.from(computed, 'hex'));
-        } catch {
-            equal = false;
-        }
-        if (!equal) {
-            throw new UnauthorizedException('Invalid Composio webhook signature');
-        }
     }
 
     async recordDelivery(subscriptionId: string, outcome: 'accepted' | 'rejected'): Promise<void> {

--- a/apps/api/src/plugins/composio-triggers/dto/composio-trigger.dto.ts
+++ b/apps/api/src/plugins/composio-triggers/dto/composio-trigger.dto.ts
@@ -36,9 +36,6 @@ export class ComposioTriggerDto {
     @ApiProperty() deliveriesRejected!: number;
     @ApiPropertyOptional({ type: String }) lastFiredAt?: string | null;
     @ApiProperty() createdAt!: string;
-
-    /** Only returned on initial creation. Never re-fetched. */
-    @ApiPropertyOptional() webhookSecret?: string;
 }
 
 export class ComposioTriggerListDto {

--- a/apps/api/src/plugins/composio/composio.service.spec.ts
+++ b/apps/api/src/plugins/composio/composio.service.spec.ts
@@ -17,6 +17,7 @@ jest.mock('@composio/core', () => ({
     Composio: jest.fn().mockImplementation(() => ({
         toolkits: { get: jest.fn() },
         connectedAccounts: { list: jest.fn(), initiate: jest.fn() },
+        triggers: { create: jest.fn(), delete: jest.fn(), verifyWebhook: jest.fn() },
     })),
 }));
 
@@ -27,6 +28,7 @@ function buildSdkStub(): ComposioSdkLike {
     return {
         toolkits: { get: jest.fn() },
         connectedAccounts: { list: jest.fn(), initiate: jest.fn() },
+        triggers: { create: jest.fn(), delete: jest.fn(), verifyWebhook: jest.fn() },
     } as unknown as ComposioSdkLike;
 }
 
@@ -268,6 +270,110 @@ describe('ComposioService', () => {
                     authConfigId: 'ac_xyz',
                 }),
             ).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+
+    describe('triggers — upstream enable + webhook verification', () => {
+        it('createTrigger calls the SDK and returns the tg_* id', async () => {
+            const sdk = buildSdkStub();
+            (sdk.triggers.create as jest.Mock).mockResolvedValue({ triggerId: 'tg_real_1' });
+            injectSdk(service, sdk);
+
+            const result = await service.createTrigger('user-1', {
+                triggerSlug: 'GMAIL_NEW_EMAIL',
+                connectedAccountId: 'ca_1',
+                config: { labelIds: ['INBOX'] },
+            });
+
+            expect(result).toEqual({ triggerId: 'tg_real_1' });
+            expect(sdk.triggers.create).toHaveBeenCalledWith('user-1', 'GMAIL_NEW_EMAIL', {
+                triggerConfig: { labelIds: ['INBOX'] },
+                connectedAccountId: 'ca_1',
+            });
+        });
+
+        it('createTrigger throws when the SDK returns no trigger id', async () => {
+            const sdk = buildSdkStub();
+            (sdk.triggers.create as jest.Mock).mockResolvedValue({});
+            injectSdk(service, sdk);
+            await expect(
+                service.createTrigger('user-1', { triggerSlug: 'X' }),
+            ).rejects.toBeInstanceOf(Error);
+        });
+
+        it('deleteTrigger returns true on success, false (swallowed) on failure', async () => {
+            const sdk = buildSdkStub();
+            (sdk.triggers.delete as jest.Mock).mockResolvedValue({ triggerId: 'tg_1' });
+            injectSdk(service, sdk);
+            await expect(service.deleteTrigger('user-1', 'tg_1')).resolves.toBe(true);
+
+            (sdk.triggers.delete as jest.Mock).mockRejectedValue(new Error('already gone'));
+            await expect(service.deleteTrigger('user-1', 'tg_1')).resolves.toBe(false);
+        });
+
+        it('verifyWebhook fails closed when no webhook secret is configured', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(buildResolvedSettings());
+            const prevEnv = process.env.COMPOSIO_WEBHOOK_SECRET;
+            delete process.env.COMPOSIO_WEBHOOK_SECRET;
+            try {
+                await expect(
+                    service.verifyWebhook('user-1', {
+                        id: 'wh_1',
+                        rawBody: '{}',
+                        signature: 'v1,sig',
+                        timestamp: '123',
+                    }),
+                ).rejects.toBeInstanceOf(UnauthorizedException);
+            } finally {
+                if (prevEnv !== undefined) process.env.COMPOSIO_WEBHOOK_SECRET = prevEnv;
+            }
+        });
+
+        it('verifyWebhook delegates to the SDK with the resolved project secret', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(
+                buildResolvedSettings({ webhookSecret: 'whsec_project' }),
+            );
+            const sdk = buildSdkStub();
+            (sdk.triggers.verifyWebhook as jest.Mock).mockResolvedValue({
+                version: 'V3',
+                payload: { ok: true },
+                rawPayload: '{}',
+            });
+            injectSdk(service, sdk);
+
+            const result = await service.verifyWebhook('user-1', {
+                id: 'wh_1',
+                rawBody: '{"a":1}',
+                signature: 'v1,sig',
+                timestamp: '1700000000',
+            });
+
+            expect(result).toEqual({ version: 'V3', payload: { ok: true } });
+            expect(sdk.triggers.verifyWebhook).toHaveBeenCalledWith({
+                id: 'wh_1',
+                payload: '{"a":1}',
+                signature: 'v1,sig',
+                timestamp: '1700000000',
+                secret: 'whsec_project',
+            });
+        });
+
+        it('verifyWebhook maps SDK verification failure to UnauthorizedException', async () => {
+            settingsService.getResolvedSettings.mockResolvedValue(
+                buildResolvedSettings({ webhookSecret: 'whsec_project' }),
+            );
+            const sdk = buildSdkStub();
+            (sdk.triggers.verifyWebhook as jest.Mock).mockRejectedValue(new Error('bad signature'));
+            injectSdk(service, sdk);
+
+            await expect(
+                service.verifyWebhook('user-1', {
+                    id: 'wh_1',
+                    rawBody: '{}',
+                    signature: 'v1,bad',
+                    timestamp: '1700000000',
+                }),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
         });
     });
 });

--- a/apps/api/src/plugins/composio/composio.service.ts
+++ b/apps/api/src/plugins/composio/composio.service.ts
@@ -46,6 +46,21 @@ export interface ComposioSdkLike {
             redirectUrl?: string;
         }>;
     };
+    triggers: {
+        create(
+            userId: string,
+            slug: string,
+            body?: { triggerConfig?: Record<string, unknown>; connectedAccountId?: string },
+        ): Promise<{ triggerId: string }>;
+        delete(triggerId: string): Promise<{ triggerId: string }>;
+        verifyWebhook(params: {
+            id: string;
+            payload: string;
+            signature: string;
+            timestamp: string;
+            secret: string;
+        }): Promise<{ version: string; payload: unknown; rawPayload: string }>;
+    };
 }
 
 /**
@@ -176,6 +191,111 @@ export class ComposioService {
             };
         } catch (error) {
             throw this.wrapComposioError(error, `initiate connection to ${body.toolkitSlug}`);
+        }
+    }
+
+    /**
+     * Enable a trigger upstream on Composio for the caller and return the
+     * Composio-assigned `tg_*` id. When `connectedAccountId` is omitted,
+     * Composio uses the user's first connected account for the toolkit.
+     */
+    async createTrigger(
+        userId: string,
+        params: {
+            triggerSlug: string;
+            connectedAccountId?: string;
+            config?: Record<string, unknown>;
+        },
+    ): Promise<{ triggerId: string }> {
+        const sdk = await this.getSdk(userId);
+        try {
+            const body: { triggerConfig?: Record<string, unknown>; connectedAccountId?: string } =
+                {};
+            if (params.config) body.triggerConfig = params.config;
+            if (params.connectedAccountId) body.connectedAccountId = params.connectedAccountId;
+            const result = await sdk.triggers.create(userId, params.triggerSlug, body);
+            if (!result?.triggerId) {
+                throw new Error('Composio did not return a trigger id for the new trigger.');
+            }
+            return { triggerId: result.triggerId };
+        } catch (error) {
+            throw this.wrapComposioError(error, `enable trigger ${params.triggerSlug}`);
+        }
+    }
+
+    /**
+     * Disable/remove a trigger upstream on Composio. Best-effort — callers
+     * still remove the local row even when the upstream delete fails (the
+     * trigger may already be gone). Returns whether the upstream call
+     * succeeded so the caller can log.
+     */
+    async deleteTrigger(userId: string, composioTriggerId: string): Promise<boolean> {
+        try {
+            const sdk = await this.getSdk(userId);
+            await sdk.triggers.delete(composioTriggerId);
+            return true;
+        } catch (error) {
+            this.logger.warn(
+                `Composio upstream trigger delete failed for ${composioTriggerId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Resolve the caller's project-level Composio webhook secret
+     * (`COMPOSIO_WEBHOOK_SECRET`, set under Composio dashboard → Project
+     * Settings → Webhook, mirrored into the plugin's `webhookSecret`
+     * setting). Returns undefined when not configured.
+     */
+    async getWebhookSecret(userId: string): Promise<string | undefined> {
+        const resolved = await this.settingsService
+            .getResolvedSettings(COMPOSIO_PLUGIN_ID, { userId, includeSecrets: true })
+            .catch(() => null);
+        const settings = (resolved?.settings ?? null) as Record<string, unknown> | null;
+        const fromSettings = readString(settings, 'webhookSecret');
+        if (fromSettings) return fromSettings;
+        const fromEnv = process.env.COMPOSIO_WEBHOOK_SECRET;
+        return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+    }
+
+    /**
+     * Verify a Composio webhook delivery for `userId` using the official
+     * SDK verifier (HMAC-SHA256 of `{webhook-id}.{webhook-timestamp}.{body}`
+     * against the project webhook secret, base64 `v1,<sig>` form). Throws
+     * `UnauthorizedException` when the secret isn't configured or the
+     * signature/timestamp is invalid. Returns the parsed payload + version.
+     */
+    async verifyWebhook(
+        userId: string,
+        delivery: { id: string; rawBody: string; signature: string; timestamp: string },
+    ): Promise<{ version: string; payload: unknown }> {
+        const secret = await this.getWebhookSecret(userId);
+        if (!secret) {
+            // Fail CLOSED: a delivery for a known trigger with no secret
+            // configured cannot be trusted — never accept-all.
+            throw new UnauthorizedException(
+                'Composio webhook secret is not configured. Set it under Settings → Plugins → Composio (from Composio dashboard → Project Settings → Webhook).',
+            );
+        }
+        const sdk = await this.getSdk(userId);
+        try {
+            const result = await sdk.triggers.verifyWebhook({
+                id: delivery.id,
+                payload: delivery.rawBody,
+                signature: delivery.signature,
+                timestamp: delivery.timestamp,
+                secret,
+            });
+            return { version: result.version, payload: result.payload };
+        } catch (error) {
+            throw new UnauthorizedException(
+                `Composio webhook signature verification failed: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
         }
     }
 

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -48,8 +48,16 @@ const sidebars: SidebarsConfig = {
 				'features/creating-a-work',
 				'features/missions',
 				'features/ideas',
+				'features/agents',
+				'features/agent-email',
 				'features/mission-templates',
 				'features/budgets-and-usage',
+				'features/knowledge-base',
+				'features/autonomous-operation',
+				'features/workers',
+				'features/store-builder',
+				'features/company-builder',
+				'features/desktop-app',
 				'features/community-pr-processing',
 				'features/work-changelog',
 				'features/collections',
@@ -65,10 +73,16 @@ const sidebars: SidebarsConfig = {
 				'features/taxonomy-system',
 				'features/api-keys',
 				'features/custom-domains',
+				'features/website-templates',
 				'features/k8s-deployment',
 				'features/mcp-server',
 				'features/data-management'
 			]
+		},
+		{
+			type: 'category',
+			label: 'Guides',
+			items: ['guides/founder-journey']
 		},
 		{
 			type: 'category',

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -153,22 +153,19 @@ export function DashboardSidebar({
                 >
                     <div className="w-full relative">
                         {/*
-                            EW-660 (Tenants & Organizations Phase 8) —
-                            the expanded sidebar swaps `<LogoEverWork>`
-                            for `<WorkspaceSwitcher>`, which itself
-                            renders the unmodified logo when the user
-                            has zero Organizations (NN #20 — extension,
-                            not replacement). The collapsed sidebar
-                            keeps the bare favicon: there's no room for
-                            a chip+chevron at 16px column width, and
-                            users in that mode already expand the
-                            sidebar before reaching for the switcher.
+                            Expanded sidebar renders `<WorkspaceSwitcher>`,
+                            which always shows `[spinning favicon] [active
+                            org name OR Ever Works wordmark] [chevron]` and
+                            opens a popover with the org list + "+ Create
+                            Organization". The collapsed sidebar keeps the
+                            bare favicon — there's no room for a chip at
+                            16px column width.
                         */}
-                        <div className={cn('flex items-center -ml-2')}>
+                        <div className="flex items-center pr-6">
                             {isCollapsed ? (
                                 <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
                             ) : (
-                                <WorkspaceSwitcher config={config} logoClassName="" />
+                                <WorkspaceSwitcher config={config} />
                             )}
                         </div>
                         <div

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -15,15 +15,15 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useOrganizations } from '@/lib/hooks/use-organizations';
 import { useActiveScope } from '@/lib/hooks/use-active-scope';
-import { LogoEverWork } from '../logos';
+import { FaviconEverWorkImage, LogoEverWorkImage } from '../logos';
 import { CreateOrganizationModal } from '../organizations/CreateOrganizationModal';
 import type { WorkConfig } from '@/lib/api';
 import type { OrganizationResponse } from '@ever-works/contracts/api';
 
 interface WorkspaceSwitcherProps {
-    /** Site config passed through to the empty-state `<LogoEverWork>`. */
+    /** Site config passed through to the inline logo / favicon. */
     config?: WorkConfig | null;
-    /** Tailwind class for the empty-state logo. Lets the sidebar size it. */
+    /** Tailwind class for the inline wordmark image. */
     logoClassName?: string;
 }
 
@@ -61,67 +61,40 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
 
 /**
  * EW-660 (Tenants & Organizations Phase 8) — top-of-sidebar component
- * showing the active Organization (or the bare Ever Works logo when
- * the user has zero Orgs) with a popover to switch between Orgs.
+ * showing the spinning favicon + the active Organization (or the
+ * Ever Works wordmark when the user has zero Orgs) with a popover to
+ * switch between Orgs or create a new one.
  *
- * Behavior matrix:
+ * The whole row is a single dropdown trigger:
  *
- * | Org count | Trigger UI                       | Popover                   |
- * |-----------|----------------------------------|---------------------------|
- * | 0         | `<LogoEverWork />` unmodified    | none (no chevron)         |
- * | 1+        | Chip: [avatar] [name] [chevron]  | List of orgs + create row |
+ *   [spinning favicon] [label] [chevron]
  *
- * The empty-state branch renders `<LogoEverWork />` AS-IS so the
- * sidebar visuals for the no-org majority of users stay pixel-identical
- * (NN #20 — extension, not replacement).
+ * The trigger renders in every state (including zero-org), so the user
+ * can always reach "+ Create Organization" — pre-fix, the zero-org
+ * branch fell back to a bare logo with no popover and clicking it did
+ * nothing useful.
  *
- * Clicking an Org row navigates to `/{org.slug}/dashboard`. Clicking
- * "+ Create Organization" is a stub for Phase 9 — it `console.log`s
- * and the modal lands in EW-661.
+ * Trigger label by state:
+ *
+ * | Org count | Label                | Popover                         |
+ * |-----------|----------------------|---------------------------------|
+ * | 0         | Wordmark image       | "+ Create Organization" only    |
+ * | 1+        | Active org name      | Org list + "+ Create"           |
  */
 export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
     const { activeOrganization } = useActiveScope();
-    // Phase 9 — EW-661 — lifts the create-Org modal state into the
-    // switcher. `+ Create Organization` opens it; on success the modal
-    // routes to `/{slug}/dashboard` and (if first Org) chains into the
-    // upgrade-or-empty dialog.
     const [isCreateOpen, setIsCreateOpen] = useState(false);
 
-    // Empty state: no orgs yet → render the existing logo unmodified.
-    // We intentionally treat `isLoading` as empty for the initial
-    // render so we don't flash a "Loading…" chip in the most common
-    // case (zero orgs). Once the fetch resolves and orgs > 0, the
-    // chip appears.
-    if (!isLoading && organizations.length === 0) {
-        return <LogoEverWork config={config} className={logoClassName} />;
-    }
-
-    // Loading state, but only on the very first fetch when we don't
-    // yet know whether the user has orgs. Render a minimal skeleton
-    // (same width as the chip) so layout doesn't jump.
-    if (isLoading && organizations.length === 0) {
-        return (
-            <div
-                className={cn(
-                    'flex items-center gap-2 px-2 py-1.5 rounded-md',
-                    'text-text-muted dark:text-text-muted-dark',
-                    'text-sm',
-                )}
-                aria-busy="true"
-            >
-                <span className="w-7 h-7 rounded-md bg-surface-tertiary/60 dark:bg-surface-tertiary-dark/60 animate-pulse" />
-                <span className="truncate">{t('loading')}</span>
-            </div>
-        );
-    }
-
-    // Active state: 1+ orgs. Pick the trigger label — if we know the
-    // active Org from the URL slug, use it; otherwise fall back to the
-    // first org in the list so the chip never shows up empty.
-    const triggerOrg = activeOrganization ?? organizations[0];
+    const hasOrgs = organizations.length > 0;
+    // Pick the trigger label org — use the active one (from URL slug) if
+    // resolved, otherwise fall back to the first org so the chip never
+    // shows up empty when orgs exist.
+    const triggerOrg: OrganizationResponse | null = hasOrgs
+        ? (activeOrganization ?? organizations[0])
+        : null;
 
     const handleSelectOrg = (org: OrganizationResponse) => {
         router.push(`/${org.slug}/dashboard`);
@@ -139,14 +112,25 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
                         'w-full rounded-md transition-colors cursor-pointer',
                         'focus:outline-none focus-visible:outline-none',
                         'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                        'px-2 py-1.5',
+                        'px-1.5 py-1',
                     )}
+                    aria-label={t('heading')}
                 >
-                    <div className="flex items-center gap-2 w-full">
-                        <OrgAvatar org={triggerOrg} />
-                        <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                            {pickLabel(triggerOrg)}
-                        </span>
+                    <div className="flex items-center gap-1.5 w-full min-w-0">
+                        <FaviconEverWorkImage
+                            config={config}
+                            className="w-9 h-9 max-h-none shrink-0"
+                        />
+                        {triggerOrg ? (
+                            <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                                {pickLabel(triggerOrg)}
+                            </span>
+                        ) : (
+                            <LogoEverWorkImage
+                                config={config}
+                                className={cn('flex-1 min-w-0', logoClassName)}
+                            />
+                        )}
                         <ChevronsUpDown
                             className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
                             strokeWidth={1.5}
@@ -155,32 +139,40 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
                     </div>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="start" className="w-60">
-                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
-                    {organizations.map((org) => {
-                        const isActive = activeOrganization?.id === org.id;
-                        return (
-                            <DropdownMenuItem
-                                key={org.id}
-                                onClick={() => handleSelectOrg(org)}
-                                className="cursor-pointer"
-                            >
-                                <div className="flex items-center gap-2 w-full">
-                                    <OrgAvatar org={org} size="xs" />
-                                    <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
-                                        {pickLabel(org)}
-                                    </span>
-                                    {isActive && (
-                                        <Check
-                                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                                            strokeWidth={1.5}
-                                            aria-label="Active organization"
-                                        />
-                                    )}
-                                </div>
-                            </DropdownMenuItem>
-                        );
-                    })}
-                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>
+                        {hasOrgs ? t('heading') : t('bareTenant')}
+                    </DropdownMenuLabel>
+                    {hasOrgs &&
+                        organizations.map((org) => {
+                            const isActive = activeOrganization?.id === org.id;
+                            return (
+                                <DropdownMenuItem
+                                    key={org.id}
+                                    onClick={() => handleSelectOrg(org)}
+                                    className="cursor-pointer"
+                                >
+                                    <div className="flex items-center gap-2 w-full">
+                                        <OrgAvatar org={org} size="xs" />
+                                        <span className="flex-1 min-w-0 truncate text-text dark:text-text-dark">
+                                            {pickLabel(org)}
+                                        </span>
+                                        {isActive && (
+                                            <Check
+                                                className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                                strokeWidth={1.5}
+                                                aria-label="Active organization"
+                                            />
+                                        )}
+                                    </div>
+                                </DropdownMenuItem>
+                            );
+                        })}
+                    {hasOrgs && <DropdownMenuSeparator />}
+                    {isLoading && !hasOrgs && (
+                        <DropdownMenuItem disabled className="text-text-muted">
+                            {t('loading')}
+                        </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem onClick={handleCreateOrg} className="cursor-pointer">
                         <div className="flex items-center gap-2 w-full">
                             <span className="w-5 h-5 inline-flex items-center justify-center shrink-0">

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -26,11 +26,18 @@ vi.mock('@/i18n/navigation', () => ({
     useRouter: () => ({ push: routerPushMock }),
 }));
 
-// Mock the LogoEverWork to a simple sentinel — we don't want to render
-// the real Next.js Image (jsdom) and we want a stable test selector
-// for the empty-state assertion.
+// Mock the image-only logo variants to simple sentinels — we don't want
+// to render real Next.js Image components in jsdom, and we want stable
+// test selectors for the empty-state assertion.
 vi.mock('../logos', () => ({
-    LogoEverWork: () => <div data-testid="logo-everwork">LogoEverWork</div>,
+    LogoEverWorkImage: () => <span data-testid="logo-everwork-image">LogoEverWork</span>,
+    FaviconEverWorkImage: () => <span data-testid="favicon-everwork-image">FaviconEverWork</span>,
+}));
+
+// `CreateOrganizationModal` pulls in next/image and the full org create
+// flow — stub it to a noop so the trigger renders without exploding.
+vi.mock('../organizations/CreateOrganizationModal', () => ({
+    CreateOrganizationModal: () => null,
 }));
 
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
@@ -68,28 +75,41 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     });
 
     /**
-     * Empty state: `organizations.length === 0` → falls back to the
-     * unmodified `<LogoEverWork>` (NN #20 — extension, not replacement).
-     * No popover trigger should be present.
+     * Empty state: even with zero orgs the switcher renders the
+     * spinning favicon + wordmark + chevron trigger so the user can
+     * still reach "+ Create Organization". The previous behaviour
+     * (bare logo, no trigger) silently broke the create flow.
      */
-    it('renders the LogoEverWork (no popover trigger) when the user has zero organizations', () => {
+    it('renders favicon + wordmark + trigger when the user has zero organizations', () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
 
-        const { container } = render(<WorkspaceSwitcher />);
+        render(<WorkspaceSwitcher />);
 
-        expect(screen.getByTestId('logo-everwork')).toBeInTheDocument();
-        // No popover-trigger button — the empty state is the bare logo.
-        expect(container.querySelector('[role="button"]')).toBeNull();
-        // And the chevron icon — used as the trigger affordance — is
-        // absent.
-        expect(container.querySelectorAll('svg').length).toBe(0);
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        expect(screen.getByTestId('logo-everwork-image')).toBeInTheDocument();
+        // Trigger button is always present.
+        expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(1);
     });
 
     /**
-     * Active state with 1 org: the chip renders with the org's display
-     * name AND a trigger affordance (chevron icon).
+     * Empty state popover: opening the trigger surfaces the
+     * "+ Create Organization" row even when no orgs exist.
      */
-    it('renders the chip with the org name and a popover trigger when the user has 1 organization', () => {
+    it('shows "+ Create Organization" in the popover when zero orgs', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        render(<WorkspaceSwitcher />);
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Active state with 1 org: the trigger shows the spinning favicon
+     * + the org's display name (no wordmark) + chevron.
+     */
+    it('renders favicon + org name + trigger when the user has 1 organization', () => {
         const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
         __seedOrganizationsStoreForTests({
             data: [org],
@@ -99,18 +119,15 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
         render(<WorkspaceSwitcher />);
 
-        // Chip text shows the display name.
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
-        // The logo from the empty-state branch should NOT render.
-        expect(screen.queryByTestId('logo-everwork')).toBeNull();
+        // Wordmark is replaced by the active-org label.
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
     });
 
     /**
      * 3 orgs — when the popover opens, all three list rows are
-     * present. We assert against the DOM (text content) rather than
-     * driving headlessui's actual open animation, since the items are
-     * rendered into the menu's items container regardless of open
-     * state at the JSX level.
+     * present plus the "+ Create Organization" footer row.
      */
     it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
         const orgs = [
@@ -124,21 +141,14 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
             error: null,
         });
 
-        // Force the popover to open by clicking the trigger. Headless UI's
-        // MenuButton handles the click; the items mount on open.
         render(<WorkspaceSwitcher />);
         const trigger = screen.getAllByRole('button')[0];
         fireEvent.click(trigger);
 
-        // All three display names appear in the rendered tree (some
-        // also in the trigger chip — assert >= 1 for each).
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Globex LLC').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Initech').length).toBeGreaterThanOrEqual(1);
 
-        // The "+ Create Organization" row uses the i18n key
-        // `organizations.switcher.createNew` (our mock returns the key
-        // verbatim).
         expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 
@@ -146,7 +156,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
      * Falls back to the org's slug when `displayName` is null — slug is
      * NOT NULL on the DB row, so this is the right fallback shape.
      */
-    it('uses the org slug as the chip label when displayName is null', () => {
+    it('uses the org slug as the trigger label when displayName is null', () => {
         const org = makeOrg({ displayName: null, slug: 'fallback-org' });
         __seedOrganizationsStoreForTests({
             data: [org],

--- a/apps/web/src/components/logos/index.tsx
+++ b/apps/web/src/components/logos/index.tsx
@@ -17,7 +17,13 @@ interface LogoEverWorkProps {
     config?: WorkConfig | null;
 }
 
-export function LogoEverWork({
+/**
+ * Wordmark image only — no `<Link>` wrapper. Use this when the logo
+ * needs to live inside another interactive element (e.g. the
+ * `<WorkspaceSwitcher>` dropdown trigger) where nesting a `<Link>`
+ * inside a `<button>` would be invalid HTML.
+ */
+export function LogoEverWorkImage({
     className,
     width = 120,
     height = 40,
@@ -25,10 +31,8 @@ export function LogoEverWork({
     config: configProps,
 }: LogoEverWorkProps) {
     const siteConfig = getSiteConfig(configProps);
-    const logoHref = siteConfig.website || '/';
-
     return (
-        <Link href={logoHref} className={cn('relative flex items-center', className)}>
+        <span className={cn('relative flex items-center', className)}>
             <Image
                 src={siteConfig.logo.light}
                 alt={siteConfig.name}
@@ -45,7 +49,64 @@ export function LogoEverWork({
                 priority={false}
                 className="hidden dark:block h-auto w-auto max-h-12 object-contain"
             />
+        </span>
+    );
+}
+
+export function LogoEverWork({
+    className,
+    width = 120,
+    height = 40,
+    priority = true,
+    config: configProps,
+}: LogoEverWorkProps) {
+    // Derive only what this wrapper needs; LogoEverWorkImage derives its own.
+    const logoHref = getSiteConfig(configProps).website || '/';
+
+    return (
+        <Link href={logoHref} className={cn('relative flex items-center', className)}>
+            <LogoEverWorkImage
+                width={width}
+                height={height}
+                priority={priority}
+                config={configProps}
+            />
         </Link>
+    );
+}
+
+/**
+ * Spinning favicon image only — no `<Link>` wrapper. Same rationale as
+ * `LogoEverWorkImage`: lets the favicon be embedded inside other
+ * interactive elements (or composed alongside other content) without
+ * nesting links.
+ */
+export function FaviconEverWorkImage({
+    className,
+    config: configProps,
+    size = 32,
+}: {
+    className?: string;
+    config?: WorkConfig | null;
+    size?: number;
+}) {
+    const siteConfig = getSiteConfig(configProps);
+    const { isDark, mounted } = useTheme();
+    const faviconSrc = mounted && isDark ? siteConfig.favicon.dark : siteConfig.favicon.light;
+
+    return (
+        <Image
+            key={faviconSrc}
+            src={faviconSrc}
+            alt={siteConfig.name}
+            width={size}
+            height={size}
+            style={{ animationDuration: '10s' }}
+            className={cn(
+                'object-contain max-h-8 animate-spin motion-reduce:animate-none',
+                className,
+            )}
+        />
     );
 }
 
@@ -57,23 +118,13 @@ export function FaviconEverWork({
     config?: WorkConfig | null;
 }) {
     const siteConfig = getSiteConfig(configProps);
-    const { isDark, mounted } = useTheme();
-    const faviconSrc = mounted && isDark ? siteConfig.favicon.dark : siteConfig.favicon.light;
 
     return (
         <Link
             href={siteConfig.website || '/'}
             className={cn('relative flex items-center', className)}
         >
-            <Image
-                key={faviconSrc}
-                src={faviconSrc}
-                alt={siteConfig.name}
-                width={32}
-                height={32}
-                style={{ animationDuration: '10s' }}
-                className="object-contain max-h-8 ml-[10.5px] animate-spin motion-reduce:animate-none"
-            />
+            <FaviconEverWorkImage config={configProps} className="ml-[10.5px]" />
         </Link>
     );
 }

--- a/apps/web/src/lib/api/plugins-capabilities/composio-triggers.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/composio-triggers.ts
@@ -12,8 +12,6 @@ export interface ComposioTrigger {
     deliveriesRejected: number;
     lastFiredAt?: string | null;
     createdAt: string;
-    /** Returned only on create — never on subsequent reads. */
-    webhookSecret?: string;
 }
 
 export interface CreateComposioTriggerInput {

--- a/docs/features/agent-email.md
+++ b/docs/features/agent-email.md
@@ -1,0 +1,80 @@
+---
+id: agent-email
+title: Agent Email & Inboxes
+sidebar_label: Agent Email & Inboxes
+---
+
+# Agent Email & Inboxes
+
+Real employees have email addresses. So do Ever Works [Agents](./agents.md). Any Agent — and any [Mission](./missions.md), [Idea](./ideas.md), or [Work](./creating-a-work.md) — can be given one or more **inbound and outbound mailboxes**, so your AI workforce can send updates, receive replies, and turn incoming mail into work, without a human in the loop.
+
+This turns email from a thing the platform occasionally _sends_ (password resets, alerts) into a first-class, two-way channel your Agents live on.
+
+## What you can do
+
+- **Give an Agent a real "from" address** so its standups, summaries, and outreach land in inboxes looking like they came from a person, not a no-reply.
+- **Receive email** on an address and route it straight into a Task (or an ongoing conversation) that the right Agent picks up.
+- **Connect mailboxes to a Mission, Idea, or Work** — e.g. `support@` feeds a support-triage Agent on your store Work; `press@` feeds your company Mission.
+- **Let Agents email each other** as a parallel channel to tasks — a clean "send a message to a peer Agent" verb.
+- **Match commit identity** — when an Agent commits to a Work's repo, the commit author email matches its assigned address.
+
+## Tenant email addresses
+
+Register addresses once under **Settings → Integrations → Email Addresses**:
+
+- **Outbound addresses** — each has an address, a provider, an optional from-name, a verified flag, and a per-address spend rollup.
+- **Inbound addresses** — same, plus a routing rule (a pattern over subject/from that decides which Mission/Idea/Work/Task the mail lands in).
+- **Add-address wizard** — pick direction (Outbound / Inbound / Both), pick a provider, enter the address and provider settings, then verify (a confirmation email outbound; a test email inbound).
+
+Addresses are backed by **Email Provider plugins**, enabled and configured per tenant exactly like AI providers:
+
+| Provider                           | Direction          |
+| ---------------------------------- | ------------------ |
+| Mailchimp Transactional (Mandrill) | Outbound + Inbound |
+| Mailgun                            | Outbound + Inbound |
+| Postmark                           | Outbound + Inbound |
+| Sendgrid                           | Outbound + Inbound |
+| Resend                             | Outbound           |
+| `local-smtp` (dev / self-host)     | Outbound           |
+
+Because providers are pluggable, you get **failover**: drain traffic from one provider to another on the same address without touching any Agent's configuration.
+
+## Assigning mailboxes to an Agent
+
+On an Agent's detail page, the **Identity** section has an **Email addresses** panel:
+
+- **Outbound** — one default (what `from:` resolves to) plus any number of additional addresses.
+- **Inbound** — zero or more addresses whose incoming mail dispatches work to this Agent.
+
+Both are searchable pickers over your registered tenant addresses.
+
+## How inbound mail becomes work
+
+When mail arrives on an Agent's inbound address, the platform verifies the provider's webhook signature, decodes it into a canonical message, stores it, and dispatches it. Each inbound assignment runs in one of two modes:
+
+```mermaid
+flowchart LR
+    Email[Inbound email] --> D{Assignment mode}
+    D -->|task-spawn| T[Create or join a Task<br/>Agent processes it]
+    D -->|conversation| C[Append to an email thread<br/>Agent replies in dialogue]
+```
+
+- **`task-spawn`** (default) — each message creates or joins a [Task](../api/tasks.md). The subject can carry a Task slug like `[ACME-123]` to thread into an existing one; otherwise a fresh Task is created with the email as its body. The assigned Agent then works the Task like any other.
+- **`conversation`** — messages append to an ongoing thread and the Agent replies in dialogue, with no new Task created. Use this for back-and-forth that isn't a discrete unit of work ("FYI, the deploy finished").
+
+## Agents sending email
+
+An Agent gets a `sendEmail` tool when it has an outbound address assigned **and** `canCallExternalTools` is on. A higher-level `messageAgent` tool lets one Agent message another by name — the platform resolves the peer's inbound address and routes the message into conversation mode. Every send records usage against the Agent (and the Task, if any) so spend rollups work automatically, and writes an `EMAIL_SENT` entry to the activity log.
+
+Outbound bodies can be authored as plain text/HTML or rendered from **React-Email templates** (server-side), and an in-app **composer** offers a rich editor with a live preview and a template picker.
+
+## Why email, not just tasks?
+
+Tasks are units of _work_ with a lifecycle. Email is the universal addressing scheme: an Agent reachable by email is reachable by humans, by external systems, by webhooks, and by other AI agents — without bespoke integration. Both coexist; you pick the right one per interaction.
+
+## See also
+
+- [Agents (Your AI Employees)](./agents.md)
+- [Missions](./missions.md) · [Creating a Work](./creating-a-work.md)
+- [Autonomous Operation](./autonomous-operation.md)
+- API reference: [Mail](../api/mail.md), [Email Templates](../api/email-templates.md), [Tasks](../api/tasks.md)

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -1,0 +1,125 @@
+---
+id: agents
+title: Agents (Your AI Employees)
+sidebar_label: Agents
+---
+
+# Agents (Your AI Employees)
+
+An **Agent** is a named, persistent AI worker you create inside Ever Works — a "CEO", a "VP of Engineering", a "Researcher", a "PR Reviewer". Agents are how Ever Works stops being a one-shot builder and starts behaving like a team that keeps working: they run on a schedule, react to tasks, write content, improve code, and hand work to each other — 24/7, on the Missions, Ideas, and Works you give them.
+
+If a [Work](./creating-a-work.md) is the thing being built and a [Mission](./missions.md) is the goal, an **Agent is the worker** that pushes both forward when you're not watching.
+
+## The Work Agent vs. your own Agents
+
+Ever Works ships with two complementary layers:
+
+| Layer                     | What it is                                                                                               | When it runs                                             |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Work Agent** (built-in) | The platform-managed engine that turns a Goal into [Ideas](./ideas.md) and Ideas into Works. Zero setup. | Always available — the default zero-friction path.       |
+| **Agents** (you define)   | Named specialists you create, scope, and give a personality, a budget, and a schedule.                   | Optional, advanced — for users who want a standing team. |
+
+The Work Agent stays the easy on-ramp. User-defined Agents are the layer you reach for when you want a _standing organization_ — a CEO that keeps every Mission on-roadmap, a Researcher that files findings every morning, a Reviewer that triages incoming community PRs.
+
+## What an Agent has
+
+Every Agent carries:
+
+- **An identity** — a `name`, an optional `title`, and a `capabilities` description that says what it's for.
+- **A scope** — exactly one of **Tenant**, **Mission**, **Idea**, or **Work**. Scope decides where the Agent shows up and what it's allowed to act on.
+- **A provider + model** — defaults to your account default; override per Agent.
+- **A heartbeat** — an optional cron cadence so the Agent wakes up and decides what to do next, even with nothing assigned.
+- **A budget** — a per-Agent spend cap (hourly / daily / weekly / monthly / unlimited) enforced before every AI call.
+- **A permission set** — granular flags (`canAssignTasks`, `canEditAgentFiles`, `canCommitToRepo`, `canCreateAgents`, `canCallExternalTools`, …) that gate what tools the Agent may call. Every flag defaults to `false`.
+- **An avatar** — initials, a curated icon, or an uploaded image.
+
+### Agent scope
+
+```mermaid
+flowchart TD
+    T[Tenant-scoped Agent<br/>e.g. CEO — available everywhere]
+    M[Mission-scoped Agent<br/>e.g. Catnip Researcher — one Mission]
+    I[Idea-scoped Agent<br/>scoped to a single Idea]
+    W[Work-scoped Agent<br/>e.g. Blog Editor — one Work]
+    T --> M --> I --> W
+```
+
+A **Tenant-scoped** Agent (like a CEO) is available across everything you own. A **Mission-scoped** Agent only appears inside that Mission. A **Work-scoped** Agent only acts on its one Work. An Agent can only create or assign work to scopes equal to or narrower than its own.
+
+## Agents as an organization
+
+Because Agents can create tasks for other Agents, you can model an actual company. A tenant-scoped **CEO** keeps the roadmap coherent; a **CTO** owns the technical Works; a **Lead Engineer** ships code; a **Researcher** feeds Ideas. They collaborate the way a real team does — through tasks and shared context, not magic.
+
+Ready-made Agent definitions (CEO, CTO, and more) ship as templates from the [`ever-works/agents`](https://github.com/ever-works/agents) repository, and [Mission Templates](./mission-templates.md) can pre-declare the Agents a Mission needs so a brand-new Mission arrives already staffed.
+
+## Agent definition files
+
+An Agent's brain is five files, stored in the **scope's Git repo** (the Mission repo for Mission-scoped Agents, the Work's data repo for Work-scoped Agents) so you own and version everything:
+
+| File           | Purpose                                            |
+| -------------- | -------------------------------------------------- |
+| `SOUL.md`      | Who the Agent is — personality, principles, voice. |
+| `AGENTS.md`    | Operating instructions and house rules.            |
+| `HEARTBEAT.md` | What to do on a scheduled tick.                    |
+| `TOOLS.md`     | Which tools the Agent leans on.                    |
+| `agent.yml`    | Metadata (provider, idle behavior, avatar, …).     |
+
+Tenant-scoped Agents with no control repo keep these inline in the database and serve them through the same API. You edit them in the Agent's **Instructions** tab (a five-tab markdown editor with autosave). The platform never auto-rewrites them — an Agent can only edit its own files, and only when `canEditAgentFiles` is on.
+
+## Heartbeats — what an Agent does on an idle tick
+
+Set a `heartbeatCadence` (a cron expression, or `manual`) and the Agent wakes on schedule. Even with nothing assigned, a heartbeat is **not** a no-op — the Agent is asked _"What's the next action you should take? Choose ONE."_ and may:
+
+- **Create a task** (self-assigned or assigned to another Agent in scope),
+- **Comment on an open task** it's part of,
+- **Edit one of its own definition files** to capture a learning, or
+- **Observe** the current state and do nothing this tick.
+
+This is the loop that makes Ever Works _keep going_. Tune it per Agent with `agent.yml`'s `idleBehavior: propose | observe | noop`.
+
+## Memory
+
+- **Short-term** — the messages within a single run; not persisted.
+- **Long-term** — the five definition files, the durable, intentional store the Agent edits deliberately.
+- **Passive history** — recent activity, read on demand (not injected every tick, to save cost).
+- **Institutional context** — the per-Work [Knowledge Base](./knowledge-base.md): brand voice, legal copy, personas, research, glossary. Agents read from it on every run.
+
+Agents cannot read each other's definition files. Shared knowledge flows through **tasks**, **KB documents**, and the **activity log**.
+
+## Tasks, skills, and email
+
+- **Tasks** — Agents create, transition, comment on, and get assigned tasks. Mention an Agent in a task chat (`@ceo can you review this?`) and it replies within seconds. Tasks are the only channel for Agent-to-Agent collaboration, which gives every interaction an audit trail and attributes cost to the Agent that did the work.
+- **Skills** — reusable capabilities bound to an Agent or inherited from its scope, surfaced via the Skills tab.
+- **Email** — Agents can have their own inbound and outbound mailboxes. See **[Agent Email & Inboxes](./agent-email.md)**.
+
+## Budgets & guardrails
+
+Every Agent can have one budget row. Before any AI call, the platform checks the Agent's remaining headroom for the current interval and short-circuits the run if the cap is hit (logging `AGENT_BUDGET_EXCEEDED`). Repeated failures auto-pause an Agent so a misbehaving worker can't run away with your spend. See [Budgets & Usage](./budgets-and-usage.md).
+
+## The Agents workbench
+
+- **Sidebar → Agents** lists every Agent you own, with Cards/Table views and filters for status (`All / Active / Paused / Error`) and scope (`Tenant / Mission / Idea / Work`).
+- Each **Agent detail page** has six tabs: **Dashboard** (live status, run history, tasks, cost snapshot), **Activity**, **Instructions**, **Skills**, **Budgets**, and **Settings**.
+- Header actions: **Run heartbeat now**, **Assign Task**, **Pause / Resume**, **Archive**, **Delete**.
+- Work, Mission, and Idea detail pages each gain an **Agents** tab listing the Agents that can act on them.
+
+A **dry-run** mode (`POST /agents/:id/dry-run`) builds the prompt and estimates cost without calling the provider — handy while iterating on an Agent's instructions. You can also **export and import** an Agent as a JSON envelope to back it up, share it, or move it between scopes.
+
+## Creating an Agent
+
+1. Sidebar → **Agents** → **+ New Agent**.
+2. Give it a `name` and `title`, and describe its `capabilities`.
+3. Pick a provider/model (or keep your account default).
+4. Choose a scope — Tenant for a company-wide role, or a specific Mission/Idea/Work.
+5. Create it (starts in `draft`), then open the **Dashboard** tab and click **Start**, optionally setting a heartbeat cadence and budget.
+
+You can also drive everything from the in-app AI Chat or any MCP client — _"Create a CEO agent for my company mission and run it daily."_
+
+## See also
+
+- [Missions](./missions.md) · [Ideas](./ideas.md) · [Creating a Work](./creating-a-work.md)
+- [Agent Email & Inboxes](./agent-email.md)
+- [Knowledge Base](./knowledge-base.md)
+- [Autonomous Operation](./autonomous-operation.md)
+- [Budgets & Usage](./budgets-and-usage.md)
+- API reference: [Agents](../api/agents.md), [Tasks](../api/tasks.md), [Skills](../api/skills.md)

--- a/docs/features/autonomous-operation.md
+++ b/docs/features/autonomous-operation.md
@@ -1,0 +1,64 @@
+---
+id: autonomous-operation
+title: Autonomous Operation (24/7)
+sidebar_label: Autonomous Operation
+---
+
+# Autonomous Operation (24/7)
+
+Most AI builders generate a site once and stop. You get code, and then you're on your own — to write the content, keep it fresh, fix what breaks, market it, and grow it. **Ever Works keeps going.** Once you've pointed it at a [Mission](./missions.md) or shipped a [Work](./creating-a-work.md), the platform's [Agents](./agents.md) and background workers keep researching, writing, building, deploying, and improving — on a schedule, not just when you prompt.
+
+This is the difference between _"here's your code, figure out the rest"_ and _"here's your working business that keeps getting better."_ It's also the half of the product that the one-shot builders don't have.
+
+## What "keeps going" actually means
+
+| It keeps…               | …by                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Adding content**      | Scheduled generation writes new blog posts, finds and adds new directory items, refreshes stale entries. |
+| **Generating ideas**    | A running Mission keeps proposing new [Ideas](./ideas.md) that ladder up to your goal.                   |
+| **Improving the build** | Agents open work on the code and content of a Work — fixes, new pages, new sections.                     |
+| **Researching**         | Agents gather findings into the [Knowledge Base](./knowledge-base.md) so future runs are smarter.        |
+| **Maintaining quality** | Scheduled updates re-run the pipeline; community PRs and item-source validation keep data accurate.      |
+| **Deploying**           | Every change is committed to Git and redeployed to your target automatically.                            |
+
+## The mechanisms
+
+Autonomy isn't one feature — it's several, working together:
+
+- **[Scheduled Updates](./scheduled-updates.md)** — re-run a Work's generation pipeline on a cadence (daily, weekly, your choice) to keep content current.
+- **Agent heartbeats** — each [Agent](./agents.md) wakes on its own cron, decides the single most useful next action, and takes it: create a task, advance one, write to the KB, or observe.
+- **Scheduled Missions** — a [Mission](./missions.md) can tick on a cadence, generating fresh Ideas each time as the world changes.
+- **Auto-build** — turn it on and accepted Ideas become Works without you clicking anything.
+- **Background workers** — the [Workers](./workers.md) layer runs all of this reliably in the background, in parallel, with retries.
+- **Community PR processing** — incoming contributions are triaged and merged into your data automatically.
+
+```mermaid
+flowchart LR
+    M[Mission ticks] --> I[New Ideas]
+    I -->|auto-build on| W[Works]
+    W --> S[Scheduled updates<br/>refresh content]
+    A[Agent heartbeats] --> W
+    A --> KB[Knowledge Base grows]
+    S --> D[Commit + redeploy]
+    A --> D
+```
+
+## You stay in control
+
+Autonomy is opt-in and bounded:
+
+- **Budgets at every level** — per-Work, per-Idea, per-Mission, per-Agent, and account-wide caps, soft (alert) or hard (block). See [Budgets & Usage](./budgets-and-usage.md).
+- **Guardrails** — max items per run, approval rules, outstanding-Ideas caps on Missions.
+- **Pause / Resume** — stop any Agent, Mission, or schedule instantly.
+- **Auto-pause on failure** — a worker that keeps erroring pauses itself rather than burning spend.
+- **Full audit trail** — every autonomous action emits activity-log entries and Git commits you can review and revert.
+
+## You own everything
+
+Because code and content both live in **your Git repositories**, autonomous operation never locks you in. Every blog post written overnight, every product added to a directory, every code change an Agent ships is a commit in a repo you own. Turn the platform off and your working business is still yours.
+
+## See also
+
+- [Missions](./missions.md) · [Ideas](./ideas.md) · [Agents](./agents.md)
+- [Scheduled Updates](./scheduled-updates.md) · [Workers](./workers.md)
+- [Knowledge Base & Memory](./knowledge-base.md) · [Budgets & Usage](./budgets-and-usage.md)

--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -1,0 +1,47 @@
+---
+id: company-builder
+title: Company Builder
+sidebar_label: Company Builder
+---
+
+# Company Builder
+
+> **Status: coming soon.** Company is a planned scope, telegraphed today by the **Company** chip on the create surface. Its foundations — [Missions](./missions.md), [Agents](./agents.md) with Tenant scope, [Tenants & Organizations](../advanced/multi-tenancy.md) — are live. The company-registration integrations and the "company-as-a-business" surface are on the roadmap. This page describes the destination.
+
+The **Company Builder** is Ever Works' most ambitious shape: not a website, but the _organization that runs websites, stores, and everything else_ — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
+
+## From idea to operating company
+
+```mermaid
+flowchart TD
+    Goal[Your Mission<br/>'launch and run an AI-tools business'] --> Co[Company]
+    Co --> Reg[Register the legal entity]
+    Co --> Org[Staff it with Agents:<br/>CEO, CTO, Lead Engineer, Researcher]
+    Co --> Works[Spin up Works:<br/>marketing site, blog, directory, store]
+    Org --> Run[Everyone works 24/7]
+    Works --> Run
+    Run --> Grow[Content ships, ideas surface,<br/>the business keeps improving]
+```
+
+## What the Company Builder is planned to do
+
+- **Help you register the company** — guided incorporation through provider integrations (planned: Stripe Atlas and other formation/banking providers), so going from idea to a real legal entity is part of the flow, not a separate scramble.
+- **Staff it with an AI organization** — Tenant-scoped [Agents](./agents.md) for company-wide roles (CEO, CTO, Lead Engineer, Researcher, …), drawn from ready-made [templates](./mission-templates.md), each with its own mailbox, budget, and heartbeat.
+- **Spin up the Works the company needs** — a marketing site, a blog, a directory, a landing page, a [store](./store-builder.md) — each its own self-maintaining Work.
+- **Give the company a shared brain** — the [Knowledge Base](./knowledge-base.md) holds the company's brand, strategy, research, and decisions; org-level `legal`/`style`/`seo` policy is inherited by every Work.
+- **Run continuously** — the whole organization operates [autonomously](./autonomous-operation.md), under budgets and guardrails you set, with a full audit trail.
+
+## How it relates to Tenants & Organizations
+
+The Company Builder is the product-facing expression of the platform's [multi-tenancy](../advanced/multi-tenancy.md) foundation. An Organization is the container; a Company is what you _do_ with it — register it, staff it with Agents, give it Works, and let it run.
+
+## You own the company's output
+
+Every site, every document, every line of code the company's Agents produce lives in **your Git repositories** and deploys to **your infrastructure**. The AI organization works for you; the assets are yours.
+
+## See also
+
+- [Missions](./missions.md) · [Agents](./agents.md) · [Mission Templates](./mission-templates.md)
+- [Store Builder](./store-builder.md) · [Knowledge Base](./knowledge-base.md)
+- [Tenants & Organizations](../advanced/multi-tenancy.md) · [Autonomous Operation](./autonomous-operation.md)
+- Guide: [The Founder Journey](../guides/founder-journey.md)

--- a/docs/features/desktop-app.md
+++ b/docs/features/desktop-app.md
@@ -1,0 +1,38 @@
+---
+id: desktop-app
+title: Desktop App
+sidebar_label: Desktop App
+---
+
+# Desktop App
+
+> **Status: coming soon.** The Desktop App is on the roadmap. Today you can run Ever Works in the cloud or self-host the full stack with Docker. This page describes where the local experience is headed.
+
+The **Desktop App** will let you run all of Ever Works **locally as a single application** — the API, the web dashboard, the [Workers](./workers.md), and the database, all bundled together. Install it, open it, and you have the entire platform on your own machine: build [Works](./creating-a-work.md), run [Agents](./agents.md), and operate [Missions](./missions.md) without depending on anyone else's servers.
+
+## What "all local" means
+
+- **Full stack in one app** — the API, frontend, background-jobs runtime, and database ship together. No separate services to wire up.
+- **Your data on your machine** — repositories, Knowledge Base, and configuration stay local by default.
+- **Works offline-first** — the platform keeps working without a constant connection to a cloud backend.
+
+## Local, but not isolated
+
+The Desktop App is designed to **connect outward** when you want it to:
+
+- Point it at an **external database** (managed Postgres, or your own server).
+- Use an **external background-jobs backend** (a hosted or self-hosted jobs service) instead of the bundled one.
+- Connect any **AI, search, deployment, storage, or email provider** through the same [plugin system](../plugin-system/index.md) the cloud uses.
+- Push your Works' code and content to **your Git provider** and deploy to **your targets**, exactly as in the cloud.
+
+So you can start fully local and selectively move pieces to the cloud as you grow — without changing how you work.
+
+## Why it matters
+
+The Desktop App is the strongest expression of the platform's ownership promise: **open source (AGPLv3), your machine, your data, your repositories.** It's Ever Works as a workshop that lives on your desk, not just in a browser tab.
+
+## See also
+
+- [Workers](./workers.md) · [Plugin System](../plugin-system/index.md)
+- [Installation](../installation.md) · [DevOps & Deployment](../devops/docker.md)
+- [Roadmap](../roadmap.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,27 +7,60 @@ sidebar_position: 1
 
 # Platform Features
 
-This section covers individual capabilities built into the Ever Works Platform beyond the core work CRUD and AI generation pipeline.
+Ever Works combines two things most tools keep separate: the **builder** that turns an idea into a shipped website, store, blog, or directory — and the **autonomous workforce** that keeps that thing researching, writing, improving, and growing 24/7. You set a goal; an AI organization runs it, with all code and content owned in your own Git.
 
-| Feature                                              | Description                                                                                               |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [Missions](./missions)                               | Long-running goals that spawn Ideas and optionally auto-build Works on a schedule                         |
-| [Ideas](./ideas)                                     | Proposed Works in the queue between "topic" and "finished website" — build, retry, dismiss, accept        |
-| [Mission Templates](./mission-templates)             | Pre-built Mission setups (cadence, guardrails, KB seed) you can fork via "Use this Template"              |
-| [Budgets & Usage](./budgets-and-usage)               | Per-Mission / per-Idea / per-Work / account-wide caps that gate AI spend before the bill arrives          |
-| [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI                       |
-| [Work Changelog](./work-changelog)                   | Track item, comparison, taxonomy, and community PR changes in a paginated work history timeline           |
-| [Collections](./collections)                         | Curate items into named groups like "Editor's Picks" or "Best for Beginners"                              |
-| [Item Source Validation](./item-source-validation)   | Validate whether item source URLs are both reachable and actually good sources for the item               |
-| [Scheduled Updates](./scheduled-updates)             | Re-run the AI generation pipeline on a recurring cadence to keep content fresh                            |
-| [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API                   |
-| [.works/works.yml Config](./works-config)            | Source-controlled work configuration in the data repo — used for onboarding existing repos and sync       |
-| [Work Import](./work-import)                         | Bootstrap a work from an existing data repo or Awesome List README                                        |
-| [Work Members](./work-members)                       | Invite collaborators with role-based access (Manager, Editor, Viewer)                                     |
-| [Comparisons](./comparisons)                         | Automatically generate A vs B comparison pages between work items with AI-powered research and scoring    |
-| [Advanced Prompts](./advanced-prompts)               | Customize AI behavior per-work with prompt overrides for each pipeline step                               |
-| [API Keys](./api-keys)                               | Generate long-lived API keys for programmatic access to the Ever Works API                                |
-| [Custom Domains](./custom-domains)                   | Assign your own domain name to a work's deployed website                                                  |
-| [Website Templates](./website-templates)             | Catalogue of base templates a Work's website can be generated from (Next.js / Astro, directory / general) |
-| [MCP Server](./mcp-server)                           | Expose the Ever Works API as tools for AI assistants like Claude                                          |
-| [Data Management](./data-management)                 | Export, import, and sync account data (works, items, plugins, secrets) with GitHub backup                 |
+This section covers the individual capabilities that make that possible, beyond the core work CRUD and AI generation pipeline.
+
+> New here? Read the [Platform Overview](../overview.md) for the big picture, or the [Founder Journey guide](../guides/founder-journey.md) for the Start → Build → Sell → Scale playbook that ties these features together.
+
+## The core loop
+
+| Feature                                        | Description                                                                                                |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [Missions](./missions)                         | Long-running goals that spawn Ideas and optionally auto-build Works on a schedule                          |
+| [Ideas](./ideas)                               | Proposed Works in the queue between "topic" and "finished website" — build, retry, dismiss, accept         |
+| [Creating a Work](./creating-a-work)           | The buildable unit — websites, blogs, directories, landing pages — created with AI, manually, or by import |
+| [Agents (AI Employees)](./agents)              | Named, persistent AI workers you create, scope, schedule, and budget — your standing team                  |
+| [Agent Email & Inboxes](./agent-email)         | Inbound + outbound mailboxes per Agent / Mission / Idea / Work — your AI team's email                      |
+| [Knowledge Base & Memory](./knowledge-base)    | Per-Work, typed, Git-backed institutional context and long-term memory every run reads from                |
+| [Autonomous Operation](./autonomous-operation) | How the platform keeps working 24/7 — the half one-shot builders don't have                                |
+| [Workers](./workers)                           | The background-execution engine that runs Agents, pipelines, and schedules in parallel                     |
+
+## Work types & templates
+
+| Feature                                  | Description                                                                                                      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [Website Templates](./website-templates) | Catalogue of base templates a Work's website is generated from (Next.js / Astro, directory / general)            |
+| [Mission Templates](./mission-templates) | Pre-built Mission playbooks (cadence, guardrails, KB seed, pre-declared Agents) you fork via "Use this Template" |
+| [Store Builder](./store-builder)         | _(Coming soon)_ eCommerce storefronts an AI team researches, stocks, writes, and optimizes                       |
+| [Company Builder](./company-builder)     | _(Coming soon)_ Register and run a whole company, staffed by AI Agents, on top of the platform                   |
+| [Desktop App](./desktop-app)             | _(Coming soon)_ Run the full stack locally as a single application                                               |
+
+## Operating a Work
+
+| Feature                                              | Description                                                                                                  |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [Budgets & Usage](./budgets-and-usage)               | Per-Mission / per-Idea / per-Work / per-Agent / account-wide caps that gate AI spend before the bill arrives |
+| [Scheduled Updates](./scheduled-updates)             | Re-run the AI generation pipeline on a recurring cadence to keep content fresh                               |
+| [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API                      |
+| [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI                          |
+| [Work Changelog](./work-changelog)                   | Track item, comparison, taxonomy, and community PR changes in a paginated work history timeline              |
+| [Collections](./collections)                         | Curate items into named groups like "Editor's Picks" or "Best for Beginners"                                 |
+| [Item Source Validation](./item-source-validation)   | Validate whether item source URLs are both reachable and actually good sources for the item                  |
+| [Comparisons](./comparisons)                         | Automatically generate A vs B comparison pages between work items with AI-powered research and scoring       |
+| [Advanced Prompts](./advanced-prompts)               | Customize AI behavior per-work with prompt overrides for each pipeline step                                  |
+| [Work Members](./work-members)                       | Invite collaborators with role-based access (Manager, Editor, Viewer)                                        |
+
+## Configuration, data & access
+
+| Feature                                   | Description                                                                                         |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [.works/works.yml Config](./works-config) | Source-controlled work configuration in the data repo — used for onboarding existing repos and sync |
+| [Work Import](./work-import)              | Bootstrap a work from an existing data repo or Awesome List README                                  |
+| [Taxonomy System](./taxonomy-system)      | Categories, tags, and structured classification across a Work's items                               |
+| [Git Operations](./git-operations)        | How the platform reads and writes your Work's Git repositories                                      |
+| [API Keys](./api-keys)                    | Generate long-lived API keys for programmatic access to the Ever Works API                          |
+| [Custom Domains](./custom-domains)        | Assign your own domain name to a work's deployed website                                            |
+| [K8s Deployment](./k8s-deployment)        | Deploy a Work to a Kubernetes cluster                                                               |
+| [MCP Server](./mcp-server)                | Expose the Ever Works API as tools for AI assistants like Claude                                    |
+| [Data Management](./data-management)      | Export, import, and sync account data (works, items, plugins, secrets) with GitHub backup           |

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -1,0 +1,81 @@
+---
+id: knowledge-base
+title: Knowledge Base & Memory
+sidebar_label: Knowledge Base & Memory
+---
+
+# Knowledge Base & Memory
+
+Every [Work](./creating-a-work.md) in Ever Works has its own **Knowledge Base (KB)** — a structured, typed, Git-backed store of institutional context: brand voice, legal copy, SEO conventions, glossary, competitor lists, audience personas, prior research, and the artifacts your [Agents](./agents.md) produce. It's the memory that makes the "maintain" half of _research → generate → deploy → maintain_ mean something. Without it, every scheduled run starts from a blank prompt; with it, the runtime accumulates a durable, owned understanding of what your business actually is.
+
+This is the built-in equivalent of an internal wiki and a long-term memory layer — owned by you, versioned in Git, and read by every pipeline automatically.
+
+## What lives in the KB
+
+A **KB document** is one piece of institutional context. Each has a markdown body, a metadata sidecar, a hierarchical path, a class, tags, and a status. Documents are **typed** by class, and the class drives how Agents use the document:
+
+| Class         | How Agents treat it                                                       |
+| ------------- | ------------------------------------------------------------------------- |
+| `brand`       | Soft guidance — "follow these brand guidelines".                          |
+| `legal`       | Verbatim-or-omitted — copied exactly, never paraphrased.                  |
+| `seo`         | Constraints — target keywords and structured-data patterns per page type. |
+| `glossary`    | Term substitution — always use these terms, never invent synonyms.        |
+| `competitors` | Inclusion / exclusion — drives comparisons and the do-not-mention rule.   |
+| `personas`    | Audience definitions — write for these readers.                           |
+| `style`       | Editorial style guide — grammar, banned words, voice, tense.              |
+| `research`    | Reference material — retrieved opportunistically and cited.               |
+| `output`      | Agent-authored artifacts — reports, summaries, decks.                     |
+| `freeform`    | Catch-all notes — retrieved by similarity or explicit mention.            |
+
+## Git-backed, two-layer storage
+
+The KB lives in two synchronized places:
+
+- **The Work's Git data repository** under `.content/kb/` — one folder per class, each document a `<slug>.md` + `<slug>.yml` pair, plus an auto-maintained `.index.yml`. This is the durable, portable, diff-able source of truth that every downstream pipeline already reads.
+- **The database** — fast queries, search, locks, and audit metadata.
+
+Because the agent-readable layer is always in Git, you own it, you can inspect it, and nothing is locked in.
+
+## The workbench
+
+A dedicated page at **`/works/:id/kb`** gives you:
+
+- A two-pane tree — the **KB** (agent-readable extracts) and the **Originals** (your uploaded source files).
+- A center editor — a WYSIWYG markdown editor for `.md` documents, and inline viewers for PDFs, spreadsheets, video, and other originals.
+- An **AI side panel** scoped to the KB — `@mention` any document (`@kb:brand/voice`) to pin it into context; answers come back with citations.
+- A top bar with search and filters by class, tag, status, and lock state.
+
+## Ingest: drop a file, get usable knowledge
+
+Drop a PDF, Word doc, spreadsheet, image, video, or URL into the workbench and the platform:
+
+1. Stores the **original** verbatim in the Work's configured storage plugin (GitHub, S3, MinIO, local FS).
+2. Normalizes media (video → MP4, audio → MP3 + transcript) where needed.
+3. Runs the configured **content extractor** plugin to produce an agent-readable markdown extract.
+4. Classifies and tags it (you choose, or let the AI suggest), writes it into Git, and indexes it for retrieval.
+
+Agents never read the binary original — they read the clean extract.
+
+## How Agents use it
+
+- **Deterministic injection** — `brand`, `legal`, `glossary`, `style`, `personas`, and page-matched `seo` documents are injected into every relevant run, capped by a token budget with class-precedence truncation.
+- **Query-driven retrieval** — `research`, `freeform`, and `output` documents are retrieved by semantic similarity for the task at hand, and every use is recorded as a **citation** so you can audit exactly what context produced a given output.
+- **Agents write back** — research notes and generated artifacts land in the KB as `output`-class documents, under the same governance (locks, audit trail, Git history) as your own documents.
+
+## Locks, inheritance, and audit
+
+- **Per-document locks** (`full` or `additions-only`) protect a document from being changed by scheduled regeneration or Agent runs.
+- **Org-level inheritance** — `legal`, `style`, and `seo` documents can be published once at the organization level and inherited by every Work, with per-Work override. (See [Tenants & Organizations](../advanced/multi-tenancy.md).)
+- **Full audit** — every KB mutation flows through the activity log and Git history.
+
+## Reaching the KB from anywhere
+
+The KB is exposed over REST, the [MCP server](./mcp-server.md) (`kb.list`, `kb.read`, `kb.search`, `kb.create`, `kb.update`, `kb.upload`), and the CLI (`ever works kb …`), so external Claude / GPT / Gemini sessions and scripts can read and write it with the same access controls.
+
+> **Built-in, with room to extend.** Memory, wiki, and knowledge management ship _inside_ Ever Works as first-class features rather than something you bolt on. Where you want to connect an external knowledge or memory system, that arrives as a plugin alongside these built-ins — additive, never a replacement.
+
+## See also
+
+- [Agents (Your AI Employees)](./agents.md) · [Advanced Prompts](./advanced-prompts.md)
+- [Creating a Work](./creating-a-work.md) · [Autonomous Operation](./autonomous-operation.md)
+- [Data Management](./data-management.md) · [MCP Server](./mcp-server.md)

--- a/docs/features/store-builder.md
+++ b/docs/features/store-builder.md
@@ -1,0 +1,48 @@
+---
+id: store-builder
+title: Store Builder (eCommerce)
+sidebar_label: Store Builder
+---
+
+# Store Builder (eCommerce)
+
+> **Status: coming soon.** Stores are a planned [Work](./creating-a-work.md) type, telegraphed today by the **Store** chip on the create surface. The Mission → Idea → Work → Agents model below is live; the storefront generator and commerce integrations are on the roadmap. This page describes where it's going.
+
+A **Store** is a Work whose output is a working storefront — products, copy, categories, checkout — built from a commerce [template](./website-templates.md) and then _kept running_ by your [Agents](./agents.md). The point isn't to hand you an empty shop. It's to research the catalog, write the product copy, populate the storefront, and keep optimizing it on a schedule. An AI workforce that's built to **act on your business, not just advise it**.
+
+## How a Store fits the model
+
+A Store is the same lifecycle as any other Work, pointed at commerce:
+
+```mermaid
+flowchart LR
+    M[Mission<br/>'run the best cat-toys store'] --> I[Idea<br/>'storefront for premium cat toys']
+    I --> W[Store Work<br/>built from a commerce template]
+    W --> R[Agents research products,<br/>write copy, set categories]
+    R --> O[Storefront deploys + keeps refreshing]
+```
+
+You can start a Store directly when you know exactly what you want, or let a [Mission](./missions.md) propose it as one of several Works needed for a bigger commerce goal.
+
+## What the Store builder is planned to do
+
+- **Research the catalog** — find products, suppliers, and pricing signals relevant to the store's niche, with sources recorded in the [Knowledge Base](./knowledge-base.md).
+- **Write the storefront** — product titles, descriptions, category pages, collection copy, and SEO metadata, on-brand via your KB.
+- **Populate and maintain inventory** — add new products as they're found, refresh descriptions, retire dead listings, keep stock data current.
+- **Run experiments** — propose and track A/B tests on copy, layout, and merchandising in an experiment notebook, so the storefront keeps improving on evidence, not guesses.
+- **Connect commerce + payments** — integrate storefront and checkout through provider plugins (planned: Stripe and other payment/commerce providers).
+- **Operate 24/7** — once live, the Store keeps refreshing content and acting on its own under your [budgets and guardrails](./budgets-and-usage.md). See [Autonomous Operation](./autonomous-operation.md).
+
+## Agents for a Store
+
+A Store can be staffed like a small commerce team: a **Merchandiser** Agent that curates the catalog, a **Copywriter** Agent that keeps product pages sharp, an **Analyst** Agent that reads experiment results and proposes the next test. They coordinate through tasks, all scoped to the Store Work. See [Agents](./agents.md).
+
+## You own the store
+
+As with every Work, the storefront's code and content live in **your Git repository** and deploy to **your target**. Nothing about your catalog, copy, or configuration is locked into the platform.
+
+## See also
+
+- [Creating a Work](./creating-a-work.md) · [Website Templates](./website-templates.md)
+- [Company Builder](./company-builder.md) · [Autonomous Operation](./autonomous-operation.md)
+- [Agents](./agents.md) · [Budgets & Usage](./budgets-and-usage.md)

--- a/docs/features/workers.md
+++ b/docs/features/workers.md
@@ -1,0 +1,42 @@
+---
+id: workers
+title: Workers (Background Execution)
+sidebar_label: Workers
+---
+
+# Workers (Background Execution)
+
+**Workers** are the engine room behind everything that happens when you're not looking. They're the background-execution layer that runs your [Agents](./agents.md), generation pipelines, [scheduled updates](./scheduled-updates.md), and [Mission](./missions.md) ticks reliably, in parallel, with retries — so the platform's [autonomous operation](./autonomous-operation.md) keeps humming whether you have one Work or a hundred.
+
+You rarely manage Workers directly. They're the "who's actually doing the job" answer underneath the Agents and schedules you _do_ manage.
+
+## What Workers run
+
+| Job kind                       | What it does                                                                  |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| **Agent heartbeats**           | Wake each active Agent on its cadence, run its decision loop, record the run. |
+| **Agent tasks & chat replies** | Execute work assigned to an Agent; reply when an Agent is mentioned.          |
+| **Generation pipelines**       | Build and refresh a Work's content and code.                                  |
+| **Scheduled updates**          | Re-run a Work's pipeline on its cadence.                                      |
+| **Mission ticks**              | Generate fresh Ideas for scheduled Missions.                                  |
+| **Inbound email**              | Turn incoming mail into Tasks or conversations.                               |
+| **Ingest & extraction**        | Normalize and extract uploaded Knowledge Base sources.                        |
+| **Community PR processing**    | Triage and merge community contributions.                                     |
+
+## How Workers behave
+
+- **Parallel** — many jobs run at once; a dispatcher claims due work in batches so thousands of Agents and schedules scale without stepping on each other.
+- **Safe under contention** — a single Agent's heartbeat can only be claimed by one Worker at a time (compare-and-set), so nothing runs twice.
+- **Retried** — transient failures (network blips, provider rate limits, upstream 5xx) are retried with backoff before a job is marked failed.
+- **Bounded** — runs have timeouts; an Agent that keeps failing auto-pauses rather than burning budget.
+- **Observable** — every run emits activity-log entries and surfaces on the relevant Dashboard, with cost attributed to the right Agent, Task, or Work.
+
+## Where they run
+
+Workers are powered by the platform's background-jobs infrastructure (Trigger.dev plus internal queues). In the cloud, this is fully managed for you. When you self-host — or run the upcoming [Desktop App](./desktop-app.md) — Workers run alongside the rest of the stack, and you can also point them at an external or self-hosted jobs backend.
+
+## See also
+
+- [Agents](./agents.md) · [Autonomous Operation](./autonomous-operation.md)
+- [Scheduled Updates](./scheduled-updates.md) · [Missions](./missions.md)
+- [Desktop App](./desktop-app.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -39,6 +39,60 @@ The overall classification system for a work, encompassing categories, tags, and
 
 A URL-friendly, human-readable identifier derived from an entity's name. Slugs are used in URLs instead of numeric IDs. For example, an item named "Visual Studio Code" might have the slug `visual-studio-code`. Slugs are unique within their scope (e.g., item slugs are unique per work).
 
+## Missions, Ideas, Agents & Autonomy
+
+### Mission
+
+An ambitious, ongoing goal that the platform keeps pursuing for you — bigger than any single website (e.g. "run the best cats business worldwide"). A Mission generates [Ideas](/features/ideas) and, optionally, auto-builds them into Works on a schedule. See [Missions](/features/missions).
+
+### Idea
+
+A one-shot proposal for a single Work — one Idea becomes one Work, then is marked done. Ideas can be suggested by the platform, added by you, or spawned by a Mission. Useful as a lightweight "plan" you can research before committing to a build. See [Ideas](/features/ideas).
+
+### Agent (AI Employee)
+
+A named, persistent, user-defined AI worker scoped to a Tenant, Mission, Idea, or Work — for example a "CEO", "CTO", or "Researcher". Distinct from the pipeline **Agent** below: this is a standing team member with its own identity files, provider, heartbeat schedule, budget, permissions, skills, tasks, and optional mailboxes. See [Agents](/features/agents).
+
+### Work Agent
+
+The built-in, platform-managed engine that turns a Goal into Ideas and Ideas into Works with zero setup. It is the default zero-friction path and stands alongside user-defined Agents.
+
+### Heartbeat
+
+An Agent's scheduled "what should I do next?" tick. On each heartbeat the Agent chooses one action — create a task, advance one, update its own instructions, or observe. The mechanism behind 24/7 [autonomous operation](/features/autonomous-operation).
+
+### Skill
+
+A reusable capability that can be bound to an Agent (or inherited from its scope), delivered through a skills-provider plugin. Skills extend what an Agent can do without changing core code.
+
+### Task
+
+A unit of work assigned to an Agent (or human), with a lifecycle and chat. Tasks are the canonical channel for Agent-to-Agent collaboration, giving every interaction an audit trail and correct cost attribution.
+
+### Knowledge Base (KB)
+
+A per-Work, typed, Git-backed store of institutional context — brand voice, legal copy, SEO conventions, glossary, competitors, personas, research, and agent outputs — that every generation run reads from. The platform's built-in memory and wiki layer. See [Knowledge Base](/features/knowledge-base).
+
+### Email Address / Inbox
+
+A tenant-registered email address (outbound, inbound, or both) backed by an email-provider plugin, assignable to an Agent / Mission / Idea / Work. Inbound mail becomes Tasks or conversations; outbound mail is sent by Agents. See [Agent Email & Inboxes](/features/agent-email).
+
+### Work Template / Mission Template
+
+A **Work Template** is the codebase a Work's website is generated from (the [website templates](/features/website-templates) catalog). A **Mission Template** is a curated playbook (docs, prompts, cadence, pre-declared Agents) for an ambitious goal. See [Mission Templates](/features/mission-templates).
+
+### Store / Company
+
+Planned [Work](/features/creating-a-work) shapes. A **Store** is a self-maintaining eCommerce storefront; a **Company** is a whole AI-staffed organization that runs Works toward a Mission. See [Store Builder](/features/store-builder) and [Company Builder](/features/company-builder).
+
+### Worker
+
+The background-execution layer (Trigger.dev plus internal queues) that runs Agent heartbeats, generation pipelines, scheduled updates, and Mission ticks in parallel, with retries. See [Workers](/features/workers).
+
+### Tenant / Organization
+
+The multi-tenancy containers that own addresses, Agents, Works, and inheritable KB policy. The foundation under the [Company Builder](/features/company-builder). See [Multi-Tenancy](/advanced/multi-tenancy).
+
 ## AI and Automation
 
 ### Pipeline

--- a/docs/guides/founder-journey.md
+++ b/docs/guides/founder-journey.md
@@ -1,0 +1,91 @@
+---
+id: founder-journey
+title: The Founder Journey — Start, Build, Sell, Scale
+sidebar_label: The Founder Journey
+---
+
+# The Founder Journey — Start, Build, Sell, Scale
+
+Most guides for founders are _just content_ — articles that tell you what to do and leave you to do it. This one is different: every step maps to something Ever Works can actually **do for you**. Read it top to bottom as one playbook, or jump to the phase you're in. The four phases — **Start → Build → Sell → Scale** — line up with the platform's core building blocks: [Missions](../features/missions.md), [Ideas](../features/ideas.md), [Works](../features/creating-a-work.md), and [Agents](../features/agents.md).
+
+The mental model in one line: **you set the goal; an AI organization researches, builds, and runs the business toward it — 24/7, in your own Git.**
+
+```mermaid
+flowchart LR
+    Start --> Build --> Sell --> Scale
+    Start -.-> M[Mission + Ideas]
+    Build -.-> W[Works + Templates]
+    Sell -.-> Co[Store + Company + Agents]
+    Scale -.-> Auto[Autonomous Operation]
+```
+
+---
+
+## 1. Start — turn a goal into a plan
+
+You don't need a finished plan to begin. You need a **goal**.
+
+- **Define a [Mission](../features/missions.md).** A Mission is an ambitious, ongoing goal — _"run the best cats business worldwide,"_ _"launch an AI-tools media company."_ It's bigger than any one website, and Ever Works keeps pursuing it for you.
+- **Let Ideas come to you.** From a Mission, the platform generates [Ideas](../features/ideas.md): atomic, one-shot proposals (_"a directory of indie cat-toy brands," "a weekly cat-care blog"_). Add your own, accept the good ones, dismiss the rest.
+- **Plan vs. commit.** Not sure yet? Capture it as an **Idea** and let the system research it before you commit — think of an Idea as a lightweight plan you can drop cheaply. Already know exactly what you want? Skip straight to a **Work**.
+- **Think about the entity early.** If this is a real business, you'll eventually want a company behind it. The planned [Company Builder](../features/company-builder.md) is designed to guide incorporation through provider integrations (e.g. Stripe Atlas) — so registering the company is part of the journey, not a side quest.
+
+**Platform pieces:** [Missions](../features/missions.md) · [Ideas](../features/ideas.md) · [Mission Templates](../features/mission-templates.md)
+
+---
+
+## 2. Build — ship the things the goal needs
+
+A goal succeeds when real things exist online. In Ever Works, each of those is a **[Work](../features/creating-a-work.md)**.
+
+- **Works are built from [Templates](../features/website-templates.md).** Websites, blogs, directories, landing pages — and soon [stores](../features/store-builder.md) — start from a base template in the catalog, so you're never staring at a blank page.
+- **One Idea → one Work.** Accept an Idea and the platform builds it: researches the topic, writes the content, generates the code, and deploys it to your target.
+- **Everything lives in your Git.** Code and content are committed to repositories you own. Nothing is locked in.
+- **Give Works a brain.** Each Work has a [Knowledge Base](../features/knowledge-base.md) — brand voice, SEO rules, personas, research — that every build reads from, so output stays on-brand and gets smarter over time.
+
+**Platform pieces:** [Creating a Work](../features/creating-a-work.md) · [Website Templates](../features/website-templates.md) · [Knowledge Base](../features/knowledge-base.md) · [Custom Domains](../features/custom-domains.md)
+
+---
+
+## 3. Sell — staff a team and open for business
+
+This is where Ever Works diverges hardest from one-shot builders. A site that exists isn't a business. You need people doing the work — and here, those people are [Agents](../features/agents.md).
+
+- **Hire an AI organization.** Create Tenant-scoped Agents for company-wide roles — a **CEO** to keep the roadmap coherent, a **CTO** to own the build, a **Researcher** to feed Ideas, a **Copywriter** to keep pages sharp. Ready-made roles ship as templates.
+- **Split global vs. focused.** Some Agents work across the whole company; others are scoped to a single Work (a "Blog Editor" for one blog). You decide the org chart.
+- **Give them mailboxes.** With [Agent Email & Inboxes](../features/agent-email.md), Agents send updates and outreach from real addresses and turn incoming mail into work — so sales and support conversations actually happen.
+- **Open a storefront.** The planned [Store Builder](../features/store-builder.md) turns a commerce goal into a working storefront that an AI team researches, stocks, writes, and optimizes — built to _act on_ your business, not just advise.
+
+**Platform pieces:** [Agents](../features/agents.md) · [Agent Email & Inboxes](../features/agent-email.md) · [Store Builder](../features/store-builder.md) · [Company Builder](../features/company-builder.md)
+
+---
+
+## 4. Scale — let it run, then grow it
+
+The point of all this is leverage: the business should keep moving without you in the loop for every step.
+
+- **Run 24/7.** With [Autonomous Operation](../features/autonomous-operation.md), Agents and [Workers](../features/workers.md) keep writing content, finding products, improving code, generating new Ideas, and redeploying — on a schedule.
+- **Stay in control of spend.** Set [budgets](../features/budgets-and-usage.md) per Work, Idea, Mission, and Agent, soft or hard, with alerts and auto-pause.
+- **Add Missions and Works as you grow.** A successful company runs many Works toward several Missions; the model scales sideways without adding process.
+- **Own it, forever.** Because everything is open source (AGPLv3) and lives in your Git, you can self-host, take it offline with the upcoming [Desktop App](../features/desktop-app.md), or move providers at any time. Growth never becomes a lock-in trap.
+
+**Platform pieces:** [Autonomous Operation](../features/autonomous-operation.md) · [Workers](../features/workers.md) · [Budgets & Usage](../features/budgets-and-usage.md) · [Desktop App](../features/desktop-app.md)
+
+---
+
+## The whole journey, in one picture
+
+| Phase     | You do                  | Ever Works does                                      | Core pieces                   |
+| --------- | ----------------------- | ---------------------------------------------------- | ----------------------------- |
+| **Start** | Set a goal              | Generates Ideas, plans, suggests the entity          | Missions, Ideas               |
+| **Build** | Pick what to ship       | Researches, writes, codes, deploys from Templates    | Works, Templates, KB          |
+| **Sell**  | Define the team & offer | Staffs Agents, gives them mailboxes, opens the store | Agents, Email, Store, Company |
+| **Scale** | Set budgets & let go    | Runs everything 24/7, keeps improving                | Autonomous Operation, Workers |
+
+You can be the solo founder who is _all of these roles at once_ — on top of a platform that does the work. Start with a single Idea, or set a Mission and watch a company take shape.
+
+## See also
+
+- [Platform Overview](../overview.md)
+- [Missions](../features/missions.md) · [Ideas](../features/ideas.md) · [Creating a Work](../features/creating-a-work.md) · [Agents](../features/agents.md)
+- [Company Builder](../features/company-builder.md) · [Autonomous Operation](../features/autonomous-operation.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,6 +9,32 @@ sidebar_position: 2
 
 The Ever Works Platform provides the backend infrastructure for building, generating, and deploying AI-powered work websites.
 
+## What Ever Works is
+
+Ever Works is an **open-source, agentic runtime** that researches, ships, and maintains content-rich websites and Git repositories. It brings together two things most tools keep apart:
+
+- **The builder experience** — describe what you want and get a shipped website, blog, directory, landing page (and, soon, [stores](/features/store-builder)) generated from a [template](/features/website-templates).
+- **The autonomous workforce** — an army of AI [Agents](/features/agents) acting as real employees that keep the work going long after the first build: writing content, finding and adding items, improving code, researching, and proposing what to do next — [24/7, on a schedule](/features/autonomous-operation).
+
+One-shot AI builders generate code and stop. Ever Works keeps building, maintaining, and growing — and because **code and content both live in your own Git**, you own everything and nothing is locked in. The platform is open source under **AGPLv3**.
+
+### The mental model
+
+```mermaid
+flowchart LR
+    M[Mission<br/>an ongoing goal] --> I[Ideas<br/>atomic proposals]
+    I --> W[Works<br/>live, self-updating sites]
+    A[Agents<br/>your AI employees] --> W
+    A --> I
+```
+
+- A **[Mission](/features/missions)** is an ambitious, ongoing goal the system keeps pursuing.
+- An **[Idea](/features/ideas)** is a one-shot proposal — one Idea becomes one Work. (Unsure what to build? Capture an Idea and let it be researched first, like a lightweight plan.)
+- A **[Work](/features/creating-a-work)** is the buildable, self-maintaining unit — a website, blog, directory, landing page, store, and more.
+- **[Agents](/features/agents)** are named AI workers (CEO, CTO, Researcher, …) that run the Missions, Ideas, and Works for you.
+
+For the full step-by-step, see the [Founder Journey guide](/guides/founder-journey).
+
 ## How It Works
 
 1. **Create a Work** — A user creates a work project through the web dashboard or API, providing a topic and description.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,10 +11,13 @@ This page outlines the current direction of Ever Works, areas of active developm
 
 ## Product Vision
 
-Ever Works aims to be the most comprehensive open-source solution for building professional work websites. The long-term vision encompasses:
+Ever Works aims to be the open-source, agentic runtime that **researches, ships, and maintains** content-rich websites and the businesses around them — merging the builder experience of one-shot AI site builders with an autonomous workforce that keeps working 24/7. The long-term vision encompasses:
 
 - **AI-first content generation** that makes it possible to build and maintain large works with minimal manual effort
-- **A thriving plugin ecosystem** that allows developers to extend the Platform with custom AI providers, data sources, and integrations
+- **An autonomous AI workforce** — user-defined [Agents](/features/agents) (CEO, CTO, Researcher, …) that run [Missions](/features/missions), [Ideas](/features/ideas), and [Works](/features/creating-a-work) on a schedule, not just on prompt — see [Autonomous Operation](/features/autonomous-operation)
+- **From idea to business** — beyond websites, planned [Store](/features/store-builder) and [Company](/features/company-builder) builders so a goal can become a registered, AI-run operation
+- **Own everything** — code and content live in your own Git under AGPLv3; a planned [Desktop App](/features/desktop-app) runs the whole stack locally
+- **A thriving plugin ecosystem** that allows developers to extend the Platform with custom AI providers, data sources, email providers, and integrations
 - **Production-grade website templates** that are beautiful, performant, and fully customizable
 - **Multi-work management** that scales from a single work to hundreds, all managed from a unified backend
 
@@ -23,6 +26,16 @@ Ever Works aims to be the most comprehensive open-source solution for building p
 ### Platform
 
 The following areas are actively being worked on in the Platform repository:
+
+#### Autonomous Workforce (Agents, Missions, Ideas)
+
+- [Missions](/features/missions) and [Ideas](/features/ideas) — the goal → proposal → Work hierarchy that lets the platform keep generating what to build next
+- User-defined [Agents](/features/agents) — named AI employees with scopes, heartbeats, budgets, permissions, skills, and tasks
+- [Agent Email & Inboxes](/features/agent-email) — inbound/outbound mailboxes per Agent and per Mission/Idea/Work, backed by pluggable email providers
+- [Knowledge Base & Memory](/features/knowledge-base) — per-Work, Git-backed institutional context and long-term memory
+- [Store](/features/store-builder) and [Company](/features/company-builder) builders — new Work shapes that turn a goal into a self-maintaining storefront or AI-run company
+- [Desktop App](/features/desktop-app) — the full stack running locally as a single application
+- Dynamic plugin distribution — install plugins on demand at runtime rather than bundling everything
 
 #### Plugin System Expansion
 

--- a/docs/specs/features/agent-memory/spec.md
+++ b/docs/specs/features/agent-memory/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Agent Memory
+
+**Feature ID**: `agent-memory`
+**Status**: `Shipped` (documented as-built)
+**Jira Epic**: [EW-672](https://evertech.atlassian.net/browse/EW-672)
+**Created**: 2026-05-28
+**Last updated**: 2026-05-28
+**Owner**: Product (Ruslan)
+**Shipped via PRs**: #1073 (plugin), #1081 (pipeline-step), #1082 (rollback), #1084 (sessions), #1086 (API controllers), #1090 (canSkipAtBuildTime + session pipe), #1095 (session pipe finish)
+
+**Related code today**:
+
+- Capability contract: `packages/plugin/src/contracts/capabilities/agent-memory.interface.ts`
+- Step facade: `packages/plugin/src/facades/agent-memory-facade.interface.ts`
+- First-party provider: `packages/plugins/agentmemory/` (external REST backend)
+- Pipeline modifier: `packages/plugins/memory-pipeline-modifier/`
+- Bound facade: `packages/agent/src/facades/agent-memory.facade.ts`
+- Pipeline wiring: `packages/agent/src/pipeline/pipeline-facade.service.ts`, `step-pipeline-executor.service.ts`, `full-pipeline-executor.service.ts`
+- REST surface: `apps/api/src/plugins-capabilities/agent-memory/`
+- Run-level session lifecycle: `packages/agent/src/services/agent-run.service.ts`
+
+---
+
+## 1. What it is
+
+Agent Memory gives Works and agent runs **persistent, retrievable memory** across
+generations: a run can fetch a digest of what prior runs learned and save a short
+observation at the end, so the next run starts informed rather than cold.
+
+Memory is **not stored in Postgres.** It lives entirely in an external
+agent-memory REST backend (default `@ever-works/agentmemory-plugin`, base URL
+`http://localhost:3111`), partitioned by a `project` namespace (derived from the
+Work slug/id). The **only** Postgres surface is a single nullable column,
+`agent_runs.memorySessionId` (migration
+`1779991011000-AddMemorySessionIdToAgentRuns.ts`), which records the opaque
+session id an agent run opened so the run row can be correlated with its memory
+session. Memory being external is a deliberate design choice — no migration
+exists for "memory entries" because there is no memory table.
+
+---
+
+## 2. Personas + use cases
+
+| Persona  | Use case                                                                                     |
+| -------- | -------------------------------------------------------------------------------------------- |
+| Operator | Enables an agent-memory provider so Works accumulate context across scheduled regenerations. |
+| User     | Turns on "Agent Memory Hooks" for a Work; each run fetches prior context and saves a digest. |
+| User     | Reviews / forgets individual memory observations from the admin UI.                          |
+| Agent    | An agent run opens one memory session and shares it across everything it does in that run.   |
+
+---
+
+## 3. Capability contract
+
+`IAgentMemoryPlugin` (full) / `IAgentMemoryStepFacade` (bound, exposed to pipeline
+steps) expose: `openSession`, `closeSession`, `saveMemory`, `searchMemory`,
+`buildContext`, `deleteEntry`, `listSessions`. `listSessions` is optional on the
+plugin — the default `agentmemory` provider does not implement it yet, so
+`GET /api/agent-memory/sessions` returns 404 against that backend. All calls are
+**best-effort** at the consumption sites: a memory failure must never crash a
+host pipeline or agent run.
+
+---
+
+## 4. Sessions and the session pipe
+
+A **session** groups the reads/writes of one logical unit of work so the backend
+can relate them (recall, recency, slot tracking). Two producers open sessions:
+
+1. **Agent runs** (`AgentRunService`) — open a session per run via
+   `tryOpenMemorySession`, persist its id to `agent_runs.memorySessionId`, and
+   close it when the run ends. Fully wired and best-effort (a no-provider or
+   DB hiccup never fails the run).
+
+2. **Work-generation pipelines** (via the `memory-pipeline-modifier`). The
+   modifier injects two steps — `memory-fetch-context` (position `first`) and
+   `memory-save` (position `last`) — into step-orchestratable pipelines
+   (`standard-pipeline`, `agent-pipeline`).
+
+**Session sharing (the "session pipe").** `StepExecutionContext.memorySessionId`
+carries an orchestrator-supplied session id down to every step.
+`PipelineExecutionOptions.memorySessionId` lets a caller that already opened a
+session (e.g. an agent run that triggers a pipeline) hand it in; both pipeline
+executors forward it to `PipelineFacadeService.createStepExecutionContext`, which
+places it on the step context. When this id is present, the memory modifier
+associates its fetch / save / rollback with that shared session instead of
+opening its own.
+
+When **no** orchestrator session is supplied (the common case for plain
+Work-generation runs), the `memory-fetch-context` step **opens one per-run
+session of its own**, stashes it on the pipeline context, and the `memory-save`
+step and the failure `rollback` reuse it — so the context read, the success
+digest, and any failure digest all land on the **same** session row. The modifier
+closes a session it opened itself at the terminal step (save, save-disabled exit,
+or rollback); it never closes an orchestrator-supplied session (the caller owns
+that lifecycle). All of this is best-effort: a failure to open/close a session
+is swallowed and the run continues session-less.
+
+---
+
+## 5. Rollback semantics
+
+`memory-save` only runs on **success** (it's the `last` step; the executor breaks
+out of the step loop before reaching it on failure/cancellation). To persist a
+digest for failed or cancelled runs, the modifier implements
+`IPipelineModifierPlugin.rollback(context, error)`, which the step executor
+invokes for every plugin modifier that contributed steps. Rollback tags the
+observation `failed` vs `cancelled` (AbortError / cancellation detection) and is
+wrapped in its own try/catch so a faulty rollback can never mask the original
+pipeline error.
+
+---
+
+## 6. `canSkipAtBuildTime`
+
+The modifier is **opt-in** (`enabled` setting, default off, work-scoped).
+`canSkipAtBuildTime` lets the pipeline builder skip injecting the two steps
+entirely when the modifier is disabled — zero overhead (no STEP_STARTED events,
+no metrics, no executor branching) on Works that don't use memory. A defensive
+`enabled` guard remains inside `execute()` for hosts that don't honour
+`canSkipAtBuildTime`.
+
+---
+
+## 7. REST surface
+
+Mounted at `/api/agent-memory`, JWT-protected (`AuthSessionGuard`):
+
+| Method + path                         | Notes                                                                   |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| `GET /check-availability`             | Whether a provider is registered + loaded.                              |
+| `POST /sessions`                      | Open a session. Ownership-checked when `workId` supplied.               |
+| `POST /sessions/:sessionId/close`     | Close a session. Ownership-checked + work-scoped when `workId` given.   |
+| `GET /sessions`                       | List sessions (404 if provider lacks `listSessions`).                   |
+| `POST /save` / `/search` / `/context` | Save / search / build-context. Ownership-checked when `workId` given.   |
+| `DELETE /entries/:entryId`            | Forget one record. Ownership-checked + work-scoped when `workId` given. |
+
+**Ownership / isolation.** When a request carries a `workId`, the controller
+runs `WorkOwnershipService.ensureCanView(workId, userId)` and scopes provider
+resolution to that Work. The id-addressed mutations (`close`, `deleteEntry`)
+accept an optional `workId` query param so they get the same check — without it
+they operate against the caller's default project. Cross-user isolation
+therefore depends on per-user / per-work `project` separation being configured in
+the backend.
+
+---
+
+## 8. Hard rules (additive)
+
+- Memory is **always best-effort** — never throw into a host pipeline or run.
+- The feature is **opt-in** per Work; default off.
+- Storage is **external**, not Postgres; the only DB column is
+  `agent_runs.memorySessionId`.
+- An orchestrator-supplied session id always wins over a self-opened one, and the
+  modifier never closes a session it did not open.

--- a/packages/agent/src/facades/__tests__/email.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/email.facade.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { EmailFacadeService, EmailFacadeError } from '../email.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import { TenantEmailAddressRepository } from '../../database/repositories/tenant-email-address.repository';
 
 /**
  * EW-668 / T11 — EmailFacadeService construction + resolution coverage.
@@ -11,6 +12,7 @@ import { PluginSettingsService } from '../../plugins/services/plugin-settings.se
 describe('EmailFacadeService', () => {
     let registry: jest.Mocked<PluginRegistryService>;
     let settings: jest.Mocked<PluginSettingsService>;
+    let emailAddresses: { findByAddress: jest.Mock };
     let facade: EmailFacadeService;
 
     beforeEach(async () => {
@@ -19,13 +21,16 @@ describe('EmailFacadeService', () => {
         } as unknown as jest.Mocked<PluginRegistryService>;
         settings = {
             getResolvedSettings: jest.fn().mockResolvedValue({}),
+            getSettings: jest.fn().mockResolvedValue({}),
         } as unknown as jest.Mocked<PluginSettingsService>;
+        emailAddresses = { findByAddress: jest.fn().mockResolvedValue(null) };
 
         const moduleRef = await Test.createTestingModule({
             providers: [
                 EmailFacadeService,
                 { provide: PluginRegistryService, useValue: registry },
                 { provide: PluginSettingsService, useValue: settings },
+                { provide: TenantEmailAddressRepository, useValue: emailAddresses },
             ],
         }).compile();
 
@@ -60,5 +65,111 @@ describe('EmailFacadeService', () => {
         await expect(
             facade.parseInbound('postmark', Buffer.from(''), {}, { userId: 'user-1' }),
         ).rejects.toBeInstanceOf(EmailFacadeError);
+    });
+
+    describe('parseInbound recipient-owner scoping (EW-670 follow-up)', () => {
+        function makeInboundPlugin() {
+            return {
+                id: 'postmark',
+                name: 'Postmark',
+                version: '1.0.0',
+                category: 'email',
+                capabilities: ['email-inbound'],
+                extractInboundRecipients: jest.fn().mockReturnValue(['inbox@ever.works']),
+                verifyWebhookSignature: jest.fn(),
+                parseInboundWebhook: jest.fn().mockResolvedValue({
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    from: 'sender@example.com',
+                    to: ['inbox@ever.works'],
+                    subject: 's',
+                    bodyText: 't',
+                    attachments: [],
+                    receivedAt: new Date(),
+                }),
+            };
+        }
+
+        it('resolves the recipient owner and verifies with the owner-scoped secret', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            (settings.getSettings as jest.Mock).mockResolvedValue({
+                inboundWebhookSecret: 'owner-secret',
+            });
+            emailAddresses.findByAddress.mockResolvedValue({
+                userId: 'owner-9',
+                pluginId: 'postmark',
+            });
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {});
+
+            expect(plugin.extractInboundRecipients).toHaveBeenCalled();
+            expect(emailAddresses.findByAddress).toHaveBeenCalledWith('inbox@ever.works');
+            // settings (and thus the secret) resolved at the OWNER's scope
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: 'owner-9', includeSecrets: true }),
+            );
+            // verification ran with those owner-scoped settings
+            expect(plugin.verifyWebhookSignature).toHaveBeenCalledWith(
+                expect.any(Buffer),
+                expect.anything(),
+                expect.objectContaining({
+                    userId: 'owner-9',
+                    settings: { inboundWebhookSecret: 'owner-secret' },
+                }),
+            );
+        });
+
+        it('falls back to default scope when no owner matches the recipient', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            emailAddresses.findByAddress.mockResolvedValue(null);
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {});
+
+            expect(emailAddresses.findByAddress).toHaveBeenCalledWith('inbox@ever.works');
+            // No owner → settings resolved without a userId (admin/env scope)
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: undefined }),
+            );
+            expect(plugin.verifyWebhookSignature).toHaveBeenCalled();
+        });
+
+        it('falls back to default scope when the matched address belongs to a different plugin', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            // Address is registered to mailgun, not the postmark webhook in flight.
+            emailAddresses.findByAddress.mockResolvedValue({
+                userId: 'owner-9',
+                pluginId: 'mailgun',
+            });
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {});
+
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: undefined }),
+            );
+        });
+
+        it('skips recipient resolution when the caller already supplies a userId', async () => {
+            const plugin = makeInboundPlugin();
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+
+            await facade.parseInbound('postmark', Buffer.from('{}'), {}, { userId: 'caller-1' });
+
+            expect(plugin.extractInboundRecipients).not.toHaveBeenCalled();
+            expect(emailAddresses.findByAddress).not.toHaveBeenCalled();
+            expect(settings.getSettings).toHaveBeenCalledWith(
+                'postmark',
+                expect.objectContaining({ userId: 'caller-1' }),
+            );
+        });
     });
 });

--- a/packages/agent/src/facades/__tests__/email.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/email.facade.spec.ts
@@ -3,6 +3,7 @@ import { EmailFacadeService, EmailFacadeError } from '../email.facade';
 import { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
 import { TenantEmailAddressRepository } from '../../database/repositories/tenant-email-address.repository';
+import { EmailMessageRepository } from '../../database/repositories/email-message.repository';
 
 /**
  * EW-668 / T11 — EmailFacadeService construction + resolution coverage.
@@ -13,6 +14,7 @@ describe('EmailFacadeService', () => {
     let registry: jest.Mocked<PluginRegistryService>;
     let settings: jest.Mocked<PluginSettingsService>;
     let emailAddresses: { findByAddress: jest.Mock };
+    let emailMessages: { findByProviderMessageId: jest.Mock; updateDeliveryStatus: jest.Mock };
     let facade: EmailFacadeService;
 
     beforeEach(async () => {
@@ -24,6 +26,10 @@ describe('EmailFacadeService', () => {
             getSettings: jest.fn().mockResolvedValue({}),
         } as unknown as jest.Mocked<PluginSettingsService>;
         emailAddresses = { findByAddress: jest.fn().mockResolvedValue(null) };
+        emailMessages = {
+            findByProviderMessageId: jest.fn().mockResolvedValue(null),
+            updateDeliveryStatus: jest.fn().mockResolvedValue(undefined),
+        };
 
         const moduleRef = await Test.createTestingModule({
             providers: [
@@ -31,6 +37,7 @@ describe('EmailFacadeService', () => {
                 { provide: PluginRegistryService, useValue: registry },
                 { provide: PluginSettingsService, useValue: settings },
                 { provide: TenantEmailAddressRepository, useValue: emailAddresses },
+                { provide: EmailMessageRepository, useValue: emailMessages },
             ],
         }).compile();
 
@@ -170,6 +177,90 @@ describe('EmailFacadeService', () => {
                 'postmark',
                 expect.objectContaining({ userId: 'caller-1' }),
             );
+        });
+    });
+
+    describe('delivery-event webhook (parseEventWebhook + recordDeliveryEvents)', () => {
+        function makeInboundPlugin(overrides: Record<string, unknown> = {}) {
+            return {
+                id: 'postmark',
+                capabilities: ['email-inbound'],
+                verifyWebhookSignature: jest.fn(),
+                parseInboundWebhook: jest.fn(),
+                parseEventWebhook: jest.fn(),
+                ...overrides,
+            };
+        }
+
+        it('verifies then decodes events via the plugin', async () => {
+            const plugin = makeInboundPlugin();
+            (plugin.parseEventWebhook as jest.Mock).mockResolvedValue([
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    type: 'delivered',
+                    occurredAt: new Date(),
+                },
+            ]);
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+
+            const events = await facade.parseEventWebhook('postmark', Buffer.from('{}'), {});
+            expect(plugin.verifyWebhookSignature).toHaveBeenCalled();
+            expect(events).toHaveLength(1);
+        });
+
+        it('returns [] when the plugin does not publish delivery events', async () => {
+            const plugin = makeInboundPlugin({ parseEventWebhook: undefined });
+            registry.getByCapability.mockImplementation(((cap: string) =>
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+            await expect(
+                facade.parseEventWebhook('postmark', Buffer.from('{}'), {}),
+            ).resolves.toEqual([]);
+        });
+
+        it('records each event onto the matching message (latest-status-wins) and counts updates', async () => {
+            emailMessages.findByProviderMessageId
+                .mockResolvedValueOnce({ id: 'msg-1' })
+                .mockResolvedValueOnce(null); // second event has no matching row
+            const recorded = await facade.recordDeliveryEvents('postmark', [
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    type: 'bounced',
+                    occurredAt: new Date(),
+                },
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-unknown',
+                    type: 'opened',
+                    occurredAt: new Date(),
+                },
+            ] as never);
+            expect(recorded).toBe(1);
+            expect(emailMessages.updateDeliveryStatus).toHaveBeenCalledWith('msg-1', 'bounced');
+        });
+
+        it('swallows a per-event update failure and continues the batch', async () => {
+            emailMessages.findByProviderMessageId.mockResolvedValue({ id: 'msg-1' });
+            emailMessages.updateDeliveryStatus
+                .mockRejectedValueOnce(new Error('db hiccup'))
+                .mockResolvedValueOnce(undefined);
+            const recorded = await facade.recordDeliveryEvents('postmark', [
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-1',
+                    type: 'bounced',
+                    occurredAt: new Date(),
+                },
+                {
+                    provider: 'postmark',
+                    providerMessageId: 'pm-2',
+                    type: 'delivered',
+                    occurredAt: new Date(),
+                },
+            ] as never);
+            expect(recorded).toBe(1);
         });
     });
 });

--- a/packages/agent/src/facades/email.facade.ts
+++ b/packages/agent/src/facades/email.facade.ts
@@ -8,6 +8,7 @@ import {
     type EmailSendInput,
     type EmailSendResult,
     type EmailInboundMessage,
+    type EmailDeliveryEvent,
     type EmailOptions,
 } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
@@ -187,6 +188,67 @@ export class EmailFacadeService extends BaseFacadeService {
         };
         plugin.verifyWebhookSignature(rawBody, headers, emailOpts);
         return plugin.parseInboundWebhook(rawBody, headers, emailOpts);
+    }
+
+    /**
+     * Verify + decode a provider delivery-event webhook (bounces, opens,
+     * clicks, complaints). Verification uses the admin/env-scoped secret
+     * (delivery events reference a `providerMessageId`, not a recipient,
+     * so per-user owner resolution isn't possible up front). Returns an
+     * empty array when the plugin doesn't publish delivery events.
+     */
+    async parseEventWebhook(
+        pluginId: string,
+        rawBody: Buffer,
+        headers: Readonly<Record<string, string>>,
+        options?: FacadeOptions,
+    ): Promise<readonly EmailDeliveryEvent[]> {
+        const plugin = this.getInboundPluginById(pluginId);
+        if (!plugin.parseEventWebhook) return [];
+        const settings = await this.resolveSettings(pluginId, options);
+        const emailOpts: EmailOptions = {
+            userId: options?.userId,
+            workId: options?.workId,
+            agentId: options?.agentId,
+            taskId: options?.taskId,
+            settings,
+        };
+        plugin.verifyWebhookSignature(rawBody, headers, emailOpts);
+        return plugin.parseEventWebhook(rawBody, headers, emailOpts);
+    }
+
+    /**
+     * Persist delivery-event outcomes onto the matching `email_messages`
+     * rows (latest-status-wins). Looks each event up by
+     * `(pluginId, providerMessageId)`; unknown ids are skipped (the
+     * message may predate audit-row persistence). Returns how many rows
+     * were updated. Best-effort per event — one failed update never
+     * aborts the batch.
+     */
+    async recordDeliveryEvents(
+        pluginId: string,
+        events: readonly EmailDeliveryEvent[],
+    ): Promise<number> {
+        if (!this.emailMessages || events.length === 0) return 0;
+        let updated = 0;
+        for (const event of events) {
+            try {
+                const message = await this.emailMessages.findByProviderMessageId(
+                    pluginId,
+                    event.providerMessageId,
+                );
+                if (!message) continue;
+                await this.emailMessages.updateDeliveryStatus(message.id, event.type);
+                updated += 1;
+            } catch (err) {
+                this.logger.warn(
+                    `recordDeliveryEvents: failed to record ${event.type} for ${event.providerMessageId} — ${
+                        (err as Error).message
+                    }`,
+                );
+            }
+        }
+        return updated;
     }
 
     /**

--- a/packages/agent/src/facades/email.facade.ts
+++ b/packages/agent/src/facades/email.facade.ts
@@ -162,16 +162,78 @@ export class EmailFacadeService extends BaseFacadeService {
         options?: FacadeOptions,
     ): Promise<EmailInboundMessage> {
         const plugin = this.getInboundPluginById(pluginId);
-        const settings = await this.resolveSettings(pluginId, options);
+
+        // EW-670 follow-up — resolve the recipient address's OWNER before
+        // verifying the signature. The inbound webhook controller can't
+        // know the owning user up front (the recipient lives in the
+        // payload), so without this the secret resolves at admin/env
+        // scope only and a per-user `inboundWebhookSecret` is never
+        // loaded — meaning a Postmark/Mailgun `if (!expected) return`
+        // accept-all path silently skips verification for user-scoped
+        // secrets. Map recipient → owning tenant address → userId, then
+        // resolve settings (and therefore the secret) at that scope.
+        // Best-effort and additive: when the caller already supplies a
+        // userId, the plugin omits `extractInboundRecipients`, or no
+        // owner matches, this falls back to the previous behaviour.
+        const scope = await this.resolveInboundScope(plugin, rawBody, headers, options);
+
+        const settings = await this.resolveSettings(pluginId, scope);
         const emailOpts: EmailOptions = {
-            userId: options?.userId,
-            workId: options?.workId,
-            agentId: options?.agentId,
-            taskId: options?.taskId,
+            userId: scope.userId,
+            workId: scope.workId,
+            agentId: scope.agentId,
+            taskId: scope.taskId,
             settings,
         };
         plugin.verifyWebhookSignature(rawBody, headers, emailOpts);
         return plugin.parseInboundWebhook(rawBody, headers, emailOpts);
+    }
+
+    /**
+     * Best-effort: widen the inbound FacadeOptions with the owning user
+     * resolved from the payload's recipient address, so signature
+     * verification reads the owner's per-user secret. Never throws —
+     * returns the original options on any failure.
+     */
+    private async resolveInboundScope(
+        plugin: IEmailInboundPlugin,
+        rawBody: Buffer,
+        headers: Readonly<Record<string, string>>,
+        options?: FacadeOptions,
+    ): Promise<FacadeOptions> {
+        const base: FacadeOptions = { ...options };
+        if (base.userId || !plugin.extractInboundRecipients || !this.emailAddresses) {
+            return base;
+        }
+        try {
+            const recipients = plugin.extractInboundRecipients(rawBody, headers);
+            for (const recipient of recipients) {
+                if (!recipient) continue;
+                const owner = await this.emailAddresses.findByAddress(recipient);
+                // Only adopt the resolved owner when the matched address is
+                // registered to THIS plugin — a mailbox can be registered by
+                // multiple tenants/providers, so an address-only match could
+                // otherwise attribute the verification scope to the wrong
+                // owner (Codex/Greptile on PR #1115). When it doesn't match we
+                // fall back to the base (admin/env) scope below.
+                //
+                // Note: widening the scope to the owner's userId never
+                // *weakens* verification — `getSettings({ userId })` resolves
+                // the admin→user hierarchy, so an admin-level
+                // `inboundWebhookSecret` is still present (and enforced) at
+                // owner scope; the user's own secret only layers on top.
+                if (owner?.userId && owner.pluginId === plugin.id) {
+                    return { ...base, userId: owner.userId };
+                }
+            }
+        } catch (err) {
+            this.logger.warn(
+                `parseInbound: recipient-owner resolution failed, falling back to default scope — ${
+                    (err as Error).message
+                }`,
+            );
+        }
+        return base;
     }
 
     /**

--- a/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.spec.ts
@@ -8,6 +8,9 @@ import {
     UserNotificationSubscriptionRepository,
     UserNotificationPreferenceRepository,
     UserNotificationCategoryMuteRepository,
+    OrganizationNotificationDefaultRepository,
+    OrganizationRepository,
+    UserRepository,
 } from '@src/database';
 
 /**
@@ -185,6 +188,105 @@ describe('UserNotificationSubscriptionService', () => {
         expect(plan.immediate).toEqual(['in-app', 'channel-1']);
         expect(plan.deferred).toEqual([]);
         expect(plan.deferUntil).toBeUndefined();
+    });
+});
+
+describe('UserNotificationSubscriptionService — organisation defaults', () => {
+    let service: UserNotificationSubscriptionService;
+    let eventTypes: { findByKey: jest.Mock };
+    let subscriptions: { findForEvent: jest.Mock };
+    let orgDefaults: { findByOrg: jest.Mock };
+    let organizations: { findByTenantId: jest.Mock };
+    let users: { findById: jest.Mock };
+
+    beforeEach(async () => {
+        eventTypes = {
+            findByKey: jest.fn().mockResolvedValue({
+                key: 'work_generation_finished',
+                category: 'work',
+                urgent: false,
+                defaultChannels: ['in-app'],
+            }),
+        };
+        subscriptions = { findForEvent: jest.fn().mockResolvedValue(null) };
+        orgDefaults = { findByOrg: jest.fn() };
+        organizations = { findByTenantId: jest.fn() };
+        users = { findById: jest.fn() };
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                UserNotificationSubscriptionService,
+                { provide: NotificationEventTypeRepository, useValue: eventTypes },
+                { provide: UserNotificationSubscriptionRepository, useValue: subscriptions },
+                { provide: OrganizationNotificationDefaultRepository, useValue: orgDefaults },
+                { provide: OrganizationRepository, useValue: organizations },
+                { provide: UserRepository, useValue: users },
+            ],
+        }).compile();
+        service = moduleRef.get(UserNotificationSubscriptionService);
+    });
+
+    it('applies the org default when the tenant owns exactly one org', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }]);
+        orgDefaults.findByOrg.mockResolvedValue({
+            organizationId: 'org-1',
+            defaults: { work_generation_finished: ['in-app', 'email'] },
+        });
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+            'email',
+        ]);
+        expect(organizations.findByTenantId).toHaveBeenCalledWith('t1');
+        expect(orgDefaults.findByOrg).toHaveBeenCalledWith('org-1');
+    });
+
+    it('falls through to event defaults when the tenant owns multiple orgs (ambiguous)', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }, { id: 'org-2' }]);
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+        ]);
+        expect(orgDefaults.findByOrg).not.toHaveBeenCalled();
+    });
+
+    it('falls through when the single org has no default for this event', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }]);
+        orgDefaults.findByOrg.mockResolvedValue({
+            organizationId: 'org-1',
+            defaults: { some_other_event: ['email'] },
+        });
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+        ]);
+    });
+
+    it('falls through when the user has no tenant', async () => {
+        users.findById.mockResolvedValue({ id: 'u', tenantId: null });
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+        ]);
+        expect(organizations.findByTenantId).not.toHaveBeenCalled();
+    });
+
+    it('per-user subscription still wins over the org default', async () => {
+        subscriptions.findForEvent.mockResolvedValue({ channelIds: ['in-app', 'slack'] });
+        users.findById.mockResolvedValue({ id: 'u', tenantId: 't1' });
+        organizations.findByTenantId.mockResolvedValue([{ id: 'org-1' }]);
+        orgDefaults.findByOrg.mockResolvedValue({
+            organizationId: 'org-1',
+            defaults: { work_generation_finished: ['in-app', 'email'] },
+        });
+
+        await expect(service.resolveChannels('u', 'work_generation_finished')).resolves.toEqual([
+            'in-app',
+            'slack',
+        ]);
+        expect(users.findById).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/agent/src/notifications/user-notification-subscription.service.ts
+++ b/packages/agent/src/notifications/user-notification-subscription.service.ts
@@ -4,6 +4,9 @@ import {
     UserNotificationSubscriptionRepository,
     UserNotificationPreferenceRepository,
     UserNotificationCategoryMuteRepository,
+    OrganizationNotificationDefaultRepository,
+    OrganizationRepository,
+    UserRepository,
 } from '@src/database';
 
 /**
@@ -13,8 +16,10 @@ import {
  * with full fallback semantics:
  *
  * 1. Per-user subscription row, if any.
- * 2. Event-type default channels.
- * 3. `['in-app']` as the ultimate fallback (matches v1 behaviour).
+ * 2. Organisation default channel map (when the user's tenant owns
+ *    exactly one organisation — see `resolveOrgDefaultChannels`).
+ * 3. Event-type default channels.
+ * 4. `['in-app']` as the ultimate fallback (matches v1 behaviour).
  *
  * Then applies two filters:
  *
@@ -26,9 +31,6 @@ import {
  *    drop all non-`in-app` channels.
  *
  * **Deferred from v1**:
- * - Organisation defaults fallback (between steps 1 and 2). The
- *   `OrganizationNotificationDefaultRepository` exists; wiring the
- *   user→organization lookup is a follow-up.
  * - BullMQ delayed-delivery: quiet-hours-caught non-urgent events
  *   currently get dropped to in-app only. v2 will queue them for
  *   delivery at end-of-quiet-window. The `deferredAt` / `dueAt`
@@ -59,6 +61,13 @@ export class UserNotificationSubscriptionService {
         private readonly subscriptions: UserNotificationSubscriptionRepository,
         @Optional() private readonly preferences?: UserNotificationPreferenceRepository,
         @Optional() private readonly mutes?: UserNotificationCategoryMuteRepository,
+        // Org-default resolution deps — all @Optional() so the resolver
+        // keeps constructing in deployments / unit tests that don't wire
+        // the org stack. When any is missing, org defaults are skipped and
+        // resolution falls through to event-type defaults (prior behaviour).
+        @Optional() private readonly orgDefaults?: OrganizationNotificationDefaultRepository,
+        @Optional() private readonly organizations?: OrganizationRepository,
+        @Optional() private readonly users?: UserRepository,
     ) {}
 
     /**
@@ -134,10 +143,52 @@ export class UserNotificationSubscriptionService {
         if (sub?.channelIds && sub.channelIds.length > 0) {
             return [...sub.channelIds];
         }
+        // Organisation defaults sit between the per-user subscription and
+        // the event-type defaults: a user with no explicit subscription
+        // inherits their organisation's default channel map for this event.
+        const orgChannels = await this.resolveOrgDefaultChannels(userId, eventTypeKey);
+        if (orgChannels && orgChannels.length > 0) {
+            return [...orgChannels];
+        }
         if (eventDefaults && eventDefaults.length > 0) {
             return [...eventDefaults];
         }
         return ['in-app'];
+    }
+
+    /**
+     * Resolve the organisation default channel list for `(userId,
+     * eventTypeKey)`. The resolver runs in a scope-less background fanout
+     * (no "active org" in context), and a tenant may own several orgs, so
+     * we only apply org defaults when the user's tenant has **exactly one**
+     * organisation — an unambiguous mapping. Multi-org tenants need an
+     * active-org signal the fanout doesn't have, so they fall through to
+     * event-type defaults (a future enhancement can thread the active org).
+     *
+     * Best-effort: any failure (missing deps, DB hiccup) returns
+     * `undefined` so notification resolution never breaks on org lookup.
+     */
+    private async resolveOrgDefaultChannels(
+        userId: string,
+        eventTypeKey: string,
+    ): Promise<string[] | undefined> {
+        if (!this.orgDefaults || !this.organizations || !this.users) return undefined;
+        try {
+            const user = await this.users.findById(userId);
+            if (!user?.tenantId) return undefined;
+            const orgs = await this.organizations.findByTenantId(user.tenantId);
+            if (orgs.length !== 1) return undefined;
+            const def = await this.orgDefaults.findByOrg(orgs[0].id);
+            const channels = def?.defaults?.[eventTypeKey];
+            return Array.isArray(channels) && channels.length > 0 ? channels : undefined;
+        } catch (err) {
+            this.logger.debug(
+                `Org-default resolution failed for user=${userId} event=${eventTypeKey}: ${
+                    (err as Error).message
+                }. Falling through to event-type defaults.`,
+            );
+            return undefined;
+        }
     }
 }
 

--- a/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
+++ b/packages/agent/src/pipeline/__tests__/step-pipeline-executor.spec.ts
@@ -708,6 +708,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId (no orchestrator session)
             );
         });
 
@@ -722,6 +723,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 
@@ -741,6 +743,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 
@@ -774,6 +777,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 bundle,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 
@@ -796,6 +800,7 @@ describe('StepPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // 7th: memorySessionId
             );
         });
 

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.spec.ts
@@ -96,6 +96,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined, // no signal in options
                 undefined, // no kbContext (no KB service wired)
                 undefined, // no kbTools (no adapter wired)
+                undefined, // no memorySessionId (no orchestrator session)
             );
 
             // plugin.execute received {...options, execContext, onLogEntry}.
@@ -144,6 +145,7 @@ describe('FullPipelineExecutorService', () => {
                 signal,
                 undefined,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
 
@@ -218,6 +220,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined,
                 bundle,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
 
@@ -246,6 +249,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
 
@@ -281,6 +285,7 @@ describe('FullPipelineExecutorService', () => {
                 undefined,
                 undefined,
                 undefined,
+                undefined, // no memorySessionId
             );
         });
     });

--- a/packages/agent/src/pipeline/full-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/full-pipeline-executor.service.ts
@@ -139,6 +139,7 @@ export class FullPipelineExecutorService {
                 options?.signal,
                 kbContext,
                 kbTools,
+                options?.memorySessionId,
             );
 
             // Delegate to the plugin's execute method with execContext

--- a/packages/agent/src/pipeline/step-pipeline-executor.service.ts
+++ b/packages/agent/src/pipeline/step-pipeline-executor.service.ts
@@ -613,6 +613,7 @@ export class StepPipelineExecutorService {
             options?.signal,
             kbContext,
             kbTools,
+            options?.memorySessionId,
         );
 
         if (executor.type === 'builtin') {

--- a/packages/plugin/src/contracts/capabilities/email-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/email-provider.interface.ts
@@ -210,6 +210,18 @@ export interface IEmailInboundPlugin extends IPlugin {
 	verifyWebhookSignature(rawBody: Buffer, headers: Readonly<Record<string, string>>, options: EmailOptions): void;
 
 	/**
+	 * Optional: best-effort extraction of the recipient mailbox
+	 * address(es) from the raw webhook payload, WITHOUT verifying the
+	 * signature. The facade uses this to map an inbound webhook to its
+	 * owning tenant address *before* signature verification, so a
+	 * per-user `inboundWebhookSecret` is resolved at the right scope
+	 * rather than only at admin/env scope. MUST NOT throw — return an
+	 * empty array when the recipient can't be determined. Plugins that
+	 * omit this fall back to admin/env-scoped secret resolution.
+	 */
+	extractInboundRecipients?(rawBody: Buffer, headers: Readonly<Record<string, string>>): readonly string[];
+
+	/**
 	 * Optional: decode a provider's delivery-event webhook (separate
 	 * shape from inbound on most providers). Plugins that don't
 	 * publish delivery events may omit this — the controller skips

--- a/packages/plugin/src/contracts/capabilities/pipeline-plugin.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/pipeline-plugin.interface.ts
@@ -38,6 +38,17 @@ export interface PipelineExecutionOptions {
 	readonly execContext?: StepExecutionContext;
 	/** Callback for structured log entries (used by log collector) */
 	readonly onLogEntry?: (log: GenerationStepLog) => void;
+	/**
+	 * Agent-memory session id supplied by an orchestrator that already
+	 * opened a session for this run (e.g. an agent run that triggers a
+	 * pipeline). When set, the executor forwards it to every step via
+	 * `StepExecutionContext.memorySessionId` so memory-touching steps
+	 * associate their reads/writes with the shared session instead of
+	 * opening their own. Left `undefined` for plain Work-generation
+	 * runs, where the `memory-pipeline-modifier` opens a per-run session
+	 * of its own.
+	 */
+	readonly memorySessionId?: string;
 }
 
 /**

--- a/packages/plugins/composio/src/composio.plugin.ts
+++ b/packages/plugins/composio/src/composio.plugin.ts
@@ -99,6 +99,15 @@ export class ComposioPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProv
 				'x-envVar': 'COMPOSIO_API_KEY',
 				'x-scope': 'user'
 			},
+			webhookSecret: {
+				type: 'string',
+				title: 'Composio Webhook Secret',
+				description:
+					'Your Composio project webhook secret, from Composio dashboard → Project Settings → Webhook. Required to verify inbound trigger webhook deliveries (HMAC-SHA256 of the signed payload). Without it, trigger deliveries are rejected.',
+				'x-secret': true,
+				'x-envVar': 'COMPOSIO_WEBHOOK_SECRET',
+				'x-scope': 'user'
+			},
 			baseUrl: {
 				type: 'string',
 				title: 'Composio API Base URL',

--- a/packages/plugins/mailgun/src/mailgun-plugin.ts
+++ b/packages/plugins/mailgun/src/mailgun-plugin.ts
@@ -193,6 +193,34 @@ export class MailgunPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin 
 		}
 	}
 
+	extractInboundRecipients(rawBody: Buffer, _headers: Readonly<Record<string, string>>): readonly string[] {
+		// Best-effort recipient extraction WITHOUT verifying the
+		// signature — used by the facade to resolve the owning user's
+		// scope before verification. Must never throw.
+		try {
+			const body = decodeBody(rawBody);
+			const raw =
+				(typeof body['recipient'] === 'string' ? (body['recipient'] as string) : undefined) ??
+				(typeof body['To'] === 'string' ? (body['To'] as string) : undefined) ??
+				'';
+			// `recipient` is a bare address, but the `To` fallback is the raw
+			// RFC 2822 header (may be `"Name" <a@b>`), so strip the display
+			// name / angle brackets before matching.
+			return raw
+				? raw
+						.split(',')
+						.map((s) => {
+							const trimmed = s.trim();
+							const match = trimmed.match(/<([^>]+)>/);
+							return (match ? match[1] : trimmed).trim();
+						})
+						.filter((s) => s.length > 0)
+				: [];
+		} catch {
+			return [];
+		}
+	}
+
 	async parseInboundWebhook(
 		rawBody: Buffer,
 		_headers: Readonly<Record<string, string>>,

--- a/packages/plugins/memory-pipeline-modifier/package.json
+++ b/packages/plugins/memory-pipeline-modifier/package.json
@@ -61,7 +61,8 @@
 			"autoEnable": false,
 			"visibility": "public",
 			"targetPipelines": [
-				"*"
+				"standard-pipeline",
+				"agent-pipeline"
 			]
 		}
 	}

--- a/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/__tests__/memory-pipeline-modifier.plugin.spec.ts
@@ -449,5 +449,135 @@ describe('MemoryPipelineModifierPlugin', () => {
 				expect.anything()
 			);
 		});
+
+		it('opens a per-run session on fetch when none supplied and threads it into buildContext', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-1',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: 'x' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.openSession).toHaveBeenCalledTimes(1);
+			expect(memoryFacade.buildContext).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-self-1' }),
+				expect.anything()
+			);
+			expect((context as Record<string, unknown>).__memoryModifierSessionId).toBe('sess-self-1');
+		});
+
+		it('reuses the self-opened session on save (no second open) and closes it once', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-2',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-2' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.openSession).toHaveBeenCalledTimes(1);
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-self-2' }),
+				expect.anything()
+			);
+			expect(memoryFacade.closeSession).toHaveBeenCalledTimes(1);
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-2', expect.anything());
+		});
+
+		it('closes the self-opened session even when saveSummary is disabled', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-3',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			const context = makeContext({
+				stepSettings: { 'memory-pipeline-modifier': { enabled: true, saveSummary: false } }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContext() }
+			});
+			expect(memoryFacade.saveMemory).not.toHaveBeenCalled();
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-3', expect.anything());
+		});
+
+		it('closes the self-opened session via rollback on failure', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-4',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-rb' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.rollback(context, new Error('boom'));
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-self-4' }),
+				expect.anything()
+			);
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-4', expect.anything());
+		});
+
+		it('closes the self-opened session on rollback even when saveSummary is disabled', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+				id: 'sess-self-5',
+				startedAt: 'now'
+			});
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			const context = makeContext({
+				stepSettings: { 'memory-pipeline-modifier': { enabled: true, saveSummary: false } }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+			});
+			await plugin.rollback(context, new Error('boom'));
+			// saveSummary off → no failure digest persisted, but the session
+			// we opened in fetch-context must still be closed.
+			expect(memoryFacade.saveMemory).not.toHaveBeenCalled();
+			expect(memoryFacade.closeSession).toHaveBeenCalledWith('sess-self-5', expect.anything());
+		});
+
+		it('does NOT open or close a session when the orchestrator supplies one', async () => {
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: '' });
+			(memoryFacade.saveMemory as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-o' });
+			const context = makeContext();
+			await plugin.execute(context, {
+				settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContextWithSession('sess-orch') }
+			});
+			await plugin.execute(context, {
+				settings: { stepId: SAVE_MEMORY_STEP_ID, execContext: makeExecContextWithSession('sess-orch') }
+			});
+			expect(memoryFacade.openSession).not.toHaveBeenCalled();
+			expect(memoryFacade.closeSession).not.toHaveBeenCalled();
+			expect(memoryFacade.saveMemory).toHaveBeenCalledWith(
+				expect.objectContaining({ sessionId: 'sess-orch' }),
+				expect.anything()
+			);
+		});
+
+		it('swallows a session-open failure and continues session-less', async () => {
+			(memoryFacade.openSession as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('session server down'));
+			(memoryFacade.buildContext as ReturnType<typeof vi.fn>).mockResolvedValue({ content: 'x' });
+			const context = makeContext();
+			await expect(
+				plugin.execute(context, {
+					settings: { stepId: FETCH_CONTEXT_STEP_ID, execContext: makeExecContext() }
+				})
+			).resolves.toBeDefined();
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/failed to open session/));
+			const buildArg = (memoryFacade.buildContext as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(buildArg).not.toHaveProperty('sessionId');
+		});
 	});
 });

--- a/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
+++ b/packages/plugins/memory-pipeline-modifier/src/memory-pipeline-modifier.plugin.ts
@@ -296,7 +296,6 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 	async rollback(context: IPipelineContext, error: Error): Promise<void> {
 		const settings = this.resolveSettings(context);
 		if (settings.enabled !== true) return;
-		if (settings.saveSummary === false) return;
 
 		const execContext = (context as ContextBag).__memoryModifierExecContext as StepExecutionContext | undefined;
 		const memoryFacade = execContext?.agentMemoryFacade;
@@ -304,7 +303,17 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 		if (!memoryFacade) {
 			// fetch-context didn't run, or the modifier was disabled when
-			// it did. Either way there's no facade to call.
+			// it did. Either way there's no facade to call (and so nothing
+			// was opened that needs closing).
+			return;
+		}
+
+		// When the failure digest is disabled we still MUST close any
+		// session this modifier opened during fetch-context — otherwise a
+		// failed/cancelled run with `saveSummary: false` leaks the session
+		// (Codex P2 on PR #1113).
+		if (settings.saveSummary === false) {
+			await this.closeSelfOpenedSession(context as ContextBag, memoryFacade, logger);
 			return;
 		}
 
@@ -315,7 +324,7 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 
 			const summary = this.buildFailureSummary(work, items, error, isCancellation);
 			const tags = this.buildFailureTags(work, isCancellation);
-			const sessionId = execContext?.memorySessionId;
+			const sessionId = this.resolveSessionId(context as ContextBag);
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
@@ -344,6 +353,99 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			// Do not rethrow — the host executor catches and demotes
 			// rollback errors, but defending here too keeps the
 			// invariant local.
+		} finally {
+			// Close the per-run session we opened (no-op when the session
+			// was supplied by an orchestrator, which owns its lifecycle).
+			await this.closeSelfOpenedSession(context as ContextBag, memoryFacade, logger);
+		}
+	}
+
+	// ── session lifecycle ──────────────────────────────────────────────
+
+	/**
+	 * Resolve the agent-memory session id to associate this run's
+	 * reads/writes with, WITHOUT opening a new one:
+	 *
+	 *   1. An orchestrator-supplied session (`execContext.memorySessionId`,
+	 *      forwarded by the pipeline executor from
+	 *      `PipelineExecutionOptions.memorySessionId`) always wins — the
+	 *      caller owns that session's lifecycle, so we never close it.
+	 *   2. Otherwise a session this modifier opened earlier in the same
+	 *      run (stashed on the context bag by `ensureSessionId`).
+	 *
+	 * Returns `undefined` when neither exists yet.
+	 */
+	private resolveSessionId(context: ContextBag): string | undefined {
+		const execContext = context.__memoryModifierExecContext as StepExecutionContext | undefined;
+		if (execContext?.memorySessionId) return execContext.memorySessionId;
+		return context.__memoryModifierSessionId as string | undefined;
+	}
+
+	/**
+	 * Resolve an existing session id or, when none is supplied by an
+	 * orchestrator, open a per-run session of our own so that the
+	 * fetch-context read, the save digest, and any failure rollback all
+	 * land on the SAME `agent_memory_sessions` row. Called from the
+	 * first-position fetch step so the session exists for the whole run.
+	 *
+	 * Best-effort: a failure to open is swallowed (memory must never crash
+	 * the host pipeline) and the run continues session-less.
+	 */
+	private async ensureSessionId(
+		context: ContextBag,
+		memoryFacade: IAgentMemoryStepFacade,
+		logger: { log(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void }
+	): Promise<string | undefined> {
+		const existing = this.resolveSessionId(context);
+		if (existing) return existing;
+
+		try {
+			const work = (context as { work?: { id?: string; slug?: string } }).work;
+			const session = await memoryFacade.openSession(
+				// Open in the SAME project namespace the fetch/save/rollback
+				// calls use (`work.slug ?? work.id`) so the session row and
+				// its memory entries live together (Codex P2 on PR #1113).
+				{ projectId: work?.slug ?? work?.id, source: this.id, workId: work?.id, workSlug: work?.slug },
+				// Bound facade ignores its facadeOptions — pass placeholder.
+				{ userId: 'bound', workId: 'bound' }
+			);
+			if (session?.id) {
+				context.__memoryModifierSessionId = session.id;
+				context.__memoryModifierSessionSelfOpened = true;
+				logger.log(`memory-session: opened session ${session.id} for Work "${work?.slug ?? work?.id ?? '?'}"`);
+				return session.id;
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`memory-session: failed to open session — ${message}`);
+		}
+		return undefined;
+	}
+
+	/**
+	 * Close the session this modifier opened, exactly once, at the end of
+	 * the run (success digest, save-disabled exit, or failure rollback).
+	 * No-ops when the session was supplied by an orchestrator (it owns the
+	 * lifecycle) or when we never opened one. Best-effort.
+	 */
+	private async closeSelfOpenedSession(
+		context: ContextBag,
+		memoryFacade: IAgentMemoryStepFacade,
+		logger: { log(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void }
+	): Promise<void> {
+		if (context.__memoryModifierSessionSelfOpened !== true) return;
+		const sessionId = context.__memoryModifierSessionId as string | undefined;
+		// Flip the flag first so a concurrent/repeated terminal step can't
+		// double-close.
+		context.__memoryModifierSessionSelfOpened = false;
+		if (!sessionId) return;
+
+		try {
+			await memoryFacade.closeSession(sessionId, { userId: 'bound', workId: 'bound' });
+			logger.log(`memory-session: closed session ${sessionId}`);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`memory-session: failed to close session ${sessionId} — ${message}`);
 		}
 	}
 
@@ -359,14 +461,13 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			const work = (context as { work?: { id?: string; name?: string; slug?: string } }).work;
 			const request = (context as { request?: { prompt?: string } }).request;
 
-			// Honour a session id supplied by the orchestrator (e.g.
-			// AgentRunService opens a session per agent run and propagates
-			// it via StepExecutionContext.memorySessionId). When absent —
-			// the usual case for plain Work-generation pipelines — the
-			// backend associates the record with no specific session.
-			const sessionId = (context as ContextBag).__memoryModifierExecContext
-				? ((context as ContextBag).__memoryModifierExecContext as StepExecutionContext).memorySessionId
-				: undefined;
+			// Associate this read with the run's session. Honour an
+			// orchestrator-supplied session id (e.g. an agent run that
+			// triggers a pipeline, forwarded via
+			// StepExecutionContext.memorySessionId); otherwise open a
+			// per-run session of our own so the fetch read, the save
+			// digest, and any failure rollback all share one session row.
+			const sessionId = await this.ensureSessionId(context, memoryFacade, logger);
 
 			const ctx: AgentMemoryContext = await memoryFacade.buildContext(
 				{
@@ -407,6 +508,7 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 	): Promise<IPipelineContext> {
 		if (settings.saveSummary === false) {
 			logger.log('memory-save: saveSummary disabled — skipping');
+			await this.closeSelfOpenedSession(context, memoryFacade, logger);
 			return context;
 		}
 
@@ -420,9 +522,7 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			// unreachable at this step's call site.
 			const summary = this.buildSummary(work, items);
 			const tags = this.buildTags(work);
-			const sessionId = (context as ContextBag).__memoryModifierExecContext
-				? ((context as ContextBag).__memoryModifierExecContext as StepExecutionContext).memorySessionId
-				: undefined;
+			const sessionId = this.resolveSessionId(context);
 
 			const record: AgentMemoryRecord = await memoryFacade.saveMemory(
 				{
@@ -441,10 +541,12 @@ export class MemoryPipelineModifierPlugin implements IPlugin, IPipelineModifierP
 			);
 
 			logger.log(`memory-save: saved observation ${record.id} for Work "${work?.slug ?? work?.id ?? '?'}"`);
+			await this.closeSelfOpenedSession(context, memoryFacade, logger);
 			return context;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			logger.warn(`memory-save: failed to save observation — ${message}`);
+			await this.closeSelfOpenedSession(context, memoryFacade, logger);
 			return context;
 		}
 	}

--- a/packages/plugins/postmark/src/postmark-plugin.spec.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.spec.ts
@@ -104,6 +104,27 @@ describe('PostmarkPlugin', () => {
 		});
 	});
 
+	describe('extractInboundRecipients', () => {
+		it('returns ToFull emails as bare addresses', () => {
+			const payload = { ToFull: [{ Email: 'inbox@acme.com' }, { Email: 'team@acme.com' }] };
+			expect(plugin.extractInboundRecipients(Buffer.from(JSON.stringify(payload)), {})).toEqual([
+				'inbox@acme.com',
+				'team@acme.com'
+			]);
+		});
+
+		it('strips the display name from the raw To header fallback', () => {
+			const payload = { To: '"Acme Inbox" <inbox@acme.com>' };
+			expect(plugin.extractInboundRecipients(Buffer.from(JSON.stringify(payload)), {})).toEqual([
+				'inbox@acme.com'
+			]);
+		});
+
+		it('returns [] on malformed JSON (never throws)', () => {
+			expect(plugin.extractInboundRecipients(Buffer.from('not json'), {})).toEqual([]);
+		});
+	});
+
 	describe('verifyWebhookSignature', () => {
 		it('throws on Authorization header mismatch when secret is set', () => {
 			expect(() =>

--- a/packages/plugins/postmark/src/postmark-plugin.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.ts
@@ -35,6 +35,16 @@ function resolveInboundSecret(options: EmailOptions): string | undefined {
 	return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
 }
 
+/**
+ * Extract the bare mailbox from a possibly display-name-wrapped RFC 2822
+ * address (`"Name" <a@b>` → `a@b`). Returns the trimmed input when no
+ * angle-bracket form is present.
+ */
+function parseEmailAddress(raw: string): string {
+	const match = raw.match(/<([^>]+)>/);
+	return (match ? match[1] : raw).trim();
+}
+
 interface PostmarkInboundPayload {
 	readonly MessageID: string;
 	readonly From: string;
@@ -160,6 +170,22 @@ export class PostmarkPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin
 		const expectedB64 = Buffer.from(`postmark:${expected}`).toString('base64');
 		if (provided !== expectedB64) {
 			throw new Error('Postmark inbound: signature mismatch.');
+		}
+	}
+
+	extractInboundRecipients(rawBody: Buffer, _headers: Readonly<Record<string, string>>): readonly string[] {
+		// Best-effort recipient extraction WITHOUT verifying the
+		// signature — used by the facade to resolve the owning user's
+		// scope before verification. Must never throw.
+		try {
+			const payload = JSON.parse(rawBody.toString('utf8')) as PostmarkInboundPayload;
+			// `ToFull[].Email` is already a bare address. The `To` fallback
+			// is the raw RFC 2822 header (may be `"Name" <a@b>`), so strip
+			// the display name / angle brackets before matching.
+			const to = payload.ToFull?.map((t) => t.Email) ?? (payload.To ? [parseEmailAddress(payload.To)] : []);
+			return to.filter((address): address is string => typeof address === 'string' && address.length > 0);
+		} catch {
+			return [];
 		}
 	}
 


### PR DESCRIPTION
## Summary

Release cascade `stage → main` — promotes the implemented review findings #1–6 (backend) + Composio trigger upstream-enable to production.

Carries: agent-memory session pipe (#1/#5), inbound email webhook owner-scoping (#2), migration timestamp collision fix (#3), Composio trigger upstream-enable + SDK webhook verification (#4), notification channel/event-type validation + org-defaults + delivery-event webhook persistence (#6).

Follows the develop → stage → main cascade ([#1120](https://github.com/ever-works/ever-works/pull/1120)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)