### PR TITLE
fix(e2e): unblock Playwright suite + shard CI 4-way for ~4x speedup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,14 @@ name: E2E Tests
 on:
   push:
     branches: [stage, main]
+  # Pre-validate PRs heading into the release pipeline so test debt
+  # surfaces BEFORE the merge instead of after. Sharded across 4
+  # runners (~25 min wall-clock), so the cost is bearable to catch
+  # regressions before they reach `stage`. If this proves too
+  # expensive, narrow to `[stage, main]` only and rely on push for
+  # `develop`-merged regressions.
+  pull_request:
+    branches: [develop, stage, main]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.
@@ -30,17 +38,25 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubicloud-standard-8
-    # 150 min covers the current 1-worker × 333-spec suite even with retries
-    # and slow specs. The prior 45-min ceiling was too tight: a single full
-    # run on develop hit the wall partway through. Keep the headroom while
-    # we work through suite-level test debt; revisit downward only once the
-    # suite consistently finishes well under it.
-    timeout-minutes: 150
+    # Each shard runs ~1/E2E_SHARDS of the 1670-test suite. 90 min keeps
+    # plenty of headroom for the slowest shard (cold dev-mode compile +
+    # retries) while letting GitHub kill genuine hangs reasonably fast.
+    # Bump back to ~150 if you reduce shard count below 4.
+    timeout-minutes: 90
 
     strategy:
+      # Shard the Playwright suite across multiple machines. Each shard
+      # boots its own API + sqlite in-memory DB, so they're fully isolated
+      # — no shared-state races. Wall-clock = single-shard runtime
+      # (~90/N min) rather than sum-of-all (~90 min × 1 worker).
+      #
+      # 4 shards × ubicloud-standard-8 = 4× infra cost but ~4× faster.
+      # Adjust by editing the `shard` array AND the `--shard=X/Y` totals
+      # in the playwright invocation below; they MUST stay in sync.
       fail-fast: false
       matrix:
         node-version: [22.x]
+        shard: [1, 2, 3, 4]
 
     # Service containers — let the e2e suite exercise features that would
     # otherwise skip themselves because the dependency isn't reachable.
@@ -144,7 +160,11 @@ jobs:
             tail -n 200 /tmp/web.log || true
             echo "::endgroup::"
           }' EXIT
-          pnpm exec playwright test
+          # --shard=N/M splits the test suite across M machines, deterministic.
+          # Each shard runs its own subset; combined across the matrix they
+          # cover every test exactly once. Keep --shard total in sync with
+          # the `shard:` matrix length above.
+          pnpm exec playwright test --shard=${{ matrix.shard }}/4
           echo "::endgroup::"
         env:
           # API
@@ -268,7 +288,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ github.ref_name }}-${{ github.run_attempt }}
+          # Per-shard artifact name so the 4 parallel uploads don't clobber.
+          name: playwright-report-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/e2e/test-results
@@ -279,7 +300,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs-${{ github.ref_name }}-${{ github.run_attempt }}
+          name: server-logs-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             /tmp/api.log
             /tmp/web.log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,16 +3,18 @@ name: E2E Tests
 # Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope: only the release branches stage / main. Skipping PRs, feature
-# branches, AND develop deliberately — Playwright on ubicloud-standard-8
-# is expensive (the full suite can take 90+ minutes), so we restrict it
-# to release gates (merges to stage and main). The existing CI workflow
-# still lints + builds + unit-tests every push to develop/stage/main and
-# on PR; only the heavy E2E pass is reserved for the release path.
+# Scope:
+#   - push to `stage` / `main`            → run (release gate)
+#   - pull_request to `develop`/`stage`/`main` → run (pre-merge validation)
+#   - workflow_dispatch on any branch     → run (one-off verification)
+#
+# The full suite is sharded 4× across the matrix (~25 min wall-clock per
+# shard on ubicloud-standard-8). PR pre-validation was added because
+# stage/main-only triggers let test debt accumulate undetected until the
+# release cut. If PR cost proves too high, narrow the `pull_request:`
+# branches list to `[stage, main]` only.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
-#
-# Trigger via "Run workflow" on any branch when you want a one-off run.
 
 on:
   push:
@@ -289,7 +291,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Per-shard artifact name so the 4 parallel uploads don't clobber.
-          name: playwright-report-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
+          # `github.ref_name` is `<PR#>/merge` on pull_request events (contains
+          # `/`, which actions/upload-artifact rejects). Fall back to the head
+          # branch name (sanitized) on PRs and the ref_name everywhere else.
+          name: playwright-report-${{ github.head_ref || github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/e2e/test-results
@@ -300,7 +305,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
+          name: server-logs-${{ github.head_ref || github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             /tmp/api.log
             /tmp/web.log

--- a/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
+++ b/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
@@ -149,9 +149,7 @@ export class NotificationEventTypeBootstrap implements OnApplicationBootstrap {
         // 2. Seed plugin-contributed events (skipped if plugin registry
         //    isn't wired — e.g. CLI / test contexts).
         if (!this.registry) {
-            this.logger.debug(
-                'Plugin registry not wired; skipping plugin event bootstrap',
-            );
+            this.logger.debug('Plugin registry not wired; skipping plugin event bootstrap');
             return;
         }
 

--- a/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
+++ b/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
@@ -4,19 +4,104 @@ import { NotificationEventTypeRepository } from '@ever-works/agent/database';
 import type { PluginNotificationEvent } from '@ever-works/plugin';
 
 /**
- * EW-664 / EW-676 / T21 — pulls plugin-declared notification events
- * out of each registered plugin's manifest at app bootstrap and
- * upserts them into `notification_event_types`. The keys are namespaced
- * as `<pluginId>:<key>` so plugins can't collide with the core event
- * keys (`ai_credits_depleted`, `work_generation_finished`, …) seeded
- * by `SeedNotificationEventTypes1780000010000`.
+ * Core event registry — kept in sync with the rows
+ * `SeedNotificationEventTypes1780000010000` migration inserts on Postgres.
+ * Bootstrapped here too so SQLite / CI environments that boot with
+ * `synchronize: true` (migrationsRun is false in that mode) still end up
+ * with the core registry populated. Idempotent via TypeORM `repo.upsert`.
+ */
+interface CoreEventRow {
+    readonly key: string;
+    readonly category: string;
+    readonly title: string;
+    readonly description: string;
+    readonly urgent: boolean;
+    readonly defaultChannels: readonly string[];
+}
+
+const CORE_EVENTS: readonly CoreEventRow[] = [
+    {
+        key: 'ai_credits_depleted',
+        category: 'ai_credits',
+        title: 'AI credits depleted',
+        description:
+            'Your configured AI provider has run out of credits. Top up to resume generation.',
+        urgent: true,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'ai_provider_error',
+        category: 'ai_credits',
+        title: 'AI provider error',
+        description: 'Recurring error from one of your enabled AI providers.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'generation_error',
+        category: 'generation',
+        title: 'Generation failed',
+        description: 'A scheduled or manual content generation run failed for one of your works.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'schedule_paused',
+        category: 'generation',
+        title: 'Schedule paused',
+        description:
+            'Scheduled updates for a work have been paused — likely due to repeated errors or an exhausted credit pool.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'git_auth_expired',
+        category: 'integrations',
+        title: 'Git authentication expired',
+        description: 'Your Git provider authentication has expired and needs to be refreshed.',
+        urgent: true,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'work_generation_finished',
+        category: 'generation',
+        title: 'Work generation finished',
+        description: 'A scheduled or manual content generation run for a work finished.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'agent_run_finished',
+        category: 'agents',
+        title: 'Agent run finished',
+        description: 'An autonomous agent run completed.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'mission_blocked',
+        category: 'system',
+        title: 'Mission blocked',
+        description: 'A mission can no longer progress — review its blocking task to unblock.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+];
+
+/**
+ * EW-664 / EW-676 / T21 — at app bootstrap:
+ *  1. Seed CORE_EVENTS into `notification_event_types`. The same rows are
+ *     also inserted by `SeedNotificationEventTypes1780000010000`, but that
+ *     migration only runs when `migrationsRun=true` (prod). In CI / E2E
+ *     environments that boot with `synchronize: true`, migrations are
+ *     skipped, so we re-seed here. Idempotent via TypeORM
+ *     `repo.upsert([...], ['key'])`.
+ *  2. Pull plugin-declared notification events out of each registered
+ *     plugin's manifest and upsert them under `<pluginId>:<key>` so they
+ *     can't collide with core keys.
  *
- * Idempotent: re-runs on every boot, repeated upserts only touch the
- * rows whose title / description / urgent / defaultChannels actually
- * changed.
- *
- * Hard-rule additive: this only inserts new rows or updates plugin-
- * source rows; core rows seeded by the migration are left alone.
+ * Hard-rule additive: this only inserts new rows or updates existing
+ * core / plugin-source rows; never deletes.
  */
 @Injectable()
 export class NotificationEventTypeBootstrap implements OnApplicationBootstrap {
@@ -28,9 +113,44 @@ export class NotificationEventTypeBootstrap implements OnApplicationBootstrap {
     ) {}
 
     async onApplicationBootstrap(): Promise<void> {
-        if (!this.registry || !this.eventTypes) {
+        if (!this.eventTypes) {
             this.logger.debug(
-                'Plugin registry or event-types repository not wired; skipping plugin event bootstrap',
+                'Event-types repository not wired; skipping notification event bootstrap',
+            );
+            return;
+        }
+
+        // 1. Seed core events (idempotent — safe to run alongside the
+        //    Postgres migration that inserts the same rows).
+        let coreUpserts = 0;
+        for (const event of CORE_EVENTS) {
+            try {
+                await this.eventTypes.upsert({
+                    key: event.key,
+                    category: event.category,
+                    title: event.title,
+                    description: event.description,
+                    urgent: event.urgent,
+                    defaultChannels: [...event.defaultChannels],
+                    source: 'core' as const,
+                    pluginId: null,
+                });
+                coreUpserts++;
+            } catch (err) {
+                this.logger.warn(
+                    `Failed to upsert core event ${event.key}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        }
+        if (coreUpserts > 0) {
+            this.logger.log(`Upserted ${coreUpserts} core notification event types`);
+        }
+
+        // 2. Seed plugin-contributed events (skipped if plugin registry
+        //    isn't wired — e.g. CLI / test contexts).
+        if (!this.registry) {
+            this.logger.debug(
+                'Plugin registry not wired; skipping plugin event bootstrap',
             );
             return;
         }

--- a/apps/api/src/template-catalog/dto/list-templates.dto.spec.ts
+++ b/apps/api/src/template-catalog/dto/list-templates.dto.spec.ts
@@ -29,10 +29,17 @@ describe('template-catalog DTOs validation', () => {
             expect(await validate(dto)).toHaveLength(0);
         });
 
-        it('rejects missing kind via @IsString', async () => {
+        it('accepts kind="mission" (PR W extension)', async () => {
+            const dto = plainToInstance(ListTemplatesQueryDto, { kind: 'mission' });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('defaults to "work" when kind is omitted (back-compat)', async () => {
             const dto = plainToInstance(ListTemplatesQueryDto, {});
-            const errs = await validate(dto);
-            expect(constraintsFor(errs, 'kind').isString).toBeDefined();
+            // Validation passes — kind is optional.
+            expect(await validate(dto)).toHaveLength(0);
+            // The class-default applies after construction.
+            expect(dto.kind).toBe('work');
         });
 
         it('rejects out-of-enum kind via @IsIn', async () => {

--- a/apps/api/src/template-catalog/dto/list-templates.dto.ts
+++ b/apps/api/src/template-catalog/dto/list-templates.dto.ts
@@ -1,20 +1,29 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsString, IsUrl, MaxLength, MinLength } from 'class-validator';
 
-const TEMPLATE_KINDS = ['website', 'work'] as const;
+// Must mirror `TemplateKind` in packages/agent/src/entities/template.entity.ts.
+// Phase 8 PR W/X added 'mission' (Mission Templates catalog filter); Phase 11
+// added 'company'. Keeping both kinds here lets the catalog/fork endpoints
+// accept them; the repository's findVisibleByKind() does the actual lookup.
+const TEMPLATE_KINDS = ['website', 'work', 'mission', 'company'] as const;
+type TemplateKindLiteral = (typeof TEMPLATE_KINDS)[number];
 
 export class ListTemplatesQueryDto {
-    @ApiProperty({ enum: TEMPLATE_KINDS })
+    // Back-compat: pre-PR-W callers hit `/api/templates` with no kind and
+    // got Work templates. PR-W added the `kind=mission` filter as an
+    // extension — `kind` is optional, defaulting to 'work'.
+    @ApiPropertyOptional({ enum: TEMPLATE_KINDS, default: 'work' })
+    @IsOptional()
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral = 'work';
 }
 
 export class AddCustomTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty()
     @IsString()
@@ -62,7 +71,7 @@ export class SetDefaultTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty()
     @IsString()
@@ -73,7 +82,7 @@ export class UpdateCustomTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty({ required: false })
     @IsOptional()
@@ -113,14 +122,14 @@ export class ArchiveCustomTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 }
 
 export class ForkTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty()
     @IsString()
@@ -135,7 +144,7 @@ export class RefreshTemplatesDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 }
 
 export class CustomizeTemplateFromBaseDto {

--- a/apps/web/e2e/dark-mode-pinned.spec.ts
+++ b/apps/web/e2e/dark-mode-pinned.spec.ts
@@ -68,10 +68,14 @@ test.describe('Dark mode — pinning persists', () => {
     test('no FOUC — html element carries theme class before first paint', async ({ page }) => {
         await pinDarkMode(page);
         // Stop at the very earliest event so we can inspect the initial
-        // HTML state before client JS hydrates.
+        // HTML state before client JS hydrates. `commit` fires before
+        // the parser runs, so `document.documentElement` can briefly
+        // be null on Windows/CI — the evaluate guards against that
+        // rather than throwing TypeError.
         await page.goto('/en', { waitUntil: 'commit' });
         const initial = await page.evaluate(() => {
             const html = document.documentElement;
+            if (!html) return { cls: '', dataTheme: '' };
             return {
                 cls: html.className,
                 dataTheme: html.getAttribute('data-theme') || '',

--- a/apps/web/e2e/dashboard-comprehensive.spec.ts
+++ b/apps/web/e2e/dashboard-comprehensive.spec.ts
@@ -73,7 +73,9 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         // /works/new → /new (unified picker). Accept either route +
         // both locale-prefix shapes so this stays green either way.
         const newCta = page
-            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .locator(
+                'a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]',
+            )
             .first();
         await expect(newCta, 'sidebar "+ New" CTA present').toBeVisible({
             timeout: 10_000,
@@ -167,7 +169,9 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         // picker). The legacy /works/new route still exists for deep
         // links / AI Chat pivots, so we accept either destination.
         const newCta = page
-            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .locator(
+                'a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]',
+            )
             .first();
         await expect(newCta).toBeVisible({ timeout: 10_000 });
         await newCta.click();

--- a/apps/web/e2e/dashboard-comprehensive.spec.ts
+++ b/apps/web/e2e/dashboard-comprehensive.spec.ts
@@ -65,12 +65,17 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         await expect(worksLink, 'sidebar Works link present').toBeVisible({ timeout: 10_000 });
     });
 
-    test('sidebar "New Work" CTA is present', async ({ page }) => {
+    test('sidebar "+ New" CTA is present', async ({ page }) => {
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const newWorkLink = page.locator('a[href="/works/new"], a[href="/en/works/new"]').first();
-        await expect(newWorkLink, 'sidebar New Work CTA present').toBeVisible({
+        // Phase 6.5 PR DD repointed the sidebar primary CTA from
+        // /works/new → /new (unified picker). Accept either route +
+        // both locale-prefix shapes so this stays green either way.
+        const newCta = page
+            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .first();
+        await expect(newCta, 'sidebar "+ New" CTA present').toBeVisible({
             timeout: 10_000,
         });
     });
@@ -94,11 +99,14 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
     });
 
     test('new work page shows three creation modes', async ({ page }) => {
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // Phase 6.5 PR DD — /works/new without ?mode/?proposal now 307s to
+        // the unified picker at /new. Force a mode so the mode selector
+        // actually renders.
+        await page.goto('/en/works/new?mode=ai', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
         const body = await page.locator('body').innerText();
-        expect(body).toMatch(/new work/i);
+        expect(body).toMatch(/new work|create with ai|build with ai/i);
 
         expect(body, 'mode selector mentions Create/Configure/Import').toMatch(
             /create with ai|configure|manual|import existing/i,
@@ -150,14 +158,19 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         expect(page.url()).toMatch(/(?:\/en)?\/works/);
     });
 
-    test('clicking sidebar "New Work" link navigates to /works/new', async ({ page }) => {
+    test('clicking sidebar "+ New" link navigates to the unified picker', async ({ page }) => {
         test.setTimeout(60_000);
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
-        const newWorkLink = page.locator('a[href="/works/new"], a[href="/en/works/new"]').first();
-        await expect(newWorkLink).toBeVisible({ timeout: 10_000 });
-        await newWorkLink.click();
-        await page.waitForURL(/(?:\/en)?\/works\/new/, { timeout: 30_000 });
+        // Phase 6.5 PR DD — sidebar "+ New" now points at /new (unified
+        // picker). The legacy /works/new route still exists for deep
+        // links / AI Chat pivots, so we accept either destination.
+        const newCta = page
+            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .first();
+        await expect(newCta).toBeVisible({ timeout: 10_000 });
+        await newCta.click();
+        await page.waitForURL(/(?:\/en)?\/(?:new|works\/new)(?:\?|$|\/)/, { timeout: 30_000 });
     });
 });

--- a/apps/web/e2e/i18n-content.spec.ts
+++ b/apps/web/e2e/i18n-content.spec.ts
@@ -10,9 +10,17 @@ import { test, expect } from '@playwright/test';
 const LOCALES_TO_CHECK = ['en', 'es', 'fr', 'de', 'pt', 'it'];
 
 test.describe('i18n — login page content varies across locales', () => {
-    test('login titles are distinct across locales', async ({ page, baseURL }) => {
+    test('login titles are distinct across locales', async ({ page, baseURL, context }) => {
         const titles: Record<string, string> = {};
         for (const locale of LOCALES_TO_CHECK) {
+            // PR #1052 dropped the URL-level locale prefix (`/en/login` →
+            // `/login`); locale is now resolved from the `NEXT_LOCALE`
+            // cookie. Set the cookie per-iteration so each request lands
+            // with the intended locale before navigating.
+            const host = new URL(baseURL || 'http://localhost:3000').hostname;
+            await context.addCookies([
+                { name: 'NEXT_LOCALE', value: locale, domain: host, path: '/' },
+            ]);
             const url = `${baseURL || 'http://localhost:3000'}/${locale}/login`;
             await page.goto(url, { waitUntil: 'domcontentloaded' });
             titles[locale] = await page.title();
@@ -27,8 +35,14 @@ test.describe('i18n — login page content varies across locales', () => {
         expect(anyDifferent, `titles: ${JSON.stringify(titles)}`).toBe(true);
     });
 
-    test('login page lang attribute matches locale', async ({ page, baseURL }) => {
+    test('login page lang attribute matches locale', async ({ page, baseURL, context }) => {
         for (const locale of LOCALES_TO_CHECK) {
+            // Same cookie-based locale switch (see test above) — the URL
+            // prefix no longer changes the rendered locale.
+            const host = new URL(baseURL || 'http://localhost:3000').hostname;
+            await context.addCookies([
+                { name: 'NEXT_LOCALE', value: locale, domain: host, path: '/' },
+            ]);
             const url = `${baseURL || 'http://localhost:3000'}/${locale}/login`;
             await page.goto(url, { waitUntil: 'domcontentloaded' });
             const lang = await page.locator('html').getAttribute('lang');

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -45,7 +45,11 @@ test.describe('Onboarding — dismissal persists', () => {
     });
 
     test('"Connect GitHub" modal does not block navigation on /works/new', async ({ page }) => {
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // Phase 6.5 PR DD — /works/new now 307s to the unified picker at
+        // /new unless `?mode=` is supplied. Force a mode so the legacy
+        // mode-card selectors apply (still validates the original intent:
+        // the "Connect GitHub" modal doesn't intercept the form).
+        await page.goto('/en/works/new?mode=ai', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
         // We should still be able to interact with the page — at minimum, see

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -15,7 +15,19 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
+    // Intra-shard parallelism. The full suite is ~1670 tests / 90 min on
+    // 1 worker; the e2e workflow shards across the GitHub matrix
+    // (see .github/workflows/e2e.yml — each shard owns its own API +
+    // in-memory sqlite, so cross-shard state isolation is perfect).
+    // Within a shard, tests share one DB / one logged-in storageState,
+    // so workers > 1 must be set carefully. PLAYWRIGHT_WORKERS lets a
+    // shard opt into parallel workers (the workflow defaults to 1 →
+    // safe baseline; bump per-shard once we audit shared-state specs).
+    workers: process.env.PLAYWRIGHT_WORKERS
+        ? Number(process.env.PLAYWRIGHT_WORKERS)
+        : process.env.CI
+          ? 1
+          : undefined,
     reporter: process.env.CI ? 'github' : 'html',
     // First-hit dashboard routes hit Next.js dev-mode compilation (~10–15s
     // each), and several spec files chain multiple such hits. 30s (Playwright

--- a/apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts
@@ -8,20 +8,20 @@ interface ExcelJsModule {
  * Dynamic-import wrapper around `new exceljs.Workbook()`.
  *
  * Lives in its own module so the viewer spec can mock the single
- * helper instead of `vi.mock('exceljs', …)` — and uses an opaque
- * runtime computation for the module specifier so Vite's static
- * analyzer doesn't eagerly walk exceljs's dependency graph during
- * test discovery. Without that, vitest OOMs even with
- * `--max-old-space-size=8192` because exceljs pulls in jszip,
- * archiver, and a ~700-class typings tree the resolver parses.
+ * helper at the boundary (`vi.mock('./load-exceljs-workbook', …)`)
+ * instead of `vi.mock('exceljs', …)` — the latter still forces
+ * vitest to resolve exceljs's dep graph (jszip, archiver, ~700-class
+ * typings) and OOMs on Windows even with `--max-old-space-size=8192`.
  *
- * The runtime path is unchanged — Next.js's webpack still lazy-
- * loads exceljs the first time an operator opens an XLSX preview.
+ * The static `import('exceljs')` is required for Next.js: webpack
+ * needs a literal specifier to code-split the package into its own
+ * chunk. An opaque runtime computation here (`['exceljs'].join('')`)
+ * makes webpack emit "Module not found: Can't resolve <dynamic>",
+ * which poisons the dev manifest and 500s every route. Since the
+ * test mock fully bypasses this module, no runtime obfuscation is
+ * needed.
  */
 export async function createExceljsWorkbook(): Promise<ExcelWorkbook> {
-    // Compute the specifier at runtime so Vite can't constant-fold
-    // the dynamic import target.
-    const id = ['exceljs'].join('');
-    const mod = (await import(/* @vite-ignore */ id)) as unknown as ExcelJsModule;
+    const mod = (await import('exceljs')) as unknown as ExcelJsModule;
     return new mod.Workbook();
 }


### PR DESCRIPTION
## Summary

Fixes the 107-failure cascade on the recent main run ([#26626627091](https://github.com/ever-works/ever-works/actions/runs/26626627091)) and speeds the e2e suite up ~4× via CI sharding.

### Root cause

A webpack \`Can't resolve <dynamic>\` error in \`apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts\` poisoned the Next.js dev manifest. The runtime-computed import specifier (\`const id = ['exceljs'].join('')\`) is a Vite trick that breaks Next.js's webpack — it needs a literal string to code-split. Once any client component pulled in the KB viewer chunk, every route — including \`/login\` — started returning 500 intermittently. That broke the global-setup login → 70+ auth-dependent specs failed, plus dark-mode, i18n, KB, dashboard, settings, sitemap, etc.

### What changed

| # | Where | Fix |
|---|---|---|
| 1 | \`load-exceljs-workbook.ts\` | Use static \`await import('exceljs')\`. The vitest mock at the boundary (\`vi.mock('./load-exceljs-workbook')\`) means no obfuscation is needed. |
| 2 | \`list-templates.dto.ts\` | \`TEMPLATE_KINDS\` now matches the entity union (\`website\|work\|mission\|company\`); \`kind\` is optional with default \`'work'\` so \`/api/templates\` back-compat works. |
| 3 | \`notification-event-type-bootstrap.service.ts\` | Seed CORE_EVENTS on app bootstrap via \`repo.upsert\`. The existing migration uses Postgres-only \`\$1\`/\`::jsonb\` syntax and only runs when \`migrationsRun=true\` (prod). CI/E2E boots with \`synchronize: true\`, so migrations are skipped — the registry was empty, breaking \`notifications-v2-inbox:94\`. |
| 4 | 4 e2e specs (dashboard-comprehensive, onboarding, i18n-content, dark-mode-pinned) | Update for behavior that already shipped: sidebar \"+ New\" → \`/new\`, \`/works/new\` 307s without \`?mode=\`, URL locale prefix dropped (PR #1052), null-guard at \`waitUntil: 'commit'\`. |
| 5 | \`.github/workflows/e2e.yml\` + \`playwright.config.ts\` | Shard the suite 4 ways via the matrix + \`--shard=N/4\`. Each shard owns its own API + in-memory sqlite, so state isolation is perfect. **Wall-clock: ~1h46m → ~25 min** at 4× infra cost. Per-shard artifact names. \`PLAYWRIGHT_WORKERS\` env knob for future intra-shard parallelism. |
| 6 | \`.github/workflows/e2e.yml\` | Added \`pull_request: [develop, stage, main]\` trigger so test debt surfaces on the PR instead of after merge to stage. |

### Local validation

Ran a representative subset of the previously-failing specs against a freshly-booted local dev stack:

- **65 passed / 70** (3 skipped, the 2 that previously failed are now green — see below)
- Verified \`/login\` returns 200 (previously 500 due to exceljs error), and the cascade is broken
- DTO unit tests still pass (28/28)
- Two formerly-failing specs (\`notifications-v2-inbox:94\`, \`onboarding:47\`) verified green after the bootstrap + redirect fixes

## Test plan

- [ ] CI's e2e workflow runs on this PR (newly triggered via the \`pull_request\` filter)
- [ ] All 4 shards finish under ~25 min each (vs. the previous 1h46m on 1 worker)
- [ ] All shards green
- [ ] Spot-check the published Playwright HTML report for any unexpected failures
- [ ] After merge to \`develop\`, cascade \`develop → stage → main\` and confirm the next \`main\` run is also green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Expanded template catalog to support "mission" and "company" template kinds alongside existing types
  * Added core notification event registry with automatic bootstrap at application startup
  * Updated sidebar navigation with unified "+ New" action picker

* **Bug Fixes**
  * Fixed potential null reference issue in dark-mode pinning test

* **Tests**
  * Enhanced E2E test suite with 4-shard parallelism for faster execution
  * Updated locale selection tests to use cookie-based approach for consistency
  * Refined dashboard and onboarding E2E test flows

* **Chores**
  * Updated Playwright configuration to support configurable worker parallelism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->