### PR TITLE
fix(kb): return terminal extraction status from create+retry upload (closes residual #1134 KB races)

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -1245,10 +1245,15 @@ describe('KnowledgeBaseService', () => {
             storage.putObject.mockResolvedValue({ key: 'kb-originals/freeform/abc.bin', url: '' });
             const uploadRow = buildUpload({ mimeType: 'application/pdf' });
             uploadRepo.create.mockResolvedValue(uploadRow);
-            uploadRepo.update.mockResolvedValue({
+            const skippedRow = {
                 ...uploadRow,
                 extractionStatus: 'skipped' as KbUploadExtractionStatus,
-            });
+            };
+            uploadRepo.update.mockResolvedValue(skippedRow);
+            // The terminal-state re-read at the bottom of createUpload —
+            // ensures `result.upload` reflects the post-extract status
+            // ('skipped'), not the create-time status ('running').
+            uploadRepo.findById.mockResolvedValueOnce(skippedRow);
 
             const result = await service.createUpload({
                 ...buildUploadInput({ mimeType: 'application/pdf', originalFilename: 'spec.pdf' }),
@@ -1256,10 +1261,16 @@ describe('KnowledgeBaseService', () => {
             });
 
             expect(result.document).toBeNull();
+            // Without the terminal re-read the response would carry the
+            // 'running' row from uploadRepo.create — the e2e A16 suite
+            // (kb-extraction-retry.spec.ts:81) asserts on this field
+            // directly, no settle-poll.
+            expect(result.upload.extractionStatus).toBe('skipped');
             expect(uploadRepo.update).toHaveBeenCalledWith(
                 uploadRow.id,
                 expect.objectContaining({ extractionStatus: 'skipped' }),
             );
+            expect(uploadRepo.findById).toHaveBeenCalledWith(WORK_ID, uploadRow.id);
             const kinds = activityLog.log.mock.calls.map(
                 (c) => (c[0] as { actionType: string }).actionType,
             );

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -1363,8 +1363,10 @@ export class KnowledgeBaseService {
         // extract path updates the row but returns only the document, so
         // `current` still carries the pre-extract RUNNING status. Re-read
         // so callers (and the API response) see the terminal state.
-        const refreshed = await this.uploadRepository.findById(workId, upload.id);
-        return { upload: refreshed ?? current, document };
+        // (Named `terminalUpload` to avoid shadowing the `refreshed` const
+        // from the earlier RUNNING-write at line 1342.)
+        const terminalUpload = await this.uploadRepository.findById(workId, upload.id);
+        return { upload: terminalUpload ?? current, document };
     }
 
     /**

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -1296,7 +1296,14 @@ export class KnowledgeBaseService {
         );
 
         const document = await this.extractAndMaterialize(upload, input);
-        return { upload, document };
+        // `upload` above was returned from `uploadRepository.create` with
+        // `extractionStatus = RUNNING`. `extractAndMaterialize` mutates the
+        // row in-place to SUCCEEDED / SKIPPED / FAILED but only returns the
+        // document. Without this re-read the API response carries the stale
+        // RUNNING value, which trips the e2e A16 suite (it asserts on the
+        // create-response shape directly, no settle-poll).
+        const refreshed = await this.uploadRepository.findById(input.workId, upload.id);
+        return { upload: refreshed ?? upload, document };
     }
 
     /**
@@ -1352,7 +1359,12 @@ export class KnowledgeBaseService {
             description: null,
             title: undefined,
         });
-        return { upload: current, document };
+        // Same stale-state hazard as createUpload (see comment there): the
+        // extract path updates the row but returns only the document, so
+        // `current` still carries the pre-extract RUNNING status. Re-read
+        // so callers (and the API response) see the terminal state.
+        const refreshed = await this.uploadRepository.findById(workId, upload.id);
+        return { upload: refreshed ?? current, document };
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes the residual ~6 KB e2e failures from PR #1134 (\`kb-activity-log\`, \`kb-dedup\`, \`kb-extraction-retry\`, \`kb-inherited\`, \`kb-upload\`, \`kb-edit-autosave\`) — all failing with:

\`\`\`
Expected: \"skipped\"
Received: \"running\"
\`\`\`

## Root cause

\`KnowledgeBaseService.createUpload\`:

\`\`\`ts
const upload = await this.uploadRepository.create({
    /* ... */
    extractionStatus: KbUploadExtractionStatus.RUNNING,   // (1)
});

await this.extractAndMaterialize(upload, input);          // (2) mutates the DB row in-place
return { upload, document };                              // (3) returns the stale (1)
\`\`\`

\`extractAndMaterialize\` updates the DB row to \`SUCCEEDED\` / \`SKIPPED\` / \`FAILED\` but only returns the document — the \`upload\` object the caller (and ultimately the HTTP response) sees is the create-time snapshot, still \`RUNNING\`.

Same bug in \`retryUploadExtraction\` (returns \`current\` from before extract).

## Fix

One indexed \`uploadRepository.findById\` after \`extractAndMaterialize\` re-reads the terminal state. Restores the doc-string contract on the controller, which explicitly promises a synchronous terminal-state response:

> Server [...] synchronously creates a KB document for text-passthrough MIME types (markdown / plain). Non-text MIMEs are stored with extractionStatus=skipped pending Phase 1B/c extractor routing.

Considered alternatives:
- **Mutate \`upload\` in place** — side-effecting and surprising.
- **Return updated upload from \`extractAndMaterialize\`** — larger diff, would have to thread through 4 return statements.

Re-read is correct, clear, and ~sub-ms (indexed lookup by PK).

## Locked-in via unit test

\`packages/agent/src/services/__tests__/knowledge-base.service.spec.ts\` — tightened the \"unsupported MIME\" case to mock the terminal \`findById\` AND assert \`result.upload.extractionStatus === 'skipped'\`. Lock prevents regression to the stale-read.

## Test plan

- [ ] CI's e2e workflow on this PR — KB shard (shard 2 historically) should turn from red to green
- [ ] \`knowledge-base.service.spec.ts\` unit tests still pass
- [ ] After merge, cascade develop → stage → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API responses for upload creation and extraction retry now reflect the final extraction status after processing completes, avoiding stale "in-progress" results.

* **Tests**
  * Updated tests to validate that the system re-reads and returns the terminal upload state after processing finishes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->