### PR TITLE
fix(web): unify WorkspaceSwitcher across collapsed/expanded sidebar

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4649,9 +4649,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -162,7 +162,12 @@ export function DashboardSidebar({
                             the same popover with org list + "Create
                             Organization".
                         */}
-                        <div className="flex items-center pr-6">
+                        <div
+                            className={cn(
+                                'flex items-center',
+                                isCollapsed ? 'justify-center' : 'pr-6',
+                            )}
+                        >
                             <WorkspaceSwitcher config={config} isCollapsed={isCollapsed} />
                         </div>
                         <div

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -39,7 +39,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu';
-import { FaviconEverWork } from '../logos';
 import { WorkspaceSwitcher } from '../layout/WorkspaceSwitcher';
 import { useWorkDetail } from '../works/detail/WorkDetailContext';
 import { ChatPanelExpandButton } from '@/components/ai/ChatPanel';
@@ -153,20 +152,18 @@ export function DashboardSidebar({
                 >
                     <div className="w-full relative">
                         {/*
-                            Expanded sidebar renders `<WorkspaceSwitcher>`,
-                            which always shows `[spinning favicon] [active
-                            org name OR Ever Works wordmark] [chevron]` and
-                            opens a popover with the org list + "+ Create
-                            Organization". The collapsed sidebar keeps the
-                            bare favicon — there's no room for a chip at
-                            16px column width.
+                            `<WorkspaceSwitcher>` is the single trigger
+                            for both states: expanded shows `[icon]
+                            [active org name OR Ever Works wordmark]
+                            [chevron]`, collapsed shows just `[icon]`.
+                            The icon is the active org's avatar when
+                            one is selected, otherwise the spinning
+                            Ever Works favicon — clicking either opens
+                            the same popover with org list + "Create
+                            Organization".
                         */}
                         <div className="flex items-center pr-6">
-                            {isCollapsed ? (
-                                <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
-                            ) : (
-                                <WorkspaceSwitcher config={config} />
-                            )}
+                            <WorkspaceSwitcher config={config} isCollapsed={isCollapsed} />
                         </div>
                         <div
                             className={cn(

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -25,6 +25,11 @@ interface WorkspaceSwitcherProps {
     config?: WorkConfig | null;
     /** Tailwind class for the inline wordmark image. */
     logoClassName?: string;
+    /**
+     * Collapsed sidebar variant — renders only the icon trigger (no
+     * label, no chevron). The popover behaviour is identical.
+     */
+    isCollapsed?: boolean;
 }
 
 function pickInitial(org: OrganizationResponse): string {
@@ -41,8 +46,14 @@ function pickLabel(org: OrganizationResponse): string {
  * TeamSwitcher's visual: a colored square with the first initial.
  * `Building2` is used as a fallback when the initial would be empty.
  */
-function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' }) {
+function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' | 'md' }) {
     const initial = pickInitial(org);
+    const sizeClass =
+        size === 'md'
+            ? 'w-6 h-6 text-[11px]'
+            : size === 'sm'
+              ? 'w-7 h-7 text-xs'
+              : 'w-5 h-5 text-[10px]';
     return (
         <div
             className={cn(
@@ -50,7 +61,7 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
                 'bg-surface-tertiary dark:bg-surface-tertiary-dark',
                 'text-text dark:text-text-dark',
                 'font-semibold',
-                size === 'sm' ? 'w-7 h-7 text-xs' : 'w-5 h-5 text-[10px]',
+                sizeClass,
             )}
             aria-hidden="true"
         >
@@ -67,21 +78,25 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
  *
  * The whole row is a single dropdown trigger:
  *
- *   [spinning favicon] [label] [chevron]
+ *   [favicon OR org avatar] [label] [chevron]
  *
  * The trigger renders in every state (including zero-org), so the user
  * can always reach "+ Create Organization" — pre-fix, the zero-org
  * branch fell back to a bare logo with no popover and clicking it did
  * nothing useful.
  *
- * Trigger label by state:
- *
- * | Org count | Label                | Popover                         |
- * |-----------|----------------------|---------------------------------|
- * | 0         | Wordmark image       | "+ Create Organization" only    |
- * | 1+        | Active org name      | Org list + "+ Create"           |
+ * When `isCollapsed`, the trigger renders just the leading icon — the
+ * label + chevron are hidden and the dropdown still opens on click.
+ * That replaces the pre-fix collapsed-sidebar `<FaviconEverWork>`,
+ * which wrapped the favicon in a `<Link>` pointing at the configured
+ * site URL (localhost:3000 in dev) and silently swallowed clicks
+ * instead of opening the org switcher.
  */
-export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({
+    config,
+    logoClassName,
+    isCollapsed = false,
+}: WorkspaceSwitcherProps) {
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
@@ -104,44 +119,56 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
         setIsCreateOpen(true);
     };
 
+    // Leading icon: the active org's avatar when one exists, otherwise
+    // the spinning Ever Works favicon. Same 24px footprint in both
+    // states so the row height doesn't shift when the user picks an org.
+    const leadingIcon = triggerOrg ? (
+        <OrgAvatar org={triggerOrg} size="md" />
+    ) : (
+        <FaviconEverWorkImage config={config} className="w-6 h-6 max-h-none shrink-0" />
+    );
+
     return (
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger
                     className={cn(
-                        'w-full rounded-md transition-colors cursor-pointer',
+                        'rounded-md transition-colors cursor-pointer',
                         'focus:outline-none focus-visible:outline-none',
                         'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                        'px-1.5 py-1',
+                        isCollapsed ? 'inline-flex p-1' : 'w-full px-1.5 py-1',
                     )}
                     aria-label={t('heading')}
                 >
-                    <div className="flex items-center gap-1.5 w-full min-w-0">
-                        <FaviconEverWorkImage
-                            config={config}
-                            className="w-9 h-9 max-h-none shrink-0"
-                        />
-                        {triggerOrg ? (
-                            <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                                {pickLabel(triggerOrg)}
-                            </span>
-                        ) : (
-                            <LogoEverWorkImage
-                                config={config}
-                                className={cn('flex-1 min-w-0', logoClassName)}
+                    <div
+                        className={cn(
+                            'flex items-center min-w-0',
+                            isCollapsed ? 'justify-center' : 'gap-1.5 w-full',
+                        )}
+                    >
+                        {leadingIcon}
+                        {!isCollapsed &&
+                            (triggerOrg ? (
+                                <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                                    {pickLabel(triggerOrg)}
+                                </span>
+                            ) : (
+                                <LogoEverWorkImage
+                                    config={config}
+                                    className={cn('flex-1 min-w-0', logoClassName)}
+                                />
+                            ))}
+                        {!isCollapsed && (
+                            <ChevronsUpDown
+                                className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                strokeWidth={1.5}
+                                aria-hidden="true"
                             />
                         )}
-                        <ChevronsUpDown
-                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                            strokeWidth={1.5}
-                            aria-hidden="true"
-                        />
                     </div>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="start" className="w-60">
-                    <DropdownMenuLabel>
-                        {hasOrgs ? t('heading') : t('bareTenant')}
-                    </DropdownMenuLabel>
+                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
                     {hasOrgs &&
                         organizations.map((org) => {
                             const isActive = activeOrganization?.id === org.id;

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -136,7 +136,10 @@ export function WorkspaceSwitcher({
                         'rounded-md transition-colors cursor-pointer',
                         'focus:outline-none focus-visible:outline-none',
                         'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                        isCollapsed ? 'inline-flex p-1' : 'w-full px-1.5 py-1',
+                        // Collapsed: fill the column and center the icon so it
+                        // sits in the same x position as the "+ New" button
+                        // beneath it. Expanded keeps the chip layout.
+                        isCollapsed ? 'flex justify-center p-1' : 'w-full px-1.5 py-1',
                     )}
                     aria-label={t('heading')}
                 >

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -77,7 +77,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     /**
      * Empty state: even with zero orgs the switcher renders the
      * spinning favicon + wordmark + chevron trigger so the user can
-     * still reach "+ Create Organization". The previous behaviour
+     * still reach "Create Organization". The previous behaviour
      * (bare logo, no trigger) silently broke the create flow.
      */
     it('renders favicon + wordmark + trigger when the user has zero organizations', () => {
@@ -93,9 +93,9 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
     /**
      * Empty state popover: opening the trigger surfaces the
-     * "+ Create Organization" row even when no orgs exist.
+     * "Create Organization" row even when no orgs exist.
      */
-    it('shows "+ Create Organization" in the popover when zero orgs', () => {
+    it('shows "Create Organization" in the popover when zero orgs', () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
 
         render(<WorkspaceSwitcher />);
@@ -106,10 +106,12 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     });
 
     /**
-     * Active state with 1 org: the trigger shows the spinning favicon
-     * + the org's display name (no wordmark) + chevron.
+     * Active state with 1 org: the trigger swaps the EverWorks favicon
+     * for the org's initial-letter avatar and shows the org's display
+     * name (no wordmark) + chevron. The favicon stays in the empty
+     * state only.
      */
-    it('renders favicon + org name + trigger when the user has 1 organization', () => {
+    it('renders org avatar + org name + trigger when the user has 1 organization', () => {
         const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
         __seedOrganizationsStoreForTests({
             data: [org],
@@ -119,7 +121,8 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
         render(<WorkspaceSwitcher />);
 
-        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        // Brand favicon is replaced by the org avatar in the trigger.
+        expect(screen.queryByTestId('favicon-everwork-image')).toBeNull();
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         // Wordmark is replaced by the active-org label.
         expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
@@ -127,7 +130,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
     /**
      * 3 orgs — when the popover opens, all three list rows are
-     * present plus the "+ Create Organization" footer row.
+     * present plus the "Create Organization" footer row.
      */
     it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
         const orgs = [
@@ -167,5 +170,26 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         render(<WorkspaceSwitcher />);
 
         expect(screen.getAllByText('fallback-org').length).toBeGreaterThanOrEqual(1);
+    });
+
+    /**
+     * Collapsed variant: the trigger renders only the leading icon —
+     * no wordmark, no org-name label, no chevron — and clicking it
+     * still opens the popover. Replaces the pre-fix collapsed-sidebar
+     * `<FaviconEverWork>` link to `siteConfig.website` (localhost:3000
+     * in dev).
+     */
+    it('renders icon-only trigger and still opens the popover when isCollapsed', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        render(<WorkspaceSwitcher isCollapsed />);
+
+        // Empty-state icon = favicon. No label, no chevron, no wordmark.
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
+
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 });

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -173,13 +173,13 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     });
 
     /**
-     * Collapsed variant: the trigger renders only the leading icon —
-     * no wordmark, no org-name label, no chevron — and clicking it
-     * still opens the popover. Replaces the pre-fix collapsed-sidebar
-     * `<FaviconEverWork>` link to `siteConfig.website` (localhost:3000
-     * in dev).
+     * Collapsed variant — empty state: the trigger renders only the
+     * leading icon (favicon, no wordmark/label/chevron) and clicking
+     * it still opens the popover. Replaces the pre-fix collapsed
+     * sidebar's `<FaviconEverWork>` link to `siteConfig.website`
+     * (localhost:3000 in dev).
      */
-    it('renders icon-only trigger and still opens the popover when isCollapsed', () => {
+    it('renders icon-only trigger and still opens the popover when isCollapsed (empty state)', () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
 
         render(<WorkspaceSwitcher isCollapsed />);
@@ -190,6 +190,35 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
         const trigger = screen.getAllByRole('button')[0];
         fireEvent.click(trigger);
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Collapsed variant — active org: the favicon is swapped for the
+     * org-initial avatar; the wordmark and the inline org-name label
+     * are both suppressed (collapsed = icon-only). Clicking still
+     * opens the popover listing the org and the create row.
+     */
+    it('renders the org-initial avatar and no label/wordmark when isCollapsed + active org', () => {
+        const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher isCollapsed />);
+
+        // Active-org icon = OrgAvatar — favicon and wordmark both absent.
+        expect(screen.queryByTestId('favicon-everwork-image')).toBeNull();
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
+        // The closed trigger has no inline label either.
+        expect(screen.queryByText('Acme Inc')).toBeNull();
+
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+        // After opening, the org list row + create row both show.
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary

Fixes the top-left org switcher in the dashboard sidebar — sizing, popover copy, the always-show-favicon-when-collapsed behaviour, and the bug where clicking the rotating brand image navigated to `localhost:3000` from `app.ever.works`.

- **Localhost:3000 bug.** Pre-fix the collapsed sidebar rendered `<FaviconEverWork>`, whose `<Link>` wrapped the favicon to `siteConfig.website` (= `http://localhost:3000` in dev). Clicking the spinning logo silently navigated away instead of opening the switcher.
- **Single component for both states.** Added `isCollapsed` to `<WorkspaceSwitcher>`. Collapsed renders only the leading icon (no label, no chevron) and still opens the same dropdown.
- **Active-org logo when one is selected.** Trigger icon = the active org's initial-letter avatar when an active org exists, else the spinning Ever Works favicon. Same 24px footprint in both states.
- **Resize.** Expanded-state favicon goes from `w-9 h-9` (36px) → `w-6 h-6` (24px) per design.
- **Popover copy:**
  - `"My account"` / `"Organizations"` → **`"Switch Organization"`** (single `heading` key; `bareTenant` removed).
  - `"+ Create Organization"` → **`"Create Organization"`** — the leading `<Plus>` icon already represents the `+`, the literal `"+ "` in the string was the visible-twice bug.
  - Synced across all 21 locales (`messages/*.json`).
- **DashboardSidebar** now passes `isCollapsed` through and drops the `FaviconEverWork` import (no longer used here).

## Test plan

- [x] `WorkspaceSwitcher.unit.spec.tsx` — 6 tests pass (existing 5 adjusted for the org-avatar swap + 1 new `isCollapsed` icon-only test).
- [x] `pnpm type-check` clean.
- [x] `pnpm lint` clean for changed files.
- [x] Prettier clean for changed files.
- [ ] Manual verify on `app.ever.works` after deploy: collapsed-state icon click opens the switcher (no more localhost:3000), expanded-state shows the 24px icon + "Switch Organization" heading + single `+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsed display mode for the organization switcher, showing only an icon when space is limited.

* **Documentation**
  * Updated organization switcher text across all supported languages for improved clarity: "Switch Organization" and "Create Organization" labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->