### PR TITLE
docs(features): expand Company/Store/Desktop builder docs with the real model

### DIFF
--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -10,6 +10,16 @@ sidebar_label: Company Builder
 
 The **Company Builder** is Ever Works' most ambitious shape: not a website, but the _organization that runs websites, stores, and everything else_ — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
 
+## A Company is your workspace and org
+
+In Ever Works, **Workspace = Company = Organization** — one top-level container for everything you build. The model:
+
+- **Many companies per account.** Create several companies inside your tenant and **switch between them from the site header** (the logo + company selector). The selected company sets the context for everything you see.
+- **Everything lives inside the selected company.** Your [Missions](./missions.md), [Ideas](./ideas.md), [Works](./creating-a-work.md), [Agents](./agents.md), and [Knowledge Base](./knowledge-base.md) are all scoped to the company you have picked. Switch companies and the whole workspace context switches with you.
+- **Register it for real — as a Work.** When you're ready to incorporate, registering the legal entity (in many countries, including the US) runs through formation **provider plugins** and is itself a **kind of Work** the platform builds for you — so going from workspace to a real company is part of the same flow.
+
+This is the product-facing expression of the platform's [Tenants & Organizations](../advanced/multi-tenancy.md) foundation.
+
 ## From idea to operating company
 
 ```mermaid

--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -18,7 +18,7 @@ In Ever Works, **Workspace = Company = Organization** — one top-level containe
 - **Everything lives inside the selected company.** Your [Missions](./missions.md), [Ideas](./ideas.md), [Works](./creating-a-work.md), [Agents](./agents.md), and [Knowledge Base](./knowledge-base.md) are all scoped to the company you have picked. Switch companies and the whole workspace context switches with you.
 - **Register it for real — as a Work.** When you're ready to incorporate, registering the legal entity (in many countries, including the US) runs through formation **provider plugins** and is itself a **kind of Work** the platform builds for you — so going from workspace to a real company is part of the same flow.
 
-This is the product-facing expression of the platform's [Tenants & Organizations](../advanced/multi-tenancy.md) foundation.
+(See [How it relates to Tenants & Organizations](#how-it-relates-to-tenants--organizations) below for the underlying multi-tenancy foundation.)
 
 ## From idea to operating company
 

--- a/docs/features/desktop-app.md
+++ b/docs/features/desktop-app.md
@@ -12,7 +12,7 @@ The **Desktop App** will let you run all of Ever Works **locally as a single app
 
 ## What "all local" means
 
-- **Full stack in one app** — the API, frontend, background-jobs runtime, and database ship together. No separate services to wire up.
+- **Full stack in one app** — the API, frontend dashboard, the background-jobs runtime (Trigger.dev-style, powering schedules and Agents), and the database ship together as a single installable application. No separate services to wire up.
 - **Your data on your machine** — repositories, Knowledge Base, and configuration stay local by default.
 - **Works offline-first** — the platform keeps working without a constant connection to a cloud backend.
 

--- a/docs/features/store-builder.md
+++ b/docs/features/store-builder.md
@@ -24,6 +24,14 @@ flowchart LR
 
 You can start a Store directly when you know exactly what you want, or let a [Mission](./missions.md) propose it as one of several Works needed for a bigger commerce goal.
 
+## Storefront templates and backends
+
+A Store is a **Work of type "Store"** — you choose how it's built:
+
+- **Many storefront templates** — pick from a catalog of eCommerce [templates](./website-templates.md), or bring your own **Custom** template.
+- **The backend you choose** — a self-hostable **open-source commerce backend** deployed for you, **Shopify**, or your own — connected through deployment plugins, so you're never locked to one commerce stack.
+- **Grow it over time** — start small and let the Store expand its catalog, content, and experiments as it runs, the same way any [Work](./creating-a-work.md) keeps improving.
+
 ## What the Store builder is planned to do
 
 - **Research the catalog** — find products, suppliers, and pricing signals relevant to the store's niche, with sources recorded in the [Knowledge Base](./knowledge-base.md).


### PR DESCRIPTION
## Summary

Expands the three roadmap builder docs to match the just-built website pages and the operator's specs, so docs + site stay consistent.

- **company-builder.md** — adds the **Workspace = Company = Organization** model: multiple companies per account, switch via the header company selector, Missions/Ideas/Works/Agents/KB scoped to the selected company, and registering the legal entity (many countries incl. the US) through formation provider plugins **as a Work**.
- **store-builder.md** — adds **storefront templates** (incl. Custom) and the **backend choice** (OSS self-hosted, Shopify, or your own via deployment plugins); a Store is a Work of type "Store".
- **desktop-app.md** — names the bundled jobs runtime (Trigger.dev-style) and the single-installable-app framing.

Additive only; Prettier-clean. Mirrors website PR (Store/Company/Desktop `/platform/*` pages).

## Test plan
- [ ] `lint-and-test` green (Prettier check)
- [ ] Docusaurus build resolves links (all targets exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Company definition clarifying how the workspace/organization container governs scoped assets like Missions, Ideas, Works, Agents, and Knowledge Base.
  * Clarified Desktop App bundled components, explicitly detailing the API, frontend dashboard, background-jobs runtime, and database shipping together.
  * Added Storefront templates and backends documentation for Store Works, describing template selection, backend options, and growth capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->