### PR TITLE
chore: cascade develop → stage (incl. fix/migration-username-dup-safe)

### DIFF
--- a/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
+++ b/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
@@ -80,7 +80,7 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
             ).map((r) => r.lname),
         );
 
-        const renames: Array<{ id: string; from: string; to: string }> = [];
+        let renames: Array<{ id: string; from: string; to: string }> = [];
 
         for (const bucket of buckets) {
             const rows = (await queryRunner.query(

--- a/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
+++ b/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
@@ -19,11 +19,19 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * suite ships a recent SQLite). This matches GitHub-style "Alice" and
  * "alice" cannot both exist semantics.
  *
- * Pre-check: fails loudly if any case-insensitive duplicates already
- * exist in the table. The platform is not yet live (no live data), so
- * this is expected to be a no-op in practice; the check exists to
- * prevent silent data corruption if someone applies this migration to a
- * snapshot that has been mucked with manually.
+ * Duplicate handling: before the index is created, any case-insensitive
+ * duplicate bucket is auto-deduped. The OLDEST row (lowest `createdAt`,
+ * tie-broken by `id`) keeps the canonical username; every other row in
+ * the bucket is renamed to `<username>-<first-6-id-chars>`. This is
+ * deterministic, collision-resistant (UUID prefix), and forward-only.
+ *
+ * Rationale for auto-rename instead of throwing: a hard throw turns any
+ * single duplicate into a full CrashLoopBackOff for the API
+ * (`migrationsRun: true` runs migrations at pod boot — see
+ * `EVER_WORKS_DB_MIGRATIONS.md`). That happened in prod on 2026-05-28
+ * with two real `paradoxe35` users (local + github registrations of the
+ * same human). Auto-rename keeps the platform up; an out-of-band human
+ * decision can later merge or relabel the renamed accounts.
  *
  * Forward-only, additive. The new index is named explicitly so the down
  * migration can drop the right one even if TypeORM's auto-naming
@@ -31,16 +39,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  */
 export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        const dupes = (await queryRunner.query(
-            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" GROUP BY lower("username") HAVING COUNT(*) > 1`,
-        )) as Array<{ lname: string; cnt: number | string }>;
-
-        if (dupes.length > 0) {
-            throw new Error(
-                `AddUniqueIndexToUsername aborted: found ${dupes.length} case-insensitive duplicate username(s) in users table. ` +
-                    `Resolve manually before re-running this migration. Sample: ${JSON.stringify(dupes.slice(0, 5))}`,
-            );
-        }
+        await this.dedupeUsernames(queryRunner);
 
         const table = await queryRunner.getTable('users');
         const hasIndex = table?.indices.some(
@@ -51,6 +50,64 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
             // model expression columns portably across dialects.
             await queryRunner.query(
                 `CREATE UNIQUE INDEX "idx_users_username_lower_unique" ON "users" (lower("username"))`,
+            );
+        }
+    }
+
+    private async dedupeUsernames(queryRunner: QueryRunner): Promise<void> {
+        const buckets = (await queryRunner.query(
+            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" WHERE "username" IS NOT NULL GROUP BY lower("username") HAVING COUNT(*) > 1`,
+        )) as Array<{ lname: string; cnt: number | string }>;
+
+        if (buckets.length === 0) {
+            return;
+        }
+
+        const isPostgres = queryRunner.connection.options.type === 'postgres';
+        const updateSql = isPostgres
+            ? `UPDATE "users" SET "username" = $1 WHERE "id" = $2`
+            : `UPDATE "users" SET "username" = ? WHERE "id" = ?`;
+
+        const renames: Array<{ id: string; from: string; to: string }> = [];
+
+        for (const bucket of buckets) {
+            const rows = (await queryRunner.query(
+                `SELECT "id", "username", "createdAt" FROM "users" WHERE lower("username") = ${
+                    isPostgres ? '$1' : '?'
+                } ORDER BY "createdAt" ASC, "id" ASC`,
+                [bucket.lname],
+            )) as Array<{ id: string; username: string; createdAt: Date | string }>;
+
+            // Keep rows[0] (oldest) as canonical; rename the rest.
+            for (let i = 1; i < rows.length; i++) {
+                const row = rows[i];
+                const suffix = String(row.id).replace(/-/g, '').slice(0, 6);
+                const renamed = `${row.username}-${suffix}`;
+                await queryRunner.query(updateSql, [renamed, row.id]);
+                renames.push({ id: row.id, from: row.username, to: renamed });
+            }
+        }
+
+        // Re-check: the rename suffix uses the UUID prefix so collisions are
+        // astronomically unlikely, but be defensive — surface the problem
+        // loudly rather than swallowing it before the index attempt.
+        const stillDupes = (await queryRunner.query(
+            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" WHERE "username" IS NOT NULL GROUP BY lower("username") HAVING COUNT(*) > 1`,
+        )) as Array<{ lname: string; cnt: number | string }>;
+
+        if (stillDupes.length > 0) {
+            throw new Error(
+                `AddUniqueIndexToUsername: dedup pass left ${stillDupes.length} ` +
+                    `case-insensitive duplicate bucket(s); rename-by-id-suffix collided. ` +
+                    `Resolve manually. Sample: ${JSON.stringify(stillDupes.slice(0, 5))}`,
+            );
+        }
+
+        if (renames.length > 0) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[migration] AddUniqueIndexToUsername renamed ${renames.length} duplicate username(s): ` +
+                    JSON.stringify(renames),
             );
         }
     }

--- a/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
+++ b/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
@@ -68,6 +68,18 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
             ? `UPDATE "users" SET "username" = $1 WHERE "id" = $2`
             : `UPDATE "users" SET "username" = ? WHERE "id" = ?`;
 
+        // Build a case-insensitive set of every username currently in use so
+        // generated rename targets cannot collide with an existing row that
+        // a prior manual cleanup already produced (e.g. prod's
+        // `paradoxe35-289966` from the 2026-05-28 incident).
+        const taken = new Set<string>(
+            (
+                (await queryRunner.query(
+                    `SELECT lower("username") AS lname FROM "users" WHERE "username" IS NOT NULL`,
+                )) as Array<{ lname: string }>
+            ).map((r) => r.lname),
+        );
+
         const renames: Array<{ id: string; from: string; to: string }> = [];
 
         for (const bucket of buckets) {
@@ -78,29 +90,18 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
                 [bucket.lname],
             )) as Array<{ id: string; username: string; createdAt: Date | string }>;
 
-            // Keep rows[0] (oldest) as canonical; rename the rest.
+            // Keep rows[0] (oldest) as canonical; rename the rest. The first
+            // bucket-row keeps the lname slot in `taken`; each rename adds the
+            // new target to `taken` so subsequent renames in the same pass
+            // cannot collide with one we just produced either.
             for (let i = 1; i < rows.length; i++) {
                 const row = rows[i];
-                const suffix = String(row.id).replace(/-/g, '').slice(0, 6);
-                const renamed = `${row.username}-${suffix}`;
+                const renamed = this.allocateRenameTarget(row.username, row.id, taken);
                 await queryRunner.query(updateSql, [renamed, row.id]);
+                taken.delete(row.username.toLowerCase());
+                taken.add(renamed.toLowerCase());
                 renames.push({ id: row.id, from: row.username, to: renamed });
             }
-        }
-
-        // Re-check: the rename suffix uses the UUID prefix so collisions are
-        // astronomically unlikely, but be defensive — surface the problem
-        // loudly rather than swallowing it before the index attempt.
-        const stillDupes = (await queryRunner.query(
-            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" WHERE "username" IS NOT NULL GROUP BY lower("username") HAVING COUNT(*) > 1`,
-        )) as Array<{ lname: string; cnt: number | string }>;
-
-        if (stillDupes.length > 0) {
-            throw new Error(
-                `AddUniqueIndexToUsername: dedup pass left ${stillDupes.length} ` +
-                    `case-insensitive duplicate bucket(s); rename-by-id-suffix collided. ` +
-                    `Resolve manually. Sample: ${JSON.stringify(stillDupes.slice(0, 5))}`,
-            );
         }
 
         if (renames.length > 0) {
@@ -110,6 +111,27 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
                     JSON.stringify(renames),
             );
         }
+    }
+
+    private allocateRenameTarget(username: string, id: string, taken: Set<string>): string {
+        const hex = String(id).replace(/-/g, '');
+        // Try increasing prefix length 6 → full UUID; any collision falls back
+        // to the next longer suffix. Stops at the full hex string, which is
+        // guaranteed unique (UUID PKs are unique by the table contract).
+        for (let len = 6; len <= hex.length; len++) {
+            const candidate = `${username}-${hex.slice(0, len)}`;
+            if (!taken.has(candidate.toLowerCase())) {
+                return candidate;
+            }
+        }
+        // Defensive: if even the full UUID is taken (impossible unless a row
+        // somewhere is already named `<username>-<full-uuid>`), append the
+        // numeric suffix `-2`, `-3`, ... like AddSlugToUsers does.
+        let n = 2;
+        while (taken.has(`${username}-${hex}-${n}`.toLowerCase())) {
+            n += 1;
+        }
+        return `${username}-${hex}-${n}`;
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
@@ -1,0 +1,153 @@
+import { DataSource } from 'typeorm';
+import { AddUniqueIndexToUsername1779991000000 } from '../1779991000000-AddUniqueIndexToUsername';
+
+/**
+ * EW-652 — migration test for the case-insensitive UNIQUE index on
+ * `users.username`, plus the auto-rename dedup path that landed after
+ * the 2026-05-28 prod incident (CrashLoopBackOff on two real users
+ * sharing username `paradoxe35`).
+ *
+ * Uses the same in-memory better-sqlite3 harness as
+ * `AddWorkKindAndStatus.spec.ts`. Asserts:
+ *   - clean DB → index is created, no renames.
+ *   - case-insensitive duplicate bucket → oldest row keeps the canonical
+ *     username; later rows get `-<id-prefix>` suffix; index is then
+ *     created successfully.
+ *   - multi-bucket + 3-way collision → all extras renamed correctly.
+ *   - idempotent: running up() twice does not throw.
+ *   - down() drops the index.
+ */
+describe('AddUniqueIndexToUsername1779991000000 (EW-652)', () => {
+    let dataSource: DataSource;
+    const migration = new AddUniqueIndexToUsername1779991000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        await dataSource.query(
+            `CREATE TABLE "users" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "username" varchar,
+                "createdAt" varchar NOT NULL
+            )`,
+        );
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    function uuid(prefix: string): string {
+        // Stable 36-char UUID-ish string keyed on prefix so tests assert on
+        // the suffix the migration produces from substring(id, 1, 6).
+        return `${prefix}aa-bbbb-cccc-dddd-eeeeeeeeeeee`.slice(0, 36);
+    }
+
+    async function insert(id: string, username: string | null, createdAt: string): Promise<void> {
+        await dataSource.query(
+            `INSERT INTO "users" ("id", "username", "createdAt") VALUES (?, ?, ?)`,
+            [id, username, createdAt],
+        );
+    }
+
+    async function usernamesById(): Promise<Record<string, string | null>> {
+        const rows: Array<{ id: string; username: string | null }> = await dataSource.query(
+            `SELECT "id", "username" FROM "users"`,
+        );
+        return Object.fromEntries(rows.map((r) => [r.id, r.username]));
+    }
+
+    async function indexExists(): Promise<boolean> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_users_username_lower_unique'`,
+        );
+        return rows.length === 1;
+    }
+
+    it('creates the unique index on a clean DB', async () => {
+        await insert(uuid('111111'), 'alice', '2026-01-01');
+        await insert(uuid('222222'), 'bob', '2026-01-02');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('auto-renames case-insensitive duplicates: oldest keeps canonical name', async () => {
+        const oldId = uuid('aaaaaa');
+        const newId = uuid('bbbbbb');
+        await insert(oldId, 'paradoxe35', '2025-09-25T14:56:57Z');
+        await insert(newId, 'paradoxe35', '2026-04-13T08:00:25Z');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const after = await usernamesById();
+        expect(after[oldId]).toBe('paradoxe35');
+        expect(after[newId]).toBe('paradoxe35-bbbbbb');
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('handles 3-way + multi-bucket duplicates', async () => {
+        // Bucket A: 3 rows
+        await insert(uuid('aaaaaa'), 'alice', '2026-01-01');
+        await insert(uuid('bbbbbb'), 'alice', '2026-02-01');
+        await insert(uuid('cccccc'), 'Alice', '2026-03-01');
+        // Bucket B: 2 rows, case-mixed
+        await insert(uuid('dddddd'), 'Bob', '2026-01-15');
+        await insert(uuid('eeeeee'), 'bob', '2026-02-15');
+        // Unrelated row
+        await insert(uuid('ffffff'), 'carol', '2026-01-10');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const after = await usernamesById();
+        expect(after[uuid('aaaaaa')]).toBe('alice');
+        expect(after[uuid('bbbbbb')]).toBe('alice-bbbbbb');
+        expect(after[uuid('cccccc')]).toBe('Alice-cccccc');
+        expect(after[uuid('dddddd')]).toBe('Bob');
+        expect(after[uuid('eeeeee')]).toBe('bob-eeeeee');
+        expect(after[uuid('ffffff')]).toBe('carol');
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('is idempotent — running up() twice does not throw', async () => {
+        await insert(uuid('111111'), 'alice', '2026-01-01');
+        await insert(uuid('222222'), 'alice', '2026-02-01');
+
+        const r1 = dataSource.createQueryRunner();
+        await migration.up(r1);
+        await r1.release();
+
+        const r2 = dataSource.createQueryRunner();
+        await expect(migration.up(r2)).resolves.toBeUndefined();
+        await r2.release();
+
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('down() drops the index', async () => {
+        await insert(uuid('111111'), 'alice', '2026-01-01');
+
+        const up = dataSource.createQueryRunner();
+        await migration.up(up);
+        await up.release();
+        expect(await indexExists()).toBe(true);
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+        expect(await indexExists()).toBe(false);
+    });
+});

--- a/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
@@ -137,6 +137,31 @@ describe('AddUniqueIndexToUsername1779991000000 (EW-652)', () => {
         expect(await indexExists()).toBe(true);
     });
 
+    it('falls back to longer id-prefix when rename target collides with existing user', async () => {
+        // A prior manual cleanup already produced `paradoxe35-bbbbbb` — the
+        // exact name the 6-char suffix would otherwise generate. The
+        // migration must avoid collision instead of throwing.
+        const oldId = uuid('aaaaaa');
+        const newId = uuid('bbbbbb');
+        const collidingId = uuid('999999');
+        await insert(oldId, 'paradoxe35', '2025-09-25');
+        await insert(newId, 'paradoxe35', '2026-04-13');
+        await insert(collidingId, 'paradoxe35-bbbbbb', '2026-04-14');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const after = await usernamesById();
+        expect(after[oldId]).toBe('paradoxe35');
+        expect(after[collidingId]).toBe('paradoxe35-bbbbbb');
+        // newId's rename target collided → migration extends suffix until free.
+        expect(after[newId]).not.toBe('paradoxe35');
+        expect(after[newId]).not.toBe('paradoxe35-bbbbbb');
+        expect(after[newId]).toMatch(/^paradoxe35-bbbbbb[a-z0-9]+/);
+        expect(await indexExists()).toBe(true);
+    });
+
     it('down() drops the index', async () => {
         await insert(uuid('111111'), 'alice', '2026-01-01');
 

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4649,9 +4649,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -39,7 +39,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu';
-import { FaviconEverWork } from '../logos';
 import { WorkspaceSwitcher } from '../layout/WorkspaceSwitcher';
 import { useWorkDetail } from '../works/detail/WorkDetailContext';
 import { ChatPanelExpandButton } from '@/components/ai/ChatPanel';
@@ -153,20 +152,23 @@ export function DashboardSidebar({
                 >
                     <div className="w-full relative">
                         {/*
-                            Expanded sidebar renders `<WorkspaceSwitcher>`,
-                            which always shows `[spinning favicon] [active
-                            org name OR Ever Works wordmark] [chevron]` and
-                            opens a popover with the org list + "+ Create
-                            Organization". The collapsed sidebar keeps the
-                            bare favicon — there's no room for a chip at
-                            16px column width.
+                            `<WorkspaceSwitcher>` is the single trigger
+                            for both states: expanded shows `[icon]
+                            [active org name OR Ever Works wordmark]
+                            [chevron]`, collapsed shows just `[icon]`.
+                            The icon is the active org's avatar when
+                            one is selected, otherwise the spinning
+                            Ever Works favicon — clicking either opens
+                            the same popover with org list + "Create
+                            Organization".
                         */}
-                        <div className="flex items-center pr-6">
-                            {isCollapsed ? (
-                                <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
-                            ) : (
-                                <WorkspaceSwitcher config={config} />
+                        <div
+                            className={cn(
+                                'flex items-center',
+                                isCollapsed ? 'justify-center' : 'pr-6',
                             )}
+                        >
+                            <WorkspaceSwitcher config={config} isCollapsed={isCollapsed} />
                         </div>
                         <div
                             className={cn(

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -25,6 +25,11 @@ interface WorkspaceSwitcherProps {
     config?: WorkConfig | null;
     /** Tailwind class for the inline wordmark image. */
     logoClassName?: string;
+    /**
+     * Collapsed sidebar variant — renders only the icon trigger (no
+     * label, no chevron). The popover behaviour is identical.
+     */
+    isCollapsed?: boolean;
 }
 
 function pickInitial(org: OrganizationResponse): string {
@@ -41,8 +46,14 @@ function pickLabel(org: OrganizationResponse): string {
  * TeamSwitcher's visual: a colored square with the first initial.
  * `Building2` is used as a fallback when the initial would be empty.
  */
-function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' }) {
+function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' | 'md' }) {
     const initial = pickInitial(org);
+    const sizeClass =
+        size === 'md'
+            ? 'w-6 h-6 text-[11px]'
+            : size === 'sm'
+              ? 'w-7 h-7 text-xs'
+              : 'w-5 h-5 text-[10px]';
     return (
         <div
             className={cn(
@@ -50,7 +61,7 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
                 'bg-surface-tertiary dark:bg-surface-tertiary-dark',
                 'text-text dark:text-text-dark',
                 'font-semibold',
-                size === 'sm' ? 'w-7 h-7 text-xs' : 'w-5 h-5 text-[10px]',
+                sizeClass,
             )}
             aria-hidden="true"
         >
@@ -67,21 +78,25 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
  *
  * The whole row is a single dropdown trigger:
  *
- *   [spinning favicon] [label] [chevron]
+ *   [favicon OR org avatar] [label] [chevron]
  *
  * The trigger renders in every state (including zero-org), so the user
  * can always reach "+ Create Organization" — pre-fix, the zero-org
  * branch fell back to a bare logo with no popover and clicking it did
  * nothing useful.
  *
- * Trigger label by state:
- *
- * | Org count | Label                | Popover                         |
- * |-----------|----------------------|---------------------------------|
- * | 0         | Wordmark image       | "+ Create Organization" only    |
- * | 1+        | Active org name      | Org list + "+ Create"           |
+ * When `isCollapsed`, the trigger renders just the leading icon — the
+ * label + chevron are hidden and the dropdown still opens on click.
+ * That replaces the pre-fix collapsed-sidebar `<FaviconEverWork>`,
+ * which wrapped the favicon in a `<Link>` pointing at the configured
+ * site URL (localhost:3000 in dev) and silently swallowed clicks
+ * instead of opening the org switcher.
  */
-export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({
+    config,
+    logoClassName,
+    isCollapsed = false,
+}: WorkspaceSwitcherProps) {
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
@@ -104,44 +119,59 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
         setIsCreateOpen(true);
     };
 
+    // Leading icon: the active org's avatar when one exists, otherwise
+    // the spinning Ever Works favicon. Same 24px footprint in both
+    // states so the row height doesn't shift when the user picks an org.
+    const leadingIcon = triggerOrg ? (
+        <OrgAvatar org={triggerOrg} size="md" />
+    ) : (
+        <FaviconEverWorkImage config={config} className="w-6 h-6 max-h-none shrink-0" />
+    );
+
     return (
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger
                     className={cn(
-                        'w-full rounded-md transition-colors cursor-pointer',
+                        'rounded-md transition-colors cursor-pointer',
                         'focus:outline-none focus-visible:outline-none',
                         'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                        'px-1.5 py-1',
+                        // Collapsed: fill the column and center the icon so it
+                        // sits in the same x position as the "+ New" button
+                        // beneath it. Expanded keeps the chip layout.
+                        isCollapsed ? 'flex justify-center p-1' : 'w-full px-1.5 py-1',
                     )}
                     aria-label={t('heading')}
                 >
-                    <div className="flex items-center gap-1.5 w-full min-w-0">
-                        <FaviconEverWorkImage
-                            config={config}
-                            className="w-9 h-9 max-h-none shrink-0"
-                        />
-                        {triggerOrg ? (
-                            <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                                {pickLabel(triggerOrg)}
-                            </span>
-                        ) : (
-                            <LogoEverWorkImage
-                                config={config}
-                                className={cn('flex-1 min-w-0', logoClassName)}
+                    <div
+                        className={cn(
+                            'flex items-center min-w-0',
+                            isCollapsed ? 'justify-center' : 'gap-1.5 w-full',
+                        )}
+                    >
+                        {leadingIcon}
+                        {!isCollapsed &&
+                            (triggerOrg ? (
+                                <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                                    {pickLabel(triggerOrg)}
+                                </span>
+                            ) : (
+                                <LogoEverWorkImage
+                                    config={config}
+                                    className={cn('flex-1 min-w-0', logoClassName)}
+                                />
+                            ))}
+                        {!isCollapsed && (
+                            <ChevronsUpDown
+                                className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                strokeWidth={1.5}
+                                aria-hidden="true"
                             />
                         )}
-                        <ChevronsUpDown
-                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                            strokeWidth={1.5}
-                            aria-hidden="true"
-                        />
                     </div>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="start" className="w-60">
-                    <DropdownMenuLabel>
-                        {hasOrgs ? t('heading') : t('bareTenant')}
-                    </DropdownMenuLabel>
+                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
                     {hasOrgs &&
                         organizations.map((org) => {
                             const isActive = activeOrganization?.id === org.id;

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -77,7 +77,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     /**
      * Empty state: even with zero orgs the switcher renders the
      * spinning favicon + wordmark + chevron trigger so the user can
-     * still reach "+ Create Organization". The previous behaviour
+     * still reach "Create Organization". The previous behaviour
      * (bare logo, no trigger) silently broke the create flow.
      */
     it('renders favicon + wordmark + trigger when the user has zero organizations', () => {
@@ -93,9 +93,9 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
     /**
      * Empty state popover: opening the trigger surfaces the
-     * "+ Create Organization" row even when no orgs exist.
+     * "Create Organization" row even when no orgs exist.
      */
-    it('shows "+ Create Organization" in the popover when zero orgs', () => {
+    it('shows "Create Organization" in the popover when zero orgs', () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
 
         render(<WorkspaceSwitcher />);
@@ -106,10 +106,12 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     });
 
     /**
-     * Active state with 1 org: the trigger shows the spinning favicon
-     * + the org's display name (no wordmark) + chevron.
+     * Active state with 1 org: the trigger swaps the EverWorks favicon
+     * for the org's initial-letter avatar and shows the org's display
+     * name (no wordmark) + chevron. The favicon stays in the empty
+     * state only.
      */
-    it('renders favicon + org name + trigger when the user has 1 organization', () => {
+    it('renders org avatar + org name + trigger when the user has 1 organization', () => {
         const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
         __seedOrganizationsStoreForTests({
             data: [org],
@@ -119,7 +121,8 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
         render(<WorkspaceSwitcher />);
 
-        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        // Brand favicon is replaced by the org avatar in the trigger.
+        expect(screen.queryByTestId('favicon-everwork-image')).toBeNull();
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         // Wordmark is replaced by the active-org label.
         expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
@@ -127,7 +130,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
     /**
      * 3 orgs — when the popover opens, all three list rows are
-     * present plus the "+ Create Organization" footer row.
+     * present plus the "Create Organization" footer row.
      */
     it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
         const orgs = [
@@ -167,5 +170,55 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         render(<WorkspaceSwitcher />);
 
         expect(screen.getAllByText('fallback-org').length).toBeGreaterThanOrEqual(1);
+    });
+
+    /**
+     * Collapsed variant — empty state: the trigger renders only the
+     * leading icon (favicon, no wordmark/label/chevron) and clicking
+     * it still opens the popover. Replaces the pre-fix collapsed
+     * sidebar's `<FaviconEverWork>` link to `siteConfig.website`
+     * (localhost:3000 in dev).
+     */
+    it('renders icon-only trigger and still opens the popover when isCollapsed (empty state)', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        render(<WorkspaceSwitcher isCollapsed />);
+
+        // Empty-state icon = favicon. No label, no chevron, no wordmark.
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
+
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Collapsed variant — active org: the favicon is swapped for the
+     * org-initial avatar; the wordmark and the inline org-name label
+     * are both suppressed (collapsed = icon-only). Clicking still
+     * opens the popover listing the org and the create row.
+     */
+    it('renders the org-initial avatar and no label/wordmark when isCollapsed + active org', () => {
+        const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher isCollapsed />);
+
+        // Active-org icon = OrgAvatar — favicon and wordmark both absent.
+        expect(screen.queryByTestId('favicon-everwork-image')).toBeNull();
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
+        // The closed trigger has no inline label either.
+        expect(screen.queryByText('Acme Inc')).toBeNull();
+
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+        // After opening, the org list row + create row both show.
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 });

--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -10,6 +10,16 @@ sidebar_label: Company Builder
 
 The **Company Builder** is Ever Works' most ambitious shape: not a website, but the _organization that runs websites, stores, and everything else_ — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
 
+## A Company is your workspace and org
+
+In Ever Works, **Workspace = Company = Organization** — one top-level container for everything you build. The model:
+
+- **Many companies per account.** Create several companies inside your tenant and **switch between them from the site header** (the logo + company selector). The selected company sets the context for everything you see.
+- **Everything lives inside the selected company.** Your [Missions](./missions.md), [Ideas](./ideas.md), [Works](./creating-a-work.md), [Agents](./agents.md), and [Knowledge Base](./knowledge-base.md) are all scoped to the company you have picked. Switch companies and the whole workspace context switches with you.
+- **Register it for real — as a Work.** When you're ready to incorporate, registering the legal entity (in many countries, including the US) runs through formation **provider plugins** and is itself a **kind of Work** the platform builds for you — so going from workspace to a real company is part of the same flow.
+
+(See [How it relates to Tenants & Organizations](#how-it-relates-to-tenants--organizations) below for the underlying multi-tenancy foundation.)
+
 ## From idea to operating company
 
 ```mermaid

--- a/docs/features/desktop-app.md
+++ b/docs/features/desktop-app.md
@@ -12,7 +12,7 @@ The **Desktop App** will let you run all of Ever Works **locally as a single app
 
 ## What "all local" means
 
-- **Full stack in one app** — the API, frontend, background-jobs runtime, and database ship together. No separate services to wire up.
+- **Full stack in one app** — the API, frontend dashboard, the background-jobs runtime (Trigger.dev-style, powering schedules and Agents), and the database ship together as a single installable application. No separate services to wire up.
 - **Your data on your machine** — repositories, Knowledge Base, and configuration stay local by default.
 - **Works offline-first** — the platform keeps working without a constant connection to a cloud backend.
 

--- a/docs/features/store-builder.md
+++ b/docs/features/store-builder.md
@@ -24,6 +24,14 @@ flowchart LR
 
 You can start a Store directly when you know exactly what you want, or let a [Mission](./missions.md) propose it as one of several Works needed for a bigger commerce goal.
 
+## Storefront templates and backends
+
+A Store is a **Work of type "Store"** — you choose how it's built:
+
+- **Many storefront templates** — pick from a catalog of eCommerce [templates](./website-templates.md), or bring your own **Custom** template.
+- **The backend you choose** — a self-hostable **open-source commerce backend** deployed for you, **Shopify**, or your own — connected through deployment plugins, so you're never locked to one commerce stack.
+- **Grow it over time** — start small and let the Store expand its catalog, content, and experiments as it runs, the same way any [Work](./creating-a-work.md) keeps improving.
+
 ## What the Store builder is planned to do
 
 - **Research the catalog** — find products, suppliers, and pricing signals relevant to the store's niche, with sources recorded in the [Knowledge Base](./knowledge-base.md).


### PR DESCRIPTION
## Summary

Cascade `develop` → `stage` to ship PR #1129 (auto-rename duplicate
usernames in `AddUniqueIndexToUsername`) along with five other commits
that landed on `develop` since the last cascade.

Highlight: **PR #1129** removes the hard `throw` on case-insensitive
username duplicates that caused the 2026-05-28 prod CrashLoopBackOff
(two real `paradoxe35` users — local + github registrations of the
same human). The migration now auto-renames non-canonical rows to
`<username>-<id-prefix>`, walking the suffix length up if it collides
with an existing username. 6 unit specs covering clean DB, single-bucket,
multi-bucket+3-way, idempotency, collision-fallback, and down().

## Other develop commits in this cascade

- docs(features): expand Company/Store/Desktop builder docs
- fix(web): unify WorkspaceSwitcher across collapsed/expanded sidebar (#1127)

## Test plan

- [x] PR #1129 lint-and-test green on develop
- [ ] lint-and-test green on this cascade
- [ ] After merge: open stage → main PR