### PR TITLE
release(cascade): stage → main for #1134

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -206,6 +206,14 @@ jobs:
           # MailHog HTTP API for specs that want to read back sent mail
           # to extract verification / reset tokens for end-to-end flows.
           MAILHOG_URL: http://127.0.0.1:8025
+          # KB upload cap — match the kb.controller's KB_UPLOAD_MAX_BYTES
+          # (200 MiB default). The local-fs storage plugin defaults its
+          # own `maxBytes` to 5 MiB and rejects anything bigger with a
+          # 500 before the controller's per-feature cap applies. The
+          # row-A14 kb-viewer-size-cap specs intentionally upload >5 MiB
+          # binaries to exercise the viewer's download-fallback path,
+          # so the storage cap needs to match. 209715200 = 200 * 1024 * 1024.
+          UPLOADS_MAX_BYTES: '209715200'
           # Redis — wire up the throttler so distributed rate-limit
           # specs see cross-replica behaviour instead of the in-memory
           # fallback. Per @nest-lab/throttler-storage-redis we just

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -294,15 +294,28 @@ jobs:
           CI: 'true'
           PLAYWRIGHT_BASE_URL: http://localhost:3000
 
+      - name: Sanitize branch tag for artifact names
+        # GitHub Actions expressions have no `replace()` function, and
+        # actions/upload-artifact rejects `/` (and other path chars) in
+        # artifact names. Branch names like `session/<id>-e2e-followup`
+        # and the `<PR#>/merge` ref on pull_request events both contain
+        # slashes, so compute a sanitized tag once in a shell step and
+        # reuse it for both upload steps below.
+        id: tag
+        run: |
+          RAW="${HEAD_REF:-$REF_NAME}"
+          SAFE="${RAW//[^A-Za-z0-9._-]/-}"
+          echo "tag=${SAFE}" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           # Per-shard artifact name so the 4 parallel uploads don't clobber.
-          # `github.ref_name` is `<PR#>/merge` on pull_request events (contains
-          # `/`, which actions/upload-artifact rejects). Fall back to the head
-          # branch name (sanitized) on PRs and the ref_name everywhere else.
-          name: playwright-report-${{ github.head_ref || github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
+          name: playwright-report-${{ steps.tag.outputs.tag }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/e2e/test-results
@@ -313,7 +326,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs-${{ github.head_ref || github.ref_name }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
+          name: server-logs-${{ steps.tag.outputs.tag }}-shard${{ matrix.shard }}-${{ github.run_attempt }}
           path: |
             /tmp/api.log
             /tmp/web.log
@@ -421,11 +434,24 @@ jobs:
           # stay in 'development' while the served pages are prod.
           E2E_PROD_BUILD: '1'
 
+      - name: Sanitize branch tag for artifact names
+        # Same rationale as the sharded e2e job above — `github.ref_name`
+        # is `<PR#>/merge` on pull_request events, which actions/upload-
+        # artifact rejects.
+        id: tag
+        run: |
+          RAW="${HEAD_REF:-$REF_NAME}"
+          SAFE="${RAW//[^A-Za-z0-9._-]/-}"
+          echo "tag=${SAFE}" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+
       - name: Upload Playwright prod-build report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-prod-build-report-${{ github.ref_name }}-${{ github.run_attempt }}
+          name: playwright-prod-build-report-${{ steps.tag.outputs.tag }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/e2e/test-results

--- a/apps/web/e2e/notification-channels.spec.ts
+++ b/apps/web/e2e/notification-channels.spec.ts
@@ -54,7 +54,12 @@ test.describe('Notification channels — preferences endpoint', () => {
         // on the modern empty-state shape.
         const serialised = JSON.stringify(body).toLowerCase();
         const hasNamedChannel = /email|in-?app|inapp|push|webhook|sms|slack/.test(serialised);
-        const hasV2Envelope = /"subscriptions"/.test(serialised) && /"mutes"/.test(serialised);
+        // Match the v2 envelope keys as JSON property names (followed by `:`),
+        // not as string values. A response like `{"error":"subscriptions
+        // channel not configured","mutes":[]}` would falsely satisfy the
+        // looser substring check and mask a non-channel-shaped body.
+        const hasV2Envelope =
+            /"subscriptions"\s*:/.test(serialised) && /"mutes"\s*:/.test(serialised);
         const looksChannelShaped = hasNamedChannel || hasV2Envelope;
         expect(
             looksChannelShaped,

--- a/apps/web/e2e/notification-channels.spec.ts
+++ b/apps/web/e2e/notification-channels.spec.ts
@@ -45,8 +45,17 @@ test.describe('Notification channels — preferences endpoint', () => {
         }
         if (!body) test.skip(true, 'no preferences endpoint accessible');
         // Look for channel-ish keys somewhere in the response tree.
+        // The Notifications v2 endpoint returns a structural shape for fresh
+        // users — `{subscriptions: [], preference: null, mutes: []}` — with
+        // no channel names embedded until subscriptions exist. Accept either
+        // (a) named channels (email/in-app/push/…) anywhere in the tree, or
+        // (b) the v2 envelope (`subscriptions` + `mutes` keys), so we don't
+        // regress on legacy preference endpoints but also stop false-failing
+        // on the modern empty-state shape.
         const serialised = JSON.stringify(body).toLowerCase();
-        const looksChannelShaped = /email|in-?app|inapp|push|webhook|sms|slack/.test(serialised);
+        const hasNamedChannel = /email|in-?app|inapp|push|webhook|sms|slack/.test(serialised);
+        const hasV2Envelope = /"subscriptions"/.test(serialised) && /"mutes"/.test(serialised);
+        const looksChannelShaped = hasNamedChannel || hasV2Envelope;
         expect(
             looksChannelShaped,
             `preferences body has no channel-ish keys: ${serialised.slice(0, 200)}`,

--- a/apps/web/e2e/plugins.spec.ts
+++ b/apps/web/e2e/plugins.spec.ts
@@ -8,10 +8,14 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Plugins', () => {
     test('should load plugins page', async ({ page }) => {
-        await page.goto('/en/plugins');
+        const response = await page.goto('/en/plugins');
 
         await expect(page).toHaveURL(/\/plugins/);
-        await expect(page.locator('body')).not.toContainText('500');
+        // Assert against the HTTP status, not the body — the page's catalog
+        // copy now includes "500+ third-party apps" (Composio plugin
+        // description) which triggers a false positive when scanning body
+        // text for "500".
+        expect(response?.status(), '/en/plugins should not 5xx').toBeLessThan(500);
     });
 
     test('should display plugin cards or list', async ({ page }) => {

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -63,8 +63,8 @@ test.describe('Settings navigation', () => {
         const dataLink = page.locator('a[href*="/settings/data"]').first();
         await dataLink.click();
 
-        await page.waitForURL(/\/settings\/data/, { timeout: 30_000 });
-        await expect(page.locator('body')).not.toContainText('500');
+        // Same client-side-nav fix as the API keys test above.
+        await expect(page).toHaveURL(/\/settings\/data/, { timeout: 30_000 });
     });
 
     test('should navigate to danger zone settings', async ({ page }) => {
@@ -73,8 +73,8 @@ test.describe('Settings navigation', () => {
         const dangerLink = page.locator('a[href*="/settings/danger"]').first();
         await dangerLink.click();
 
-        await page.waitForURL(/\/settings\/danger/, { timeout: 30_000 });
-        await expect(page.locator('body')).not.toContainText('500');
+        // Same client-side-nav fix as the API keys test above.
+        await expect(page).toHaveURL(/\/settings\/danger/, { timeout: 30_000 });
     });
 });
 

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -51,8 +51,10 @@ test.describe('Settings navigation', () => {
         const apiKeysLink = page.locator('a[href*="/settings/api-keys"]').first();
         await apiKeysLink.click();
 
-        await page.waitForURL(/\/settings\/api-keys/, { timeout: 30_000 });
-        await expect(page.locator('body')).not.toContainText('500');
+        // Next.js client-side navigation doesn't fire 'load', so waitForURL
+        // (default waitUntil:'load') times out even when the URL is correct.
+        // toHaveURL polls the URL itself and tolerates client-side nav.
+        await expect(page).toHaveURL(/\/settings\/api-keys/, { timeout: 30_000 });
     });
 
     test('should navigate to data management settings', async ({ page }) => {

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -89,21 +89,17 @@ test.describe('Complete user journey', () => {
             await page.waitForTimeout(500);
         }
 
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // PR DD — bare /works/new now 307s to the unified /new picker.
+        // Pin `?mode=manual` so we land directly on the manual form (which
+        // is what the rest of this journey drives) without needing to
+        // click through a chooser that no longer exists at /works/new.
+        await page.goto('/en/works/new?mode=manual', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
         // Also dismiss on /works/new in case the modal re-renders there.
         if (await dismissGithubModal.isVisible({ timeout: 3_000 }).catch(() => false)) {
             await dismissGithubModal.click();
             await page.waitForTimeout(500);
         }
-
-        // Select manual creation mode
-        const manualCard = page
-            .locator('button')
-            .filter({ hasText: /Configure|Manual/i })
-            .first();
-        await expect(manualCard).toBeVisible({ timeout: 10_000 });
-        await manualCard.click();
 
         // Fill work form (scope to the work creation form, not the AI chat input form)
         const dirSlug = `journey-${suffix}`;

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -101,19 +101,24 @@ test.describe('Complete user journey', () => {
             await page.waitForTimeout(500);
         }
 
-        // Fill work form (scope to the work creation form, not the AI chat input form)
+        // The previously separate "Create Manually" flow was merged into
+        // the unified WorkAICreator (new-work-client.tsx:405-426), which
+        // uses discrete <Input>/<Textarea> components rather than a single
+        // <form> wrapper. Target the inputs directly by their `name`s.
         const dirSlug = `journey-${suffix}`;
-        const workForm = page.locator('form.space-y-6, form[autocomplete="off"]').first();
-        await expect(workForm).toBeVisible({ timeout: 10_000 });
-
-        const nameInput = workForm.locator('input[type="text"]').first();
+        const nameInput = page.locator('input[name="name"]').first();
+        await expect(nameInput).toBeVisible({ timeout: 10_000 });
         await nameInput.fill(`Journey Dir ${dirSlug}`);
 
-        const descriptionTextarea = workForm.locator('textarea').first();
+        const descriptionTextarea = page.locator('textarea[name="prompt"], textarea').first();
         await descriptionTextarea.fill('Full journey test work');
 
-        // Submit
-        const submitButton = workForm.locator('button[type="submit"]');
+        // Submit via the primary CTA (WorkAICreator uses an onClick handler,
+        // not form onSubmit — no `button[type="submit"]` to scope to).
+        const submitButton = page
+            .locator('button')
+            .filter({ hasText: /(create|submit|build|generate)/i })
+            .first();
         await submitButton.click();
 
         // Wait for redirect or error

--- a/apps/web/e2e/work-create-ui-journey.spec.ts
+++ b/apps/web/e2e/work-create-ui-journey.spec.ts
@@ -12,7 +12,10 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Work create — full UI wizard', () => {
     test('user lands on /works/new and form renders', async ({ page }) => {
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // PR DD — /works/new without ?mode 307s to /new. Pin manual mode so
+        // the wizard form is present to drive (the chooser page on /new
+        // doesn't carry the name/description/submit triple this spec relies on).
+        await page.goto('/en/works/new?mode=manual', { waitUntil: 'domcontentloaded' });
         await expect(page).not.toHaveURL(/\/login/);
         // /works/new is now a chooser screen (AI / Manual / Import) where
         // the actual form is revealed AFTER picking a mode. We pin that
@@ -26,7 +29,10 @@ test.describe('Work create — full UI wizard', () => {
     });
 
     test('submitting an empty form surfaces validation', async ({ page }) => {
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // PR DD — /works/new without ?mode 307s to /new. Pin manual mode so
+        // the wizard form is present to drive (the chooser page on /new
+        // doesn't carry the name/description/submit triple this spec relies on).
+        await page.goto('/en/works/new?mode=manual', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_000);
         const submit = page
             .getByRole('button', { name: /create|next|continue|save|submit/i })
@@ -43,7 +49,10 @@ test.describe('Work create — full UI wizard', () => {
 
     test('filling the wizard and submitting creates a work + lands on detail', async ({ page }) => {
         const name = `e2e ui ${Date.now().toString(36)}`;
-        await page.goto('/en/works/new', { waitUntil: 'domcontentloaded' });
+        // PR DD — /works/new without ?mode 307s to /new. Pin manual mode so
+        // the wizard form is present to drive (the chooser page on /new
+        // doesn't carry the name/description/submit triple this spec relies on).
+        await page.goto('/en/works/new?mode=manual', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(2_500);
 
         // Fill the first text input — typically the name. Some builds

--- a/apps/web/e2e/works-detail.spec.ts
+++ b/apps/web/e2e/works-detail.spec.ts
@@ -72,14 +72,23 @@ test.describe('Works list page — interactive surface', () => {
         await expect(search).toHaveValue('zzznonexistent-search-needle-zzz');
     });
 
-    test('"+ New Work" CTA on the works list navigates to /works/new', async ({ page }) => {
+    test('"+ New Work" CTA on the works list navigates to the new-work picker', async ({
+        page,
+    }) => {
         await page.goto('/en/works', { waitUntil: 'domcontentloaded' });
         await page.waitForTimeout(1_500);
 
-        const newWorkLink = page.locator('a[href$="/works/new"], a[href*="/works/new?"]').first();
+        // Phase 6.5 PR DD repointed primary "+ New" CTAs from /works/new to
+        // the unified /new picker; the legacy /works/new route still exists
+        // for deep links. Accept either destination.
+        const newWorkLink = page
+            .locator(
+                'a[href$="/new"]:not([href*="/works/"]), a[href$="/works/new"], a[href*="/works/new?"], a[href$="/en/new"]',
+            )
+            .first();
         await expect(newWorkLink).toBeVisible({ timeout: 10_000 });
         await newWorkLink.click();
-        await page.waitForURL(/(?:\/en)?\/works\/new/, { timeout: 30_000 });
+        await page.waitForURL(/(?:\/en)?\/(?:new|works\/new)(?:\?|$|\/)/, { timeout: 30_000 });
     });
 });
 

--- a/apps/web/e2e/works.spec.ts
+++ b/apps/web/e2e/works.spec.ts
@@ -8,24 +8,34 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Work listing', () => {
     test('should load the works page', async ({ page }) => {
-        await page.goto('/en/works');
+        const response = await page.goto('/en/works');
 
         await expect(page).toHaveURL(/\/works/);
-        // Page should render without server error
-        await expect(page.locator('body')).not.toContainText('500');
+        // Assert against HTTP status — the body now includes "500+ third-
+        // party apps" copy (Composio plugin description) when the Plugins
+        // panel is in view, which false-positives a body substring check.
+        expect(response?.status(), '/en/works should not 5xx').toBeLessThan(500);
     });
 
     test('should show "new work" button or link', async ({ page }) => {
         await page.goto('/en/works');
 
-        const newDirLink = page.locator('a[href*="/works/new"]');
+        // PR DD repointed primary "+ New" CTAs from /works/new → /new (the
+        // unified picker). Accept either destination; both shapes also with
+        // the legacy /en locale prefix.
+        const newDirLink = page.locator(
+            'a[href$="/new"]:not([href*="/works/"]), a[href$="/works/new"], a[href*="/works/new?"]',
+        );
         await expect(newDirLink.first()).toBeVisible({ timeout: 10_000 });
     });
 });
 
 test.describe('Work creation', () => {
     test('should show creation mode selector on new work page', async ({ page }) => {
-        await page.goto('/en/works/new');
+        // PR DD — /works/new without ?mode/?proposal 307s to the unified
+        // /new picker. Force `?mode=ai` so the legacy mode-card selector
+        // assertion still applies.
+        await page.goto('/en/works/new?mode=ai');
 
         // Should show 3 creation mode cards: AI, Manual, Import
         // Each is a <button> with descriptive text
@@ -36,15 +46,9 @@ test.describe('Work creation', () => {
     });
 
     test('should navigate to manual creation mode', async ({ page }) => {
-        await page.goto('/en/works/new');
-
-        // Click the manual creation card (second button with PenLine icon)
-        const manualCard = page
-            .locator('button')
-            .filter({ hasText: /Configure|Manual/i })
-            .first();
-        await expect(manualCard).toBeVisible({ timeout: 10_000 });
-        await manualCard.click();
+        // Land directly on manual mode — PR DD redirect now means a bare
+        // /works/new goes to /new; `?mode=manual` keeps us on the form.
+        await page.goto('/en/works/new?mode=manual');
 
         // Should show the manual form with name, slug, description fields
         await expect(page.locator('input[placeholder]').first()).toBeVisible({ timeout: 5_000 });
@@ -53,14 +57,7 @@ test.describe('Work creation', () => {
     test('should create a work via manual form', async ({ page }) => {
         const slug = `e2e-test-${Date.now().toString(36)}`;
 
-        await page.goto('/en/works/new');
-
-        // Select manual mode
-        const manualCard = page
-            .locator('button')
-            .filter({ hasText: /Configure|Manual/i })
-            .first();
-        await manualCard.click();
+        await page.goto('/en/works/new?mode=manual');
 
         // Wait for the work creation form (scoped to avoid the AI chat input form)
         const workForm = page.locator('form.space-y-6, form[autocomplete="off"]').first();
@@ -90,24 +87,21 @@ test.describe('Work creation', () => {
     });
 
     test('should navigate back from manual form to mode selector', async ({ page }) => {
-        await page.goto('/en/works/new');
-
-        // Enter manual mode
-        const manualCard = page
-            .locator('button')
-            .filter({ hasText: /Configure|Manual/i })
-            .first();
-        await manualCard.click();
+        // Land on manual mode directly (see comment on the previous test).
+        await page.goto('/en/works/new?mode=manual');
 
         // Wait for the work creation form (scoped to avoid AI chat input form)
         const workForm = page.locator('form.space-y-6, form[autocomplete="off"]').first();
         await expect(workForm).toBeVisible({ timeout: 10_000 });
 
-        // Click back button
+        // Click back button → returns to the mode-card selector on /works/new.
         const backButton = page.locator('button').filter({ hasText: /back/i }).first();
         if (await backButton.isVisible()) {
             await backButton.click();
-            // Should show mode selector again with 3 cards
+            const manualCard = page
+                .locator('button')
+                .filter({ hasText: /Configure|Manual/i })
+                .first();
             await expect(manualCard).toBeVisible({ timeout: 5_000 });
         }
     });
@@ -124,8 +118,13 @@ test.describe('Work detail', () => {
         if (await workLink.isVisible({ timeout: 5_000 }).catch(() => false)) {
             await workLink.click();
             await expect(page).toHaveURL(/\/works\/.+/);
-            // Should render without error
-            await expect(page.locator('body')).not.toContainText('500');
+            // Assert via HTTP status rather than body text — the plugins panel
+            // copy can contain "500+ third-party apps".
+            const status = (await page.evaluate(() => performance.getEntriesByType('navigation')[0]))
+                ?.responseStatus;
+            if (typeof status === 'number') {
+                expect(status, 'work detail navigation should not 5xx').toBeLessThan(500);
+            }
         }
     });
 });

--- a/apps/web/e2e/works.spec.ts
+++ b/apps/web/e2e/works.spec.ts
@@ -116,14 +116,27 @@ test.describe('Work detail', () => {
         const workLink = page.locator('a[href*="/works/"]').first();
 
         if (await workLink.isVisible({ timeout: 5_000 }).catch(() => false)) {
-            await workLink.click();
+            // Capture the actual work-detail navigation response (works with
+            // Next.js soft routing — the RSC fetch is a real HTTP request).
+            // `performance.getEntriesByType('navigation')` only reflects the
+            // initial /en/works load and would always be 200 on a soft nav,
+            // silently passing even if the detail page 5xx'd.
+            const [response] = await Promise.all([
+                page
+                    .waitForResponse(
+                        (r) =>
+                            /\/works\/[^/?#]+/.test(new URL(r.url()).pathname) &&
+                            r.request().method() === 'GET',
+                        { timeout: 10_000 },
+                    )
+                    .catch(() => null),
+                workLink.click(),
+            ]);
             await expect(page).toHaveURL(/\/works\/.+/);
-            // Assert via HTTP status rather than body text — the plugins panel
-            // copy can contain "500+ third-party apps".
-            const status = (await page.evaluate(() => performance.getEntriesByType('navigation')[0]))
-                ?.responseStatus;
-            if (typeof status === 'number') {
-                expect(status, 'work detail navigation should not 5xx').toBeLessThan(500);
+            if (response) {
+                expect(response.status(), 'work detail navigation should not 5xx').toBeLessThan(
+                    500,
+                );
             }
         }
     });

--- a/apps/web/e2e/works.spec.ts
+++ b/apps/web/e2e/works.spec.ts
@@ -59,30 +59,35 @@ test.describe('Work creation', () => {
 
         await page.goto('/en/works/new?mode=manual');
 
-        // Wait for the work creation form (scoped to avoid the AI chat input form)
-        const workForm = page.locator('form.space-y-6, form[autocomplete="off"]').first();
-        await expect(workForm).toBeVisible({ timeout: 10_000 });
-
-        // Fill in the work form
-        const nameInput = workForm.locator('input[type="text"]').first();
+        // The previously separate "Create Manually" flow was merged into the
+        // unified WorkAICreator (new-work-client.tsx:405-426), which uses
+        // discrete <Input>/<Textarea> components rather than a single <form>
+        // wrapper. Target the inputs directly via their `name` attributes
+        // instead of scoping by form element.
+        const nameInput = page.locator('input[name="name"]').first();
+        await expect(nameInput).toBeVisible({ timeout: 10_000 });
         await nameInput.fill(`E2E Test Dir ${slug}`);
 
-        // Slug should auto-populate, but let's verify it exists
-        const slugInput = workForm.locator('input[type="text"]').nth(1);
+        // Slug auto-populates from name; just verify it picked something up.
+        const slugInput = page.locator('input[name="slug"]').first();
         await expect(slugInput).toHaveValue(/.+/);
 
-        // Description — textarea
-        const descriptionTextarea = workForm.locator('textarea').first();
-        await descriptionTextarea.fill('Automated E2E test work for Playwright testing');
+        // Description / prompt textarea (the AI/manual flow shares one).
+        const promptTextarea = page.locator('textarea[name="prompt"], textarea').first();
+        await promptTextarea.fill('Automated E2E test work for Playwright testing');
 
-        // Submit the form
-        const submitButton = workForm.locator('button[type="submit"]');
+        // Submit — the primary CTA on the page. WorkAICreator handles submit
+        // via an onClick handler on a Button, not a form's onSubmit.
+        const submitButton = page
+            .locator('button')
+            .filter({ hasText: /(create|submit|build|generate)/i })
+            .first();
         await submitButton.click();
 
-        // Should either redirect to the new work or show success
-        // Wait for navigation away from /new page or for a toast success
+        // Should either redirect to the new work or show success.
         await page.waitForURL(/\/works\/(?!new)/, { timeout: 15_000 }).catch(() => {
-            // If no redirect, check for error toast
+            // If no redirect, check for error toast — assertion below is
+            // loose because git-provider-less E2E may surface a soft error.
         });
     });
 
@@ -90,9 +95,10 @@ test.describe('Work creation', () => {
         // Land on manual mode directly (see comment on the previous test).
         await page.goto('/en/works/new?mode=manual');
 
-        // Wait for the work creation form (scoped to avoid AI chat input form)
-        const workForm = page.locator('form.space-y-6, form[autocomplete="off"]').first();
-        await expect(workForm).toBeVisible({ timeout: 10_000 });
+        // Same selector update — the unified WorkAICreator no longer wraps
+        // its fields in `<form className="space-y-6" autocomplete="off">`.
+        const nameInput = page.locator('input[name="name"]').first();
+        await expect(nameInput).toBeVisible({ timeout: 10_000 });
 
         // Click back button → returns to the mode-card selector on /works/new.
         const backButton = page.locator('button').filter({ hasText: /back/i }).first();


### PR DESCRIPTION
Cascade of #1134 (via #1136) from \`stage\` to \`main\`. Ships the e2e test-debt cleanup to production.

Combined diff vs prior main: #1134's test-only test hygiene changes — narrower selectors after the WorkManualForm consolidation, v2 notification envelope acceptance, KB upload cap, HTTP-status-based 5xx checks, settings client-side-nav, artifact-name slash sanitization. No app code beyond test specs + e2e workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)