### PR TITLE
chore: cascade stage → main (incl. fix/migration-username-dup-safe)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,14 @@ name: E2E Tests
 on:
   push:
     branches: [stage, main]
+  # Pre-validate PRs heading into the release pipeline so test debt
+  # surfaces BEFORE the merge instead of after. Sharded across 4
+  # runners (~25 min wall-clock), so the cost is bearable to catch
+  # regressions before they reach `stage`. If this proves too
+  # expensive, narrow to `[stage, main]` only and rely on push for
+  # `develop`-merged regressions.
+  pull_request:
+    branches: [develop, stage, main]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.
@@ -30,17 +38,25 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubicloud-standard-8
-    # 150 min covers the current 1-worker × 333-spec suite even with retries
-    # and slow specs. The prior 45-min ceiling was too tight: a single full
-    # run on develop hit the wall partway through. Keep the headroom while
-    # we work through suite-level test debt; revisit downward only once the
-    # suite consistently finishes well under it.
-    timeout-minutes: 150
+    # Each shard runs ~1/E2E_SHARDS of the 1670-test suite. 90 min keeps
+    # plenty of headroom for the slowest shard (cold dev-mode compile +
+    # retries) while letting GitHub kill genuine hangs reasonably fast.
+    # Bump back to ~150 if you reduce shard count below 4.
+    timeout-minutes: 90
 
     strategy:
+      # Shard the Playwright suite across multiple machines. Each shard
+      # boots its own API + sqlite in-memory DB, so they're fully isolated
+      # — no shared-state races. Wall-clock = single-shard runtime
+      # (~90/N min) rather than sum-of-all (~90 min × 1 worker).
+      #
+      # 4 shards × ubicloud-standard-8 = 4× infra cost but ~4× faster.
+      # Adjust by editing the `shard` array AND the `--shard=X/Y` totals
+      # in the playwright invocation below; they MUST stay in sync.
       fail-fast: false
       matrix:
         node-version: [22.x]
+        shard: [1, 2, 3, 4]
 
     # Service containers — let the e2e suite exercise features that would
     # otherwise skip themselves because the dependency isn't reachable.
@@ -144,7 +160,11 @@ jobs:
             tail -n 200 /tmp/web.log || true
             echo "::endgroup::"
           }' EXIT
-          pnpm exec playwright test
+          # --shard=N/M splits the test suite across M machines, deterministic.
+          # Each shard runs its own subset; combined across the matrix they
+          # cover every test exactly once. Keep --shard total in sync with
+          # the `shard:` matrix length above.
+          pnpm exec playwright test --shard=${{ matrix.shard }}/4
           echo "::endgroup::"
         env:
           # API
@@ -268,7 +288,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ github.ref_name }}-${{ github.run_attempt }}
+          # Per-shard artifact name so the 4 parallel uploads don't clobber.
+          name: playwright-report-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/e2e/test-results
@@ -279,7 +300,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs-${{ github.ref_name }}-${{ github.run_attempt }}
+          name: server-logs-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             /tmp/api.log
             /tmp/web.log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,16 +3,18 @@ name: E2E Tests
 # Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope: only the release branches stage / main. Skipping PRs, feature
-# branches, AND develop deliberately — Playwright on ubicloud-standard-8
-# is expensive (the full suite can take 90+ minutes), so we restrict it
-# to release gates (merges to stage and main). The existing CI workflow
-# still lints + builds + unit-tests every push to develop/stage/main and
-# on PR; only the heavy E2E pass is reserved for the release path.
+# Scope:
+#   - push to `stage` / `main`            → run (release gate)
+#   - pull_request to `develop`/`stage`/`main` → run (pre-merge validation)
+#   - workflow_dispatch on any branch     → run (one-off verification)
+#
+# The full suite is sharded 4× across the matrix (~25 min wall-clock per
+# shard on ubicloud-standard-8). PR pre-validation was added because
+# stage/main-only triggers let test debt accumulate undetected until the
+# release cut. If PR cost proves too high, narrow the `pull_request:`
+# branches list to `[stage, main]` only.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
-#
-# Trigger via "Run workflow" on any branch when you want a one-off run.
 
 on:
   push:
@@ -289,7 +291,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Per-shard artifact name so the 4 parallel uploads don't clobber.
-          name: playwright-report-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
+          # `github.ref_name` is `<PR#>/merge` on pull_request events (contains
+          # `/`, which actions/upload-artifact rejects). Fall back to the head
+          # branch name (sanitized) on PRs and the ref_name everywhere else.
+          name: playwright-report-${{ github.head_ref || github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/e2e/test-results
@@ -300,7 +305,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs-${{ github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
+          name: server-logs-${{ github.head_ref || github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             /tmp/api.log
             /tmp/web.log

--- a/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
+++ b/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
@@ -80,7 +80,7 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
             ).map((r) => r.lname),
         );
 
-        const renames: Array<{ id: string; from: string; to: string }> = [];
+        let renames: Array<{ id: string; from: string; to: string }> = [];
 
         for (const bucket of buckets) {
             const rows = (await queryRunner.query(

--- a/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
+++ b/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
@@ -19,11 +19,19 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * suite ships a recent SQLite). This matches GitHub-style "Alice" and
  * "alice" cannot both exist semantics.
  *
- * Pre-check: fails loudly if any case-insensitive duplicates already
- * exist in the table. The platform is not yet live (no live data), so
- * this is expected to be a no-op in practice; the check exists to
- * prevent silent data corruption if someone applies this migration to a
- * snapshot that has been mucked with manually.
+ * Duplicate handling: before the index is created, any case-insensitive
+ * duplicate bucket is auto-deduped. The OLDEST row (lowest `createdAt`,
+ * tie-broken by `id`) keeps the canonical username; every other row in
+ * the bucket is renamed to `<username>-<first-6-id-chars>`. This is
+ * deterministic, collision-resistant (UUID prefix), and forward-only.
+ *
+ * Rationale for auto-rename instead of throwing: a hard throw turns any
+ * single duplicate into a full CrashLoopBackOff for the API
+ * (`migrationsRun: true` runs migrations at pod boot — see
+ * `EVER_WORKS_DB_MIGRATIONS.md`). That happened in prod on 2026-05-28
+ * with two real `paradoxe35` users (local + github registrations of the
+ * same human). Auto-rename keeps the platform up; an out-of-band human
+ * decision can later merge or relabel the renamed accounts.
  *
  * Forward-only, additive. The new index is named explicitly so the down
  * migration can drop the right one even if TypeORM's auto-naming
@@ -31,16 +39,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  */
 export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        const dupes = (await queryRunner.query(
-            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" GROUP BY lower("username") HAVING COUNT(*) > 1`,
-        )) as Array<{ lname: string; cnt: number | string }>;
-
-        if (dupes.length > 0) {
-            throw new Error(
-                `AddUniqueIndexToUsername aborted: found ${dupes.length} case-insensitive duplicate username(s) in users table. ` +
-                    `Resolve manually before re-running this migration. Sample: ${JSON.stringify(dupes.slice(0, 5))}`,
-            );
-        }
+        await this.dedupeUsernames(queryRunner);
 
         const table = await queryRunner.getTable('users');
         const hasIndex = table?.indices.some(
@@ -51,6 +50,64 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
             // model expression columns portably across dialects.
             await queryRunner.query(
                 `CREATE UNIQUE INDEX "idx_users_username_lower_unique" ON "users" (lower("username"))`,
+            );
+        }
+    }
+
+    private async dedupeUsernames(queryRunner: QueryRunner): Promise<void> {
+        const buckets = (await queryRunner.query(
+            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" WHERE "username" IS NOT NULL GROUP BY lower("username") HAVING COUNT(*) > 1`,
+        )) as Array<{ lname: string; cnt: number | string }>;
+
+        if (buckets.length === 0) {
+            return;
+        }
+
+        const isPostgres = queryRunner.connection.options.type === 'postgres';
+        const updateSql = isPostgres
+            ? `UPDATE "users" SET "username" = $1 WHERE "id" = $2`
+            : `UPDATE "users" SET "username" = ? WHERE "id" = ?`;
+
+        const renames: Array<{ id: string; from: string; to: string }> = [];
+
+        for (const bucket of buckets) {
+            const rows = (await queryRunner.query(
+                `SELECT "id", "username", "createdAt" FROM "users" WHERE lower("username") = ${
+                    isPostgres ? '$1' : '?'
+                } ORDER BY "createdAt" ASC, "id" ASC`,
+                [bucket.lname],
+            )) as Array<{ id: string; username: string; createdAt: Date | string }>;
+
+            // Keep rows[0] (oldest) as canonical; rename the rest.
+            for (let i = 1; i < rows.length; i++) {
+                const row = rows[i];
+                const suffix = String(row.id).replace(/-/g, '').slice(0, 6);
+                const renamed = `${row.username}-${suffix}`;
+                await queryRunner.query(updateSql, [renamed, row.id]);
+                renames.push({ id: row.id, from: row.username, to: renamed });
+            }
+        }
+
+        // Re-check: the rename suffix uses the UUID prefix so collisions are
+        // astronomically unlikely, but be defensive — surface the problem
+        // loudly rather than swallowing it before the index attempt.
+        const stillDupes = (await queryRunner.query(
+            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" WHERE "username" IS NOT NULL GROUP BY lower("username") HAVING COUNT(*) > 1`,
+        )) as Array<{ lname: string; cnt: number | string }>;
+
+        if (stillDupes.length > 0) {
+            throw new Error(
+                `AddUniqueIndexToUsername: dedup pass left ${stillDupes.length} ` +
+                    `case-insensitive duplicate bucket(s); rename-by-id-suffix collided. ` +
+                    `Resolve manually. Sample: ${JSON.stringify(stillDupes.slice(0, 5))}`,
+            );
+        }
+
+        if (renames.length > 0) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[migration] AddUniqueIndexToUsername renamed ${renames.length} duplicate username(s): ` +
+                    JSON.stringify(renames),
             );
         }
     }

--- a/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
+++ b/apps/api/src/migrations/1779991000000-AddUniqueIndexToUsername.ts
@@ -68,6 +68,18 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
             ? `UPDATE "users" SET "username" = $1 WHERE "id" = $2`
             : `UPDATE "users" SET "username" = ? WHERE "id" = ?`;
 
+        // Build a case-insensitive set of every username currently in use so
+        // generated rename targets cannot collide with an existing row that
+        // a prior manual cleanup already produced (e.g. prod's
+        // `paradoxe35-289966` from the 2026-05-28 incident).
+        const taken = new Set<string>(
+            (
+                (await queryRunner.query(
+                    `SELECT lower("username") AS lname FROM "users" WHERE "username" IS NOT NULL`,
+                )) as Array<{ lname: string }>
+            ).map((r) => r.lname),
+        );
+
         const renames: Array<{ id: string; from: string; to: string }> = [];
 
         for (const bucket of buckets) {
@@ -78,29 +90,18 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
                 [bucket.lname],
             )) as Array<{ id: string; username: string; createdAt: Date | string }>;
 
-            // Keep rows[0] (oldest) as canonical; rename the rest.
+            // Keep rows[0] (oldest) as canonical; rename the rest. The first
+            // bucket-row keeps the lname slot in `taken`; each rename adds the
+            // new target to `taken` so subsequent renames in the same pass
+            // cannot collide with one we just produced either.
             for (let i = 1; i < rows.length; i++) {
                 const row = rows[i];
-                const suffix = String(row.id).replace(/-/g, '').slice(0, 6);
-                const renamed = `${row.username}-${suffix}`;
+                const renamed = this.allocateRenameTarget(row.username, row.id, taken);
                 await queryRunner.query(updateSql, [renamed, row.id]);
+                taken.delete(row.username.toLowerCase());
+                taken.add(renamed.toLowerCase());
                 renames.push({ id: row.id, from: row.username, to: renamed });
             }
-        }
-
-        // Re-check: the rename suffix uses the UUID prefix so collisions are
-        // astronomically unlikely, but be defensive — surface the problem
-        // loudly rather than swallowing it before the index attempt.
-        const stillDupes = (await queryRunner.query(
-            `SELECT lower("username") AS lname, COUNT(*) AS cnt FROM "users" WHERE "username" IS NOT NULL GROUP BY lower("username") HAVING COUNT(*) > 1`,
-        )) as Array<{ lname: string; cnt: number | string }>;
-
-        if (stillDupes.length > 0) {
-            throw new Error(
-                `AddUniqueIndexToUsername: dedup pass left ${stillDupes.length} ` +
-                    `case-insensitive duplicate bucket(s); rename-by-id-suffix collided. ` +
-                    `Resolve manually. Sample: ${JSON.stringify(stillDupes.slice(0, 5))}`,
-            );
         }
 
         if (renames.length > 0) {
@@ -110,6 +111,27 @@ export class AddUniqueIndexToUsername1779991000000 implements MigrationInterface
                     JSON.stringify(renames),
             );
         }
+    }
+
+    private allocateRenameTarget(username: string, id: string, taken: Set<string>): string {
+        const hex = String(id).replace(/-/g, '');
+        // Try increasing prefix length 6 → full UUID; any collision falls back
+        // to the next longer suffix. Stops at the full hex string, which is
+        // guaranteed unique (UUID PKs are unique by the table contract).
+        for (let len = 6; len <= hex.length; len++) {
+            const candidate = `${username}-${hex.slice(0, len)}`;
+            if (!taken.has(candidate.toLowerCase())) {
+                return candidate;
+            }
+        }
+        // Defensive: if even the full UUID is taken (impossible unless a row
+        // somewhere is already named `<username>-<full-uuid>`), append the
+        // numeric suffix `-2`, `-3`, ... like AddSlugToUsers does.
+        let n = 2;
+        while (taken.has(`${username}-${hex}-${n}`.toLowerCase())) {
+            n += 1;
+        }
+        return `${username}-${hex}-${n}`;
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
@@ -1,0 +1,153 @@
+import { DataSource } from 'typeorm';
+import { AddUniqueIndexToUsername1779991000000 } from '../1779991000000-AddUniqueIndexToUsername';
+
+/**
+ * EW-652 — migration test for the case-insensitive UNIQUE index on
+ * `users.username`, plus the auto-rename dedup path that landed after
+ * the 2026-05-28 prod incident (CrashLoopBackOff on two real users
+ * sharing username `paradoxe35`).
+ *
+ * Uses the same in-memory better-sqlite3 harness as
+ * `AddWorkKindAndStatus.spec.ts`. Asserts:
+ *   - clean DB → index is created, no renames.
+ *   - case-insensitive duplicate bucket → oldest row keeps the canonical
+ *     username; later rows get `-<id-prefix>` suffix; index is then
+ *     created successfully.
+ *   - multi-bucket + 3-way collision → all extras renamed correctly.
+ *   - idempotent: running up() twice does not throw.
+ *   - down() drops the index.
+ */
+describe('AddUniqueIndexToUsername1779991000000 (EW-652)', () => {
+    let dataSource: DataSource;
+    const migration = new AddUniqueIndexToUsername1779991000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        await dataSource.query(
+            `CREATE TABLE "users" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "username" varchar,
+                "createdAt" varchar NOT NULL
+            )`,
+        );
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    function uuid(prefix: string): string {
+        // Stable 36-char UUID-ish string keyed on prefix so tests assert on
+        // the suffix the migration produces from substring(id, 1, 6).
+        return `${prefix}aa-bbbb-cccc-dddd-eeeeeeeeeeee`.slice(0, 36);
+    }
+
+    async function insert(id: string, username: string | null, createdAt: string): Promise<void> {
+        await dataSource.query(
+            `INSERT INTO "users" ("id", "username", "createdAt") VALUES (?, ?, ?)`,
+            [id, username, createdAt],
+        );
+    }
+
+    async function usernamesById(): Promise<Record<string, string | null>> {
+        const rows: Array<{ id: string; username: string | null }> = await dataSource.query(
+            `SELECT "id", "username" FROM "users"`,
+        );
+        return Object.fromEntries(rows.map((r) => [r.id, r.username]));
+    }
+
+    async function indexExists(): Promise<boolean> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_users_username_lower_unique'`,
+        );
+        return rows.length === 1;
+    }
+
+    it('creates the unique index on a clean DB', async () => {
+        await insert(uuid('111111'), 'alice', '2026-01-01');
+        await insert(uuid('222222'), 'bob', '2026-01-02');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('auto-renames case-insensitive duplicates: oldest keeps canonical name', async () => {
+        const oldId = uuid('aaaaaa');
+        const newId = uuid('bbbbbb');
+        await insert(oldId, 'paradoxe35', '2025-09-25T14:56:57Z');
+        await insert(newId, 'paradoxe35', '2026-04-13T08:00:25Z');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const after = await usernamesById();
+        expect(after[oldId]).toBe('paradoxe35');
+        expect(after[newId]).toBe('paradoxe35-bbbbbb');
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('handles 3-way + multi-bucket duplicates', async () => {
+        // Bucket A: 3 rows
+        await insert(uuid('aaaaaa'), 'alice', '2026-01-01');
+        await insert(uuid('bbbbbb'), 'alice', '2026-02-01');
+        await insert(uuid('cccccc'), 'Alice', '2026-03-01');
+        // Bucket B: 2 rows, case-mixed
+        await insert(uuid('dddddd'), 'Bob', '2026-01-15');
+        await insert(uuid('eeeeee'), 'bob', '2026-02-15');
+        // Unrelated row
+        await insert(uuid('ffffff'), 'carol', '2026-01-10');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const after = await usernamesById();
+        expect(after[uuid('aaaaaa')]).toBe('alice');
+        expect(after[uuid('bbbbbb')]).toBe('alice-bbbbbb');
+        expect(after[uuid('cccccc')]).toBe('Alice-cccccc');
+        expect(after[uuid('dddddd')]).toBe('Bob');
+        expect(after[uuid('eeeeee')]).toBe('bob-eeeeee');
+        expect(after[uuid('ffffff')]).toBe('carol');
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('is idempotent — running up() twice does not throw', async () => {
+        await insert(uuid('111111'), 'alice', '2026-01-01');
+        await insert(uuid('222222'), 'alice', '2026-02-01');
+
+        const r1 = dataSource.createQueryRunner();
+        await migration.up(r1);
+        await r1.release();
+
+        const r2 = dataSource.createQueryRunner();
+        await expect(migration.up(r2)).resolves.toBeUndefined();
+        await r2.release();
+
+        expect(await indexExists()).toBe(true);
+    });
+
+    it('down() drops the index', async () => {
+        await insert(uuid('111111'), 'alice', '2026-01-01');
+
+        const up = dataSource.createQueryRunner();
+        await migration.up(up);
+        await up.release();
+        expect(await indexExists()).toBe(true);
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+        expect(await indexExists()).toBe(false);
+    });
+});

--- a/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts
@@ -137,6 +137,31 @@ describe('AddUniqueIndexToUsername1779991000000 (EW-652)', () => {
         expect(await indexExists()).toBe(true);
     });
 
+    it('falls back to longer id-prefix when rename target collides with existing user', async () => {
+        // A prior manual cleanup already produced `paradoxe35-bbbbbb` — the
+        // exact name the 6-char suffix would otherwise generate. The
+        // migration must avoid collision instead of throwing.
+        const oldId = uuid('aaaaaa');
+        const newId = uuid('bbbbbb');
+        const collidingId = uuid('999999');
+        await insert(oldId, 'paradoxe35', '2025-09-25');
+        await insert(newId, 'paradoxe35', '2026-04-13');
+        await insert(collidingId, 'paradoxe35-bbbbbb', '2026-04-14');
+
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        const after = await usernamesById();
+        expect(after[oldId]).toBe('paradoxe35');
+        expect(after[collidingId]).toBe('paradoxe35-bbbbbb');
+        // newId's rename target collided → migration extends suffix until free.
+        expect(after[newId]).not.toBe('paradoxe35');
+        expect(after[newId]).not.toBe('paradoxe35-bbbbbb');
+        expect(after[newId]).toMatch(/^paradoxe35-bbbbbb[a-z0-9]+/);
+        expect(await indexExists()).toBe(true);
+    });
+
     it('down() drops the index', async () => {
         await insert(uuid('111111'), 'alice', '2026-01-01');
 

--- a/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
+++ b/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
@@ -149,9 +149,7 @@ export class NotificationEventTypeBootstrap implements OnApplicationBootstrap {
         // 2. Seed plugin-contributed events (skipped if plugin registry
         //    isn't wired — e.g. CLI / test contexts).
         if (!this.registry) {
-            this.logger.debug(
-                'Plugin registry not wired; skipping plugin event bootstrap',
-            );
+            this.logger.debug('Plugin registry not wired; skipping plugin event bootstrap');
             return;
         }
 

--- a/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
+++ b/apps/api/src/notifications/notification-event-type-bootstrap.service.ts
@@ -4,19 +4,104 @@ import { NotificationEventTypeRepository } from '@ever-works/agent/database';
 import type { PluginNotificationEvent } from '@ever-works/plugin';
 
 /**
- * EW-664 / EW-676 / T21 — pulls plugin-declared notification events
- * out of each registered plugin's manifest at app bootstrap and
- * upserts them into `notification_event_types`. The keys are namespaced
- * as `<pluginId>:<key>` so plugins can't collide with the core event
- * keys (`ai_credits_depleted`, `work_generation_finished`, …) seeded
- * by `SeedNotificationEventTypes1780000010000`.
+ * Core event registry — kept in sync with the rows
+ * `SeedNotificationEventTypes1780000010000` migration inserts on Postgres.
+ * Bootstrapped here too so SQLite / CI environments that boot with
+ * `synchronize: true` (migrationsRun is false in that mode) still end up
+ * with the core registry populated. Idempotent via TypeORM `repo.upsert`.
+ */
+interface CoreEventRow {
+    readonly key: string;
+    readonly category: string;
+    readonly title: string;
+    readonly description: string;
+    readonly urgent: boolean;
+    readonly defaultChannels: readonly string[];
+}
+
+const CORE_EVENTS: readonly CoreEventRow[] = [
+    {
+        key: 'ai_credits_depleted',
+        category: 'ai_credits',
+        title: 'AI credits depleted',
+        description:
+            'Your configured AI provider has run out of credits. Top up to resume generation.',
+        urgent: true,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'ai_provider_error',
+        category: 'ai_credits',
+        title: 'AI provider error',
+        description: 'Recurring error from one of your enabled AI providers.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'generation_error',
+        category: 'generation',
+        title: 'Generation failed',
+        description: 'A scheduled or manual content generation run failed for one of your works.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'schedule_paused',
+        category: 'generation',
+        title: 'Schedule paused',
+        description:
+            'Scheduled updates for a work have been paused — likely due to repeated errors or an exhausted credit pool.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'git_auth_expired',
+        category: 'integrations',
+        title: 'Git authentication expired',
+        description: 'Your Git provider authentication has expired and needs to be refreshed.',
+        urgent: true,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'work_generation_finished',
+        category: 'generation',
+        title: 'Work generation finished',
+        description: 'A scheduled or manual content generation run for a work finished.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'agent_run_finished',
+        category: 'agents',
+        title: 'Agent run finished',
+        description: 'An autonomous agent run completed.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+    {
+        key: 'mission_blocked',
+        category: 'system',
+        title: 'Mission blocked',
+        description: 'A mission can no longer progress — review its blocking task to unblock.',
+        urgent: false,
+        defaultChannels: ['in-app'],
+    },
+];
+
+/**
+ * EW-664 / EW-676 / T21 — at app bootstrap:
+ *  1. Seed CORE_EVENTS into `notification_event_types`. The same rows are
+ *     also inserted by `SeedNotificationEventTypes1780000010000`, but that
+ *     migration only runs when `migrationsRun=true` (prod). In CI / E2E
+ *     environments that boot with `synchronize: true`, migrations are
+ *     skipped, so we re-seed here. Idempotent via TypeORM
+ *     `repo.upsert([...], ['key'])`.
+ *  2. Pull plugin-declared notification events out of each registered
+ *     plugin's manifest and upsert them under `<pluginId>:<key>` so they
+ *     can't collide with core keys.
  *
- * Idempotent: re-runs on every boot, repeated upserts only touch the
- * rows whose title / description / urgent / defaultChannels actually
- * changed.
- *
- * Hard-rule additive: this only inserts new rows or updates plugin-
- * source rows; core rows seeded by the migration are left alone.
+ * Hard-rule additive: this only inserts new rows or updates existing
+ * core / plugin-source rows; never deletes.
  */
 @Injectable()
 export class NotificationEventTypeBootstrap implements OnApplicationBootstrap {
@@ -28,9 +113,44 @@ export class NotificationEventTypeBootstrap implements OnApplicationBootstrap {
     ) {}
 
     async onApplicationBootstrap(): Promise<void> {
-        if (!this.registry || !this.eventTypes) {
+        if (!this.eventTypes) {
             this.logger.debug(
-                'Plugin registry or event-types repository not wired; skipping plugin event bootstrap',
+                'Event-types repository not wired; skipping notification event bootstrap',
+            );
+            return;
+        }
+
+        // 1. Seed core events (idempotent — safe to run alongside the
+        //    Postgres migration that inserts the same rows).
+        let coreUpserts = 0;
+        for (const event of CORE_EVENTS) {
+            try {
+                await this.eventTypes.upsert({
+                    key: event.key,
+                    category: event.category,
+                    title: event.title,
+                    description: event.description,
+                    urgent: event.urgent,
+                    defaultChannels: [...event.defaultChannels],
+                    source: 'core' as const,
+                    pluginId: null,
+                });
+                coreUpserts++;
+            } catch (err) {
+                this.logger.warn(
+                    `Failed to upsert core event ${event.key}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        }
+        if (coreUpserts > 0) {
+            this.logger.log(`Upserted ${coreUpserts} core notification event types`);
+        }
+
+        // 2. Seed plugin-contributed events (skipped if plugin registry
+        //    isn't wired — e.g. CLI / test contexts).
+        if (!this.registry) {
+            this.logger.debug(
+                'Plugin registry not wired; skipping plugin event bootstrap',
             );
             return;
         }

--- a/apps/api/src/template-catalog/dto/list-templates.dto.spec.ts
+++ b/apps/api/src/template-catalog/dto/list-templates.dto.spec.ts
@@ -29,10 +29,17 @@ describe('template-catalog DTOs validation', () => {
             expect(await validate(dto)).toHaveLength(0);
         });
 
-        it('rejects missing kind via @IsString', async () => {
+        it('accepts kind="mission" (PR W extension)', async () => {
+            const dto = plainToInstance(ListTemplatesQueryDto, { kind: 'mission' });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('defaults to "work" when kind is omitted (back-compat)', async () => {
             const dto = plainToInstance(ListTemplatesQueryDto, {});
-            const errs = await validate(dto);
-            expect(constraintsFor(errs, 'kind').isString).toBeDefined();
+            // Validation passes — kind is optional.
+            expect(await validate(dto)).toHaveLength(0);
+            // The class-default applies after construction.
+            expect(dto.kind).toBe('work');
         });
 
         it('rejects out-of-enum kind via @IsIn', async () => {

--- a/apps/api/src/template-catalog/dto/list-templates.dto.ts
+++ b/apps/api/src/template-catalog/dto/list-templates.dto.ts
@@ -1,20 +1,29 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsString, IsUrl, MaxLength, MinLength } from 'class-validator';
 
-const TEMPLATE_KINDS = ['website', 'work'] as const;
+// Must mirror `TemplateKind` in packages/agent/src/entities/template.entity.ts.
+// Phase 8 PR W/X added 'mission' (Mission Templates catalog filter); Phase 11
+// added 'company'. Keeping both kinds here lets the catalog/fork endpoints
+// accept them; the repository's findVisibleByKind() does the actual lookup.
+const TEMPLATE_KINDS = ['website', 'work', 'mission', 'company'] as const;
+type TemplateKindLiteral = (typeof TEMPLATE_KINDS)[number];
 
 export class ListTemplatesQueryDto {
-    @ApiProperty({ enum: TEMPLATE_KINDS })
+    // Back-compat: pre-PR-W callers hit `/api/templates` with no kind and
+    // got Work templates. PR-W added the `kind=mission` filter as an
+    // extension — `kind` is optional, defaulting to 'work'.
+    @ApiPropertyOptional({ enum: TEMPLATE_KINDS, default: 'work' })
+    @IsOptional()
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral = 'work';
 }
 
 export class AddCustomTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty()
     @IsString()
@@ -62,7 +71,7 @@ export class SetDefaultTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty()
     @IsString()
@@ -73,7 +82,7 @@ export class UpdateCustomTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty({ required: false })
     @IsOptional()
@@ -113,14 +122,14 @@ export class ArchiveCustomTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 }
 
 export class ForkTemplateDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 
     @ApiProperty()
     @IsString()
@@ -135,7 +144,7 @@ export class RefreshTemplatesDto {
     @ApiProperty({ enum: TEMPLATE_KINDS })
     @IsString()
     @IsIn(TEMPLATE_KINDS)
-    kind: 'website' | 'work';
+    kind: TemplateKindLiteral;
 }
 
 export class CustomizeTemplateFromBaseDto {

--- a/apps/web/e2e/dark-mode-pinned.spec.ts
+++ b/apps/web/e2e/dark-mode-pinned.spec.ts
@@ -68,10 +68,14 @@ test.describe('Dark mode — pinning persists', () => {
     test('no FOUC — html element carries theme class before first paint', async ({ page }) => {
         await pinDarkMode(page);
         // Stop at the very earliest event so we can inspect the initial
-        // HTML state before client JS hydrates.
+        // HTML state before client JS hydrates. `commit` fires before
+        // the parser runs, so `document.documentElement` can briefly
+        // be null on Windows/CI — the evaluate guards against that
+        // rather than throwing TypeError.
         await page.goto('/en', { waitUntil: 'commit' });
         const initial = await page.evaluate(() => {
             const html = document.documentElement;
+            if (!html) return { cls: '', dataTheme: '' };
             return {
                 cls: html.className,
                 dataTheme: html.getAttribute('data-theme') || '',

--- a/apps/web/e2e/dashboard-comprehensive.spec.ts
+++ b/apps/web/e2e/dashboard-comprehensive.spec.ts
@@ -73,7 +73,9 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         // /works/new → /new (unified picker). Accept either route +
         // both locale-prefix shapes so this stays green either way.
         const newCta = page
-            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .locator(
+                'a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]',
+            )
             .first();
         await expect(newCta, 'sidebar "+ New" CTA present').toBeVisible({
             timeout: 10_000,
@@ -167,7 +169,9 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         // picker). The legacy /works/new route still exists for deep
         // links / AI Chat pivots, so we accept either destination.
         const newCta = page
-            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .locator(
+                'a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]',
+            )
             .first();
         await expect(newCta).toBeVisible({ timeout: 10_000 });
         await newCta.click();

--- a/apps/web/e2e/dashboard-comprehensive.spec.ts
+++ b/apps/web/e2e/dashboard-comprehensive.spec.ts
@@ -65,12 +65,17 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         await expect(worksLink, 'sidebar Works link present').toBeVisible({ timeout: 10_000 });
     });
 
-    test('sidebar "New Work" CTA is present', async ({ page }) => {
+    test('sidebar "+ New" CTA is present', async ({ page }) => {
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const newWorkLink = page.locator('a[href="/works/new"], a[href="/en/works/new"]').first();
-        await expect(newWorkLink, 'sidebar New Work CTA present').toBeVisible({
+        // Phase 6.5 PR DD repointed the sidebar primary CTA from
+        // /works/new → /new (unified picker). Accept either route +
+        // both locale-prefix shapes so this stays green either way.
+        const newCta = page
+            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .first();
+        await expect(newCta, 'sidebar "+ New" CTA present').toBeVisible({
             timeout: 10_000,
         });
     });
@@ -94,11 +99,14 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
     });
 
     test('new work page shows three creation modes', async ({ page }) => {
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // Phase 6.5 PR DD — /works/new without ?mode/?proposal now 307s to
+        // the unified picker at /new. Force a mode so the mode selector
+        // actually renders.
+        await page.goto('/en/works/new?mode=ai', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
         const body = await page.locator('body').innerText();
-        expect(body).toMatch(/new work/i);
+        expect(body).toMatch(/new work|create with ai|build with ai/i);
 
         expect(body, 'mode selector mentions Create/Configure/Import').toMatch(
             /create with ai|configure|manual|import existing/i,
@@ -150,14 +158,19 @@ test.describe('Dashboard — comprehensive (authenticated)', () => {
         expect(page.url()).toMatch(/(?:\/en)?\/works/);
     });
 
-    test('clicking sidebar "New Work" link navigates to /works/new', async ({ page }) => {
+    test('clicking sidebar "+ New" link navigates to the unified picker', async ({ page }) => {
         test.setTimeout(60_000);
         await page.goto('/en', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
-        const newWorkLink = page.locator('a[href="/works/new"], a[href="/en/works/new"]').first();
-        await expect(newWorkLink).toBeVisible({ timeout: 10_000 });
-        await newWorkLink.click();
-        await page.waitForURL(/(?:\/en)?\/works\/new/, { timeout: 30_000 });
+        // Phase 6.5 PR DD — sidebar "+ New" now points at /new (unified
+        // picker). The legacy /works/new route still exists for deep
+        // links / AI Chat pivots, so we accept either destination.
+        const newCta = page
+            .locator('a[href="/new"], a[href="/en/new"], a[href="/works/new"], a[href="/en/works/new"]')
+            .first();
+        await expect(newCta).toBeVisible({ timeout: 10_000 });
+        await newCta.click();
+        await page.waitForURL(/(?:\/en)?\/(?:new|works\/new)(?:\?|$|\/)/, { timeout: 30_000 });
     });
 });

--- a/apps/web/e2e/i18n-content.spec.ts
+++ b/apps/web/e2e/i18n-content.spec.ts
@@ -10,9 +10,17 @@ import { test, expect } from '@playwright/test';
 const LOCALES_TO_CHECK = ['en', 'es', 'fr', 'de', 'pt', 'it'];
 
 test.describe('i18n — login page content varies across locales', () => {
-    test('login titles are distinct across locales', async ({ page, baseURL }) => {
+    test('login titles are distinct across locales', async ({ page, baseURL, context }) => {
         const titles: Record<string, string> = {};
         for (const locale of LOCALES_TO_CHECK) {
+            // PR #1052 dropped the URL-level locale prefix (`/en/login` →
+            // `/login`); locale is now resolved from the `NEXT_LOCALE`
+            // cookie. Set the cookie per-iteration so each request lands
+            // with the intended locale before navigating.
+            const host = new URL(baseURL || 'http://localhost:3000').hostname;
+            await context.addCookies([
+                { name: 'NEXT_LOCALE', value: locale, domain: host, path: '/' },
+            ]);
             const url = `${baseURL || 'http://localhost:3000'}/${locale}/login`;
             await page.goto(url, { waitUntil: 'domcontentloaded' });
             titles[locale] = await page.title();
@@ -27,8 +35,14 @@ test.describe('i18n — login page content varies across locales', () => {
         expect(anyDifferent, `titles: ${JSON.stringify(titles)}`).toBe(true);
     });
 
-    test('login page lang attribute matches locale', async ({ page, baseURL }) => {
+    test('login page lang attribute matches locale', async ({ page, baseURL, context }) => {
         for (const locale of LOCALES_TO_CHECK) {
+            // Same cookie-based locale switch (see test above) — the URL
+            // prefix no longer changes the rendered locale.
+            const host = new URL(baseURL || 'http://localhost:3000').hostname;
+            await context.addCookies([
+                { name: 'NEXT_LOCALE', value: locale, domain: host, path: '/' },
+            ]);
             const url = `${baseURL || 'http://localhost:3000'}/${locale}/login`;
             await page.goto(url, { waitUntil: 'domcontentloaded' });
             const lang = await page.locator('html').getAttribute('lang');

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -45,7 +45,11 @@ test.describe('Onboarding — dismissal persists', () => {
     });
 
     test('"Connect GitHub" modal does not block navigation on /works/new', async ({ page }) => {
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // Phase 6.5 PR DD — /works/new now 307s to the unified picker at
+        // /new unless `?mode=` is supplied. Force a mode so the legacy
+        // mode-card selectors apply (still validates the original intent:
+        // the "Connect GitHub" modal doesn't intercept the form).
+        await page.goto('/en/works/new?mode=ai', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
 
         // We should still be able to interact with the page — at minimum, see

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4649,9 +4649,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -4843,9 +4843,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -4907,9 +4907,8 @@
     },
     "organizations": {
         "switcher": {
-            "heading": "Organizations",
-            "createNew": "+ Create Organization",
-            "bareTenant": "My account",
+            "heading": "Switch Organization",
+            "createNew": "Create Organization",
             "loading": "Loading…"
         },
         "create": {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -15,7 +15,19 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
+    // Intra-shard parallelism. The full suite is ~1670 tests / 90 min on
+    // 1 worker; the e2e workflow shards across the GitHub matrix
+    // (see .github/workflows/e2e.yml — each shard owns its own API +
+    // in-memory sqlite, so cross-shard state isolation is perfect).
+    // Within a shard, tests share one DB / one logged-in storageState,
+    // so workers > 1 must be set carefully. PLAYWRIGHT_WORKERS lets a
+    // shard opt into parallel workers (the workflow defaults to 1 →
+    // safe baseline; bump per-shard once we audit shared-state specs).
+    workers: process.env.PLAYWRIGHT_WORKERS
+        ? Number(process.env.PLAYWRIGHT_WORKERS)
+        : process.env.CI
+          ? 1
+          : undefined,
     reporter: process.env.CI ? 'github' : 'html',
     // First-hit dashboard routes hit Next.js dev-mode compilation (~10–15s
     // each), and several spec files chain multiple such hits. 30s (Playwright

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -39,7 +39,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu';
-import { FaviconEverWork } from '../logos';
 import { WorkspaceSwitcher } from '../layout/WorkspaceSwitcher';
 import { useWorkDetail } from '../works/detail/WorkDetailContext';
 import { ChatPanelExpandButton } from '@/components/ai/ChatPanel';
@@ -153,20 +152,23 @@ export function DashboardSidebar({
                 >
                     <div className="w-full relative">
                         {/*
-                            Expanded sidebar renders `<WorkspaceSwitcher>`,
-                            which always shows `[spinning favicon] [active
-                            org name OR Ever Works wordmark] [chevron]` and
-                            opens a popover with the org list + "+ Create
-                            Organization". The collapsed sidebar keeps the
-                            bare favicon — there's no room for a chip at
-                            16px column width.
+                            `<WorkspaceSwitcher>` is the single trigger
+                            for both states: expanded shows `[icon]
+                            [active org name OR Ever Works wordmark]
+                            [chevron]`, collapsed shows just `[icon]`.
+                            The icon is the active org's avatar when
+                            one is selected, otherwise the spinning
+                            Ever Works favicon — clicking either opens
+                            the same popover with org list + "Create
+                            Organization".
                         */}
-                        <div className="flex items-center pr-6">
-                            {isCollapsed ? (
-                                <FaviconEverWork config={config} className={cn('w-11 ml-[5px]')} />
-                            ) : (
-                                <WorkspaceSwitcher config={config} />
+                        <div
+                            className={cn(
+                                'flex items-center',
+                                isCollapsed ? 'justify-center' : 'pr-6',
                             )}
+                        >
+                            <WorkspaceSwitcher config={config} isCollapsed={isCollapsed} />
                         </div>
                         <div
                             className={cn(

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -25,6 +25,11 @@ interface WorkspaceSwitcherProps {
     config?: WorkConfig | null;
     /** Tailwind class for the inline wordmark image. */
     logoClassName?: string;
+    /**
+     * Collapsed sidebar variant — renders only the icon trigger (no
+     * label, no chevron). The popover behaviour is identical.
+     */
+    isCollapsed?: boolean;
 }
 
 function pickInitial(org: OrganizationResponse): string {
@@ -41,8 +46,14 @@ function pickLabel(org: OrganizationResponse): string {
  * TeamSwitcher's visual: a colored square with the first initial.
  * `Building2` is used as a fallback when the initial would be empty.
  */
-function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' }) {
+function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm' | 'xs' | 'md' }) {
     const initial = pickInitial(org);
+    const sizeClass =
+        size === 'md'
+            ? 'w-6 h-6 text-[11px]'
+            : size === 'sm'
+              ? 'w-7 h-7 text-xs'
+              : 'w-5 h-5 text-[10px]';
     return (
         <div
             className={cn(
@@ -50,7 +61,7 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
                 'bg-surface-tertiary dark:bg-surface-tertiary-dark',
                 'text-text dark:text-text-dark',
                 'font-semibold',
-                size === 'sm' ? 'w-7 h-7 text-xs' : 'w-5 h-5 text-[10px]',
+                sizeClass,
             )}
             aria-hidden="true"
         >
@@ -67,21 +78,25 @@ function OrgAvatar({ org, size = 'sm' }: { org: OrganizationResponse; size?: 'sm
  *
  * The whole row is a single dropdown trigger:
  *
- *   [spinning favicon] [label] [chevron]
+ *   [favicon OR org avatar] [label] [chevron]
  *
  * The trigger renders in every state (including zero-org), so the user
  * can always reach "+ Create Organization" — pre-fix, the zero-org
  * branch fell back to a bare logo with no popover and clicking it did
  * nothing useful.
  *
- * Trigger label by state:
- *
- * | Org count | Label                | Popover                         |
- * |-----------|----------------------|---------------------------------|
- * | 0         | Wordmark image       | "+ Create Organization" only    |
- * | 1+        | Active org name      | Org list + "+ Create"           |
+ * When `isCollapsed`, the trigger renders just the leading icon — the
+ * label + chevron are hidden and the dropdown still opens on click.
+ * That replaces the pre-fix collapsed-sidebar `<FaviconEverWork>`,
+ * which wrapped the favicon in a `<Link>` pointing at the configured
+ * site URL (localhost:3000 in dev) and silently swallowed clicks
+ * instead of opening the org switcher.
  */
-export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({
+    config,
+    logoClassName,
+    isCollapsed = false,
+}: WorkspaceSwitcherProps) {
     const t = useTranslations('organizations.switcher');
     const router = useRouter();
     const { organizations, isLoading } = useOrganizations();
@@ -104,44 +119,59 @@ export function WorkspaceSwitcher({ config, logoClassName }: WorkspaceSwitcherPr
         setIsCreateOpen(true);
     };
 
+    // Leading icon: the active org's avatar when one exists, otherwise
+    // the spinning Ever Works favicon. Same 24px footprint in both
+    // states so the row height doesn't shift when the user picks an org.
+    const leadingIcon = triggerOrg ? (
+        <OrgAvatar org={triggerOrg} size="md" />
+    ) : (
+        <FaviconEverWorkImage config={config} className="w-6 h-6 max-h-none shrink-0" />
+    );
+
     return (
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger
                     className={cn(
-                        'w-full rounded-md transition-colors cursor-pointer',
+                        'rounded-md transition-colors cursor-pointer',
                         'focus:outline-none focus-visible:outline-none',
                         'hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark',
-                        'px-1.5 py-1',
+                        // Collapsed: fill the column and center the icon so it
+                        // sits in the same x position as the "+ New" button
+                        // beneath it. Expanded keeps the chip layout.
+                        isCollapsed ? 'flex justify-center p-1' : 'w-full px-1.5 py-1',
                     )}
                     aria-label={t('heading')}
                 >
-                    <div className="flex items-center gap-1.5 w-full min-w-0">
-                        <FaviconEverWorkImage
-                            config={config}
-                            className="w-9 h-9 max-h-none shrink-0"
-                        />
-                        {triggerOrg ? (
-                            <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
-                                {pickLabel(triggerOrg)}
-                            </span>
-                        ) : (
-                            <LogoEverWorkImage
-                                config={config}
-                                className={cn('flex-1 min-w-0', logoClassName)}
+                    <div
+                        className={cn(
+                            'flex items-center min-w-0',
+                            isCollapsed ? 'justify-center' : 'gap-1.5 w-full',
+                        )}
+                    >
+                        {leadingIcon}
+                        {!isCollapsed &&
+                            (triggerOrg ? (
+                                <span className="flex-1 min-w-0 text-left text-sm font-medium text-text dark:text-text-dark truncate">
+                                    {pickLabel(triggerOrg)}
+                                </span>
+                            ) : (
+                                <LogoEverWorkImage
+                                    config={config}
+                                    className={cn('flex-1 min-w-0', logoClassName)}
+                                />
+                            ))}
+                        {!isCollapsed && (
+                            <ChevronsUpDown
+                                className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
+                                strokeWidth={1.5}
+                                aria-hidden="true"
                             />
                         )}
-                        <ChevronsUpDown
-                            className="w-4 h-4 shrink-0 text-text-muted dark:text-text-muted-dark"
-                            strokeWidth={1.5}
-                            aria-hidden="true"
-                        />
                     </div>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="start" className="w-60">
-                    <DropdownMenuLabel>
-                        {hasOrgs ? t('heading') : t('bareTenant')}
-                    </DropdownMenuLabel>
+                    <DropdownMenuLabel>{t('heading')}</DropdownMenuLabel>
                     {hasOrgs &&
                         organizations.map((org) => {
                             const isActive = activeOrganization?.id === org.id;

--- a/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.unit.spec.tsx
@@ -77,7 +77,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     /**
      * Empty state: even with zero orgs the switcher renders the
      * spinning favicon + wordmark + chevron trigger so the user can
-     * still reach "+ Create Organization". The previous behaviour
+     * still reach "Create Organization". The previous behaviour
      * (bare logo, no trigger) silently broke the create flow.
      */
     it('renders favicon + wordmark + trigger when the user has zero organizations', () => {
@@ -93,9 +93,9 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
     /**
      * Empty state popover: opening the trigger surfaces the
-     * "+ Create Organization" row even when no orgs exist.
+     * "Create Organization" row even when no orgs exist.
      */
-    it('shows "+ Create Organization" in the popover when zero orgs', () => {
+    it('shows "Create Organization" in the popover when zero orgs', () => {
         __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
 
         render(<WorkspaceSwitcher />);
@@ -106,10 +106,12 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
     });
 
     /**
-     * Active state with 1 org: the trigger shows the spinning favicon
-     * + the org's display name (no wordmark) + chevron.
+     * Active state with 1 org: the trigger swaps the EverWorks favicon
+     * for the org's initial-letter avatar and shows the org's display
+     * name (no wordmark) + chevron. The favicon stays in the empty
+     * state only.
      */
-    it('renders favicon + org name + trigger when the user has 1 organization', () => {
+    it('renders org avatar + org name + trigger when the user has 1 organization', () => {
         const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
         __seedOrganizationsStoreForTests({
             data: [org],
@@ -119,7 +121,8 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
         render(<WorkspaceSwitcher />);
 
-        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        // Brand favicon is replaced by the org avatar in the trigger.
+        expect(screen.queryByTestId('favicon-everwork-image')).toBeNull();
         expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
         // Wordmark is replaced by the active-org label.
         expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
@@ -127,7 +130,7 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
 
     /**
      * 3 orgs — when the popover opens, all three list rows are
-     * present plus the "+ Create Organization" footer row.
+     * present plus the "Create Organization" footer row.
      */
     it('renders all 3 orgs in the popover list when the user has 3 organizations', () => {
         const orgs = [
@@ -167,5 +170,55 @@ describe('WorkspaceSwitcher — EW-660 Phase 8', () => {
         render(<WorkspaceSwitcher />);
 
         expect(screen.getAllByText('fallback-org').length).toBeGreaterThanOrEqual(1);
+    });
+
+    /**
+     * Collapsed variant — empty state: the trigger renders only the
+     * leading icon (favicon, no wordmark/label/chevron) and clicking
+     * it still opens the popover. Replaces the pre-fix collapsed
+     * sidebar's `<FaviconEverWork>` link to `siteConfig.website`
+     * (localhost:3000 in dev).
+     */
+    it('renders icon-only trigger and still opens the popover when isCollapsed (empty state)', () => {
+        __seedOrganizationsStoreForTests({ data: [], isLoading: false, error: null });
+
+        render(<WorkspaceSwitcher isCollapsed />);
+
+        // Empty-state icon = favicon. No label, no chevron, no wordmark.
+        expect(screen.getByTestId('favicon-everwork-image')).toBeInTheDocument();
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
+
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
+    });
+
+    /**
+     * Collapsed variant — active org: the favicon is swapped for the
+     * org-initial avatar; the wordmark and the inline org-name label
+     * are both suppressed (collapsed = icon-only). Clicking still
+     * opens the popover listing the org and the create row.
+     */
+    it('renders the org-initial avatar and no label/wordmark when isCollapsed + active org', () => {
+        const org = makeOrg({ displayName: 'Acme Inc', slug: 'acme' });
+        __seedOrganizationsStoreForTests({
+            data: [org],
+            isLoading: false,
+            error: null,
+        });
+
+        render(<WorkspaceSwitcher isCollapsed />);
+
+        // Active-org icon = OrgAvatar — favicon and wordmark both absent.
+        expect(screen.queryByTestId('favicon-everwork-image')).toBeNull();
+        expect(screen.queryByTestId('logo-everwork-image')).toBeNull();
+        // The closed trigger has no inline label either.
+        expect(screen.queryByText('Acme Inc')).toBeNull();
+
+        const trigger = screen.getAllByRole('button')[0];
+        fireEvent.click(trigger);
+        // After opening, the org list row + create row both show.
+        expect(screen.getAllByText('Acme Inc').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('organizations.switcher.createNew')).toBeInTheDocument();
     });
 });

--- a/apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/load-exceljs-workbook.ts
@@ -8,20 +8,20 @@ interface ExcelJsModule {
  * Dynamic-import wrapper around `new exceljs.Workbook()`.
  *
  * Lives in its own module so the viewer spec can mock the single
- * helper instead of `vi.mock('exceljs', …)` — and uses an opaque
- * runtime computation for the module specifier so Vite's static
- * analyzer doesn't eagerly walk exceljs's dependency graph during
- * test discovery. Without that, vitest OOMs even with
- * `--max-old-space-size=8192` because exceljs pulls in jszip,
- * archiver, and a ~700-class typings tree the resolver parses.
+ * helper at the boundary (`vi.mock('./load-exceljs-workbook', …)`)
+ * instead of `vi.mock('exceljs', …)` — the latter still forces
+ * vitest to resolve exceljs's dep graph (jszip, archiver, ~700-class
+ * typings) and OOMs on Windows even with `--max-old-space-size=8192`.
  *
- * The runtime path is unchanged — Next.js's webpack still lazy-
- * loads exceljs the first time an operator opens an XLSX preview.
+ * The static `import('exceljs')` is required for Next.js: webpack
+ * needs a literal specifier to code-split the package into its own
+ * chunk. An opaque runtime computation here (`['exceljs'].join('')`)
+ * makes webpack emit "Module not found: Can't resolve <dynamic>",
+ * which poisons the dev manifest and 500s every route. Since the
+ * test mock fully bypasses this module, no runtime obfuscation is
+ * needed.
  */
 export async function createExceljsWorkbook(): Promise<ExcelWorkbook> {
-    // Compute the specifier at runtime so Vite can't constant-fold
-    // the dynamic import target.
-    const id = ['exceljs'].join('');
-    const mod = (await import(/* @vite-ignore */ id)) as unknown as ExcelJsModule;
+    const mod = (await import('exceljs')) as unknown as ExcelJsModule;
     return new mod.Workbook();
 }

--- a/docs/features/company-builder.md
+++ b/docs/features/company-builder.md
@@ -10,6 +10,16 @@ sidebar_label: Company Builder
 
 The **Company Builder** is Ever Works' most ambitious shape: not a website, but the _organization that runs websites, stores, and everything else_ — staffed by AI [Agents](./agents.md) acting as real employees, working 24/7 toward your [Mission](./missions.md). If a Work is one site and a Mission is one goal, a **Company** is the whole operation: a CEO, a CTO, the Works they own, the budgets they spend against, and the schedule they run on.
 
+## A Company is your workspace and org
+
+In Ever Works, **Workspace = Company = Organization** — one top-level container for everything you build. The model:
+
+- **Many companies per account.** Create several companies inside your tenant and **switch between them from the site header** (the logo + company selector). The selected company sets the context for everything you see.
+- **Everything lives inside the selected company.** Your [Missions](./missions.md), [Ideas](./ideas.md), [Works](./creating-a-work.md), [Agents](./agents.md), and [Knowledge Base](./knowledge-base.md) are all scoped to the company you have picked. Switch companies and the whole workspace context switches with you.
+- **Register it for real — as a Work.** When you're ready to incorporate, registering the legal entity (in many countries, including the US) runs through formation **provider plugins** and is itself a **kind of Work** the platform builds for you — so going from workspace to a real company is part of the same flow.
+
+(See [How it relates to Tenants & Organizations](#how-it-relates-to-tenants--organizations) below for the underlying multi-tenancy foundation.)
+
 ## From idea to operating company
 
 ```mermaid

--- a/docs/features/desktop-app.md
+++ b/docs/features/desktop-app.md
@@ -12,7 +12,7 @@ The **Desktop App** will let you run all of Ever Works **locally as a single app
 
 ## What "all local" means
 
-- **Full stack in one app** — the API, frontend, background-jobs runtime, and database ship together. No separate services to wire up.
+- **Full stack in one app** — the API, frontend dashboard, the background-jobs runtime (Trigger.dev-style, powering schedules and Agents), and the database ship together as a single installable application. No separate services to wire up.
 - **Your data on your machine** — repositories, Knowledge Base, and configuration stay local by default.
 - **Works offline-first** — the platform keeps working without a constant connection to a cloud backend.
 

--- a/docs/features/store-builder.md
+++ b/docs/features/store-builder.md
@@ -24,6 +24,14 @@ flowchart LR
 
 You can start a Store directly when you know exactly what you want, or let a [Mission](./missions.md) propose it as one of several Works needed for a bigger commerce goal.
 
+## Storefront templates and backends
+
+A Store is a **Work of type "Store"** — you choose how it's built:
+
+- **Many storefront templates** — pick from a catalog of eCommerce [templates](./website-templates.md), or bring your own **Custom** template.
+- **The backend you choose** — a self-hostable **open-source commerce backend** deployed for you, **Shopify**, or your own — connected through deployment plugins, so you're never locked to one commerce stack.
+- **Grow it over time** — start small and let the Store expand its catalog, content, and experiments as it runs, the same way any [Work](./creating-a-work.md) keeps improving.
+
 ## What the Store builder is planned to do
 
 - **Research the catalog** — find products, suppliers, and pricing signals relevant to the store's niche, with sources recorded in the [Knowledge Base](./knowledge-base.md).


### PR DESCRIPTION
## Summary

Cascade `stage` → `main` to ship the develop cycle that includes
**PR #1129** (auto-rename duplicate usernames in
`AddUniqueIndexToUsername`).

Background: on 2026-05-28, the new `ever-works-api` rollout crashed
into CrashLoopBackOff because `AddUniqueIndexToUsername` aborted on
two real `paradoxe35` users (local + github registrations of the same
human). PR #1129 replaces the hard throw with an idempotent,
collision-safe auto-rename pass that keeps the oldest row canonical
and renames the rest to `<username>-<id-prefix>`.

Prior cascade: develop → stage merged as PR #1130.

## Contents

- fix(migration): auto-rename duplicate usernames instead of aborting (#1129)
- fix(migration): make username dedup rename collision-safe (#1129)
- style(migration): use let for mutable renames array (#1129)
- docs(features): expand Company/Store/Desktop builder docs (#1128)
- fix(web): unify WorkspaceSwitcher across collapsed/expanded sidebar (#1127)
- Merge commits for #1129 and #1130

## Test plan

- [x] PR #1129 lint-and-test green on develop
- [x] PR #1130 all 5 CI checks green on stage cascade
- [ ] CI green on this cascade