### PR TITLE
feat(web): notification channels settings UI — add-channel wizard + Test/Remove (#6)

### DIFF
--- a/apps/web/src/app/actions/notification-channels.ts
+++ b/apps/web/src/app/actions/notification-channels.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import {
+    notificationChannelsAPI,
+    type NotificationChannel,
+    type CreateChannelDto,
+} from '@/lib/api/notification-channels';
+
+export interface ChannelMutationResult {
+    success: boolean;
+    channel?: NotificationChannel;
+    error?: string;
+}
+
+export interface ChannelTestResult {
+    success: boolean;
+    status?: string;
+    providerMessageId?: string;
+    error?: string;
+}
+
+/** Create a notification channel (Add-channel wizard submit). */
+export async function createNotificationChannel(
+    input: CreateChannelDto,
+): Promise<ChannelMutationResult> {
+    try {
+        const channel = await notificationChannelsAPI.create(input);
+        return { success: true, channel };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to create channel',
+        };
+    }
+}
+
+/** Send a test notification through a channel (Test button). */
+export async function sendNotificationChannelTest(id: string): Promise<ChannelTestResult> {
+    try {
+        const result = await notificationChannelsAPI.sendTest(id);
+        // The provider plugin returns `{ status, error?, providerMessageId? }`.
+        // A delivered/queued status is success; a returned `error` is failure.
+        const ok = !result.error && result.status !== 'failed';
+        return {
+            success: ok,
+            status: result.status,
+            providerMessageId: result.providerMessageId,
+            error: result.error,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Test failed',
+        };
+    }
+}
+
+/** Delete a notification channel. */
+export async function deleteNotificationChannel(id: string): Promise<ChannelMutationResult> {
+    try {
+        await notificationChannelsAPI.remove(id);
+        return { success: true };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to delete channel',
+        };
+    }
+}

--- a/apps/web/src/app/actions/notification-channels.ts
+++ b/apps/web/src/app/actions/notification-channels.ts
@@ -1,10 +1,22 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
 import {
     notificationChannelsAPI,
     type NotificationChannel,
     type CreateChannelDto,
 } from '@/lib/api/notification-channels';
+
+/**
+ * Revalidate cached server components that render channel state (e.g. the
+ * channels settings page + any layout that counts channels) after a
+ * create/delete. Mirrors the `revalidatePath` calls in
+ * `app/actions/notifications.ts`. `'layout'` scope invalidates nested
+ * routes too, which covers the locale-prefixed dashboard tree.
+ */
+function revalidateChannels(): void {
+    revalidatePath('/', 'layout');
+}
 
 export interface ChannelMutationResult {
     success: boolean;
@@ -25,6 +37,7 @@ export async function createNotificationChannel(
 ): Promise<ChannelMutationResult> {
     try {
         const channel = await notificationChannelsAPI.create(input);
+        revalidateChannels();
         return { success: true, channel };
     } catch (error) {
         return {
@@ -59,6 +72,7 @@ export async function sendNotificationChannelTest(id: string): Promise<ChannelTe
 export async function deleteNotificationChannel(id: string): Promise<ChannelMutationResult> {
     try {
         await notificationChannelsAPI.remove(id);
+        revalidateChannels();
         return { success: true };
     } catch (error) {
         return {

--- a/apps/web/src/components/settings/NotificationChannelsSettings.tsx
+++ b/apps/web/src/components/settings/NotificationChannelsSettings.tsx
@@ -104,12 +104,22 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
     const [channels, setChannels] = useState<NotificationChannel[]>(initialChannels);
     const [wizardOpen, setWizardOpen] = useState(false);
     const [testResults, setTestResults] = useState<Record<string, TestState>>({});
-    const [pendingTestId, setPendingTestId] = useState<string | null>(null);
-    const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
+    // Per-channel pending sets — multiple rows can run Test/Remove
+    // concurrently, so a single id can't be shared (Greptile P1).
+    const [pendingTestIds, setPendingTestIds] = useState<ReadonlySet<string>>(new Set());
+    const [pendingRemoveIds, setPendingRemoveIds] = useState<ReadonlySet<string>>(new Set());
+    const [removeErrors, setRemoveErrors] = useState<Record<string, string>>({});
     const [, startTransition] = useTransition();
 
+    function withId(set: ReadonlySet<string>, id: string, present: boolean): Set<string> {
+        const next = new Set(set);
+        if (present) next.add(id);
+        else next.delete(id);
+        return next;
+    }
+
     function handleTest(id: string) {
-        setPendingTestId(id);
+        setPendingTestIds((prev) => withId(prev, id, true));
         startTransition(async () => {
             const result = await sendNotificationChannelTest(id);
             setTestResults((prev) => ({
@@ -121,12 +131,17 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                       }
                     : { status: 'error', message: result.error ?? 'Test failed' },
             }));
-            setPendingTestId(null);
+            setPendingTestIds((prev) => withId(prev, id, false));
         });
     }
 
     function handleRemove(id: string) {
-        setPendingRemoveId(id);
+        setPendingRemoveIds((prev) => withId(prev, id, true));
+        setRemoveErrors((prev) => {
+            const next = { ...prev };
+            delete next[id];
+            return next;
+        });
         startTransition(async () => {
             const result = await deleteNotificationChannel(id);
             if (result.success) {
@@ -136,8 +151,13 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                     delete next[id];
                     return next;
                 });
+            } else {
+                setRemoveErrors((prev) => ({
+                    ...prev,
+                    [id]: result.error ?? 'Failed to remove channel',
+                }));
             }
-            setPendingRemoveId(null);
+            setPendingRemoveIds((prev) => withId(prev, id, false));
         });
     }
 
@@ -180,6 +200,9 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                     <tbody>
                         {channels.map((c) => {
                             const test = testResults[c.id];
+                            const removeError = removeErrors[c.id];
+                            const testing = pendingTestIds.has(c.id);
+                            const removing = pendingRemoveIds.has(c.id);
                             return (
                                 <tr key={c.id} className="border-b">
                                     <td className="py-2 font-medium">{c.name}</td>
@@ -187,6 +210,11 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                                     <td className="py-2">{c.verified ? '✓' : '—'}</td>
                                     <td className="py-2 text-right">
                                         <div className="flex items-center justify-end gap-3">
+                                            {removeError && (
+                                                <span className="text-xs text-red-600">
+                                                    ✗ {removeError}
+                                                </span>
+                                            )}
                                             {test && (
                                                 <span
                                                     className={
@@ -202,18 +230,18 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                                             <button
                                                 type="button"
                                                 className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
-                                                disabled={pendingTestId === c.id}
+                                                disabled={testing}
                                                 onClick={() => handleTest(c.id)}
                                             >
-                                                {pendingTestId === c.id ? 'Testing…' : 'Test'}
+                                                {testing ? 'Testing…' : 'Test'}
                                             </button>
                                             <button
                                                 type="button"
                                                 className="text-sm text-red-600 hover:text-red-700 disabled:opacity-50"
-                                                disabled={pendingRemoveId === c.id}
+                                                disabled={removing}
                                                 onClick={() => handleRemove(c.id)}
                                             >
-                                                {pendingRemoveId === c.id ? 'Removing…' : 'Remove'}
+                                                {removing ? 'Removing…' : 'Remove'}
                                             </button>
                                         </div>
                                     </td>
@@ -272,7 +300,9 @@ function AddChannelWizard({
             setError('Name is required.');
             return;
         }
-        const targetConfig: Record<string, string> = {};
+        // `let` (not const) per the team style rule for objects whose
+        // properties are assigned after declaration (Greptile).
+        let targetConfig: Record<string, string> = {};
         for (const field of provider.fields) {
             const v = (values[field.key] ?? '').trim();
             if (!v) {

--- a/apps/web/src/components/settings/NotificationChannelsSettings.tsx
+++ b/apps/web/src/components/settings/NotificationChannelsSettings.tsx
@@ -1,17 +1,145 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import type { NotificationChannel } from '@/lib/api/notification-channels';
+import {
+    createNotificationChannel,
+    sendNotificationChannelTest,
+    deleteNotificationChannel,
+} from '@/app/actions/notification-channels';
 
 interface Props {
     initialChannels: NotificationChannel[];
 }
 
+interface ProviderField {
+    key: string;
+    label: string;
+    type: 'text' | 'url' | 'password';
+    placeholder?: string;
+}
+
+interface ProviderDef {
+    id: string;
+    label: string;
+    fields: ProviderField[];
+}
+
 /**
- * EW-663 / EW-679 — Notification Channels settings UI shell.
+ * Add-channel wizard provider catalog. Each provider's `fields` map to the
+ * `targetConfig` keys the matching channel plugin validates (see
+ * `packages/plugins/<provider>-channel`).
+ */
+const PROVIDERS: ProviderDef[] = [
+    {
+        id: 'discord-channel',
+        label: 'Discord',
+        fields: [
+            {
+                key: 'webhookUrl',
+                label: 'Webhook URL',
+                type: 'url',
+                placeholder: 'https://discord.com/api/webhooks/…',
+            },
+        ],
+    },
+    {
+        id: 'slack-channel',
+        label: 'Slack',
+        fields: [
+            {
+                key: 'webhookUrl',
+                label: 'Incoming Webhook URL',
+                type: 'url',
+                placeholder: 'https://hooks.slack.com/services/…',
+            },
+        ],
+    },
+    {
+        id: 'telegram-channel',
+        label: 'Telegram',
+        fields: [
+            {
+                key: 'botToken',
+                label: 'Bot Token',
+                type: 'password',
+                placeholder: '123456:ABC-DEF…',
+            },
+            {
+                key: 'chatId',
+                label: 'Chat ID',
+                type: 'text',
+                placeholder: '@channel or numeric id',
+            },
+        ],
+    },
+    {
+        id: 'whatsapp-channel',
+        label: 'WhatsApp',
+        fields: [
+            { key: 'accessToken', label: 'Access Token', type: 'password' },
+            { key: 'phoneNumberId', label: 'Phone Number ID', type: 'text' },
+            { key: 'to', label: 'Recipient (to)', type: 'text', placeholder: '+15551234567' },
+        ],
+    },
+    {
+        id: 'novu-channel',
+        label: 'Novu',
+        fields: [
+            { key: 'apiKey', label: 'API Key', type: 'password' },
+            { key: 'workflowId', label: 'Workflow ID', type: 'text' },
+            { key: 'subscriberId', label: 'Subscriber ID', type: 'text' },
+        ],
+    },
+];
+
+type TestState = { status: 'ok' | 'error'; message: string };
+
+/**
+ * EW-663 / EW-679 — Notification Channels settings UI.
+ * Lists channels and provides the Add-channel wizard, per-row Test, and
+ * Remove actions (all via server actions in `app/actions/notification-channels`).
  */
 export function NotificationChannelsSettings({ initialChannels }: Props) {
-    const [channels] = useState(initialChannels);
+    const [channels, setChannels] = useState<NotificationChannel[]>(initialChannels);
+    const [wizardOpen, setWizardOpen] = useState(false);
+    const [testResults, setTestResults] = useState<Record<string, TestState>>({});
+    const [pendingTestId, setPendingTestId] = useState<string | null>(null);
+    const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
+    const [, startTransition] = useTransition();
+
+    function handleTest(id: string) {
+        setPendingTestId(id);
+        startTransition(async () => {
+            const result = await sendNotificationChannelTest(id);
+            setTestResults((prev) => ({
+                ...prev,
+                [id]: result.success
+                    ? {
+                          status: 'ok',
+                          message: `Sent${result.status ? ` (${result.status})` : ''}`,
+                      }
+                    : { status: 'error', message: result.error ?? 'Test failed' },
+            }));
+            setPendingTestId(null);
+        });
+    }
+
+    function handleRemove(id: string) {
+        setPendingRemoveId(id);
+        startTransition(async () => {
+            const result = await deleteNotificationChannel(id);
+            if (result.success) {
+                setChannels((prev) => prev.filter((c) => c.id !== id));
+                setTestResults((prev) => {
+                    const next = { ...prev };
+                    delete next[id];
+                    return next;
+                });
+            }
+            setPendingRemoveId(null);
+        });
+    }
 
     return (
         <div className="space-y-6">
@@ -26,10 +154,7 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                 <button
                     type="button"
                     className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
-                    onClick={() => {
-                        // TODO(EW-679 follow-up): open AddChannelWizard sheet
-                        alert('Add-channel wizard: implementation in follow-up tick');
-                    }}
+                    onClick={() => setWizardOpen(true)}
                 >
                     Add channel
                 </button>
@@ -53,21 +178,198 @@ export function NotificationChannelsSettings({ initialChannels }: Props) {
                         </tr>
                     </thead>
                     <tbody>
-                        {channels.map((c) => (
-                            <tr key={c.id} className="border-b">
-                                <td className="py-2 font-medium">{c.name}</td>
-                                <td className="py-2">{c.pluginId}</td>
-                                <td className="py-2">{c.verified ? '✓' : '—'}</td>
-                                <td className="py-2 text-right">
-                                    <button type="button" className="text-sm text-muted-foreground">
-                                        Test
-                                    </button>
-                                </td>
-                            </tr>
-                        ))}
+                        {channels.map((c) => {
+                            const test = testResults[c.id];
+                            return (
+                                <tr key={c.id} className="border-b">
+                                    <td className="py-2 font-medium">{c.name}</td>
+                                    <td className="py-2">{providerLabel(c.pluginId)}</td>
+                                    <td className="py-2">{c.verified ? '✓' : '—'}</td>
+                                    <td className="py-2 text-right">
+                                        <div className="flex items-center justify-end gap-3">
+                                            {test && (
+                                                <span
+                                                    className={
+                                                        test.status === 'ok'
+                                                            ? 'text-xs text-green-600'
+                                                            : 'text-xs text-red-600'
+                                                    }
+                                                >
+                                                    {test.status === 'ok' ? '✓ ' : '✗ '}
+                                                    {test.message}
+                                                </span>
+                                            )}
+                                            <button
+                                                type="button"
+                                                className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+                                                disabled={pendingTestId === c.id}
+                                                onClick={() => handleTest(c.id)}
+                                            >
+                                                {pendingTestId === c.id ? 'Testing…' : 'Test'}
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className="text-sm text-red-600 hover:text-red-700 disabled:opacity-50"
+                                                disabled={pendingRemoveId === c.id}
+                                                onClick={() => handleRemove(c.id)}
+                                            >
+                                                {pendingRemoveId === c.id ? 'Removing…' : 'Remove'}
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            );
+                        })}
                     </tbody>
                 </table>
             )}
+
+            {wizardOpen && (
+                <AddChannelWizard
+                    onClose={() => setWizardOpen(false)}
+                    onCreated={(channel) => {
+                        setChannels((prev) => [...prev, channel]);
+                        setWizardOpen(false);
+                    }}
+                />
+            )}
+        </div>
+    );
+}
+
+function providerLabel(pluginId: string): string {
+    return PROVIDERS.find((p) => p.id === pluginId)?.label ?? pluginId;
+}
+
+function AddChannelWizard({
+    onClose,
+    onCreated,
+}: {
+    onClose: () => void;
+    onCreated: (channel: NotificationChannel) => void;
+}) {
+    const [provider, setProvider] = useState<ProviderDef>(PROVIDERS[0]);
+    const [name, setName] = useState('');
+    const [values, setValues] = useState<Record<string, string>>({});
+    const [error, setError] = useState<string | null>(null);
+    const [submitting, startSubmit] = useTransition();
+
+    function setField(key: string, value: string) {
+        setValues((prev) => ({ ...prev, [key]: value }));
+    }
+
+    function selectProvider(id: string) {
+        const next = PROVIDERS.find((p) => p.id === id) ?? PROVIDERS[0];
+        setProvider(next);
+        setValues({});
+        setError(null);
+    }
+
+    function submit() {
+        setError(null);
+        const trimmedName = name.trim();
+        if (!trimmedName) {
+            setError('Name is required.');
+            return;
+        }
+        const targetConfig: Record<string, string> = {};
+        for (const field of provider.fields) {
+            const v = (values[field.key] ?? '').trim();
+            if (!v) {
+                setError(`${field.label} is required.`);
+                return;
+            }
+            targetConfig[field.key] = v;
+        }
+        startSubmit(async () => {
+            const result = await createNotificationChannel({
+                pluginId: provider.id,
+                name: trimmedName,
+                targetConfig,
+            });
+            if (result.success && result.channel) {
+                onCreated(result.channel);
+            } else {
+                setError(result.error ?? 'Failed to create channel.');
+            }
+        });
+    }
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Add notification channel"
+        >
+            <div className="w-full max-w-md space-y-4 rounded-lg border bg-background p-6 shadow-lg">
+                <div>
+                    <h2 className="text-lg font-semibold">Add channel</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Pick a provider and enter its delivery details. You can send a test after
+                        saving.
+                    </p>
+                </div>
+
+                <label className="block space-y-1">
+                    <span className="text-sm font-medium">Provider</span>
+                    <select
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        value={provider.id}
+                        onChange={(e) => selectProvider(e.target.value)}
+                    >
+                        {PROVIDERS.map((p) => (
+                            <option key={p.id} value={p.id}>
+                                {p.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                <label className="block space-y-1">
+                    <span className="text-sm font-medium">Name</span>
+                    <input
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder={`My ${provider.label} channel`}
+                    />
+                </label>
+
+                {provider.fields.map((field) => (
+                    <label key={field.key} className="block space-y-1">
+                        <span className="text-sm font-medium">{field.label}</span>
+                        <input
+                            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                            type={field.type === 'url' ? 'text' : field.type}
+                            value={values[field.key] ?? ''}
+                            onChange={(e) => setField(field.key, e.target.value)}
+                            placeholder={field.placeholder}
+                        />
+                    </label>
+                ))}
+
+                {error && <p className="text-sm text-red-600">{error}</p>}
+
+                <div className="flex justify-end gap-3 pt-2">
+                    <button
+                        type="button"
+                        className="rounded-md border px-4 py-2 text-sm font-medium"
+                        onClick={onClose}
+                        disabled={submitting}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+                        onClick={submit}
+                        disabled={submitting}
+                    >
+                        {submitting ? 'Creating…' : 'Create channel'}
+                    </button>
+                </div>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Final piece of review finding **#6** — the notification channels settings UI. Replaces the shell's `alert()` placeholder + no-op Test button with a working interface.

- **Add-channel wizard** (modal): provider select (Discord / Slack / Telegram / WhatsApp / Novu) with per-provider `targetConfig` fields that exactly match each channel plugin's validated keys (`webhookUrl`; `botToken`+`chatId`; `accessToken`+`phoneNumberId`+`to`; `apiKey`+`workflowId`+`subscriberId`).
- **Per-row Test** → sends a test delivery, shows ✓/✗ inline.
- **Per-row Remove**.
- New `app/actions/notification-channels.ts` server actions (`create`/`sendTest`/`delete`) wrap the `server-only` API client, mirroring the existing `app/actions/notifications.ts` pattern.

## Verification
- [x] `tsc --noEmit` clean on the changed files (workspace deps built).
- [x] `eslint` clean on the changed files.
- [x] Server-action ↔ client-component boundary matches the established pattern; `'use server'` file imports the `server-only` client (both server-side).
- [ ] Runtime browser pass — pending a live API/DB/auth stack (the page is dashboard-auth-gated and reads channels from the API).
- [ ] CI green on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guided wizard to add notification channels with provider selection and required fields
  * Test notification channels and view per-channel test results (status, provider details, errors) inline
  * Delete notification channels from settings with immediate UI updates
  * Per-channel pending indicators for test and removal actions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->